### PR TITLE
Add v0 team flow: picking, role.md seeding, CLAUDE.md/AGENTS.md sync

### DIFF
--- a/.amq-squad/team-rules.md
+++ b/.amq-squad/team-rules.md
@@ -1,0 +1,48 @@
+# Team Rules
+
+Shared norms for the amq-squad project team. Every agent reads this file
+via their priming prompt regardless of binary. Edit this file and run
+`amq-squad team sync --apply` to refresh CLAUDE.md and AGENTS.md.
+
+Team members (see .amq-squad/team.json):
+- cto (codex): owns technical direction, architecture, sign-off.
+- fullstack (claude): implements features end to end.
+
+## Workflow
+
+- All code changes ship via a pull request. No direct pushes to main.
+- Open PRs with `gh pr create` from a topic branch. Use a HEREDOC for the
+  body per the repo's existing conventions.
+- Do not commit until the user explicitly asks. Do not push without permission.
+- Prefer creating new commits over amending.
+
+## Approvals
+
+- Every PR requires review and approval from cto before merge.
+- Cto review focuses on: architectural shape, Go idioms, test coverage,
+  whether the change respects the project's non-negotiables (zero required
+  AMQ changes, stdlib only, launch.json as the durable source of truth).
+- Disagreement is surfaced on the PR thread (p2p/cto__fullstack) rather
+  than blocking silently.
+
+## Quality gates
+
+- `make ci` (vet + tests) must pass before requesting review.
+- `gofmt -l .` must be clean.
+- New packages ship with tests. Round-trip code (serialize/deserialize,
+  plan/apply) gets explicit coverage of both directions.
+
+## Communication
+
+- 1-on-1 threads: p2p/cto__fullstack.
+- Decisions that change the shape of the system go in a
+  decision/<topic> thread (see AMQ decision protocol).
+- Fullstack pings cto early when a design decision feels bigger than the
+  PR it sits in. Escalate the shape before writing a lot of code.
+- Keep messages focused. One concern per message when possible.
+
+## Style
+
+- No em dashes in any written output or source.
+- Default to writing no comments; only justify the WHY when non-obvious.
+- No backward-compat shims or dead feature flags. Delete unused code.

--- a/.amq-squad/team.json
+++ b/.amq-squad/team.json
@@ -1,0 +1,18 @@
+{
+  "schema": 1,
+  "members": [
+    {
+      "role": "cto",
+      "binary": "codex",
+      "handle": "cto",
+      "session": "cto"
+    },
+    {
+      "role": "fullstack",
+      "binary": "claude",
+      "handle": "fullstack",
+      "session": "fullstack"
+    }
+  ],
+  "created_at": "2026-04-23T11:11:38.671934Z"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/amq-squad
+*.test
+*.out
+coverage.txt
+.DS_Store
+.idea/
+.vscode/
+.agent-mail/
+.amqrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+<!-- amq-squad:managed:begin -->
+<!-- Managed by amq-squad. Edit .amq-squad/team-rules.md and run
+     `amq-squad team sync --apply` to refresh. -->
+
+# Team Rules
+
+Shared norms for the amq-squad project team. Every agent reads this file
+via their priming prompt regardless of binary. Edit this file and run
+`amq-squad team sync --apply` to refresh CLAUDE.md and AGENTS.md.
+
+Team members (see .amq-squad/team.json):
+- cto (codex): owns technical direction, architecture, sign-off.
+- fullstack (claude): implements features end to end.
+
+## Workflow
+
+- All code changes ship via a pull request. No direct pushes to main.
+- Open PRs with `gh pr create` from a topic branch. Use a HEREDOC for the
+  body per the repo's existing conventions.
+- Do not commit until the user explicitly asks. Do not push without permission.
+- Prefer creating new commits over amending.
+
+## Approvals
+
+- Every PR requires review and approval from cto before merge.
+- Cto review focuses on: architectural shape, Go idioms, test coverage,
+  whether the change respects the project's non-negotiables (zero required
+  AMQ changes, stdlib only, launch.json as the durable source of truth).
+- Disagreement is surfaced on the PR thread (p2p/cto__fullstack) rather
+  than blocking silently.
+
+## Quality gates
+
+- `make ci` (vet + tests) must pass before requesting review.
+- `gofmt -l .` must be clean.
+- New packages ship with tests. Round-trip code (serialize/deserialize,
+  plan/apply) gets explicit coverage of both directions.
+
+## Communication
+
+- 1-on-1 threads: p2p/cto__fullstack.
+- Decisions that change the shape of the system go in a
+  decision/<topic> thread (see AMQ decision protocol).
+- Fullstack pings cto early when a design decision feels bigger than the
+  PR it sits in. Escalate the shape before writing a lot of code.
+- Keep messages focused. One concern per message when possible.
+
+## Style
+
+- No em dashes in any written output or source.
+- Default to writing no comments; only justify the WHY when non-obvious.
+- No backward-compat shims or dead feature flags. Delete unused code.
+
+<!-- amq-squad:managed:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+<!-- amq-squad:managed:begin -->
+<!-- Managed by amq-squad. Edit .amq-squad/team-rules.md and run
+     `amq-squad team sync --apply` to refresh. -->
+
+# Team Rules
+
+Shared norms for the amq-squad project team. Every agent reads this file
+via their priming prompt regardless of binary. Edit this file and run
+`amq-squad team sync --apply` to refresh CLAUDE.md and AGENTS.md.
+
+Team members (see .amq-squad/team.json):
+- cto (codex): owns technical direction, architecture, sign-off.
+- fullstack (claude): implements features end to end.
+
+## Workflow
+
+- All code changes ship via a pull request. No direct pushes to main.
+- Open PRs with `gh pr create` from a topic branch. Use a HEREDOC for the
+  body per the repo's existing conventions.
+- Do not commit until the user explicitly asks. Do not push without permission.
+- Prefer creating new commits over amending.
+
+## Approvals
+
+- Every PR requires review and approval from cto before merge.
+- Cto review focuses on: architectural shape, Go idioms, test coverage,
+  whether the change respects the project's non-negotiables (zero required
+  AMQ changes, stdlib only, launch.json as the durable source of truth).
+- Disagreement is surfaced on the PR thread (p2p/cto__fullstack) rather
+  than blocking silently.
+
+## Quality gates
+
+- `make ci` (vet + tests) must pass before requesting review.
+- `gofmt -l .` must be clean.
+- New packages ship with tests. Round-trip code (serialize/deserialize,
+  plan/apply) gets explicit coverage of both directions.
+
+## Communication
+
+- 1-on-1 threads: p2p/cto__fullstack.
+- Decisions that change the shape of the system go in a
+  decision/<topic> thread (see AMQ decision protocol).
+- Fullstack pings cto early when a design decision feels bigger than the
+  PR it sits in. Escalate the shape before writing a lot of code.
+- Keep messages focused. One concern per message when possible.
+
+## Style
+
+- No em dashes in any written output or source.
+- Default to writing no comments; only justify the WHY when non-obvious.
+- No backward-compat shims or dead feature flags. Delete unused code.
+
+<!-- amq-squad:managed:end -->

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build test fmt fmt-check vet ci install clean
+
+GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
+build:
+	go build -ldflags "-X main.version=$(VERSION)" -o amq-squad ./cmd/amq-squad
+
+test:
+	go test ./...
+
+fmt:
+	gofmt -w $(GO_FILES)
+
+fmt-check:
+	@test -z "$(shell gofmt -l $(GO_FILES))"
+
+vet:
+	go vet ./...
+
+ci: fmt-check vet test
+
+install: build
+	install amq-squad $(GOPATH)/bin/amq-squad 2>/dev/null || install amq-squad $(HOME)/go/bin/amq-squad
+
+clean:
+	rm -f amq-squad

--- a/README.md
+++ b/README.md
@@ -1,1 +1,123 @@
 # amq-squad
+
+Role-aware agent team launcher built on top of [AMQ](https://github.com/avivsinai/agent-message-queue).
+
+AMQ owns messaging between agents. `amq-squad` owns the layer above: who is in the team, what role each agent plays, and how to bring the whole squad back up after a restart.
+
+## Why
+
+AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `claude` or `codex`, but it doesn't know:
+
+- Which agent is the "CPO" vs "CTO" vs "Fullstack" vs "QA" vs "PM" vs "Designer"
+- What command you originally used to launch each one (cwd, binary, flags, session)
+- What slash commands or skills that role leans on
+- Which peers a given agent actively talks to
+
+`amq-squad` captures this at team-setup time (`.amq-squad/team.json`) and per-agent at launch time (`launch.json` + `role.md` inside the AMQ mailbox). AMQ itself stays unchanged.
+
+## Quick start
+
+```
+cd ~/Code/my-project
+amq-squad team
+```
+
+First time: you're prompted to pick which of the built-in roles should be on the team. A `.amq-squad/team.json` is written. Every subsequent run prints the launch commands, one per role. Paste each into its own terminal tab.
+
+Non-interactive setup:
+
+```
+amq-squad team init --roles cpo,cto,fullstack,qa,pm,designer
+```
+
+With per-role overrides:
+
+```
+amq-squad team init \
+  --roles cpo,fullstack,qa \
+  --binary fullstack=codex \
+  --session cpo=stream1,fullstack=stream2,qa=stream3
+```
+
+Members don't have to share a working directory. The dir where you run `team init` becomes the team-home (where team.json and team-rules.md live); individual members can live in other projects:
+
+```
+cd ~/Code/project-a
+amq-squad team init \
+  --roles cpo,cto,fullstack,qa \
+  --cwd qa=~/Code/project-b
+```
+
+`team show` emits a `cd <member-cwd>` per command so every agent boots in the right project. `team sync` walks each unique member cwd and syncs CLAUDE.md + AGENTS.md in all of them.
+
+## Built-in roles
+
+| ID          | Label                                | Default binary | Notable skills                      |
+|-------------|--------------------------------------|----------------|-------------------------------------|
+| `cpo`       | CPO                                  | codex          | `/product-strategy`                 |
+| `cto`       | CTO                                  | codex          |                                     |
+| `fullstack` | Fullstack Developer                  | claude         |                                     |
+| `qa`        | QA Manager                           | claude         |                                     |
+| `pm`        | Project Manager / Product Owner      | claude         |                                     |
+| `designer`  | Product Designer                     | claude         | `/frontend-design`, `/canvas-design`|
+
+Defaults are starting points. Override binary or session per role via flags at `team init` time, or edit `.amq-squad/team.json` directly.
+
+## Shared team rules
+
+Team-wide norms ("every change ships via a PR", "CTO approves before merge") live in a single file:
+
+```
+.amq-squad/team-rules.md
+```
+
+Claude reads `CLAUDE.md`, Codex reads `AGENTS.md`. Rather than maintaining both by hand, you edit `team-rules.md` and `amq-squad team sync` pushes the content into a managed block in both files. Everything outside the markers is yours and stays untouched.
+
+```
+amq-squad team rules init        Seed .amq-squad/team-rules.md with a stub
+amq-squad team sync              Preview what would change (exit 1 if drift)
+amq-squad team sync --apply      Write the managed block into CLAUDE.md and AGENTS.md
+```
+
+On first `--apply` with an existing CLAUDE.md, your content is adopted as the user region and the managed block is appended. Subsequent syncs only refresh the managed block.
+
+## Commands
+
+```
+amq-squad team                      Smart default: show commands, or init if none exists
+amq-squad team init [--roles ...]   Set up this project's team
+amq-squad team show                 Print launch commands for the configured team
+amq-squad team rules init           Seed .amq-squad/team-rules.md
+amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
+
+amq-squad launch --role <r> --session <s> --me <handle> <binary> [-- <flags>]
+                                    Launch one agent. Writes launch.json + role.md
+                                    in the AMQ mailbox, then execs 'amq coop exec'.
+                                    Usually called by the output of 'team show'.
+
+amq-squad restore [--project dir1,dir2,...]
+                                    Reconstruct launch commands from existing
+                                    launch.json files (post-boot evidence, in
+                                    contrast to team.json which is pre-boot intent).
+
+amq-squad list [--json]             List registered agents across known projects.
+```
+
+## Files it writes
+
+```
+<project>/.amq-squad/team.json           Team intent: which roles are on this squad.
+<project>/.amq-squad/team-rules.md       Shared norms and workflow (user-edited).
+<project>/CLAUDE.md, AGENTS.md           Managed block synced from team-rules.md;
+                                         user content outside markers untouched.
+<AM_ROOT>/agents/<handle>/launch.json    Per-agent invocation record, written at launch.
+<AM_ROOT>/agents/<handle>/role.md        Per-agent role doc, seeded from the catalog
+                                         and never overwritten once it exists.
+```
+
+`<AM_ROOT>` is resolved via `amq env --json` so amq-squad and `amq coop exec` always agree on where the mailbox lives.
+
+## Requires
+
+- Go 1.25+
+- `amq` binary in PATH (v0.32+)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,20 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 `amq-squad` captures this at team-setup time (`.amq-squad/team.json`) and per-agent at launch time (`launch.json` + `role.md` inside the AMQ mailbox). AMQ itself stays unchanged.
 
+## Install
+
+```
+go install github.com/omriariav/amq-squad/cmd/amq-squad@latest
+```
+
+Requires Go 1.25+ and the `amq` binary in `PATH` (v0.32+). Installing to `$GOBIN` (or `$HOME/go/bin`) is enough; the launch commands `team show` emits use the absolute path to whichever `amq-squad` binary is running, so nothing else needs to be on `PATH`.
+
 ## Quick start
 
 ```
 cd ~/Code/my-project
-amq-squad team
+amq coop init          # one time, sets up .amqrc and .agent-mail/
+amq-squad team         # pick roles, writes .amq-squad/team.json, prints launch commands
 ```
 
 First time: you're prompted to pick which of the built-in roles should be on the team. A `.amq-squad/team.json` is written. Every subsequent run prints the launch commands, one per role. Paste each into its own terminal tab.
@@ -116,6 +125,11 @@ amq-squad list [--json]             List registered agents across known projects
 ```
 
 `<AM_ROOT>` is resolved via `amq env --json` so amq-squad and `amq coop exec` always agree on where the mailbox lives.
+
+## Known gaps
+
+- Sending a cross-session message from a setup terminal (outside any `amq coop exec`) has no clean idiom upstream. Tracked in [avivsinai/agent-message-queue#96](https://github.com/avivsinai/agent-message-queue/issues/96) with a proposed `--from-session` flag. Current workaround: boot your own session first, then send from inside it.
+- Multi-cwd teams still need manual `peers` config in each project's `.amqrc` for cross-project AMQ routing. `team sync` doesn't touch `.amqrc`; that's left to the user until we're sure of the shape.
 
 ## Requires
 

--- a/cmd/amq-squad/main.go
+++ b/cmd/amq-squad/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/omriariav/amq-squad/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	if err := cli.Run(os.Args[1:], version); err != nil {
+		if _, ok := err.(cli.UsageError); ok {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/omriariav/amq-squad
+
+go 1.25.9

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,95 @@
+// Package catalog is the built-in directory of role archetypes amq-squad
+// understands. It's intentionally small and Go-native so a new role is one
+// code change plus a rebuild, not a config file users have to discover.
+package catalog
+
+// Role is one entry in the catalog. Field semantics:
+//
+//	ID               short slug (also used as default handle and session name)
+//	Label            human title shown in listings and role.md
+//	PreferredBinary  "claude" or "codex", user can override at team init time
+//	Description      one-line summary seeded into role.md
+//	Skills           slash commands worth invoking in this role's priming
+//	DefaultPeers     role IDs this archetype usually talks to (used by slice B)
+type Role struct {
+	ID              string
+	Label           string
+	PreferredBinary string
+	Description     string
+	Skills          []string
+	DefaultPeers    []string
+}
+
+var roles = []Role{
+	{
+		ID:              "cpo",
+		Label:           "CPO",
+		PreferredBinary: "codex",
+		Description:     "Owns product strategy, vision, and prioritization. Pushes back on scope and sharpens the why before the what.",
+		Skills:          []string{"/product-strategy"},
+		DefaultPeers:    []string{"cto", "pm", "designer"},
+	},
+	{
+		ID:              "cto",
+		Label:           "CTO",
+		PreferredBinary: "codex",
+		Description:     "Owns technical direction, architecture, and engineering tradeoffs. Signs off on the shape of the system.",
+		DefaultPeers:    []string{"cpo", "fullstack", "qa"},
+	},
+	{
+		ID:              "fullstack",
+		Label:           "Fullstack Developer",
+		PreferredBinary: "claude",
+		Description:     "Implements features end to end across frontend and backend. Writes code that gets merged.",
+		DefaultPeers:    []string{"cto", "qa", "pm", "designer"},
+	},
+	{
+		ID:              "qa",
+		Label:           "QA Manager",
+		PreferredBinary: "claude",
+		Description:     "Owns test strategy, regression coverage, and release gating. Turns intent into verifiable checks.",
+		DefaultPeers:    []string{"fullstack", "cto", "pm"},
+	},
+	{
+		ID:              "pm",
+		Label:           "Project Manager / Product Owner",
+		PreferredBinary: "claude",
+		Description:     "Translates product strategy into ordered work. Tracks scope, unblocks, and keeps the team aligned on what ships next.",
+		DefaultPeers:    []string{"cpo", "fullstack", "qa", "designer"},
+	},
+	{
+		ID:              "designer",
+		Label:           "Product Designer",
+		PreferredBinary: "claude",
+		Description:     "Designs the product surface. Produces UI components, flows, and visual assets, leaning on /frontend-design and /canvas-design.",
+		Skills:          []string{"/frontend-design", "/canvas-design"},
+		DefaultPeers:    []string{"cpo", "fullstack", "pm"},
+	},
+}
+
+// All returns a copy of the catalog in display order.
+func All() []Role {
+	out := make([]Role, len(roles))
+	copy(out, roles)
+	return out
+}
+
+// Lookup returns the role with the given ID, or nil if unknown.
+func Lookup(id string) *Role {
+	for i := range roles {
+		if roles[i].ID == id {
+			r := roles[i]
+			return &r
+		}
+	}
+	return nil
+}
+
+// IDs returns the set of known role IDs in catalog order.
+func IDs() []string {
+	out := make([]string, len(roles))
+	for i, r := range roles {
+		out[i] = r.ID
+	}
+	return out
+}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,0 +1,63 @@
+package catalog
+
+import "testing"
+
+func TestAllReturnsCopy(t *testing.T) {
+	a := All()
+	if len(a) == 0 {
+		t.Fatal("catalog is empty")
+	}
+	// Mutating the returned slice must not affect internal state.
+	a[0].Label = "MUTATED"
+	b := All()
+	if b[0].Label == "MUTATED" {
+		t.Error("All() exposes internal slice; expected a copy")
+	}
+}
+
+func TestLookupKnownAndUnknown(t *testing.T) {
+	r := Lookup("designer")
+	if r == nil {
+		t.Fatal("expected designer in catalog")
+	}
+	if r.PreferredBinary != "claude" {
+		t.Errorf("designer binary = %q, want claude", r.PreferredBinary)
+	}
+	if len(r.Skills) == 0 {
+		t.Error("designer should have skills")
+	}
+	if Lookup("not-a-role") != nil {
+		t.Error("Lookup returned non-nil for unknown role")
+	}
+}
+
+func TestEveryRoleIsConsistent(t *testing.T) {
+	for _, r := range All() {
+		if r.ID == "" || r.Label == "" {
+			t.Errorf("role %+v missing ID or Label", r)
+		}
+		if r.PreferredBinary != "claude" && r.PreferredBinary != "codex" {
+			t.Errorf("role %s has unexpected binary %q", r.ID, r.PreferredBinary)
+		}
+		// DefaultPeers must reference known role IDs so team show doesn't
+		// emit stale role references.
+		for _, p := range r.DefaultPeers {
+			if Lookup(p) == nil {
+				t.Errorf("role %s declares unknown peer %q", r.ID, p)
+			}
+		}
+	}
+}
+
+func TestIDsMatchAllOrder(t *testing.T) {
+	ids := IDs()
+	all := All()
+	if len(ids) != len(all) {
+		t.Fatalf("IDs len %d, All len %d", len(ids), len(all))
+	}
+	for i := range ids {
+		if ids[i] != all[i].ID {
+			t.Errorf("IDs[%d] = %q, All[%d].ID = %q", i, ids[i], i, all[i].ID)
+		}
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,54 @@
+// Package cli is the top-level command dispatcher for amq-squad.
+package cli
+
+import "fmt"
+
+// UsageError signals a misuse of the CLI; main prints it and exits 2.
+type UsageError string
+
+func (e UsageError) Error() string { return string(e) }
+
+func usageErrorf(format string, args ...any) error {
+	return UsageError(fmt.Sprintf(format, args...))
+}
+
+// Run dispatches to a subcommand.
+func Run(args []string, version string) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		printUsage()
+		return nil
+	}
+	if args[0] == "--version" || args[0] == "-v" {
+		fmt.Println("amq-squad", version)
+		return nil
+	}
+
+	switch args[0] {
+	case "team":
+		return runTeam(args[1:])
+	case "launch":
+		return runLaunch(args[1:])
+	case "restore":
+		return runRestore(args[1:])
+	case "list":
+		return runList(args[1:])
+	default:
+		return usageErrorf("unknown command: %q. Run 'amq-squad --help' for usage.", args[0])
+	}
+}
+
+func printUsage() {
+	fmt.Print(`amq-squad - role-aware agent team launcher on top of AMQ
+
+Usage:
+  amq-squad <command> [options]
+
+Commands:
+  team      Pick your team once, then print launch commands on demand
+  launch    Launch a single agent with a role (called by 'team show' output)
+  restore   Emit bash commands to restore registered agents from launch.json
+  list      List registered agents across known projects
+
+Run 'amq-squad <command> --help' for command-specific options.
+`)
+}

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// jsonEncoder returns a stdout JSON encoder with readable indentation.
+func jsonEncoder() *json.Encoder {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc
+}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -45,6 +45,9 @@ Side effects before exec:
   2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
   3. Writes a role.md stub if one does not already exist.
   4. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+
+With --dry-run, none of the above run: the resolved coop exec command is
+printed and amq-squad exits. Disk state is untouched.
 `)
 	}
 
@@ -90,19 +93,9 @@ Side effects before exec:
 		Root:      root,
 		StartedAt: time.Now().UTC(),
 	}
-	if err := launch.Write(agentDir, rec); err != nil {
-		return fmt.Errorf("write launch record: %w", err)
-	}
 
-	// Seed role.md from the catalog when the role is known. Never
-	// overwrites existing user edits.
-	if *roleFlag != "" {
-		if err := seedRoleStub(agentDir, *roleFlag); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: seed role.md: %v\n", err)
-		}
-	}
-
-	// Build the coop exec invocation.
+	// Build the coop exec invocation. Done before any disk writes so
+	// --dry-run is a true preview with zero side effects.
 	coopArgs := []string{"coop", "exec"}
 	if *session != "" {
 		coopArgs = append(coopArgs, "--session", *session)
@@ -121,8 +114,20 @@ Side effects before exec:
 
 	if *dryRun {
 		fmt.Println("amq", strings.Join(coopArgs, " "))
-		fmt.Fprintln(os.Stderr, "(dry run - launch.json written, not execing)")
+		fmt.Fprintln(os.Stderr, "(dry run - no files written, not execing)")
 		return nil
+	}
+
+	if err := launch.Write(agentDir, rec); err != nil {
+		return fmt.Errorf("write launch record: %w", err)
+	}
+
+	// Seed role.md from the catalog when the role is known. Never
+	// overwrites existing user edits.
+	if *roleFlag != "" {
+		if err := seedRoleStub(agentDir, *roleFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: seed role.md: %v\n", err)
+		}
 	}
 
 	amqBin, err := exec.LookPath("amq")

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/role"
+)
+
+func runLaunch(args []string) error {
+	// Split at "--" so launcher flags aren't consumed by amq-squad's parser.
+	squadArgs, childArgs := splitDashDash(args)
+
+	fs := flag.NewFlagSet("launch", flag.ContinueOnError)
+	roleFlag := fs.String("role", "", "role label for this agent (e.g. cpo, cto, dev, qa)")
+	session := fs.String("session", "", "AMQ session name (passed through to coop exec)")
+	me := fs.String("me", "", "override the agent handle (defaults to binary basename)")
+	rootFlag := fs.String("root", "", "override AMQ root directory")
+	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad launch - launch an agent with role metadata
+
+Usage:
+  amq-squad launch [options] <binary> [-- <binary-flags>]
+
+Options:
+`)
+		fs.PrintDefaults()
+		fmt.Fprint(os.Stderr, `
+The <binary> is the agent launcher (claude, codex, etc). Flags after "--"
+are passed through to that binary via 'amq coop exec'.
+
+Side effects before exec:
+  1. Resolves AMQ root via 'amq env --json' for the target session.
+  2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
+  3. Writes a role.md stub if one does not already exist.
+  4. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+`)
+	}
+
+	if err := fs.Parse(squadArgs); err != nil {
+		return err
+	}
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		return usageErrorf("launch requires a binary (e.g. 'amq-squad launch --role cpo codex')")
+	}
+	binary := remaining[0]
+	// Positional args before "--" get folded into childArgs.
+	if len(remaining) > 1 {
+		childArgs = append(remaining[1:], childArgs...)
+	}
+
+	handle := *me
+	if handle == "" {
+		handle = strings.ToLower(filepath.Base(binary))
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+
+	// Resolve the AMQ root via the amq CLI. This respects .amqrc, --session,
+	// and --root exactly as coop exec will, so launch.json and the actual
+	// mailbox agree.
+	root, err := resolveAMQRoot(*rootFlag, *session, handle)
+	if err != nil {
+		return fmt.Errorf("resolve amq root: %w", err)
+	}
+
+	agentDir := filepath.Join(root, "agents", handle)
+	rec := launch.Record{
+		CWD:       cwd,
+		Binary:    binary,
+		Argv:      childArgs,
+		Session:   *session,
+		Handle:    handle,
+		Role:      *roleFlag,
+		Root:      root,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		return fmt.Errorf("write launch record: %w", err)
+	}
+
+	// Seed role.md from the catalog when the role is known. Never
+	// overwrites existing user edits.
+	if *roleFlag != "" {
+		if err := seedRoleStub(agentDir, *roleFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: seed role.md: %v\n", err)
+		}
+	}
+
+	// Build the coop exec invocation.
+	coopArgs := []string{"coop", "exec"}
+	if *session != "" {
+		coopArgs = append(coopArgs, "--session", *session)
+	}
+	if *rootFlag != "" {
+		coopArgs = append(coopArgs, "--root", *rootFlag)
+	}
+	if *me != "" {
+		coopArgs = append(coopArgs, "--me", *me)
+	}
+	coopArgs = append(coopArgs, binary)
+	if len(childArgs) > 0 {
+		coopArgs = append(coopArgs, "--")
+		coopArgs = append(coopArgs, childArgs...)
+	}
+
+	if *dryRun {
+		fmt.Println("amq", strings.Join(coopArgs, " "))
+		fmt.Fprintln(os.Stderr, "(dry run - launch.json written, not execing)")
+		return nil
+	}
+
+	amqBin, err := exec.LookPath("amq")
+	if err != nil {
+		return fmt.Errorf("amq not found in PATH: %w", err)
+	}
+	return syscall.Exec(amqBin, append([]string{"amq"}, coopArgs...), os.Environ())
+}
+
+// resolveAMQRoot shells out to `amq env --json` to discover the final root
+// path that coop exec will use. This keeps amq-squad out of the root
+// resolution business - amq owns it, we just ask.
+func resolveAMQRoot(rootFlag, session, handle string) (string, error) {
+	args := []string{"env", "--json", "--me", handle}
+	if rootFlag != "" {
+		args = append(args, "--root", rootFlag)
+	}
+	if session != "" {
+		args = append(args, "--session", session)
+	}
+	cmd := exec.Command("amq", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("amq env: %w", err)
+	}
+	var parsed struct {
+		Root string `json:"root"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return "", fmt.Errorf("parse amq env output: %w", err)
+	}
+	if parsed.Root == "" {
+		return "", fmt.Errorf("amq env returned empty root")
+	}
+	return parsed.Root, nil
+}
+
+// seedRoleStub writes a role.md stub for the given agent directory based on
+// the catalog entry for roleID. If the role isn't in the catalog, it still
+// writes a minimal stub with the label = roleID.
+func seedRoleStub(agentDir, roleID string) error {
+	stub := role.Stub{RoleID: roleID, Label: roleID}
+	if r := catalog.Lookup(roleID); r != nil {
+		stub.Label = r.Label
+		stub.Description = r.Description
+		stub.Skills = r.Skills
+		stub.Peers = r.DefaultPeers
+	}
+	_, err := role.EnsureStub(agentDir, stub)
+	return err
+}
+
+// splitDashDash splits argv at the first "--" separator.
+func splitDashDash(args []string) ([]string, []string) {
+	for i, a := range args {
+		if a == "--" {
+			return args[:i], args[i+1:]
+		}
+	}
+	return args, nil
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func runList(args []string) error {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	projectDirs := fs.String("project", "", "comma-separated project directories to scan (default: cwd)")
+	jsonOut := fs.Bool("json", false, "emit records as JSON array")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad list - list registered agents
+
+Usage:
+  amq-squad list [--project dir1,dir2,...] [--json]
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var dirs []string
+	if *projectDirs == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		dirs = []string{cwd}
+	} else {
+		for _, d := range strings.Split(*projectDirs, ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+	}
+
+	var all []launch.Record
+	for _, dir := range dirs {
+		recs, err := launch.Scan(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
+			continue
+		}
+		all = append(all, recs...)
+	}
+
+	if *jsonOut {
+		return printJSON(all)
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Role != all[j].Role {
+			return all[i].Role < all[j].Role
+		}
+		return all[i].Handle < all[j].Handle
+	})
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tCWD\tSTARTED")
+	for _, r := range all {
+		role := r.Role
+		if role == "" {
+			role = "(none)"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			role, r.Handle, r.Binary, r.Session, r.CWD, r.StartedAt.Format("2006-01-02 15:04"))
+	}
+	return w.Flush()
+}
+
+func printJSON(recs []launch.Record) error {
+	enc := jsonEncoder()
+	return enc.Encode(recs)
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func runRestore(args []string) error {
+	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
+	projectDirs := fs.String("project", "", "comma-separated project directories to scan (default: cwd)")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad restore - emit bash commands to restore every registered agent
+
+Usage:
+  amq-squad restore [--project dir1,dir2,...]
+
+Scans each project for .agent-mail/<session>/agents/<handle>/launch.json
+records and prints a bash command per agent. Default scope is the current
+working directory if --project is omitted.
+
+Each emitted command is ready to paste into its own terminal tab.
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	var dirs []string
+	if *projectDirs == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		dirs = []string{cwd}
+	} else {
+		for _, d := range strings.Split(*projectDirs, ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+	}
+
+	type found struct {
+		project string
+		rec     launch.Record
+	}
+	var records []found
+
+	for _, dir := range dirs {
+		recs, err := launch.Scan(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
+			continue
+		}
+		for _, r := range recs {
+			records = append(records, found{project: dir, rec: r})
+		}
+	}
+
+	if len(records) == 0 {
+		return fmt.Errorf("no launch.json records found in %s", strings.Join(dirs, ", "))
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].rec.Role != records[j].rec.Role {
+			return records[i].rec.Role < records[j].rec.Role
+		}
+		return records[i].rec.Handle < records[j].rec.Handle
+	})
+
+	fmt.Println("# amq-squad restore - run each command in its own terminal tab")
+	fmt.Println()
+	for i, f := range records {
+		label := f.rec.Role
+		if label == "" {
+			label = f.rec.Handle
+		}
+		fmt.Printf("# %d. %s - %s (%s/%s)\n", i+1, label, f.rec.Binary, f.rec.CWD, f.rec.Session)
+		fmt.Println(emitCommand(f.rec))
+		fmt.Println()
+	}
+	return nil
+}
+
+// emitCommand reconstructs the bash command for a launch record.
+// It prefers 'amq-squad launch' so role + metadata round-trip cleanly;
+// callers who want the raw amq invocation can run with --dry-run to see it.
+func emitCommand(rec launch.Record) string {
+	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellQuote(rec.CWD))
+	b.WriteString(" && amq-squad launch")
+	if rec.Role != "" {
+		b.WriteString(" --role ")
+		b.WriteString(shellQuote(rec.Role))
+	}
+	if rec.Session != "" {
+		b.WriteString(" --session ")
+		b.WriteString(shellQuote(rec.Session))
+	}
+	if rec.Handle != "" && rec.Handle != defaultHandleFor(rec.Binary) {
+		b.WriteString(" --me ")
+		b.WriteString(shellQuote(rec.Handle))
+	}
+	b.WriteString(" ")
+	b.WriteString(shellQuote(rec.Binary))
+	if len(rec.Argv) > 0 {
+		b.WriteString(" --")
+		for _, a := range rec.Argv {
+			b.WriteString(" ")
+			b.WriteString(shellQuote(a))
+		}
+	}
+	return b.String()
+}
+
+func defaultHandleFor(binary string) string {
+	return strings.ToLower(filepath.Base(binary))
+}
+
+// shellQuote wraps a string in single quotes for safe shell pasting.
+// If the string has no special chars, returns it as-is.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	safe := true
+	for _, r := range s {
+		if !(r == '/' || r == '.' || r == '-' || r == '_' || r == '=' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+			safe = false
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func TestShellQuoteSafeString(t *testing.T) {
+	cases := map[string]string{
+		"claude":          "claude",
+		"/usr/bin/amq":    "/usr/bin/amq",
+		"stream1":         "stream1",
+		"role_123":        "role_123",
+		"with space":      "'with space'",
+		"with'apostrophe": `'with'\''apostrophe'`,
+		"":                "''",
+		"a;b":             "'a;b'",
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEmitCommandIncludesRoleAndSession(t *testing.T) {
+	rec := launch.Record{
+		CWD:     "/home/user/proj",
+		Binary:  "claude",
+		Session: "stream1",
+		Handle:  "claude",
+		Role:    "qa",
+	}
+	cmd := emitCommand(rec)
+	for _, want := range []string{
+		"cd /home/user/proj",
+		"amq-squad launch",
+		"--role qa",
+		"--session stream1",
+		"claude",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitCommand missing %q in: %s", want, cmd)
+		}
+	}
+	// Handle equals defaultHandleFor(binary), so --me should be omitted.
+	if strings.Contains(cmd, "--me") {
+		t.Errorf("emitCommand should omit --me when handle == default; got: %s", cmd)
+	}
+}
+
+func TestEmitCommandIncludesMeWhenHandleDiffers(t *testing.T) {
+	rec := launch.Record{
+		CWD:     "/p",
+		Binary:  "codex",
+		Session: "s",
+		Handle:  "cpo",
+		Role:    "cpo",
+	}
+	cmd := emitCommand(rec)
+	if !strings.Contains(cmd, "--me cpo") {
+		t.Errorf("expected --me cpo in: %s", cmd)
+	}
+}
+
+func TestEmitCommandQuotesArgvWithSpaces(t *testing.T) {
+	rec := launch.Record{
+		CWD:    "/p",
+		Binary: "claude",
+		Argv:   []string{"--prompt", "hello world"},
+	}
+	cmd := emitCommand(rec)
+	if !strings.Contains(cmd, "'hello world'") {
+		t.Errorf("expected quoted argv in: %s", cmd)
+	}
+	if !strings.Contains(cmd, " -- ") {
+		t.Errorf("expected -- separator before argv in: %s", cmd)
+	}
+}
+
+func TestDefaultHandleFromPath(t *testing.T) {
+	if got := defaultHandleFor("/usr/local/bin/Claude"); got != "claude" {
+		t.Errorf("defaultHandleFor lower-cases basename, got %q", got)
+	}
+	if got := defaultHandleFor("codex"); got != "codex" {
+		t.Errorf("defaultHandleFor plain = %q", got)
+	}
+}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1,0 +1,505 @@
+package cli
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/internal/rules"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func runTeam(args []string) error {
+	if len(args) == 0 {
+		return runTeamSmart()
+	}
+	switch args[0] {
+	case "-h", "--help":
+		printTeamUsage()
+		return nil
+	case "init":
+		return runTeamInit(args[1:])
+	case "show":
+		return runTeamShow(args[1:])
+	case "rules":
+		return runTeamRules(args[1:])
+	case "sync":
+		return runTeamSync(args[1:])
+	default:
+		// Unknown subcommand. Treat as flags to the smart default so
+		// `amq-squad team --help` and similar still work.
+		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'show', 'rules', or 'sync'.", args[0])
+	}
+}
+
+// runTeamSmart: if team.json exists, print the launch commands. If not,
+// run interactive init and then print.
+func runTeamSmart() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	if team.Exists(cwd) {
+		return emitTeamCommands(cwd)
+	}
+	fmt.Fprintln(os.Stderr, "No team configured for this project yet. Let's set one up.")
+	fmt.Fprintln(os.Stderr)
+	if err := runTeamInit(nil); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stderr)
+	return emitTeamCommands(cwd)
+}
+
+func runTeamInit(args []string) error {
+	fs := flag.NewFlagSet("team init", flag.ContinueOnError)
+	rolesFlag := fs.String("roles", "", "comma-separated role IDs to include (skips interactive prompt)")
+	binaryFlag := fs.String("binary", "", "per-role binary overrides, e.g. qa=codex,pm=codex")
+	sessionFlag := fs.String("session", "", "per-role session overrides, e.g. cpo=stream1,cto=stream2")
+	cwdFlag := fs.String("cwd", "", "per-role working directory overrides, e.g. qa=/path/to/sibling-project")
+	force := fs.Bool("force", false, "overwrite an existing team.json")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
+
+Usage:
+  amq-squad team init [--roles id1,id2,...] [--binary role=bin,...] [--session role=name,...] [--force]
+
+Without --roles, prompts interactively. Writes <cwd>/.amq-squad/team.json.
+The directory where this runs becomes the team-home. Members can live in
+other directories via --cwd role=/path.
+
+Known roles:
+`)
+		for _, r := range catalog.All() {
+			fmt.Fprintf(os.Stderr, "  %-10s %s (default: %s)\n", r.ID, r.Label, r.PreferredBinary)
+		}
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+
+	if team.Exists(cwd) && !*force {
+		return fmt.Errorf("team.json already exists at %s. Use --force to overwrite.", team.Path(cwd))
+	}
+
+	var picked []string
+	if *rolesFlag != "" {
+		picked = splitCSV(*rolesFlag)
+	} else {
+		picked, err = promptRoleSelection()
+		if err != nil {
+			return err
+		}
+	}
+	if len(picked) == 0 {
+		return fmt.Errorf("no roles selected, aborting")
+	}
+
+	binaryOverrides, err := parseKV(*binaryFlag)
+	if err != nil {
+		return fmt.Errorf("parse --binary: %w", err)
+	}
+	sessionOverrides, err := parseKV(*sessionFlag)
+	if err != nil {
+		return fmt.Errorf("parse --session: %w", err)
+	}
+	cwdOverrides, err := parseKV(*cwdFlag)
+	if err != nil {
+		return fmt.Errorf("parse --cwd: %w", err)
+	}
+
+	members := make([]team.Member, 0, len(picked))
+	seen := make(map[string]bool)
+	for _, id := range picked {
+		id = strings.TrimSpace(strings.ToLower(id))
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		r := catalog.Lookup(id)
+		if r == nil {
+			return fmt.Errorf("unknown role %q. Known roles: %s", id, strings.Join(catalog.IDs(), ", "))
+		}
+		binary := r.PreferredBinary
+		if b, ok := binaryOverrides[id]; ok {
+			binary = b
+		}
+		session := id
+		if s, ok := sessionOverrides[id]; ok {
+			session = s
+		}
+		m := team.Member{
+			Role:    id,
+			Binary:  binary,
+			Handle:  id,
+			Session: session,
+		}
+		if c, ok := cwdOverrides[id]; ok {
+			abs, err := filepath.Abs(c)
+			if err != nil {
+				return fmt.Errorf("resolve cwd for %s: %w", id, err)
+			}
+			if abs != cwd {
+				m.CWD = abs
+			}
+		}
+		members = append(members, m)
+	}
+
+	t := team.Team{
+		Project: cwd,
+		Members: members,
+	}
+	if err := team.Write(cwd, t); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Wrote %s with %d members.\n", team.Path(cwd), len(members))
+	return nil
+}
+
+func runTeamShow(args []string) error {
+	fs := flag.NewFlagSet("team show", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
+
+Usage:
+  amq-squad team show
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	if !team.Exists(cwd) {
+		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
+	}
+	return emitTeamCommands(cwd)
+}
+
+func emitTeamCommands(projectDir string) error {
+	t, err := team.Read(projectDir)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	if len(t.Members) == 0 {
+		return fmt.Errorf("team has no members")
+	}
+
+	// Stable display order: catalog order, not file order. Keeps output
+	// consistent regardless of how the user listed roles at init.
+	idx := make(map[string]int, len(catalog.IDs()))
+	for i, id := range catalog.IDs() {
+		idx[id] = i
+	}
+	members := append([]team.Member(nil), t.Members...)
+	sort.SliceStable(members, func(i, j int) bool {
+		return idx[members[i].Role] < idx[members[j].Role]
+	})
+
+	fmt.Println("# amq-squad team - run each command in its own terminal tab")
+	fmt.Println("#")
+	fmt.Printf("# team-home: %s\n", t.Project)
+	fmt.Printf("# members:   %d\n", len(members))
+	// List unique member cwds so a multi-project team is obvious at a glance.
+	uniqueCWDs := uniqueMemberCWDs(t.Project, members)
+	if len(uniqueCWDs) > 1 {
+		fmt.Printf("# cwds:      %s\n", strings.Join(uniqueCWDs, ", "))
+	}
+	rulesPath := rules.Path(t.Project)
+	if _, err := os.Stat(rulesPath); err == nil {
+		fmt.Printf("# rules:     %s\n", rulesPath)
+	} else {
+		fmt.Printf("# rules:     (not set; run 'amq-squad team rules init')\n")
+	}
+	fmt.Println()
+	// Use the running amq-squad's absolute path so emitted commands work
+	// even when amq-squad isn't on PATH.
+	squadBin := "amq-squad"
+	if p, err := os.Executable(); err == nil {
+		squadBin = p
+	}
+
+	for i, m := range members {
+		label := m.Role
+		if r := catalog.Lookup(m.Role); r != nil {
+			label = r.Label
+		}
+		cwd := m.EffectiveCWD(t.Project)
+		fmt.Printf("# %d. %s - %s (session: %s, cwd: %s)\n", i+1, label, m.Binary, m.Session, cwd)
+		fmt.Println(emitTeamCommand(cwd, squadBin, m))
+		fmt.Println()
+	}
+	return nil
+}
+
+func uniqueMemberCWDs(projectDir string, members []team.Member) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, m := range members {
+		cwd := m.EffectiveCWD(projectDir)
+		if seen[cwd] {
+			continue
+		}
+		seen[cwd] = true
+		out = append(out, cwd)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func emitTeamCommand(cwd, squadBin string, m team.Member) string {
+	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellQuote(cwd))
+	b.WriteString(" && ")
+	b.WriteString(shellQuote(squadBin))
+	b.WriteString(" launch")
+	b.WriteString(" --role ")
+	b.WriteString(shellQuote(m.Role))
+	b.WriteString(" --session ")
+	b.WriteString(shellQuote(m.Session))
+	if m.Handle != "" {
+		// Always explicit: a role-named handle avoids collisions when the
+		// same binary (e.g. codex) hosts multiple roles in one project.
+		b.WriteString(" --me ")
+		b.WriteString(shellQuote(m.Handle))
+	}
+	b.WriteString(" ")
+	b.WriteString(shellQuote(m.Binary))
+	return b.String()
+}
+
+func promptRoleSelection() ([]string, error) {
+	fmt.Fprintln(os.Stderr, "Available roles:")
+	for _, r := range catalog.All() {
+		skills := ""
+		if len(r.Skills) > 0 {
+			skills = "  [" + strings.Join(r.Skills, ", ") + "]"
+		}
+		fmt.Fprintf(os.Stderr, "  %-10s %s (%s)%s\n", r.ID, r.Label, r.PreferredBinary, skills)
+	}
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprint(os.Stderr, "Which roles do you want on this team? (comma-separated IDs, or 'all'): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read selection: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil, fmt.Errorf("no selection provided")
+	}
+	if strings.EqualFold(line, "all") {
+		return catalog.IDs(), nil
+	}
+	return splitCSV(line), nil
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func parseKV(s string) (map[string]string, error) {
+	out := map[string]string{}
+	if s == "" {
+		return out, nil
+	}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		eq := strings.IndexByte(pair, '=')
+		if eq <= 0 || eq == len(pair)-1 {
+			return nil, fmt.Errorf("expected key=value, got %q", pair)
+		}
+		k := strings.TrimSpace(pair[:eq])
+		v := strings.TrimSpace(pair[eq+1:])
+		out[k] = v
+	}
+	return out, nil
+}
+
+func runTeamRules(args []string) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprint(os.Stderr, `amq-squad team rules - manage .amq-squad/team-rules.md
+
+Usage:
+  amq-squad team rules init   Seed team-rules.md with a stub (won't clobber)
+`)
+		if len(args) == 0 {
+			return usageErrorf("rules requires a subcommand (e.g. 'init')")
+		}
+		return nil
+	}
+	switch args[0] {
+	case "init":
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		wrote, err := rules.EnsureStub(cwd)
+		if err != nil {
+			return fmt.Errorf("seed team-rules.md: %w", err)
+		}
+		if wrote {
+			fmt.Fprintf(os.Stderr, "Wrote %s\n", rules.Path(cwd))
+		} else {
+			fmt.Fprintf(os.Stderr, "%s already exists, leaving it alone.\n", rules.Path(cwd))
+		}
+		return nil
+	default:
+		return usageErrorf("unknown 'rules' subcommand: %q", args[0])
+	}
+}
+
+func runTeamSync(args []string) error {
+	fs := flag.NewFlagSet("team sync", flag.ContinueOnError)
+	apply := fs.Bool("apply", false, "write the planned changes (default: preview only)")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad team sync - sync CLAUDE.md and AGENTS.md from team-rules.md
+
+Usage:
+  amq-squad team sync            Preview what would change (exit 1 if drift)
+  amq-squad team sync --apply    Write the managed block into both files
+
+Existing content in CLAUDE.md / AGENTS.md is preserved. On first run,
+existing content is adopted as the user region and a managed block is
+appended between markers. Subsequent runs only refresh the managed block.
+
+When team members span multiple directories, sync walks every unique cwd
+in team.json and syncs CLAUDE.md + AGENTS.md in each.
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+
+	body, err := rules.Read(cwd)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no team-rules.md at %s. Run 'amq-squad team rules init' first.", rules.Path(cwd))
+		}
+		return err
+	}
+
+	// Walk every unique cwd the team spans so each project's CLAUDE.md and
+	// AGENTS.md picks up the managed block.
+	targetDirs := []string{cwd}
+	if team.Exists(cwd) {
+		if t, err := team.Read(cwd); err == nil {
+			targetDirs = uniqueMemberCWDs(cwd, t.Members)
+			if !containsString(targetDirs, cwd) {
+				// Team-home cwd may not host a member, but it still owns
+				// team-rules.md so its own CLAUDE.md/AGENTS.md should sync.
+				targetDirs = append(targetDirs, cwd)
+				sort.Strings(targetDirs)
+			}
+		}
+	}
+
+	var allPlans []rules.SyncPlan
+	for _, dir := range targetDirs {
+		plans, err := rules.Plan(dir, body)
+		if err != nil {
+			return fmt.Errorf("plan sync for %s: %w", dir, err)
+		}
+		allPlans = append(allPlans, plans...)
+	}
+
+	drift := false
+	var currentDir string
+	for _, p := range allPlans {
+		dir := filepath.Dir(p.Target)
+		if dir != currentDir {
+			if currentDir != "" {
+				fmt.Println()
+			}
+			fmt.Printf("# %s\n", dir)
+			currentDir = dir
+		}
+		status := describePlan(p)
+		fmt.Printf("  %-12s %s\n", p.Basename, status)
+		if !p.Unchanged {
+			drift = true
+		}
+	}
+
+	if !*apply {
+		if drift {
+			fmt.Fprintln(os.Stderr, "\nPreview only. Re-run with --apply to write.")
+			return fmt.Errorf("drift detected")
+		}
+		return nil
+	}
+
+	n, err := rules.Apply(allPlans)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Wrote %d file(s).\n", n)
+	return nil
+}
+
+func containsString(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func describePlan(p rules.SyncPlan) string {
+	switch {
+	case p.Unchanged:
+		return "up to date"
+	case p.Creating:
+		return "will create"
+	case p.Adopting:
+		return "will adopt existing content and add managed block"
+	default:
+		return "will refresh managed block"
+	}
+}
+
+func printTeamUsage() {
+	fmt.Print(`amq-squad team - manage this project's agent team
+
+Usage:
+  amq-squad team                      Smart default: show commands, or init if none exists
+  amq-squad team init [options]       Set up .amq-squad/team.json
+  amq-squad team show                 Print launch commands for configured team
+  amq-squad team rules init           Seed .amq-squad/team-rules.md with a stub
+  amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
+                                      (default: preview; --apply writes)
+
+Roles come from the built-in catalog. Run 'amq-squad team init --help' to
+see them and the available flags.
+`)
+}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -145,7 +145,7 @@ Known roles:
 			Session: session,
 		}
 		if c, ok := cwdOverrides[id]; ok {
-			abs, err := filepath.Abs(c)
+			abs, err := expandPath(c)
 			if err != nil {
 				return fmt.Errorf("resolve cwd for %s: %w", id, err)
 			}
@@ -318,6 +318,23 @@ func splitCSV(s string) []string {
 		}
 	}
 	return out
+}
+
+// expandPath resolves a user-supplied path: expands a leading "~" or "~/"
+// to the user's home directory, then makes the result absolute.
+func expandPath(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home dir: %w", err)
+		}
+		if p == "~" {
+			p = home
+		} else {
+			p = filepath.Join(home, p[2:])
+		}
+	}
+	return filepath.Abs(p)
 }
 
 func parseKV(s string) (map[string]string, error) {

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func TestSplitCSV(t *testing.T) {
+	cases := map[string][]string{
+		"a,b,c":       {"a", "b", "c"},
+		" a , b , c ": {"a", "b", "c"},
+		",,a,,":       {"a"},
+		"":            {},
+		"  ":          {},
+	}
+	for in, want := range cases {
+		got := splitCSV(in)
+		if !reflect.DeepEqual(got, want) && !(len(got) == 0 && len(want) == 0) {
+			t.Errorf("splitCSV(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestParseKV(t *testing.T) {
+	got, err := parseKV("qa=codex, pm=codex,cto=claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"qa": "codex", "pm": "codex", "cto": "claude"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	empty, err := parseKV("")
+	if err != nil || len(empty) != 0 {
+		t.Errorf("parseKV(\"\") = %v, %v", empty, err)
+	}
+
+	for _, bad := range []string{"nokey", "=noval", "key="} {
+		if _, err := parseKV(bad); err == nil {
+			t.Errorf("parseKV(%q) expected error", bad)
+		}
+	}
+}
+
+func TestEmitTeamCommandShape(t *testing.T) {
+	m := team.Member{
+		Role:    "designer",
+		Binary:  "claude",
+		Handle:  "designer",
+		Session: "designer",
+	}
+	cmd := emitTeamCommand("/home/u/proj", "amq-squad", m)
+	for _, want := range []string{
+		"cd /home/u/proj",
+		"amq-squad launch",
+		"--role designer",
+		"--session designer",
+		"--me designer",
+		" claude",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
+func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
+	m := team.Member{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"}
+	cmd := emitTeamCommand("/home/user/my project", "amq-squad", m)
+	if !strings.Contains(cmd, "'/home/user/my project'") {
+		t.Errorf("project path not quoted: %s", cmd)
+	}
+}
+
+func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
+	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", m)
+	if !strings.Contains(cmd, "/usr/local/bin/amq-squad launch") {
+		t.Errorf("expected absolute binary path in: %s", cmd)
+	}
+}
+
+func TestUniqueMemberCWDs(t *testing.T) {
+	home := "/home/u/proj-a"
+	members := []team.Member{
+		{Role: "cto", CWD: ""},              // inherits home
+		{Role: "cpo", CWD: ""},              // inherits home
+		{Role: "qa", CWD: "/home/u/proj-b"}, // different project
+		{Role: "fullstack", CWD: home},      // explicit but same as home
+	}
+	got := uniqueMemberCWDs(home, members)
+	if len(got) != 2 {
+		t.Fatalf("uniqueMemberCWDs = %v, want 2 entries", got)
+	}
+	if got[0] != "/home/u/proj-a" || got[1] != "/home/u/proj-b" {
+		t.Errorf("uniqueMemberCWDs = %v, want [proj-a proj-b]", got)
+	}
+}
+
+func TestEffectiveCWDFallback(t *testing.T) {
+	m := team.Member{Role: "cto"} // CWD empty
+	if got := m.EffectiveCWD("/home/u/proj"); got != "/home/u/proj" {
+		t.Errorf("EffectiveCWD empty: got %q, want /home/u/proj", got)
+	}
+	m.CWD = "/other"
+	if got := m.EffectiveCWD("/home/u/proj"); got != "/other" {
+		t.Errorf("EffectiveCWD set: got %q, want /other", got)
+	}
+}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -98,6 +100,32 @@ func TestUniqueMemberCWDs(t *testing.T) {
 	}
 	if got[0] != "/home/u/proj-a" || got[1] != "/home/u/proj-b" {
 		t.Errorf("uniqueMemberCWDs = %v, want [proj-a proj-b]", got)
+	}
+}
+
+func TestExpandPathTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	cases := map[string]string{
+		"~":               home,
+		"~/Code/proj":     filepath.Join(home, "Code", "proj"),
+		"/already/abs":    "/already/abs",
+		"relative/subdir": "", // expect an absolute result; exact value depends on cwd
+	}
+	for in, want := range cases {
+		got, err := expandPath(in)
+		if err != nil {
+			t.Errorf("expandPath(%q) err: %v", in, err)
+			continue
+		}
+		if !filepath.IsAbs(got) {
+			t.Errorf("expandPath(%q) = %q, not absolute", in, got)
+		}
+		if want != "" && got != want {
+			t.Errorf("expandPath(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -1,0 +1,92 @@
+// Package launch defines the launch record written into each agent's mailbox
+// at coop exec time. It is the durable input to `amq-squad restore`.
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// SchemaVersion is bumped on any breaking change to the on-disk record.
+	SchemaVersion = 1
+
+	// FileName is the name of the launch record inside an agent's mailbox dir.
+	FileName = "launch.json"
+)
+
+// Record is the persisted launch invocation for a single agent. It lives at
+// <AM_ROOT>/agents/<handle>/launch.json.
+type Record struct {
+	Schema    int       `json:"schema"`
+	CWD       string    `json:"cwd"`
+	Binary    string    `json:"binary"`
+	Argv      []string  `json:"argv"`
+	Session   string    `json:"session"`
+	Handle    string    `json:"handle"`
+	Role      string    `json:"role,omitempty"`
+	Root      string    `json:"root"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// Write atomically writes the record into the agent's mailbox directory.
+// The agent mailbox is expected to exist (coop exec creates it), but Write
+// also creates missing parents so the record can be written pre-exec.
+func Write(agentDir string, rec Record) error {
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		return fmt.Errorf("ensure agent dir: %w", err)
+	}
+	path := filepath.Join(agentDir, FileName)
+	tmp := path + ".tmp"
+
+	rec.Schema = SchemaVersion
+	b, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal launch record: %w", err)
+	}
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// Read loads a launch record from an agent's mailbox directory. Returns
+// os.ErrNotExist if no launch.json is present.
+func Read(agentDir string) (Record, error) {
+	path := filepath.Join(agentDir, FileName)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Record{}, err
+	}
+	var rec Record
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return Record{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return rec, nil
+}
+
+// Scan walks <projectRoot>/.agent-mail/*/agents/*/ for launch.json records
+// and returns every record found. Order is whatever filepath.Glob returns;
+// callers that care about ordering should sort the result themselves.
+func Scan(projectRoot string) ([]Record, error) {
+	pattern := filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*", FileName)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob: %w", err)
+	}
+	out := make([]Record, 0, len(matches))
+	for _, m := range matches {
+		rec, err := Read(filepath.Dir(m))
+		if err != nil {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -71,22 +71,36 @@ func Read(agentDir string) (Record, error) {
 	return rec, nil
 }
 
-// Scan walks <projectRoot>/.agent-mail/*/agents/*/ for launch.json records
-// and returns every record found. Order is whatever filepath.Glob returns;
+// Scan walks a projectRoot for launch.json records across both AMQ layouts:
+//
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json  (coop exec)
+//	<projectRoot>/.agent-mail/agents/<handle>/launch.json            (base root, no session)
+//
+// Returns every record found. Order is whatever filepath.Glob returns;
 // callers that care about ordering should sort the result themselves.
 func Scan(projectRoot string) ([]Record, error) {
-	pattern := filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*", FileName)
-	matches, err := filepath.Glob(pattern)
-	if err != nil {
-		return nil, fmt.Errorf("glob: %w", err)
+	patterns := []string{
+		filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*", FileName),
+		filepath.Join(projectRoot, ".agent-mail", "agents", "*", FileName),
 	}
-	out := make([]Record, 0, len(matches))
-	for _, m := range matches {
-		rec, err := Read(filepath.Dir(m))
+	seen := map[string]bool{}
+	var out []Record
+	for _, p := range patterns {
+		matches, err := filepath.Glob(p)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("glob %s: %w", p, err)
 		}
-		out = append(out, rec)
+		for _, m := range matches {
+			if seen[m] {
+				continue
+			}
+			seen[m] = true
+			rec, err := Read(filepath.Dir(m))
+			if err != nil {
+				continue
+			}
+			out = append(out, rec)
+		}
 	}
 	return out, nil
 }

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -1,0 +1,115 @@
+package launch
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := Record{
+		CWD:       "/some/project",
+		Binary:    "claude",
+		Argv:      []string{"--flag", "value"},
+		Session:   "stream1",
+		Handle:    "cpo",
+		Role:      "cpo",
+		Root:      dir,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := Write(dir, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	out, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if out.Schema != SchemaVersion {
+		t.Errorf("Schema = %d, want %d", out.Schema, SchemaVersion)
+	}
+	// Write sets Schema, so zero out in.Schema for comparison of other fields.
+	in.Schema = SchemaVersion
+	if out.CWD != in.CWD || out.Binary != in.Binary || out.Session != in.Session ||
+		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
+	}
+	if len(out.Argv) != len(in.Argv) {
+		t.Fatalf("Argv len mismatch: %v vs %v", out.Argv, in.Argv)
+	}
+	for i := range in.Argv {
+		if out.Argv[i] != in.Argv[i] {
+			t.Errorf("Argv[%d] = %q, want %q", i, out.Argv[i], in.Argv[i])
+		}
+	}
+	if !out.StartedAt.Equal(in.StartedAt) {
+		t.Errorf("StartedAt = %v, want %v", out.StartedAt, in.StartedAt)
+	}
+}
+
+func TestReadMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Read(dir)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestScanFindsRecordsAcrossSessions(t *testing.T) {
+	project := t.TempDir()
+	// Simulate two sessions, one agent each.
+	makeAgent := func(session, handle, role string) {
+		dir := filepath.Join(project, ".agent-mail", session, "agents", handle)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rec := Record{
+			CWD:       project,
+			Binary:    "claude",
+			Session:   session,
+			Handle:    handle,
+			Role:      role,
+			Root:      filepath.Join(project, ".agent-mail", session),
+			StartedAt: time.Now().UTC(),
+		}
+		if err := Write(dir, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	makeAgent("stream1", "cpo", "cpo")
+	makeAgent("stream2", "fullstack", "fullstack")
+
+	// Add a noise file that shouldn't be picked up.
+	if err := os.WriteFile(filepath.Join(project, ".agent-mail", "not-a-launch.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	recs, err := Scan(project)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("Scan returned %d records, want 2", len(recs))
+	}
+
+	roles := []string{recs[0].Role, recs[1].Role}
+	sort.Strings(roles)
+	if roles[0] != "cpo" || roles[1] != "fullstack" {
+		t.Errorf("roles = %v, want [cpo fullstack]", roles)
+	}
+}
+
+func TestScanEmptyProject(t *testing.T) {
+	recs, err := Scan(t.TempDir())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Errorf("Scan on empty project returned %d records", len(recs))
+	}
+}

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -104,6 +104,62 @@ func TestScanFindsRecordsAcrossSessions(t *testing.T) {
 	}
 }
 
+func TestScanMatchesBaseRootLayout(t *testing.T) {
+	// Base-root agents (no session) live at .agent-mail/agents/<handle>,
+	// not under .agent-mail/<session>/agents/<handle>. Scan must find both.
+	project := t.TempDir()
+	dir := filepath.Join(project, ".agent-mail", "agents", "claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := Record{
+		CWD:       project,
+		Binary:    "claude",
+		Handle:    "claude",
+		Role:      "fullstack",
+		Root:      filepath.Join(project, ".agent-mail"),
+		StartedAt: time.Now().UTC(),
+	}
+	if err := Write(dir, rec); err != nil {
+		t.Fatal(err)
+	}
+	recs, err := Scan(project)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("Scan returned %d records, want 1", len(recs))
+	}
+	if recs[0].Handle != "claude" || recs[0].Role != "fullstack" {
+		t.Errorf("unexpected record: %+v", recs[0])
+	}
+}
+
+func TestScanDedupesAcrossPatterns(t *testing.T) {
+	// Mix session and base-root layouts in one project. Both should be
+	// returned, with no duplicates.
+	project := t.TempDir()
+	mk := func(path string, rec Record) {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := Write(filepath.Dir(path), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk(filepath.Join(project, ".agent-mail", "collab", "agents", "cto", FileName),
+		Record{Handle: "cto", Role: "cto", Binary: "codex"})
+	mk(filepath.Join(project, ".agent-mail", "agents", "claude", FileName),
+		Record{Handle: "claude", Role: "fullstack", Binary: "claude"})
+	recs, err := Scan(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("want 2 records (cto + claude), got %d: %+v", len(recs), recs)
+	}
+}
+
 func TestScanEmptyProject(t *testing.T) {
 	recs, err := Scan(t.TempDir())
 	if err != nil {

--- a/internal/role/role.go
+++ b/internal/role/role.go
@@ -1,0 +1,99 @@
+// Package role reads and writes role.md, the per-agent markdown doc that
+// lives alongside launch.json in the agent's mailbox directory. role.md is
+// the human-editable source of a role's description, peers, system prompt
+// override, and priming template. Slice B composes the priming prompt from
+// it; slice A (this one) just authors the stub.
+package role
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const FileName = "role.md"
+
+// Stub is the data used to seed a new role.md. Fields come from the catalog
+// entry at team init time; the user can edit the rendered file freely.
+type Stub struct {
+	Label       string
+	RoleID      string
+	Description string
+	Skills      []string
+	Peers       []string
+}
+
+// Path returns the role.md path inside an agent's mailbox directory.
+func Path(agentDir string) string {
+	return filepath.Join(agentDir, FileName)
+}
+
+// EnsureStub writes a role.md for the given agent if one doesn't already
+// exist. It never overwrites existing user edits. Returns true if it wrote
+// a new file, false if one was already there.
+func EnsureStub(agentDir string, s Stub) (bool, error) {
+	p := Path(agentDir)
+	if _, err := os.Stat(p); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("stat %s: %w", p, err)
+	}
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		return false, fmt.Errorf("ensure agent dir: %w", err)
+	}
+	body := render(s)
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, []byte(body), 0o600); err != nil {
+		return false, fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, p); err != nil {
+		return false, fmt.Errorf("rename: %w", err)
+	}
+	return true, nil
+}
+
+func render(s Stub) string {
+	var b strings.Builder
+	label := s.Label
+	if label == "" {
+		label = s.RoleID
+	}
+	fmt.Fprintf(&b, "# Role: %s\n\n", label)
+
+	b.WriteString("## Description\n")
+	if s.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", s.Description)
+	} else {
+		b.WriteString("TODO: describe this role in one paragraph.\n\n")
+	}
+
+	b.WriteString("## Peers\n")
+	if len(s.Peers) > 0 {
+		for _, p := range s.Peers {
+			fmt.Fprintf(&b, "- %s\n", p)
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString("TODO: list the role IDs this agent talks to most.\n\n")
+	}
+
+	b.WriteString("## Skills\n")
+	if len(s.Skills) > 0 {
+		for _, sk := range s.Skills {
+			fmt.Fprintf(&b, "- %s\n", sk)
+		}
+		b.WriteString("\n")
+	} else {
+		b.WriteString("TODO: list slash commands or skills this role should invoke.\n\n")
+	}
+
+	b.WriteString("## System Prompt\n")
+	b.WriteString("TODO: optional override. Leave blank to use the binary default.\n\n")
+
+	b.WriteString("## Priming Template\n")
+	b.WriteString("TODO: the prompt text used when this agent boots. Slice B will\n")
+	b.WriteString("compose this with active peers and active thread at restore time.\n")
+
+	return b.String()
+}

--- a/internal/role/role_test.go
+++ b/internal/role/role_test.go
@@ -1,0 +1,81 @@
+package role
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEnsureStubWritesAllSections(t *testing.T) {
+	dir := t.TempDir()
+	stub := Stub{
+		Label:       "Product Designer",
+		RoleID:      "designer",
+		Description: "Designs the product surface.",
+		Skills:      []string{"/frontend-design", "/canvas-design"},
+		Peers:       []string{"cpo", "fullstack"},
+	}
+	wrote, err := EnsureStub(dir, stub)
+	if err != nil {
+		t.Fatalf("EnsureStub: %v", err)
+	}
+	if !wrote {
+		t.Fatal("EnsureStub returned false on first call")
+	}
+
+	b, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(b)
+	for _, want := range []string{
+		"# Role: Product Designer",
+		"## Description",
+		"Designs the product surface.",
+		"## Peers",
+		"- cpo",
+		"- fullstack",
+		"## Skills",
+		"/frontend-design",
+		"/canvas-design",
+		"## System Prompt",
+		"## Priming Template",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("role.md missing %q", want)
+		}
+	}
+}
+
+func TestEnsureStubNoClobber(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(Path(dir), []byte("USER EDIT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wrote, err := EnsureStub(dir, Stub{RoleID: "cpo", Label: "CPO"})
+	if err != nil {
+		t.Fatalf("EnsureStub: %v", err)
+	}
+	if wrote {
+		t.Error("EnsureStub wrote over existing role.md")
+	}
+	b, _ := os.ReadFile(Path(dir))
+	if string(b) != "USER EDIT" {
+		t.Error("existing content clobbered")
+	}
+}
+
+func TestEnsureStubFallsBackToRoleID(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsureStub(dir, Stub{RoleID: "unknown"}); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(Path(dir))
+	if !strings.Contains(string(b), "# Role: unknown") {
+		t.Error("stub should fall back to RoleID when Label is empty")
+	}
+	// Missing optional fields should emit TODO markers.
+	if !strings.Contains(string(b), "TODO: describe") {
+		t.Error("missing description should emit TODO")
+	}
+}

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -1,0 +1,187 @@
+// Package rules manages .amq-squad/team-rules.md, the single source of
+// truth for team-wide norms and approval flow, and keeps CLAUDE.md +
+// AGENTS.md in sync with it.
+//
+// Design rules:
+//   - team-rules.md is the only authoritative source. No structured
+//     approver map, no parallel config fields. Rules are prose.
+//   - CLAUDE.md / AGENTS.md get a "managed block" delimited by markers.
+//     Content outside the markers belongs to the user and is never touched.
+//   - Sync never writes on its own. The caller previews, then opts in.
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	FileName = "team-rules.md"
+
+	BeginMarker = "<!-- amq-squad:managed:begin -->"
+	EndMarker   = "<!-- amq-squad:managed:end -->"
+
+	ClaudeFile = "CLAUDE.md"
+	AgentsFile = "AGENTS.md"
+)
+
+// Path returns the team-rules.md path for the given project directory.
+func Path(projectDir string) string {
+	return filepath.Join(projectDir, ".amq-squad", FileName)
+}
+
+// StubContent is what we seed team-rules.md with on first `rules init`.
+const StubContent = `# Team Rules
+
+Shared norms and workflow for this project's agent squad. Every agent reads
+this file via their priming prompt regardless of binary.
+
+## Workflow
+
+- TODO: describe how work flows from intent to shipped (e.g. "All code
+  changes ship via a pull request").
+
+## Approvals
+
+- TODO: list required approvals (e.g. "Every PR needs CTO approval before
+  merge").
+
+## Communication
+
+- TODO: describe how agents should talk to each other (channels,
+  escalation, when to page a peer).
+`
+
+// Read returns the team-rules.md contents. Returns os.ErrNotExist if the
+// file isn't there.
+func Read(projectDir string) (string, error) {
+	b, err := os.ReadFile(Path(projectDir))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// EnsureStub writes a stub team-rules.md if one does not already exist.
+// Returns true if it wrote a new file.
+func EnsureStub(projectDir string) (bool, error) {
+	p := Path(projectDir)
+	if _, err := os.Stat(p); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(p, []byte(StubContent), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SyncPlan describes what sync would do for a single target file.
+type SyncPlan struct {
+	Target    string // absolute path
+	Basename  string // "CLAUDE.md" or "AGENTS.md"
+	Before    string // current file contents ("" if missing)
+	After     string // desired contents
+	Adopting  bool   // true = first-time wrap of existing content
+	Creating  bool   // true = file doesn't exist yet, will be created
+	Unchanged bool   // true = already in desired state
+}
+
+// Plan builds a SyncPlan for CLAUDE.md and AGENTS.md under projectDir,
+// using rulesBody as the content to place inside the managed block.
+func Plan(projectDir, rulesBody string) ([]SyncPlan, error) {
+	managed := buildManagedBlock(rulesBody)
+	plans := make([]SyncPlan, 0, 2)
+	for _, name := range []string{ClaudeFile, AgentsFile} {
+		p := filepath.Join(projectDir, name)
+		before, existed, err := readIfExists(p)
+		if err != nil {
+			return nil, err
+		}
+		after, adopting := renderTarget(before, existed, managed)
+		plans = append(plans, SyncPlan{
+			Target:    p,
+			Basename:  name,
+			Before:    before,
+			After:     after,
+			Adopting:  adopting,
+			Creating:  !existed,
+			Unchanged: before == after,
+		})
+	}
+	return plans, nil
+}
+
+// Apply writes each plan whose After differs from Before. Returns the
+// number of files touched.
+func Apply(plans []SyncPlan) (int, error) {
+	n := 0
+	for _, p := range plans {
+		if p.Unchanged {
+			continue
+		}
+		if err := os.WriteFile(p.Target, []byte(p.After), 0o644); err != nil {
+			return n, fmt.Errorf("write %s: %w", p.Target, err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+func buildManagedBlock(rulesBody string) string {
+	body := strings.TrimSpace(rulesBody)
+	return BeginMarker + "\n" +
+		"<!-- Managed by amq-squad. Edit .amq-squad/team-rules.md and run\n" +
+		"     `amq-squad team sync --apply` to refresh. -->\n\n" +
+		body + "\n\n" +
+		EndMarker
+}
+
+// renderTarget returns the desired file contents and whether this is a
+// first-time adoption of pre-existing user content.
+func renderTarget(before string, existed bool, managed string) (string, bool) {
+	if !existed {
+		return managed + "\n", false
+	}
+	if hasMarkers(before) {
+		return replaceManagedBlock(before, managed), false
+	}
+	// Adopt: keep existing content as user region, append managed block.
+	trimmed := strings.TrimRight(before, "\n")
+	if trimmed == "" {
+		return managed + "\n", true
+	}
+	return trimmed + "\n\n" + managed + "\n", true
+}
+
+func hasMarkers(s string) bool {
+	return strings.Contains(s, BeginMarker) && strings.Contains(s, EndMarker)
+}
+
+func replaceManagedBlock(existing, managed string) string {
+	beginIdx := strings.Index(existing, BeginMarker)
+	endIdx := strings.Index(existing, EndMarker)
+	if beginIdx < 0 || endIdx < 0 || endIdx < beginIdx {
+		// Shouldn't happen: hasMarkers guards this. Fall back to append.
+		return strings.TrimRight(existing, "\n") + "\n\n" + managed + "\n"
+	}
+	endIdx += len(EndMarker)
+	return existing[:beginIdx] + managed + existing[endIdx:]
+}
+
+func readIfExists(p string) (string, bool, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return string(b), true, nil
+}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,186 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPlanCreateWhenMissing(t *testing.T) {
+	project := t.TempDir()
+	plans, err := Plan(project, "# Team Rules\n\n- one rule\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("got %d plans, want 2", len(plans))
+	}
+	for _, p := range plans {
+		if !p.Creating {
+			t.Errorf("%s: Creating = false, want true", p.Basename)
+		}
+		if p.Unchanged {
+			t.Errorf("%s: Unchanged = true, want false", p.Basename)
+		}
+		if p.Adopting {
+			t.Errorf("%s: Adopting = true, want false", p.Basename)
+		}
+		if !strings.Contains(p.After, "one rule") {
+			t.Errorf("%s: After missing rule body", p.Basename)
+		}
+		if !strings.Contains(p.After, BeginMarker) || !strings.Contains(p.After, EndMarker) {
+			t.Errorf("%s: After missing markers", p.Basename)
+		}
+	}
+}
+
+func TestPlanAdoptsExistingContent(t *testing.T) {
+	project := t.TempDir()
+	existing := "# My Project\n\nUser docs.\n"
+	if err := os.WriteFile(filepath.Join(project, ClaudeFile), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	byName := map[string]SyncPlan{}
+	for _, p := range plans {
+		byName[p.Basename] = p
+	}
+	claude := byName[ClaudeFile]
+	if !claude.Adopting {
+		t.Error("CLAUDE.md: Adopting = false, want true")
+	}
+	if claude.Creating {
+		t.Error("CLAUDE.md: Creating = true for pre-existing file")
+	}
+	if !strings.Contains(claude.After, "User docs.") {
+		t.Error("CLAUDE.md: user content not preserved")
+	}
+	if !strings.Contains(claude.After, BeginMarker) {
+		t.Error("CLAUDE.md: no markers inserted")
+	}
+	// User content must come before the managed block.
+	userIdx := strings.Index(claude.After, "User docs.")
+	markerIdx := strings.Index(claude.After, BeginMarker)
+	if userIdx >= markerIdx {
+		t.Error("CLAUDE.md: managed block not placed after user content")
+	}
+
+	agents := byName[AgentsFile]
+	if !agents.Creating {
+		t.Error("AGENTS.md: should be created fresh")
+	}
+}
+
+func TestPlanRefreshesManagedBlockOnly(t *testing.T) {
+	project := t.TempDir()
+	// File already has markers with stale content.
+	userPrefix := "# My Project\n\nUser docs.\n\n"
+	stale := userPrefix + BeginMarker + "\nOLD RULES\n" + EndMarker + "\n"
+	for _, name := range []string{ClaudeFile, AgentsFile} {
+		if err := os.WriteFile(filepath.Join(project, name), []byte(stale), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plans, err := Plan(project, "# Team Rules\n\n- NEW RULE\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	for _, p := range plans {
+		if p.Adopting || p.Creating {
+			t.Errorf("%s: Adopting=%v Creating=%v, want both false", p.Basename, p.Adopting, p.Creating)
+		}
+		if p.Unchanged {
+			t.Errorf("%s: Unchanged = true when rules differ", p.Basename)
+		}
+		if strings.Contains(p.After, "OLD RULES") {
+			t.Errorf("%s: stale content not removed", p.Basename)
+		}
+		if !strings.Contains(p.After, "NEW RULE") {
+			t.Errorf("%s: new rule missing", p.Basename)
+		}
+		if !strings.Contains(p.After, "User docs.") {
+			t.Errorf("%s: user content outside markers clobbered", p.Basename)
+		}
+	}
+}
+
+func TestPlanUnchangedWhenAlreadyInSync(t *testing.T) {
+	project := t.TempDir()
+	body := "# Team Rules\n\n- a rule\n"
+
+	// First pass: Plan + Apply to get files into canonical state.
+	plans, err := Plan(project, body)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if _, err := Apply(plans); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Second pass with same body: all unchanged.
+	plans, err = Plan(project, body)
+	if err != nil {
+		t.Fatalf("Plan second: %v", err)
+	}
+	for _, p := range plans {
+		if !p.Unchanged {
+			t.Errorf("%s: Unchanged = false on no-op sync", p.Basename)
+		}
+	}
+}
+
+func TestApplyOnlyWritesChanged(t *testing.T) {
+	project := t.TempDir()
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	n, err := Apply(plans)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("Apply touched %d files, want 2", n)
+	}
+
+	// No changes now.
+	plans, _ = Plan(project, "# Team Rules\n")
+	n, err = Apply(plans)
+	if err != nil {
+		t.Fatalf("Apply 2: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Apply touched %d files on no-op, want 0", n)
+	}
+}
+
+func TestEnsureStub(t *testing.T) {
+	project := t.TempDir()
+	wrote, err := EnsureStub(project)
+	if err != nil {
+		t.Fatalf("EnsureStub: %v", err)
+	}
+	if !wrote {
+		t.Error("first EnsureStub should write")
+	}
+
+	// Second call: don't clobber.
+	if err := os.WriteFile(Path(project), []byte("USER EDIT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wrote, err = EnsureStub(project)
+	if err != nil {
+		t.Fatalf("EnsureStub 2: %v", err)
+	}
+	if wrote {
+		t.Error("EnsureStub wrote over existing file")
+	}
+	b, _ := os.ReadFile(Path(project))
+	if string(b) != "USER EDIT" {
+		t.Error("EnsureStub clobbered user content")
+	}
+}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -1,0 +1,106 @@
+// Package team persists the set of agents the user wants booted for a
+// project. It's a thin wrapper around a JSON file at <project>/.amq-squad/team.json.
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	SchemaVersion = 1
+	DirName       = ".amq-squad"
+	FileName      = "team.json"
+)
+
+// Member is one row of the team: a role picked from the catalog plus the
+// overrides the user chose at team init time.
+//
+// CWD is the working directory this agent runs from. Empty means "same as
+// the team's project dir". Members can live in different directories; the
+// team-home (where team.json lives) is just one of them.
+type Member struct {
+	Role    string `json:"role"`    // catalog role ID, e.g. "cpo"
+	Binary  string `json:"binary"`  // "claude" or "codex"
+	Handle  string `json:"handle"`  // AMQ handle, defaults to Role
+	Session string `json:"session"` // AMQ session name, defaults to Role
+	CWD     string `json:"cwd,omitempty"`
+}
+
+// EffectiveCWD returns the member's working directory, falling back to the
+// team's project dir when CWD is empty.
+func (m Member) EffectiveCWD(projectDir string) string {
+	if m.CWD != "" {
+		return m.CWD
+	}
+	return projectDir
+}
+
+// Team is the persisted team config.
+//
+// Project is not serialized: it's always the directory that contains
+// .amq-squad/team.json, derived at Read time. Persisting an absolute path
+// would leak local paths into shared repos and break when the repo moves.
+// CreatedAt is informational.
+type Team struct {
+	Schema    int       `json:"schema"`
+	Project   string    `json:"-"`
+	Members   []Member  `json:"members"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Path returns the team.json path for the given project directory.
+func Path(projectDir string) string {
+	return filepath.Join(projectDir, DirName, FileName)
+}
+
+// Read loads the team config from projectDir. Returns os.ErrNotExist if
+// no team.json is present.
+func Read(projectDir string) (Team, error) {
+	p := Path(projectDir)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return Team{}, err
+	}
+	var t Team
+	if err := json.Unmarshal(b, &t); err != nil {
+		return Team{}, fmt.Errorf("parse %s: %w", p, err)
+	}
+	t.Project = projectDir
+	return t, nil
+}
+
+// Write atomically persists the team config under projectDir.
+func Write(projectDir string, t Team) error {
+	dir := filepath.Join(projectDir, DirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensure %s: %w", dir, err)
+	}
+	t.Schema = SchemaVersion
+	// Project is not serialized (json:"-") so nothing to set here.
+	if t.CreatedAt.IsZero() {
+		t.CreatedAt = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal team: %w", err)
+	}
+	path := Path(projectDir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// Exists reports whether a team.json is present under projectDir.
+func Exists(projectDir string) bool {
+	_, err := os.Stat(Path(projectDir))
+	return err == nil
+}

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -1,0 +1,103 @@
+package team
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := Team{
+		Project: dir,
+		Members: []Member{
+			{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "stream1"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "stream2"},
+		},
+	}
+	if err := Write(dir, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if !Exists(dir) {
+		t.Error("Exists reported false after Write")
+	}
+
+	out, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if out.Schema != SchemaVersion {
+		t.Errorf("Schema = %d, want %d", out.Schema, SchemaVersion)
+	}
+	if out.Project != dir {
+		t.Errorf("Project = %q, want %q", out.Project, dir)
+	}
+	if len(out.Members) != len(in.Members) {
+		t.Fatalf("Members len = %d, want %d", len(out.Members), len(in.Members))
+	}
+	for i, m := range out.Members {
+		if m != in.Members[i] {
+			t.Errorf("Members[%d] = %+v, want %+v", i, m, in.Members[i])
+		}
+	}
+	if out.CreatedAt.IsZero() {
+		t.Error("CreatedAt not set by Write")
+	}
+}
+
+func TestReadMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Read(dir)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Read missing: err = %v, want ErrNotExist", err)
+	}
+	if Exists(dir) {
+		t.Error("Exists true for empty dir")
+	}
+}
+
+func TestPathShape(t *testing.T) {
+	got := Path("/foo")
+	want := filepath.Join("/foo", DirName, FileName)
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}
+
+func TestWriteDoesNotLeakProjectPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, Team{Project: dir, Members: []Member{{Role: "cto"}}}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(b, []byte(dir)) {
+		t.Errorf("team.json contains the project path (would leak on commit):\n%s", b)
+	}
+	if bytes.Contains(b, []byte(`"project"`)) {
+		t.Errorf("team.json serializes 'project' field; should be json:\"-\"")
+	}
+}
+
+func TestWriteIsAtomic(t *testing.T) {
+	// Write must not leave a .tmp file behind on success.
+	dir := t.TempDir()
+	if err := Write(dir, Team{Project: dir}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, DirName))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover tmp file: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Ship the user-facing team layer above AMQ: pick a team from a built-in 6-role catalog (cpo, cto, fullstack, qa, pm, designer), persist it to `.amq-squad/team.json`, and emit `cd && amq-squad launch` commands on demand.
- Seed per-agent `role.md` stubs from the catalog at launch time; never clobber existing edits.
- Single source of truth for team norms: `.amq-squad/team-rules.md`. `team sync` mirrors it into a managed block in every member cwd's `CLAUDE.md` + `AGENTS.md`, non-destructively adopting any pre-existing content on first apply.
- Members can span multiple working directories (the motivating scenario is not single-cwd). `team show` emits the right `cd` per member; `team sync` walks every unique cwd.

## Design principles held throughout

1. Zero required AMQ changes. Shells out to `amq env --json` / `amq coop exec`.
2. `launch.json` is the durable post-boot source of truth; `team.json` is the pre-boot intent.
3. stdlib only.
4. No em dashes in output or source.

## Commands

```
amq-squad team                      smart default: show or init
amq-squad team init [options]       pick the team, write .amq-squad/team.json
amq-squad team show                 print launch commands
amq-squad team rules init           seed team-rules.md
amq-squad team sync [--apply]       preview (exit 1 on drift) or write
amq-squad launch --role ... <bin>   unchanged surface, now seeds role.md
amq-squad restore / list            unchanged
```

## Notable choices (flagging for CTO review)

- **Catalog in Go source, not a config file.** Adding a role = code change + rebuild. Argued this keeps role metadata typed and discoverable.
- **team-rules.md as single source of truth for rules.** Rejected a parallel structured `approvers` map in team.json to avoid drift. `team show` references the file path; rules consumed by agents via the synced managed block.
- **Adopt-on-first-apply for CLAUDE.md/AGENTS.md.** Existing hand-written content is wrapped above marker comments, never overwritten. Preview mode shows this explicitly before any write.
- **team.json does not serialize the project path.** Derived at `Read` time from the team.json location; prevents absolute-path leaks into shared repos. Test in `internal/team/team_test.go:TestWriteDoesNotLeakProjectPath` guards this.
- **Binary path in emitted commands is absolute** (`os.Executable()`), so `team show` output works without `amq-squad` in PATH.

## Explicitly NOT in this PR

- Priming prompt composition (next slice: compose `team-rules.md` + `role.md` + derived active peers + active thread into the positional prompt passed to `coop exec`).
- Peer `.amqrc` auto-generation across multi-cwd teams. Today each project's `.amqrc` needs peer entries set manually. Flagged as a followup; amq-squad writing into other projects' `.amqrc` is invasive enough to want an explicit decision.
- Enforcement of team rules. amq-squad surfaces; agents follow. Git hooks / CI / branch protection handle the hard gating.

## Related

- Upstream AMQ gap filed while building this: avivsinai/agent-message-queue#96 (cross-session send from outside coop exec has no clean sender-session idiom). Workaround captured; waiting on AMQ direction.

## Test plan

- [x] `make ci` (go vet + go test ./...) clean
- [x] `gofmt -l .` clean
- [x] Manual smoke of `team init` / `show` / `sync` in a scratch dir spanning two cwds, verified adoption of hand-written `CLAUDE.md` above managed block
- [x] Manual smoke of `amq-squad launch --role designer` writing both `launch.json` and catalog-seeded `role.md` in the mailbox
- [x] Live dogfood: this project's team booted via the emitted commands, `p2p/cto__fullstack` handshake round-tripped
- [ ] CTO review via `p2p/cto__fullstack`