### PR TITLE
Harden v0.5.2 local safety paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.1
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2
 ```
 
 Use `@latest` if you intentionally want the newest published tag.
@@ -235,11 +235,17 @@ yours and stays untouched.
 amq-squad team rules init        Seed missing .amq-squad/team-rules.md with a stub
 amq-squad team sync              Preview what would change (exit 1 if drift)
 amq-squad team sync --apply      Write the managed block into CLAUDE.md and AGENTS.md
+amq-squad team sync --apply --allow-outside
+                                  Also write member cwds outside team-home
 ```
 
 On first `--apply` with an existing CLAUDE.md, your content is adopted as the
 user region and the managed block is appended. Subsequent syncs only refresh
-the managed block.
+the managed block. Sync writes are guarded with same-directory temporary files,
+atomic rename, and a stale-plan check. Member cwds outside the team-home
+directory require `--allow-outside` so a hand-edited `team.json` cannot write
+instructions into unrelated folders by surprise. Every configured cwd must
+already exist before sync writes there.
 
 ## Walkthroughs
 
@@ -329,7 +335,7 @@ Edit `~/Code/project-a/.amq-squad/team-rules.md`. Then sync. Because one member
 lives elsewhere, sync walks both cwds and writes CLAUDE.md + AGENTS.md in each:
 
 ```sh
-amq-squad team sync --apply
+amq-squad team sync --apply --allow-outside
 # Wrote 4 files: CLAUDE.md and AGENTS.md in project-a, same in project-b
 ```
 
@@ -368,7 +374,8 @@ amq-squad team launch [--terminal tmux] [--target current-window|new-session]
                       [--no-bootstrap] [--dry-run]
                                     Open the configured team in tmux panes
 amq-squad team rules init [--force] Seed or refresh .amq-squad/team-rules.md
-amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
+amq-squad team sync [--apply] [--allow-outside]
+                                    Sync CLAUDE.md and AGENTS.md from team-rules.md
 
 amq-squad launch --role <r> --session <s> [--team-workstream] --me <handle> [--conversation ref] [--no-bootstrap] [--no-default-args] <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md

--- a/doc.html
+++ b/doc.html
@@ -510,7 +510,7 @@
     <main>
       <header class="hero">
         <div class="hero-inner">
-          <p class="eyebrow">v0.5.1 guide</p>
+          <p class="eyebrow">v0.5.2 guide</p>
           <h1>How to use amq-squad</h1>
           <p class="lead">
             amq-squad is the project layer above AMQ. It records who is on the
@@ -542,7 +542,7 @@
             into <code class="inline-code">$GOBIN</code> or
             <code class="inline-code">$HOME/go/bin</code>.
           </p>
-          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.1
+          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2
 amq-squad version</code></pre></div>
           <p>
             You also need Go 1.25 or newer, the <code class="inline-code">amq</code>
@@ -709,7 +709,8 @@ amq-squad team launch --fresh --session issue-96</code></pre></div>
             <div class="panel">
               <h3>Sync rules</h3>
               <div class="code"><pre><code>amq-squad team sync
-amq-squad team sync --apply</code></pre></div>
+amq-squad team sync --apply
+amq-squad team sync --apply --allow-outside</code></pre></div>
               <p>Preview first. Apply writes managed blocks into CLAUDE.md and AGENTS.md.</p>
             </div>
           </div>
@@ -717,6 +718,12 @@ amq-squad team sync --apply</code></pre></div>
             Content outside the managed markers remains yours. Update
             <code class="inline-code">team-rules.md</code> and sync again when
             team norms change.
+          </p>
+          <p>
+            Sync writes use same-directory temporary files, atomic rename, and
+            a stale-plan check. Member cwds outside the team-home require
+            <code class="inline-code">--allow-outside</code>, and every
+            configured cwd must already exist before sync writes there.
           </p>
         </div>
       </section>
@@ -848,7 +855,7 @@ amq drain --include-body</code></pre></div>
               <p>Check which binary is running, then reinstall the desired tag.</p>
               <div class="code"><pre><code>which -a amq-squad
 amq-squad version
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.1</code></pre></div>
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2</code></pre></div>
             </div>
             <div class="panel">
               <h3>Launch plan looks wrong</h3>
@@ -867,7 +874,8 @@ amq-squad restore</code></pre></div>
               <p>Use per-role <code class="inline-code">--cwd</code> mappings, then configure AMQ peers in each project when members live in different repos.</p>
               <div class="code"><pre><code>amq-squad team init \
   --personas cto,fullstack,qa \
-  --cwd qa=~/Code/project-b</code></pre></div>
+  --cwd qa=~/Code/project-b
+amq-squad team sync --apply --allow-outside</code></pre></div>
             </div>
           </div>
         </div>

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -33,20 +33,23 @@ type bootstrapContext struct {
 	LaunchPath    string
 	CurrentTeam   []bootstrapTeamMember
 	Workstreams   []bootstrapWorkstream
+	Warnings      []string
 }
 
 type bootstrapTeamMember struct {
-	Role    string
-	Handle  string
-	Binary  string
-	Session string
-	Project string
-	CWD     string
-	Route   string
-	You     bool
+	Role       string
+	Handle     string
+	Binary     string
+	Session    string
+	Project    string
+	CWD        string
+	Route      string
+	RouteError string
+	You        bool
 }
 
 func buildBootstrapPrompt(ctx bootstrapContext) (string, error) {
+	ctx = sanitizeBootstrapContext(ctx)
 	tpl, err := template.New("bootstrap").Funcs(template.FuncMap{
 		"orDefault": func(s, fallback string) string {
 			if s == "" {
@@ -65,6 +68,60 @@ func buildBootstrapPrompt(ctx bootstrapContext) (string, error) {
 	return b.String(), nil
 }
 
+func sanitizeBootstrapContext(ctx bootstrapContext) bootstrapContext {
+	ctx.Role = promptText(ctx.Role)
+	ctx.Handle = promptText(ctx.Handle)
+	ctx.Binary = promptText(ctx.Binary)
+	ctx.Session = promptText(ctx.Session)
+	ctx.CWD = promptText(ctx.CWD)
+	ctx.Root = promptText(ctx.Root)
+	ctx.AgentDir = promptText(ctx.AgentDir)
+	ctx.TeamHome = promptText(ctx.TeamHome)
+	ctx.TeamRulesPath = promptText(ctx.TeamRulesPath)
+	ctx.RolePath = promptText(ctx.RolePath)
+	ctx.LaunchPath = promptText(ctx.LaunchPath)
+	for i := range ctx.CurrentTeam {
+		m := &ctx.CurrentTeam[i]
+		m.Role = promptText(m.Role)
+		m.Handle = promptText(m.Handle)
+		m.Binary = promptText(m.Binary)
+		m.Session = promptText(m.Session)
+		m.Project = promptText(m.Project)
+		m.CWD = promptText(m.CWD)
+		m.Route = promptText(m.Route)
+		m.RouteError = promptText(m.RouteError)
+	}
+	for i := range ctx.Workstreams {
+		w := &ctx.Workstreams[i]
+		w.Name = promptText(w.Name)
+		w.Handles = promptText(w.Handles)
+		w.LastTouched = promptText(w.LastTouched)
+	}
+	for i := range ctx.Warnings {
+		ctx.Warnings[i] = promptText(ctx.Warnings[i])
+	}
+	return ctx
+}
+
+func promptText(s string) string {
+	// Keep prompt data single-line and out of inline-code delimiters; team.Read
+	// already rejects control characters in persisted team fields.
+	var b strings.Builder
+	lastSpace := false
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f || r == '`' {
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		lastSpace = false
+	}
+	return strings.TrimSpace(b.String())
+}
+
 func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrapContext {
 	teamRulesPath := ""
 	if teamHome != "" {
@@ -72,6 +129,7 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 	} else if _, err := os.Stat(rules.Path(rec.CWD)); err == nil {
 		teamRulesPath = rules.Path(rec.CWD)
 	}
+	currentTeam, warnings := bootstrapCurrentTeam(rec, teamHome)
 	return bootstrapContext{
 		Role:          rec.Role,
 		Handle:        rec.Handle,
@@ -84,40 +142,49 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 		TeamRulesPath: teamRulesPath,
 		RolePath:      role.Path(agentDir),
 		LaunchPath:    filepath.Join(agentDir, launch.FileName),
-		CurrentTeam:   bootstrapCurrentTeam(rec, teamHome),
+		CurrentTeam:   currentTeam,
 		Workstreams:   siblingWorkstreamSummaries(rec.Root, rec.Session),
+		Warnings:      warnings,
 	}
 }
 
-func bootstrapCurrentTeam(rec launch.Record, teamHome string) []bootstrapTeamMember {
+func bootstrapCurrentTeam(rec launch.Record, teamHome string) ([]bootstrapTeamMember, []string) {
 	home := teamHome
 	if home == "" {
 		home = rec.CWD
 	}
 	t, err := team.Read(home)
-	if err != nil || len(t.Members) == 0 {
-		return nil
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []string{fmt.Sprintf("current team routing unavailable: %v", err)}
+	}
+	if len(t.Members) == 0 {
+		return nil, nil
 	}
 
-	currentProject := projectNameForCWD(rec.CWD)
+	currentProject := projectIdentityForCWD(rec.CWD)
 	out := make([]bootstrapTeamMember, 0, len(t.Members))
 	for _, m := range t.Members {
 		cwd := m.EffectiveCWD(t.Project)
-		project := projectNameForCWD(cwd)
+		project := projectIdentityForCWD(cwd)
 		handle := memberHandle(m)
 		session := routingSessionForMember(rec, m)
+		route, routeError := routeCommandFor(currentProject, project, samePath(rec.CWD, cwd), rec.Handle, handle, session)
 		out = append(out, bootstrapTeamMember{
-			Role:    m.Role,
-			Handle:  handle,
-			Binary:  m.Binary,
-			Session: session,
-			Project: project,
-			CWD:     cwd,
-			Route:   routeCommandFor(currentProject, project, rec.Handle, handle, session),
-			You:     sameLaunchTarget(rec, cwd, handle, m),
+			Role:       m.Role,
+			Handle:     handle,
+			Binary:     m.Binary,
+			Session:    session,
+			Project:    project.DisplayName(),
+			CWD:        cwd,
+			Route:      route,
+			RouteError: routeError,
+			You:        sameLaunchTarget(rec, cwd, handle, m),
 		})
 	}
-	return out
+	return out, nil
 }
 
 func routingSessionForMember(rec launch.Record, m team.Member) string {
@@ -144,10 +211,29 @@ func sameLaunchTarget(rec launch.Record, cwd, handle string, m team.Member) bool
 		rec.CWD == cwd
 }
 
-func routeCommandFor(currentProject, targetProject, fromHandle, handle, session string) string {
+type projectIdentity struct {
+	Name  string
+	Dir   string
+	Known bool
+}
+
+func (p projectIdentity) DisplayName() string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return "(unknown)"
+}
+
+func routeCommandFor(currentProject, targetProject projectIdentity, sameCWD bool, fromHandle, handle, session string) (string, string) {
+	if !sameCWD && (!currentProject.Known || !targetProject.Known) {
+		return "", "AMQ project identity is missing; add .amqrc project names or use amq route manually"
+	}
+	if !sameCWD && currentProject.Name == targetProject.Name && !samePath(currentProject.Dir, targetProject.Dir) {
+		return "", "AMQ project identity is ambiguous; matching project names come from different .amqrc roots"
+	}
 	args := []string{"amq", "send", "--to", handle}
-	if currentProject != "" && targetProject != "" && currentProject != targetProject {
-		args = append(args, "--project", targetProject)
+	if !sameCWD && currentProject.Name != targetProject.Name {
+		args = append(args, "--project", targetProject.Name)
 	}
 	if session != "" {
 		args = append(args, "--session", session)
@@ -158,19 +244,29 @@ func routeCommandFor(currentProject, targetProject, fromHandle, handle, session 
 	for i, arg := range args {
 		args[i] = shellQuote(arg)
 	}
-	return strings.Join(args, " ")
+	return strings.Join(args, " "), ""
 }
 
-func projectNameForCWD(cwd string) string {
+func projectIdentityForCWD(cwd string) projectIdentity {
 	if cwd == "" {
-		return ""
+		return projectIdentity{}
 	}
 	if dir, name := findProjectName(cwd); name != "" {
-		return name
-	} else if dir != "" {
-		return filepath.Base(dir)
+		return projectIdentity{Name: name, Dir: dir, Known: true}
 	}
-	return filepath.Base(cwd)
+	return projectIdentity{}
+}
+
+func samePath(a, b string) bool {
+	aa, err := filepath.Abs(a)
+	if err != nil {
+		aa = filepath.Clean(a)
+	}
+	bb, err := filepath.Abs(b)
+	if err != nil {
+		bb = filepath.Clean(b)
+	}
+	return aa == bb
 }
 
 func findProjectName(start string) (string, string) {

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -21,7 +21,11 @@ Current team routing:
 These entries come from the current `.amq-squad/team.json` and are authoritative for live routing. Treat `amq-squad list` and `amq-squad restore` output as history only unless the user explicitly asks to resume an old session.
 {{- range .CurrentTeam }}
 - {{.Role}}{{if .You}} (you){{end}}: handle {{.Handle}}, binary {{.Binary}}, workstream {{orDefault .Session "(default)"}}, project {{.Project}}, cwd {{.CWD}}
+  {{- if .Route }}
   send: `{{.Route}}`
+  {{- else }}
+  send: unavailable ({{.RouteError}})
+  {{- end }}
 {{- end }}
 
 {{- end }}
@@ -30,6 +34,13 @@ Other workstreams in this project:
 These are sibling AMQ sessions for orientation only. Do not load their message bodies unless the user asks.
 {{- range .Workstreams }}
 - {{.Name}}: handles {{.Handles}}{{if .LastTouched}}, last touched {{.LastTouched}}{{end}}
+{{- end }}
+
+{{- end }}
+{{- if .Warnings }}
+Startup warnings:
+{{- range .Warnings }}
+- {{.}}
 {{- end }}
 
 {{- end }}

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -116,7 +116,10 @@ func TestBootstrapCurrentTeamFallsBackToRoleWhenHandleMissing(t *testing.T) {
 	}
 
 	rec := launch.Record{Role: "cpo", Handle: "cpo", CWD: teamHome}
-	got := bootstrapCurrentTeam(rec, teamHome)
+	got, warnings := bootstrapCurrentTeam(rec, teamHome)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
 	if len(got) != 1 {
 		t.Fatalf("bootstrapCurrentTeam returned %d members, want 1", len(got))
 	}
@@ -140,7 +143,10 @@ func TestBootstrapCurrentTeamKeepsLegacyRoleSessions(t *testing.T) {
 	}
 
 	rec := launch.Record{Role: "cto", Handle: "cto", Session: "cto", CWD: teamHome}
-	got := bootstrapCurrentTeam(rec, teamHome)
+	got, warnings := bootstrapCurrentTeam(rec, teamHome)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
 	if len(got) != 2 {
 		t.Fatalf("bootstrapCurrentTeam returned %d members, want 2", len(got))
 	}
@@ -176,7 +182,10 @@ func TestBootstrapCurrentTeamUsesExplicitSharedWorkstreamEvenWhenNameMatchesRole
 		SharedWorkstream: true,
 		CWD:              teamHome,
 	}
-	got := bootstrapCurrentTeam(rec, teamHome)
+	got, warnings := bootstrapCurrentTeam(rec, teamHome)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
 	if len(got) != 2 {
 		t.Fatalf("bootstrapCurrentTeam returned %d members, want 2", len(got))
 	}
@@ -194,11 +203,98 @@ func TestBootstrapCurrentTeamUsesExplicitSharedWorkstreamEvenWhenNameMatchesRole
 	}
 }
 
+func TestBootstrapCurrentTeamDoesNotGuessCrossProjectRouteWithoutProjectIdentity(t *testing.T) {
+	teamHome := t.TempDir()
+	qaProject := t.TempDir()
+	if err := team.Write(teamHome, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96", CWD: qaProject},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := launch.Record{Role: "cto", Handle: "cto", Session: "issue-96", CWD: teamHome}
+	got, warnings := bootstrapCurrentTeam(rec, teamHome)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	var qa bootstrapTeamMember
+	for _, m := range got {
+		if m.Role == "qa" {
+			qa = m
+		}
+	}
+	if qa.Route != "" {
+		t.Fatalf("qa route = %q, want no guessed route", qa.Route)
+	}
+	if !strings.Contains(qa.RouteError, "project identity is missing") {
+		t.Fatalf("qa route error = %q, want missing identity", qa.RouteError)
+	}
+}
+
 func TestRouteCommandQuotesUnsafeValues(t *testing.T) {
-	got := routeCommandFor("project-a", "project b", "cto", "qa lead", "fresh qa")
+	got, errText := routeCommandFor(
+		projectIdentity{Name: "project-a", Known: true},
+		projectIdentity{Name: "project b", Known: true},
+		false,
+		"cto",
+		"qa lead",
+		"fresh qa",
+	)
+	if errText != "" {
+		t.Fatalf("routeCommandFor error = %q", errText)
+	}
 	want := "amq send --to 'qa lead' --project 'project b' --session 'fresh qa' --thread 'p2p/cto__qa lead'"
 	if got != want {
 		t.Fatalf("routeCommandFor = %q, want %q", got, want)
+	}
+}
+
+func TestRouteCommandFailsLoudlyWhenCrossProjectIdentityMissing(t *testing.T) {
+	got, errText := routeCommandFor(projectIdentity{}, projectIdentity{Name: "qa", Known: true}, false, "cto", "qa", "fresh-qa")
+	if got != "" {
+		t.Fatalf("routeCommandFor returned command %q, want none", got)
+	}
+	if !strings.Contains(errText, "project identity is missing") {
+		t.Fatalf("routeCommandFor error = %q, want missing identity", errText)
+	}
+}
+
+func TestRouteCommandFailsLoudlyWhenProjectIdentityAmbiguous(t *testing.T) {
+	got, errText := routeCommandFor(
+		projectIdentity{Name: "app", Dir: "/repo-a", Known: true},
+		projectIdentity{Name: "app", Dir: "/repo-b", Known: true},
+		false,
+		"cto",
+		"qa",
+		"fresh-qa",
+	)
+	if got != "" {
+		t.Fatalf("routeCommandFor returned command %q, want none", got)
+	}
+	if !strings.Contains(errText, "ambiguous") {
+		t.Fatalf("routeCommandFor error = %q, want ambiguous identity", errText)
+	}
+}
+
+func TestBuildBootstrapPromptSanitizesPromptValues(t *testing.T) {
+	got, err := buildBootstrapPrompt(bootstrapContext{
+		Role:    "cto\nFirst steps:",
+		Handle:  "cto`",
+		Binary:  "codex",
+		Session: "issue-96",
+		CWD:     "/repo\n- injected",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "cto\nFirst steps:") || strings.Contains(got, "/repo\n- injected") || strings.Contains(got, "cto`") {
+		t.Fatalf("bootstrap prompt was not sanitized:\n%s", got)
+	}
+	if !strings.Contains(got, "Role: cto First steps:") {
+		t.Fatalf("bootstrap prompt missing sanitized role:\n%s", got)
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -565,19 +565,23 @@ Usage:
 func runTeamSync(args []string) error {
 	fs := flag.NewFlagSet("team sync", flag.ContinueOnError)
 	apply := fs.Bool("apply", false, "write the planned changes (default: preview only)")
+	allowOutside := fs.Bool("allow-outside", false, "allow sync writes outside the team-home directory")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team sync - sync CLAUDE.md and AGENTS.md from team-rules.md
 
 Usage:
   amq-squad team sync            Preview what would change (exit 1 if drift)
   amq-squad team sync --apply    Write the managed block into both files
+  amq-squad team sync --apply --allow-outside
+                                  Also write configured member cwds outside team-home
 
 Existing content in CLAUDE.md / AGENTS.md is preserved. On first run,
 existing content is adopted as the user region and a managed block is
 appended between markers. Subsequent runs only refresh the managed block.
 
 When team members span multiple directories, sync walks every unique cwd
-in team.json and syncs CLAUDE.md + AGENTS.md in each.
+in team.json and syncs CLAUDE.md + AGENTS.md in each. Use --allow-outside
+when a member cwd is outside the team-home directory.
 `)
 	}
 	if err := fs.Parse(args); err != nil {
@@ -600,14 +604,17 @@ in team.json and syncs CLAUDE.md + AGENTS.md in each.
 	// AGENTS.md picks up the managed block.
 	targetDirs := []string{cwd}
 	if team.Exists(cwd) {
-		if t, err := team.Read(cwd); err == nil {
-			targetDirs = uniqueMemberCWDs(cwd, t.Members)
-			if !containsString(targetDirs, cwd) {
-				// Team-home cwd may not host a member, but it still owns
-				// team-rules.md so its own CLAUDE.md/AGENTS.md should sync.
-				targetDirs = append(targetDirs, cwd)
-				sort.Strings(targetDirs)
-			}
+		t, err := team.Read(cwd)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
+		}
+		targetDirs, err = syncTargetDirs(cwd, t.Members, *allowOutside)
+		if err != nil {
+			return err
+		}
+		targetDirs, err = ensureTeamHomeSyncTarget(targetDirs, cwd)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -661,6 +668,75 @@ func containsString(xs []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func syncTargetDirs(projectDir string, members []team.Member, allowOutside bool) ([]string, error) {
+	home, err := canonicalDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve team-home: %w", err)
+	}
+	targets := uniqueMemberCWDs(home, members)
+	if len(targets) == 0 {
+		targets = []string{home}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(targets))
+	for _, raw := range targets {
+		dir, err := canonicalDir(raw)
+		if err != nil {
+			return nil, fmt.Errorf("resolve sync target %s: %w", raw, err)
+		}
+		if !allowOutside && !pathWithin(home, dir) {
+			return nil, fmt.Errorf("sync target %s is outside team-home %s; pass --allow-outside to write there", dir, home)
+		}
+		if !seen[dir] {
+			seen[dir] = true
+			out = append(out, dir)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func ensureTeamHomeSyncTarget(targetDirs []string, projectDir string) ([]string, error) {
+	homeDir, err := canonicalDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve team-home: %w", err)
+	}
+	if containsString(targetDirs, homeDir) {
+		return targetDirs, nil
+	}
+	out := append([]string(nil), targetDirs...)
+	out = append(out, homeDir)
+	sort.Strings(out)
+	return out, nil
+}
+
+func canonicalDir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", abs)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+func pathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func describePlan(p rules.SyncPlan) string {

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -819,6 +819,60 @@ func TestUniqueMemberCWDs(t *testing.T) {
 	}
 }
 
+func TestSyncTargetDirsRejectsOutsideTeamHome(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	_, err := syncTargetDirs(home, []team.Member{{Role: "qa", CWD: outside}}, false)
+	if err == nil || !strings.Contains(err.Error(), "outside team-home") {
+		t.Fatalf("syncTargetDirs error = %v, want outside team-home", err)
+	}
+}
+
+func TestSyncTargetDirsAllowsOutsideWhenExplicit(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	got, err := syncTargetDirs(home, []team.Member{{Role: "qa", CWD: outside}}, true)
+	if err != nil {
+		t.Fatalf("syncTargetDirs: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("syncTargetDirs = %v, want [%s]", got, want)
+	}
+}
+
+func TestSyncTargetDirsRequiresExistingDirectory(t *testing.T) {
+	home := t.TempDir()
+	missing := filepath.Join(home, "missing")
+	_, err := syncTargetDirs(home, []team.Member{{Role: "qa", CWD: missing}}, true)
+	if err == nil || !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("syncTargetDirs error = %v, want missing dir", err)
+	}
+}
+
+func TestEnsureTeamHomeSyncTargetUsesCanonicalPath(t *testing.T) {
+	realHome := t.TempDir()
+	linkParent := t.TempDir()
+	linkHome := filepath.Join(linkParent, "team-home")
+	if err := os.Symlink(realHome, linkHome); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	canonical, err := filepath.EvalSymlinks(linkHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ensureTeamHomeSyncTarget([]string{canonical}, linkHome)
+	if err != nil {
+		t.Fatalf("ensureTeamHomeSyncTarget: %v", err)
+	}
+	if len(got) != 1 || got[0] != canonical {
+		t.Fatalf("ensureTeamHomeSyncTarget = %v, want one canonical target %s", got, canonical)
+	}
+}
+
 func TestExpandPathTilde(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -141,12 +141,98 @@ func Apply(plans []SyncPlan) (int, error) {
 		if p.Unchanged {
 			continue
 		}
-		if err := os.WriteFile(p.Target, []byte(p.After), 0o644); err != nil {
+		if err := verifyPlanCurrent(p); err != nil {
+			return n, err
+		}
+		mode, err := targetMode(p.Target, 0o644)
+		if err != nil {
+			return n, err
+		}
+		if err := atomicWriteFile(p.Target, []byte(p.After), mode); err != nil {
 			return n, fmt.Errorf("write %s: %w", p.Target, err)
 		}
 		n++
 	}
 	return n, nil
+}
+
+func verifyPlanCurrent(p SyncPlan) error {
+	current, existed, err := readIfExists(p.Target)
+	if err != nil {
+		return fmt.Errorf("read current %s: %w", p.Target, err)
+	}
+	if p.Creating {
+		if existed {
+			return fmt.Errorf("%s changed since sync plan was created", p.Target)
+		}
+		return nil
+	}
+	if !existed {
+		return fmt.Errorf("%s changed since sync plan was created", p.Target)
+	}
+	if current != p.Before {
+		return fmt.Errorf("%s changed since sync plan was created", p.Target)
+	}
+	return nil
+}
+
+func targetMode(path string, fallback os.FileMode) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.Mode().Perm(), nil
+	}
+	if os.IsNotExist(err) {
+		return fallback, nil
+	}
+	return 0, fmt.Errorf("stat %s: %w", path, err)
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return syncDir(dir)
+}
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func buildManagedBlock(rulesBody string) string {

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -158,6 +158,78 @@ func TestApplyOnlyWritesChanged(t *testing.T) {
 	}
 }
 
+func TestApplyRejectsChangedFileSincePlan(t *testing.T) {
+	project := t.TempDir()
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ClaudeFile), []byte("user edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = Apply(plans)
+	if err == nil || !strings.Contains(err.Error(), "changed since sync plan") {
+		t.Fatalf("Apply error = %v, want stale plan error", err)
+	}
+}
+
+func TestApplyRejectsNewEmptyFileSincePlan(t *testing.T) {
+	project := t.TempDir()
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ClaudeFile), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = Apply(plans)
+	if err == nil || !strings.Contains(err.Error(), "changed since sync plan") {
+		t.Fatalf("Apply error = %v, want stale plan error", err)
+	}
+}
+
+func TestApplyDoesNotLeaveTempFiles(t *testing.T) {
+	project := t.TempDir()
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if _, err := Apply(plans); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	entries, err := os.ReadDir(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Fatalf("left temp file behind: %s", e.Name())
+		}
+	}
+}
+
+func TestApplyPreservesExistingFileMode(t *testing.T) {
+	project := t.TempDir()
+	path := filepath.Join(project, ClaudeFile)
+	if err := os.WriteFile(path, []byte("# Existing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plans, err := Plan(project, "# Team Rules\n")
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if _, err := Apply(plans); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 600", got)
+	}
+}
+
 func TestEnsureStub(t *testing.T) {
 	project := t.TempDir()
 	wrote, err := EnsureStub(project)

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -76,6 +77,9 @@ func Read(projectDir string) (Team, error) {
 		return Team{}, fmt.Errorf("parse %s: %w", p, err)
 	}
 	t.Project = projectDir
+	if err := Validate(t); err != nil {
+		return Team{}, fmt.Errorf("validate %s: %w", p, err)
+	}
 	return t, nil
 }
 
@@ -89,6 +93,9 @@ func Write(projectDir string, t Team) error {
 	// Project is not serialized (json:"-") so nothing to set here.
 	if t.CreatedAt.IsZero() {
 		t.CreatedAt = time.Now().UTC()
+	}
+	if err := Validate(t); err != nil {
+		return fmt.Errorf("validate team: %w", err)
 	}
 	b, err := json.MarshalIndent(t, "", "  ")
 	if err != nil {
@@ -109,4 +116,100 @@ func Write(projectDir string, t Team) error {
 func Exists(projectDir string) bool {
 	_, err := os.Stat(Path(projectDir))
 	return err == nil
+}
+
+func Validate(t Team) error {
+	if t.Workstream != "" {
+		if err := ValidateSessionName(t.Workstream); err != nil {
+			return fmt.Errorf("workstream: %w", err)
+		}
+	}
+	seenHandles := map[string]bool{}
+	for i, m := range t.Members {
+		prefix := fmt.Sprintf("members[%d]", i)
+		if err := validateMember(prefix, m); err != nil {
+			return err
+		}
+		handle := m.Handle
+		if handle == "" {
+			handle = m.Role
+		}
+		if handle != "" {
+			if seenHandles[handle] {
+				return fmt.Errorf("%s: duplicate handle %q", prefix, handle)
+			}
+			seenHandles[handle] = true
+		}
+	}
+	return nil
+}
+
+func validateMember(prefix string, m Member) error {
+	if m.Role == "" {
+		return fmt.Errorf("%s.role: cannot be empty", prefix)
+	}
+	if err := ValidateRoleID(m.Role); err != nil {
+		return fmt.Errorf("%s.role: %w", prefix, err)
+	}
+	if m.Handle != "" {
+		if err := ValidateHandle(m.Handle); err != nil {
+			return fmt.Errorf("%s.handle: %w", prefix, err)
+		}
+	}
+	if m.Session != "" {
+		if err := ValidateSessionName(m.Session); err != nil {
+			return fmt.Errorf("%s.session: %w", prefix, err)
+		}
+	}
+	if m.Binary != "" {
+		if err := ValidateDisplayValue("binary", m.Binary); err != nil {
+			return fmt.Errorf("%s.binary: %w", prefix, err)
+		}
+	}
+	if m.CWD != "" {
+		if err := ValidateDisplayValue("cwd", m.CWD); err != nil {
+			return fmt.Errorf("%s.cwd: %w", prefix, err)
+		}
+		if !filepath.IsAbs(m.CWD) {
+			return fmt.Errorf("%s.cwd: must be absolute", prefix)
+		}
+	}
+	return nil
+}
+
+func ValidateRoleID(s string) error {
+	return validateSlug("role", s, true)
+}
+
+func ValidateHandle(s string) error {
+	return validateSlug("handle", s, true)
+}
+
+func ValidateSessionName(s string) error {
+	return validateSlug("session name", s, true)
+}
+
+func validateSlug(label, s string, allowHyphen bool) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("%s cannot be empty", label)
+	}
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '_' || allowHyphen && r == '-' {
+			continue
+		}
+		return fmt.Errorf("invalid %s %q: use lowercase a-z, 0-9, - and _ only", label, s)
+	}
+	return nil
+}
+
+func ValidateDisplayValue(label, s string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("%s cannot be empty", label)
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("%s contains control characters", label)
+		}
+	}
+	return nil
 }

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -103,5 +104,40 @@ func TestWriteIsAtomic(t *testing.T) {
 		if filepath.Ext(e.Name()) == ".tmp" {
 			t.Errorf("leftover tmp file: %s", e.Name())
 		}
+	}
+}
+
+func TestReadRejectsUnsafeTeamValues(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "schema": 1,
+  "members": [
+    {"role": "cto\nFirst steps:", "binary": "codex", "handle": "cto", "session": "issue-96"}
+  ]
+}`
+	if err := os.WriteFile(Path(dir), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Read(dir)
+	if err == nil {
+		t.Fatal("Read succeeded, want validation error")
+	}
+	if !strings.Contains(err.Error(), "members[0].role") {
+		t.Fatalf("Read error = %v, want role context", err)
+	}
+}
+
+func TestValidateRejectsDuplicateHandles(t *testing.T) {
+	err := Validate(Team{
+		Members: []Member{
+			{Role: "cto", Binary: "codex", Handle: "lead", Session: "issue-96"},
+			{Role: "cpo", Binary: "codex", Handle: "lead", Session: "issue-96"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate handle") {
+		t.Fatalf("Validate error = %v, want duplicate handle", err)
 	}
 }


### PR DESCRIPTION
## Summary

- validate persisted `team.json` on read and write, including slug-like role, handle, session, and workstream values, absolute member cwds, duplicate effective handles, and unsafe control characters
- sanitize generated bootstrap prompt data and fail loudly when cross-project route inference lacks a known or unambiguous project identity
- guard `team sync --apply` with existing-directory checks, canonical target dirs, and an explicit `--allow-outside` flag for member cwds outside the team-home
- make rules sync application stale-plan aware and crash-safer with same-directory temp files, preserved existing file modes, atomic rename, and parent directory sync
- update README and `doc.html` for v0.5.2 install commands and the new sync safety behavior

## Upgrade note

`team.Read` now validates persisted team configs. Users with hand-edited `.amq-squad/team.json` files must use lowercase slug-style values for role, handle, session, and workstream fields before upgrading. Persona catalog output and `team init` already emit values in the accepted shape, so generated configs are unaffected.

## Validation

- `make ci`
- `gofmt -l .`
- `git diff --check`
- checked changed diff for em dashes

Closes #18
Refs #12
Refs #19
