### PR TITLE
Add version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ amq-squad restore --exec --role cto Exec one selected local launch through
 amq-squad list [--json]             List restorable amq-squad records and
                                     AMQ-only inferred history across known
                                     projects.
+amq-squad version                   Print the installed amq-squad version.
 ```
 
 ## Files it writes

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,7 +18,7 @@ func Run(args []string, version string) error {
 		printUsage()
 		return nil
 	}
-	if args[0] == "--version" || args[0] == "-v" {
+	if args[0] == "--version" || args[0] == "-v" || args[0] == "version" {
 		fmt.Println("amq-squad", version)
 		return nil
 	}
@@ -48,6 +48,7 @@ Commands:
   launch    Launch a single agent with a role (called by 'team show' output)
   restore   Restore registered agents from local launch history
   list      List registered agents across known projects
+  version   Print the amq-squad version
 
 Run 'amq-squad <command> --help' for command-specific options.
 `)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunVersionCommand(t *testing.T) {
+	stdout, stderr, err := captureOutput(t, func() error {
+		return Run([]string{"version"}, "v-test")
+	})
+	if err != nil {
+		t.Fatalf("Run version: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "amq-squad v-test" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestRunHelpIncludesVersionCommand(t *testing.T) {
+	stdout, stderr, err := captureOutput(t, func() error {
+		return Run([]string{"--help"}, "v-test")
+	})
+	if err != nil {
+		t.Fatalf("Run help: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "version   Print the amq-squad version") {
+		t.Fatalf("help missing version command:\n%s", stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- add amq-squad version as an alias for --version
- include the command in top-level help and README
- cover the command and help output with CLI tests

## Tests
- go test ./internal/cli
- make ci
- make build