### PR TITLE
Fix go install version reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet ci install clean
+.PHONY: build test fmt fmt-check vet ci install release-smoke clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -22,6 +22,19 @@ ci: fmt-check vet test
 
 install: build
 	install amq-squad $(GOPATH)/bin/amq-squad 2>/dev/null || install amq-squad $(HOME)/go/bin/amq-squad
+
+release-smoke:
+	@test "$(VERSION)" != "dev" || (echo "VERSION is required, for example VERSION=v0.5.1" >&2; exit 1)
+	@tmp="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	GOBIN="$$tmp" GOPROXY=direct go install github.com/omriariav/amq-squad/cmd/amq-squad@$(VERSION); \
+	got="$$("$$tmp/amq-squad" version)"; \
+	want="amq-squad $(VERSION)"; \
+	if [ "$$got" != "$$want" ]; then \
+		echo "version mismatch: got '$$got', want '$$want'" >&2; \
+		exit 1; \
+	fi; \
+	echo "$$got"
 
 clean:
 	rm -f amq-squad

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.1
 ```
 
 Use `@latest` if you intentionally want the newest published tag.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,26 @@
+# Releasing amq-squad
+
+Release changes must go through a PR and `make ci` before merge.
+
+## Patch Release Checklist
+
+1. Update user-facing install references, usually the README `go install` tag.
+2. Merge the release PR.
+3. Tag the merge commit:
+
+   ```sh
+   git tag -a v0.5.1 -m "amq-squad v0.5.1"
+   git push origin v0.5.1
+   ```
+
+4. Create the GitHub release for the tag.
+5. Smoke test the published install path:
+
+   ```sh
+   make release-smoke VERSION=v0.5.1
+   ```
+
+The smoke test installs `github.com/omriariav/amq-squad/cmd/amq-squad@VERSION`
+into a temporary `GOBIN` and fails unless `amq-squad version` prints the same
+version. This catches releases where the source tag works but the documented
+`go install` path reports `dev` or an old version.

--- a/cmd/amq-squad/main.go
+++ b/cmd/amq-squad/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/omriariav/amq-squad/internal/cli"
 )
@@ -10,7 +11,7 @@ import (
 var version = "dev"
 
 func main() {
-	if err := cli.Run(os.Args[1:], version); err != nil {
+	if err := cli.Run(os.Args[1:], effectiveVersion()); err != nil {
 		if _, ok := err.(cli.UsageError); ok {
 			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(2)
@@ -18,4 +19,26 @@ func main() {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}
+}
+
+func effectiveVersion() string {
+	return resolveVersion(version, buildInfoVersion())
+}
+
+func buildInfoVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return info.Main.Version
+}
+
+func resolveVersion(ldflagVersion string, moduleVersion string) string {
+	if ldflagVersion != "" && ldflagVersion != "dev" {
+		return ldflagVersion
+	}
+	if moduleVersion == "" || moduleVersion == "(devel)" {
+		return ldflagVersion
+	}
+	return moduleVersion
 }

--- a/cmd/amq-squad/main_test.go
+++ b/cmd/amq-squad/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+func TestResolveVersionPrefersLdflagVersion(t *testing.T) {
+	if got := resolveVersion("v1.2.3", "v9.9.9"); got != "v1.2.3" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestResolveVersionFallsBackToModuleVersion(t *testing.T) {
+	if got := resolveVersion("dev", "v1.2.3"); got != "v1.2.3" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "v1.2.3")
+	}
+}
+
+func TestResolveVersionKeepsDevForDevelBuild(t *testing.T) {
+	if got := resolveVersion("dev", "(devel)"); got != "dev" {
+		t.Fatalf("resolveVersion() = %q, want %q", got, "dev")
+	}
+}


### PR DESCRIPTION
## Summary

- fall back to Go build metadata when Makefile ldflags do not set the binary version
- add unit coverage for version resolution
- add a release smoke target that installs a published tag into a temporary GOBIN and verifies `amq-squad version`
- document the release checklist and update README install docs for v0.5.1

## Validation

- `make ci`
- `make release-smoke VERSION=v0.5.0` fails with `got 'amq-squad dev', want 'amq-squad v0.5.0'`, proving the guard catches the existing release issue
