### PR TITLE
Prepare v0.6.0 AMQ integration release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0
 ```
 
 Use `@latest` if you intentionally want the newest published tag.
 
-Requires Go 1.25+ and the `amq` binary in `PATH` (v0.32+). Installing to
+Requires Go 1.25+ and the `amq` binary in `PATH` (v0.34+). Installing to
 `$GOBIN` (or `$HOME/go/bin`) is enough; the launch commands `team show` emits
 use the absolute path to whichever `amq-squad` binary is running, so nothing
 else needs to be on `PATH`.
@@ -439,14 +439,20 @@ amq-squad version                   Print the installed amq-squad version.
 <project>/.amq-squad/team-rules.md       Shared norms and workflow (user-edited).
 <project>/CLAUDE.md, AGENTS.md           Managed block synced from team-rules.md;
                                          user content outside markers untouched.
-<AM_ROOT>/agents/<handle>/launch.json    Per-agent invocation record, written at launch.
+<AM_ROOT>/agents/<handle>/extensions/
+  io.github.omriariav.amq-squad/
+    launch.json                          Per-agent invocation record, written at launch.
                                          Includes conversation ref when supplied.
-<AM_ROOT>/agents/<handle>/role.md        Per-agent role doc, seeded from the catalog
+    role.md                              Per-agent role doc, seeded from the catalog
                                          with default operating guidance. User
                                          edits are preserved.
 ```
 
-`<AM_ROOT>` is resolved via `amq env --json` so amq-squad and `amq coop exec` always agree on where the mailbox lives.
+`<AM_ROOT>` is resolved via AMQ's JSON env contract (`amq env --json`) so
+amq-squad and `amq coop exec` always agree on the mailbox, root source, handle,
+and session. v0.6.0 writes extension namespaced metadata under
+`extensions/io.github.omriariav.amq-squad/` and still reads legacy
+direct-agent `launch.json` and `role.md` files created by v0.5.x.
 
 ## Known gaps
 
@@ -462,5 +468,5 @@ amq-squad version                   Print the installed amq-squad version.
 ## Requires
 
 - Go 1.25+
-- `amq` binary in PATH (v0.32+)
+- `amq` binary in PATH (v0.34+)
 - `tmux` in PATH for `amq-squad team launch`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3
 ```
 
 Use `@latest` if you intentionally want the newest published tag.
@@ -89,6 +89,25 @@ the generated bootstrap prompt is still added at launch time. Direct
 `amq-squad launch` calls also prepend these defaults when they are missing, so
 custom prompts still inherit the expected permission mode. Pass
 `--no-default-args` to opt out.
+
+Add native Codex or Claude flags as binary args when the whole team should run
+with the same extra switches:
+
+```sh
+amq-squad team init \
+  --personas cto,fullstack \
+  --codex-args '--enable goals' \
+  --claude-args '--chrome'
+```
+
+Those args are stored in `.amq-squad/team.json`, included in `team show` and
+`team launch`, and treated as launch defaults so bootstrap and `--conversation`
+continue to work. Use the same flags on `team show` or `team launch` for a
+one-off run without changing `team.json`:
+
+```sh
+amq-squad team launch --codex-args '--enable goals' --claude-args '--chrome'
+```
 
 ## Launching a team in tmux
 
@@ -364,31 +383,39 @@ amq send --to qa --project project-b --session project-a --thread p2p/cto__qa
 ```text
 amq-squad team                      Smart default: show commands, or init if none exists
 amq-squad team init [--personas ...] [--session workstream]
+                    [--codex-args args] [--claude-args args]
                                     Pick personas, choose CLIs, and seed rules
 amq-squad team show [--session name] [--fresh] [--no-bootstrap]
+                    [--codex-args args] [--claude-args args]
                                     Print launch commands for the configured team
 amq-squad team launch [--terminal tmux] [--target current-window|new-session]
                       [--session workstream] [--fresh]
                       [--layout vertical|horizontal|tiled]
                       [--terminal-session name] [--stagger 750ms]
-                      [--no-bootstrap] [--dry-run]
+                      [--no-bootstrap]
+                      [--codex-args args] [--claude-args args]
+                      [--dry-run]
                                     Open the configured team in tmux panes
 amq-squad team rules init [--force] Seed or refresh .amq-squad/team-rules.md
 amq-squad team sync [--apply] [--allow-outside]
                                     Sync CLAUDE.md and AGENTS.md from team-rules.md
 
-amq-squad launch --role <r> --session <s> [--team-workstream] --me <handle> [--conversation ref] [--no-bootstrap] [--no-default-args] <binary> [-- <flags>]
+amq-squad launch --role <r> --session <s> [--team-workstream] --me <handle> [--conversation ref] [--no-bootstrap] [--no-default-args] [--codex-args args] [--claude-args args] <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md
                                     in the AMQ mailbox, adds a bootstrap prompt,
                                     then execs 'amq coop exec'.
                                     Usually called by the output of 'team show'.
                                     Codex and Claude default permission flags
                                     are prepended when missing.
+                                    --codex-args and --claude-args add native
+                                    binary flags, such as '--enable goals' or
+                                    '--chrome', while still allowing bootstrap.
                                     --conversation stores a restore ref and
                                     translates it to Codex or Claude resume args.
-                                    Do not combine --conversation with extra
-                                    binary args. For advanced flags, pass native
-                                    resume args after "--" instead.
+                                    Do not combine --conversation with extra args
+                                    after "--"; use --codex-args or --claude-args
+                                    for native flags that should remain compatible
+                                    with conversation restore.
 
 amq-squad restore [--project dir1,dir2,...] [--conversation ref]
                                     Reconstruct launch commands from local

--- a/doc.html
+++ b/doc.html
@@ -510,7 +510,7 @@
     <main>
       <header class="hero">
         <div class="hero-inner">
-          <p class="eyebrow">v0.5.2 guide</p>
+          <p class="eyebrow">v0.5.3 guide</p>
           <h1>How to use amq-squad</h1>
           <p class="lead">
             amq-squad is the project layer above AMQ. It records who is on the
@@ -542,7 +542,7 @@
             into <code class="inline-code">$GOBIN</code> or
             <code class="inline-code">$HOME/go/bin</code>.
           </p>
-          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2
+          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3
 amq-squad version</code></pre></div>
           <p>
             You also need Go 1.25 or newer, the <code class="inline-code">amq</code>
@@ -636,6 +636,16 @@ amq-squad team</code></pre></div>
             The <code class="inline-code">--session</code> value is the AMQ
             workstream name. Use an explicit name when the work should be easy
             to resume later.
+          </p>
+          <h3>Native binary flags</h3>
+          <div class="code"><pre><code>amq-squad team init \
+  --personas cto,fullstack \
+  --codex-args '--enable goals' \
+  --claude-args '--chrome'</code></pre></div>
+          <p>
+            Binary args are stored in <code class="inline-code">team.json</code>
+            and added to every matching Codex or Claude launch. They are treated
+            as launch defaults, so bootstrap and conversation restore still work.
           </p>
         </div>
       </section>
@@ -747,6 +757,14 @@ amq-squad team sync --apply --allow-outside</code></pre></div>
 amq-squad team launch --session issue-96 --layout tiled
 amq-squad team launch --session issue-96 --dry-run</code></pre></div>
 
+          <h3>One-off binary flags</h3>
+          <div class="code"><pre><code>amq-squad team show --codex-args '--enable goals'
+amq-squad team launch --claude-args '--chrome'</code></pre></div>
+          <p>
+            Use these when a single run needs extra native CLI flags without
+            changing the stored team config.
+          </p>
+
           <h3>Launch into a named tmux session</h3>
           <div class="code"><pre><code>amq-squad team launch \
   --target new-session \
@@ -822,7 +840,7 @@ amq drain --include-body</code></pre></div>
               <tbody>
                 <tr>
                   <td><code>.amq-squad/team.json</code></td>
-                  <td>Team intent: roles, handles, binaries, member cwds, and shared workstream defaults.</td>
+                  <td>Team intent: roles, handles, binaries, binary args, member cwds, and shared workstream defaults.</td>
                 </tr>
                 <tr>
                   <td><code>.amq-squad/team-rules.md</code></td>
@@ -855,7 +873,7 @@ amq drain --include-body</code></pre></div>
               <p>Check which binary is running, then reinstall the desired tag.</p>
               <div class="code"><pre><code>which -a amq-squad
 amq-squad version
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.2</code></pre></div>
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3</code></pre></div>
             </div>
             <div class="panel">
               <h3>Launch plan looks wrong</h3>

--- a/doc.html
+++ b/doc.html
@@ -510,7 +510,7 @@
     <main>
       <header class="hero">
         <div class="hero-inner">
-          <p class="eyebrow">v0.5.3 guide</p>
+          <p class="eyebrow">v0.6.0 guide</p>
           <h1>How to use amq-squad</h1>
           <p class="lead">
             amq-squad is the project layer above AMQ. It records who is on the
@@ -542,11 +542,11 @@
             into <code class="inline-code">$GOBIN</code> or
             <code class="inline-code">$HOME/go/bin</code>.
           </p>
-          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3
+          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0
 amq-squad version</code></pre></div>
           <p>
             You also need Go 1.25 or newer, the <code class="inline-code">amq</code>
-            binary in <code class="inline-code">PATH</code>, and
+            binary in <code class="inline-code">PATH</code> at v0.34 or newer, and
             <code class="inline-code">tmux</code> if you want automatic pane launch.
           </p>
         </div>
@@ -851,12 +851,12 @@ amq drain --include-body</code></pre></div>
                   <td>Managed blocks synced from team rules so each binary starts with the same team norms.</td>
                 </tr>
                 <tr>
-                  <td><code>.agent-mail/&lt;session&gt;/agents/&lt;handle&gt;/launch.json</code></td>
-                  <td>Durable launch record for one role in one AMQ workstream.</td>
+                  <td><code>.agent-mail/&lt;session&gt;/agents/&lt;handle&gt;/extensions/io.github.omriariav.amq-squad/launch.json</code></td>
+                  <td>Durable launch record for one role in one AMQ workstream. Legacy direct-agent launch records remain readable.</td>
                 </tr>
                 <tr>
-                  <td><code>.agent-mail/&lt;session&gt;/agents/&lt;handle&gt;/role.md</code></td>
-                  <td>Role-specific operating guidance seeded from the persona catalog.</td>
+                  <td><code>.agent-mail/&lt;session&gt;/agents/&lt;handle&gt;/extensions/io.github.omriariav.amq-squad/role.md</code></td>
+                  <td>Role-specific operating guidance seeded from the persona catalog. Legacy direct-agent role files remain readable.</td>
                 </tr>
               </tbody>
             </table>
@@ -873,7 +873,7 @@ amq drain --include-body</code></pre></div>
               <p>Check which binary is running, then reinstall the desired tag.</p>
               <div class="code"><pre><code>which -a amq-squad
 amq-squad version
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.5.3</code></pre></div>
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0</code></pre></div>
             </div>
             <div class="panel">
               <h3>Launch plan looks wrong</h3>

--- a/internal/cli/agent_args.go
+++ b/internal/cli/agent_args.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+func parseBinaryArgFlags(codexRaw, claudeRaw string) (map[string][]string, error) {
+	out := map[string][]string{}
+	if strings.TrimSpace(codexRaw) != "" {
+		args, err := parseAgentArgs(codexRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parse --codex-args: %w", err)
+		}
+		if len(args) > 0 {
+			out["codex"] = args
+		}
+	}
+	if strings.TrimSpace(claudeRaw) != "" {
+		args, err := parseAgentArgs(claudeRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parse --claude-args: %w", err)
+		}
+		if len(args) > 0 {
+			out["claude"] = args
+		}
+	}
+	return out, nil
+}
+
+func parseAgentArgs(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	args := []string{}
+	var b strings.Builder
+	var quote rune
+	tokenStarted := false
+	escaped := false
+	for _, r := range raw {
+		if escaped {
+			b.WriteRune(r)
+			tokenStarted = true
+			escaped = false
+			continue
+		}
+		if quote == '\'' {
+			if r == '\'' {
+				quote = 0
+			} else {
+				b.WriteRune(r)
+				tokenStarted = true
+			}
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			tokenStarted = true
+			continue
+		}
+		if quote == '"' {
+			if r == '"' {
+				quote = 0
+			} else {
+				b.WriteRune(r)
+				tokenStarted = true
+			}
+			continue
+		}
+		switch {
+		case r == '\'' || r == '"':
+			quote = r
+			tokenStarted = true
+		case unicode.IsSpace(r):
+			if tokenStarted {
+				args = append(args, b.String())
+				b.Reset()
+				tokenStarted = false
+			}
+		default:
+			b.WriteRune(r)
+			tokenStarted = true
+		}
+	}
+	if escaped {
+		return nil, fmt.Errorf("trailing escape")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	if tokenStarted {
+		args = append(args, b.String())
+	}
+	return args, nil
+}
+
+func binaryArgsFor(binary string, binaryArgs map[string][]string) []string {
+	if len(binaryArgs) == 0 {
+		return nil
+	}
+	args := binaryArgs[normalizedAgentBinary(binary)]
+	return append([]string(nil), args...)
+}
+
+func mergeBinaryArgs(base, extra map[string][]string) map[string][]string {
+	if len(base) == 0 && len(extra) == 0 {
+		return nil
+	}
+	out := map[string][]string{}
+	for k, args := range base {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		out[key] = append(out[key], args...)
+	}
+	for k, args := range extra {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		out[key] = append(out[key], args...)
+	}
+	return out
+}
+
+func joinedAgentArgs(args []string) string {
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatBinaryArgs(binaryArgs map[string][]string) string {
+	if len(binaryArgs) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(binaryArgs))
+	for k := range binaryArgs {
+		if len(binaryArgs[k]) > 0 {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+": "+joinedAgentArgs(binaryArgs[k]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -11,17 +11,33 @@ func defaultChildArgsForBinary(binary string) []string {
 	}
 }
 
+func launchDefaultChildArgs(binary string, includeBuiltIn bool, extraArgs []string) []string {
+	out := []string{}
+	if includeBuiltIn {
+		out = append(out, defaultChildArgsForBinary(binary)...)
+	}
+	out = append(out, extraArgs...)
+	return out
+}
+
 func ensureDefaultChildArgs(binary string, childArgs []string) []string {
-	defaultArgs := defaultChildArgsForBinary(binary)
-	if len(defaultArgs) == 0 || hasLeadingDefaultChildArgs(binary, childArgs) {
+	return ensureLeadingChildArgs(defaultChildArgsForBinary(binary), childArgs)
+}
+
+func ensureLeadingChildArgs(defaultArgs, childArgs []string) []string {
+	if len(defaultArgs) == 0 || hasLeadingArgs(defaultArgs, childArgs) {
 		return childArgs
 	}
+	prefixLen := leadingDefaultPrefixLen(defaultArgs, childArgs)
 	out := append([]string(nil), defaultArgs...)
-	return append(out, childArgs...)
+	return append(out, childArgs[prefixLen:]...)
 }
 
 func hasLeadingDefaultChildArgs(binary string, childArgs []string) bool {
-	defaultArgs := defaultChildArgsForBinary(binary)
+	return hasLeadingArgs(defaultChildArgsForBinary(binary), childArgs)
+}
+
+func hasLeadingArgs(defaultArgs, childArgs []string) bool {
 	if len(defaultArgs) == 0 || len(childArgs) < len(defaultArgs) {
 		return false
 	}
@@ -33,11 +49,34 @@ func hasLeadingDefaultChildArgs(binary string, childArgs []string) bool {
 	return true
 }
 
+func leadingDefaultPrefixLen(defaultArgs, childArgs []string) int {
+	max := len(defaultArgs)
+	if len(childArgs) < max {
+		max = len(childArgs)
+	}
+	for n := max; n > 0; n-- {
+		match := true
+		for i := 0; i < n; i++ {
+			if childArgs[i] != defaultArgs[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return n
+		}
+	}
+	return 0
+}
+
 func shouldAppendBootstrap(binary string, childArgs []string) bool {
+	return shouldAppendBootstrapWithDefaults(childArgs, defaultChildArgsForBinary(binary))
+}
+
+func shouldAppendBootstrapWithDefaults(childArgs []string, defaultArgs []string) bool {
 	if len(childArgs) == 0 {
 		return true
 	}
-	defaultArgs := defaultChildArgsForBinary(binary)
 	if len(childArgs) != len(defaultArgs) {
 		return false
 	}

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+type amqEnv struct {
+	SchemaVersion int               `json:"schema_version"`
+	AMQVersion    string            `json:"amq_version"`
+	Root          string            `json:"root"`
+	BaseRoot      string            `json:"base_root"`
+	SessionName   string            `json:"session_name"`
+	InSession     bool              `json:"in_session"`
+	Me            string            `json:"me"`
+	Project       string            `json:"project"`
+	RootSource    string            `json:"root_source"`
+	Peers         map[string]string `json:"peers"`
+}
+
+func resolveAMQEnv(rootFlag, session, handle string) (amqEnv, error) {
+	return resolveAMQEnvInDir("", rootFlag, session, handle)
+}
+
+func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
+	args := []string{"env", "--json"}
+	if handle != "" {
+		args = append(args, "--me", handle)
+	}
+	if rootFlag != "" {
+		args = append(args, "--root", rootFlag)
+	}
+	if session != "" {
+		args = append(args, "--session", session)
+	}
+	cmd := exec.Command("amq", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return amqEnv{}, fmt.Errorf("amq env: %w", err)
+	}
+	var parsed amqEnv
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return amqEnv{}, fmt.Errorf("parse amq env output: %w", err)
+	}
+	if parsed.Root == "" {
+		return amqEnv{}, fmt.Errorf("amq env returned empty root")
+	}
+	if parsed.BaseRoot == "" {
+		parsed.BaseRoot = parsed.Root
+	}
+	if parsed.Me == "" {
+		parsed.Me = handle
+	}
+	if parsed.SessionName == "" {
+		parsed.SessionName = session
+	}
+	return parsed, nil
+}
+
+func scanBaseRootForProject(projectDir string) (string, error) {
+	env, err := resolveAMQEnvInDir(projectDir, "", "", "amq-squad")
+	if err != nil {
+		return "", err
+	}
+	if env.BaseRoot != "" {
+		return env.BaseRoot, nil
+	}
+	return env.Root, nil
+}

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 type amqEnv struct {
@@ -37,6 +39,7 @@ func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 	cmd := exec.Command("amq", args...)
 	if cwd != "" {
 		cmd.Dir = cwd
+		cmd.Env = envWithoutAMQIdentity(os.Environ())
 	}
 	out, err := cmd.Output()
 	if err != nil {
@@ -59,6 +62,22 @@ func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 		parsed.SessionName = session
 	}
 	return parsed, nil
+}
+
+func envWithoutAMQIdentity(env []string) []string {
+	remove := map[string]bool{
+		"AM_ROOT":      true,
+		"AM_BASE_ROOT": true,
+		"AM_ME":        true,
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || !remove[key] {
+			out = append(out, entry)
+		}
+	}
+	return out
 }
 
 func scanBaseRootForProject(projectDir string) (string, error) {

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAMQEnvUsesV1Fields(t *testing.T) {
+	setupFakeAMQEnv(t, `{"schema_version":1,"amq_version":"0.34.0","root":"/tmp/mail/stream1","base_root":"/tmp/mail","session_name":"stream1","me":"cto","project":"amq-squad","root_source":"project_amqrc"}`)
+
+	got, err := resolveAMQEnv("/ignored", "stream1", "codex")
+	if err != nil {
+		t.Fatalf("resolveAMQEnv: %v", err)
+	}
+	if got.SchemaVersion != 1 || got.AMQVersion != "0.34.0" ||
+		got.Root != "/tmp/mail/stream1" || got.BaseRoot != "/tmp/mail" ||
+		got.SessionName != "stream1" || got.Me != "cto" ||
+		got.Project != "amq-squad" || got.RootSource != "project_amqrc" {
+		t.Fatalf("resolveAMQEnv = %+v", got)
+	}
+}
+
+func TestResolveAMQEnvBackfillsOlderRootOnlyOutput(t *testing.T) {
+	setupFakeAMQEnv(t, `{"root":"/tmp/mail/stream1"}`)
+
+	got, err := resolveAMQEnv("", "stream1", "cto")
+	if err != nil {
+		t.Fatalf("resolveAMQEnv: %v", err)
+	}
+	if got.Root != "/tmp/mail/stream1" || got.BaseRoot != "/tmp/mail/stream1" ||
+		got.SessionName != "stream1" || got.Me != "cto" {
+		t.Fatalf("resolveAMQEnv = %+v", got)
+	}
+}
+
+func setupFakeAMQEnv(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"env\" ] && [ \"$2\" = \"--json\" ]; then\n" +
+		"  printf '%s\\n' \"$AMQ_FAKE_ENV\"\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"unexpected amq command: $*\" >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(binDir, "amq"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_FAKE_ENV", body)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -34,13 +34,46 @@ func TestResolveAMQEnvBackfillsOlderRootOnlyOutput(t *testing.T) {
 	}
 }
 
+func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"env\" ] && [ \"$2\" = \"--json\" ]; then\n" +
+		"  actual_cwd=$(pwd)\n" +
+		"  if [ \"$actual_cwd\" != \"$AMQ_EXPECT_CWD\" ]; then\n" +
+		"    echo \"unexpected cwd: $actual_cwd\" >&2\n" +
+		"    exit 2\n" +
+		"  fi\n" +
+		"  if [ -n \"$AM_ROOT$AM_BASE_ROOT$AM_ME\" ]; then\n" +
+		"    printf '%s\\n' '{\"root\":\"/live/session\",\"base_root\":\"/live\",\"me\":\"cto\",\"project\":\"live-project\"}'\n" +
+		"    exit 0\n" +
+		"  fi\n" +
+		"  printf '%s\\n' '{\"root\":\"/target/session\",\"base_root\":\"/target\",\"me\":\"amq-squad\",\"project\":\"target-project\"}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"unexpected amq command: $*\" >&2\n" +
+		"exit 1\n"
+	setupFakeAMQScript(t, script)
+	projectDir := t.TempDir()
+	expectedCWD := projectDir
+	if resolved, err := filepath.EvalSymlinks(projectDir); err == nil {
+		expectedCWD = resolved
+	}
+	t.Setenv("AMQ_EXPECT_CWD", expectedCWD)
+	t.Setenv("AM_ROOT", "/live/session")
+	t.Setenv("AM_BASE_ROOT", "/live")
+	t.Setenv("AM_ME", "cto")
+
+	got, err := resolveAMQEnvInDir(projectDir, "", "", "amq-squad")
+	if err != nil {
+		t.Fatalf("resolveAMQEnvInDir: %v", err)
+	}
+	if got.Root != "/target/session" || got.BaseRoot != "/target" ||
+		got.Me != "amq-squad" || got.Project != "target-project" {
+		t.Fatalf("resolveAMQEnvInDir = %+v", got)
+	}
+}
+
 func setupFakeAMQEnv(t *testing.T, body string) {
 	t.Helper()
-	dir := t.TempDir()
-	binDir := filepath.Join(dir, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"env\" ] && [ \"$2\" = \"--json\" ]; then\n" +
 		"  printf '%s\\n' \"$AMQ_FAKE_ENV\"\n" +
@@ -48,9 +81,19 @@ func setupFakeAMQEnv(t *testing.T, body string) {
 		"fi\n" +
 		"echo \"unexpected amq command: $*\" >&2\n" +
 		"exit 1\n"
+	setupFakeAMQScript(t, script)
+	t.Setenv("AMQ_FAKE_ENV", body)
+}
+
+func setupFakeAMQScript(t *testing.T, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(binDir, "amq"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("AMQ_FAKE_ENV", body)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -140,8 +141,8 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 		AgentDir:      agentDir,
 		TeamHome:      teamHome,
 		TeamRulesPath: teamRulesPath,
-		RolePath:      role.Path(agentDir),
-		LaunchPath:    filepath.Join(agentDir, launch.FileName),
+		RolePath:      role.ExistingPath(agentDir),
+		LaunchPath:    launch.ExistingPath(agentDir),
 		CurrentTeam:   currentTeam,
 		Workstreams:   siblingWorkstreamSummaries(rec.Root, rec.Session),
 		Warnings:      warnings,
@@ -171,7 +172,7 @@ func bootstrapCurrentTeam(rec launch.Record, teamHome string) ([]bootstrapTeamMe
 		project := projectIdentityForCWD(cwd)
 		handle := memberHandle(m)
 		session := routingSessionForMember(rec, m)
-		route, routeError := routeCommandFor(currentProject, project, samePath(rec.CWD, cwd), rec.Handle, handle, session)
+		route, routeError := routeCommandFor(rec.Root, rec.Session, currentProject, project, samePath(rec.CWD, cwd), rec.Handle, handle, session)
 		out = append(out, bootstrapTeamMember{
 			Role:       m.Role,
 			Handle:     handle,
@@ -224,12 +225,17 @@ func (p projectIdentity) DisplayName() string {
 	return "(unknown)"
 }
 
-func routeCommandFor(currentProject, targetProject projectIdentity, sameCWD bool, fromHandle, handle, session string) (string, string) {
+func routeCommandFor(sourceRoot, sourceSession string, currentProject, targetProject projectIdentity, sameCWD bool, fromHandle, handle, session string) (string, string) {
 	if !sameCWD && (!currentProject.Known || !targetProject.Known) {
 		return "", "AMQ project identity is missing; add .amqrc project names or use amq route manually"
 	}
 	if !sameCWD && currentProject.Name == targetProject.Name && !samePath(currentProject.Dir, targetProject.Dir) {
 		return "", "AMQ project identity is ambiguous; matching project names come from different .amqrc roots"
+	}
+	if sourceRoot != "" && fromHandle != "" && handle != "" {
+		if route, routeError, ok := routeExplainCommand(sourceRoot, sourceSession, currentProject, targetProject, sameCWD, fromHandle, handle, session); ok {
+			return route, routeError
+		}
 	}
 	args := []string{"amq", "send", "--to", handle}
 	if !sameCWD && currentProject.Name != targetProject.Name {
@@ -247,9 +253,56 @@ func routeCommandFor(currentProject, targetProject projectIdentity, sameCWD bool
 	return strings.Join(args, " "), ""
 }
 
+type routeExplainResult struct {
+	Routable       bool     `json:"routable"`
+	Argv           []string `json:"argv"`
+	DisplayCommand string   `json:"display_command"`
+	Error          string   `json:"error"`
+}
+
+func routeExplainCommand(sourceRoot, sourceSession string, currentProject, targetProject projectIdentity, sameCWD bool, fromHandle, handle, session string) (string, string, bool) {
+	args := []string{"route", "explain", "--from-root", sourceRoot, "--me", fromHandle, "--to", handle, "--json"}
+	if !sameCWD && currentProject.Name != targetProject.Name && targetProject.Name != "" {
+		args = append(args, "--project", targetProject.Name)
+	}
+	if session != "" && session != sourceSession {
+		args = append(args, "--session", session)
+	}
+	cmd := exec.Command("amq", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", false
+	}
+	var parsed routeExplainResult
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return "", "", false
+	}
+	if !parsed.Routable {
+		if parsed.Error == "" {
+			parsed.Error = "AMQ route explain reported route is not routable"
+		}
+		return "", parsed.Error, true
+	}
+	if len(parsed.Argv) == 0 {
+		return "", "AMQ route explain returned empty argv", true
+	}
+	argv := append([]string(nil), parsed.Argv...)
+	if fromHandle != "" && handle != "" && fromHandle != handle {
+		argv = append(argv, "--thread", canonicalP2PThread(fromHandle, handle))
+	}
+	return shellCommand(argv[0], argv[1:]...), "", true
+}
+
 func projectIdentityForCWD(cwd string) projectIdentity {
 	if cwd == "" {
 		return projectIdentity{}
+	}
+	if env, err := resolveAMQEnvInDir(cwd, "", "", "amq-squad"); err == nil && env.Project != "" {
+		dir := env.BaseRoot
+		if dir == "" {
+			dir = env.Root
+		}
+		return projectIdentity{Name: env.Project, Dir: dir, Known: true}
 	}
 	if dir, name := findProjectName(cwd); name != "" {
 		return projectIdentity{Name: name, Dir: dir, Known: true}

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -49,5 +49,5 @@ First steps:
 2. Use the current team routing above for live messages and handoffs.
 3. Inspect prior AMQ history in this workstream relevant to your role using `amq-squad list`, `amq-squad restore`, `amq list`, `amq read`, and `amq thread --include-body` as needed.
 4. Do not resume old sessions or route work to historical agents unless the user explicitly asks.
-5. Summarize your role, relevant prior context, and what you are waiting for.
+5. Start your first response by stating your role and handle, then summarize relevant prior context and what you are waiting for.
 6. Stop and wait for instructions.

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -60,7 +60,12 @@ func TestBuildBootstrapPromptWithoutRules(t *testing.T) {
 func TestBootstrapPromptIncludesCurrentTeamRouting(t *testing.T) {
 	teamHome := t.TempDir()
 	qaProject := t.TempDir()
-	if err := os.WriteFile(filepath.Join(teamHome, ".amqrc"), []byte(`{"root":".agent-mail","project":"pm-context"}`), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(qaProject, ".agent-mail", "fresh-cpo", "agents", "qa", "inbox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	qaRoot := strings.ReplaceAll(filepath.Join(qaProject, ".agent-mail"), `\`, `\\`)
+	teamAMQRC := `{"root":".agent-mail","project":"pm-context","peers":{"omri-pm":"` + qaRoot + `"}}`
+	if err := os.WriteFile(filepath.Join(teamHome, ".amqrc"), []byte(teamAMQRC), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(qaProject, ".amqrc"), []byte(`{"root":".agent-mail","project":"omri-pm"}`), 0o644); err != nil {
@@ -94,9 +99,11 @@ func TestBootstrapPromptIncludesCurrentTeamRouting(t *testing.T) {
 		"Current team routing:",
 		"from the current `.amq-squad/team.json`",
 		"- cpo (you): handle cpo, binary codex, workstream fresh-cpo, project pm-context",
-		"send: `amq send --to cpo --session fresh-cpo`",
+		"send: `amq send --root",
+		"--me cpo --to cpo`",
 		"- qa: handle qa, binary claude, workstream fresh-cpo, project omri-pm",
-		"send: `amq send --to qa --project omri-pm --session fresh-cpo --thread p2p/cpo__qa`",
+		"--project omri-pm",
+		"--thread p2p/cpo__qa`",
 		"Do not resume old sessions or route work to historical agents unless the user explicitly asks.",
 	} {
 		if !strings.Contains(got, want) {
@@ -236,6 +243,8 @@ func TestBootstrapCurrentTeamDoesNotGuessCrossProjectRouteWithoutProjectIdentity
 
 func TestRouteCommandQuotesUnsafeValues(t *testing.T) {
 	got, errText := routeCommandFor(
+		"",
+		"",
 		projectIdentity{Name: "project-a", Known: true},
 		projectIdentity{Name: "project b", Known: true},
 		false,
@@ -253,7 +262,7 @@ func TestRouteCommandQuotesUnsafeValues(t *testing.T) {
 }
 
 func TestRouteCommandFailsLoudlyWhenCrossProjectIdentityMissing(t *testing.T) {
-	got, errText := routeCommandFor(projectIdentity{}, projectIdentity{Name: "qa", Known: true}, false, "cto", "qa", "fresh-qa")
+	got, errText := routeCommandFor("", "", projectIdentity{}, projectIdentity{Name: "qa", Known: true}, false, "cto", "qa", "fresh-qa")
 	if got != "" {
 		t.Fatalf("routeCommandFor returned command %q, want none", got)
 	}
@@ -264,6 +273,8 @@ func TestRouteCommandFailsLoudlyWhenCrossProjectIdentityMissing(t *testing.T) {
 
 func TestRouteCommandFailsLoudlyWhenProjectIdentityAmbiguous(t *testing.T) {
 	got, errText := routeCommandFor(
+		"",
+		"",
 		projectIdentity{Name: "app", Dir: "/repo-a", Known: true},
 		projectIdentity{Name: "app", Dir: "/repo-b", Known: true},
 		false,

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -33,6 +33,7 @@ func TestBuildBootstrapPrompt(t *testing.T) {
 		"Team rules: /repo/.amq-squad/team-rules.md",
 		"Role file: /repo/.agent-mail/fresh-cto/agents/cto/role.md",
 		"Launch record: /repo/.agent-mail/fresh-cto/agents/cto/launch.json",
+		"Start your first response by stating your role and handle",
 		"Stop and wait for instructions.",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -135,6 +135,8 @@ still combine with --conversation.
 		BaseRoot:         env.BaseRoot,
 		RootSource:       env.RootSource,
 		AMQVersion:       env.AMQVersion,
+		CodexArgs:        binaryArgs["codex"],
+		ClaudeArgs:       binaryArgs["claude"],
 		StartedAt:        time.Now().UTC(),
 	}
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -137,6 +137,7 @@ still combine with --conversation.
 		AMQVersion:       env.AMQVersion,
 		CodexArgs:        binaryArgs["codex"],
 		ClaudeArgs:       binaryArgs["claude"],
+		NoDefaultArgs:    *noDefaultArgs,
 		StartedAt:        time.Now().UTC(),
 	}
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -31,6 +31,8 @@ func runLaunch(args []string) error {
 	conversationID := fs.String("conversation-id", "", "alias for --conversation")
 	noBootstrap := fs.Bool("no-bootstrap", false, "do not pass the generated bootstrap prompt to the agent")
 	noDefaultArgs := fs.Bool("no-default-args", false, "do not prepend Codex or Claude default permission args")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args to treat as launch defaults, e.g. '--enable goals'")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args to treat as launch defaults, e.g. '--chrome'")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 
 	fs.Usage = func() {
@@ -52,17 +54,18 @@ Side effects before exec:
   3. Writes a role.md stub if one does not already exist.
   4. Prepends Codex and Claude default permission args unless
      --no-default-args is set.
-  5. Translates --conversation for Codex or Claude resume when provided.
-  6. Adds a generated bootstrap prompt unless --no-bootstrap is set or
+  5. Prepends --codex-args or --claude-args for the matching binary.
+  6. Translates --conversation for Codex or Claude resume when provided.
+  7. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
-  7. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+  8. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
 With --dry-run, none of the above run: the resolved coop exec command is
 printed and amq-squad exits. Disk state is untouched.
 
-When --conversation generates resume args, do not pass additional child args.
-For advanced Codex or Claude flags, omit --conversation and pass native resume
-args after "--".
+When --conversation generates resume args, do not pass additional child args
+after "--". Use --codex-args or --claude-args for native flags that should
+still combine with --conversation.
 `)
 	}
 
@@ -70,6 +73,10 @@ args after "--".
 		return err
 	}
 	conversationRef, err := conversationRefFromFlags(*conversation, *conversationID)
+	if err != nil {
+		return err
+	}
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
 		return err
 	}
@@ -82,12 +89,12 @@ args after "--".
 	if len(remaining) > 1 {
 		childArgs = append(remaining[1:], childArgs...)
 	}
-	if !*noDefaultArgs {
-		childArgs = ensureDefaultChildArgs(binary, childArgs)
-	}
+	extraDefaultArgs := binaryArgsFor(binary, binaryArgs)
+	defaultArgs := launchDefaultChildArgs(binary, !*noDefaultArgs, extraDefaultArgs)
+	childArgs = ensureLeadingChildArgs(defaultArgs, childArgs)
 	if conversationRef != "" {
 		var err error
-		childArgs, err = applyConversationRestoreArgs(binary, childArgs, conversationRef)
+		childArgs, err = applyConversationRestoreArgsWithDefaults(binary, childArgs, conversationRef, defaultArgs)
 		if err != nil {
 			return err
 		}
@@ -128,7 +135,7 @@ args after "--".
 	// Keep generated bootstrap out of launch.json so restore stays compact
 	// and does not replay stale startup text.
 	effectiveChildArgs := append([]string(nil), childArgs...)
-	if !*noBootstrap && shouldAppendBootstrap(binary, childArgs) {
+	if !*noBootstrap && shouldAppendBootstrapWithDefaults(childArgs, defaultArgs) {
 		prompt, err := buildBootstrapPrompt(bootstrapContextFor(rec, agentDir, *teamHome))
 		if err != nil {
 			return err
@@ -192,6 +199,10 @@ func conversationRefFromFlags(conversation, conversationID string) (string, erro
 }
 
 func applyConversationRestoreArgs(binary string, childArgs []string, conversation string) ([]string, error) {
+	return applyConversationRestoreArgsWithDefaults(binary, childArgs, conversation, defaultChildArgsForBinary(binary))
+}
+
+func applyConversationRestoreArgsWithDefaults(binary string, childArgs []string, conversation string, defaultArgs []string) ([]string, error) {
 	conversation = strings.TrimSpace(conversation)
 	if conversation == "" {
 		return childArgs, nil
@@ -205,12 +216,12 @@ func applyConversationRestoreArgs(binary string, childArgs []string, conversatio
 			if ref != conversation {
 				return nil, fmt.Errorf("--conversation %q conflicts with existing codex resume %q", conversation, ref)
 			}
-			if !hasNoExtraConversationArgs(binary, stripCodexResumeRef(childArgs, conversation)) {
+			if !hasNoExtraConversationArgs(stripCodexResumeRef(childArgs, conversation), defaultArgs) {
 				return nil, fmt.Errorf("--conversation cannot be combined with extra codex args; omit --conversation and pass native resume args after --")
 			}
 			return childArgs, nil
 		}
-		if !hasNoExtraConversationArgs(binary, childArgs) {
+		if !hasNoExtraConversationArgs(childArgs, defaultArgs) {
 			return nil, fmt.Errorf("--conversation cannot be combined with extra codex args; omit --conversation and pass native resume args after --")
 		}
 		out := append([]string(nil), childArgs...)
@@ -223,12 +234,12 @@ func applyConversationRestoreArgs(binary string, childArgs []string, conversatio
 			if ref != conversation {
 				return nil, fmt.Errorf("--conversation %q conflicts with existing claude resume %q", conversation, ref)
 			}
-			if !hasNoExtraConversationArgs(binary, stripClaudeResumeRef(childArgs, conversation)) {
+			if !hasNoExtraConversationArgs(stripClaudeResumeRef(childArgs, conversation), defaultArgs) {
 				return nil, fmt.Errorf("--conversation cannot be combined with extra claude args; omit --conversation and pass native resume args after --")
 			}
 			return childArgs, nil
 		}
-		if !hasNoExtraConversationArgs(binary, childArgs) {
+		if !hasNoExtraConversationArgs(childArgs, defaultArgs) {
 			return nil, fmt.Errorf("--conversation cannot be combined with extra claude args; omit --conversation and pass native resume args after --")
 		}
 		out := append([]string(nil), childArgs...)
@@ -238,11 +249,10 @@ func applyConversationRestoreArgs(binary string, childArgs []string, conversatio
 	}
 }
 
-func hasNoExtraConversationArgs(binary string, childArgs []string) bool {
+func hasNoExtraConversationArgs(childArgs []string, defaultArgs []string) bool {
 	if len(childArgs) == 0 {
 		return true
 	}
-	defaultArgs := defaultChildArgsForBinary(binary)
 	if len(childArgs) != len(defaultArgs) {
 		return false
 	}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -49,8 +48,8 @@ The <binary> is the agent launcher (claude, codex, etc). Flags after "--"
 are passed through to that binary via 'amq coop exec'.
 
 Side effects before exec:
-  1. Resolves AMQ root via 'amq env --json' for the target session.
-  2. Writes <root>/agents/<handle>/launch.json with cwd, binary, argv, role.
+  1. Resolves AMQ env via 'amq env --json' for the target session.
+  2. Writes launch.json under the amq-squad extension namespace.
   3. Writes a role.md stub if one does not already exist.
   4. Prepends Codex and Claude default permission args unless
      --no-default-args is set.
@@ -60,8 +59,8 @@ Side effects before exec:
      non-default binary args were provided.
   8. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
-With --dry-run, none of the above run: the resolved coop exec command is
-printed and amq-squad exits. Disk state is untouched.
+With --dry-run, the resolved coop exec command is printed and amq-squad exits.
+Disk state is untouched and no exec occurs.
 
 When --conversation generates resume args, do not pass additional child args
 after "--". Use --codex-args or --claude-args for native flags that should
@@ -110,12 +109,16 @@ still combine with --conversation.
 		return fmt.Errorf("getwd: %w", err)
 	}
 
-	// Resolve the AMQ root via the amq CLI. This respects .amqrc, --session,
-	// and --root exactly as coop exec will, so launch.json and the actual
-	// mailbox agree.
-	root, err := resolveAMQRoot(*rootFlag, *session, handle)
+	// Resolve the AMQ env via the amq CLI. This respects .amqrc, --session,
+	// --root, and AMQ's validated sender identity exactly as coop exec will, so
+	// launch.json and the actual mailbox agree.
+	env, err := resolveAMQEnv(*rootFlag, *session, handle)
 	if err != nil {
-		return fmt.Errorf("resolve amq root: %w", err)
+		return fmt.Errorf("resolve amq env: %w", err)
+	}
+	root := env.Root
+	if env.Me != "" {
+		handle = env.Me
 	}
 
 	agentDir := filepath.Join(root, "agents", handle)
@@ -123,12 +126,15 @@ still combine with --conversation.
 		CWD:              cwd,
 		Binary:           binary,
 		Argv:             childArgs,
-		Session:          *session,
+		Session:          env.SessionName,
 		SharedWorkstream: *sharedWorkstream,
 		Conversation:     conversationRef,
 		Handle:           handle,
 		Role:             *roleFlag,
 		Root:             root,
+		BaseRoot:         env.BaseRoot,
+		RootSource:       env.RootSource,
+		AMQVersion:       env.AMQVersion,
 		StartedAt:        time.Now().UTC(),
 	}
 
@@ -343,39 +349,17 @@ func stripClaudeResumeRef(args []string, conversation string) []string {
 	return out
 }
 
-// resolveAMQRoot shells out to `amq env --json` to discover the final root
-// path that coop exec will use. This keeps amq-squad out of the root
-// resolution business - amq owns it, we just ask.
+// resolveAMQRoot shells out to `amq env --json` to discover the final root path.
 func resolveAMQRoot(rootFlag, session, handle string) (string, error) {
 	return resolveAMQRootInDir("", rootFlag, session, handle)
 }
 
 func resolveAMQRootInDir(cwd, rootFlag, session, handle string) (string, error) {
-	args := []string{"env", "--json", "--me", handle}
-	if rootFlag != "" {
-		args = append(args, "--root", rootFlag)
-	}
-	if session != "" {
-		args = append(args, "--session", session)
-	}
-	cmd := exec.Command("amq", args...)
-	if cwd != "" {
-		cmd.Dir = cwd
-	}
-	out, err := cmd.Output()
+	env, err := resolveAMQEnvInDir(cwd, rootFlag, session, handle)
 	if err != nil {
-		return "", fmt.Errorf("amq env: %w", err)
+		return "", err
 	}
-	var parsed struct {
-		Root string `json:"root"`
-	}
-	if err := json.Unmarshal(out, &parsed); err != nil {
-		return "", fmt.Errorf("parse amq env output: %w", err)
-	}
-	if parsed.Root == "" {
-		return "", fmt.Errorf("amq env returned empty root")
-	}
-	return parsed.Root, nil
+	return env.Root, nil
 }
 
 // seedRoleStub writes a role.md stub for the given agent directory based on

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -41,6 +41,39 @@ func TestRunLaunchDryRunNoDefaultArgsOptOut(t *testing.T) {
 	}
 }
 
+func TestRunLaunchDryRunAddsBinaryArgs(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--codex-args=--enable goals", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	want := "amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox --enable goals"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchDryRunNoDefaultArgsKeepsExplicitBinaryArgs(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-default-args", "--codex-args=--enable goals", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("stdout should not include codex default args:\n%s", stdout)
+	}
+	want := "amq coop exec codex -- --enable goals"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
 func TestRunLaunchDryRunConversationCodexResume(t *testing.T) {
 	setupFakeAMQ(t)
 
@@ -51,6 +84,21 @@ func TestRunLaunchDryRunConversationCodexResume(t *testing.T) {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
 	}
 	want := "amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox resume cto-thread"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchDryRunConversationAllowsBinaryArgs(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--conversation", "cto-thread", "--codex-args=--enable goals", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	want := "amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox --enable goals resume cto-thread"
 	if !strings.Contains(stdout, want) {
 		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
 	}
@@ -129,6 +177,17 @@ func TestApplyConversationRestoreArgsIsIdempotent(t *testing.T) {
 	}
 	if strings.Join(got, " ") != "--permission-mode auto --resume abc" {
 		t.Fatalf("claude args = %v", got)
+	}
+}
+
+func TestApplyConversationRestoreArgsAllowsConfiguredDefaults(t *testing.T) {
+	defaults := []string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals"}
+	got, err := applyConversationRestoreArgsWithDefaults("codex", defaults, "abc", defaults)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(got, " ") != "--dangerously-bypass-approvals-and-sandbox --enable goals resume abc" {
+		t.Fatalf("codex args = %v", got)
 	}
 }
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -59,7 +59,17 @@ where the original binary can be inferred.
 
 	var all []launch.Entry
 	for _, dir := range dirs {
-		entries, err := launch.ScanRestorableEntries(dir)
+		baseRoot, err := scanBaseRootForProject(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: resolve amq env for %s: %v\n", dir, err)
+			baseRoot = ""
+		}
+		var entries []launch.Entry
+		if baseRoot != "" {
+			entries, err = launch.ScanRestorableEntriesInRoot(dir, baseRoot)
+		} else {
+			entries, err = launch.ScanRestorableEntries(dir)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
 			continue

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -228,6 +228,12 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.Conversation != "" {
 		args = append(args, "--conversation", rec.Conversation)
 	}
+	if len(rec.CodexArgs) > 0 {
+		args = append(args, "--codex-args", joinedAgentArgs(rec.CodexArgs))
+	}
+	if len(rec.ClaudeArgs) > 0 {
+		args = append(args, "--claude-args", joinedAgentArgs(rec.ClaudeArgs))
+	}
 	if rec.Handle != "" {
 		args = append(args, "--me", rec.Handle)
 	}
@@ -241,10 +247,46 @@ func launchArgsFromRecord(rec launch.Record) []string {
 }
 
 func restoreArgvFromRecord(rec launch.Record) []string {
-	if rec.Conversation == "" {
-		return append([]string(nil), rec.Argv...)
+	argv := append([]string(nil), rec.Argv...)
+	if rec.Conversation != "" {
+		argv = stripConversationRestoreArgs(rec.Binary, argv, rec.Conversation)
 	}
-	return stripConversationRestoreArgs(rec.Binary, rec.Argv, rec.Conversation)
+	if extras := launchExtraBinaryArgs(rec); len(extras) > 0 {
+		argv = removeContiguousSubsequence(argv, extras)
+	}
+	return argv
+}
+
+func launchExtraBinaryArgs(rec launch.Record) []string {
+	switch normalizedAgentBinary(rec.Binary) {
+	case "codex":
+		return rec.CodexArgs
+	case "claude":
+		return rec.ClaudeArgs
+	}
+	return nil
+}
+
+func removeContiguousSubsequence(args, sub []string) []string {
+	if len(sub) == 0 || len(args) < len(sub) {
+		return args
+	}
+	for i := 0; i+len(sub) <= len(args); i++ {
+		match := true
+		for j := range sub {
+			if args[i+j] != sub[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			out := make([]string, 0, len(args)-len(sub))
+			out = append(out, args[:i]...)
+			out = append(out, args[i+len(sub):]...)
+			return out
+		}
+	}
+	return args
 }
 
 // emitCommand reconstructs the bash command for a launch record.
@@ -277,6 +319,14 @@ func emitCommand(rec launch.Record) string {
 	if rec.Conversation != "" {
 		b.WriteString(" --conversation ")
 		b.WriteString(shellQuote(rec.Conversation))
+	}
+	if len(rec.CodexArgs) > 0 {
+		b.WriteString(" --codex-args ")
+		b.WriteString(shellQuote(joinedAgentArgs(rec.CodexArgs)))
+	}
+	if len(rec.ClaudeArgs) > 0 {
+		b.WriteString(" --claude-args ")
+		b.WriteString(shellQuote(joinedAgentArgs(rec.ClaudeArgs)))
 	}
 	if rec.Handle != "" && rec.Handle != defaultHandleFor(rec.Binary) {
 		b.WriteString(" --me ")

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -32,11 +32,11 @@ Usage:
   amq-squad restore [--project dir1,dir2,...] [--role r] [--handle h] [--session s] [--conversation ref]
   amq-squad restore --exec --role cto
 
-Scans each project for .agent-mail/<session>/agents/<handle>/launch.json
-records, nearby role.md persona files, and older AMQ mailbox history when
-launch.json is missing and the original binary can be inferred. Default
-scope is the current working directory if --project is omitted. Without
---exec, prints a bash command per matching agent.
+Scans each project for amq-squad extension launch records, nearby role.md
+persona files, and older AMQ mailbox history when launch.json is missing and
+the original binary can be inferred. Default scope is the current working
+directory if --project is omitted. Without --exec, prints a bash command per
+matching agent.
 
 With --exec, exactly one record must match; amq-squad changes to that
 record's cwd and execs the saved launch through 'amq coop exec'.
@@ -64,7 +64,17 @@ record's cwd and execs the saved launch through 'amq coop exec'.
 	var records []restoreCandidate
 
 	for _, dir := range dirs {
-		entries, err := launch.ScanRestorableEntries(dir)
+		baseRoot, err := scanBaseRootForProject(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: resolve amq env for %s: %v\n", dir, err)
+			baseRoot = ""
+		}
+		var entries []launch.Entry
+		if baseRoot != "" {
+			entries, err = launch.ScanRestorableEntriesInRoot(dir, baseRoot)
+		} else {
+			entries, err = launch.ScanRestorableEntries(dir)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: scan %s: %v\n", dir, err)
 			continue
@@ -155,7 +165,7 @@ func restoreMetadata(entry launch.Entry) string {
 	if rec.Handle != "" {
 		parts = append(parts, "handle: "+rec.Handle)
 	}
-	if _, err := os.Stat(filepath.Join(entry.AgentDir, role.FileName)); err == nil {
+	if role.Exists(entry.AgentDir) {
 		parts = append(parts, "persona: role.md")
 	} else {
 		parts = append(parts, "persona: missing")
@@ -206,6 +216,9 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	}
 	if rec.Session != "" {
 		args = append(args, "--session", rec.Session)
+		if rec.BaseRoot != "" {
+			args = append(args, "--root", rec.BaseRoot)
+		}
 	} else if rec.Root != "" {
 		args = append(args, "--root", rec.Root)
 	}
@@ -250,6 +263,10 @@ func emitCommand(rec launch.Record) string {
 	if rec.Session != "" {
 		b.WriteString(" --session ")
 		b.WriteString(shellQuote(rec.Session))
+		if rec.BaseRoot != "" {
+			b.WriteString(" --root ")
+			b.WriteString(shellQuote(rec.BaseRoot))
+		}
 	} else if rec.Root != "" {
 		b.WriteString(" --root ")
 		b.WriteString(shellQuote(rec.Root))

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -231,11 +231,13 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoDefaultArgs {
 		args = append(args, "--no-default-args")
 	}
+	// =VALUE form keeps the value glued to the flag so a literal "--" inside
+	// the binary args never reaches splitDashDash on replay.
 	if len(rec.CodexArgs) > 0 {
-		args = append(args, "--codex-args", joinedAgentArgs(rec.CodexArgs))
+		args = append(args, "--codex-args="+joinedAgentArgs(rec.CodexArgs))
 	}
 	if len(rec.ClaudeArgs) > 0 {
-		args = append(args, "--claude-args", joinedAgentArgs(rec.ClaudeArgs))
+		args = append(args, "--claude-args="+joinedAgentArgs(rec.ClaudeArgs))
 	}
 	if rec.Handle != "" {
 		args = append(args, "--me", rec.Handle)
@@ -327,11 +329,11 @@ func emitCommand(rec launch.Record) string {
 		b.WriteString(" --no-default-args")
 	}
 	if len(rec.CodexArgs) > 0 {
-		b.WriteString(" --codex-args ")
+		b.WriteString(" --codex-args=")
 		b.WriteString(shellQuote(joinedAgentArgs(rec.CodexArgs)))
 	}
 	if len(rec.ClaudeArgs) > 0 {
-		b.WriteString(" --claude-args ")
+		b.WriteString(" --claude-args=")
 		b.WriteString(shellQuote(joinedAgentArgs(rec.ClaudeArgs)))
 	}
 	if rec.Handle != "" && rec.Handle != defaultHandleFor(rec.Binary) {

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -228,6 +228,9 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.Conversation != "" {
 		args = append(args, "--conversation", rec.Conversation)
 	}
+	if rec.NoDefaultArgs {
+		args = append(args, "--no-default-args")
+	}
 	if len(rec.CodexArgs) > 0 {
 		args = append(args, "--codex-args", joinedAgentArgs(rec.CodexArgs))
 	}
@@ -319,6 +322,9 @@ func emitCommand(rec launch.Record) string {
 	if rec.Conversation != "" {
 		b.WriteString(" --conversation ")
 		b.WriteString(shellQuote(rec.Conversation))
+	}
+	if rec.NoDefaultArgs {
+		b.WriteString(" --no-default-args")
 	}
 	if len(rec.CodexArgs) > 0 {
 		b.WriteString(" --codex-args ")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -119,6 +119,23 @@ func TestEmitCommandIncludesRootWhenSessionMissing(t *testing.T) {
 	}
 }
 
+func TestEmitCommandIncludesBaseRootWithSession(t *testing.T) {
+	rec := launch.Record{
+		CWD:      "/p",
+		Binary:   "claude",
+		Session:  "stream1",
+		Handle:   "claude",
+		Root:     "/tmp/mail/stream1",
+		BaseRoot: "/tmp/mail",
+	}
+	cmd := emitCommand(rec)
+	for _, want := range []string{"--root /tmp/mail", "--session stream1"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
 func TestLaunchArgsFromRecord(t *testing.T) {
 	rec := launch.Record{
 		CWD:          "/p",
@@ -172,6 +189,21 @@ func TestLaunchArgsFromRecordUsesRootWithoutSession(t *testing.T) {
 	}
 	got := launchArgsFromRecord(rec)
 	want := []string{"--no-bootstrap", "--root", "/p/.agent-mail", "--me", "codex", "codex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+}
+
+func TestLaunchArgsFromRecordPreservesBaseRootWithSession(t *testing.T) {
+	rec := launch.Record{
+		Binary:   "claude",
+		Session:  "stream1",
+		Handle:   "claude",
+		Root:     "/tmp/mail/stream1",
+		BaseRoot: "/tmp/mail",
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{"--no-bootstrap", "--session", "stream1", "--root", "/tmp/mail", "--me", "claude", "claude"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
 	}

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"reflect"
 	"strings"
 	"testing"
@@ -206,6 +207,140 @@ func TestLaunchArgsFromRecordPreservesBaseRootWithSession(t *testing.T) {
 	want := []string{"--no-bootstrap", "--session", "stream1", "--root", "/tmp/mail", "--me", "claude", "claude"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+}
+
+// Restore round-trip: a launch made with --conversation plus --codex-args must
+// re-emit through the same flag rather than baking the binary args into the
+// argv after "--", otherwise the conversation gate on the second pass rejects
+// them as "extra codex args".
+func TestLaunchArgsFromRecordRoundTripsConversationWithCodexArgs(t *testing.T) {
+	rec := launch.Record{
+		CWD:          "/p",
+		Binary:       "codex",
+		Argv:         []string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals", "resume", "X"},
+		Session:      "cto",
+		Conversation: "X",
+		Handle:       "cto",
+		Role:         "cto",
+		CodexArgs:    []string{"--enable", "goals"},
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{
+		"--no-bootstrap",
+		"--role", "cto",
+		"--session", "cto",
+		"--conversation", "X",
+		"--codex-args", "--enable goals",
+		"--me", "cto",
+		"codex",
+		"--",
+		"--dangerously-bypass-approvals-and-sandbox",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+
+	assertConversationReplayAccepted(t, got)
+}
+
+func TestLaunchArgsFromRecordRoundTripsConversationWithClaudeArgs(t *testing.T) {
+	rec := launch.Record{
+		CWD:          "/p",
+		Binary:       "claude",
+		Argv:         []string{"--permission-mode", "auto", "--chrome", "--resume", "Y"},
+		Session:      "fs",
+		Conversation: "Y",
+		Handle:       "fullstack",
+		Role:         "fullstack",
+		ClaudeArgs:   []string{"--chrome"},
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{
+		"--no-bootstrap",
+		"--role", "fullstack",
+		"--session", "fs",
+		"--conversation", "Y",
+		"--claude-args", "--chrome",
+		"--me", "fullstack",
+		"claude",
+		"--",
+		"--permission-mode", "auto",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+	assertConversationReplayAccepted(t, got)
+}
+
+// joinedAgentArgs writes a value that parseAgentArgs must re-tokenize
+// identically — pin the round-trip for spaces, single quotes, double quotes,
+// and backslash escapes.
+func TestBinaryArgsJoinedRoundTripPreservesQuotingAndEscapes(t *testing.T) {
+	cases := [][]string{
+		{"--enable", "goals"},
+		{"--prompt", "hello world"},
+		{"--label", "it's fine"},
+		{`--regex`, `a\nb`},
+		{"--quoted", `say "hi"`},
+		{"--empty", ""},
+	}
+	for _, args := range cases {
+		joined := joinedAgentArgs(args)
+		got, err := parseAgentArgs(joined)
+		if err != nil {
+			t.Fatalf("parseAgentArgs(%q) error: %v", joined, err)
+		}
+		if !reflect.DeepEqual(got, args) {
+			t.Errorf("round-trip %q -> %q -> %v, want %v", args, joined, got, args)
+		}
+	}
+}
+
+func TestRemoveContiguousSubsequenceFirstMatchOnly(t *testing.T) {
+	// Stripping is intentionally first-match. Document the behavior so a
+	// future refactor doesn't quietly change it.
+	got := removeContiguousSubsequence(
+		[]string{"--enable", "goals", "x", "--enable", "goals"},
+		[]string{"--enable", "goals"},
+	)
+	want := []string{"x", "--enable", "goals"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("removeContiguousSubsequence = %v, want %v", got, want)
+	}
+}
+
+// assertConversationReplayAccepted reproduces the replay path runLaunch takes
+// and confirms the conversation gate accepts the restored argv.
+func assertConversationReplayAccepted(t *testing.T, args []string) {
+	t.Helper()
+	squadArgs, postDash := splitDashDash(args)
+	fs := flag.NewFlagSet("launch", flag.ContinueOnError)
+	codexArgsRaw := fs.String("codex-args", "", "")
+	claudeArgsRaw := fs.String("claude-args", "", "")
+	conversation := fs.String("conversation", "", "")
+	_ = fs.Bool("no-bootstrap", false, "")
+	_ = fs.String("role", "", "")
+	_ = fs.String("session", "", "")
+	_ = fs.String("me", "", "")
+	if err := fs.Parse(squadArgs); err != nil {
+		t.Fatalf("parse restore squadArgs: %v", err)
+	}
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
+	if err != nil {
+		t.Fatalf("parseBinaryArgFlags: %v", err)
+	}
+	remaining := fs.Args()
+	if len(remaining) == 0 {
+		t.Fatalf("restore args missing binary: %#v", args)
+	}
+	binary := remaining[0]
+	childArgs := append([]string(nil), remaining[1:]...)
+	childArgs = append(childArgs, postDash...)
+	defaultArgs := launchDefaultChildArgs(binary, true, binaryArgsFor(binary, binaryArgs))
+	childArgs = ensureLeadingChildArgs(defaultArgs, childArgs)
+	if _, err := applyConversationRestoreArgsWithDefaults(binary, childArgs, *conversation, defaultArgs); err != nil {
+		t.Fatalf("conversation restore rejected: %v", err)
 	}
 }
 

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -297,6 +297,37 @@ func TestBinaryArgsJoinedRoundTripPreservesQuotingAndEscapes(t *testing.T) {
 	}
 }
 
+// --no-default-args must round-trip — without persistence the restore replay
+// silently re-injects the binary defaults the original launch opted out of.
+func TestLaunchArgsFromRecordPreservesNoDefaultArgs(t *testing.T) {
+	rec := launch.Record{
+		CWD:           "/p",
+		Binary:        "codex",
+		Argv:          []string{"--enable", "goals"},
+		Session:       "rt",
+		Handle:        "cto",
+		Role:          "cto",
+		CodexArgs:     []string{"--enable", "goals"},
+		NoDefaultArgs: true,
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{
+		"--no-bootstrap",
+		"--role", "cto",
+		"--session", "rt",
+		"--no-default-args",
+		"--codex-args", "--enable goals",
+		"--me", "cto",
+		"codex",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+	if cmd := emitCommand(rec); !strings.Contains(cmd, "--no-default-args") {
+		t.Errorf("emitCommand missing --no-default-args: %s", cmd)
+	}
+}
+
 func TestRemoveContiguousSubsequenceFirstMatchOnly(t *testing.T) {
 	// Stripping is intentionally first-match. Document the behavior so a
 	// future refactor doesn't quietly change it.

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -231,7 +231,7 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithCodexArgs(t *testing.T) {
 		"--role", "cto",
 		"--session", "cto",
 		"--conversation", "X",
-		"--codex-args", "--enable goals",
+		"--codex-args=--enable goals",
 		"--me", "cto",
 		"codex",
 		"--",
@@ -261,7 +261,7 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithClaudeArgs(t *testing.T) 
 		"--role", "fullstack",
 		"--session", "fs",
 		"--conversation", "Y",
-		"--claude-args", "--chrome",
+		"--claude-args=--chrome",
 		"--me", "fullstack",
 		"claude",
 		"--",
@@ -316,7 +316,7 @@ func TestLaunchArgsFromRecordPreservesNoDefaultArgs(t *testing.T) {
 		"--role", "cto",
 		"--session", "rt",
 		"--no-default-args",
-		"--codex-args", "--enable goals",
+		"--codex-args=--enable goals",
 		"--me", "cto",
 		"codex",
 	}
@@ -326,6 +326,54 @@ func TestLaunchArgsFromRecordPreservesNoDefaultArgs(t *testing.T) {
 	if cmd := emitCommand(rec); !strings.Contains(cmd, "--no-default-args") {
 		t.Errorf("emitCommand missing --no-default-args: %s", cmd)
 	}
+}
+
+// A literal "--" inside CodexArgs must not be intercepted by splitDashDash on
+// replay. The =VALUE emission keeps the value glued to the flag name; the
+// only bare "--" left in the emitted args is the binary/child separator,
+// which sits AFTER the binary token and is intentionally split there.
+func TestLaunchArgsFromRecordEscapesLiteralDashDashInBinaryArgs(t *testing.T) {
+	rec := launch.Record{
+		CWD:       "/p",
+		Binary:    "codex",
+		Argv:      []string{"--dangerously-bypass-approvals-and-sandbox", "--"},
+		Session:   "rt",
+		Handle:    "cto",
+		Role:      "cto",
+		CodexArgs: []string{"--"},
+	}
+	got := launchArgsFromRecord(rec)
+	squadArgs, postDash := splitDashDash(got)
+	// The emitted "--codex-args=--" token must survive into squadArgs; the
+	// only thing past the binary/child separator should be the leftover argv
+	// (the built-in default). If splitDashDash had grabbed the "--" inside
+	// the flag value, --codex-args would land with no value and the flag
+	// state would shift entirely.
+	for _, a := range squadArgs {
+		if a == "--codex-args" || a == "--codex-args=" {
+			t.Fatalf("--codex-args lost its value on replay: %#v", squadArgs)
+		}
+	}
+	if !reflect.DeepEqual(postDash, []string{"--dangerously-bypass-approvals-and-sandbox"}) {
+		t.Fatalf("postDash = %#v, want only the leftover default", postDash)
+	}
+	parsed, err := parseAgentArgs(extractFlagValue(squadArgs, "--codex-args"))
+	if err != nil {
+		t.Fatalf("parseAgentArgs: %v", err)
+	}
+	if !reflect.DeepEqual(parsed, []string{"--"}) {
+		t.Errorf("parsed CodexArgs = %#v, want [--]", parsed)
+	}
+}
+
+func extractFlagValue(args []string, name string) string {
+	prefix := name + "="
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return strings.TrimPrefix(a, prefix)
+		}
+	}
+	return ""
 }
 
 func TestRemoveContiguousSubsequenceFirstMatchOnly(t *testing.T) {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -49,7 +49,7 @@ func runTeamSmart() error {
 		return fmt.Errorf("getwd: %w", err)
 	}
 	if team.Exists(cwd) {
-		return emitTeamCommands(cwd, false, "", false, false)
+		return emitTeamCommands(cwd, false, "", false, false, nil)
 	}
 	fmt.Fprintln(os.Stderr, "No team configured for this project yet. Let's set one up.")
 	fmt.Fprintln(os.Stderr)
@@ -57,7 +57,7 @@ func runTeamSmart() error {
 		return err
 	}
 	fmt.Fprintln(os.Stderr)
-	return emitTeamCommands(cwd, false, "", false, false)
+	return emitTeamCommands(cwd, false, "", false, false, nil)
 }
 
 func runTeamInit(args []string) error {
@@ -67,13 +67,15 @@ func runTeamInit(args []string) error {
 	binaryFlag := fs.String("binary", "", "per-persona CLI overrides, e.g. fullstack=codex,qa=claude")
 	sessionFlag := fs.String("session", "", "AMQ workstream session name for all members (lowercase a-z, 0-9, -, _)")
 	cwdFlag := fs.String("cwd", "", "per-persona working directory overrides, e.g. qa=/path/to/sibling-project")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for every Codex member, e.g. '--enable goals'")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for every Claude member, e.g. '--chrome'")
 	force := fs.Bool("force", false, "overwrite an existing team.json")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
 
 Usage:
-  amq-squad team init [--personas id1,id2,...] [--binary persona=cli,...] [--session workstream] [--force]
-  amq-squad team init [--roles id1,id2,...] [--binary role=cli,...] [--session workstream] [--force]
+  amq-squad team init [--personas id1,id2,...] [--binary persona=cli,...] [--session workstream] [--codex-args args] [--claude-args args] [--force]
+  amq-squad team init [--roles id1,id2,...] [--binary role=cli,...] [--session workstream] [--codex-args args] [--claude-args args] [--force]
 
 Without --personas or --roles, prompts interactively: first choose personas,
 then choose the CLI for each persona. Writes <cwd>/.amq-squad/team.json and
@@ -118,6 +120,10 @@ Known personas:
 	cwdOverrides, err := parseKV(*cwdFlag)
 	if err != nil {
 		return fmt.Errorf("parse --cwd: %w", err)
+	}
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
+	if err != nil {
+		return err
 	}
 
 	var picked []string
@@ -180,6 +186,7 @@ Known personas:
 	t := team.Team{
 		Project:    cwd,
 		Workstream: workstream,
+		BinaryArgs: binaryArgs,
 		Members:    members,
 	}
 	if err := team.Write(cwd, t); err != nil {
@@ -205,14 +212,20 @@ func runTeamShow(args []string) error {
 	noBootstrap := fs.Bool("no-bootstrap", false, "emit launch commands that skip the generated bootstrap prompt")
 	session := fs.String("session", "", "AMQ workstream session name (default: sanitized team-home directory name; lowercase a-z, 0-9, -, _)")
 	fresh := fs.Bool("fresh", false, "fail if the selected workstream session already exists")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
 
 Usage:
-  amq-squad team show [--session name] [--fresh] [--no-bootstrap]
+  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--codex-args args] [--claude-args args]
 `)
 	}
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
+	if err != nil {
 		return err
 	}
 	cwd, err := os.Getwd()
@@ -222,10 +235,10 @@ Usage:
 	if !team.Exists(cwd) {
 		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
 	}
-	return emitTeamCommands(cwd, *noBootstrap, *session, flagWasSet(fs, "session"), *fresh)
+	return emitTeamCommands(cwd, *noBootstrap, *session, flagWasSet(fs, "session"), *fresh, binaryArgs)
 }
 
-func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession string, explicitSession bool, fresh bool) error {
+func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession string, explicitSession bool, fresh bool, extraBinaryArgs map[string][]string) error {
 	t, err := team.Read(projectDir)
 	if err != nil {
 		return fmt.Errorf("read team: %w", err)
@@ -248,12 +261,16 @@ func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession stri
 	}
 
 	members := orderedTeamMembers(t.Members)
+	binaryArgs := mergeBinaryArgs(t.BinaryArgs, extraBinaryArgs)
 
 	fmt.Println("# amq-squad team - run each command in its own terminal tab")
 	fmt.Println("#")
 	fmt.Printf("# team-home: %s\n", t.Project)
 	fmt.Printf("# workstream: %s\n", workstream)
 	fmt.Printf("# members:   %d\n", len(members))
+	if formatted := formatBinaryArgs(binaryArgs); formatted != "" {
+		fmt.Printf("# binary args: %s\n", formatted)
+	}
 	// List unique member cwds so a multi-project team is obvious at a glance.
 	uniqueCWDs := uniqueMemberCWDs(t.Project, members)
 	if len(uniqueCWDs) > 1 {
@@ -280,7 +297,7 @@ func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession stri
 		}
 		cwd := m.EffectiveCWD(t.Project)
 		fmt.Printf("# %d. %s - %s (workstream: %s, cwd: %s)\n", i+1, label, m.Binary, workstream, cwd)
-		fmt.Println(emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream))
+		fmt.Println(emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream, binaryArgs))
 		fmt.Println()
 	}
 	return nil
@@ -324,7 +341,7 @@ func uniqueMemberCWDs(projectDir string, members []team.Member) []string {
 	return out
 }
 
-func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap bool, workstream string) string {
+func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap bool, workstream string, binaryArgs map[string][]string) string {
 	var b strings.Builder
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(cwd))
@@ -349,9 +366,20 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 		b.WriteString(" --me ")
 		b.WriteString(shellQuote(m.Handle))
 	}
+	extraDefaultArgs := binaryArgsFor(m.Binary, binaryArgs)
+	if len(extraDefaultArgs) > 0 {
+		switch normalizedAgentBinary(m.Binary) {
+		case "codex":
+			b.WriteString(" --codex-args=")
+			b.WriteString(shellQuote(joinedAgentArgs(extraDefaultArgs)))
+		case "claude":
+			b.WriteString(" --claude-args=")
+			b.WriteString(shellQuote(joinedAgentArgs(extraDefaultArgs)))
+		}
+	}
 	b.WriteString(" ")
 	b.WriteString(shellQuote(m.Binary))
-	if defaultArgs := defaultChildArgsForBinary(m.Binary); len(defaultArgs) > 0 {
+	if defaultArgs := launchDefaultChildArgs(m.Binary, true, extraDefaultArgs); len(defaultArgs) > 0 {
 		b.WriteString(" --")
 		for _, arg := range defaultArgs {
 			b.WriteString(" ")

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -22,6 +22,7 @@ type teamLaunchOptions struct {
 	Stagger         time.Duration
 	DryRun          bool
 	SquadBin        string
+	BinaryArgs      map[string][]string
 }
 
 type teamLaunchPane struct {
@@ -62,6 +63,8 @@ func runTeamLaunch(args []string) error {
 	terminalSession := fs.String("terminal-session", "", "terminal session name when the backend creates one")
 	fresh := fs.Bool("fresh", false, "fail if the selected workstream session already exists")
 	noBootstrap := fs.Bool("no-bootstrap", false, "launch agents without the generated bootstrap prompt")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'")
 	_ = fs.Bool("no-attach", false, "legacy no-op; new-session never attaches automatically")
 	stagger := fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes")
 	dryRun := fs.Bool("dry-run", false, "print terminal commands without executing them")
@@ -69,7 +72,7 @@ func runTeamLaunch(args []string) error {
 		fmt.Fprintf(os.Stderr, `amq-squad team launch - open the configured team in a terminal
 
 Usage:
-  amq-squad team launch [--session workstream] [--fresh] [--terminal tmux] [--target current-window|new-session] [--layout vertical|horizontal|tiled] [--terminal-session name] [--stagger 750ms] [--no-bootstrap] [--dry-run]
+  amq-squad team launch [--session workstream] [--fresh] [--terminal tmux] [--target current-window|new-session] [--layout vertical|horizontal|tiled] [--terminal-session name] [--stagger 750ms] [--no-bootstrap] [--codex-args args] [--claude-args args] [--dry-run]
 
 Supported terminal backends: %s
 
@@ -84,6 +87,10 @@ to create a detached squad session.
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
+	if err != nil {
+		return err
+	}
 	opts := teamLaunchOptions{
 		Terminal:        *terminal,
 		Target:          *target,
@@ -95,6 +102,7 @@ to create a detached squad session.
 		Stagger:         *stagger,
 		DryRun:          *dryRun,
 		SquadBin:        teamSquadBin(),
+		BinaryArgs:      binaryArgs,
 	}
 	backend, ok := teamLaunchBackends[opts.Terminal]
 	if !ok {
@@ -145,15 +153,16 @@ func registeredTeamLaunchTerminals() []string {
 	return names
 }
 
-func buildTeamLaunchPanes(t team.Team, squadBin string, noBootstrap bool, workstream string) []teamLaunchPane {
+func buildTeamLaunchPanes(t team.Team, squadBin string, noBootstrap bool, workstream string, extraBinaryArgs map[string][]string) []teamLaunchPane {
 	members := orderedTeamMembers(t.Members)
+	binaryArgs := mergeBinaryArgs(t.BinaryArgs, extraBinaryArgs)
 	panes := make([]teamLaunchPane, 0, len(members))
 	for _, m := range members {
 		cwd := m.EffectiveCWD(t.Project)
 		panes = append(panes, teamLaunchPane{
 			Role:    m.Role,
 			CWD:     cwd,
-			Command: emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream),
+			Command: emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream, binaryArgs),
 		})
 	}
 	return panes

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -18,7 +18,7 @@ func TestBuildTmuxLaunchPlanUsesCatalogOrderAndLaunchCommands(t *testing.T) {
 			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
 		},
 	}
-	plan := buildTmuxLaunchPlan(tm, "/bin/amq-squad", "amq-squad-repo", "new-session", "vertical", false, 750*time.Millisecond, "repo")
+	plan := buildTmuxLaunchPlan(tm, "/bin/amq-squad", "amq-squad-repo", "new-session", "vertical", false, 750*time.Millisecond, "repo", nil)
 	if plan.Session != "amq-squad-repo" {
 		t.Fatalf("Session = %q", plan.Session)
 	}
@@ -210,6 +210,47 @@ func TestRunTeamLaunchDryRunUsesExplicitSharedWorkstream(t *testing.T) {
 	}
 	if strings.Contains(stdout, "--session cto") || strings.Contains(stdout, "--session fullstack") {
 		t.Fatalf("dry-run used role-per-session routing instead of shared workstream:\n%s", stdout)
+	}
+}
+
+func TestRunTeamLaunchDryRunUsesBinaryArgs(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamLaunch([]string{"--dry-run", "--no-bootstrap", "--codex-args=--enable goals", "--claude-args=--chrome"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"--codex-args=",
+		"codex -- --dangerously-bypass-approvals-and-sandbox --enable goals",
+		"--claude-args=--chrome",
+		"claude -- --permission-mode auto --chrome",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("dry-run output missing %q in:\n%s", want, stdout)
+		}
 	}
 }
 

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -69,16 +69,16 @@ func (tmuxTeamLaunchBackend) buildPlan(t team.Team, opts teamLaunchOptions) tmux
 	if session == "" {
 		session = defaultTmuxSessionName(t.Project)
 	}
-	return buildTmuxLaunchPlan(t, opts.SquadBin, session, opts.Target, opts.Layout, opts.NoBootstrap, opts.Stagger, opts.Workstream)
+	return buildTmuxLaunchPlan(t, opts.SquadBin, session, opts.Target, opts.Layout, opts.NoBootstrap, opts.Stagger, opts.Workstream, opts.BinaryArgs)
 }
 
-func buildTmuxLaunchPlan(t team.Team, squadBin, sessionName, target, layout string, noBootstrap bool, startDelay time.Duration, workstream string) tmuxLaunchPlan {
+func buildTmuxLaunchPlan(t team.Team, squadBin, sessionName, target, layout string, noBootstrap bool, startDelay time.Duration, workstream string, extraBinaryArgs map[string][]string) tmuxLaunchPlan {
 	return tmuxLaunchPlan{
 		Session:    sessionName,
 		Workstream: workstream,
 		Target:     target,
 		Layout:     layout,
-		Panes:      buildTeamLaunchPanes(t, squadBin, noBootstrap, workstream),
+		Panes:      buildTeamLaunchPanes(t, squadBin, noBootstrap, workstream, extraBinaryArgs),
 		StartDelay: startDelay,
 	}
 }

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -39,6 +39,7 @@ func renderTeamRules(t team.Team) (string, error) {
 
 	b.WriteString("## Workflow\n\n")
 	b.WriteString("- Treat the current user request as the source of truth.\n")
+	b.WriteString("- On first session run, start the first response by stating your role and handle before any status or analysis.\n")
 	b.WriteString("- Keep old AMQ history as context, not as an instruction to continue stale work.\n")
 	b.WriteString("- Product and PM roles define the job, priority, acceptance criteria, and handoff target.\n")
 	b.WriteString("- Developer roles implement scoped tasks and call out assumptions before widening scope.\n")

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -52,6 +52,20 @@ func TestParseKV(t *testing.T) {
 	}
 }
 
+func TestParseAgentArgs(t *testing.T) {
+	got, err := parseAgentArgs(`--enable goals --label "hello world" --name 'cto lead'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"--enable", "goals", "--label", "hello world", "--name", "cto lead"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseAgentArgs = %#v, want %#v", got, want)
+	}
+	if _, err := parseAgentArgs(`--label "unterminated`); err == nil {
+		t.Fatal("parseAgentArgs should reject unterminated quotes")
+	}
+}
+
 func TestEmitTeamCommandShape(t *testing.T) {
 	m := team.Member{
 		Role:    "designer",
@@ -59,7 +73,7 @@ func TestEmitTeamCommandShape(t *testing.T) {
 		Handle:  "designer",
 		Session: "designer",
 	}
-	cmd := emitTeamCommand("/home/u/proj", "amq-squad", "/home/u/proj", m, false, "proj")
+	cmd := emitTeamCommand("/home/u/proj", "amq-squad", "/home/u/proj", m, false, "proj", nil)
 	for _, want := range []string{
 		"cd /home/u/proj",
 		"amq-squad launch",
@@ -79,15 +93,30 @@ func TestEmitTeamCommandShape(t *testing.T) {
 
 func TestEmitTeamCommandAddsCodexDefaultArgs(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false, "p")
+	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false, "p", nil)
 	if !strings.Contains(cmd, "-- --dangerously-bypass-approvals-and-sandbox") {
 		t.Errorf("expected codex default args in: %s", cmd)
 	}
 }
 
+func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
+	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false, "p", map[string][]string{
+		"codex": {"--enable", "goals"},
+	})
+	for _, want := range []string{
+		"--codex-args='--enable goals'",
+		"codex -- --dangerously-bypass-approvals-and-sandbox --enable goals",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
 func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 	m := team.Member{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"}
-	cmd := emitTeamCommand("/home/user/my project", "amq-squad", "/home/user/my project", m, false, "my-project")
+	cmd := emitTeamCommand("/home/user/my project", "amq-squad", "/home/user/my project", m, false, "my-project", nil)
 	if !strings.Contains(cmd, "'/home/user/my project'") {
 		t.Errorf("project path not quoted: %s", cmd)
 	}
@@ -95,7 +124,7 @@ func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 
 func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", "/p", m, false, "p")
+	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", "/p", m, false, "p", nil)
 	if !strings.Contains(cmd, "/usr/local/bin/amq-squad launch") {
 		t.Errorf("expected absolute binary path in: %s", cmd)
 	}
@@ -103,7 +132,7 @@ func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
 
 func TestEmitTeamCommandNoBootstrap(t *testing.T) {
 	m := team.Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "qa"}
-	cmd := emitTeamCommand("/p", "amq-squad", "/team", m, true, "team")
+	cmd := emitTeamCommand("/p", "amq-squad", "/team", m, true, "team", nil)
 	if !strings.Contains(cmd, "--no-bootstrap") {
 		t.Errorf("expected --no-bootstrap in: %s", cmd)
 	}
@@ -185,6 +214,46 @@ func TestRunTeamShowUsesStoredSharedWorkstream(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "# workstream: issue-96") || !strings.Contains(stdout, "--session issue-96 --team-workstream --team-home") {
 		t.Fatalf("team show did not use stored shared workstream:\n%s", stdout)
+	}
+}
+
+func TestRunTeamShowMergesStoredAndRunBinaryArgs(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := team.Write(dir, team.Team{
+		BinaryArgs: map[string][]string{"codex": {"--enable", "goals"}},
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamShow([]string{"--no-bootstrap", "--codex-args=--profile fast"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamShow: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"# binary args: codex: --enable goals --profile fast",
+		"--codex-args='--enable goals --profile fast'",
+		"codex -- --dangerously-bypass-approvals-and-sandbox --enable goals --profile fast",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("team show output missing %q in:\n%s", want, stdout)
+		}
 	}
 }
 
@@ -335,6 +404,13 @@ func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
 			t.Errorf("%s: shouldAppendBootstrap(%q, %v) = %v, want %v", tc.name, tc.binary, tc.childArgs, got, tc.want)
 		}
 	}
+	defaults := []string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals"}
+	if !shouldAppendBootstrapWithDefaults(defaults, defaults) {
+		t.Errorf("configured binary args should still allow bootstrap")
+	}
+	if shouldAppendBootstrapWithDefaults([]string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals", "prompt"}, defaults) {
+		t.Errorf("configured binary args plus prompt should not auto-bootstrap")
+	}
 }
 
 func TestEnsureDefaultChildArgs(t *testing.T) {
@@ -362,6 +438,11 @@ func TestEnsureDefaultChildArgs(t *testing.T) {
 	want = []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt", "--dangerously-bypass-approvals-and-sandbox"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ensureDefaultChildArgs should keep defaults before prompts: got %v, want %v", got, want)
+	}
+	got = ensureLeadingChildArgs([]string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals"}, []string{"--dangerously-bypass-approvals-and-sandbox", "prompt"})
+	want = []string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals", "prompt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ensureLeadingChildArgs should insert missing configured defaults after existing prefix: got %v, want %v", got, want)
 	}
 }
 
@@ -481,6 +562,40 @@ func TestRunTeamInitPersonasAliasAndBinaryOverride(t *testing.T) {
 	m := got.Members[0]
 	if m.Role != "fullstack" || m.Binary != "codex" {
 		t.Fatalf("member = %+v, want fullstack on codex", m)
+	}
+}
+
+func TestRunTeamInitStoresBinaryArgs(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	if err := runTeamInit([]string{
+		"--personas", "cto,fullstack",
+		"--codex-args=--enable goals",
+		"--claude-args=--chrome",
+	}); err != nil {
+		t.Fatalf("runTeamInit: %v", err)
+	}
+	got, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got.BinaryArgs["codex"], []string{"--enable", "goals"}) {
+		t.Fatalf("codex args = %#v", got.BinaryArgs["codex"])
+	}
+	if !reflect.DeepEqual(got.BinaryArgs["claude"], []string{"--chrome"}) {
+		t.Fatalf("claude args = %#v", got.BinaryArgs["claude"])
 	}
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -773,6 +773,7 @@ func TestRunTeamInitSeedsTeamRules(t *testing.T) {
 	body := string(got)
 	for _, want := range []string{
 		"## Role Scope",
+		"On first session run, start the first response by stating your role and handle",
 		"pm (Project Manager / Product Owner)",
 		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
 		"fullstack (Fullstack Developer)",
@@ -862,6 +863,7 @@ func TestRunTeamRulesInitForceRefreshesScopedRules(t *testing.T) {
 		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
 		"fullstack (Fullstack Developer)",
 		fmt.Sprintf("default workstream `%s`", defaultWorkstreamName(dir)),
+		"On first session run, start the first response by stating your role and handle",
 		"Use the `amq-squad` skill for team setup",
 		"Use `amq-cli` only for raw AMQ debugging",
 	} {

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -42,6 +42,7 @@ type Record struct {
 	AMQVersion       string    `json:"amq_version,omitempty"`
 	CodexArgs        []string  `json:"codex_args,omitempty"`
 	ClaudeArgs       []string  `json:"claude_args,omitempty"`
+	NoDefaultArgs    bool      `json:"no_default_args,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 }
 

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -15,12 +15,15 @@ const (
 	// SchemaVersion is bumped on any breaking change to the on-disk record.
 	SchemaVersion = 1
 
+	// LayerName is the AMQ extension namespace used for amq-squad metadata.
+	LayerName = "io.github.omriariav.amq-squad"
+
 	// FileName is the name of the launch record inside an agent's mailbox dir.
 	FileName = "launch.json"
 )
 
-// Record is the persisted launch invocation for a single agent. It lives at
-// <AM_ROOT>/agents/<handle>/launch.json.
+// Record is the persisted launch invocation for a single agent. New records
+// live under the amq-squad extension namespace inside the agent mailbox.
 type Record struct {
 	Schema  int      `json:"schema"`
 	CWD     string   `json:"cwd"`
@@ -34,6 +37,9 @@ type Record struct {
 	Handle           string    `json:"handle"`
 	Role             string    `json:"role,omitempty"`
 	Root             string    `json:"root"`
+	BaseRoot         string    `json:"base_root,omitempty"`
+	RootSource       string    `json:"root_source,omitempty"`
+	AMQVersion       string    `json:"amq_version,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 }
 
@@ -44,14 +50,54 @@ type Entry struct {
 	Source   string
 }
 
-// Write atomically writes the record into the agent's mailbox directory.
+// ExtensionDir returns the amq-squad extension directory for an agent mailbox.
+func ExtensionDir(agentDir string) string {
+	return filepath.Join(agentDir, "extensions", LayerName)
+}
+
+// Path returns the v0.6+ launch record path for an agent mailbox.
+func Path(agentDir string) string {
+	return filepath.Join(ExtensionDir(agentDir), FileName)
+}
+
+// LegacyPath returns the pre-v0.6 launch record path for an agent mailbox.
+func LegacyPath(agentDir string) string {
+	return filepath.Join(agentDir, FileName)
+}
+
+// ExistingPath returns the launch record path that should be read, preferring
+// the extension namespace and falling back to the legacy direct-agent path.
+func ExistingPath(agentDir string) string {
+	p := Path(agentDir)
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	if _, err := os.Stat(LegacyPath(agentDir)); err == nil {
+		return LegacyPath(agentDir)
+	}
+	return p
+}
+
+// HasRecord reports whether either the extension or legacy record exists.
+func HasRecord(agentDir string) bool {
+	if _, err := os.Stat(Path(agentDir)); err == nil {
+		return true
+	}
+	if _, err := os.Stat(LegacyPath(agentDir)); err == nil {
+		return true
+	}
+	return false
+}
+
+// Write atomically writes the record into the agent's amq-squad extension dir.
 // The agent mailbox is expected to exist (coop exec creates it), but Write
 // also creates missing parents so the record can be written pre-exec.
 func Write(agentDir string, rec Record) error {
-	if err := os.MkdirAll(agentDir, 0o700); err != nil {
-		return fmt.Errorf("ensure agent dir: %w", err)
+	dir := ExtensionDir(agentDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("ensure extension dir: %w", err)
 	}
-	path := filepath.Join(agentDir, FileName)
+	path := Path(agentDir)
 	tmp := path + ".tmp"
 
 	rec.Schema = SchemaVersion
@@ -71,7 +117,7 @@ func Write(agentDir string, rec Record) error {
 // Read loads a launch record from an agent's mailbox directory. Returns
 // os.ErrNotExist if no launch.json is present.
 func Read(agentDir string) (Record, error) {
-	path := filepath.Join(agentDir, FileName)
+	path := ExistingPath(agentDir)
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return Record{}, err
@@ -83,37 +129,71 @@ func Read(agentDir string) (Record, error) {
 	return rec, nil
 }
 
-// ScanEntries walks a projectRoot for launch.json records across both AMQ layouts:
+// ScanEntries walks a projectRoot for launch.json records across AMQ layouts:
 //
-//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json  (coop exec)
-//	<projectRoot>/.agent-mail/agents/<handle>/launch.json            (base root, no session)
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/extensions/<layer>/launch.json
+//	<projectRoot>/.agent-mail/agents/<handle>/extensions/<layer>/launch.json
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json
+//	<projectRoot>/.agent-mail/agents/<handle>/launch.json
 //
 // Returns every record found. Order is whatever filepath.Glob returns;
 // callers that care about ordering should sort the result themselves.
 func ScanEntries(projectRoot string) ([]Entry, error) {
-	patterns := []string{
-		filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*", FileName),
-		filepath.Join(projectRoot, ".agent-mail", "agents", "*", FileName),
+	return ScanEntriesInRoot(projectRoot, filepath.Join(projectRoot, ".agent-mail"))
+}
+
+// ScanEntriesInRoot walks an AMQ base root for launch.json records across
+// extension and legacy layouts.
+func ScanEntriesInRoot(projectRoot, baseRoot string) ([]Entry, error) {
+	patterns := []struct {
+		glob     string
+		agentDir func(string) string
+	}{
+		{
+			glob: filepath.Join(baseRoot, "*", "agents", "*", "extensions", LayerName, FileName),
+			agentDir: func(path string) string {
+				return filepath.Dir(filepath.Dir(filepath.Dir(path)))
+			},
+		},
+		{
+			glob: filepath.Join(baseRoot, "agents", "*", "extensions", LayerName, FileName),
+			agentDir: func(path string) string {
+				return filepath.Dir(filepath.Dir(filepath.Dir(path)))
+			},
+		},
+		{
+			glob: filepath.Join(baseRoot, "*", "agents", "*", FileName),
+			agentDir: func(path string) string {
+				return filepath.Dir(path)
+			},
+		},
+		{
+			glob: filepath.Join(baseRoot, "agents", "*", FileName),
+			agentDir: func(path string) string {
+				return filepath.Dir(path)
+			},
+		},
 	}
 	seen := map[string]bool{}
 	var out []Entry
 	for _, p := range patterns {
-		matches, err := filepath.Glob(p)
+		matches, err := filepath.Glob(p.glob)
 		if err != nil {
-			return nil, fmt.Errorf("glob %s: %w", p, err)
+			return nil, fmt.Errorf("glob %s: %w", p.glob, err)
 		}
 		for _, m := range matches {
-			if seen[m] {
+			agentDir := p.agentDir(m)
+			if seen[agentDir] {
 				continue
 			}
-			seen[m] = true
-			rec, err := Read(filepath.Dir(m))
+			seen[agentDir] = true
+			rec, err := Read(agentDir)
 			if err != nil {
 				continue
 			}
 			out = append(out, Entry{
 				Record:   rec,
-				AgentDir: filepath.Dir(m),
+				AgentDir: agentDir,
 				Source:   FileName,
 			})
 		}
@@ -124,7 +204,13 @@ func ScanEntries(projectRoot string) ([]Entry, error) {
 // ScanRestorableEntries returns launch records plus best-effort records
 // inferred from older AMQ mailboxes that predate amq-squad launch.json.
 func ScanRestorableEntries(projectRoot string) ([]Entry, error) {
-	entries, err := ScanEntries(projectRoot)
+	return ScanRestorableEntriesInRoot(projectRoot, filepath.Join(projectRoot, ".agent-mail"))
+}
+
+// ScanRestorableEntriesInRoot returns launch records plus best-effort records
+// inferred from older AMQ mailboxes under a resolved AMQ base root.
+func ScanRestorableEntriesInRoot(projectRoot, baseRoot string) ([]Entry, error) {
+	entries, err := ScanEntriesInRoot(projectRoot, baseRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +219,7 @@ func ScanRestorableEntries(projectRoot string) ([]Entry, error) {
 		seen[e.AgentDir] = true
 	}
 
-	legacy, err := ScanLegacyEntries(projectRoot)
+	legacy, err := ScanLegacyEntriesInRoot(projectRoot, baseRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -150,19 +236,24 @@ func ScanRestorableEntries(projectRoot string) ([]Entry, error) {
 // directories that do not have launch.json. The binary is inferred from the
 // handle, which matches AMQ's default handle derivation for claude/codex.
 func ScanLegacyEntries(projectRoot string) ([]Entry, error) {
-	agentDirs, err := legacyAgentDirs(projectRoot)
+	return ScanLegacyEntriesInRoot(projectRoot, filepath.Join(projectRoot, ".agent-mail"))
+}
+
+// ScanLegacyEntriesInRoot infers restorable launches under a resolved AMQ base root.
+func ScanLegacyEntriesInRoot(projectRoot, baseRoot string) ([]Entry, error) {
+	agentDirs, err := legacyAgentDirs(baseRoot)
 	if err != nil {
 		return nil, err
 	}
 	var out []Entry
 	for _, agentDir := range agentDirs {
-		if _, err := os.Stat(filepath.Join(agentDir, FileName)); err == nil {
+		if HasRecord(agentDir) {
 			continue
 		}
 		if !hasLegacyActivity(agentDir) {
 			continue
 		}
-		rec, err := legacyRecord(projectRoot, agentDir)
+		rec, err := legacyRecord(projectRoot, baseRoot, agentDir)
 		if err != nil {
 			continue
 		}
@@ -175,10 +266,10 @@ func ScanLegacyEntries(projectRoot string) ([]Entry, error) {
 	return out, nil
 }
 
-func legacyAgentDirs(projectRoot string) ([]string, error) {
+func legacyAgentDirs(baseRoot string) ([]string, error) {
 	patterns := []string{
-		filepath.Join(projectRoot, ".agent-mail", "*", "agents", "*"),
-		filepath.Join(projectRoot, ".agent-mail", "agents", "*"),
+		filepath.Join(baseRoot, "*", "agents", "*"),
+		filepath.Join(baseRoot, "agents", "*"),
 	}
 	seen := map[string]bool{}
 	var out []string
@@ -223,9 +314,8 @@ func hasFiles(root string) bool {
 	return found
 }
 
-func legacyRecord(projectRoot, agentDir string) (Record, error) {
-	rootDir := filepath.Join(projectRoot, ".agent-mail")
-	rel, err := filepath.Rel(rootDir, agentDir)
+func legacyRecord(projectRoot, baseRoot, agentDir string) (Record, error) {
+	rel, err := filepath.Rel(baseRoot, agentDir)
 	if err != nil {
 		return Record{}, err
 	}
@@ -235,7 +325,7 @@ func legacyRecord(projectRoot, agentDir string) (Record, error) {
 	}
 
 	session := ""
-	root := rootDir
+	root := baseRoot
 	handle := filepath.Base(agentDir)
 	binary, ok := inferLegacyBinary(handle)
 	if !ok {
@@ -243,7 +333,7 @@ func legacyRecord(projectRoot, agentDir string) (Record, error) {
 	}
 	if parts[0] != "agents" {
 		session = parts[0]
-		root = filepath.Join(rootDir, session)
+		root = filepath.Join(baseRoot, session)
 	}
 
 	return Record{
@@ -253,6 +343,7 @@ func legacyRecord(projectRoot, agentDir string) (Record, error) {
 		Handle:    handle,
 		Role:      inferLegacyRole(handle),
 		Root:      root,
+		BaseRoot:  baseRoot,
 		StartedAt: legacyActivityTime(agentDir),
 	}, nil
 }
@@ -316,10 +407,12 @@ func readPresenceLastSeen(path string) (time.Time, bool) {
 	return parsed.LastSeen, true
 }
 
-// Scan walks a projectRoot for launch.json records across both AMQ layouts:
+// Scan walks a projectRoot for launch.json records across AMQ layouts:
 //
-//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json  (coop exec)
-//	<projectRoot>/.agent-mail/agents/<handle>/launch.json            (base root, no session)
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/extensions/<layer>/launch.json
+//	<projectRoot>/.agent-mail/agents/<handle>/extensions/<layer>/launch.json
+//	<projectRoot>/.agent-mail/<session>/agents/<handle>/launch.json
+//	<projectRoot>/.agent-mail/agents/<handle>/launch.json
 //
 // Returns every record found. Order is whatever filepath.Glob returns;
 // callers that care about ordering should sort the result themselves.

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -40,6 +40,8 @@ type Record struct {
 	BaseRoot         string    `json:"base_root,omitempty"`
 	RootSource       string    `json:"root_source,omitempty"`
 	AMQVersion       string    `json:"amq_version,omitempty"`
+	CodexArgs        []string  `json:"codex_args,omitempty"`
+	ClaudeArgs       []string  `json:"claude_args,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 }
 

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,10 +22,19 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		Handle:           "cpo",
 		Role:             "cpo",
 		Root:             dir,
+		BaseRoot:         filepath.Dir(dir),
+		RootSource:       "project_amqrc",
+		AMQVersion:       "0.34.0",
 		StartedAt:        time.Now().UTC().Truncate(time.Second),
 	}
 	if err := Write(dir, in); err != nil {
 		t.Fatalf("Write: %v", err)
+	}
+	if _, err := os.Stat(Path(dir)); err != nil {
+		t.Fatalf("Write did not create extension launch record: %v", err)
+	}
+	if _, err := os.Stat(LegacyPath(dir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Write created legacy launch record, err=%v", err)
 	}
 
 	out, err := Read(dir)
@@ -40,7 +50,9 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	if out.CWD != in.CWD || out.Binary != in.Binary || out.Session != in.Session ||
 		out.SharedWorkstream != in.SharedWorkstream ||
 		out.Conversation != in.Conversation ||
-		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root {
+		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root ||
+		out.BaseRoot != in.BaseRoot || out.RootSource != in.RootSource ||
+		out.AMQVersion != in.AMQVersion {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
 	}
 	if len(out.Argv) != len(in.Argv) {
@@ -61,6 +73,37 @@ func TestReadMissing(t *testing.T) {
 	_, err := Read(dir)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestReadFallsBackToLegacyPath(t *testing.T) {
+	dir := t.TempDir()
+	rec := Record{
+		Schema:  SchemaVersion,
+		CWD:     "/some/project",
+		Binary:  "codex",
+		Session: "stream1",
+		Handle:  "cto",
+		Role:    "cto",
+		Root:    "/some/project/.agent-mail/stream1",
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(LegacyPath(dir), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Handle != "cto" || got.Root != rec.Root {
+		t.Fatalf("Read = %+v, want legacy record %+v", got, rec)
+	}
+	if ExistingPath(dir) != LegacyPath(dir) {
+		t.Fatalf("ExistingPath = %q, want legacy path %q", ExistingPath(dir), LegacyPath(dir))
 	}
 }
 
@@ -136,6 +179,38 @@ func TestScanEntriesIncludesAgentDir(t *testing.T) {
 	}
 	if entries[0].Record.Handle != "cto" {
 		t.Errorf("Record.Handle = %q, want cto", entries[0].Record.Handle)
+	}
+}
+
+func TestScanEntriesInRootFindsExtensionRecordsUnderCustomBaseRoot(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(t.TempDir(), "mail")
+	agentDir := filepath.Join(baseRoot, "stream1", "agents", "cto")
+	rec := Record{
+		CWD:      project,
+		Binary:   "codex",
+		Session:  "stream1",
+		Handle:   "cto",
+		Role:     "cto",
+		Root:     filepath.Join(baseRoot, "stream1"),
+		BaseRoot: baseRoot,
+	}
+	if err := Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ScanEntriesInRoot(project, baseRoot)
+	if err != nil {
+		t.Fatalf("ScanEntriesInRoot: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("ScanEntriesInRoot returned %d records, want 1", len(entries))
+	}
+	if entries[0].AgentDir != agentDir {
+		t.Fatalf("AgentDir = %q, want %q", entries[0].AgentDir, agentDir)
+	}
+	if entries[0].Record.BaseRoot != baseRoot {
+		t.Fatalf("BaseRoot = %q, want %q", entries[0].Record.BaseRoot, baseRoot)
 	}
 }
 

--- a/internal/role/role.go
+++ b/internal/role/role.go
@@ -149,10 +149,10 @@ func render(s Stub) string {
 	}
 
 	b.WriteString("## System Prompt\n")
-	b.WriteString("Use the binary default system behavior together with team-rules.md and this role file. Stay within the role scope, use the amq-squad protocol for team handoffs, and treat old AMQ history as context unless the user asks to resume it.\n\n")
+	b.WriteString("Use the binary default system behavior together with team-rules.md and this role file. Stay within the role scope, use the amq-squad protocol for team handoffs, and treat old AMQ history as context unless the user asks to resume it. On your first response in a fresh session, start by identifying your role and handle before any status or analysis.\n\n")
 
 	b.WriteString("## Priming Template\n")
-	b.WriteString("At launch, amq-squad injects identity, startup file paths, current team routing, first steps, and the path to this role file. Read those startup files, summarize relevant context, then stop and wait for the user's instruction.\n")
+	b.WriteString("At launch, amq-squad injects identity, startup file paths, current team routing, first steps, and the path to this role file. Read those startup files, start your first response by stating your role and handle, summarize relevant context, then stop and wait for the user's instruction.\n")
 
 	return b.String()
 }

--- a/internal/role/role.go
+++ b/internal/role/role.go
@@ -1,5 +1,5 @@
 // Package role reads and writes role.md, the per-agent markdown doc that
-// lives alongside launch.json in the agent's mailbox directory. role.md is
+// lives alongside launch.json in the amq-squad extension directory. role.md is
 // the human-editable source of a role's description, peers, system prompt
 // guidance, and priming notes.
 package role
@@ -11,7 +11,10 @@ import (
 	"strings"
 )
 
-const FileName = "role.md"
+const (
+	FileName  = "role.md"
+	LayerName = "io.github.omriariav.amq-squad"
+)
 
 // Stub is the data used to seed a new role.md. Fields come from the catalog
 // entry at team init time; the user can edit the rendered file freely.
@@ -23,9 +26,43 @@ type Stub struct {
 	Peers       []string
 }
 
-// Path returns the role.md path inside an agent's mailbox directory.
+// ExtensionDir returns the amq-squad extension directory for an agent mailbox.
+func ExtensionDir(agentDir string) string {
+	return filepath.Join(agentDir, "extensions", LayerName)
+}
+
+// Path returns the v0.6+ role.md path inside an agent's extension directory.
 func Path(agentDir string) string {
+	return filepath.Join(ExtensionDir(agentDir), FileName)
+}
+
+// LegacyPath returns the pre-v0.6 direct-agent role.md path.
+func LegacyPath(agentDir string) string {
 	return filepath.Join(agentDir, FileName)
+}
+
+// ExistingPath returns the role.md path that should be read, preferring the
+// extension namespace and falling back to the legacy direct-agent path.
+func ExistingPath(agentDir string) string {
+	p := Path(agentDir)
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	if _, err := os.Stat(LegacyPath(agentDir)); err == nil {
+		return LegacyPath(agentDir)
+	}
+	return p
+}
+
+// Exists reports whether either the extension or legacy role file exists.
+func Exists(agentDir string) bool {
+	if _, err := os.Stat(Path(agentDir)); err == nil {
+		return true
+	}
+	if _, err := os.Stat(LegacyPath(agentDir)); err == nil {
+		return true
+	}
+	return false
 }
 
 // EnsureStub writes a role.md for the given agent if one doesn't already
@@ -49,8 +86,13 @@ func EnsureStub(agentDir string, s Stub) (bool, error) {
 	} else if !os.IsNotExist(err) {
 		return false, fmt.Errorf("stat %s: %w", p, err)
 	}
-	if err := os.MkdirAll(agentDir, 0o700); err != nil {
-		return false, fmt.Errorf("ensure agent dir: %w", err)
+	if _, err := os.Stat(LegacyPath(agentDir)); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("stat %s: %w", LegacyPath(agentDir), err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return false, fmt.Errorf("ensure extension dir: %w", err)
 	}
 	if err := writeFile(p, render(s)); err != nil {
 		return false, err

--- a/internal/role/role_test.go
+++ b/internal/role/role_test.go
@@ -49,8 +49,10 @@ func TestEnsureStubWritesAllSections(t *testing.T) {
 		"amq-cli only for raw AMQ debugging",
 		"## System Prompt",
 		"Use the binary default system behavior",
+		"start by identifying your role and handle",
 		"## Priming Template",
 		"At launch, amq-squad injects identity",
+		"start your first response by stating your role and handle",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("role.md missing %q", want)

--- a/internal/role/role_test.go
+++ b/internal/role/role_test.go
@@ -2,6 +2,7 @@ package role
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -21,6 +22,12 @@ func TestEnsureStubWritesAllSections(t *testing.T) {
 	}
 	if !wrote {
 		t.Fatal("EnsureStub returned false on first call")
+	}
+	if _, err := os.Stat(Path(dir)); err != nil {
+		t.Fatalf("EnsureStub did not create extension role file: %v", err)
+	}
+	if _, err := os.Stat(LegacyPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("EnsureStub created legacy role file, err=%v", err)
 	}
 
 	b, err := os.ReadFile(Path(dir))
@@ -56,6 +63,9 @@ func TestEnsureStubWritesAllSections(t *testing.T) {
 
 func TestEnsureStubNoClobber(t *testing.T) {
 	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(Path(dir), []byte("USER EDIT"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -93,6 +103,30 @@ func TestEnsureStubFallsBackToRoleID(t *testing.T) {
 	}
 }
 
+func TestExistingPathFallsBackToLegacyRole(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(LegacyPath(dir), []byte("USER EDIT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := ExistingPath(dir); got != LegacyPath(dir) {
+		t.Fatalf("ExistingPath = %q, want %q", got, LegacyPath(dir))
+	}
+	if !Exists(dir) {
+		t.Fatal("Exists returned false for legacy role file")
+	}
+	wrote, err := EnsureStub(dir, Stub{RoleID: "qa", Label: "QA"})
+	if err != nil {
+		t.Fatalf("EnsureStub: %v", err)
+	}
+	if wrote {
+		t.Fatal("EnsureStub wrote over legacy role file")
+	}
+	if _, err := os.Stat(Path(dir)); !os.IsNotExist(err) {
+		t.Fatalf("EnsureStub created extension role despite legacy role, err=%v", err)
+	}
+}
+
 func TestEnsureStubUpgradesUntouchedLegacyPlaceholder(t *testing.T) {
 	dir := t.TempDir()
 	stub := Stub{
@@ -100,6 +134,9 @@ func TestEnsureStubUpgradesUntouchedLegacyPlaceholder(t *testing.T) {
 		RoleID:      "qa",
 		Description: "Owns test strategy.",
 		Peers:       []string{"cto", "fullstack"},
+	}
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
 	}
 	if err := os.WriteFile(Path(dir), []byte(renderLegacyPlaceholder(stub)), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -50,13 +50,15 @@ func (m Member) EffectiveCWD(projectDir string) string {
 // would leak local paths into shared repos and break when the repo moves.
 // Workstream is the team's default shared AMQ session. CreatedAt is
 // informational. Member sessions are legacy/default workstream hints; the live
-// workstream can be overridden at launch time.
+// workstream can be overridden at launch time. BinaryArgs stores extra native
+// CLI args by binary name, for example codex or claude.
 type Team struct {
-	Schema     int       `json:"schema"`
-	Project    string    `json:"-"`
-	Workstream string    `json:"workstream,omitempty"`
-	Members    []Member  `json:"members"`
-	CreatedAt  time.Time `json:"created_at"`
+	Schema     int                 `json:"schema"`
+	Project    string              `json:"-"`
+	Workstream string              `json:"workstream,omitempty"`
+	BinaryArgs map[string][]string `json:"binary_args,omitempty"`
+	Members    []Member            `json:"members"`
+	CreatedAt  time.Time           `json:"created_at"`
 }
 
 // Path returns the team.json path for the given project directory.
@@ -122,6 +124,16 @@ func Validate(t Team) error {
 	if t.Workstream != "" {
 		if err := ValidateSessionName(t.Workstream); err != nil {
 			return fmt.Errorf("workstream: %w", err)
+		}
+	}
+	for binary, args := range t.BinaryArgs {
+		if err := ValidateDisplayValue("binary_args key", binary); err != nil {
+			return fmt.Errorf("binary_args[%q]: %w", binary, err)
+		}
+		for i, arg := range args {
+			if err := ValidateDisplayValue("arg", arg); err != nil {
+				return fmt.Errorf("binary_args[%q][%d]: %w", binary, i, err)
+			}
 		}
 	}
 	seenHandles := map[string]bool{}

--- a/skills/claude/amq-squad/SKILL.md
+++ b/skills/claude/amq-squad/SKILL.md
@@ -70,6 +70,7 @@ Supported user inputs:
    - Model web UI work as `frontend-dev`; model mobile app work as `mobile-dev`; model APIs/services work as `backend-dev`.
    - Model backend/dev as `fullstack` unless the user wants a narrower persona.
    - Use `--binary persona=cli` when the user wants a persona on a different CLI, for example `--binary fullstack=codex`.
+   - Use `--codex-args '<args>'` or `--claude-args '<args>'` when every matching binary should launch with native flags, for example `--codex-args '--enable goals'`.
    - Use one shared workstream name with `--session <workstream>`. Do not use the removed comma-separated `role=name` session syntax.
    - If the user does not name a workstream, let amq-squad default to the sanitized team-home directory name.
 
@@ -89,6 +90,7 @@ Supported user inputs:
 6. Print launch commands.
    - Run `amq-squad team show --session <workstream>` when the user named a workstream.
    - Run `amq-squad team launch --session <workstream>` from tmux when the user wants panes created automatically.
+   - Add one-off `--codex-args '<args>'` or `--claude-args '<args>'` to `team show` or `team launch` when the user wants native binary flags for only this run.
    - Use `--fresh --session <workstream>` when accidental reuse should fail.
    - Expect generated commands to include `--team-workstream`, Codex `--dangerously-bypass-approvals-and-sandbox`, and Claude `--permission-mode auto`.
    - Tell the user to paste one command into each terminal pane or tab when not using `team launch`.

--- a/skills/codex/amq-squad/SKILL.md
+++ b/skills/codex/amq-squad/SKILL.md
@@ -66,6 +66,7 @@ Supported user inputs:
    - Model web UI work as `frontend-dev`; model mobile app work as `mobile-dev`; model APIs/services work as `backend-dev`.
    - Model backend/dev as `fullstack` unless the user wants a narrower persona.
    - Use `--binary persona=cli` when the user wants a persona on a different CLI, for example `--binary fullstack=codex`.
+   - Use `--codex-args '<args>'` or `--claude-args '<args>'` when every matching binary should launch with native flags, for example `--codex-args '--enable goals'`.
    - Use one shared workstream name with `--session <workstream>`. Do not use the removed comma-separated `role=name` session syntax.
    - If the user does not name a workstream, let amq-squad default to the sanitized team-home directory name.
 
@@ -85,6 +86,7 @@ Supported user inputs:
 6. Print launch commands.
    - Run `amq-squad team show --session <workstream>` when the user named a workstream.
    - Run `amq-squad team launch --session <workstream>` from tmux when the user wants panes created automatically.
+   - Add one-off `--codex-args '<args>'` or `--claude-args '<args>'` to `team show` or `team launch` when the user wants native binary flags for only this run.
    - Use `--fresh --session <workstream>` when accidental reuse should fail.
    - Expect generated commands to include `--team-workstream`, Codex `--dangerously-bypass-approvals-and-sandbox`, and Claude `--permission-mode auto`.
    - Tell the user to paste one command into each terminal pane or tab when not using `team launch`.


### PR DESCRIPTION
## Summary
- keep the native binary args release scope with `--codex-args` and `--claude-args`
- require AMQ v0.34+ and consume AMQ env JSON v1 for resolved root, base root, session, handle, root source, and AMQ version
- clear inherited AMQ identity variables during cwd-scoped env lookup so live agent sessions do not leak `AM_ROOT`, `AM_BASE_ROOT`, or `AM_ME` into project scans
- write new `launch.json` and `role.md` metadata under `extensions/io.github.omriariav.amq-squad/` while still reading v0.5.x direct-agent files
- scan AMQ resolved base roots for list and restore so custom `.amqrc` roots work
- use `amq route explain --json` for bootstrap routing when AMQ can answer, with the existing local fallback kept for older or unavailable route explain output
- teach generated bootstrap prompts, `team-rules.md`, and `role.md` to make fresh agents identify their role and handle in their first response
- update README and doc.html for v0.6.0 install, AMQ v0.34+, and extension namespaced files

## Testing
- `go test ./internal/cli -run TestResolveAMQEnv`
- `go test ./internal/role ./internal/cli`
- `go test ./...`
- `make ci`
- `gofmt -l .` clean
- `git diff --check` clean
- `make build VERSION=v0.6.0`
- `./amq-squad version` prints `amq-squad v0.6.0`

## Release notes
- Latest published amq-squad release remains `v0.5.2`; this PR supersedes the planned `v0.5.3` cut.
- Do not tag `v0.6.0` until this PR is reviewed, approved, and merged.
- After merge, tag the merge commit with `git tag -a v0.6.0 -m "amq-squad v0.6.0"`, push the tag, create the GitHub release, then run `make release-smoke VERSION=v0.6.0`.
- AMQ v0.34.0 was checked locally; issue #12 APIs were introduced in AMQ v0.33.0 and are present in v0.34.0.
- GitHub reports no status checks or workflow runs for this branch; local release gates above are green.
