### PR TITLE
Release v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ amq-squad team init \
 
 `team show` emits a `cd <member-cwd>` per command so every agent boots in the right project. `team sync` walks each unique member cwd and syncs CLAUDE.md + AGENTS.md in all of them.
 
+Generated launch commands include low-friction agent defaults: Codex gets
+`--dangerously-bypass-approvals-and-sandbox`, and Claude gets
+`--permission-mode auto`. These defaults are passed through after `--` while
+the generated bootstrap prompt is still added at launch time.
+
+At launch time, each agent's bootstrap prompt includes a current team routing
+block generated from `.amq-squad/team.json`. That block is the live routing
+source of truth: role, handle, session, project, cwd, and the appropriate
+`amq send` shape from the agent's current project. Restorable AMQ history is
+still useful context, but it should not be used as the active roster when it
+conflicts with `team.json`.
+
 ## Built-in roles
 
 | ID          | Label                                | Default binary | Notable skills                      |
@@ -178,6 +190,14 @@ amq-squad team
 
 You'll get three commands, each with the correct `cd <member-cwd>` so every agent boots in the right repo. Open three panes and paste one per pane. QA's codex or claude will live in `project-b`'s mailbox tree; CTO and Fullstack in `project-a`'s. AMQ uses the `peers` config you set above to route messages across.
 
+The generated bootstrap for each role prints send commands relative to that
+role's project. For example, a `project-a` agent sending to QA in `project-b`
+will see a route shaped like:
+
+```
+amq send --to qa --project project-b --session qa
+```
+
 ## Commands
 
 ```
@@ -193,6 +213,8 @@ amq-squad launch --role <r> --session <s> --me <handle> [--no-bootstrap] <binary
                                     in the AMQ mailbox, adds a bootstrap prompt,
                                     then execs 'amq coop exec'.
                                     Usually called by the output of 'team show'.
+                                    'team show' passes Codex and Claude default
+                                    permission flags after '--'.
 
 amq-squad restore [--project dir1,dir2,...]
                                     Reconstruct launch commands from local

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -1,0 +1,28 @@
+package cli
+
+func defaultChildArgsForBinary(binary string) []string {
+	switch defaultHandleFor(binary) {
+	case "codex":
+		return []string{"--dangerously-bypass-approvals-and-sandbox"}
+	case "claude":
+		return []string{"--permission-mode", "auto"}
+	default:
+		return nil
+	}
+}
+
+func shouldAppendBootstrap(binary string, childArgs []string) bool {
+	if len(childArgs) == 0 {
+		return true
+	}
+	defaultArgs := defaultChildArgsForBinary(binary)
+	if len(childArgs) != len(defaultArgs) {
+		return false
+	}
+	for i := range childArgs {
+		if childArgs[i] != defaultArgs[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -3,14 +3,17 @@ package cli
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/role"
 	"github.com/omriariav/amq-squad/internal/rules"
+	"github.com/omriariav/amq-squad/internal/team"
 )
 
 //go:embed bootstrap.md
@@ -28,6 +31,18 @@ type bootstrapContext struct {
 	TeamRulesPath string
 	RolePath      string
 	LaunchPath    string
+	CurrentTeam   []bootstrapTeamMember
+}
+
+type bootstrapTeamMember struct {
+	Role    string
+	Handle  string
+	Binary  string
+	Session string
+	Project string
+	CWD     string
+	Route   string
+	You     bool
 }
 
 func buildBootstrapPrompt(ctx bootstrapContext) (string, error) {
@@ -68,5 +83,103 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 		TeamRulesPath: teamRulesPath,
 		RolePath:      role.Path(agentDir),
 		LaunchPath:    filepath.Join(agentDir, launch.FileName),
+		CurrentTeam:   bootstrapCurrentTeam(rec, teamHome),
+	}
+}
+
+func bootstrapCurrentTeam(rec launch.Record, teamHome string) []bootstrapTeamMember {
+	home := teamHome
+	if home == "" {
+		home = rec.CWD
+	}
+	t, err := team.Read(home)
+	if err != nil || len(t.Members) == 0 {
+		return nil
+	}
+
+	currentProject := projectNameForCWD(rec.CWD)
+	out := make([]bootstrapTeamMember, 0, len(t.Members))
+	for _, m := range t.Members {
+		cwd := m.EffectiveCWD(t.Project)
+		project := projectNameForCWD(cwd)
+		handle := memberHandle(m)
+		out = append(out, bootstrapTeamMember{
+			Role:    m.Role,
+			Handle:  handle,
+			Binary:  m.Binary,
+			Session: m.Session,
+			Project: project,
+			CWD:     cwd,
+			Route:   routeCommandFor(currentProject, project, handle, m.Session),
+			You:     sameLaunchTarget(rec, cwd, handle, m),
+		})
+	}
+	return out
+}
+
+func memberHandle(m team.Member) string {
+	if m.Handle != "" {
+		return m.Handle
+	}
+	if m.Role != "" {
+		return m.Role
+	}
+	return m.Binary
+}
+
+func sameLaunchTarget(rec launch.Record, cwd, handle string, m team.Member) bool {
+	return rec.Role == m.Role &&
+		rec.Handle == handle &&
+		rec.Session == m.Session &&
+		rec.CWD == cwd
+}
+
+func routeCommandFor(currentProject, targetProject, handle, session string) string {
+	args := []string{"amq", "send", "--to", handle}
+	if currentProject != "" && targetProject != "" && currentProject != targetProject {
+		args = append(args, "--project", targetProject)
+	}
+	if session != "" {
+		args = append(args, "--session", session)
+	}
+	for i, arg := range args {
+		args[i] = shellQuote(arg)
+	}
+	return strings.Join(args, " ")
+}
+
+func projectNameForCWD(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	if dir, name := findProjectName(cwd); name != "" {
+		return name
+	} else if dir != "" {
+		return filepath.Base(dir)
+	}
+	return filepath.Base(cwd)
+}
+
+func findProjectName(start string) (string, string) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		dir = start
+	}
+	for {
+		path := filepath.Join(dir, ".amqrc")
+		if b, err := os.ReadFile(path); err == nil {
+			var cfg struct {
+				Project string `json:"project"`
+			}
+			if json.Unmarshal(b, &cfg) == nil && cfg.Project != "" {
+				return dir, cfg.Project
+			}
+			return dir, ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", ""
+		}
+		dir = parent
 	}
 }

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -16,9 +16,19 @@ Startup files:
 - Role file: {{.RolePath}}
 - Launch record: {{.LaunchPath}}
 
+{{- if .CurrentTeam }}
+Current team routing:
+These entries come from the current `.amq-squad/team.json` and are authoritative for live routing. Treat `amq-squad list` and `amq-squad restore` output as history only unless the user explicitly asks to resume an old session.
+{{- range .CurrentTeam }}
+- {{.Role}}{{if .You}} (you){{end}}: handle {{.Handle}}, binary {{.Binary}}, session {{orDefault .Session "(default)"}}, project {{.Project}}, cwd {{.CWD}}
+  send: `{{.Route}}`
+{{- end }}
+
+{{- end }}
 First steps:
 1. Read the startup files that exist.
-2. Inspect prior AMQ history relevant to your role using `amq-squad list`, `amq-squad restore`, `amq list`, `amq read`, and `amq thread --include-body` as needed.
-3. Do not resume old sessions as active work unless the user explicitly asks.
-4. Summarize your role, relevant prior context, and what you are waiting for.
-5. Stop and wait for instructions.
+2. Use the current team routing above for live messages and handoffs.
+3. Inspect prior AMQ history relevant to your role using `amq-squad list`, `amq-squad restore`, `amq list`, `amq read`, and `amq thread --include-body` as needed.
+4. Do not resume old sessions or route work to historical agents unless the user explicitly asks.
+5. Summarize your role, relevant prior context, and what you are waiting for.
+6. Stop and wait for instructions.

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
 )
 
 func TestBuildBootstrapPrompt(t *testing.T) {
@@ -48,5 +53,84 @@ func TestBuildBootstrapPromptWithoutRules(t *testing.T) {
 	}
 	if !strings.Contains(got, "Role: (none)") {
 		t.Errorf("bootstrap prompt should default empty role:\n%s", got)
+	}
+}
+
+func TestBootstrapPromptIncludesCurrentTeamRouting(t *testing.T) {
+	teamHome := t.TempDir()
+	qaProject := t.TempDir()
+	if err := os.WriteFile(filepath.Join(teamHome, ".amqrc"), []byte(`{"root":".agent-mail","project":"pm-context"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qaProject, ".amqrc"), []byte(`{"root":".agent-mail","project":"omri-pm"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := team.Write(teamHome, team.Team{
+		Members: []team.Member{
+			{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "fresh-cpo"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "fresh-qa", CWD: qaProject},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	root := filepath.Join(teamHome, ".agent-mail", "fresh-cpo")
+	rec := launch.Record{
+		Role:    "cpo",
+		Handle:  "cpo",
+		Binary:  "codex",
+		Session: "fresh-cpo",
+		CWD:     teamHome,
+		Root:    root,
+	}
+	ctx := bootstrapContextFor(rec, filepath.Join(root, "agents", "cpo"), teamHome)
+	got, err := buildBootstrapPrompt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		"Current team routing:",
+		"from the current `.amq-squad/team.json`",
+		"- cpo (you): handle cpo, binary codex, session fresh-cpo, project pm-context",
+		"send: `amq send --to cpo --session fresh-cpo`",
+		"- qa: handle qa, binary claude, session fresh-qa, project omri-pm",
+		"send: `amq send --to qa --project omri-pm --session fresh-qa`",
+		"Do not resume old sessions or route work to historical agents unless the user explicitly asks.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bootstrap prompt missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestBootstrapCurrentTeamFallsBackToRoleWhenHandleMissing(t *testing.T) {
+	teamHome := t.TempDir()
+	if err := team.Write(teamHome, team.Team{
+		Members: []team.Member{
+			{Role: "qa", Binary: "claude", Session: "fresh-qa"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := launch.Record{Role: "cpo", Handle: "cpo", CWD: teamHome}
+	got := bootstrapCurrentTeam(rec, teamHome)
+	if len(got) != 1 {
+		t.Fatalf("bootstrapCurrentTeam returned %d members, want 1", len(got))
+	}
+	if got[0].Handle != "qa" {
+		t.Fatalf("Handle = %q, want role fallback qa", got[0].Handle)
+	}
+	if got[0].Route != "amq send --to qa --session fresh-qa" {
+		t.Fatalf("Route = %q", got[0].Route)
+	}
+}
+
+func TestRouteCommandQuotesUnsafeValues(t *testing.T) {
+	got := routeCommandFor("project-a", "project b", "qa lead", "fresh qa")
+	want := "amq send --to 'qa lead' --project 'project b' --session 'fresh qa'"
+	if got != want {
+		t.Fatalf("routeCommandFor = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -47,7 +47,7 @@ Side effects before exec:
   2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
   3. Writes a role.md stub if one does not already exist.
   4. Adds a generated bootstrap prompt unless --no-bootstrap is set or
-     explicit binary args were provided.
+     non-default binary args were provided.
   5. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
 With --dry-run, none of the above run: the resolved coop exec command is
@@ -100,8 +100,8 @@ printed and amq-squad exits. Disk state is untouched.
 
 	// Keep generated bootstrap out of launch.json so restore stays compact
 	// and does not replay stale startup text.
-	effectiveChildArgs := childArgs
-	if !*noBootstrap && len(childArgs) == 0 {
+	effectiveChildArgs := append([]string(nil), childArgs...)
+	if !*noBootstrap && shouldAppendBootstrap(binary, childArgs) {
 		prompt, err := buildBootstrapPrompt(bootstrapContextFor(rec, agentDir, *teamHome))
 		if err != nil {
 			return err

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -287,6 +287,13 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 	}
 	b.WriteString(" ")
 	b.WriteString(shellQuote(m.Binary))
+	if defaultArgs := defaultChildArgsForBinary(m.Binary); len(defaultArgs) > 0 {
+		b.WriteString(" --")
+		for _, arg := range defaultArgs {
+			b.WriteString(" ")
+			b.WriteString(shellQuote(arg))
+		}
+	}
 	return b.String()
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -64,10 +64,19 @@ func TestEmitTeamCommandShape(t *testing.T) {
 		"--team-home /home/u/proj",
 		"--me designer",
 		" claude",
+		"-- --permission-mode auto",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
 		}
+	}
+}
+
+func TestEmitTeamCommandAddsCodexDefaultArgs(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
+	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false)
+	if !strings.Contains(cmd, "-- --dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("expected codex default args in: %s", cmd)
 	}
 }
 
@@ -92,6 +101,26 @@ func TestEmitTeamCommandNoBootstrap(t *testing.T) {
 	cmd := emitTeamCommand("/p", "amq-squad", "/team", m, true)
 	if !strings.Contains(cmd, "--no-bootstrap") {
 		t.Errorf("expected --no-bootstrap in: %s", cmd)
+	}
+}
+
+func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
+	cases := []struct {
+		name      string
+		binary    string
+		childArgs []string
+		want      bool
+	}{
+		{name: "empty args", binary: "codex", want: true},
+		{name: "codex defaults", binary: "codex", childArgs: []string{"--dangerously-bypass-approvals-and-sandbox"}, want: true},
+		{name: "claude defaults", binary: "claude", childArgs: []string{"--permission-mode", "auto"}, want: true},
+		{name: "non-default args", binary: "claude", childArgs: []string{"--resume", "abc"}, want: false},
+		{name: "defaults plus custom args", binary: "codex", childArgs: []string{"--dangerously-bypass-approvals-and-sandbox", "--foo"}, want: false},
+	}
+	for _, tc := range cases {
+		if got := shouldAppendBootstrap(tc.binary, tc.childArgs); got != tc.want {
+			t.Errorf("%s: shouldAppendBootstrap(%q, %v) = %v, want %v", tc.name, tc.binary, tc.childArgs, got, tc.want)
+		}
 	}
 }
 

--- a/skills/claude/amq-squad-team/SKILL.md
+++ b/skills/claude/amq-squad-team/SKILL.md
@@ -49,7 +49,9 @@ Supported user inputs:
 4. Generate team rules.
    - Run `amq-squad team rules init` if `.amq-squad/team-rules.md` does not exist.
    - Write a concise rules file tailored to the requested team.
+   - Include exact active routes from `.amq-squad/team.json`: role, handle, session, project, and member cwd.
    - Include a startup-context section that names the old AMQ sessions to inspect.
+   - State that old AMQ history is context only and must not override the active roster.
    - Preserve existing user rules unless the user asks to replace them.
    - Use `references/team-rules-template.md` as the starting template.
 
@@ -59,6 +61,7 @@ Supported user inputs:
 
 6. Print fresh launch commands.
    - Run `amq-squad team show`.
+   - Expect generated commands to include Codex `--dangerously-bypass-approvals-and-sandbox` and Claude `--permission-mode auto` after `--`.
    - Tell the user to paste one command into each terminal pane or tab.
 
 ## Command Pattern
@@ -84,7 +87,7 @@ amq-squad team show
 
 Generate `.amq-squad/team-rules.md` with these sections:
 
-- Team members and ownership
+- Team members, ownership, and exact active routes
 - Startup context from previous AMQ history
 - Workflow
 - Approvals
@@ -101,6 +104,7 @@ For fresh teams, use old history for context, not execution:
 - Good: `amq-squad list`, `amq list`, `amq read`, `amq thread --include-body`
 - Good: `amq-squad restore` as a preview list
 - Avoid: `amq-squad restore --exec` unless the user asks to resume an old agent
+- Avoid: sending new work to a restorable legacy handle when `team.json` names a different current handle/session for that role
 
 ## Validation
 

--- a/skills/claude/amq-squad-team/references/team-rules-template.md
+++ b/skills/claude/amq-squad-team/references/team-rules-template.md
@@ -4,10 +4,14 @@ Shared norms for this amq-squad team. Every fresh agent should read this before 
 
 ## Team Members
 
-- cpo (codex): Owns product direction, priorities, and scope.
-- cto (codex): Owns technical direction, architecture, and final engineering sign-off.
-- fullstack (claude): Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
-- qa (claude): Owns validation and regression checks. May run from a different project cwd.
+- cpo (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns product direction, priorities, and scope.
+- cto (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns technical direction, architecture, and final engineering sign-off.
+- fullstack (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- qa (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns validation and regression checks. May run from a different project cwd.
+
+The current `.amq-squad/team.json` roster is authoritative for live routing.
+Use old AMQ history only as context. Do not route new work to an inferred or
+restorable legacy handle when it conflicts with the current roster.
 
 ## Startup Context
 
@@ -47,6 +51,7 @@ Each agent should summarize the prior context it used before taking new work.
 
 - Use focused AMQ threads.
 - Use p2p threads for role-to-role handoffs.
+- Route messages by the current roster's handle, project, and session.
 - Include project, session, and role when referencing old history.
 - One concern per message when practical.
 

--- a/skills/codex/amq-squad-team/SKILL.md
+++ b/skills/codex/amq-squad-team/SKILL.md
@@ -45,7 +45,9 @@ Supported user inputs:
 4. Generate team rules.
    - Run `amq-squad team rules init` if `.amq-squad/team-rules.md` does not exist.
    - Write a concise rules file tailored to the requested team.
+   - Include exact active routes from `.amq-squad/team.json`: role, handle, session, project, and member cwd.
    - Include a startup-context section that names the old AMQ sessions to inspect.
+   - State that old AMQ history is context only and must not override the active roster.
    - Preserve existing user rules unless the user asks to replace them.
    - Use `references/team-rules-template.md` as the starting template.
 
@@ -55,6 +57,7 @@ Supported user inputs:
 
 6. Print fresh launch commands.
    - Run `amq-squad team show`.
+   - Expect generated commands to include Codex `--dangerously-bypass-approvals-and-sandbox` and Claude `--permission-mode auto` after `--`.
    - Tell the user to paste one command into each terminal pane or tab.
 
 ## Command Pattern
@@ -80,7 +83,7 @@ amq-squad team show
 
 Generate `.amq-squad/team-rules.md` with these sections:
 
-- Team members and ownership
+- Team members, ownership, and exact active routes
 - Startup context from previous AMQ history
 - Workflow
 - Approvals
@@ -97,6 +100,7 @@ For fresh teams, use old history for context, not execution:
 - Good: `amq-squad list`, `amq list`, `amq read`, `amq thread --include-body`
 - Good: `amq-squad restore` as a preview list
 - Avoid: `amq-squad restore --exec` unless the user asks to resume an old agent
+- Avoid: sending new work to a restorable legacy handle when `team.json` names a different current handle/session for that role
 
 ## Validation
 

--- a/skills/codex/amq-squad-team/references/team-rules-template.md
+++ b/skills/codex/amq-squad-team/references/team-rules-template.md
@@ -4,10 +4,14 @@ Shared norms for this amq-squad team. Every fresh agent should read this before 
 
 ## Team Members
 
-- cpo (codex): Owns product direction, priorities, and scope.
-- cto (codex): Owns technical direction, architecture, and final engineering sign-off.
-- fullstack (claude): Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
-- qa (claude): Owns validation and regression checks. May run from a different project cwd.
+- cpo (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns product direction, priorities, and scope.
+- cto (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns technical direction, architecture, and final engineering sign-off.
+- fullstack (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- qa (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns validation and regression checks. May run from a different project cwd.
+
+The current `.amq-squad/team.json` roster is authoritative for live routing.
+Use old AMQ history only as context. Do not route new work to an inferred or
+restorable legacy handle when it conflicts with the current roster.
 
 ## Startup Context
 
@@ -47,6 +51,7 @@ Each agent should summarize the prior context it used before taking new work.
 
 - Use focused AMQ threads.
 - Use p2p threads for role-to-role handoffs.
+- Route messages by the current roster's handle, project, and session.
 - Include project, session, and role when referencing old history.
 - One concern per message when practical.
 


### PR DESCRIPTION
## Summary
- add current team routing to the generated bootstrap prompt
- add Codex and Claude default permission flags to generated launch commands
- document the routing and launch defaults in README and bundled skills

## Verification
- go test ./...
- make ci
- git diff --check
- make build VERSION=v0.2.2
- ./amq-squad --version
- team show and launch --dry-run smoke checks