### PR TITLE
Restore existing agent launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,21 +183,29 @@ You'll get three commands, each with the correct `cd <member-cwd>` so every agen
 ```
 amq-squad team                      Smart default: show commands, or init if none exists
 amq-squad team init [--roles ...]   Set up this project's team
-amq-squad team show                 Print launch commands for the configured team
+amq-squad team show [--no-bootstrap]
+                                    Print launch commands for the configured team
 amq-squad team rules init           Seed .amq-squad/team-rules.md
 amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
 
-amq-squad launch --role <r> --session <s> --me <handle> <binary> [-- <flags>]
+amq-squad launch --role <r> --session <s> --me <handle> [--no-bootstrap] <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md
-                                    in the AMQ mailbox, then execs 'amq coop exec'.
+                                    in the AMQ mailbox, adds a bootstrap prompt,
+                                    then execs 'amq coop exec'.
                                     Usually called by the output of 'team show'.
 
 amq-squad restore [--project dir1,dir2,...]
-                                    Reconstruct launch commands from existing
-                                    launch.json files (post-boot evidence, in
-                                    contrast to team.json which is pre-boot intent).
+                                    Reconstruct launch commands from local
+                                    launch.json history and nearby role.md
+                                    persona files. Falls back to older AMQ
+                                    mailbox history when launch.json is absent
+                                    and the binary can be inferred.
+amq-squad restore --exec --role cto Exec one selected local launch through
+                                    amq coop exec.
 
-amq-squad list [--json]             List registered agents across known projects.
+amq-squad list [--json]             List restorable amq-squad records and
+                                    AMQ-only inferred history across known
+                                    projects.
 ```
 
 ## Files it writes

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/role"
+	"github.com/omriariav/amq-squad/internal/rules"
+)
+
+//go:embed bootstrap.md
+var defaultBootstrapTemplate string
+
+type bootstrapContext struct {
+	Role          string
+	Handle        string
+	Binary        string
+	Session       string
+	CWD           string
+	Root          string
+	AgentDir      string
+	TeamHome      string
+	TeamRulesPath string
+	RolePath      string
+	LaunchPath    string
+}
+
+func buildBootstrapPrompt(ctx bootstrapContext) (string, error) {
+	tpl, err := template.New("bootstrap").Funcs(template.FuncMap{
+		"orDefault": func(s, fallback string) string {
+			if s == "" {
+				return fallback
+			}
+			return s
+		},
+	}).Parse(defaultBootstrapTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parse bootstrap template: %w", err)
+	}
+	var b bytes.Buffer
+	if err := tpl.Execute(&b, ctx); err != nil {
+		return "", fmt.Errorf("render bootstrap template: %w", err)
+	}
+	return b.String(), nil
+}
+
+func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrapContext {
+	teamRulesPath := ""
+	if teamHome != "" {
+		teamRulesPath = rules.Path(teamHome)
+	} else if _, err := os.Stat(rules.Path(rec.CWD)); err == nil {
+		teamRulesPath = rules.Path(rec.CWD)
+	}
+	return bootstrapContext{
+		Role:          rec.Role,
+		Handle:        rec.Handle,
+		Binary:        rec.Binary,
+		Session:       rec.Session,
+		CWD:           rec.CWD,
+		Root:          rec.Root,
+		AgentDir:      agentDir,
+		TeamHome:      teamHome,
+		TeamRulesPath: teamRulesPath,
+		RolePath:      role.Path(agentDir),
+		LaunchPath:    filepath.Join(agentDir, launch.FileName),
+	}
+}

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -1,0 +1,24 @@
+You are a fresh amq-squad agent.
+
+Identity:
+- Role: {{orDefault .Role "(none)"}}
+- Handle: {{.Handle}}
+- Binary: {{.Binary}}
+- Session: {{orDefault .Session "(default)"}}
+- CWD: {{.CWD}}
+
+Startup files:
+{{- if .TeamRulesPath }}
+- Team rules: {{.TeamRulesPath}}
+{{- else }}
+- Team rules: not configured
+{{- end }}
+- Role file: {{.RolePath}}
+- Launch record: {{.LaunchPath}}
+
+First steps:
+1. Read the startup files that exist.
+2. Inspect prior AMQ history relevant to your role using `amq-squad list`, `amq-squad restore`, `amq list`, `amq read`, and `amq thread --include-body` as needed.
+3. Do not resume old sessions as active work unless the user explicitly asks.
+4. Summarize your role, relevant prior context, and what you are waiting for.
+5. Stop and wait for instructions.

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildBootstrapPrompt(t *testing.T) {
+	got, err := buildBootstrapPrompt(bootstrapContext{
+		Role:          "cto",
+		Handle:        "cto",
+		Binary:        "codex",
+		Session:       "fresh-cto",
+		CWD:           "/repo",
+		Root:          "/repo/.agent-mail/fresh-cto",
+		TeamRulesPath: "/repo/.amq-squad/team-rules.md",
+		RolePath:      "/repo/.agent-mail/fresh-cto/agents/cto/role.md",
+		LaunchPath:    "/repo/.agent-mail/fresh-cto/agents/cto/launch.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"You are a fresh amq-squad agent.",
+		"Role: cto",
+		"Handle: cto",
+		"Team rules: /repo/.amq-squad/team-rules.md",
+		"Role file: /repo/.agent-mail/fresh-cto/agents/cto/role.md",
+		"Launch record: /repo/.agent-mail/fresh-cto/agents/cto/launch.json",
+		"Stop and wait for instructions.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bootstrap prompt missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildBootstrapPromptWithoutRules(t *testing.T) {
+	got, err := buildBootstrapPrompt(bootstrapContext{
+		Handle: "claude",
+		Binary: "claude",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "Team rules: not configured") {
+		t.Errorf("bootstrap prompt should mention missing team rules:\n%s", got)
+	}
+	if !strings.Contains(got, "Role: (none)") {
+		t.Errorf("bootstrap prompt should default empty role:\n%s", got)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,7 +46,7 @@ Usage:
 Commands:
   team      Pick your team once, then print launch commands on demand
   launch    Launch a single agent with a role (called by 'team show' output)
-  restore   Emit bash commands to restore registered agents from launch.json
+  restore   Restore registered agents from local launch history
   list      List registered agents across known projects
 
 Run 'amq-squad <command> --help' for command-specific options.

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -25,6 +25,8 @@ func runLaunch(args []string) error {
 	session := fs.String("session", "", "AMQ session name (passed through to coop exec)")
 	me := fs.String("me", "", "override the agent handle (defaults to binary basename)")
 	rootFlag := fs.String("root", "", "override AMQ root directory")
+	teamHome := fs.String("team-home", "", "team-home directory used to find .amq-squad/team-rules.md for bootstrap")
+	noBootstrap := fs.Bool("no-bootstrap", false, "do not pass the generated bootstrap prompt to the agent")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 
 	fs.Usage = func() {
@@ -44,7 +46,9 @@ Side effects before exec:
   1. Resolves AMQ root via 'amq env --json' for the target session.
   2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
   3. Writes a role.md stub if one does not already exist.
-  4. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+  4. Adds a generated bootstrap prompt unless --no-bootstrap is set or
+     explicit binary args were provided.
+  5. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
 With --dry-run, none of the above run: the resolved coop exec command is
 printed and amq-squad exits. Disk state is untouched.
@@ -92,6 +96,15 @@ printed and amq-squad exits. Disk state is untouched.
 		Role:      *roleFlag,
 		Root:      root,
 		StartedAt: time.Now().UTC(),
+	}
+
+	if !*noBootstrap && len(childArgs) == 0 {
+		prompt, err := buildBootstrapPrompt(bootstrapContextFor(rec, agentDir, *teamHome))
+		if err != nil {
+			return err
+		}
+		childArgs = append(childArgs, prompt)
+		rec.Argv = childArgs
 	}
 
 	// Build the coop exec invocation. Done before any disk writes so

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -98,13 +98,15 @@ printed and amq-squad exits. Disk state is untouched.
 		StartedAt: time.Now().UTC(),
 	}
 
+	// Keep generated bootstrap out of launch.json so restore stays compact
+	// and does not replay stale startup text.
+	effectiveChildArgs := childArgs
 	if !*noBootstrap && len(childArgs) == 0 {
 		prompt, err := buildBootstrapPrompt(bootstrapContextFor(rec, agentDir, *teamHome))
 		if err != nil {
 			return err
 		}
-		childArgs = append(childArgs, prompt)
-		rec.Argv = childArgs
+		effectiveChildArgs = append(effectiveChildArgs, prompt)
 	}
 
 	// Build the coop exec invocation. Done before any disk writes so
@@ -120,9 +122,9 @@ printed and amq-squad exits. Disk state is untouched.
 		coopArgs = append(coopArgs, "--me", *me)
 	}
 	coopArgs = append(coopArgs, binary)
-	if len(childArgs) > 0 {
+	if len(effectiveChildArgs) > 0 {
 		coopArgs = append(coopArgs, "--")
-		coopArgs = append(coopArgs, childArgs...)
+		coopArgs = append(coopArgs, effectiveChildArgs...)
 	}
 
 	if *dryRun {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -7,9 +7,20 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/omriariav/amq-squad/internal/launch"
 )
+
+type listRecord struct {
+	Role      string    `json:"role"`
+	Handle    string    `json:"handle"`
+	Binary    string    `json:"binary"`
+	Session   string    `json:"session"`
+	Source    string    `json:"source"`
+	CWD       string    `json:"cwd"`
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
 
 func runList(args []string) error {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
@@ -17,10 +28,13 @@ func runList(args []string) error {
 	jsonOut := fs.Bool("json", false, "emit records as JSON array")
 
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, `amq-squad list - list registered agents
+		fmt.Fprint(os.Stderr, `amq-squad list - list restorable agents
 
 Usage:
   amq-squad list [--project dir1,dir2,...] [--json]
+
+Includes full amq-squad launch records and older AMQ-only mailbox history
+where the original binary can be inferred.
 `)
 	}
 	if err := fs.Parse(args); err != nil {
@@ -42,41 +56,75 @@ Usage:
 		}
 	}
 
-	var all []launch.Record
+	var all []launch.Entry
 	for _, dir := range dirs {
-		recs, err := launch.Scan(dir)
+		entries, err := launch.ScanRestorableEntries(dir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
 			continue
 		}
-		all = append(all, recs...)
+		all = append(all, entries...)
 	}
+
+	sortRestorableEntries(all)
+	rows := listRecordsFromEntries(all)
 
 	if *jsonOut {
-		return printJSON(all)
+		return printJSON(rows)
 	}
 
-	sort.Slice(all, func(i, j int) bool {
-		if all[i].Role != all[j].Role {
-			return all[i].Role < all[j].Role
-		}
-		return all[i].Handle < all[j].Handle
-	})
-
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tCWD\tSTARTED")
-	for _, r := range all {
+	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tSOURCE\tCWD\tSTARTED")
+	for _, r := range rows {
 		role := r.Role
 		if role == "" {
 			role = "(none)"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			role, r.Handle, r.Binary, r.Session, r.CWD, r.StartedAt.Format("2006-01-02 15:04"))
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			role, r.Handle, r.Binary, r.Session, r.Source, r.CWD, formatListTime(r.StartedAt))
 	}
 	return w.Flush()
 }
 
-func printJSON(recs []launch.Record) error {
+func sortRestorableEntries(entries []launch.Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		a := entries[i].Record
+		b := entries[j].Record
+		if a.Role != b.Role {
+			return a.Role < b.Role
+		}
+		if a.Handle != b.Handle {
+			return a.Handle < b.Handle
+		}
+		return entries[i].Source < entries[j].Source
+	})
+}
+
+func listRecordsFromEntries(entries []launch.Entry) []listRecord {
+	rows := make([]listRecord, 0, len(entries))
+	for _, e := range entries {
+		r := e.Record
+		rows = append(rows, listRecord{
+			Role:      r.Role,
+			Handle:    r.Handle,
+			Binary:    r.Binary,
+			Session:   r.Session,
+			Source:    sourceLabel(e.Source),
+			CWD:       r.CWD,
+			StartedAt: r.StartedAt,
+		})
+	}
+	return rows
+}
+
+func formatListTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+func printJSON(recs any) error {
 	enc := jsonEncoder()
 	return enc.Encode(recs)
 }

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func TestListRecordsFromEntriesIncludesSource(t *testing.T) {
+	when := time.Date(2026, 4, 25, 5, 48, 0, 0, time.UTC)
+	entries := []launch.Entry{
+		{
+			Record: launch.Record{
+				Role:      "cto",
+				Handle:    "cto",
+				Binary:    "codex",
+				Session:   "cto",
+				CWD:       "/p",
+				StartedAt: when,
+			},
+			Source: launch.FileName,
+		},
+		{
+			Record: launch.Record{
+				Handle:  "claude",
+				Binary:  "claude",
+				Session: "stream1",
+				CWD:     "/legacy",
+			},
+			Source: "amq history",
+		},
+	}
+
+	rows := listRecordsFromEntries(entries)
+	if rows[0].Source != "amq-squad" {
+		t.Errorf("Source[0] = %q, want amq-squad", rows[0].Source)
+	}
+	if rows[1].Source != "amq" {
+		t.Errorf("Source[1] = %q, want amq", rows[1].Source)
+	}
+	if !rows[0].StartedAt.Equal(when) {
+		t.Errorf("StartedAt = %v, want %v", rows[0].StartedAt, when)
+	}
+}
+
+func TestFormatListTime(t *testing.T) {
+	if got := formatListTime(time.Time{}); got != "" {
+		t.Errorf("zero time formatted as %q, want empty", got)
+	}
+	when := time.Date(2026, 4, 25, 5, 48, 0, 0, time.UTC)
+	if got := formatListTime(when); got != "2026-04-25 05:48" {
+		t.Errorf("formatListTime = %q, want 2026-04-25 05:48", got)
+	}
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -9,23 +9,36 @@ import (
 	"strings"
 
 	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/role"
 )
+
+type restoreCandidate struct {
+	entry launch.Entry
+}
 
 func runRestore(args []string) error {
 	fs := flag.NewFlagSet("restore", flag.ContinueOnError)
 	projectDirs := fs.String("project", "", "comma-separated project directories to scan (default: cwd)")
+	execRestore := fs.Bool("exec", false, "exec the selected launch in this terminal")
+	roleFilter := fs.String("role", "", "only consider records with this role")
+	handleFilter := fs.String("handle", "", "only consider records with this handle")
+	sessionFilter := fs.String("session", "", "only consider records with this session")
 
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, `amq-squad restore - emit bash commands to restore every registered agent
+		fmt.Fprint(os.Stderr, `amq-squad restore - restore registered agents from local launch history
 
 Usage:
-  amq-squad restore [--project dir1,dir2,...]
+  amq-squad restore [--project dir1,dir2,...] [--role r] [--handle h] [--session s]
+  amq-squad restore --exec --role cto
 
 Scans each project for .agent-mail/<session>/agents/<handle>/launch.json
-records and prints a bash command per agent. Default scope is the current
-working directory if --project is omitted.
+records, nearby role.md persona files, and older AMQ mailbox history when
+launch.json is missing and the original binary can be inferred. Default
+scope is the current working directory if --project is omitted. Without
+--exec, prints a bash command per matching agent.
 
-Each emitted command is ready to paste into its own terminal tab.
+With --exec, exactly one record must match; amq-squad changes to that
+record's cwd and execs the saved launch through 'amq coop exec'.
 `)
 	}
 	if err := fs.Parse(args); err != nil {
@@ -47,46 +60,157 @@ Each emitted command is ready to paste into its own terminal tab.
 		}
 	}
 
-	type found struct {
-		project string
-		rec     launch.Record
-	}
-	var records []found
+	var records []restoreCandidate
 
 	for _, dir := range dirs {
-		recs, err := launch.Scan(dir)
+		entries, err := launch.ScanRestorableEntries(dir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
 			continue
 		}
-		for _, r := range recs {
-			records = append(records, found{project: dir, rec: r})
+		for _, e := range entries {
+			if !matchesRestoreFilters(e.Record, *roleFilter, *handleFilter, *sessionFilter) {
+				continue
+			}
+			records = append(records, restoreCandidate{entry: e})
 		}
 	}
 
 	if len(records) == 0 {
-		return fmt.Errorf("no launch.json records found in %s", strings.Join(dirs, ", "))
+		return fmt.Errorf("no matching launch.json records found in %s", strings.Join(dirs, ", "))
 	}
 
 	sort.Slice(records, func(i, j int) bool {
-		if records[i].rec.Role != records[j].rec.Role {
-			return records[i].rec.Role < records[j].rec.Role
+		if records[i].entry.Record.Role != records[j].entry.Record.Role {
+			return records[i].entry.Record.Role < records[j].entry.Record.Role
 		}
-		return records[i].rec.Handle < records[j].rec.Handle
+		return records[i].entry.Record.Handle < records[j].entry.Record.Handle
 	})
+
+	if *execRestore {
+		if len(records) != 1 {
+			printRestoreCandidates(os.Stderr, records)
+			return fmt.Errorf("--exec requires exactly one matching record; narrow with --role, --handle, or --session")
+		}
+		rec := records[0].entry.Record
+		fmt.Fprintf(os.Stderr, "Restoring %s via amq coop exec.\n", restoreLabel(rec))
+		return execRestoreRecord(rec)
+	}
 
 	fmt.Println("# amq-squad restore - run each command in its own terminal tab")
 	fmt.Println()
 	for i, f := range records {
-		label := f.rec.Role
-		if label == "" {
-			label = f.rec.Handle
-		}
-		fmt.Printf("# %d. %s - %s (%s/%s)\n", i+1, label, f.rec.Binary, f.rec.CWD, f.rec.Session)
-		fmt.Println(emitCommand(f.rec))
+		rec := f.entry.Record
+		fmt.Printf("# %d. %s - %s (%s)\n", i+1, restoreLabel(rec), rec.Binary, restoreMetadata(f.entry))
+		fmt.Println(emitCommand(rec))
 		fmt.Println()
 	}
 	return nil
+}
+
+func matchesRestoreFilters(rec launch.Record, roleFilter, handleFilter, sessionFilter string) bool {
+	if roleFilter != "" && rec.Role != roleFilter {
+		return false
+	}
+	if handleFilter != "" && rec.Handle != handleFilter {
+		return false
+	}
+	if sessionFilter != "" && rec.Session != sessionFilter {
+		return false
+	}
+	return true
+}
+
+func printRestoreCandidates(out *os.File, records []restoreCandidate) {
+	fmt.Fprintln(out, "Matching restore candidates:")
+	for i, f := range records {
+		rec := f.entry.Record
+		fmt.Fprintf(out, "  %d. %s - %s (%s)\n", i+1, restoreLabel(rec), rec.Binary, restoreMetadata(f.entry))
+	}
+}
+
+func restoreLabel(rec launch.Record) string {
+	if rec.Role != "" {
+		return rec.Role
+	}
+	if rec.Handle != "" {
+		return rec.Handle
+	}
+	return "(unknown)"
+}
+
+func restoreMetadata(entry launch.Entry) string {
+	rec := entry.Record
+	parts := []string{}
+	if rec.Session != "" {
+		parts = append(parts, "session: "+rec.Session)
+	}
+	if rec.Handle != "" {
+		parts = append(parts, "handle: "+rec.Handle)
+	}
+	if _, err := os.Stat(filepath.Join(entry.AgentDir, role.FileName)); err == nil {
+		parts = append(parts, "persona: role.md")
+	} else {
+		parts = append(parts, "persona: missing")
+	}
+	if entry.Source != "" {
+		parts = append(parts, "source: "+sourceLabel(entry.Source))
+	}
+	if !rec.StartedAt.IsZero() {
+		label := "started"
+		if entry.Source != "" && entry.Source != launch.FileName {
+			label = "last seen"
+		}
+		parts = append(parts, label+": "+rec.StartedAt.Format("2006-01-02 15:04"))
+	}
+	if rec.CWD != "" {
+		parts = append(parts, "cwd: "+rec.CWD)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func sourceLabel(source string) string {
+	switch source {
+	case launch.FileName:
+		return "amq-squad"
+	case "amq history":
+		return "amq"
+	case "":
+		return "(unknown)"
+	default:
+		return source
+	}
+}
+
+func execRestoreRecord(rec launch.Record) error {
+	if rec.CWD == "" {
+		return fmt.Errorf("launch record has empty cwd")
+	}
+	if err := os.Chdir(rec.CWD); err != nil {
+		return fmt.Errorf("chdir %s: %w", rec.CWD, err)
+	}
+	return runLaunch(launchArgsFromRecord(rec))
+}
+
+func launchArgsFromRecord(rec launch.Record) []string {
+	args := []string{"--no-bootstrap"}
+	if rec.Role != "" {
+		args = append(args, "--role", rec.Role)
+	}
+	if rec.Session != "" {
+		args = append(args, "--session", rec.Session)
+	} else if rec.Root != "" {
+		args = append(args, "--root", rec.Root)
+	}
+	if rec.Handle != "" {
+		args = append(args, "--me", rec.Handle)
+	}
+	args = append(args, rec.Binary)
+	if len(rec.Argv) > 0 {
+		args = append(args, "--")
+		args = append(args, rec.Argv...)
+	}
+	return args
 }
 
 // emitCommand reconstructs the bash command for a launch record.
@@ -97,6 +221,7 @@ func emitCommand(rec launch.Record) string {
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(rec.CWD))
 	b.WriteString(" && amq-squad launch")
+	b.WriteString(" --no-bootstrap")
 	if rec.Role != "" {
 		b.WriteString(" --role ")
 		b.WriteString(shellQuote(rec.Role))
@@ -104,6 +229,9 @@ func emitCommand(rec launch.Record) string {
 	if rec.Session != "" {
 		b.WriteString(" --session ")
 		b.WriteString(shellQuote(rec.Session))
+	} else if rec.Root != "" {
+		b.WriteString(" --root ")
+		b.WriteString(shellQuote(rec.Root))
 	}
 	if rec.Handle != "" && rec.Handle != defaultHandleFor(rec.Binary) {
 		b.WriteString(" --me ")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -37,6 +38,7 @@ func TestEmitCommandIncludesRoleAndSession(t *testing.T) {
 	for _, want := range []string{
 		"cd /home/user/proj",
 		"amq-squad launch",
+		"--no-bootstrap",
 		"--role qa",
 		"--session stream1",
 		"claude",
@@ -77,6 +79,107 @@ func TestEmitCommandQuotesArgvWithSpaces(t *testing.T) {
 	}
 	if !strings.Contains(cmd, " -- ") {
 		t.Errorf("expected -- separator before argv in: %s", cmd)
+	}
+}
+
+func TestEmitCommandIncludesRootWhenSessionMissing(t *testing.T) {
+	rec := launch.Record{
+		CWD:    "/p",
+		Binary: "claude",
+		Handle: "claude",
+		Root:   "/p/.agent-mail",
+	}
+	cmd := emitCommand(rec)
+	if !strings.Contains(cmd, "--root /p/.agent-mail") {
+		t.Errorf("expected --root for base-root restore in: %s", cmd)
+	}
+}
+
+func TestLaunchArgsFromRecord(t *testing.T) {
+	rec := launch.Record{
+		CWD:     "/p",
+		Binary:  "claude",
+		Argv:    []string{"--resume", "abc"},
+		Session: "stream1",
+		Handle:  "fullstack",
+		Role:    "fullstack",
+		Root:    "/p/.agent-mail/stream1",
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{
+		"--no-bootstrap",
+		"--role", "fullstack",
+		"--session", "stream1",
+		"--me", "fullstack",
+		"claude",
+		"--",
+		"--resume", "abc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+}
+
+func TestLaunchArgsFromRecordUsesRootWithoutSession(t *testing.T) {
+	rec := launch.Record{
+		Binary: "codex",
+		Handle: "codex",
+		Root:   "/p/.agent-mail",
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{"--no-bootstrap", "--root", "/p/.agent-mail", "--me", "codex", "codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+}
+
+func TestMatchesRestoreFilters(t *testing.T) {
+	rec := launch.Record{Role: "cto", Handle: "cto", Session: "stream1"}
+	cases := []struct {
+		name    string
+		role    string
+		handle  string
+		session string
+		want    bool
+	}{
+		{name: "no filters", want: true},
+		{name: "role match", role: "cto", want: true},
+		{name: "role mismatch", role: "qa", want: false},
+		{name: "handle match", handle: "cto", want: true},
+		{name: "handle mismatch", handle: "fullstack", want: false},
+		{name: "session match", session: "stream1", want: true},
+		{name: "session mismatch", session: "stream2", want: false},
+	}
+	for _, tc := range cases {
+		got := matchesRestoreFilters(rec, tc.role, tc.handle, tc.session)
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRestoreMetadataMarksLegacyHistory(t *testing.T) {
+	entry := launch.Entry{
+		Record: launch.Record{
+			CWD:     "/p",
+			Binary:  "claude",
+			Session: "stream1",
+			Handle:  "claude",
+		},
+		AgentDir: "/p/.agent-mail/stream1/agents/claude",
+		Source:   "amq history",
+	}
+	got := restoreMetadata(entry)
+	for _, want := range []string{
+		"session: stream1",
+		"handle: claude",
+		"persona: missing",
+		"source: amq",
+		"cwd: /p",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("restoreMetadata missing %q in: %s", want, got)
+		}
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -45,7 +45,7 @@ func runTeamSmart() error {
 		return fmt.Errorf("getwd: %w", err)
 	}
 	if team.Exists(cwd) {
-		return emitTeamCommands(cwd)
+		return emitTeamCommands(cwd, false)
 	}
 	fmt.Fprintln(os.Stderr, "No team configured for this project yet. Let's set one up.")
 	fmt.Fprintln(os.Stderr)
@@ -53,7 +53,7 @@ func runTeamSmart() error {
 		return err
 	}
 	fmt.Fprintln(os.Stderr)
-	return emitTeamCommands(cwd)
+	return emitTeamCommands(cwd, false)
 }
 
 func runTeamInit(args []string) error {
@@ -169,11 +169,12 @@ Known roles:
 
 func runTeamShow(args []string) error {
 	fs := flag.NewFlagSet("team show", flag.ContinueOnError)
+	noBootstrap := fs.Bool("no-bootstrap", false, "emit launch commands that skip the generated bootstrap prompt")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
 
 Usage:
-  amq-squad team show
+  amq-squad team show [--no-bootstrap]
 `)
 	}
 	if err := fs.Parse(args); err != nil {
@@ -186,10 +187,10 @@ Usage:
 	if !team.Exists(cwd) {
 		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
 	}
-	return emitTeamCommands(cwd)
+	return emitTeamCommands(cwd, *noBootstrap)
 }
 
-func emitTeamCommands(projectDir string) error {
+func emitTeamCommands(projectDir string, noBootstrap bool) error {
 	t, err := team.Read(projectDir)
 	if err != nil {
 		return fmt.Errorf("read team: %w", err)
@@ -239,7 +240,7 @@ func emitTeamCommands(projectDir string) error {
 		}
 		cwd := m.EffectiveCWD(t.Project)
 		fmt.Printf("# %d. %s - %s (session: %s, cwd: %s)\n", i+1, label, m.Binary, m.Session, cwd)
-		fmt.Println(emitTeamCommand(cwd, squadBin, m))
+		fmt.Println(emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap))
 		fmt.Println()
 	}
 	return nil
@@ -260,7 +261,7 @@ func uniqueMemberCWDs(projectDir string, members []team.Member) []string {
 	return out
 }
 
-func emitTeamCommand(cwd, squadBin string, m team.Member) string {
+func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap bool) string {
 	var b strings.Builder
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(cwd))
@@ -271,6 +272,13 @@ func emitTeamCommand(cwd, squadBin string, m team.Member) string {
 	b.WriteString(shellQuote(m.Role))
 	b.WriteString(" --session ")
 	b.WriteString(shellQuote(m.Session))
+	if teamHome != "" {
+		b.WriteString(" --team-home ")
+		b.WriteString(shellQuote(teamHome))
+	}
+	if noBootstrap {
+		b.WriteString(" --no-bootstrap")
+	}
 	if m.Handle != "" {
 		// Always explicit: a role-named handle avoids collisions when the
 		// same binary (e.g. codex) hosts multiple roles in one project.
@@ -511,7 +519,8 @@ func printTeamUsage() {
 Usage:
   amq-squad team                      Smart default: show commands, or init if none exists
   amq-squad team init [options]       Set up .amq-squad/team.json
-  amq-squad team show                 Print launch commands for configured team
+  amq-squad team show [--no-bootstrap]
+                                      Print launch commands for configured team
   amq-squad team rules init           Seed .amq-squad/team-rules.md with a stub
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -55,12 +55,13 @@ func TestEmitTeamCommandShape(t *testing.T) {
 		Handle:  "designer",
 		Session: "designer",
 	}
-	cmd := emitTeamCommand("/home/u/proj", "amq-squad", m)
+	cmd := emitTeamCommand("/home/u/proj", "amq-squad", "/home/u/proj", m, false)
 	for _, want := range []string{
 		"cd /home/u/proj",
 		"amq-squad launch",
 		"--role designer",
 		"--session designer",
+		"--team-home /home/u/proj",
 		"--me designer",
 		" claude",
 	} {
@@ -72,7 +73,7 @@ func TestEmitTeamCommandShape(t *testing.T) {
 
 func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 	m := team.Member{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"}
-	cmd := emitTeamCommand("/home/user/my project", "amq-squad", m)
+	cmd := emitTeamCommand("/home/user/my project", "amq-squad", "/home/user/my project", m, false)
 	if !strings.Contains(cmd, "'/home/user/my project'") {
 		t.Errorf("project path not quoted: %s", cmd)
 	}
@@ -80,9 +81,17 @@ func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 
 func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", m)
+	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", "/p", m, false)
 	if !strings.Contains(cmd, "/usr/local/bin/amq-squad launch") {
 		t.Errorf("expected absolute binary path in: %s", cmd)
+	}
+}
+
+func TestEmitTeamCommandNoBootstrap(t *testing.T) {
+	m := team.Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "qa"}
+	cmd := emitTeamCommand("/p", "amq-squad", "/team", m, true)
+	if !strings.Contains(cmd, "--no-bootstrap") {
+		t.Errorf("expected --no-bootstrap in: %s", cmd)
 	}
 }
 

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -30,6 +31,13 @@ type Record struct {
 	Role      string    `json:"role,omitempty"`
 	Root      string    `json:"root"`
 	StartedAt time.Time `json:"started_at"`
+}
+
+// Entry is a launch record plus the mailbox directory it was discovered in.
+type Entry struct {
+	Record   Record
+	AgentDir string
+	Source   string
 }
 
 // Write atomically writes the record into the agent's mailbox directory.
@@ -71,20 +79,20 @@ func Read(agentDir string) (Record, error) {
 	return rec, nil
 }
 
-// Scan walks a projectRoot for launch.json records across both AMQ layouts:
+// ScanEntries walks a projectRoot for launch.json records across both AMQ layouts:
 //
 //	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json  (coop exec)
 //	<projectRoot>/.agent-mail/agents/<handle>/launch.json            (base root, no session)
 //
 // Returns every record found. Order is whatever filepath.Glob returns;
 // callers that care about ordering should sort the result themselves.
-func Scan(projectRoot string) ([]Record, error) {
+func ScanEntries(projectRoot string) ([]Entry, error) {
 	patterns := []string{
 		filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*", FileName),
 		filepath.Join(projectRoot, ".agent-mail", "agents", "*", FileName),
 	}
 	seen := map[string]bool{}
-	var out []Record
+	var out []Entry
 	for _, p := range patterns {
 		matches, err := filepath.Glob(p)
 		if err != nil {
@@ -99,8 +107,226 @@ func Scan(projectRoot string) ([]Record, error) {
 			if err != nil {
 				continue
 			}
-			out = append(out, rec)
+			out = append(out, Entry{
+				Record:   rec,
+				AgentDir: filepath.Dir(m),
+				Source:   FileName,
+			})
 		}
+	}
+	return out, nil
+}
+
+// ScanRestorableEntries returns launch records plus best-effort records
+// inferred from older AMQ mailboxes that predate amq-squad launch.json.
+func ScanRestorableEntries(projectRoot string) ([]Entry, error) {
+	entries, err := ScanEntries(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		seen[e.AgentDir] = true
+	}
+
+	legacy, err := ScanLegacyEntries(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range legacy {
+		if seen[e.AgentDir] {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+// ScanLegacyEntries infers restorable launches from AMQ agent mailbox
+// directories that do not have launch.json. The binary is inferred from the
+// handle, which matches AMQ's default handle derivation for claude/codex.
+func ScanLegacyEntries(projectRoot string) ([]Entry, error) {
+	agentDirs, err := legacyAgentDirs(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	var out []Entry
+	for _, agentDir := range agentDirs {
+		if _, err := os.Stat(filepath.Join(agentDir, FileName)); err == nil {
+			continue
+		}
+		if !hasLegacyActivity(agentDir) {
+			continue
+		}
+		rec, err := legacyRecord(projectRoot, agentDir)
+		if err != nil {
+			continue
+		}
+		out = append(out, Entry{
+			Record:   rec,
+			AgentDir: agentDir,
+			Source:   "amq history",
+		})
+	}
+	return out, nil
+}
+
+func legacyAgentDirs(projectRoot string) ([]string, error) {
+	patterns := []string{
+		filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*"),
+		filepath.Join(projectRoot, ".agent-mail", "agents", "*"),
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range patterns {
+		matches, err := filepath.Glob(p)
+		if err != nil {
+			return nil, fmt.Errorf("glob %s: %w", p, err)
+		}
+		for _, m := range matches {
+			info, err := os.Stat(m)
+			if err != nil || !info.IsDir() || seen[m] {
+				continue
+			}
+			seen[m] = true
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+func hasLegacyActivity(agentDir string) bool {
+	if _, err := os.Stat(filepath.Join(agentDir, "presence.json")); err == nil {
+		return true
+	}
+	for _, name := range []string{"inbox", "outbox", "acks", "receipts", "dlq"} {
+		if hasFiles(filepath.Join(agentDir, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFiles(root string) bool {
+	found := false
+	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		found = true
+		return filepath.SkipAll
+	})
+	return found
+}
+
+func legacyRecord(projectRoot, agentDir string) (Record, error) {
+	rootDir := filepath.Join(projectRoot, ".agent-mail")
+	rel, err := filepath.Rel(rootDir, agentDir)
+	if err != nil {
+		return Record{}, err
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 {
+		return Record{}, fmt.Errorf("invalid agent dir: %s", agentDir)
+	}
+
+	session := ""
+	root := rootDir
+	handle := filepath.Base(agentDir)
+	binary, ok := inferLegacyBinary(handle)
+	if !ok {
+		return Record{}, fmt.Errorf("cannot infer binary for legacy handle: %s", handle)
+	}
+	if parts[0] != "agents" {
+		session = parts[0]
+		root = filepath.Join(rootDir, session)
+	}
+
+	return Record{
+		CWD:       projectRoot,
+		Binary:    binary,
+		Session:   session,
+		Handle:    handle,
+		Role:      inferLegacyRole(handle),
+		Root:      root,
+		StartedAt: legacyActivityTime(agentDir),
+	}, nil
+}
+
+func inferLegacyBinary(handle string) (string, bool) {
+	switch handle {
+	case "claude", "codex":
+		return handle, true
+	default:
+		for _, binary := range []string{"claude", "codex"} {
+			if strings.HasPrefix(handle, binary+"-") {
+				return binary, true
+			}
+		}
+		return "", false
+	}
+}
+
+func inferLegacyRole(handle string) string {
+	for _, binary := range []string{"claude", "codex"} {
+		prefix := binary + "-"
+		if strings.HasPrefix(handle, prefix) {
+			return strings.TrimPrefix(handle, prefix)
+		}
+	}
+	return ""
+}
+
+func legacyActivityTime(agentDir string) time.Time {
+	if t, ok := readPresenceLastSeen(filepath.Join(agentDir, "presence.json")); ok {
+		return t
+	}
+	var latest time.Time
+	filepath.WalkDir(agentDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.ModTime().After(latest) {
+			latest = info.ModTime()
+		}
+		return nil
+	})
+	return latest
+}
+
+func readPresenceLastSeen(path string) (time.Time, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	var parsed struct {
+		LastSeen time.Time `json:"last_seen"`
+	}
+	if err := json.Unmarshal(b, &parsed); err != nil || parsed.LastSeen.IsZero() {
+		return time.Time{}, false
+	}
+	return parsed.LastSeen, true
+}
+
+// Scan walks a projectRoot for launch.json records across both AMQ layouts:
+//
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json  (coop exec)
+//	<projectRoot>/.agent-mail/agents/<handle>/launch.json            (base root, no session)
+//
+// Returns every record found. Order is whatever filepath.Glob returns;
+// callers that care about ordering should sort the result themselves.
+func Scan(projectRoot string) ([]Record, error) {
+	entries, err := ScanEntries(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Record, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Record)
 	}
 	return out, nil
 }

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -104,6 +104,167 @@ func TestScanFindsRecordsAcrossSessions(t *testing.T) {
 	}
 }
 
+func TestScanEntriesIncludesAgentDir(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".agent-mail", "stream1", "agents", "cto")
+	rec := Record{
+		CWD:       project,
+		Binary:    "codex",
+		Session:   "stream1",
+		Handle:    "cto",
+		Role:      "cto",
+		Root:      filepath.Join(project, ".agent-mail", "stream1"),
+		StartedAt: time.Now().UTC(),
+	}
+	if err := Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanEntries(project)
+	if err != nil {
+		t.Fatalf("ScanEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanEntries returned %d records, want 1", len(entries))
+	}
+	if entries[0].AgentDir != agentDir {
+		t.Errorf("AgentDir = %q, want %q", entries[0].AgentDir, agentDir)
+	}
+	if entries[0].Record.Handle != "cto" {
+		t.Errorf("Record.Handle = %q, want cto", entries[0].Record.Handle)
+	}
+}
+
+func TestScanLegacyEntriesFromPresence(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".agent-mail", "stream1", "agents", "claude")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lastSeen := "2026-04-25T05:48:47Z"
+	if err := os.WriteFile(filepath.Join(agentDir, "presence.json"), []byte(`{"last_seen":"`+lastSeen+`"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanLegacyEntries(project)
+	if err != nil {
+		t.Fatalf("ScanLegacyEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanLegacyEntries returned %d records, want 1", len(entries))
+	}
+	rec := entries[0].Record
+	if rec.CWD != project || rec.Binary != "claude" || rec.Handle != "claude" ||
+		rec.Session != "stream1" || rec.Root != filepath.Join(project, ".agent-mail", "stream1") {
+		t.Errorf("unexpected legacy record: %+v", rec)
+	}
+	if entries[0].Source != "amq history" {
+		t.Errorf("Source = %q, want amq history", entries[0].Source)
+	}
+	if got := rec.StartedAt.Format(time.RFC3339); got != lastSeen {
+		t.Errorf("StartedAt = %q, want %q", got, lastSeen)
+	}
+}
+
+func TestScanLegacyEntriesFromBaseRootHistory(t *testing.T) {
+	project := t.TempDir()
+	sentDir := filepath.Join(project, ".agent-mail", "agents", "codex", "outbox", "sent")
+	if err := os.MkdirAll(sentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sentDir, "message.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanLegacyEntries(project)
+	if err != nil {
+		t.Fatalf("ScanLegacyEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanLegacyEntries returned %d records, want 1", len(entries))
+	}
+	rec := entries[0].Record
+	if rec.Binary != "codex" || rec.Handle != "codex" || rec.Session != "" ||
+		rec.Root != filepath.Join(project, ".agent-mail") {
+		t.Errorf("unexpected base-root legacy record: %+v", rec)
+	}
+}
+
+func TestScanLegacyEntriesSkipsUnknownBinaryHandle(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".agent-mail", "stream1", "agents", "fullstack")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "presence.json"), []byte(`{"last_seen":"2026-04-25T05:48:47Z"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanLegacyEntries(project)
+	if err != nil {
+		t.Fatalf("ScanLegacyEntries: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ScanLegacyEntries returned %d records, want 0: %+v", len(entries), entries)
+	}
+}
+
+func TestScanLegacyEntriesInfersRoleFromBinaryPrefixedHandle(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".agent-mail", "stream1", "agents", "claude-qa")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	receiptDir := filepath.Join(agentDir, "receipts")
+	if err := os.MkdirAll(receiptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(receiptDir, "receipt.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanLegacyEntries(project)
+	if err != nil {
+		t.Fatalf("ScanLegacyEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanLegacyEntries returned %d records, want 1", len(entries))
+	}
+	rec := entries[0].Record
+	if rec.Binary != "claude" || rec.Handle != "claude-qa" || rec.Role != "qa" {
+		t.Errorf("unexpected inferred record: %+v", rec)
+	}
+}
+
+func TestScanRestorableEntriesDedupesLegacyWhenLaunchExists(t *testing.T) {
+	project := t.TempDir()
+	agentDir := filepath.Join(project, ".agent-mail", "stream1", "agents", "claude")
+	rec := Record{
+		CWD:     project,
+		Binary:  "claude",
+		Session: "stream1",
+		Handle:  "claude",
+		Root:    filepath.Join(project, ".agent-mail", "stream1"),
+	}
+	if err := Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "presence.json"), []byte(`{"last_seen":"2026-04-25T05:48:47Z"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanRestorableEntries(project)
+	if err != nil {
+		t.Fatalf("ScanRestorableEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanRestorableEntries returned %d records, want 1", len(entries))
+	}
+	if entries[0].Source != FileName {
+		t.Errorf("Source = %q, want %s", entries[0].Source, FileName)
+	}
+}
+
 func TestScanMatchesBaseRootLayout(t *testing.T) {
 	// Base-root agents (no session) live at .agent-mail/agents/<handle>,
 	// not under .agent-mail/<session>/agents/<handle>. Scan must find both.

--- a/skills/claude/amq-squad-team/SKILL.md
+++ b/skills/claude/amq-squad-team/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: amq-squad-team
+description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting roles, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa roles, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep
+argument-hint: "[team-home=current] [roles/cwds/history folders]"
+user-invocable: true
+trigger: /amq-squad-team
+---
+
+# AMQ Squad Team
+
+Create a fresh amq-squad team without accidentally reusing old live sessions. Use old AMQ mailboxes as context sources only unless the user explicitly asks to restore an old session.
+
+## Scope Defaults
+
+- Default team-home is the current working directory.
+- Default history scope is the current working directory only.
+- Do not inspect or configure other repositories just because they appeared in prior conversation.
+- Expand scope only when the user explicitly names folders, projects, member cwd mappings, or history sources.
+- If the requested team spans folders, treat the first named primary project as team-home unless the user says otherwise.
+- If scope is ambiguous and acting on the wrong repo could write files, ask for the team-home path before running `team init`.
+
+Supported user inputs:
+
+- `team-home`: one project directory that owns `.amq-squad/team.json` and `.amq-squad/team-rules.md`.
+- `member cwd`: per-role working directories, emitted as `--cwd role=/path`.
+- `history folders`: one or more project directories to inspect with `amq-squad list` and mention in team rules.
+
+## Workflow
+
+1. Choose the team-home directory.
+   - Default to the current working directory.
+   - Prefer the project where most agents will work only when the user explicitly names several projects.
+   - Use `--cwd role=/path/to/project` for members that work elsewhere.
+   - Verify `.amqrc` peer config if members span projects.
+
+2. Discover local history.
+   - Run `amq-squad list` in the current directory by default.
+   - Also run it in explicitly named history folders.
+   - Treat `SOURCE=amq-squad` as exact launch history.
+   - Treat `SOURCE=amq` as legacy AMQ mailbox history. It can show session, handle, and inferred role, but may not know role, args, or persona.
+   - Do not run `amq-squad restore --exec` for a fresh team.
+
+3. Create or update the team.
+   - Use built-in role IDs when possible: `cpo`, `cto`, `fullstack`, `qa`, `pm`, `designer`.
+   - Model backend/dev as `fullstack` unless the user wants a custom manual launch.
+   - Use fresh session names such as `fresh-cpo`, `fresh-cto`, `fresh-backend`, `fresh-qa`.
+
+4. Generate team rules.
+   - Run `amq-squad team rules init` if `.amq-squad/team-rules.md` does not exist.
+   - Write a concise rules file tailored to the requested team.
+   - Include a startup-context section that names the old AMQ sessions to inspect.
+   - Preserve existing user rules unless the user asks to replace them.
+   - Use `references/team-rules-template.md` as the starting template.
+
+5. Sync only if requested or clearly desired.
+   - `amq-squad team sync --apply` writes the managed block into `CLAUDE.md` and `AGENTS.md` in each member cwd.
+   - If the user does not want sync, tell them to paste the startup context manually into each fresh agent.
+
+6. Print fresh launch commands.
+   - Run `amq-squad team show`.
+   - Tell the user to paste one command into each terminal pane or tab.
+
+## Command Pattern
+
+For a four-agent team with CPO, CTO, backend/dev, and QA in a second project:
+
+```sh
+cd /path/to/team-home
+
+amq-squad team init --force \
+  --roles cpo,cto,fullstack,qa \
+  --binary cpo=codex,cto=codex,fullstack=claude,qa=claude \
+  --session cpo=fresh-cpo,cto=fresh-cto,fullstack=fresh-backend,qa=fresh-qa \
+  --cwd qa=/path/to/qa-project
+
+amq-squad team rules init
+# edit .amq-squad/team-rules.md
+
+amq-squad team show
+```
+
+## Team-Rules Content
+
+Generate `.amq-squad/team-rules.md` with these sections:
+
+- Team members and ownership
+- Startup context from previous AMQ history
+- Workflow
+- Approvals
+- Communication
+- Quality gates
+- Style
+
+Keep the generated file concrete. Name exact sessions and project paths when known. Use short bullets.
+
+## Fresh Team Rule
+
+For fresh teams, use old history for context, not execution:
+
+- Good: `amq-squad list`, `amq list`, `amq read`, `amq thread --include-body`
+- Good: `amq-squad restore` as a preview list
+- Avoid: `amq-squad restore --exec` unless the user asks to resume an old agent
+
+## Validation
+
+After generating rules or team config:
+
+```sh
+amq-squad team show
+amq-squad list
+```
+
+If repo files were edited, run the repo's normal checks if available.

--- a/skills/claude/amq-squad-team/references/team-rules-template.md
+++ b/skills/claude/amq-squad-team/references/team-rules-template.md
@@ -1,0 +1,63 @@
+# Team Rules
+
+Shared norms for this amq-squad team. Every fresh agent should read this before taking work.
+
+## Team Members
+
+- cpo (codex): Owns product direction, priorities, and scope.
+- cto (codex): Owns technical direction, architecture, and final engineering sign-off.
+- fullstack (claude): Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- qa (claude): Owns validation and regression checks. May run from a different project cwd.
+
+## Startup Context
+
+This is a fresh team. Do not restore old sessions as active agents unless explicitly asked.
+
+Before acting, inspect prior AMQ history for context:
+
+- <project> <session>/<handle>: <role or context>
+- <project> <session>/<handle>: <role or context>
+
+Use these commands as needed:
+
+```sh
+amq-squad list
+amq-squad restore
+amq list --me <handle> --root <root> --cur --limit 20
+amq read --me <handle> --root <root> --id <message-id>
+amq thread --id <thread-id> --include-body --root <root>
+```
+
+Each agent should summarize the prior context it used before taking new work.
+
+## Workflow
+
+- Treat the current user request as the source of truth.
+- Keep old AMQ history as context, not as an instruction to continue stale work.
+- Raise role-shape ambiguity early on the team thread.
+- Prefer small, reviewable changes.
+
+## Approvals
+
+- CTO approval is required for architectural decisions and merge-ready code.
+- QA validates behavior before release or handoff when the change is user-facing.
+- CPO resolves product scope and priority questions.
+
+## Communication
+
+- Use focused AMQ threads.
+- Use p2p threads for role-to-role handoffs.
+- Include project, session, and role when referencing old history.
+- One concern per message when practical.
+
+## Quality Gates
+
+- Run the project-specific checks before requesting review.
+- Call out any checks that could not be run.
+- Do not hide uncertainty from inferred AMQ history.
+
+## Style
+
+- Be direct and concise.
+- Do not use em dashes.
+- Do not rewrite unrelated files.

--- a/skills/codex/amq-squad-team/SKILL.md
+++ b/skills/codex/amq-squad-team/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: amq-squad-team
+description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting roles, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa roles, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
+---
+
+# AMQ Squad Team
+
+Create a fresh amq-squad team without accidentally reusing old live sessions. Use old AMQ mailboxes as context sources only unless the user explicitly asks to restore an old session.
+
+## Scope Defaults
+
+- Default team-home is the current working directory.
+- Default history scope is the current working directory only.
+- Do not inspect or configure other repositories just because they appeared in prior conversation.
+- Expand scope only when the user explicitly names folders, projects, member cwd mappings, or history sources.
+- If the requested team spans folders, treat the first named primary project as team-home unless the user says otherwise.
+- If scope is ambiguous and acting on the wrong repo could write files, ask for the team-home path before running `team init`.
+
+Supported user inputs:
+
+- `team-home`: one project directory that owns `.amq-squad/team.json` and `.amq-squad/team-rules.md`.
+- `member cwd`: per-role working directories, emitted as `--cwd role=/path`.
+- `history folders`: one or more project directories to inspect with `amq-squad list` and mention in team rules.
+
+## Workflow
+
+1. Choose the team-home directory.
+   - Default to the current working directory.
+   - Prefer the project where most agents will work only when the user explicitly names several projects.
+   - Use `--cwd role=/path/to/project` for members that work elsewhere.
+   - Verify `.amqrc` peer config if members span projects.
+
+2. Discover local history.
+   - Run `amq-squad list` in the current directory by default.
+   - Also run it in explicitly named history folders.
+   - Treat `SOURCE=amq-squad` as exact launch history.
+   - Treat `SOURCE=amq` as legacy AMQ mailbox history. It can show session, handle, and inferred role, but may not know role, args, or persona.
+   - Do not run `amq-squad restore --exec` for a fresh team.
+
+3. Create or update the team.
+   - Use built-in role IDs when possible: `cpo`, `cto`, `fullstack`, `qa`, `pm`, `designer`.
+   - Model backend/dev as `fullstack` unless the user wants a custom manual launch.
+   - Use fresh session names such as `fresh-cpo`, `fresh-cto`, `fresh-backend`, `fresh-qa`.
+
+4. Generate team rules.
+   - Run `amq-squad team rules init` if `.amq-squad/team-rules.md` does not exist.
+   - Write a concise rules file tailored to the requested team.
+   - Include a startup-context section that names the old AMQ sessions to inspect.
+   - Preserve existing user rules unless the user asks to replace them.
+   - Use `references/team-rules-template.md` as the starting template.
+
+5. Sync only if requested or clearly desired.
+   - `amq-squad team sync --apply` writes the managed block into `CLAUDE.md` and `AGENTS.md` in each member cwd.
+   - If the user does not want sync, tell them to paste the startup context manually into each fresh agent.
+
+6. Print fresh launch commands.
+   - Run `amq-squad team show`.
+   - Tell the user to paste one command into each terminal pane or tab.
+
+## Command Pattern
+
+For a four-agent team with CPO, CTO, backend/dev, and QA in a second project:
+
+```sh
+cd /path/to/team-home
+
+amq-squad team init --force \
+  --roles cpo,cto,fullstack,qa \
+  --binary cpo=codex,cto=codex,fullstack=claude,qa=claude \
+  --session cpo=fresh-cpo,cto=fresh-cto,fullstack=fresh-backend,qa=fresh-qa \
+  --cwd qa=/path/to/qa-project
+
+amq-squad team rules init
+# edit .amq-squad/team-rules.md
+
+amq-squad team show
+```
+
+## Team-Rules Content
+
+Generate `.amq-squad/team-rules.md` with these sections:
+
+- Team members and ownership
+- Startup context from previous AMQ history
+- Workflow
+- Approvals
+- Communication
+- Quality gates
+- Style
+
+Keep the generated file concrete. Name exact sessions and project paths when known. Use short bullets.
+
+## Fresh Team Rule
+
+For fresh teams, use old history for context, not execution:
+
+- Good: `amq-squad list`, `amq list`, `amq read`, `amq thread --include-body`
+- Good: `amq-squad restore` as a preview list
+- Avoid: `amq-squad restore --exec` unless the user asks to resume an old agent
+
+## Validation
+
+After generating rules or team config:
+
+```sh
+amq-squad team show
+amq-squad list
+```
+
+If repo files were edited, run the repo's normal checks if available.

--- a/skills/codex/amq-squad-team/agents/openai.yaml
+++ b/skills/codex/amq-squad-team/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AMQ Squad Team"
+  short_description: "Bootstrap local amq-squad teams and rules"
+  default_prompt: "Use $amq-squad-team to create a fresh amq-squad team for this project and generate team-rules.md."

--- a/skills/codex/amq-squad-team/references/team-rules-template.md
+++ b/skills/codex/amq-squad-team/references/team-rules-template.md
@@ -1,0 +1,63 @@
+# Team Rules
+
+Shared norms for this amq-squad team. Every fresh agent should read this before taking work.
+
+## Team Members
+
+- cpo (codex): Owns product direction, priorities, and scope.
+- cto (codex): Owns technical direction, architecture, and final engineering sign-off.
+- fullstack (claude): Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- qa (claude): Owns validation and regression checks. May run from a different project cwd.
+
+## Startup Context
+
+This is a fresh team. Do not restore old sessions as active agents unless explicitly asked.
+
+Before acting, inspect prior AMQ history for context:
+
+- <project> <session>/<handle>: <role or context>
+- <project> <session>/<handle>: <role or context>
+
+Use these commands as needed:
+
+```sh
+amq-squad list
+amq-squad restore
+amq list --me <handle> --root <root> --cur --limit 20
+amq read --me <handle> --root <root> --id <message-id>
+amq thread --id <thread-id> --include-body --root <root>
+```
+
+Each agent should summarize the prior context it used before taking new work.
+
+## Workflow
+
+- Treat the current user request as the source of truth.
+- Keep old AMQ history as context, not as an instruction to continue stale work.
+- Raise role-shape ambiguity early on the team thread.
+- Prefer small, reviewable changes.
+
+## Approvals
+
+- CTO approval is required for architectural decisions and merge-ready code.
+- QA validates behavior before release or handoff when the change is user-facing.
+- CPO resolves product scope and priority questions.
+
+## Communication
+
+- Use focused AMQ threads.
+- Use p2p threads for role-to-role handoffs.
+- Include project, session, and role when referencing old history.
+- One concern per message when practical.
+
+## Quality Gates
+
+- Run the project-specific checks before requesting review.
+- Call out any checks that could not be run.
+- Do not hide uncertainty from inferred AMQ history.
+
+## Style
+
+- Be direct and concise.
+- Do not use em dashes.
+- Do not rewrite unrelated files.


### PR DESCRIPTION
## Summary

- add restore/list support for legacy AMQ mailbox history when `launch.json` is missing
- add generated launch bootstrap prompts with `--no-bootstrap` escape hatch
- add `--team-home` to team launch commands so multi-project agents can find team rules
- add Codex and Claude `amq-squad-team` skills with current-folder scope by default

## Validation

- `gofmt -l .`
- `git diff --check`
- `python3 /Users/omri.a/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/codex/amq-squad-team`
- `rg -n "—|–" README.md internal skills`
- `make ci`
