### PR TITLE
Prepare amq-squad v0.3.0 persona market

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ cd ~/Code/my-project
 amq-squad team
 ```
 
-First run: pick personas, then choose which CLI runs each one. `amq-squad`
-writes `.amq-squad/team.json`, seeds `.amq-squad/team-rules.md`, and prints
-launch commands. Later runs print the same launch commands without asking
-again. Paste one command into each terminal pane or tab.
+First run: pick personas from the squad market, then choose which CLI runs
+each one. `amq-squad` writes `.amq-squad/team.json`, seeds
+`.amq-squad/team-rules.md`, and prints launch commands. Later runs print the
+same launch commands without asking again. Paste one command into each terminal
+pane or tab.
 
 You do not need to run `amq coop init` for the normal single-project flow.
 Generated launch commands include `--session`, and AMQ creates the needed
@@ -53,16 +54,16 @@ cross-project peer routing.
 Non-interactive setup:
 
 ```sh
-amq-squad team init --personas cpo,cto,fullstack,qa,pm,designer
+amq-squad team init --personas cpo,cto,senior-dev,frontend-dev,mobile-dev,qa,pm,designer
 ```
 
 With per-persona CLI overrides:
 
 ```sh
 amq-squad team init \
-  --personas cpo,fullstack,qa \
-  --binary fullstack=codex \
-  --session cpo=stream1,fullstack=stream2,qa=stream3
+  --personas cto,junior-dev,qa \
+  --binary junior-dev=codex,qa=claude \
+  --session cto=stream1,junior-dev=stream2,qa=stream3
 ```
 
 Members don't have to share a working directory. The dir where you run
@@ -112,14 +113,22 @@ conflicts with `team.json`.
 
 ## Built-in personas
 
-| ID          | Label                                | Default binary | Notable skills                      |
-|-------------|--------------------------------------|----------------|-------------------------------------|
-| `cpo`       | CPO                                  | codex          | `/product-strategy`                 |
-| `cto`       | CTO                                  | codex          |                                     |
-| `fullstack` | Fullstack Developer                  | claude         |                                     |
-| `qa`        | QA Manager                           | claude         |                                     |
-| `pm`        | Project Manager / Product Owner      | claude         |                                     |
-| `designer`  | Product Designer                     | claude         | `/frontend-design`, `/canvas-design`|
+Think of personas as employees in a small internal market. The persona is the
+job you are hiring for; the CLI is the tool that employee runs on.
+
+| ID             | Label                                | Default binary | Profile                                            |
+|----------------|--------------------------------------|----------------|----------------------------------------------------|
+| `cpo`          | CPO                                  | codex          | Product direction, scope pressure, user value.     |
+| `cto`          | CTO                                  | codex          | Architecture, tradeoffs, final technical review.   |
+| `senior-dev`   | Senior Developer                     | codex          | Takes harder code paths and reviews junior work.   |
+| `fullstack`    | Fullstack Developer                  | claude         | End-to-end feature builder across UI and backend.  |
+| `frontend-dev` | Frontend Developer                   | claude         | Product UI, components, state, browser polish.     |
+| `backend-dev`  | Backend Developer                    | codex          | APIs, data flow, services, integrations.           |
+| `mobile-dev`   | Mobile Developer                     | claude         | Native and mobile app flows, device polish.        |
+| `junior-dev`   | Junior Developer                     | codex          | Fast on scoped tasks, needs review before merge.   |
+| `qa`           | QA Manager                           | claude         | Regression thinking, release risk, test coverage.  |
+| `pm`           | Project Manager / Product Owner      | claude         | Keeps work ordered, unblocked, and shippable.      |
+| `designer`     | Product Designer                     | claude         | Product flows, visual shape, UI polish.            |
 
 Defaults are starting points. Override binary or session per persona via flags at
 `team init` time, or edit `.amq-squad/team.json` directly.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ cd ~/Code/my-project
 amq-squad team
 ```
 
-First run: pick roles. `amq-squad` writes `.amq-squad/team.json`, seeds
-`.amq-squad/team-rules.md`, and prints launch commands. Later runs print the
-same launch commands without asking again. Paste one command into each terminal
-pane or tab.
+First run: pick personas, then choose which CLI runs each one. `amq-squad`
+writes `.amq-squad/team.json`, seeds `.amq-squad/team-rules.md`, and prints
+launch commands. Later runs print the same launch commands without asking
+again. Paste one command into each terminal pane or tab.
 
 You do not need to run `amq coop init` for the normal single-project flow.
 Generated launch commands include `--session`, and AMQ creates the needed
@@ -53,14 +53,14 @@ cross-project peer routing.
 Non-interactive setup:
 
 ```sh
-amq-squad team init --roles cpo,cto,fullstack,qa,pm,designer
+amq-squad team init --personas cpo,cto,fullstack,qa,pm,designer
 ```
 
-With per-role overrides:
+With per-persona CLI overrides:
 
 ```sh
 amq-squad team init \
-  --roles cpo,fullstack,qa \
+  --personas cpo,fullstack,qa \
   --binary fullstack=codex \
   --session cpo=stream1,fullstack=stream2,qa=stream3
 ```
@@ -72,7 +72,7 @@ individual members can live in other projects:
 ```sh
 cd ~/Code/project-a
 amq-squad team init \
-  --roles cpo,cto,fullstack,qa \
+  --personas cpo,cto,fullstack,qa \
   --cwd qa=~/Code/project-b
 ```
 
@@ -110,7 +110,7 @@ source of truth: role, handle, session, project, cwd, and the appropriate
 still useful context, but it should not be used as the active roster when it
 conflicts with `team.json`.
 
-## Built-in roles
+## Built-in personas
 
 | ID          | Label                                | Default binary | Notable skills                      |
 |-------------|--------------------------------------|----------------|-------------------------------------|
@@ -121,7 +121,7 @@ conflicts with `team.json`.
 | `pm`        | Project Manager / Product Owner      | claude         |                                     |
 | `designer`  | Product Designer                     | claude         | `/frontend-design`, `/canvas-design`|
 
-Defaults are starting points. Override binary or session per role via flags at
+Defaults are starting points. Override binary or session per persona via flags at
 `team init` time, or edit `.amq-squad/team.json` directly.
 
 ## Shared team rules
@@ -156,7 +156,7 @@ Two agents in one repo: CTO on codex, Fullstack on claude.
 
 ```sh
 cd ~/Code/my-project
-amq-squad team init --roles cto,fullstack
+amq-squad team init --personas cto,fullstack
 ```
 
 Open `.amq-squad/team-rules.md` and replace the template sections with your
@@ -227,7 +227,7 @@ Now pick the team from the team-home project:
 
 ```sh
 cd ~/Code/project-a
-amq-squad team init --roles cto,fullstack,qa --cwd qa=~/Code/project-b
+amq-squad team init --personas cto,fullstack,qa --cwd qa=~/Code/project-b
 ```
 
 Edit `~/Code/project-a/.amq-squad/team-rules.md`. Then sync. Because one member
@@ -262,7 +262,8 @@ amq send --to qa --project project-b --session qa
 
 ```text
 amq-squad team                      Smart default: show commands, or init if none exists
-amq-squad team init [--roles ...]   Set up this project's team and rules stub
+amq-squad team init [--personas ...]
+                                    Pick personas, choose CLIs, and seed rules
 amq-squad team show [--no-bootstrap]
                                     Print launch commands for the configured team
 amq-squad team rules init           Seed missing .amq-squad/team-rules.md

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ cd ~/Code/my-project
 amq-squad team
 ```
 
-First run: pick roles. `amq-squad` writes `.amq-squad/team.json` and prints
-launch commands. Later runs print the same launch commands without asking
-again. Paste one command into each terminal pane or tab.
+First run: pick roles. `amq-squad` writes `.amq-squad/team.json`, seeds
+`.amq-squad/team-rules.md`, and prints launch commands. Later runs print the
+same launch commands without asking again. Paste one command into each terminal
+pane or tab.
 
 You do not need to run `amq coop init` for the normal single-project flow.
 Generated launch commands include `--session`, and AMQ creates the needed
@@ -138,7 +139,7 @@ content into a managed block in both files. Everything outside the markers is
 yours and stays untouched.
 
 ```text
-amq-squad team rules init        Seed .amq-squad/team-rules.md with a stub
+amq-squad team rules init        Seed missing .amq-squad/team-rules.md with a stub
 amq-squad team sync              Preview what would change (exit 1 if drift)
 amq-squad team sync --apply      Write the managed block into CLAUDE.md and AGENTS.md
 ```
@@ -155,8 +156,7 @@ Two agents in one repo: CTO on codex, Fullstack on claude.
 
 ```sh
 cd ~/Code/my-project
-amq-squad team init --roles cto,fullstack  # writes .amq-squad/team.json
-amq-squad team rules init                  # seeds .amq-squad/team-rules.md
+amq-squad team init --roles cto,fullstack
 ```
 
 Open `.amq-squad/team-rules.md` and replace the template sections with your
@@ -228,7 +228,6 @@ Now pick the team from the team-home project:
 ```sh
 cd ~/Code/project-a
 amq-squad team init --roles cto,fullstack,qa --cwd qa=~/Code/project-b
-amq-squad team rules init
 ```
 
 Edit `~/Code/project-a/.amq-squad/team-rules.md`. Then sync. Because one member
@@ -263,10 +262,10 @@ amq send --to qa --project project-b --session qa
 
 ```text
 amq-squad team                      Smart default: show commands, or init if none exists
-amq-squad team init [--roles ...]   Set up this project's team
+amq-squad team init [--roles ...]   Set up this project's team and rules stub
 amq-squad team show [--no-bootstrap]
                                     Print launch commands for the configured team
-amq-squad team rules init           Seed .amq-squad/team-rules.md
+amq-squad team rules init           Seed missing .amq-squad/team-rules.md
 amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
 
 amq-squad launch --role <r> --session <s> --me <handle> [--no-bootstrap] <binary> [-- <flags>]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.2.2
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.3.0
 ```
 
 Use `@latest` if you intentionally want the newest published tag.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,20 +1,22 @@
-// Package catalog is the built-in directory of role archetypes amq-squad
-// understands. It's intentionally small and Go-native so a new role is one
-// code change plus a rebuild, not a config file users have to discover.
+// Package catalog is the built-in directory of personas amq-squad understands.
+// It's intentionally small and Go-native so a new persona is one code change
+// plus a rebuild, not a config file users have to discover.
 package catalog
 
-// Role is one entry in the catalog. Field semantics:
+// Role is one persona entry in the catalog. Field semantics:
 //
 //	ID               short slug (also used as default handle and session name)
 //	Label            human title shown in listings and role.md
 //	PreferredBinary  "claude" or "codex", user can override at team init time
+//	Profile          short market-listing copy shown in interactive setup
 //	Description      one-line summary seeded into role.md
 //	Skills           slash commands worth invoking in this role's priming
-//	DefaultPeers     role IDs this archetype usually talks to (used by slice B)
+//	DefaultPeers     persona IDs this archetype usually talks to
 type Role struct {
 	ID              string
 	Label           string
 	PreferredBinary string
+	Profile         string
 	Description     string
 	Skills          []string
 	DefaultPeers    []string
@@ -25,6 +27,7 @@ var roles = []Role{
 		ID:              "cpo",
 		Label:           "CPO",
 		PreferredBinary: "codex",
+		Profile:         "Product direction, scope pressure, user value.",
 		Description:     "Owns product strategy, vision, and prioritization. Pushes back on scope and sharpens the why before the what.",
 		Skills:          []string{"/product-strategy"},
 		DefaultPeers:    []string{"cto", "pm", "designer"},
@@ -33,34 +36,79 @@ var roles = []Role{
 		ID:              "cto",
 		Label:           "CTO",
 		PreferredBinary: "codex",
+		Profile:         "Architecture, tradeoffs, final technical review.",
 		Description:     "Owns technical direction, architecture, and engineering tradeoffs. Signs off on the shape of the system.",
-		DefaultPeers:    []string{"cpo", "fullstack", "qa"},
+		DefaultPeers:    []string{"cpo", "senior-dev", "fullstack", "frontend-dev", "backend-dev", "mobile-dev", "junior-dev", "qa"},
+	},
+	{
+		ID:              "senior-dev",
+		Label:           "Senior Developer",
+		PreferredBinary: "codex",
+		Profile:         "Takes harder code paths and reviews junior work.",
+		Description:     "Owns complex implementation, code review, and technical mentorship. Turns architecture into maintainable changes.",
+		DefaultPeers:    []string{"cto", "junior-dev", "fullstack", "frontend-dev", "backend-dev", "mobile-dev", "qa"},
 	},
 	{
 		ID:              "fullstack",
 		Label:           "Fullstack Developer",
 		PreferredBinary: "claude",
+		Profile:         "End-to-end feature builder across UI and backend.",
 		Description:     "Implements features end to end across frontend and backend. Writes code that gets merged.",
-		DefaultPeers:    []string{"cto", "qa", "pm", "designer"},
+		DefaultPeers:    []string{"cto", "senior-dev", "frontend-dev", "backend-dev", "qa", "pm", "designer"},
+	},
+	{
+		ID:              "frontend-dev",
+		Label:           "Frontend Developer",
+		PreferredBinary: "claude",
+		Profile:         "Product UI, components, state, browser polish.",
+		Description:     "Builds and refines the browser product surface. Focuses on components, state, accessibility, and front-end quality.",
+		DefaultPeers:    []string{"designer", "pm", "fullstack", "backend-dev", "qa", "cto"},
+	},
+	{
+		ID:              "backend-dev",
+		Label:           "Backend Developer",
+		PreferredBinary: "codex",
+		Profile:         "APIs, data flow, services, integrations.",
+		Description:     "Builds backend behavior, APIs, persistence, and service integrations. Keeps data flow and operational boundaries clear.",
+		DefaultPeers:    []string{"cto", "fullstack", "frontend-dev", "qa", "pm"},
+	},
+	{
+		ID:              "mobile-dev",
+		Label:           "Mobile Developer",
+		PreferredBinary: "claude",
+		Profile:         "Native and mobile app flows, device polish.",
+		Description:     "Builds mobile app flows and platform-specific UX. Focuses on device behavior, responsiveness, and release-ready interaction.",
+		DefaultPeers:    []string{"designer", "pm", "backend-dev", "qa", "cto"},
+	},
+	{
+		ID:              "junior-dev",
+		Label:           "Junior Developer",
+		PreferredBinary: "codex",
+		Profile:         "Fast on scoped tasks, needs review before merge.",
+		Description:     "Moves quickly on well-scoped implementation tasks. Needs senior or CTO review before changes are considered ready.",
+		DefaultPeers:    []string{"senior-dev", "cto", "qa", "fullstack"},
 	},
 	{
 		ID:              "qa",
 		Label:           "QA Manager",
 		PreferredBinary: "claude",
+		Profile:         "Regression thinking, release risk, test coverage.",
 		Description:     "Owns test strategy, regression coverage, and release gating. Turns intent into verifiable checks.",
-		DefaultPeers:    []string{"fullstack", "cto", "pm"},
+		DefaultPeers:    []string{"junior-dev", "fullstack", "frontend-dev", "backend-dev", "mobile-dev", "senior-dev", "cto", "pm"},
 	},
 	{
 		ID:              "pm",
 		Label:           "Project Manager / Product Owner",
 		PreferredBinary: "claude",
+		Profile:         "Keeps work ordered, unblocked, and shippable.",
 		Description:     "Translates product strategy into ordered work. Tracks scope, unblocks, and keeps the team aligned on what ships next.",
-		DefaultPeers:    []string{"cpo", "fullstack", "qa", "designer"},
+		DefaultPeers:    []string{"cpo", "fullstack", "frontend-dev", "mobile-dev", "junior-dev", "qa", "designer"},
 	},
 	{
 		ID:              "designer",
 		Label:           "Product Designer",
 		PreferredBinary: "claude",
+		Profile:         "Product flows, visual shape, UI polish.",
 		Description:     "Designs the product surface. Produces UI components, flows, and visual assets, leaning on /frontend-design and /canvas-design.",
 		Skills:          []string{"/frontend-design", "/canvas-design"},
 		DefaultPeers:    []string{"cpo", "fullstack", "pm"},

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -31,6 +31,31 @@ func TestLookupKnownAndUnknown(t *testing.T) {
 	}
 }
 
+func TestMarketPersonas(t *testing.T) {
+	cases := map[string]struct {
+		label  string
+		binary string
+	}{
+		"senior-dev":   {label: "Senior Developer", binary: "codex"},
+		"frontend-dev": {label: "Frontend Developer", binary: "claude"},
+		"backend-dev":  {label: "Backend Developer", binary: "codex"},
+		"mobile-dev":   {label: "Mobile Developer", binary: "claude"},
+		"junior-dev":   {label: "Junior Developer", binary: "codex"},
+	}
+	for id, want := range cases {
+		got := Lookup(id)
+		if got == nil {
+			t.Fatalf("persona %s missing from catalog", id)
+		}
+		if got.Label != want.label || got.PreferredBinary != want.binary {
+			t.Errorf("persona %s = (%q, %q), want (%q, %q)", id, got.Label, got.PreferredBinary, want.label, want.binary)
+		}
+		if got.Profile == "" || got.Description == "" {
+			t.Errorf("persona %s should have profile and description", id)
+		}
+	}
+}
+
 func TestEveryRoleIsConsistent(t *testing.T) {
 	for _, r := range All() {
 		if r.ID == "" || r.Label == "" {

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -36,10 +36,13 @@ func TestEveryRoleIsConsistent(t *testing.T) {
 		if r.ID == "" || r.Label == "" {
 			t.Errorf("role %+v missing ID or Label", r)
 		}
+		if r.Profile == "" {
+			t.Errorf("role %s missing profile", r.ID)
+		}
 		if r.PreferredBinary != "claude" && r.PreferredBinary != "codex" {
 			t.Errorf("role %s has unexpected binary %q", r.ID, r.PreferredBinary)
 		}
-		// DefaultPeers must reference known role IDs so team show doesn't
+		// DefaultPeers must reference known persona IDs so team show doesn't
 		// emit stale role references.
 		for _, p := range r.DefaultPeers {
 			if Lookup(p) == nil {

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -11,6 +11,17 @@ func defaultChildArgsForBinary(binary string) []string {
 	}
 }
 
+func applyDefaultChildArgs(binary string, childArgs []string) []string {
+	if len(childArgs) > 0 {
+		return childArgs
+	}
+	defaultArgs := defaultChildArgsForBinary(binary)
+	if len(defaultArgs) == 0 {
+		return childArgs
+	}
+	return append([]string(nil), defaultArgs...)
+}
+
 func shouldAppendBootstrap(binary string, childArgs []string) bool {
 	if len(childArgs) == 0 {
 		return true

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -67,6 +67,7 @@ printed and amq-squad exits. Disk state is untouched.
 	if len(remaining) > 1 {
 		childArgs = append(remaining[1:], childArgs...)
 	}
+	childArgs = applyDefaultChildArgs(binary, childArgs)
 
 	handle := *me
 	if handle == "" {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -58,8 +59,9 @@ func runTeamSmart() error {
 
 func runTeamInit(args []string) error {
 	fs := flag.NewFlagSet("team init", flag.ContinueOnError)
-	rolesFlag := fs.String("roles", "", "comma-separated role IDs to include (skips interactive prompt)")
-	binaryFlag := fs.String("binary", "", "per-role binary overrides, e.g. qa=codex,pm=codex")
+	personasFlag := fs.String("personas", "", "comma-separated persona IDs to include (alias for --roles)")
+	rolesFlag := fs.String("roles", "", "comma-separated role/persona IDs to include (skips interactive prompt)")
+	binaryFlag := fs.String("binary", "", "per-persona CLI overrides, e.g. fullstack=codex,qa=claude")
 	sessionFlag := fs.String("session", "", "per-role session overrides, e.g. cpo=stream1,cto=stream2")
 	cwdFlag := fs.String("cwd", "", "per-role working directory overrides, e.g. qa=/path/to/sibling-project")
 	force := fs.Bool("force", false, "overwrite an existing team.json")
@@ -67,21 +69,26 @@ func runTeamInit(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
 
 Usage:
-  amq-squad team init [--roles id1,id2,...] [--binary role=bin,...] [--session role=name,...] [--force]
+  amq-squad team init [--personas id1,id2,...] [--binary persona=cli,...] [--session role=name,...] [--force]
+  amq-squad team init [--roles id1,id2,...] [--binary role=cli,...] [--session role=name,...] [--force]
 
-Without --roles, prompts interactively. Writes <cwd>/.amq-squad/team.json.
-Also seeds <cwd>/.amq-squad/team-rules.md if it does not already exist.
-The directory where this runs becomes the team-home. Members can live in other
+Without --personas or --roles, prompts interactively: first choose personas,
+then choose the CLI for each persona. Writes <cwd>/.amq-squad/team.json and
+seeds <cwd>/.amq-squad/team-rules.md if it does not already exist. The
+directory where this runs becomes the team-home. Members can live in other
 directories via --cwd role=/path.
 
-Known roles:
+Known personas:
 `)
 		for _, r := range catalog.All() {
-			fmt.Fprintf(os.Stderr, "  %-10s %s (default: %s)\n", r.ID, r.Label, r.PreferredBinary)
+			fmt.Fprintf(os.Stderr, "  %-10s %s (default CLI: %s)\n", r.ID, r.Label, r.PreferredBinary)
 		}
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if *rolesFlag != "" && *personasFlag != "" {
+		return fmt.Errorf("use either --personas or --roles, not both")
 	}
 
 	cwd, err := os.Getwd()
@@ -91,19 +98,6 @@ Known roles:
 
 	if team.Exists(cwd) && !*force {
 		return fmt.Errorf("team.json already exists at %s. Use --force to overwrite.", team.Path(cwd))
-	}
-
-	var picked []string
-	if *rolesFlag != "" {
-		picked = splitCSV(*rolesFlag)
-	} else {
-		picked, err = promptRoleSelection()
-		if err != nil {
-			return err
-		}
-	}
-	if len(picked) == 0 {
-		return fmt.Errorf("no roles selected, aborting")
 	}
 
 	binaryOverrides, err := parseKV(*binaryFlag)
@@ -117,6 +111,26 @@ Known roles:
 	cwdOverrides, err := parseKV(*cwdFlag)
 	if err != nil {
 		return fmt.Errorf("parse --cwd: %w", err)
+	}
+
+	var picked []string
+	interactive := *rolesFlag == "" && *personasFlag == ""
+	if *personasFlag != "" {
+		picked = splitCSV(*personasFlag)
+	} else if *rolesFlag != "" {
+		picked = splitCSV(*rolesFlag)
+	} else {
+		reader := bufio.NewReader(os.Stdin)
+		picked, err = promptPersonaSelection(reader, os.Stderr)
+		if err != nil {
+			return err
+		}
+		if err := promptBinarySelection(reader, os.Stderr, picked, binaryOverrides); err != nil {
+			return err
+		}
+	}
+	if len(picked) == 0 {
+		return fmt.Errorf("no personas selected, aborting")
 	}
 
 	members := make([]team.Member, 0, len(picked))
@@ -134,6 +148,9 @@ Known roles:
 		binary := r.PreferredBinary
 		if b, ok := binaryOverrides[id]; ok {
 			binary = b
+		}
+		if interactive && binary == "" {
+			binary = r.PreferredBinary
 		}
 		session := id
 		if s, ok := sessionOverrides[id]; ok {
@@ -305,19 +322,18 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 	return b.String()
 }
 
-func promptRoleSelection() ([]string, error) {
-	fmt.Fprintln(os.Stderr, "Available roles:")
+func promptPersonaSelection(reader *bufio.Reader, out io.Writer) ([]string, error) {
+	fmt.Fprintln(out, "Available personas:")
 	for _, r := range catalog.All() {
 		skills := ""
 		if len(r.Skills) > 0 {
 			skills = "  [" + strings.Join(r.Skills, ", ") + "]"
 		}
-		fmt.Fprintf(os.Stderr, "  %-10s %s (%s)%s\n", r.ID, r.Label, r.PreferredBinary, skills)
+		fmt.Fprintf(out, "  %-10s %s (default CLI: %s)%s\n", r.ID, r.Label, r.PreferredBinary, skills)
 	}
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprint(os.Stderr, "Which roles do you want on this team? (comma-separated IDs, or 'all'): ")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "Which personas do you want on this team? (comma-separated IDs, or 'all'): ")
 
-	reader := bufio.NewReader(os.Stdin)
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return nil, fmt.Errorf("read selection: %w", err)
@@ -330,6 +346,34 @@ func promptRoleSelection() ([]string, error) {
 		return catalog.IDs(), nil
 	}
 	return splitCSV(line), nil
+}
+
+func promptBinarySelection(reader *bufio.Reader, out io.Writer, personas []string, overrides map[string]string) error {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Choose CLI per persona. Press Enter to use the default.")
+	for _, raw := range personas {
+		id := strings.TrimSpace(strings.ToLower(raw))
+		if id == "" {
+			continue
+		}
+		if _, ok := overrides[id]; ok {
+			continue
+		}
+		r := catalog.Lookup(id)
+		if r == nil {
+			continue
+		}
+		fmt.Fprintf(out, "CLI for %s (%s) [%s]: ", id, r.Label, r.PreferredBinary)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read CLI for %s: %w", id, err)
+		}
+		cli := strings.TrimSpace(line)
+		if cli != "" {
+			overrides[id] = cli
+		}
+	}
+	return nil
 }
 
 func splitCSV(s string) []string {
@@ -533,14 +577,15 @@ func printTeamUsage() {
 
 Usage:
   amq-squad team                      Smart default: show commands, or init if none exists
-  amq-squad team init [options]       Set up team.json and seed team-rules.md
+  amq-squad team init [options]       Pick personas, choose CLIs, and seed rules
   amq-squad team show [--no-bootstrap]
                                       Print launch commands for configured team
   amq-squad team rules init           Seed missing team-rules.md with a stub
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)
 
-Roles come from the built-in catalog. Run 'amq-squad team init --help' to
-see them and the available flags.
+Personas come from the built-in catalog. Run 'amq-squad team init --help' to
+see them and the available flags. Use --binary fullstack=codex to run a
+persona with a different CLI.
 `)
 }

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/omriariav/amq-squad/internal/catalog"
@@ -62,8 +63,8 @@ func runTeamInit(args []string) error {
 	personasFlag := fs.String("personas", "", "comma-separated persona IDs to include (alias for --roles)")
 	rolesFlag := fs.String("roles", "", "comma-separated role/persona IDs to include (skips interactive prompt)")
 	binaryFlag := fs.String("binary", "", "per-persona CLI overrides, e.g. fullstack=codex,qa=claude")
-	sessionFlag := fs.String("session", "", "per-role session overrides, e.g. cpo=stream1,cto=stream2")
-	cwdFlag := fs.String("cwd", "", "per-role working directory overrides, e.g. qa=/path/to/sibling-project")
+	sessionFlag := fs.String("session", "", "per-persona session overrides, e.g. cpo=stream1,cto=stream2")
+	cwdFlag := fs.String("cwd", "", "per-persona working directory overrides, e.g. qa=/path/to/sibling-project")
 	force := fs.Bool("force", false, "overwrite an existing team.json")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
@@ -143,7 +144,7 @@ Known personas:
 		seen[id] = true
 		r := catalog.Lookup(id)
 		if r == nil {
-			return fmt.Errorf("unknown role %q. Known roles: %s", id, strings.Join(catalog.IDs(), ", "))
+			return fmt.Errorf("unknown persona %q. Known personas: %s", id, strings.Join(catalog.IDs(), ", "))
 		}
 		binary := r.PreferredBinary
 		if b, ok := binaryOverrides[id]; ok {
@@ -232,7 +233,18 @@ func emitTeamCommands(projectDir string, noBootstrap bool) error {
 	}
 	members := append([]team.Member(nil), t.Members...)
 	sort.SliceStable(members, func(i, j int) bool {
-		return idx[members[i].Role] < idx[members[j].Role]
+		left, lok := idx[members[i].Role]
+		right, rok := idx[members[j].Role]
+		if !lok && !rok {
+			return members[i].Role < members[j].Role
+		}
+		if !lok {
+			return false
+		}
+		if !rok {
+			return true
+		}
+		return left < right
 	})
 
 	fmt.Println("# amq-squad team - run each command in its own terminal tab")
@@ -323,21 +335,61 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 }
 
 func promptPersonaSelection(reader *bufio.Reader, out io.Writer) ([]string, error) {
-	fmt.Fprintln(out, "Available personas:")
-	for _, r := range catalog.All() {
-		skills := ""
-		if len(r.Skills) > 0 {
-			skills = "  [" + strings.Join(r.Skills, ", ") + "]"
-		}
-		fmt.Fprintf(out, "  %-10s %s (default CLI: %s)%s\n", r.ID, r.Label, r.PreferredBinary, skills)
-	}
+	fmt.Fprintln(out, "Squad market")
+	printPersonaMarket(out)
 	fmt.Fprintln(out)
-	fmt.Fprint(out, "Which personas do you want on this team? (comma-separated IDs, or 'all'): ")
+	fmt.Fprintln(out, "Choose personas to hire:")
+	fmt.Fprintln(out, "  names or numbers, comma-separated")
+	fmt.Fprintln(out, "  examples: cto,junior-dev,qa | 2,8,9 | all")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "> ")
 
 	line, err := reader.ReadString('\n')
 	if err != nil {
 		return nil, fmt.Errorf("read selection: %w", err)
 	}
+	return parsePersonaSelection(line)
+}
+
+func promptBinarySelection(reader *bufio.Reader, out io.Writer, personas []string, overrides map[string]string) error {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Squad plan")
+	printSquadPlan(out, personas, overrides)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "CLI overrides?")
+	fmt.Fprintln(out, "  Press Enter to keep defaults.")
+	fmt.Fprintln(out, "  Example: fullstack=codex,junior-dev=claude")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "> ")
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read CLI overrides: %w", err)
+	}
+	overrideLine := strings.TrimSpace(line)
+	if overrideLine == "" {
+		return nil
+	}
+	parsed, err := parseKV(overrideLine)
+	if err != nil {
+		return fmt.Errorf("parse CLI overrides: %w", err)
+	}
+	for k, v := range parsed {
+		overrides[strings.ToLower(k)] = v
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Updated squad plan")
+	printSquadPlan(out, personas, overrides)
+	return nil
+}
+
+func printPersonaMarket(out io.Writer) {
+	fmt.Fprintf(out, "  %-2s %-12s %-31s %-7s %s\n", "#", "PERSONA", "PROFILE", "CLI", "FIT")
+	for i, r := range catalog.All() {
+		fmt.Fprintf(out, "  %-2d %-12s %-31s %-7s %s\n", i+1, r.ID, r.Label, r.PreferredBinary, r.Profile)
+	}
+}
+
+func parsePersonaSelection(line string) ([]string, error) {
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return nil, fmt.Errorf("no selection provided")
@@ -345,35 +397,40 @@ func promptPersonaSelection(reader *bufio.Reader, out io.Writer) ([]string, erro
 	if strings.EqualFold(line, "all") {
 		return catalog.IDs(), nil
 	}
-	return splitCSV(line), nil
+	all := catalog.All()
+	picked := splitCSV(line)
+	out := make([]string, 0, len(picked))
+	for _, p := range picked {
+		if n, err := strconv.Atoi(p); err == nil {
+			if n < 1 || n > len(all) {
+				return nil, fmt.Errorf("persona number %d is out of range", n)
+			}
+			out = append(out, all[n-1].ID)
+			continue
+		}
+		out = append(out, strings.ToLower(p))
+	}
+	return out, nil
 }
 
-func promptBinarySelection(reader *bufio.Reader, out io.Writer, personas []string, overrides map[string]string) error {
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Choose CLI per persona. Press Enter to use the default.")
+func printSquadPlan(out io.Writer, personas []string, overrides map[string]string) {
+	fmt.Fprintf(out, "  %-12s %-31s %-7s %s\n", "PERSONA", "PROFILE", "CLI", "SESSION")
 	for _, raw := range personas {
 		id := strings.TrimSpace(strings.ToLower(raw))
 		if id == "" {
 			continue
 		}
-		if _, ok := overrides[id]; ok {
-			continue
-		}
 		r := catalog.Lookup(id)
 		if r == nil {
+			fmt.Fprintf(out, "  %-12s %-31s %-7s %s\n", id, "(unknown)", "", id)
 			continue
 		}
-		fmt.Fprintf(out, "CLI for %s (%s) [%s]: ", id, r.Label, r.PreferredBinary)
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			return fmt.Errorf("read CLI for %s: %w", id, err)
+		binary := r.PreferredBinary
+		if b, ok := overrides[id]; ok {
+			binary = b
 		}
-		cli := strings.TrimSpace(line)
-		if cli != "" {
-			overrides[id] = cli
-		}
+		fmt.Fprintf(out, "  %-12s %-31s %-7s %s\n", id, r.Label, binary, id)
 	}
-	return nil
 }
 
 func splitCSV(s string) []string {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -70,8 +70,9 @@ Usage:
   amq-squad team init [--roles id1,id2,...] [--binary role=bin,...] [--session role=name,...] [--force]
 
 Without --roles, prompts interactively. Writes <cwd>/.amq-squad/team.json.
-The directory where this runs becomes the team-home. Members can live in
-other directories via --cwd role=/path.
+Also seeds <cwd>/.amq-squad/team-rules.md if it does not already exist.
+The directory where this runs becomes the team-home. Members can live in other
+directories via --cwd role=/path.
 
 Known roles:
 `)
@@ -164,6 +165,13 @@ Known roles:
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "Wrote %s with %d members.\n", team.Path(cwd), len(members))
+	wroteRules, err := rules.EnsureStub(cwd)
+	if err != nil {
+		return fmt.Errorf("seed team-rules.md: %w", err)
+	}
+	if wroteRules {
+		fmt.Fprintf(os.Stderr, "Wrote %s.\n", rules.Path(cwd))
+	}
 	return nil
 }
 
@@ -525,10 +533,10 @@ func printTeamUsage() {
 
 Usage:
   amq-squad team                      Smart default: show commands, or init if none exists
-  amq-squad team init [options]       Set up .amq-squad/team.json
+  amq-squad team init [options]       Set up team.json and seed team-rules.md
   amq-squad team show [--no-bootstrap]
                                       Print launch commands for configured team
-  amq-squad team rules init           Seed .amq-squad/team-rules.md with a stub
+  amq-squad team rules init           Seed missing team-rules.md with a stub
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -161,6 +161,24 @@ func TestPromptPersonaSelection(t *testing.T) {
 	}
 }
 
+func TestPrintPersonaMarketIncludesEmployeeProfiles(t *testing.T) {
+	var out bytes.Buffer
+	printPersonaMarket(&out)
+	got := out.String()
+	for _, want := range []string{
+		"frontend-dev",
+		"Frontend Developer",
+		"mobile-dev",
+		"Mobile Developer",
+		"junior-dev",
+		"Fast on scoped tasks",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("market output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestParsePersonaSelection(t *testing.T) {
 	got, err := parsePersonaSelection("junior-dev,2")
 	if err != nil {
@@ -243,6 +261,57 @@ func TestRunTeamInitPersonasAliasAndBinaryOverride(t *testing.T) {
 	m := got.Members[0]
 	if m.Role != "fullstack" || m.Binary != "codex" {
 		t.Fatalf("member = %+v, want fullstack on codex", m)
+	}
+}
+
+func TestRunTeamInitMarketPersonasAndBinaryOverrides(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	err = runTeamInit([]string{
+		"--personas", "cto,frontend-dev,mobile-dev,junior-dev,qa",
+		"--binary", "frontend-dev=codex,mobile-dev=codex",
+	})
+	if err != nil {
+		t.Fatalf("runTeamInit: %v", err)
+	}
+	got, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBinary := map[string]string{
+		"cto":          "codex",
+		"frontend-dev": "codex",
+		"mobile-dev":   "codex",
+		"junior-dev":   "codex",
+		"qa":           "claude",
+	}
+	if len(got.Members) != len(wantBinary) {
+		t.Fatalf("members = %v, want %d members", got.Members, len(wantBinary))
+	}
+	for _, m := range got.Members {
+		want, ok := wantBinary[m.Role]
+		if !ok {
+			t.Errorf("unexpected member %+v", m)
+			continue
+		}
+		if m.Binary != want {
+			t.Errorf("member %s binary = %q, want %q", m.Role, m.Binary, want)
+		}
+		if m.Handle != m.Role || m.Session != m.Role {
+			t.Errorf("member %s handle/session = %q/%q, want role defaults", m.Role, m.Handle, m.Session)
+		}
 	}
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bufio"
+	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -140,6 +142,93 @@ func TestApplyDefaultChildArgs(t *testing.T) {
 	got = applyDefaultChildArgs("codex", explicit)
 	if !reflect.DeepEqual(got, explicit) {
 		t.Errorf("applyDefaultChildArgs should preserve explicit args: got %v, want %v", got, explicit)
+	}
+}
+
+func TestPromptPersonaSelection(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("fullstack,cto\n"))
+	var out bytes.Buffer
+	got, err := promptPersonaSelection(reader, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"fullstack", "cto"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("promptPersonaSelection = %v, want %v", got, want)
+	}
+	if !strings.Contains(out.String(), "Available personas") {
+		t.Errorf("prompt output missing personas list: %s", out.String())
+	}
+}
+
+func TestPromptBinarySelection(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("codex\n\n"))
+	var out bytes.Buffer
+	overrides := map[string]string{}
+	if err := promptBinarySelection(reader, &out, []string{"fullstack", "qa"}, overrides); err != nil {
+		t.Fatal(err)
+	}
+	if overrides["fullstack"] != "codex" {
+		t.Errorf("fullstack override = %q, want codex", overrides["fullstack"])
+	}
+	if _, ok := overrides["qa"]; ok {
+		t.Errorf("qa should keep default, got override %q", overrides["qa"])
+	}
+	if !strings.Contains(out.String(), "CLI for fullstack") {
+		t.Errorf("prompt output missing fullstack CLI prompt: %s", out.String())
+	}
+}
+
+func TestPromptBinarySelectionPreservesFlagOverride(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+	overrides := map[string]string{"fullstack": "codex"}
+	if err := promptBinarySelection(reader, &out, []string{"fullstack"}, overrides); err != nil {
+		t.Fatal(err)
+	}
+	if overrides["fullstack"] != "codex" {
+		t.Errorf("fullstack override = %q, want codex", overrides["fullstack"])
+	}
+	if strings.Contains(out.String(), "CLI for fullstack") {
+		t.Errorf("prompt should skip personas with flag overrides: %s", out.String())
+	}
+}
+
+func TestRunTeamInitPersonasAliasAndBinaryOverride(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := runTeamInit([]string{"--personas", "fullstack", "--binary", "fullstack=codex"}); err != nil {
+		t.Fatalf("runTeamInit: %v", err)
+	}
+	got, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Members) != 1 {
+		t.Fatalf("members = %v, want one", got.Members)
+	}
+	m := got.Members[0]
+	if m.Role != "fullstack" || m.Binary != "codex" {
+		t.Fatalf("member = %+v, want fullstack on codex", m)
+	}
+}
+
+func TestRunTeamInitRejectsRolesAndPersonasTogether(t *testing.T) {
+	err := runTeamInit([]string{"--roles", "cto", "--personas", "fullstack"})
+	if err == nil || !strings.Contains(err.Error(), "either --personas or --roles") {
+		t.Fatalf("runTeamInit error = %v, want roles/personas conflict", err)
 	}
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -146,7 +146,7 @@ func TestApplyDefaultChildArgs(t *testing.T) {
 }
 
 func TestPromptPersonaSelection(t *testing.T) {
-	reader := bufio.NewReader(strings.NewReader("fullstack,cto\n"))
+	reader := bufio.NewReader(strings.NewReader("4,2\n"))
 	var out bytes.Buffer
 	got, err := promptPersonaSelection(reader, &out)
 	if err != nil {
@@ -156,13 +156,34 @@ func TestPromptPersonaSelection(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("promptPersonaSelection = %v, want %v", got, want)
 	}
-	if !strings.Contains(out.String(), "Available personas") {
-		t.Errorf("prompt output missing personas list: %s", out.String())
+	if !strings.Contains(out.String(), "Squad market") {
+		t.Errorf("prompt output missing squad market: %s", out.String())
+	}
+}
+
+func TestParsePersonaSelection(t *testing.T) {
+	got, err := parsePersonaSelection("junior-dev,2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"junior-dev", "cto"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parsePersonaSelection = %v, want %v", got, want)
+	}
+	got, err = parsePersonaSelection("all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0] != "cpo" {
+		t.Errorf("parsePersonaSelection all = %v, want catalog IDs", got)
+	}
+	if _, err := parsePersonaSelection("999"); err == nil {
+		t.Error("parsePersonaSelection should reject out-of-range numbers")
 	}
 }
 
 func TestPromptBinarySelection(t *testing.T) {
-	reader := bufio.NewReader(strings.NewReader("codex\n\n"))
+	reader := bufio.NewReader(strings.NewReader("fullstack=codex\n"))
 	var out bytes.Buffer
 	overrides := map[string]string{}
 	if err := promptBinarySelection(reader, &out, []string{"fullstack", "qa"}, overrides); err != nil {
@@ -174,8 +195,8 @@ func TestPromptBinarySelection(t *testing.T) {
 	if _, ok := overrides["qa"]; ok {
 		t.Errorf("qa should keep default, got override %q", overrides["qa"])
 	}
-	if !strings.Contains(out.String(), "CLI for fullstack") {
-		t.Errorf("prompt output missing fullstack CLI prompt: %s", out.String())
+	if !strings.Contains(out.String(), "Squad plan") || !strings.Contains(out.String(), "Updated squad plan") {
+		t.Errorf("prompt output missing squad plans: %s", out.String())
 	}
 }
 
@@ -189,8 +210,8 @@ func TestPromptBinarySelectionPreservesFlagOverride(t *testing.T) {
 	if overrides["fullstack"] != "codex" {
 		t.Errorf("fullstack override = %q, want codex", overrides["fullstack"])
 	}
-	if strings.Contains(out.String(), "CLI for fullstack") {
-		t.Errorf("prompt should skip personas with flag overrides: %s", out.String())
+	if !strings.Contains(out.String(), "fullstack") || !strings.Contains(out.String(), "codex") {
+		t.Errorf("prompt should show existing override in plan: %s", out.String())
 	}
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omriariav/amq-squad/internal/rules"
 	"github.com/omriariav/amq-squad/internal/team"
 )
 
@@ -121,6 +122,84 @@ func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
 		if got := shouldAppendBootstrap(tc.binary, tc.childArgs); got != tc.want {
 			t.Errorf("%s: shouldAppendBootstrap(%q, %v) = %v, want %v", tc.name, tc.binary, tc.childArgs, got, tc.want)
 		}
+	}
+}
+
+func TestApplyDefaultChildArgs(t *testing.T) {
+	got := applyDefaultChildArgs("codex", nil)
+	want := []string{"--dangerously-bypass-approvals-and-sandbox"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyDefaultChildArgs codex = %v, want %v", got, want)
+	}
+	got = applyDefaultChildArgs("claude", nil)
+	want = []string{"--permission-mode", "auto"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("applyDefaultChildArgs claude = %v, want %v", got, want)
+	}
+	explicit := []string{"--resume", "abc"}
+	got = applyDefaultChildArgs("codex", explicit)
+	if !reflect.DeepEqual(got, explicit) {
+		t.Errorf("applyDefaultChildArgs should preserve explicit args: got %v, want %v", got, explicit)
+	}
+}
+
+func TestRunTeamInitSeedsTeamRules(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := runTeamInit([]string{"--roles", "cto,fullstack"}); err != nil {
+		t.Fatalf("runTeamInit: %v", err)
+	}
+	if !team.Exists(dir) {
+		t.Fatalf("team.json was not written")
+	}
+	if _, err := os.Stat(rules.Path(dir)); err != nil {
+		t.Fatalf("team-rules.md was not written: %v", err)
+	}
+}
+
+func TestRunTeamInitDoesNotClobberTeamRules(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	custom := "custom rules\n"
+	if err := os.MkdirAll(filepath.Dir(rules.Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rules.Path(dir), []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runTeamInit([]string{"--roles", "cto"}); err != nil {
+		t.Fatalf("runTeamInit: %v", err)
+	}
+	got, err := os.ReadFile(rules.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != custom {
+		t.Fatalf("team-rules.md was clobbered: got %q, want %q", string(got), custom)
 	}
 }
 

--- a/skills/claude/amq-squad-team/SKILL.md
+++ b/skills/claude/amq-squad-team/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: amq-squad-team
-description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting roles, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa roles, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
+description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting personas, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa personas, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
 allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep
-argument-hint: "[team-home=current] [roles/cwds/history folders]"
+argument-hint: "[team-home=current] [personas/cwds/history folders]"
 user-invocable: true
 trigger: /amq-squad-team
 ---
@@ -42,8 +42,11 @@ Supported user inputs:
    - Do not run `amq-squad restore --exec` for a fresh team.
 
 3. Create or update the team.
-   - Use built-in role IDs when possible: `cpo`, `cto`, `fullstack`, `qa`, `pm`, `designer`.
-   - Model backend/dev as `fullstack` unless the user wants a custom manual launch.
+   - Use built-in persona IDs when possible: `cpo`, `cto`, `senior-dev`, `fullstack`, `frontend-dev`, `backend-dev`, `mobile-dev`, `junior-dev`, `qa`, `pm`, `designer`.
+   - Model "works fast but needs review" as `junior-dev`.
+   - Model web UI work as `frontend-dev`; model mobile app work as `mobile-dev`; model APIs/services work as `backend-dev`.
+   - Model backend/dev as `fullstack` unless the user wants a narrower persona.
+   - Use `--binary persona=cli` when the user wants a persona on a different CLI, for example `--binary fullstack=codex`.
    - Use fresh session names such as `fresh-cpo`, `fresh-cto`, `fresh-backend`, `fresh-qa`.
 
 4. Generate team rules.
@@ -72,7 +75,7 @@ For a four-agent team with CPO, CTO, backend/dev, and QA in a second project:
 cd /path/to/team-home
 
 amq-squad team init --force \
-  --roles cpo,cto,fullstack,qa \
+  --personas cpo,cto,fullstack,qa \
   --binary cpo=codex,cto=codex,fullstack=claude,qa=claude \
   --session cpo=fresh-cpo,cto=fresh-cto,fullstack=fresh-backend,qa=fresh-qa \
   --cwd qa=/path/to/qa-project

--- a/skills/codex/amq-squad-team/SKILL.md
+++ b/skills/codex/amq-squad-team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-squad-team
-description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting roles, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa roles, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
+description: Bootstrap or refresh an amq-squad team for the current project by default, including selecting personas, mapping agents across explicit project directories, discovering prior AMQ history in explicitly scoped folders, generating .amq-squad/team-rules.md, optionally syncing CLAUDE.md and AGENTS.md, and printing fresh launch commands. Use when the user asks to start a fresh agent team, set up cpo/cto/dev/qa personas, preserve context from old AMQ sessions, or generate team-rules for amq-squad. Default to the current working directory unless the user names one or more other folders.
 ---
 
 # AMQ Squad Team
@@ -38,8 +38,11 @@ Supported user inputs:
    - Do not run `amq-squad restore --exec` for a fresh team.
 
 3. Create or update the team.
-   - Use built-in role IDs when possible: `cpo`, `cto`, `fullstack`, `qa`, `pm`, `designer`.
-   - Model backend/dev as `fullstack` unless the user wants a custom manual launch.
+   - Use built-in persona IDs when possible: `cpo`, `cto`, `senior-dev`, `fullstack`, `frontend-dev`, `backend-dev`, `mobile-dev`, `junior-dev`, `qa`, `pm`, `designer`.
+   - Model "works fast but needs review" as `junior-dev`.
+   - Model web UI work as `frontend-dev`; model mobile app work as `mobile-dev`; model APIs/services work as `backend-dev`.
+   - Model backend/dev as `fullstack` unless the user wants a narrower persona.
+   - Use `--binary persona=cli` when the user wants a persona on a different CLI, for example `--binary fullstack=codex`.
    - Use fresh session names such as `fresh-cpo`, `fresh-cto`, `fresh-backend`, `fresh-qa`.
 
 4. Generate team rules.
@@ -68,7 +71,7 @@ For a four-agent team with CPO, CTO, backend/dev, and QA in a second project:
 cd /path/to/team-home
 
 amq-squad team init --force \
-  --roles cpo,cto,fullstack,qa \
+  --personas cpo,cto,fullstack,qa \
   --binary cpo=codex,cto=codex,fullstack=claude,qa=claude \
   --session cpo=fresh-cpo,cto=fresh-cto,fullstack=fresh-backend,qa=fresh-qa \
   --cwd qa=/path/to/qa-project


### PR DESCRIPTION
## Summary

- prepare the docs for `v0.3.0`
- make `amq-squad team init` seed `.amq-squad/team-rules.md` when missing
- preserve existing `team-rules.md` content if the user already wrote one
- apply Codex and Claude default child args in `launch` when no explicit binary args are supplied
- add `--personas` as the clearer setup flag while keeping `--roles` compatible
- replace the basic interactive picker with a squad market: numbered personas, short profiles, CLI defaults, and one CLI override prompt
- add employee-style personas: `senior-dev`, `frontend-dev`, `backend-dev`, `mobile-dev`, and `junior-dev`
- update README and skill guidance to match the new setup behavior

## Validation

- `make ci`
- `git diff --check`
- `rg -n "—|–" README.md internal skills`
- `python3 /Users/omri.a/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/codex/amq-squad-team`
- added tests:
  - catalog pins the new market personas, labels, default CLIs, profiles, and descriptions
  - CLI market output includes frontend, mobile, and junior profiles
  - `team init --personas cto,frontend-dev,mobile-dev,junior-dev,qa --binary frontend-dev=codex,mobile-dev=codex` stores the expected CLIs
- temp-project checks:
  - `amq-squad team init --roles cto,fullstack` wrote both `team.json` and `team-rules.md`
  - `amq-squad team show` printed Codex with `--dangerously-bypass-approvals-and-sandbox`
  - `amq-squad launch --dry-run --role cto --session cto --me cto codex` included the Codex default arg
  - `amq-squad team init --personas fullstack --binary fullstack=codex` stored Fullstack on Codex and printed the Codex default arg
  - interactive market selected CTO, Frontend Developer, Mobile Developer, Junior Developer, and QA by number; CLI overrides switched frontend and mobile to Codex; `team show` emitted the expected launch commands
