### PR TITLE
Clarify README setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Role-aware agent team launcher built on top of [AMQ](https://github.com/avivsinai/agent-message-queue).
 
-AMQ owns messaging between agents. `amq-squad` owns the layer above: who is in the team, what role each agent plays, and how to bring the whole squad back up after a restart.
+AMQ owns messaging between agents. `amq-squad` owns the layer above: who is in
+the team, what role each agent plays, and how to bring the whole squad back up
+after a restart.
 
 ## Why
 
@@ -13,56 +15,92 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 - What slash commands or skills that role leans on
 - Which peers a given agent actively talks to
 
-`amq-squad` captures this at team-setup time (`.amq-squad/team.json`) and per-agent at launch time (`launch.json` + `role.md` inside the AMQ mailbox). AMQ itself stays unchanged.
+`amq-squad` captures this at team-setup time (`.amq-squad/team.json`) and
+per-agent at launch time (`launch.json` + `role.md` inside the AMQ mailbox).
+AMQ itself stays unchanged.
 
 ## Install
 
-```
-go install github.com/omriariav/amq-squad/cmd/amq-squad@latest
+```sh
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.2.2
 ```
 
-Requires Go 1.25+ and the `amq` binary in `PATH` (v0.32+). Installing to `$GOBIN` (or `$HOME/go/bin`) is enough; the launch commands `team show` emits use the absolute path to whichever `amq-squad` binary is running, so nothing else needs to be on `PATH`.
+Use `@latest` if you intentionally want the newest published tag.
+
+Requires Go 1.25+ and the `amq` binary in `PATH` (v0.32+). Installing to
+`$GOBIN` (or `$HOME/go/bin`) is enough; the launch commands `team show` emits
+use the absolute path to whichever `amq-squad` binary is running, so nothing
+else needs to be on `PATH`.
 
 ## Quick start
 
-```
+```sh
 cd ~/Code/my-project
-amq coop init          # one time, sets up .amqrc and .agent-mail/
-amq-squad team         # pick roles, writes .amq-squad/team.json, prints launch commands
+amq-squad team
 ```
 
-First time: you're prompted to pick which of the built-in roles should be on the team. A `.amq-squad/team.json` is written. Every subsequent run prints the launch commands, one per role. Paste each into its own terminal tab.
+First run: pick roles. `amq-squad` writes `.amq-squad/team.json` and prints
+launch commands. Later runs print the same launch commands without asking
+again. Paste one command into each terminal pane or tab.
+
+You do not need to run `amq coop init` for the normal single-project flow.
+Generated launch commands include `--session`, and AMQ creates the needed
+mailbox directories on first launch. Use `amq coop init` or a hand-written
+`.amqrc` only when you want a custom root, explicit project name, or
+cross-project peer routing.
 
 Non-interactive setup:
 
-```
+```sh
 amq-squad team init --roles cpo,cto,fullstack,qa,pm,designer
 ```
 
 With per-role overrides:
 
-```
+```sh
 amq-squad team init \
   --roles cpo,fullstack,qa \
   --binary fullstack=codex \
   --session cpo=stream1,fullstack=stream2,qa=stream3
 ```
 
-Members don't have to share a working directory. The dir where you run `team init` becomes the team-home (where team.json and team-rules.md live); individual members can live in other projects:
+Members don't have to share a working directory. The dir where you run
+`team init` becomes the team-home (where team.json and team-rules.md live);
+individual members can live in other projects:
 
-```
+```sh
 cd ~/Code/project-a
 amq-squad team init \
   --roles cpo,cto,fullstack,qa \
   --cwd qa=~/Code/project-b
 ```
 
-`team show` emits a `cd <member-cwd>` per command so every agent boots in the right project. `team sync` walks each unique member cwd and syncs CLAUDE.md + AGENTS.md in all of them.
+`team show` emits a `cd <member-cwd>` per command so every agent boots in the
+right project. `team sync` walks each unique member cwd and syncs CLAUDE.md +
+AGENTS.md in all of them.
 
-Generated launch commands include low-friction agent defaults: Codex gets
+Generated launch commands include these agent defaults: Codex gets
 `--dangerously-bypass-approvals-and-sandbox`, and Claude gets
 `--permission-mode auto`. These defaults are passed through after `--` while
 the generated bootstrap prompt is still added at launch time.
+
+Representative generated commands look like this:
+
+```sh
+cd ~/Code/my-project && /path/to/amq-squad launch \
+  --role cto \
+  --session cto \
+  --team-home /Users/you/Code/my-project \
+  --me cto \
+  codex -- --dangerously-bypass-approvals-and-sandbox
+
+cd ~/Code/my-project && /path/to/amq-squad launch \
+  --role fullstack \
+  --session fullstack \
+  --team-home /Users/you/Code/my-project \
+  --me fullstack \
+  claude -- --permission-mode auto
+```
 
 At launch time, each agent's bootstrap prompt includes a current team routing
 block generated from `.amq-squad/team.json`. That block is the live routing
@@ -82,25 +120,32 @@ conflicts with `team.json`.
 | `pm`        | Project Manager / Product Owner      | claude         |                                     |
 | `designer`  | Product Designer                     | claude         | `/frontend-design`, `/canvas-design`|
 
-Defaults are starting points. Override binary or session per role via flags at `team init` time, or edit `.amq-squad/team.json` directly.
+Defaults are starting points. Override binary or session per role via flags at
+`team init` time, or edit `.amq-squad/team.json` directly.
 
 ## Shared team rules
 
-Team-wide norms ("every change ships via a PR", "CTO approves before merge") live in a single file:
+Team-wide norms ("every change ships via a PR", "CTO approves before merge")
+live in a single file:
 
-```
+```text
 .amq-squad/team-rules.md
 ```
 
-Claude reads `CLAUDE.md`, Codex reads `AGENTS.md`. Rather than maintaining both by hand, you edit `team-rules.md` and `amq-squad team sync` pushes the content into a managed block in both files. Everything outside the markers is yours and stays untouched.
+Claude reads `CLAUDE.md`, Codex reads `AGENTS.md`. Rather than maintaining
+both by hand, you edit `team-rules.md` and `amq-squad team sync` pushes the
+content into a managed block in both files. Everything outside the markers is
+yours and stays untouched.
 
-```
+```text
 amq-squad team rules init        Seed .amq-squad/team-rules.md with a stub
 amq-squad team sync              Preview what would change (exit 1 if drift)
 amq-squad team sync --apply      Write the managed block into CLAUDE.md and AGENTS.md
 ```
 
-On first `--apply` with an existing CLAUDE.md, your content is adopted as the user region and the managed block is appended. Subsequent syncs only refresh the managed block.
+On first `--apply` with an existing CLAUDE.md, your content is adopted as the
+user region and the managed block is appended. Subsequent syncs only refresh
+the managed block.
 
 ## Walkthroughs
 
@@ -108,40 +153,51 @@ On first `--apply` with an existing CLAUDE.md, your content is adopted as the us
 
 Two agents in one repo: CTO on codex, Fullstack on claude.
 
-```
+```sh
 cd ~/Code/my-project
-amq coop init                              # one time; writes .amqrc and .agent-mail/
 amq-squad team init --roles cto,fullstack  # writes .amq-squad/team.json
 amq-squad team rules init                  # seeds .amq-squad/team-rules.md
 ```
 
-Open `.amq-squad/team-rules.md` and replace the TODO sections with your team's actual workflow, approvals, and communication norms. Then push the managed block into the doc files each binary reads:
+Open `.amq-squad/team-rules.md` and replace the template sections with your
+team's actual workflow, approvals, and communication norms. Then push the
+managed block into the doc files each binary reads:
 
-```
+```sh
 amq-squad team sync          # preview (exit 1 if anything would change)
 amq-squad team sync --apply  # writes the managed block into CLAUDE.md and AGENTS.md
 ```
 
 Print the launch commands:
 
-```
+```sh
 amq-squad team
 ```
 
-You'll get two commands, one per role. Open an iTerm2 window (⌘N) and split (⌘D), paste one command per pane. Each agent boots through `amq-squad launch`, which writes `launch.json` + a catalog-seeded `role.md` into the mailbox before handing off to `amq coop exec`. From there both agents share the thread `p2p/cto__fullstack` for design escalations and review handoffs.
+You'll get two commands, one per role. Open separate terminal panes or tabs and
+paste one command per pane. Each agent boots through `amq-squad launch`, which
+writes `launch.json` + a catalog-seeded `role.md` into the mailbox before
+handing off to `amq coop exec`. From there both agents share the thread
+`p2p/cto__fullstack` for design escalations and review handoffs.
 
 ### Squad spanning two projects
 
-One team, members in two repos: CTO and Fullstack in `project-a`, QA in `project-b`. The team-home (`team.json` + `team-rules.md`) lives in `project-a`.
+One team, members in two repos: CTO and Fullstack in `project-a`, QA in
+`project-b`. The team-home (`team.json` + `team-rules.md`) lives in
+`project-a`.
 
-Initialize AMQ in each project so the mailbox trees exist:
+Create AMQ project config in each project so cross-project peers have stable
+project names. `amq coop init` is the easiest way to create the starter
+`.amqrc` files:
 
-```
+```sh
 (cd ~/Code/project-a && amq coop init)
 (cd ~/Code/project-b && amq coop init)
 ```
 
-For cross-project messages to route, each project's `.amqrc` needs a `peers` entry pointing at the other project's `.agent-mail/`. Edit `~/Code/project-a/.amqrc`:
+For cross-project messages to route, each project's `.amqrc` needs a `peers`
+entry pointing at the other project's `.agent-mail/`. Edit
+`~/Code/project-a/.amqrc`:
 
 ```json
 {
@@ -169,38 +225,43 @@ This peers step is manual today; see the **Known gaps** section below.
 
 Now pick the team from the team-home project:
 
-```
+```sh
 cd ~/Code/project-a
 amq-squad team init --roles cto,fullstack,qa --cwd qa=~/Code/project-b
 amq-squad team rules init
 ```
 
-Edit `~/Code/project-a/.amq-squad/team-rules.md`. Then sync. Because one member lives elsewhere, sync walks both cwds and writes CLAUDE.md + AGENTS.md in each:
+Edit `~/Code/project-a/.amq-squad/team-rules.md`. Then sync. Because one member
+lives elsewhere, sync walks both cwds and writes CLAUDE.md + AGENTS.md in each:
 
-```
+```sh
 amq-squad team sync --apply
 # Wrote 4 files: CLAUDE.md and AGENTS.md in project-a, same in project-b
 ```
 
 Print the launch commands:
 
-```
+```sh
 amq-squad team
 ```
 
-You'll get three commands, each with the correct `cd <member-cwd>` so every agent boots in the right repo. Open three panes and paste one per pane. QA's codex or claude will live in `project-b`'s mailbox tree; CTO and Fullstack in `project-a`'s. AMQ uses the `peers` config you set above to route messages across.
+You'll get three commands, each with the correct `cd <member-cwd>` so every
+agent boots in the right repo. Open three panes and paste one per pane. QA's
+codex or claude will live in `project-b`'s mailbox tree; CTO and Fullstack in
+`project-a`'s. AMQ uses the `peers` config you set above to route messages
+across.
 
 The generated bootstrap for each role prints send commands relative to that
 role's project. For example, a `project-a` agent sending to QA in `project-b`
 will see a route shaped like:
 
-```
+```sh
 amq send --to qa --project project-b --session qa
 ```
 
 ## Commands
 
-```
+```text
 amq-squad team                      Smart default: show commands, or init if none exists
 amq-squad team init [--roles ...]   Set up this project's team
 amq-squad team show [--no-bootstrap]
@@ -232,7 +293,7 @@ amq-squad list [--json]             List restorable amq-squad records and
 
 ## Files it writes
 
-```
+```text
 <project>/.amq-squad/team.json           Team intent: which roles are on this squad.
 <project>/.amq-squad/team-rules.md       Shared norms and workflow (user-edited).
 <project>/CLAUDE.md, AGENTS.md           Managed block synced from team-rules.md;
@@ -246,8 +307,14 @@ amq-squad list [--json]             List restorable amq-squad records and
 
 ## Known gaps
 
-- Sending a cross-session message from a setup terminal (outside any `amq coop exec`) has no clean idiom upstream. Tracked in [avivsinai/agent-message-queue#96](https://github.com/avivsinai/agent-message-queue/issues/96) with a proposed `--from-session` flag. Current workaround: boot your own session first, then send from inside it.
-- Multi-cwd teams still need manual `peers` config in each project's `.amqrc` for cross-project AMQ routing. `team sync` doesn't touch `.amqrc`; that's left to the user until we're sure of the shape.
+- Sending a cross-session message from a setup terminal (outside any
+  `amq coop exec`) has no clean idiom upstream. Tracked in
+  [avivsinai/agent-message-queue#96](https://github.com/avivsinai/agent-message-queue/issues/96)
+  with a proposed `--from-session` flag. Current workaround: boot your own
+  session first, then send from inside it.
+- Multi-cwd teams still need manual `peers` config in each project's `.amqrc`
+  for cross-project AMQ routing. `team sync` doesn't touch `.amqrc`; that's
+  left to the user until we're sure of the shape.
 
 ## Requires
 


### PR DESCRIPTION
## Summary
- remove amq coop init from the normal single-project setup path
- document when coop init is still useful for .amqrc and cross-project peers
- show v0.2.2 install and generated launch command defaults
- clean README code fences and line wrapping

## Verification
- git diff --check
- checked README for long lines and stale TODO/shortcut punctuation