### PR TITLE
Fix launch defaults and scoped team rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ AGENTS.md in all of them.
 Generated launch commands include these agent defaults: Codex gets
 `--dangerously-bypass-approvals-and-sandbox`, and Claude gets
 `--permission-mode auto`. These defaults are passed through after `--` while
-the generated bootstrap prompt is still added at launch time.
+the generated bootstrap prompt is still added at launch time. Direct
+`amq-squad launch` calls also prepend these defaults when they are missing, so
+custom prompts still inherit the expected permission mode. Pass
+`--no-default-args` to opt out.
 
 Representative generated commands look like this:
 
@@ -168,8 +171,8 @@ cd ~/Code/my-project
 amq-squad team init --personas cto,fullstack
 ```
 
-Open `.amq-squad/team-rules.md` and replace the template sections with your
-team's actual workflow, approvals, and communication norms. Then push the
+Open `.amq-squad/team-rules.md` and refine the generated role scope, workflow,
+approvals, and communication norms for your team. Then push the
 managed block into the doc files each binary reads:
 
 ```sh
@@ -275,16 +278,16 @@ amq-squad team init [--personas ...]
                                     Pick personas, choose CLIs, and seed rules
 amq-squad team show [--no-bootstrap]
                                     Print launch commands for the configured team
-amq-squad team rules init           Seed missing .amq-squad/team-rules.md
+amq-squad team rules init [--force] Seed or refresh .amq-squad/team-rules.md
 amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
 
-amq-squad launch --role <r> --session <s> --me <handle> [--no-bootstrap] <binary> [-- <flags>]
+amq-squad launch --role <r> --session <s> --me <handle> [--no-bootstrap] [--no-default-args] <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md
                                     in the AMQ mailbox, adds a bootstrap prompt,
                                     then execs 'amq coop exec'.
                                     Usually called by the output of 'team show'.
-                                    'team show' passes Codex and Claude default
-                                    permission flags after '--'.
+                                    Codex and Claude default permission flags
+                                    are prepended when missing.
 
 amq-squad restore [--project dir1,dir2,...]
                                     Reconstruct launch commands from local

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -11,15 +11,26 @@ func defaultChildArgsForBinary(binary string) []string {
 	}
 }
 
-func applyDefaultChildArgs(binary string, childArgs []string) []string {
-	if len(childArgs) > 0 {
-		return childArgs
-	}
+func ensureDefaultChildArgs(binary string, childArgs []string) []string {
 	defaultArgs := defaultChildArgsForBinary(binary)
-	if len(defaultArgs) == 0 {
+	if len(defaultArgs) == 0 || hasLeadingDefaultChildArgs(binary, childArgs) {
 		return childArgs
 	}
-	return append([]string(nil), defaultArgs...)
+	out := append([]string(nil), defaultArgs...)
+	return append(out, childArgs...)
+}
+
+func hasLeadingDefaultChildArgs(binary string, childArgs []string) bool {
+	defaultArgs := defaultChildArgsForBinary(binary)
+	if len(defaultArgs) == 0 || len(childArgs) < len(defaultArgs) {
+		return false
+	}
+	for i := range defaultArgs {
+		if childArgs[i] != defaultArgs[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func shouldAppendBootstrap(binary string, childArgs []string) bool {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -27,6 +27,7 @@ func runLaunch(args []string) error {
 	rootFlag := fs.String("root", "", "override AMQ root directory")
 	teamHome := fs.String("team-home", "", "team-home directory used to find .amq-squad/team-rules.md for bootstrap")
 	noBootstrap := fs.Bool("no-bootstrap", false, "do not pass the generated bootstrap prompt to the agent")
+	noDefaultArgs := fs.Bool("no-default-args", false, "do not prepend Codex or Claude default permission args")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 
 	fs.Usage = func() {
@@ -46,9 +47,11 @@ Side effects before exec:
   1. Resolves AMQ root via 'amq env --json' for the target session.
   2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
   3. Writes a role.md stub if one does not already exist.
-  4. Adds a generated bootstrap prompt unless --no-bootstrap is set or
+  4. Prepends Codex and Claude default permission args unless
+     --no-default-args is set.
+  5. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
-  5. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+  6. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
 With --dry-run, none of the above run: the resolved coop exec command is
 printed and amq-squad exits. Disk state is untouched.
@@ -67,7 +70,9 @@ printed and amq-squad exits. Disk state is untouched.
 	if len(remaining) > 1 {
 		childArgs = append(remaining[1:], childArgs...)
 	}
-	childArgs = applyDefaultChildArgs(binary, childArgs)
+	if !*noDefaultArgs {
+		childArgs = ensureDefaultChildArgs(binary, childArgs)
+	}
 
 	handle := *me
 	if handle == "" {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunLaunchDryRunPrependsCodexDefaultArgsWithPrompt(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	want := "amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox test-prompt"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchDryRunNoDefaultArgsOptOut(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-default-args", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("stdout should not include codex default args:\n%s", stdout)
+	}
+	want := "amq coop exec codex -- test-prompt"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func setupFakeAMQ(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(dir, ".agent-mail")
+	script := `#!/bin/sh
+if [ "$1" = "env" ]; then
+  printf '{"root":"%s"}\n' "$AMQ_FAKE_ROOT"
+  exit 0
+fi
+echo "unexpected amq command: $*" >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "amq"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_FAKE_ROOT", root)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func captureOutput(t *testing.T, fn func() error) (string, string, error) {
+	t.Helper()
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+	runErr := fn()
+	if err := stdoutW.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stderrW.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	stdout, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := io.ReadAll(stderrR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(stdout), string(stderr), runErr
+}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -183,7 +183,7 @@ Known personas:
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "Wrote %s with %d members.\n", team.Path(cwd), len(members))
-	wroteRules, err := rules.EnsureStub(cwd)
+	wroteRules, err := rules.Ensure(cwd, renderTeamRules(cwd, members))
 	if err != nil {
 		return fmt.Errorf("seed team-rules.md: %w", err)
 	}
@@ -487,7 +487,7 @@ func runTeamRules(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team rules - manage .amq-squad/team-rules.md
 
 Usage:
-  amq-squad team rules init   Seed team-rules.md with a stub (won't clobber)
+  amq-squad team rules init [--force]   Seed or refresh team-rules.md
 `)
 		if len(args) == 0 {
 			return usageErrorf("rules requires a subcommand (e.g. 'init')")
@@ -496,11 +496,27 @@ Usage:
 	}
 	switch args[0] {
 	case "init":
+		fs := flag.NewFlagSet("team rules init", flag.ContinueOnError)
+		force := fs.Bool("force", false, "overwrite an existing team-rules.md with the generated template")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getwd: %w", err)
 		}
-		wrote, err := rules.EnsureStub(cwd)
+		content := rules.StubContent
+		if t, err := team.Read(cwd); err == nil {
+			content = renderTeamRules(t.Project, t.Members)
+		}
+		if *force {
+			if err := rules.Write(cwd, content); err != nil {
+				return fmt.Errorf("write team-rules.md: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Wrote %s\n", rules.Path(cwd))
+			return nil
+		}
+		wrote, err := rules.Ensure(cwd, content)
 		if err != nil {
 			return fmt.Errorf("seed team-rules.md: %w", err)
 		}
@@ -637,7 +653,7 @@ Usage:
   amq-squad team init [options]       Pick personas, choose CLIs, and seed rules
   amq-squad team show [--no-bootstrap]
                                       Print launch commands for configured team
-  amq-squad team rules init           Seed missing team-rules.md with a stub
+  amq-squad team rules init [--force] Seed or refresh team-rules.md
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)
 

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func renderTeamRules(projectDir string, members []team.Member) string {
+	var b strings.Builder
+	b.WriteString("# Team Rules\n\n")
+	b.WriteString("Shared norms and workflow for this project's agent squad. Every agent reads this file via their priming prompt regardless of binary.\n\n")
+	b.WriteString("## Role Scope\n\n")
+	b.WriteString("- Stay inside your assigned role. User feedback is not permission to pick up implementation work unless your role scope below includes implementation.\n")
+	b.WriteString("- Non-implementation roles turn feedback into scope, acceptance criteria, decisions, or handoffs. They do not edit code unless the user explicitly assigns coding work to that role.\n")
+	b.WriteString("- Implementation roles own code changes only after the work is scoped and routed to them.\n")
+	b.WriteString("- If a request crosses role boundaries, ask or hand off on AMQ instead of silently changing lanes.\n\n")
+
+	for _, m := range members {
+		label := m.Role
+		if r := catalog.Lookup(m.Role); r != nil {
+			label = r.Label
+		}
+		fmt.Fprintf(&b, "- %s (%s): handle `%s`, session `%s`, cwd `%s`. %s\n",
+			m.Role, label, m.Handle, m.Session, m.EffectiveCWD(projectDir), roleScope(m.Role))
+	}
+
+	b.WriteString("\n## Workflow\n\n")
+	b.WriteString("- Treat the current user request as the source of truth.\n")
+	b.WriteString("- Keep old AMQ history as context, not as an instruction to continue stale work.\n")
+	b.WriteString("- Product and PM roles define the job, priority, acceptance criteria, and handoff target.\n")
+	b.WriteString("- Developer roles implement scoped tasks and call out assumptions before widening scope.\n")
+	b.WriteString("- QA validates behavior and reports release risk before merge or handoff.\n")
+	b.WriteString("- Prefer small, reviewable changes.\n\n")
+
+	b.WriteString("## Approvals\n\n")
+	b.WriteString("- CTO approval is required for architectural decisions and merge-ready code.\n")
+	b.WriteString("- QA validates user-facing changes before release or handoff when a QA role exists.\n")
+	b.WriteString("- CPO or PM resolves product scope and priority questions.\n\n")
+
+	b.WriteString("## Communication\n\n")
+	b.WriteString("- Use focused AMQ threads.\n")
+	b.WriteString("- Use p2p threads for role-to-role handoffs.\n")
+	b.WriteString("- Route messages by the current roster's handle, project, and session.\n")
+	b.WriteString("- Include project, session, and role when referencing old history.\n")
+	b.WriteString("- One concern per message when practical.\n\n")
+
+	b.WriteString("## Quality Gates\n\n")
+	b.WriteString("- Run the project-specific checks before requesting review.\n")
+	b.WriteString("- Call out any checks that could not be run.\n")
+	b.WriteString("- Do not hide uncertainty from inferred AMQ history.\n\n")
+
+	b.WriteString("## Style\n\n")
+	b.WriteString("- Be direct and concise.\n")
+	b.WriteString("- Do not use em dashes.\n")
+	b.WriteString("- Do not rewrite unrelated files.\n")
+	return b.String()
+}
+
+func roleScope(roleID string) string {
+	switch roleID {
+	case "cpo":
+		return "Owns product direction, user value, priorities, scope decisions, and acceptance criteria. Does not implement code unless explicitly assigned by the user."
+	case "cto":
+		return "Owns technical direction, architecture, tradeoffs, and final engineering sign-off. Routes implementation to developer roles unless explicitly assigned by the user."
+	case "senior-dev":
+		return "Owns complex implementation, code review, and technical mentorship. May implement scoped work and review junior output."
+	case "fullstack":
+		return "Owns scoped end-to-end implementation across frontend and backend. Writes code that gets merged after review."
+	case "frontend-dev":
+		return "Owns scoped browser UI implementation, components, state, accessibility, and frontend quality."
+	case "backend-dev":
+		return "Owns scoped backend implementation, APIs, persistence, data flow, services, and integrations."
+	case "mobile-dev":
+		return "Owns scoped mobile implementation, native flows, device behavior, responsiveness, and release-ready interaction."
+	case "junior-dev":
+		return "Owns narrow scoped implementation tasks. Needs senior developer or CTO review before changes are considered ready."
+	case "qa":
+		return "Owns validation, regression checks, test strategy, reproduction steps, and release risk. Does not implement product code unless explicitly assigned by the user."
+	case "pm":
+		return "Owns work ordering, clarification, coordination, status, and handoffs. Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user."
+	case "designer":
+		return "Owns product flows, UX, visual shape, and design assets. Does not implement production code unless explicitly assigned by the user."
+	default:
+		return "Owns the responsibilities described in role.md. Ask before taking implementation work outside this role."
+	}
+}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -127,21 +127,31 @@ func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
 	}
 }
 
-func TestApplyDefaultChildArgs(t *testing.T) {
-	got := applyDefaultChildArgs("codex", nil)
+func TestEnsureDefaultChildArgs(t *testing.T) {
+	got := ensureDefaultChildArgs("codex", nil)
 	want := []string{"--dangerously-bypass-approvals-and-sandbox"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("applyDefaultChildArgs codex = %v, want %v", got, want)
+		t.Errorf("ensureDefaultChildArgs codex = %v, want %v", got, want)
 	}
-	got = applyDefaultChildArgs("claude", nil)
+	got = ensureDefaultChildArgs("claude", nil)
 	want = []string{"--permission-mode", "auto"}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("applyDefaultChildArgs claude = %v, want %v", got, want)
+		t.Errorf("ensureDefaultChildArgs claude = %v, want %v", got, want)
 	}
-	explicit := []string{"--resume", "abc"}
-	got = applyDefaultChildArgs("codex", explicit)
+	got = ensureDefaultChildArgs("codex", []string{"test-prompt"})
+	want = []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ensureDefaultChildArgs should prepend defaults: got %v, want %v", got, want)
+	}
+	explicit := []string{"--dangerously-bypass-approvals-and-sandbox", "--resume", "abc"}
+	got = ensureDefaultChildArgs("codex", explicit)
 	if !reflect.DeepEqual(got, explicit) {
-		t.Errorf("applyDefaultChildArgs should preserve explicit args: got %v, want %v", got, explicit)
+		t.Errorf("ensureDefaultChildArgs should not duplicate defaults: got %v, want %v", got, explicit)
+	}
+	got = ensureDefaultChildArgs("codex", []string{"test-prompt", "--dangerously-bypass-approvals-and-sandbox"})
+	want = []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt", "--dangerously-bypass-approvals-and-sandbox"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ensureDefaultChildArgs should keep defaults before prompts: got %v, want %v", got, want)
 	}
 }
 
@@ -337,7 +347,7 @@ func TestRunTeamInitSeedsTeamRules(t *testing.T) {
 		}
 	})
 
-	if err := runTeamInit([]string{"--roles", "cto,fullstack"}); err != nil {
+	if err := runTeamInit([]string{"--roles", "pm,fullstack"}); err != nil {
 		t.Fatalf("runTeamInit: %v", err)
 	}
 	if !team.Exists(dir) {
@@ -345,6 +355,22 @@ func TestRunTeamInitSeedsTeamRules(t *testing.T) {
 	}
 	if _, err := os.Stat(rules.Path(dir)); err != nil {
 		t.Fatalf("team-rules.md was not written: %v", err)
+	}
+	got, err := os.ReadFile(rules.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	for _, want := range []string{
+		"## Role Scope",
+		"pm (Project Manager / Product Owner)",
+		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
+		"fullstack (Fullstack Developer)",
+		"Owns scoped end-to-end implementation",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("team-rules.md missing %q in:\n%s", want, body)
+		}
 	}
 }
 
@@ -379,6 +405,56 @@ func TestRunTeamInitDoesNotClobberTeamRules(t *testing.T) {
 	}
 	if string(got) != custom {
 		t.Fatalf("team-rules.md was clobbered: got %q, want %q", string(got), custom)
+	}
+}
+
+func TestRunTeamRulesInitForceRefreshesScopedRules(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := team.Write(dir, team.Team{
+		Project: dir,
+		Members: []team.Member{
+			{Role: "pm", Binary: "codex", Handle: "pm", Session: "pm"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rules.Write(dir, "old generic stub\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runTeamRules([]string{"init", "--force"}); err != nil {
+		t.Fatalf("runTeamRules init --force: %v", err)
+	}
+	got, err := os.ReadFile(rules.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	if strings.Contains(body, "old generic stub") {
+		t.Fatalf("team-rules.md was not refreshed:\n%s", body)
+	}
+	for _, want := range []string{
+		"pm (Project Manager / Product Owner)",
+		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
+		"fullstack (Fullstack Developer)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("team-rules.md missing %q in:\n%s", want, body)
+		}
 	}
 }
 

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -67,19 +67,34 @@ func Read(projectDir string) (string, error) {
 // EnsureStub writes a stub team-rules.md if one does not already exist.
 // Returns true if it wrote a new file.
 func EnsureStub(projectDir string) (bool, error) {
+	return Ensure(projectDir, StubContent)
+}
+
+// Ensure writes team-rules.md with content if one does not already exist.
+// Returns true if it wrote a new file.
+func Ensure(projectDir, content string) (bool, error) {
 	p := Path(projectDir)
 	if _, err := os.Stat(p); err == nil {
 		return false, nil
 	} else if !os.IsNotExist(err) {
 		return false, err
 	}
-	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
-		return false, err
-	}
-	if err := os.WriteFile(p, []byte(StubContent), 0o644); err != nil {
+	if err := Write(projectDir, content); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// Write writes team-rules.md with content, creating .amq-squad if needed.
+func Write(projectDir, content string) error {
+	p := Path(projectDir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SyncPlan describes what sync would do for a single target file.

--- a/skills/claude/amq-squad-team/SKILL.md
+++ b/skills/claude/amq-squad-team/SKILL.md
@@ -91,6 +91,7 @@ amq-squad team show
 Generate `.amq-squad/team-rules.md` with these sections:
 
 - Team members, ownership, and exact active routes
+- Role scope and boundaries for each selected persona
 - Startup context from previous AMQ history
 - Workflow
 - Approvals
@@ -99,6 +100,8 @@ Generate `.amq-squad/team-rules.md` with these sections:
 - Style
 
 Keep the generated file concrete. Name exact sessions and project paths when known. Use short bullets.
+Make role boundaries explicit: PM, CPO, Designer, QA, and CTO route implementation
+to developer roles by default instead of editing code themselves.
 
 ## Fresh Team Rule
 

--- a/skills/claude/amq-squad-team/references/team-rules-template.md
+++ b/skills/claude/amq-squad-team/references/team-rules-template.md
@@ -6,12 +6,29 @@ Shared norms for this amq-squad team. Every fresh agent should read this before 
 
 - cpo (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns product direction, priorities, and scope.
 - cto (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns technical direction, architecture, and final engineering sign-off.
+- senior-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns complex implementation, code review, and technical mentorship.
 - fullstack (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- frontend-dev (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns browser UI implementation and frontend polish.
+- backend-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns backend implementation, APIs, persistence, services, and integrations.
+- mobile-dev (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns mobile implementation, native flows, and device behavior.
+- junior-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns narrow implementation tasks and needs review before work is ready.
 - qa (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns validation and regression checks. May run from a different project cwd.
+- pm (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns work ordering, clarification, coordination, and handoffs.
+- designer (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns product flows, UX, visual shape, and design assets.
+
+Keep only active roster entries in the final rules file.
 
 The current `.amq-squad/team.json` roster is authoritative for live routing.
 Use old AMQ history only as context. Do not route new work to an inferred or
 restorable legacy handle when it conflicts with the current roster.
+
+## Role Scope
+
+- Stay inside your assigned role. User feedback is not permission to pick up implementation work unless your role scope includes implementation.
+- Non-implementation roles turn feedback into scope, acceptance criteria, decisions, or handoffs. They do not edit code unless the user explicitly assigns coding work to that role.
+- PM, CPO, Designer, QA, and CTO should route implementation to the right developer role by default.
+- Developer roles own code changes only after the work is scoped and routed to them.
+- If a request crosses role boundaries, ask or hand off on AMQ instead of silently changing lanes.
 
 ## Startup Context
 

--- a/skills/codex/amq-squad-team/SKILL.md
+++ b/skills/codex/amq-squad-team/SKILL.md
@@ -87,6 +87,7 @@ amq-squad team show
 Generate `.amq-squad/team-rules.md` with these sections:
 
 - Team members, ownership, and exact active routes
+- Role scope and boundaries for each selected persona
 - Startup context from previous AMQ history
 - Workflow
 - Approvals
@@ -95,6 +96,8 @@ Generate `.amq-squad/team-rules.md` with these sections:
 - Style
 
 Keep the generated file concrete. Name exact sessions and project paths when known. Use short bullets.
+Make role boundaries explicit: PM, CPO, Designer, QA, and CTO route implementation
+to developer roles by default instead of editing code themselves.
 
 ## Fresh Team Rule
 

--- a/skills/codex/amq-squad-team/references/team-rules-template.md
+++ b/skills/codex/amq-squad-team/references/team-rules-template.md
@@ -6,12 +6,29 @@ Shared norms for this amq-squad team. Every fresh agent should read this before 
 
 - cpo (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns product direction, priorities, and scope.
 - cto (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns technical direction, architecture, and final engineering sign-off.
+- senior-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns complex implementation, code review, and technical mentorship.
 - fullstack (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns backend/dev implementation. Rename in prose if the user calls this "backend dev".
+- frontend-dev (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns browser UI implementation and frontend polish.
+- backend-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns backend implementation, APIs, persistence, services, and integrations.
+- mobile-dev (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns mobile implementation, native flows, and device behavior.
+- junior-dev (codex): handle `<handle>`, session `<session>`, project `<project>`. Owns narrow implementation tasks and needs review before work is ready.
 - qa (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns validation and regression checks. May run from a different project cwd.
+- pm (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns work ordering, clarification, coordination, and handoffs.
+- designer (claude): handle `<handle>`, session `<session>`, project `<project>`. Owns product flows, UX, visual shape, and design assets.
+
+Keep only active roster entries in the final rules file.
 
 The current `.amq-squad/team.json` roster is authoritative for live routing.
 Use old AMQ history only as context. Do not route new work to an inferred or
 restorable legacy handle when it conflicts with the current roster.
+
+## Role Scope
+
+- Stay inside your assigned role. User feedback is not permission to pick up implementation work unless your role scope includes implementation.
+- Non-implementation roles turn feedback into scope, acceptance criteria, decisions, or handoffs. They do not edit code unless the user explicitly assigns coding work to that role.
+- PM, CPO, Designer, QA, and CTO should route implementation to the right developer role by default.
+- Developer roles own code changes only after the work is scoped and routed to them.
+- If a request crosses role boundaries, ask or hand off on AMQ instead of silently changing lanes.
 
 ## Startup Context
 


### PR DESCRIPTION
## Summary
- prepend Codex and Claude launch defaults when custom child args are present, with --no-default-args as an opt-out
- generate roster-aware team-rules.md with explicit role boundaries so PM and product roles hand off implementation by default
- add team rules refresh with amq-squad team rules init --force and update skill templates/docs

## Tests
- make ci