### PR TITLE
Add 'team open' subcommand: one-shot iTerm2 multi-pane launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ amq-squad team sync          # preview (exit 1 if anything would change)
 amq-squad team sync --apply  # writes the managed block into CLAUDE.md and AGENTS.md
 ```
 
-Print the launch commands:
+Boot the whole team in one iTerm2 window (macOS + iTerm2 only):
 
 ```
-amq-squad team
+amq-squad team open --layout horizontal   # or --layout vertical for side-by-side
 ```
 
-You'll get two commands, one per role. Open an iTerm2 window (⌘N) and split (⌘D), paste one command per pane. Each agent boots through `amq-squad launch`, which writes `launch.json` + a catalog-seeded `role.md` into the mailbox before handing off to `amq coop exec`. From there both agents share the thread `p2p/cto__fullstack` for design escalations and review handoffs.
+That opens a new window, splits it one pane per role, and pastes each launch command. Each agent boots through `amq-squad launch`, which writes `launch.json` + a catalog-seeded `role.md` into the mailbox before handing off to `amq coop exec`. From there both agents share the thread `p2p/cto__fullstack` for design escalations and review handoffs.
+
+Prefer to handle the panes yourself? `amq-squad team` prints the same commands to stdout so you can paste them manually.
 
 ### Squad spanning two projects
 
@@ -186,6 +188,8 @@ amq-squad team init [--roles ...]   Set up this project's team
 amq-squad team show                 Print launch commands for the configured team
 amq-squad team rules init           Seed .amq-squad/team-rules.md
 amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
+amq-squad team open [--layout h|v]  Open every team member in one iTerm2 window
+                                    (macOS + iTerm2 only; --dry-run prints the osascript)
 
 amq-squad launch --role <r> --session <s> --me <handle> <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -30,10 +30,12 @@ func runTeam(args []string) error {
 		return runTeamRules(args[1:])
 	case "sync":
 		return runTeamSync(args[1:])
+	case "open":
+		return runTeamOpen(args[1:])
 	default:
 		// Unknown subcommand. Treat as flags to the smart default so
 		// `amq-squad team --help` and similar still work.
-		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'show', 'rules', or 'sync'.", args[0])
+		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'show', 'rules', 'sync', or 'open'.", args[0])
 	}
 }
 
@@ -515,6 +517,8 @@ Usage:
   amq-squad team rules init           Seed .amq-squad/team-rules.md with a stub
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)
+  amq-squad team open [--layout h|v]  Open every team member in an iTerm2 window
+                                      (macOS + iTerm2 only)
 
 Roles come from the built-in catalog. Run 'amq-squad team init --help' to
 see them and the available flags.

--- a/internal/cli/team_open.go
+++ b/internal/cli/team_open.go
@@ -88,14 +88,17 @@ only.
 // iTerm2 uses. In iTerm2's terminology: "split vertically" creates a pane
 // to the right (divider is vertical); "split horizontally" creates a pane
 // below (divider is horizontal).
+//
+// Accepts the short aliases "v" and "h" alongside the full names, matching
+// the --help / README usage strings.
 func splitVerbFor(layout string) (string, error) {
-	switch layout {
-	case "vertical":
+	switch strings.ToLower(layout) {
+	case "vertical", "v":
 		return "split vertically", nil
-	case "horizontal":
+	case "horizontal", "h":
 		return "split horizontally", nil
 	default:
-		return "", fmt.Errorf("unknown layout %q (want: vertical, horizontal)", layout)
+		return "", fmt.Errorf("unknown layout %q (want: vertical|v or horizontal|h)", layout)
 	}
 }
 
@@ -125,7 +128,11 @@ func buildITermScript(projectDir, squadBin string, members []team.Member, splitV
 		cmd := emitTeamCommand(m.EffectiveCWD(projectDir), squadBin, m)
 		paneVar := fmt.Sprintf("pane%d", i+1)
 		if i > 0 {
-			fmt.Fprintf(&b, `  tell current tab of newWindow to set %s to (%s with default profile)`+"\n", paneVar, splitVerb)
+			// iTerm2: `split ...` is a session command, not a tab command.
+			// Split off the immediately preceding pane so new panes cascade
+			// naturally rather than repeatedly subdividing pane1.
+			prevPane := fmt.Sprintf("pane%d", i)
+			fmt.Fprintf(&b, `  tell %s to set %s to (%s with default profile)`+"\n", prevPane, paneVar, splitVerb)
 		}
 		fmt.Fprintf(&b, `  tell %s to write text %s`+"\n", paneVar, applescriptString(cmd))
 	}

--- a/internal/cli/team_open.go
+++ b/internal/cli/team_open.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func runTeamOpen(args []string) error {
+	fs := flag.NewFlagSet("team open", flag.ContinueOnError)
+	layout := fs.String("layout", "vertical", "pane layout: vertical | horizontal")
+	dryRun := fs.Bool("dry-run", false, "print the osascript without running it")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad team open - launch every team member in one iTerm2 window
+
+Usage:
+  amq-squad team open [--layout vertical|horizontal] [--dry-run]
+
+Opens a new iTerm2 window, splits it into one pane per team member, and
+pastes each launch command. Vertical layout stacks panes side-by-side
+(divider is vertical); horizontal stacks them top-to-bottom. macOS + iTerm2
+only.
+
+--dry-run prints the generated osascript to stdout and exits.
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	splitVerb, err := splitVerbFor(*layout)
+	if err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	if !team.Exists(cwd) {
+		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
+	}
+	t, err := team.Read(cwd)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	if len(t.Members) == 0 {
+		return fmt.Errorf("team has no members")
+	}
+
+	members := sortedMembers(t.Members)
+
+	squadBin := "amq-squad"
+	if p, err := os.Executable(); err == nil {
+		squadBin = p
+	}
+
+	script := buildITermScript(t.Project, squadBin, members, splitVerb)
+
+	if *dryRun {
+		fmt.Println(script)
+		return nil
+	}
+
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("team open requires macOS + iTerm2; on %s, use 'team show' and paste the commands yourself", runtime.GOOS)
+	}
+
+	cmd := exec.Command("osascript", "-")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("osascript: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Opened %d pane(s) in iTerm2 (%s layout).\n", len(members), *layout)
+	return nil
+}
+
+// splitVerbFor maps the user-facing layout name to the AppleScript verb
+// iTerm2 uses. In iTerm2's terminology: "split vertically" creates a pane
+// to the right (divider is vertical); "split horizontally" creates a pane
+// below (divider is horizontal).
+func splitVerbFor(layout string) (string, error) {
+	switch layout {
+	case "vertical":
+		return "split vertically", nil
+	case "horizontal":
+		return "split horizontally", nil
+	default:
+		return "", fmt.Errorf("unknown layout %q (want: vertical, horizontal)", layout)
+	}
+}
+
+func sortedMembers(members []team.Member) []team.Member {
+	idx := make(map[string]int, len(catalog.IDs()))
+	for i, id := range catalog.IDs() {
+		idx[id] = i
+	}
+	out := append([]team.Member(nil), members...)
+	sort.SliceStable(out, func(i, j int) bool {
+		return idx[out[i].Role] < idx[out[j].Role]
+	})
+	return out
+}
+
+// buildITermScript assembles the osascript that opens a new iTerm2 window,
+// splits it one pane per member in catalog order, and writes each launch
+// command into its pane.
+func buildITermScript(projectDir, squadBin string, members []team.Member, splitVerb string) string {
+	var b strings.Builder
+	b.WriteString(`tell application "iTerm"` + "\n")
+	b.WriteString(`  activate` + "\n")
+	b.WriteString(`  set newWindow to (create window with default profile)` + "\n")
+	b.WriteString(`  set pane1 to (current session of current tab of newWindow)` + "\n")
+
+	for i, m := range members {
+		cmd := emitTeamCommand(m.EffectiveCWD(projectDir), squadBin, m)
+		paneVar := fmt.Sprintf("pane%d", i+1)
+		if i > 0 {
+			fmt.Fprintf(&b, `  tell current tab of newWindow to set %s to (%s with default profile)`+"\n", paneVar, splitVerb)
+		}
+		fmt.Fprintf(&b, `  tell %s to write text %s`+"\n", paneVar, applescriptString(cmd))
+	}
+	b.WriteString(`end tell` + "\n")
+	return b.String()
+}
+
+// applescriptString renders a Go string as an AppleScript string literal.
+// AppleScript accepts double-quoted strings with \\ and \" escapes, which
+// is a subset of Go's %q encoding; the common cases (paths, single-quoted
+// shell args, unicode text) round-trip correctly.
+func applescriptString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/cli/team_open_test.go
+++ b/internal/cli/team_open_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func TestSplitVerbFor(t *testing.T) {
+	if v, err := splitVerbFor("vertical"); err != nil || v != "split vertically" {
+		t.Errorf(`splitVerbFor("vertical") = %q, %v`, v, err)
+	}
+	if v, err := splitVerbFor("horizontal"); err != nil || v != "split horizontally" {
+		t.Errorf(`splitVerbFor("horizontal") = %q, %v`, v, err)
+	}
+	if _, err := splitVerbFor("sideways"); err == nil {
+		t.Error("splitVerbFor(invalid): expected error")
+	}
+}
+
+func TestApplescriptStringEscapes(t *testing.T) {
+	cases := map[string]string{
+		"hello":             `"hello"`,
+		`with "quotes"`:     `"with \"quotes\""`,
+		`back\slash`:        `"back\\slash"`,
+		`'single'`:          `"'single'"`,
+		`/path/with spaces`: `"/path/with spaces"`,
+	}
+	for in, want := range cases {
+		if got := applescriptString(in); got != want {
+			t.Errorf("applescriptString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildITermScriptShape(t *testing.T) {
+	members := []team.Member{
+		{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+		{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+	}
+	script := buildITermScript("/home/u/proj", "/usr/local/bin/amq-squad", members, "split horizontally")
+
+	wantSubstrings := []string{
+		`tell application "iTerm"`,
+		`activate`,
+		`create window with default profile`,
+		`set pane1 to (current session of current tab of newWindow)`,
+		`tell pane1 to write text`,
+		`amq-squad launch --role cto`,
+		`set pane2 to (split horizontally with default profile)`,
+		`tell pane2 to write text`,
+		`amq-squad launch --role fullstack`,
+		`end tell`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q. Script:\n%s", want, script)
+		}
+	}
+
+	// First member must NOT get a split; only subsequent members split.
+	firstSplitIdx := strings.Index(script, "split horizontally")
+	firstPane1Idx := strings.Index(script, "pane1 to write text")
+	if firstSplitIdx < firstPane1Idx {
+		t.Error("first member must be written into the initial pane, not a split")
+	}
+}
+
+func TestBuildITermScriptUsesMemberCWD(t *testing.T) {
+	members := []team.Member{
+		{Role: "qa", Binary: "claude", Handle: "qa", Session: "qa", CWD: "/other/project-b"},
+	}
+	script := buildITermScript("/home/u/project-a", "amq-squad", members, "split vertically")
+	if !strings.Contains(script, "cd /other/project-b") {
+		t.Errorf("expected member CWD in cd prefix. Script:\n%s", script)
+	}
+}

--- a/internal/cli/team_open_test.go
+++ b/internal/cli/team_open_test.go
@@ -8,11 +8,23 @@ import (
 )
 
 func TestSplitVerbFor(t *testing.T) {
-	if v, err := splitVerbFor("vertical"); err != nil || v != "split vertically" {
-		t.Errorf(`splitVerbFor("vertical") = %q, %v`, v, err)
+	cases := map[string]string{
+		"vertical":   "split vertically",
+		"v":          "split vertically",
+		"Vertical":   "split vertically", // case-insensitive
+		"horizontal": "split horizontally",
+		"h":          "split horizontally",
+		"H":          "split horizontally",
 	}
-	if v, err := splitVerbFor("horizontal"); err != nil || v != "split horizontally" {
-		t.Errorf(`splitVerbFor("horizontal") = %q, %v`, v, err)
+	for in, want := range cases {
+		got, err := splitVerbFor(in)
+		if err != nil {
+			t.Errorf(`splitVerbFor(%q) err: %v`, in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf(`splitVerbFor(%q) = %q, want %q`, in, got, want)
+		}
 	}
 	if _, err := splitVerbFor("sideways"); err == nil {
 		t.Error("splitVerbFor(invalid): expected error")
@@ -48,7 +60,9 @@ func TestBuildITermScriptShape(t *testing.T) {
 		`set pane1 to (current session of current tab of newWindow)`,
 		`tell pane1 to write text`,
 		`amq-squad launch --role cto`,
-		`set pane2 to (split horizontally with default profile)`,
+		// Splits target a session (the preceding pane), never a tab.
+		// iTerm2's `split ...` is a session command.
+		`tell pane1 to set pane2 to (split horizontally with default profile)`,
 		`tell pane2 to write text`,
 		`amq-squad launch --role fullstack`,
 		`end tell`,
@@ -59,11 +73,37 @@ func TestBuildITermScriptShape(t *testing.T) {
 		}
 	}
 
+	// Regression guard: the previous incarnation invoked `split` on
+	// `current tab of newWindow`, which is a tab command and not valid
+	// for split. Nothing in the new script should split off a tab.
+	if strings.Contains(script, "tell current tab of newWindow to set") {
+		t.Errorf("split must target a session, not a tab. Script:\n%s", script)
+	}
+
 	// First member must NOT get a split; only subsequent members split.
 	firstSplitIdx := strings.Index(script, "split horizontally")
 	firstPane1Idx := strings.Index(script, "pane1 to write text")
 	if firstSplitIdx < firstPane1Idx {
 		t.Error("first member must be written into the initial pane, not a split")
+	}
+}
+
+func TestBuildITermScriptCascadesOffPreviousPane(t *testing.T) {
+	// Three members should cascade: pane2 splits off pane1, pane3 off pane2.
+	members := []team.Member{
+		{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"},
+		{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+		{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+	}
+	script := buildITermScript("/p", "amq-squad", members, "split vertically")
+	wants := []string{
+		`tell pane1 to set pane2 to (split vertically with default profile)`,
+		`tell pane2 to set pane3 to (split vertically with default profile)`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(script, w) {
+			t.Errorf("cascade missing %q. Script:\n%s", w, script)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`amq-squad team open` opens a new iTerm2 window, splits it one pane per team member, and pastes each launch command. Replaces the manual ⌘N + ⌘D + paste loop with a single command.

- `--layout vertical` (default): side-by-side panes.
- `--layout horizontal`: stacked panes.
- `--dry-run`: prints the generated osascript and exits (for audit / CI).
- Errors cleanly on non-darwin rather than producing a broken command.

## Design choices

- **osascript + stdin**, not a Python API or a bundled library. Zero new deps, stdlib only. AppleScript verb mapping is 3 lines; the generated script is a straight linear chain of `split vertically`/`split horizontally` calls.
- **Catalog-order panes**. Same sort as `team show`, so the same team layout every time.
- **Reuses `emitTeamCommand`**. The pane content is exactly what `team show` would print, including the absolute `amq-squad` binary path (via `os.Executable()`) and the per-member cwd.
- **Own AppleScript escaper**. `applescriptString()` handles `\\` and `\"`; Go's `strconv.Quote` would work for common cases but emits Unicode escapes AppleScript can misinterpret, so a small purpose-built escaper is safer.

## Known caveat not in scope here

Emitted launch commands do not include `--dangerously-skip-permissions` (claude) or `--dangerously-bypass-approvals-and-sandbox` (codex). Users need those flags for unattended coop exec. This PR inherits whatever `team show` emits today, so it matches that behavior. If you want opt-in per-binary default flags, file a separate issue; I'd rather not fold that into this PR.

## Test plan

- [x] `make ci` green
- [x] Table-driven tests for layout mapping and AppleScript escaping (backslash + double-quote round-trip, path with spaces, single quotes pass-through)
- [x] Script shape test: 2-member team, horizontal layout, first member goes into `pane1` without a split, second into `pane2` via `split horizontally`
- [x] Per-member CWD flows into the `cd` prefix (test `TestBuildITermScriptUsesMemberCWD`)
- [x] `--dry-run` smoke in repo: generates the expected osascript structure
- [ ] Live iTerm2 run: request reviewer confirm on a real iTerm2 session
- [ ] CTO review via `p2p/cto__fullstack`