### PR TITLE
Release v0.6.1 DX hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ AMQ itself stays unchanged.
 ## Install
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.1
 ```
 
 Use `@latest` if you intentionally want the newest published tag.
@@ -82,13 +82,39 @@ amq-squad team init \
 right project. `team sync` walks each unique member cwd and syncs CLAUDE.md +
 AGENTS.md in all of them.
 
-Generated launch commands include these agent defaults: Codex gets
-`--dangerously-bypass-approvals-and-sandbox`, and Claude gets
-`--permission-mode auto`. These defaults are passed through after `--` while
-the generated bootstrap prompt is still added at launch time. Direct
-`amq-squad launch` calls also prepend these defaults when they are missing, so
-custom prompts still inherit the expected permission mode. Pass
-`--no-default-args` to opt out.
+Generated launch commands include these agent defaults:
+
+- **Claude**: `--permission-mode auto`
+- **Codex**: nothing by default (sandboxed). Pass `--trust trusted` to
+  prepend `--dangerously-bypass-approvals-and-sandbox` for the local
+  power-user path. The trust profile is persisted in `team.json` from
+  `team init` and re-emitted by `team show` / `team launch`.
+
+`amq-squad launch --trust sandboxed|trusted` controls the same boundary for
+direct launches. Trust is Codex-specific; Claude defaults are unaffected.
+Pass `--no-default-args` to skip all built-in defaults entirely.
+
+`--trust trusted` and `--no-default-args` together are rejected, as is
+sandboxed mode with `--dangerously-bypass-approvals-and-sandbox` smuggled
+through `--codex-args`.
+
+Pass a model name to either binary natively via `--model`:
+
+```sh
+amq-squad launch --model gpt-5 codex
+amq-squad launch --model sonnet claude
+```
+
+`team init --model role=model,...` persists per-member models in
+`team.json`. `team show --model role=model,...` and `team launch --model ...`
+override per run. Restore replays the persisted model.
+
+Duplicate-launch guard: `amq-squad launch` refuses by default when a live
+agent for the same handle/workstream is detected (live `amq wake` lock,
+running agent PID with matching command, or fresh active presence). Stale
+artifacts are cleaned up automatically. `team launch` preflights the entire
+roster before any tmux command so a partial team never appears. Override
+with `--force-duplicate` when you really want a second instance.
 
 Add native Codex or Claude flags as binary args when the whole team should run
 with the same extra switches:
@@ -181,25 +207,79 @@ Adding another terminal should be isolated to a new
 `internal/cli/team_launch_<name>.go` file that implements `teamLaunchBackend`
 and registers itself with `registerTeamLaunchBackend` from `init`.
 
-Representative generated commands look like this:
+Representative generated commands look like this (sandboxed Codex, the new
+default):
 
 ```sh
 cd ~/Code/my-project && /path/to/amq-squad launch \
   --role cto \
   --session my-project \
   --team-workstream \
+  --trust sandboxed \
   --team-home /Users/you/Code/my-project \
   --me cto \
-  codex -- --dangerously-bypass-approvals-and-sandbox
+  codex
 
 cd ~/Code/my-project && /path/to/amq-squad launch \
   --role fullstack \
   --session my-project \
   --team-workstream \
+  --trust sandboxed \
   --team-home /Users/you/Code/my-project \
   --me fullstack \
   claude -- --permission-mode auto
 ```
+
+Run `amq-squad team init --trust trusted` (or pick `trusted` in the
+interactive prompt) for the local-power-user profile that includes
+`--dangerously-bypass-approvals-and-sandbox` for Codex.
+
+## Bringing the team back after reboot, terminal close, or upgrade
+
+When a terminal closes, the machine reboots, or you upgrade Codex/Claude,
+you do not need to remember whether to use `team launch` or `restore`. Run:
+
+```sh
+amq-squad team resume
+```
+
+This inspects `.amq-squad/team.json`, local launch history, and live-agent
+signals (wake locks, agent PIDs, presence) and prints a per-member plan
+plus copy-pasteable commands. Per-member action labels:
+
+- `live`: a matching agent is still running; the command is suppressed by
+  default. Pass `--force-duplicate` to launch a second instance anyway.
+- `restore`: a launch record exists for the workstream; the emitted
+  command replays it and preserves trust, model, conversation, role,
+  handle, and binary args.
+- `launch fresh`: no matching launch history; the emitted command is the
+  same shape `team launch` would use, with current team trust/model/binary
+  args.
+- `blocked`: ambiguous live state; choose `--force-duplicate` or narrow
+  with `--session`.
+
+Common flows:
+
+```sh
+# Default: resume the team's saved workstream, prefer restore.
+amq-squad team resume
+
+# Resume into an explicit session.
+amq-squad team resume --session v0-6-0-review
+
+# Refuse if no member has restorable history (catch a stale workstream pick).
+amq-squad team resume --restore-existing
+
+# Start a brand-new workstream from team.json (ignore restore records).
+amq-squad team resume --fresh --session v0-6-1
+
+# Force a second instance even when a live agent is detected.
+amq-squad team resume --force-duplicate
+```
+
+`team resume` is plan-only. The existing power-user commands stay
+available: `team launch` for tmux-pane launches from team intent, `restore`
+for explicit launch-history replay, and `list` for inspection.
 
 At launch time, each agent's bootstrap prompt includes a current team routing
 block generated from `.amq-squad/team.json`. That block is the live routing
@@ -383,35 +463,72 @@ amq send --to qa --project project-b --session project-a --thread p2p/cto__qa
 ```text
 amq-squad team                      Smart default: show commands, or init if none exists
 amq-squad team init [--personas ...] [--session workstream]
+                    [--trust sandboxed|trusted]
+                    [--model role=model,...]
                     [--codex-args args] [--claude-args args]
-                                    Pick personas, choose CLIs, and seed rules
+                                    Pick personas, choose CLIs, models, and
+                                    Codex trust profile; seed rules.
 amq-squad team show [--session name] [--fresh] [--no-bootstrap]
+                    [--trust sandboxed|trusted]
+                    [--model role=model,...]
                     [--codex-args args] [--claude-args args]
+                    [--force-duplicate]
                                     Print launch commands for the configured team
 amq-squad team launch [--terminal tmux] [--target current-window|new-session]
                       [--session workstream] [--fresh]
                       [--layout vertical|horizontal|tiled]
                       [--terminal-session name] [--stagger 750ms]
                       [--no-bootstrap]
+                      [--trust sandboxed|trusted]
+                      [--model role=model,...]
                       [--codex-args args] [--claude-args args]
-                      [--dry-run]
-                                    Open the configured team in tmux panes
+                      [--force-duplicate] [--dry-run]
+                                    Open the configured team in tmux panes.
+                                    Whole-roster live-agent preflight runs
+                                    before any tmux command; --force-duplicate
+                                    overrides.
+amq-squad team resume [--session name] [--fresh] [--restore-existing]
+                      [--dry-run] [--force-duplicate]
+                      [--no-bootstrap] [--trust sandboxed|trusted]
+                      [--model role=model,...]
+                      [--codex-args args] [--claude-args args]
+                                    Plan the safe path to bring the team back
+                                    after reboot/upgrade/terminal close.
+                                    Classifies each member as
+                                    live / restore / launch fresh / blocked
+                                    and prints copy-pasteable commands.
+                                    Plan-only; no disk mutation.
 amq-squad team rules init [--force] Seed or refresh .amq-squad/team-rules.md
 amq-squad team sync [--apply] [--allow-outside]
                                     Sync CLAUDE.md and AGENTS.md from team-rules.md
 
-amq-squad launch --role <r> --session <s> [--team-workstream] --me <handle> [--conversation ref] [--no-bootstrap] [--no-default-args] [--codex-args args] [--claude-args args] <binary> [-- <flags>]
+amq-squad launch --role <r> --session <s> [--team-workstream] --me <handle>
+                 [--conversation ref] [--no-bootstrap] [--no-default-args]
+                 [--trust sandboxed|trusted] [--model <name>]
+                 [--codex-args args] [--claude-args args]
+                 [--force-duplicate]
+                 <binary> [-- <flags>]
                                     Launch one agent. Writes launch.json + role.md
                                     in the AMQ mailbox, adds a bootstrap prompt,
                                     then execs 'amq coop exec'.
                                     Usually called by the output of 'team show'.
-                                    Codex and Claude default permission flags
-                                    are prepended when missing.
+                                    --trust sandboxed (default) keeps Codex
+                                    out of bypass mode; --trust trusted
+                                    prepends --dangerously-bypass-approvals-and-sandbox.
+                                    Claude defaults (--permission-mode auto)
+                                    are still prepended when missing.
+                                    --no-default-args opts out of all built-in
+                                    defaults.
+                                    --model passes a native --model <name>
+                                    flag to Codex or Claude.
                                     --codex-args and --claude-args add native
                                     binary flags, such as '--enable goals' or
                                     '--chrome', while still allowing bootstrap.
                                     --conversation stores a restore ref and
                                     translates it to Codex or Claude resume args.
+                                    --force-duplicate overrides the duplicate
+                                    live-agent guard for the same handle and
+                                    workstream.
                                     Do not combine --conversation with extra args
                                     after "--"; use --codex-args or --claude-args
                                     for native flags that should remain compatible
@@ -423,6 +540,15 @@ amq-squad restore [--project dir1,dir2,...] [--conversation ref]
                                     persona files. Falls back to older AMQ
                                     mailbox history when launch.json is absent
                                     and the binary can be inferred.
+                                    For records that look active, the metadata
+                                    line surfaces wake-health:
+                                      wake: pid:N    wake.lock present and
+                                                     the wake process is alive
+                                      wake: missing  agent looks active but
+                                                     no wake.lock was found
+                                      wake: stale    wake.lock present but
+                                                     the PID is dead or
+                                                     unrelated
 amq-squad restore --exec --role cto Exec one selected local launch through
                                     amq coop exec.
 
@@ -450,7 +576,7 @@ amq-squad version                   Print the installed amq-squad version.
 
 `<AM_ROOT>` is resolved via AMQ's JSON env contract (`amq env --json`) so
 amq-squad and `amq coop exec` always agree on the mailbox, root source, handle,
-and session. v0.6.0 writes extension namespaced metadata under
+and session. v0.6.1 writes extension namespaced metadata under
 `extensions/io.github.omriariav.amq-squad/` and still reads legacy
 direct-agent `launch.json` and `role.md` files created by v0.5.x.
 

--- a/doc.html
+++ b/doc.html
@@ -510,7 +510,7 @@
     <main>
       <header class="hero">
         <div class="hero-inner">
-          <p class="eyebrow">v0.6.0 guide</p>
+          <p class="eyebrow">v0.6.1 guide</p>
           <h1>How to use amq-squad</h1>
           <p class="lead">
             amq-squad is the project layer above AMQ. It records who is on the
@@ -542,7 +542,7 @@
             into <code class="inline-code">$GOBIN</code> or
             <code class="inline-code">$HOME/go/bin</code>.
           </p>
-          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0
+          <div class="code"><pre><code>go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.1
 amq-squad version</code></pre></div>
           <p>
             You also need Go 1.25 or newer, the <code class="inline-code">amq</code>
@@ -646,6 +646,101 @@ amq-squad team</code></pre></div>
             Binary args are stored in <code class="inline-code">team.json</code>
             and added to every matching Codex or Claude launch. They are treated
             as launch defaults, so bootstrap and conversation restore still work.
+          </p>
+
+          <h3>Codex trust profile</h3>
+          <div class="code"><pre><code>amq-squad team init --personas cto,fullstack --trust trusted
+amq-squad launch --trust sandboxed codex
+amq-squad launch --trust trusted codex</code></pre></div>
+          <p>
+            Codex launches default to <code class="inline-code">--trust sandboxed</code>:
+            no <code class="inline-code">--dangerously-bypass-approvals-and-sandbox</code>
+            is added. Choose <code class="inline-code">trusted</code> only for
+            local power-user setups; that profile prepends the bypass flag and
+            is persisted in <code class="inline-code">team.json</code>.
+          </p>
+          <p>
+            Trust is Codex-specific. Claude defaults are unaffected. Combining
+            <code class="inline-code">--trust trusted</code> with
+            <code class="inline-code">--no-default-args</code> is rejected, as
+            is sandboxed mode with the bypass flag smuggled through
+            <code class="inline-code">--codex-args</code>.
+          </p>
+
+          <h3>Model selection</h3>
+          <div class="code"><pre><code>amq-squad team init --personas cto,fullstack --model cto=gpt-5,fullstack=sonnet
+amq-squad launch --model gpt-5 codex
+amq-squad team launch --model cto=gpt-5</code></pre></div>
+          <p>
+            Per-member model is persisted in
+            <code class="inline-code">team.json</code> and emitted as the
+            native <code class="inline-code">--model &lt;name&gt;</code> flag for
+            Codex and Claude. <code class="inline-code">team show</code> /
+            <code class="inline-code">team launch</code> accept run-time
+            overrides; restore replays the persisted model.
+          </p>
+
+          <h3>Duplicate-launch guard</h3>
+          <p>
+            <code class="inline-code">amq-squad launch</code> refuses by default
+            when a live agent for the same handle / workstream is detected
+            (live <code class="inline-code">amq wake</code> lock, an agent PID
+            still running, or fresh active presence). Stale artifacts are
+            removed automatically. <code class="inline-code">team launch</code>
+            preflights every member before opening any tmux pane so a
+            half-launched team never appears. Override with
+            <code class="inline-code">--force-duplicate</code> when intentional.
+          </p>
+
+          <h3>Wake health in list / restore</h3>
+          <p>
+            <code class="inline-code">amq-squad list</code> exposes a
+            <code class="inline-code">WAKE</code> column for active-looking
+            records (<code class="inline-code">pid:N</code>,
+            <code class="inline-code">missing</code>, or
+            <code class="inline-code">stale</code>).
+            <code class="inline-code">amq-squad restore</code> appends the same
+            tag to its metadata line so split-brain situations show up before
+            you launch into them.
+          </p>
+
+          <h3>Bringing the team back</h3>
+          <p>
+            After a reboot, terminal close, or Codex/Claude upgrade, run a
+            single command and let amq-squad pick the right path per member:
+          </p>
+          <div class="code"><pre><code>amq-squad team resume
+amq-squad team resume --session v0-6-0-review
+amq-squad team resume --restore-existing
+amq-squad team resume --fresh --session v0-6-1</code></pre></div>
+          <p>
+            <code class="inline-code">team resume</code> reads
+            <code class="inline-code">.amq-squad/team.json</code>, scans
+            local launch history, and inspects live-agent signals (wake
+            locks, agent PIDs, presence). It prints a per-member plan plus
+            copy-pasteable commands. Action labels:
+          </p>
+          <ul>
+            <li><strong>live</strong>: matching agent is running; command
+              suppressed unless <code class="inline-code">--force-duplicate</code>.</li>
+            <li><strong>restore</strong>: launch record exists for the
+              workstream; replay preserves trust, model, conversation,
+              role, handle, and binary args.</li>
+            <li><strong>launch fresh</strong>: no record; emitted command
+              matches <code class="inline-code">team launch</code> for the
+              member.</li>
+            <li><strong>blocked</strong>: ambiguous live state; pick
+              <code class="inline-code">--force-duplicate</code> or narrow
+              with <code class="inline-code">--session</code>.</li>
+          </ul>
+          <p>
+            <code class="inline-code">team resume</code> is plan-only and
+            does not mutate disk. Existing power-user commands remain:
+            <code class="inline-code">team launch</code> for tmux-pane
+            launches from team intent,
+            <code class="inline-code">restore</code> for explicit
+            launch-history replay, and
+            <code class="inline-code">list</code> for inspection.
           </p>
         </div>
       </section>
@@ -873,7 +968,7 @@ amq drain --include-body</code></pre></div>
               <p>Check which binary is running, then reinstall the desired tag.</p>
               <div class="code"><pre><code>which -a amq-squad
 amq-squad version
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.0</code></pre></div>
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v0.6.1</code></pre></div>
             </div>
             <div class="panel">
               <h3>Launch plan looks wrong</h3>

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -1,9 +1,36 @@
 package cli
 
+import "strings"
+
+const (
+	trustModeSandboxed = "sandboxed"
+	trustModeTrusted   = "trusted"
+)
+
+var codexTrustedArgs = []string{"--dangerously-bypass-approvals-and-sandbox"}
+
+func normalizeTrustMode(mode string) (string, error) {
+	switch mode {
+	case "", trustModeSandboxed:
+		return trustModeSandboxed, nil
+	case trustModeTrusted:
+		return trustModeTrusted, nil
+	default:
+		return "", usageErrorf("invalid trust mode %q: use sandboxed or trusted", mode)
+	}
+}
+
 func defaultChildArgsForBinary(binary string) []string {
+	return defaultChildArgsForBinaryWithTrust(binary, trustModeSandboxed)
+}
+
+func defaultChildArgsForBinaryWithTrust(binary, trustMode string) []string {
 	switch defaultHandleFor(binary) {
 	case "codex":
-		return []string{"--dangerously-bypass-approvals-and-sandbox"}
+		if trustMode == trustModeTrusted {
+			return append([]string(nil), codexTrustedArgs...)
+		}
+		return nil
 	case "claude":
 		return []string{"--permission-mode", "auto"}
 	default:
@@ -11,13 +38,55 @@ func defaultChildArgsForBinary(binary string) []string {
 	}
 }
 
-func launchDefaultChildArgs(binary string, includeBuiltIn bool, extraArgs []string) []string {
+func launchDefaultChildArgs(binary string, includeBuiltIn bool, modelArgs, extraArgs []string) []string {
+	return launchDefaultChildArgsWithTrust(binary, includeBuiltIn, modelArgs, extraArgs, trustModeSandboxed)
+}
+
+func launchDefaultChildArgsWithTrust(binary string, includeBuiltIn bool, modelArgs, extraArgs []string, trustMode string) []string {
 	out := []string{}
 	if includeBuiltIn {
-		out = append(out, defaultChildArgsForBinary(binary)...)
+		out = append(out, defaultChildArgsForBinaryWithTrust(binary, trustMode)...)
 	}
+	out = append(out, modelArgs...)
 	out = append(out, extraArgs...)
 	return out
+}
+
+// validateTrustCombination rejects user input that contradicts the trust mode.
+// trusted plus --no-default-args is incoherent: trust would prepend the bypass
+// flag while no-default-args asks to omit defaults. sandboxed plus a manually
+// supplied bypass via --codex-args is also rejected to keep the trust boundary
+// the single, visible source of truth.
+func validateTrustCombination(trustMode string, trustExplicit, noDefaultArgs bool, binaryArgs map[string][]string) error {
+	if trustMode == trustModeTrusted && noDefaultArgs {
+		return usageErrorf("--trust trusted cannot be combined with --no-default-args; trusted prepends the Codex permission flag, --no-default-args opts out of defaults")
+	}
+	if trustMode != trustModeTrusted {
+		for _, arg := range binaryArgs["codex"] {
+			if arg == "--dangerously-bypass-approvals-and-sandbox" {
+				if trustExplicit {
+					return usageErrorf("--trust sandboxed cannot be combined with --codex-args containing --dangerously-bypass-approvals-and-sandbox; pass --trust trusted instead")
+				}
+				return usageErrorf("--codex-args contains --dangerously-bypass-approvals-and-sandbox; pass --trust trusted instead so the trust boundary is explicit")
+			}
+		}
+	}
+	return nil
+}
+
+// modelArgsForBinary returns the native model-selection flag for the binary.
+// codex and claude both accept --model <name>; unknown binaries get nothing.
+func modelArgsForBinary(binary, model string) []string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+	switch normalizedAgentBinary(binary) {
+	case "codex", "claude":
+		return []string{"--model", model}
+	default:
+		return nil
+	}
 }
 
 func ensureDefaultChildArgs(binary string, childArgs []string) []string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,7 +1,11 @@
 // Package cli is the top-level command dispatcher for amq-squad.
 package cli
 
-import "fmt"
+import (
+	"errors"
+	"flag"
+	"fmt"
+)
 
 // UsageError signals a misuse of the CLI; main prints it and exits 2.
 type UsageError string
@@ -12,7 +16,8 @@ func usageErrorf(format string, args ...any) error {
 	return UsageError(fmt.Sprintf(format, args...))
 }
 
-// Run dispatches to a subcommand.
+// Run dispatches to a subcommand. flag.ErrHelp from any --help path is
+// swallowed so help output exits 0 across commands.
 func Run(args []string, version string) error {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
 		printUsage()
@@ -23,6 +28,14 @@ func Run(args []string, version string) error {
 		return nil
 	}
 
+	err := dispatch(args)
+	if errors.Is(err, flag.ErrHelp) {
+		return nil
+	}
+	return err
+}
+
+func dispatch(args []string) error {
 	switch args[0] {
 	case "team":
 		return runTeam(args[1:])

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each --help path must exit 0. flag.ContinueOnError returns flag.ErrHelp
+// from fs.Parse when --help is present; that error must be swallowed at the
+// dispatch boundary so users do not see a misleading "error: flag: help
+// requested" message under a help invocation.
+func TestHelpExitsZeroAcrossCommands(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "launch --help", args: []string{"launch", "--help"}, want: "amq-squad launch"},
+		{name: "restore --help", args: []string{"restore", "--help"}, want: "amq-squad restore"},
+		{name: "list --help", args: []string{"list", "--help"}, want: "amq-squad list"},
+		{name: "team init --help", args: []string{"team", "init", "--help"}, want: "amq-squad team init"},
+		{name: "team show --help", args: []string{"team", "show", "--help"}, want: "amq-squad team show"},
+		{name: "team launch --help", args: []string{"team", "launch", "--help"}, want: "--force-duplicate"},
+	}
+	for _, tc := range cases {
+		_, stderr, err := captureOutput(t, func() error { return Run(tc.args, "test") })
+		if err != nil {
+			t.Errorf("%s: Run returned %v (must be nil for --help)", tc.name, err)
+		}
+		if !strings.Contains(stderr, tc.want) {
+			t.Errorf("%s: stderr missing %q in:\n%s", tc.name, tc.want, stderr)
+		}
+	}
+}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -30,8 +30,11 @@ func runLaunch(args []string) error {
 	conversationID := fs.String("conversation-id", "", "alias for --conversation")
 	noBootstrap := fs.Bool("no-bootstrap", false, "do not pass the generated bootstrap prompt to the agent")
 	noDefaultArgs := fs.Bool("no-default-args", false, "do not prepend Codex or Claude default permission args")
+	trustRaw := fs.String("trust", "", "Codex trust profile: sandboxed (default) or trusted (local power mode)")
+	model := fs.String("model", "", "native model name to pass to the agent binary, e.g. 'gpt-5' or 'sonnet'")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args to treat as launch defaults, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args to treat as launch defaults, e.g. '--chrome'")
+	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent for the same handle/workstream is detected")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 
 	fs.Usage = func() {
@@ -49,15 +52,19 @@ are passed through to that binary via 'amq coop exec'.
 
 Side effects before exec:
   1. Resolves AMQ env via 'amq env --json' for the target session.
-  2. Writes launch.json under the amq-squad extension namespace.
-  3. Writes a role.md stub if one does not already exist.
-  4. Prepends Codex and Claude default permission args unless
-     --no-default-args is set.
-  5. Prepends --codex-args or --claude-args for the matching binary.
-  6. Translates --conversation for Codex or Claude resume when provided.
-  7. Adds a generated bootstrap prompt unless --no-bootstrap is set or
+  2. Refuses by default when a live agent for the same handle/workstream is
+     already running. Override with --force-duplicate.
+  3. Writes launch.json under the amq-squad extension namespace.
+  4. Writes a role.md stub if one does not already exist.
+  5. Prepends Claude default permission args, and prepends Codex permission
+     args only when --trust trusted is set. --no-default-args opts out of all
+     built-in defaults.
+  6. Inserts --model <name> for codex or claude when --model is provided.
+  7. Prepends --codex-args or --claude-args for the matching binary.
+  8. Translates --conversation for Codex or Claude resume when provided.
+  9. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
-  8. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+ 10. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
 
 With --dry-run, the resolved coop exec command is printed and amq-squad exits.
 Disk state is untouched and no exec occurs.
@@ -71,12 +78,20 @@ still combine with --conversation.
 	if err := fs.Parse(squadArgs); err != nil {
 		return err
 	}
+	trustExplicit := flagWasSet(fs, "trust")
+	trustMode, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
+		return err
+	}
 	conversationRef, err := conversationRefFromFlags(*conversation, *conversationID)
 	if err != nil {
 		return err
 	}
 	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
+		return err
+	}
+	if err := validateTrustCombination(trustMode, trustExplicit, *noDefaultArgs, binaryArgs); err != nil {
 		return err
 	}
 	remaining := fs.Args()
@@ -89,7 +104,8 @@ still combine with --conversation.
 		childArgs = append(remaining[1:], childArgs...)
 	}
 	extraDefaultArgs := binaryArgsFor(binary, binaryArgs)
-	defaultArgs := launchDefaultChildArgs(binary, !*noDefaultArgs, extraDefaultArgs)
+	modelArgs := modelArgsForBinary(binary, *model)
+	defaultArgs := launchDefaultChildArgsWithTrust(binary, !*noDefaultArgs, modelArgs, extraDefaultArgs, trustMode)
 	childArgs = ensureLeadingChildArgs(defaultArgs, childArgs)
 	if conversationRef != "" {
 		var err error
@@ -137,7 +153,11 @@ still combine with --conversation.
 		AMQVersion:       env.AMQVersion,
 		CodexArgs:        binaryArgs["codex"],
 		ClaudeArgs:       binaryArgs["claude"],
+		Model:            strings.TrimSpace(*model),
+		Trust:            trustMode,
 		NoDefaultArgs:    *noDefaultArgs,
+		AgentPID:         os.Getpid(),
+		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
 	}
 
@@ -174,6 +194,20 @@ still combine with --conversation.
 		fmt.Println(shellCommand("amq", coopArgs...))
 		fmt.Fprintln(os.Stderr, "(dry run - no files written, not execing)")
 		return nil
+	}
+
+	preflight := agentLaunchPreflight{
+		AgentDir:   agentDir,
+		Handle:     handle,
+		Workstream: env.SessionName,
+		Root:       root,
+		Binary:     binary,
+		Force:      *forceDuplicate,
+	}
+	if blocker, err := preflight.check(defaultDuplicateLaunchProbe); err != nil {
+		return err
+	} else if blocker != nil {
+		return blocker
 	}
 
 	if err := launch.Write(agentDir, rec); err != nil {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestRunLaunchDryRunPrependsCodexDefaultArgsWithPrompt(t *testing.T) {
+func TestRunLaunchDryRunSandboxedCodexOmitsBypassDefault(t *testing.T) {
 	setupFakeAMQ(t)
 
 	stdout, stderr, err := captureOutput(t, func() error {
@@ -17,7 +17,81 @@ func TestRunLaunchDryRunPrependsCodexDefaultArgsWithPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
 	}
+	if strings.Contains(stdout, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("sandboxed codex must not include bypass arg by default:\n%s", stdout)
+	}
+	want := "amq coop exec codex -- test-prompt"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchDryRunTrustedCodexPrependsBypass(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "trusted", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
 	want := "amq coop exec codex -- --dangerously-bypass-approvals-and-sandbox test-prompt"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchTrustedRejectsNoDefaultArgs(t *testing.T) {
+	setupFakeAMQ(t)
+	_, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "trusted", "--no-default-args", "codex"})
+	})
+	if err == nil {
+		t.Fatalf("expected --trust trusted with --no-default-args to fail\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(err.Error(), "--no-default-args") {
+		t.Fatalf("error should mention --no-default-args, got %v", err)
+	}
+}
+
+func TestRunLaunchSandboxedRejectsBypassInCodexArgs(t *testing.T) {
+	setupFakeAMQ(t)
+	_, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--codex-args=--dangerously-bypass-approvals-and-sandbox", "codex"})
+	})
+	if err == nil {
+		t.Fatalf("expected sandboxed codex with bypass in --codex-args to fail\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(err.Error(), "trusted") {
+		t.Fatalf("error should suggest --trust trusted, got %v", err)
+	}
+}
+
+func TestRunLaunchModelInsertsNativeFlag(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--model", "gpt-5", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	want := "amq coop exec codex -- --model gpt-5"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestRunLaunchModelClaudePlacement(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--model", "sonnet", "claude"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	want := "amq coop exec claude -- --permission-mode auto --model sonnet"
 	if !strings.Contains(stdout, want) {
 		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
 	}
@@ -45,7 +119,7 @@ func TestRunLaunchDryRunAddsBinaryArgs(t *testing.T) {
 	setupFakeAMQ(t)
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--codex-args=--enable goals", "codex"})
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "trusted", "--codex-args=--enable goals", "codex"})
 	})
 	if err != nil {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
@@ -78,7 +152,7 @@ func TestRunLaunchDryRunConversationCodexResume(t *testing.T) {
 	setupFakeAMQ(t)
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runLaunch([]string{"--dry-run", "--conversation", "cto-thread", "codex"})
+		return runLaunch([]string{"--dry-run", "--trust", "trusted", "--conversation", "cto-thread", "codex"})
 	})
 	if err != nil {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
@@ -89,11 +163,29 @@ func TestRunLaunchDryRunConversationCodexResume(t *testing.T) {
 	}
 }
 
+func TestRunLaunchDryRunConversationCodexResumeSandboxed(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--conversation", "cto-thread", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("sandboxed conversation restore must not include bypass:\n%s", stdout)
+	}
+	want := "amq coop exec codex -- resume cto-thread"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
 func TestRunLaunchDryRunConversationAllowsBinaryArgs(t *testing.T) {
 	setupFakeAMQ(t)
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runLaunch([]string{"--dry-run", "--conversation", "cto-thread", "--codex-args=--enable goals", "codex"})
+		return runLaunch([]string{"--dry-run", "--trust", "trusted", "--conversation", "cto-thread", "--codex-args=--enable goals", "codex"})
 	})
 	if err != nil {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
@@ -163,12 +255,24 @@ func TestRunLaunchConversationRejectsPassthroughArgs(t *testing.T) {
 }
 
 func TestApplyConversationRestoreArgsIsIdempotent(t *testing.T) {
-	got, err := applyConversationRestoreArgs("codex", []string{"--dangerously-bypass-approvals-and-sandbox", "resume", "abc"}, "abc")
+	// Trusted Codex: defaults include bypass, so argv with bypass + resume
+	// should round-trip cleanly via the WithDefaults form.
+	trustedDefaults := defaultChildArgsForBinaryWithTrust("codex", trustModeTrusted)
+	got, err := applyConversationRestoreArgsWithDefaults("codex", []string{"--dangerously-bypass-approvals-and-sandbox", "resume", "abc"}, "abc", trustedDefaults)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if strings.Join(got, " ") != "--dangerously-bypass-approvals-and-sandbox resume abc" {
 		t.Fatalf("codex args = %v", got)
+	}
+
+	// Sandboxed Codex: defaults are empty. argv with just resume should round-trip.
+	got, err = applyConversationRestoreArgs("codex", []string{"resume", "abc"}, "abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(got, " ") != "resume abc" {
+		t.Fatalf("sandboxed codex args = %v", got)
 	}
 
 	got, err = applyConversationRestoreArgs("claude", []string{"--permission-mode", "auto", "--resume", "abc"}, "abc")

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -20,6 +22,7 @@ type listRecord struct {
 	Conversation string    `json:"conversation,omitempty"`
 	Source       string    `json:"source"`
 	CWD          string    `json:"cwd"`
+	Wake         string    `json:"wake,omitempty"`
 	StartedAt    time.Time `json:"started_at,omitempty"`
 }
 
@@ -85,14 +88,18 @@ where the original binary can be inferred.
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tCONVERSATION\tSOURCE\tCWD\tSTARTED")
+	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tCONVERSATION\tSOURCE\tWAKE\tCWD\tSTARTED")
 	for _, r := range rows {
 		role := r.Role
 		if role == "" {
 			role = "(none)"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			role, r.Handle, r.Binary, r.Session, r.Conversation, r.Source, r.CWD, formatListTime(r.StartedAt))
+		wake := r.Wake
+		if wake == "" {
+			wake = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			role, r.Handle, r.Binary, r.Session, r.Conversation, r.Source, wake, r.CWD, formatListTime(r.StartedAt))
 	}
 	return w.Flush()
 }
@@ -123,10 +130,81 @@ func listRecordsFromEntries(entries []launch.Entry) []listRecord {
 			Conversation: r.Conversation,
 			Source:       sourceLabel(e.Source),
 			CWD:          r.CWD,
+			Wake:         wakeHealthForEntry(e, defaultDuplicateLaunchProbe),
 			StartedAt:    r.StartedAt,
 		})
 	}
 	return rows
+}
+
+// wakeHealthForEntry returns a short label describing wake state. Empty when
+// the record does not look active enough to investigate. Output values:
+//   - "pid:<n>": wake.lock present and wake process alive
+//   - "missing": agent looks active but no wake.lock found
+//   - "stale":   wake.lock present but PID dead or unrelated
+func wakeHealthForEntry(e launch.Entry, probe duplicateLaunchProbe) string {
+	if !looksActive(e, probe) {
+		return ""
+	}
+	lockPath := wakeLockPath(e.AgentDir)
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return "missing"
+	}
+	var lock wakeLockFile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return "stale"
+	}
+	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {
+		return "stale"
+	}
+	expectedRoot := e.Record.Root
+	if lock.Root != "" {
+		expectedRoot = lock.Root
+	}
+	if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(e.Record.Handle, expectedRoot)) {
+		return "stale"
+	}
+	return fmt.Sprintf("pid:%d", lock.PID)
+}
+
+// looksActive reports whether a launch entry is fresh enough to bother
+// inspecting wake state. A record is "active-looking" when its agent PID is
+// alive and the binary command matches, or when presence is fresh.
+func looksActive(e launch.Entry, probe duplicateLaunchProbe) bool {
+	rec := e.Record
+	if rec.AgentPID > 0 && probe.PIDAlive(rec.AgentPID) {
+		if rec.Binary == "" || probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(rec.Binary)) {
+			return true
+		}
+	}
+	pres, err := readPresenceForEntry(e.AgentDir)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(pres.Status, "active") {
+		return false
+	}
+	if pres.LastSeen.IsZero() {
+		return false
+	}
+	return probe.Now().Sub(pres.LastSeen) <= presenceFreshness
+}
+
+func readPresenceForEntry(agentDir string) (presenceFile, error) {
+	data, err := os.ReadFile(presencePath(agentDir))
+	if err != nil {
+		return presenceFile{}, err
+	}
+	var pres presenceFile
+	if err := json.Unmarshal(data, &pres); err != nil {
+		return presenceFile{}, err
+	}
+	return pres, nil
+}
+
+func presencePath(agentDir string) string {
+	return filepath.Join(agentDir, "presence.json")
 }
 
 func formatListTime(t time.Time) string {

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -1,0 +1,552 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+// presenceFreshness defines how recently a presence.json must have been
+// updated for it to count as a live signal. Older presence is treated as
+// stale and ignored.
+const presenceFreshness = 90 * time.Second
+
+// duplicateBlocker describes a refusal reason raised by preflight.
+type duplicateBlocker struct {
+	Handle     string
+	Workstream string
+	Root       string
+	AgentDir   string
+	Reasons    []blockerReason
+}
+
+type blockerReason struct {
+	// Source is a short label: "wake", "launch", "presence".
+	Source string
+	// Message is a human-readable description of what was detected.
+	Message string
+	// Hint is a single suggested next action.
+	Hint string
+}
+
+// Error implements error so a blocker can be returned as the launch error.
+func (b *duplicateBlocker) Error() string {
+	var lines []string
+	header := fmt.Sprintf("refusing to launch %q", b.Handle)
+	if b.Workstream != "" {
+		header += fmt.Sprintf(" in workstream %q", b.Workstream)
+	}
+	header += ":"
+	lines = append(lines, header)
+	for _, r := range b.Reasons {
+		lines = append(lines, "  - "+r.Source+": "+r.Message)
+	}
+	if b.Root != "" {
+		lines = append(lines, "  root: "+b.Root)
+	}
+	if b.AgentDir != "" {
+		lines = append(lines, "  agent dir: "+b.AgentDir)
+	}
+	lines = append(lines, "Next actions:")
+	lines = append(lines, "  - attach the existing terminal, or stop the old process")
+	lines = append(lines, "  - rerun with --force-duplicate to launch anyway")
+	return strings.Join(lines, "\n")
+}
+
+// agentLaunchPreflight inspects existing artifacts for a target agent identity
+// and reports whether a launch should be refused.
+type agentLaunchPreflight struct {
+	AgentDir   string
+	Handle     string
+	Workstream string
+	Root       string
+	Binary     string
+	Force      bool
+	// DryRun keeps the preflight inspection read-only: stale lock files are
+	// detected as non-blocking but never removed. Required for --dry-run paths
+	// where the operator expects zero side effects on disk.
+	DryRun bool
+}
+
+// duplicateLaunchProbe abstracts liveness and process-inspection checks so
+// tests can substitute deterministic implementations.
+type duplicateLaunchProbe struct {
+	PIDAlive     func(pid int) bool
+	ProcessMatch func(pid int, predicate func(args string) bool) bool
+	Now          func() time.Time
+}
+
+var defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+	PIDAlive:     defaultPIDAlive,
+	ProcessMatch: defaultProcessMatch,
+	Now:          time.Now,
+}
+
+func defaultPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// defaultProcessMatch shells out to ps to read the process command line for
+// pid and applies the predicate. Returns false on any error (best effort).
+func defaultProcessMatch(pid int, predicate func(args string) bool) bool {
+	if pid <= 0 || predicate == nil {
+		return false
+	}
+	cmd := exec.Command("ps", "-o", "args=", "-p", fmt.Sprintf("%d", pid))
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	args := strings.TrimSpace(string(out))
+	return predicate(args)
+}
+
+// check inspects wake locks, prior launch records, and presence. It returns
+// a *duplicateBlocker (as an error) when a hard-block condition is met and
+// Force is false. Stale artifacts are removed in place. The second return
+// value is reserved for I/O errors that should abort preflight.
+func (p agentLaunchPreflight) check(probe duplicateLaunchProbe) (*duplicateBlocker, error) {
+	blocker := &duplicateBlocker{
+		Handle:     p.Handle,
+		Workstream: p.Workstream,
+		Root:       p.Root,
+		AgentDir:   p.AgentDir,
+	}
+
+	// Wake lock.
+	if reason, err := p.inspectWakeLock(probe); err != nil {
+		return nil, err
+	} else if reason != nil {
+		blocker.Reasons = append(blocker.Reasons, *reason)
+	}
+
+	// Prior launch record (PID alive + plausible command).
+	if reason, err := p.inspectLaunchRecord(probe); err != nil {
+		return nil, err
+	} else if reason != nil {
+		blocker.Reasons = append(blocker.Reasons, *reason)
+	}
+
+	// Presence (secondary signal).
+	if reason, err := p.inspectPresence(probe); err != nil {
+		return nil, err
+	} else if reason != nil {
+		blocker.Reasons = append(blocker.Reasons, *reason)
+	}
+
+	if len(blocker.Reasons) == 0 {
+		return nil, nil
+	}
+	if p.Force {
+		// Honor force but echo what was overridden so the operator sees it.
+		fmt.Fprintln(os.Stderr, "warning: --force-duplicate overrode the following live-agent signals:")
+		for _, r := range blocker.Reasons {
+			fmt.Fprintln(os.Stderr, "  - "+r.Source+": "+r.Message)
+		}
+		return nil, nil
+	}
+	return blocker, nil
+}
+
+func (p agentLaunchPreflight) inspectWakeLock(probe duplicateLaunchProbe) (*blockerReason, error) {
+	path := wakeLockPath(p.AgentDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read wake lock: %w", err)
+	}
+	var lock wakeLockFile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		// Corrupt lock file: treat as stale.
+		p.removeIfNotDryRun(path)
+		return nil, nil
+	}
+	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {
+		p.removeIfNotDryRun(path)
+		return nil, nil
+	}
+	expectedRoot := p.Root
+	if lock.Root != "" {
+		expectedRoot = lock.Root
+	}
+	if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(p.Handle, expectedRoot)) {
+		// PID reuse or unrelated process: stale. The lock dir anchors the
+		// handle, but the live PID's --root must still point to the same
+		// workstream root we're targeting; otherwise it belongs to another
+		// project's wake.
+		p.removeIfNotDryRun(path)
+		return nil, nil
+	}
+	msg := fmt.Sprintf("live amq wake at pid %d", lock.PID)
+	if lock.TTY != "" && lock.TTY != "unknown" {
+		msg += " (tty " + lock.TTY + ")"
+	}
+	if !lock.Started.IsZero() {
+		msg += " started " + lock.Started.UTC().Format(time.RFC3339)
+	}
+	msg += "; lock " + path
+	return &blockerReason{
+		Source:  "wake",
+		Message: msg,
+		Hint:    "stop wake (kill " + fmt.Sprintf("%d", lock.PID) + ") or attach its terminal",
+	}, nil
+}
+
+func (p agentLaunchPreflight) inspectLaunchRecord(probe duplicateLaunchProbe) (*blockerReason, error) {
+	rec, err := launch.Read(p.AgentDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		// Tolerate parse errors: previous record is informational only.
+		return nil, nil
+	}
+	if rec.AgentPID <= 0 {
+		return nil, nil
+	}
+	if !probe.PIDAlive(rec.AgentPID) {
+		return nil, nil
+	}
+	binary := strings.TrimSpace(rec.Binary)
+	if binary == "" {
+		binary = p.Binary
+	}
+	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
+		// PID reuse: not our agent.
+		return nil, nil
+	}
+	msg := fmt.Sprintf("live %s agent at pid %d", binary, rec.AgentPID)
+	if rec.AgentTTY != "" && rec.AgentTTY != "unknown" {
+		msg += " (tty " + rec.AgentTTY + ")"
+	}
+	if !rec.StartedAt.IsZero() {
+		msg += " started " + rec.StartedAt.UTC().Format(time.RFC3339)
+	}
+	msg += "; record " + launch.ExistingPath(p.AgentDir)
+	return &blockerReason{
+		Source:  "launch",
+		Message: msg,
+		Hint:    "stop pid " + fmt.Sprintf("%d", rec.AgentPID) + " or attach its terminal",
+	}, nil
+}
+
+func (p agentLaunchPreflight) inspectPresence(probe duplicateLaunchProbe) (*blockerReason, error) {
+	path := filepath.Join(p.AgentDir, "presence.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, nil
+	}
+	var pres presenceFile
+	if err := json.Unmarshal(data, &pres); err != nil {
+		return nil, nil
+	}
+	if !strings.EqualFold(pres.Status, "active") {
+		return nil, nil
+	}
+	if pres.LastSeen.IsZero() {
+		return nil, nil
+	}
+	now := probe.Now()
+	if now.Sub(pres.LastSeen) > presenceFreshness {
+		return nil, nil
+	}
+	if pres.Handle != "" && pres.Handle != p.Handle {
+		return nil, nil
+	}
+	msg := fmt.Sprintf("active presence updated %s", pres.LastSeen.UTC().Format(time.RFC3339))
+	msg += "; presence " + path
+	return &blockerReason{
+		Source:  "presence",
+		Message: msg,
+		Hint:    "wait for presence to expire, stop the running agent, or use --force-duplicate",
+	}, nil
+}
+
+// wakeLockFile mirrors AMQ's wake.lock JSON shape.
+type wakeLockFile struct {
+	PID     int       `json:"pid"`
+	TTY     string    `json:"tty,omitempty"`
+	Root    string    `json:"root,omitempty"`
+	Started time.Time `json:"started"`
+}
+
+type presenceFile struct {
+	Schema   int       `json:"schema"`
+	Handle   string    `json:"handle"`
+	Status   string    `json:"status"`
+	LastSeen time.Time `json:"last_seen"`
+}
+
+func wakeLockPath(agentDir string) string {
+	return filepath.Join(agentDir, ".wake.lock")
+}
+
+// wakeProcessMatcher returns a predicate that recognizes an "amq wake"
+// process for the given handle and expected root. The match anchors on the
+// process command shape (`amq ... wake ... --me <handle>`) AND on the
+// --root token when present. The --me value is parsed as a token, not a
+// substring, so handle="cto" does not false-match a sibling wake with
+// --me cto2 or --me=cto-extra. Root comparison tolerates relative /
+// absolute equivalents but rejects unrelated roots. If the process args
+// do not carry a --root token (root may be passed via env) the match
+// accepts on the agent-dir anchoring of the lock alone.
+func wakeProcessMatcher(handle, expectedRoot string) func(args string) bool {
+	return func(args string) bool {
+		if args == "" {
+			return false
+		}
+		if !strings.Contains(args, "amq") {
+			return false
+		}
+		if !strings.Contains(args, "wake") {
+			return false
+		}
+		if handle != "" {
+			me, found := extractMeFromArgs(args)
+			if !found || me != handle {
+				return false
+			}
+		}
+		if expectedRoot == "" {
+			return true
+		}
+		// Fast path: expectedRoot present literally in ps args, bounded on
+		// the right by whitespace, end of string, or a quote character.
+		// Survives path tokens that contain spaces (where strings.Fields
+		// would otherwise split the value) without falsely accepting a
+		// sibling root that has expectedRoot only as a prefix, e.g.
+		// expected /a/issue-96 vs actual /a/issue-96-old.
+		if rootSubstringMatchesBounded(args, expectedRoot) {
+			return true
+		}
+		if psRoot, ok := extractRootFromArgs(args); ok {
+			return rootsMatch(psRoot, expectedRoot)
+		}
+		return true
+	}
+}
+
+// rootSubstringMatchesBounded reports whether expectedRoot occurs in args
+// bounded on both sides by a value boundary. The right boundary is
+// end-of-string or whitespace/quote; the left boundary is start-of-string
+// or whitespace/quote/`=`. Without both checks the fast path would accept
+// expected as a prefix of a longer, unrelated root (e.g. /a/issue-96 vs
+// /a/issue-96-old) or as a suffix of a different absolute root (e.g.
+// /a/issue-96 inside /tmp/a/issue-96).
+func rootSubstringMatchesBounded(args, expectedRoot string) bool {
+	if expectedRoot == "" {
+		return false
+	}
+	for i := 0; ; {
+		idx := strings.Index(args[i:], expectedRoot)
+		if idx < 0 {
+			return false
+		}
+		start := i + idx
+		end := start + len(expectedRoot)
+		if isRootBoundary(start, args, true) && isRootBoundary(end, args, false) {
+			return true
+		}
+		i = start + 1
+	}
+}
+
+// isRootBoundary reports whether position pos in args is a valid value
+// boundary on the side indicated by left. left=true checks the character
+// immediately before pos; left=false checks the character at pos. The valid
+// boundary characters are end/start of string, whitespace, quote, and `=`
+// on the left (matching --root=value).
+func isRootBoundary(pos int, args string, left bool) bool {
+	if left {
+		if pos == 0 {
+			return true
+		}
+		switch args[pos-1] {
+		case ' ', '\t', '\n', '"', '\'', '=':
+			return true
+		}
+		return false
+	}
+	if pos == len(args) {
+		return true
+	}
+	switch args[pos] {
+	case ' ', '\t', '\n', '"', '\'':
+		return true
+	}
+	return false
+}
+
+// extractMeFromArgs pulls the --me <value> or --me=<value> token out of a
+// ps args string. Returns ("", false) when no --me flag is present. The
+// match is strict-equal on the token so handle="cto" does not match
+// --me cto2 or --me=cto-extra.
+func extractMeFromArgs(args string) (string, bool) {
+	fields := strings.Fields(args)
+	for i, f := range fields {
+		if f == "--me" {
+			if i+1 < len(fields) {
+				return fields[i+1], true
+			}
+			return "", false
+		}
+		if strings.HasPrefix(f, "--me=") {
+			return strings.TrimPrefix(f, "--me="), true
+		}
+	}
+	return "", false
+}
+
+// extractRootFromArgs pulls the --root <value> or --root=<value> value out
+// of a ps args string. Values that contain spaces are reconstructed by
+// concatenating tokens after --root until the next flag token (anything
+// starting with "--"). Returns ("", false) when no --root flag is present.
+func extractRootFromArgs(args string) (string, bool) {
+	fields := strings.Fields(args)
+	for i, f := range fields {
+		if f == "--root" {
+			joined := joinNonFlagTokens(fields[i+1:])
+			return joined, joined != ""
+		}
+		if strings.HasPrefix(f, "--root=") {
+			head := strings.TrimPrefix(f, "--root=")
+			tail := joinNonFlagTokens(fields[i+1:])
+			if tail != "" {
+				head = head + " " + tail
+			}
+			return head, true
+		}
+	}
+	return "", false
+}
+
+// joinNonFlagTokens reassembles a path token that strings.Fields split on
+// internal whitespace. It stops at the next flag token (prefix "--").
+func joinNonFlagTokens(fields []string) string {
+	var b strings.Builder
+	for i, f := range fields {
+		if strings.HasPrefix(f, "--") {
+			break
+		}
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(f)
+	}
+	return b.String()
+}
+
+// rootsMatch reports whether two AMQ root paths refer to the same location,
+// tolerating one being relative and the other absolute. Both relative paths
+// must match literally; otherwise the absolute side must end with the
+// relative side's cleaned form.
+func rootsMatch(actual, expected string) bool {
+	a := filepath.Clean(actual)
+	b := filepath.Clean(expected)
+	if a == b {
+		return true
+	}
+	if filepath.IsAbs(a) && filepath.IsAbs(b) {
+		// Different absolute paths: not the same root.
+		return false
+	}
+	rel, abs := a, b
+	if filepath.IsAbs(rel) {
+		rel, abs = abs, rel
+	}
+	if !filepath.IsAbs(abs) {
+		// Neither side is absolute and they didn't match literally.
+		return false
+	}
+	return abs == rel || strings.HasSuffix(abs, string(filepath.Separator)+rel)
+}
+
+// removeIfNotDryRun removes path unless the preflight is in dry-run mode.
+// In dry-run, stale artifacts are detected but left untouched on disk.
+func (p agentLaunchPreflight) removeIfNotDryRun(path string) {
+	if p.DryRun {
+		return
+	}
+	_ = os.Remove(path)
+}
+
+// agentProcessMatcher returns a predicate that recognizes the agent binary.
+func agentProcessMatcher(binary string) func(args string) bool {
+	binary = strings.TrimSpace(binary)
+	return func(args string) bool {
+		if args == "" || binary == "" {
+			return false
+		}
+		base := filepath.Base(binary)
+		// Match either the absolute or basename form. Avoid false positives
+		// like "claude-mem" by anchoring on a token boundary.
+		fields := strings.Fields(args)
+		if len(fields) == 0 {
+			return false
+		}
+		first := filepath.Base(fields[0])
+		return first == base || first == binary
+	}
+}
+
+// preflightTeam runs preflight for every member and aggregates blockers.
+// It returns a single error containing all blockers when any member is
+// blocked. force=true downgrades blockers to warnings (delegated to
+// agentLaunchPreflight.check via Force).
+func preflightTeam(plans []agentLaunchPreflight, probe duplicateLaunchProbe) error {
+	var blockers []*duplicateBlocker
+	for _, plan := range plans {
+		blocker, err := plan.check(probe)
+		if err != nil {
+			return err
+		}
+		if blocker != nil {
+			blockers = append(blockers, blocker)
+		}
+	}
+	if len(blockers) == 0 {
+		return nil
+	}
+	var lines []string
+	lines = append(lines, fmt.Sprintf("refusing to launch team: %d member(s) blocked by live-agent signals", len(blockers)))
+	for _, b := range blockers {
+		lines = append(lines, "")
+		lines = append(lines, b.Error())
+	}
+	return errors.New(strings.Join(lines, "\n"))
+}
+
+// currentLaunchTTY returns a best-effort identifier for the launching TTY.
+// This is recorded in launch.json so duplicate-launch errors can name the
+// terminal that owns an existing agent.
+func currentLaunchTTY() string {
+	if tty := strings.TrimSpace(os.Getenv("TTY")); tty != "" {
+		return tty
+	}
+	for _, fd := range []string{"/dev/stdin", "/dev/stdout", "/dev/stderr"} {
+		if name, err := os.Readlink(fd); err == nil && name != "" {
+			return name
+		}
+	}
+	return ""
+}

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -1,0 +1,646 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func writeWakeLock(t *testing.T, agentDir string, lock wakeLockFile) {
+	t.Helper()
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wakeLockPath(agentDir), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writePresence(t *testing.T, agentDir string, pres presenceFile) {
+	t.Helper()
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(pres)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, "presence.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fakeProbe returns a probe with controllable PID/process behavior.
+func fakeProbe(alive map[int]bool, match map[int]string, now time.Time) duplicateLaunchProbe {
+	return duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return alive[pid] },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			args, ok := match[pid]
+			if !ok {
+				return false
+			}
+			return predicate(args)
+		},
+		Now: func() time.Time { return now },
+	}
+}
+
+func TestPreflightStaleWakeLockIsRemoved(t *testing.T) {
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 99999, Root: "/r"})
+
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("stale lock should not block: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("stale wake lock should have been removed: stat err = %v", err)
+	}
+}
+
+func TestPreflightLiveWakeLockBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1234, Root: "/r"})
+
+	probe := fakeProbe(
+		map[int]bool{1234: true},
+		map[int]string{1234: "amq wake --me cto --root /r"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("live wake lock should block")
+	}
+	if !strings.Contains(blocker.Error(), "wake") || !strings.Contains(blocker.Error(), "1234") {
+		t.Fatalf("blocker should name wake source and pid: %s", blocker.Error())
+	}
+}
+
+func TestPreflightLiveWakePIDReuseIsStale(t *testing.T) {
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1234, Root: "/r"})
+
+	probe := fakeProbe(
+		map[int]bool{1234: true},
+		map[int]string{1234: "node /usr/local/bin/something-else"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("PID reuse with non-wake command should be stale: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("PID-reuse stale wake lock should be removed: %v", err)
+	}
+}
+
+func TestPreflightLiveAgentRecordBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	rec := launch.Record{
+		Binary:    "codex",
+		Handle:    "cto",
+		AgentPID:  4242,
+		AgentTTY:  "/dev/ttys001",
+		StartedAt: time.Now().Add(-5 * time.Minute),
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := fakeProbe(
+		map[int]bool{4242: true},
+		map[int]string{4242: "/usr/local/bin/codex"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("live agent record should block")
+	}
+	if !strings.Contains(blocker.Error(), "launch") || !strings.Contains(blocker.Error(), "4242") {
+		t.Fatalf("blocker should name launch source and pid: %s", blocker.Error())
+	}
+}
+
+func TestPreflightDeadAgentRecordIsNonBlocking(t *testing.T) {
+	agentDir := t.TempDir()
+	if err := launch.Write(agentDir, launch.Record{Binary: "codex", Handle: "cto", AgentPID: 9999, StartedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("dead PID should not block: %v", blocker)
+	}
+}
+
+func TestPreflightActivePresenceWithLiveWakeBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now().Add(-5 * time.Second)})
+
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("fresh active presence should block")
+	}
+	if !strings.Contains(blocker.Error(), "presence") {
+		t.Fatalf("blocker should mention presence: %s", blocker.Error())
+	}
+}
+
+func TestPreflightStalePresenceDoesNotBlock(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now().Add(-10 * time.Minute)})
+
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("stale presence should not block: %v", blocker)
+	}
+}
+
+func TestPreflightForceDuplicateOverridesAllSignals(t *testing.T) {
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1234, Root: "/r"})
+	probe := fakeProbe(
+		map[int]bool{1234: true},
+		map[int]string{1234: "amq wake --me cto --root /r"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Force: true}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("--force-duplicate should override blockers: %v", blocker)
+	}
+}
+
+func TestPreflightDryRunDoesNotRemoveStaleWakeLock(t *testing.T) {
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 9999, Root: "/r"})
+
+	// PID is dead -> normally classified stale and removed. With DryRun,
+	// the file must remain.
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", DryRun: true}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("dead PID under dry-run should not block: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("dry-run preflight must not remove stale wake lock: %v", err)
+	}
+}
+
+func TestWakeProcessMatcherRejectsForeignRoot(t *testing.T) {
+	// Regression: the previous handle-only matcher accepted any live
+	// `amq wake --me cto` for the lock PID, even if the live process
+	// belonged to a wake from a different workstream/root. The matcher
+	// must still recognize relative-root equivalents but reject unrelated
+	// absolute roots.
+	cases := []struct {
+		name     string
+		args     string
+		expected string
+		want     bool
+	}{
+		{
+			name:     "relative root matches absolute expected (suffix)",
+			args:     "amq wake --me cto --root .agent-mail/issue-96",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "absolute root equal to expected",
+			args:     "amq wake --me cto --root /abs/proj/.agent-mail/issue-96",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "absolute root different from expected blocks match",
+			args:     "amq wake --me cto --root /other/proj/.agent-mail/issue-96",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "no --root token in args defers to agent-dir anchoring",
+			args:     "amq wake --me cto",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "wrong handle never matches",
+			args:     "amq wake --me fullstack --root /abs/proj/.agent-mail/issue-96",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "--root=value form accepted",
+			args:     "amq wake --me=cto --root=/abs/proj/.agent-mail/issue-96",
+			expected: "/abs/proj/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "absolute root with spaces survives strings.Fields",
+			args:     "amq wake --me cto --root /Users/me/my project/.agent-mail/issue-96",
+			expected: "/Users/me/my project/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "relative root with spaces against absolute expected",
+			args:     "amq wake --me cto --root my project/.agent-mail/issue-96",
+			expected: "/Users/me/my project/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "absolute root with spaces unrelated to expected blocks match",
+			args:     "amq wake --me cto --root /Users/me/other project/.agent-mail/issue-96",
+			expected: "/Users/me/my project/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "trailing flag stops the joined --root value",
+			args:     "amq wake --me cto --root /Users/me/my project/.agent-mail/issue-96 --tty foo",
+			expected: "/Users/me/my project/.agent-mail/issue-96",
+			want:     true,
+		},
+		{
+			name:     "expected root that is only a prefix of actual root rejects",
+			args:     "amq wake --me cto --root /Users/me/proj/.agent-mail/issue-96-old",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "expected root prefix of a deeper actual path rejects",
+			args:     "amq wake --me cto --root /Users/me/proj/.agent-mail/issue-96/sub",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "expected root that is only a suffix of actual root rejects",
+			args:     "amq wake --me cto --root /tmp/Users/me/proj/.agent-mail/issue-96",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "prefix handle does not false-match (cto vs cto2)",
+			args:     "amq wake --me cto2 --root /Users/me/proj/.agent-mail/issue-96",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "prefix handle with hyphen suffix does not false-match",
+			args:     "amq wake --me cto-extra --root /Users/me/proj/.agent-mail/issue-96",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+		{
+			name:     "prefix handle with --me=value form does not false-match",
+			args:     "amq wake --me=cto2 --root /Users/me/proj/.agent-mail/issue-96",
+			expected: "/Users/me/proj/.agent-mail/issue-96",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		got := wakeProcessMatcher("cto", tc.expected)(tc.args)
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestPreflightLiveWakeWithSpacesInRootBlocks(t *testing.T) {
+	// Regression: extractRootFromArgs used to split paths with spaces on
+	// strings.Fields and reject the live wake as PID reuse. The fast-path
+	// substring check + joined-token fallback must keep the live wake live.
+	agentDir := t.TempDir()
+	expectedRoot := "/Users/me/my project/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 7777, Root: expectedRoot})
+
+	probe := fakeProbe(
+		map[int]bool{7777: true},
+		map[int]string{7777: "amq wake --me cto --root " + expectedRoot},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: expectedRoot}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("live wake with spaces in root should still block")
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("live wake lock with spaces in root must remain on block: %v", err)
+	}
+}
+
+// Regression: a wake.lock for handle "cto" whose live PID is actually a
+// sibling wake for "cto2" must classify as stale, not pid:N.
+func TestWakeHealthForMemberRejectsPrefixHandleReuse(t *testing.T) {
+	agentDir := t.TempDir()
+	expectedRoot := "/abs/proj/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 8888, Root: expectedRoot})
+
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == 8888 },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto2 --root " + expectedRoot)
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	got := wakeHealthForMember(agentDir, expectedRoot, "cto", launch.Record{}, false)
+	if got != "stale" {
+		t.Errorf("prefix-handle PID reuse must classify as stale, got %q", got)
+	}
+}
+
+func TestPreflightSiblingWorkstreamRootIsStale(t *testing.T) {
+	// Regression: the literal-substring fast path used to accept a sibling
+	// workstream's wake whose --root was a strict superstring of expected
+	// (e.g. issue-96 vs issue-96-old). Bounded matching must reject it and
+	// the stale lock must be removed.
+	agentDir := t.TempDir()
+	expectedRoot := "/Users/me/proj/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 5555, Root: expectedRoot})
+
+	probe := fakeProbe(
+		map[int]bool{5555: true},
+		map[int]string{5555: "amq wake --me cto --root /Users/me/proj/.agent-mail/issue-96-old"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: expectedRoot}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("sibling workstream PID reuse should not block: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("sibling-root stale lock should be removed: %v", err)
+	}
+}
+
+func TestPreflightSuffixOfForeignRootIsStale(t *testing.T) {
+	// Regression: the fast path needs a left boundary too; a different
+	// absolute root that ends with the expected root must classify the
+	// lock as stale.
+	agentDir := t.TempDir()
+	expectedRoot := "/Users/me/proj/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 6666, Root: expectedRoot})
+
+	probe := fakeProbe(
+		map[int]bool{6666: true},
+		map[int]string{6666: "amq wake --me cto --root /tmp/Users/me/proj/.agent-mail/issue-96"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: expectedRoot}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("foreign root containing expected as suffix should not block: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("foreign-suffix stale lock should be removed: %v", err)
+	}
+}
+
+func TestWakeHealthWithSpacesInRoot(t *testing.T) {
+	// Regression for list/restore wake-health column.
+	agentDir := t.TempDir()
+	expectedRoot := "/Users/me/my project/.agent-mail/issue-96"
+	rec := launch.Record{
+		Binary:   "codex",
+		Handle:   "cto",
+		Root:     expectedRoot,
+		AgentPID: 100,
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 42, Root: expectedRoot})
+	entry := launch.Entry{Record: rec, AgentDir: agentDir}
+
+	probe := fakeProbe(
+		map[int]bool{100: true, 42: true},
+		map[int]string{
+			100: "/usr/local/bin/codex",
+			42:  "amq wake --me cto --root " + expectedRoot,
+		},
+		time.Now(),
+	)
+	if got := wakeHealthForEntry(entry, probe); got != "pid:42" {
+		t.Errorf("spaces-in-root wake health: got %q, want pid:42", got)
+	}
+}
+
+func TestPreflightForeignRootPIDReuseIsStale(t *testing.T) {
+	// PID reused by another project's `amq wake --me cto` must classify
+	// the stale lock as stale, not block the new launch.
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1234, Root: "/abs/proj/.agent-mail/issue-96"})
+
+	probe := fakeProbe(
+		map[int]bool{1234: true},
+		map[int]string{1234: "amq wake --me cto --root /other/proj/.agent-mail/issue-96"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/abs/proj/.agent-mail/issue-96"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("foreign-root PID reuse should not block: %v", blocker)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("foreign-root stale lock should be removed: %v", err)
+	}
+}
+
+func TestPreflightLiveWakeWithRelativeRootBlocks(t *testing.T) {
+	// Regression: ps args may carry --root as a relative path while p.Root
+	// is the canonical absolute resolution. Identity is anchored on the
+	// agent dir + --me; root tokens must not be required to match literally.
+	agentDir := t.TempDir()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1234, Root: "/abs/.agent-mail/issue-96"})
+
+	probe := fakeProbe(
+		map[int]bool{1234: true},
+		map[int]string{1234: "amq wake --me cto --root .agent-mail/issue-96"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/abs/.agent-mail/issue-96"}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("relative-root wake should still block")
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("live wake lock must remain on block: %v", err)
+	}
+}
+
+func TestWakeHealthForRelativeRootStillReportsLive(t *testing.T) {
+	// Regression: list/restore must not report a relative-root live wake
+	// as stale.
+	agentDir := t.TempDir()
+	rec := launch.Record{
+		Binary:   "codex",
+		Handle:   "cto",
+		Root:     "/abs/.agent-mail/issue-96",
+		AgentPID: 100,
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 42, Root: "/abs/.agent-mail/issue-96"})
+	entry := launch.Entry{Record: rec, AgentDir: agentDir}
+
+	probe := fakeProbe(
+		map[int]bool{100: true, 42: true},
+		map[int]string{
+			100: "/usr/local/bin/codex",
+			42:  "amq wake --me cto --root .agent-mail/issue-96",
+		},
+		time.Now(),
+	)
+	if got := wakeHealthForEntry(entry, probe); got != "pid:42" {
+		t.Errorf("relative-root wake health: got %q, want pid:42", got)
+	}
+}
+
+func TestPreflightTeamAggregatesBlockers(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	writeWakeLock(t, dir1, wakeLockFile{PID: 11, Root: "/r"})
+	writeWakeLock(t, dir2, wakeLockFile{PID: 22, Root: "/r"})
+	probe := fakeProbe(
+		map[int]bool{11: true, 22: true},
+		map[int]string{
+			11: "amq wake --me cto --root /r",
+			22: "amq wake --me fullstack --root /r",
+		},
+		time.Now(),
+	)
+	plans := []agentLaunchPreflight{
+		{AgentDir: dir1, Handle: "cto", Workstream: "w", Root: "/r"},
+		{AgentDir: dir2, Handle: "fullstack", Workstream: "w", Root: "/r"},
+	}
+	err := preflightTeam(plans, probe)
+	if err == nil {
+		t.Fatal("two live members should block team launch")
+	}
+	if !strings.Contains(err.Error(), "cto") || !strings.Contains(err.Error(), "fullstack") {
+		t.Fatalf("aggregated error should name both members: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "2 member(s) blocked") {
+		t.Fatalf("aggregated error should count blockers: %s", err.Error())
+	}
+}
+
+func TestWakeHealthForEntry(t *testing.T) {
+	agentDir := t.TempDir()
+	rec := launch.Record{
+		Binary:   "codex",
+		Handle:   "cto",
+		Root:     "/r",
+		AgentPID: 100,
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	entry := launch.Entry{Record: rec, AgentDir: agentDir}
+
+	now := time.Now()
+
+	// looks active but no wake.lock → "missing"
+	probeNoLock := fakeProbe(
+		map[int]bool{100: true},
+		map[int]string{100: "/usr/local/bin/codex"},
+		now,
+	)
+	if got := wakeHealthForEntry(entry, probeNoLock); got != "missing" {
+		t.Errorf("missing wake: got %q, want missing", got)
+	}
+
+	// wake lock present, PID alive, command matches → "pid:42"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 42, Root: "/r"})
+	probeAlive := fakeProbe(
+		map[int]bool{100: true, 42: true},
+		map[int]string{
+			100: "/usr/local/bin/codex",
+			42:  "amq wake --me cto --root /r",
+		},
+		now,
+	)
+	if got := wakeHealthForEntry(entry, probeAlive); got != "pid:42" {
+		t.Errorf("alive wake: got %q, want pid:42", got)
+	}
+
+	// wake lock present but PID dead → "stale"
+	probeDead := fakeProbe(
+		map[int]bool{100: true},
+		map[int]string{100: "/usr/local/bin/codex"},
+		now,
+	)
+	if got := wakeHealthForEntry(entry, probeDead); got != "stale" {
+		t.Errorf("dead wake: got %q, want stale", got)
+	}
+
+	// not active-looking → "" (no inspection)
+	probeInactive := fakeProbe(map[int]bool{}, nil, now)
+	if got := wakeHealthForEntry(entry, probeInactive); got != "" {
+		t.Errorf("inactive: got %q, want empty", got)
+	}
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -40,6 +40,11 @@ matching agent.
 
 With --exec, exactly one record must match; amq-squad changes to that
 record's cwd and execs the saved launch through 'amq coop exec'.
+
+For records that look active, the metadata line includes wake-health:
+  wake: pid:N    - wake.lock present and the wake process is alive
+  wake: missing  - agent looks active but no wake.lock was found
+  wake: stale    - wake.lock present but the PID is dead or unrelated
 `)
 	}
 	if err := fs.Parse(args); err != nil {
@@ -173,6 +178,9 @@ func restoreMetadata(entry launch.Entry) string {
 	if entry.Source != "" {
 		parts = append(parts, "source: "+sourceLabel(entry.Source))
 	}
+	if wake := wakeHealthForEntry(entry, defaultDuplicateLaunchProbe); wake != "" {
+		parts = append(parts, "wake: "+wake)
+	}
 	if !rec.StartedAt.IsZero() {
 		label := "started"
 		if entry.Source != "" && entry.Source != launch.FileName {
@@ -231,6 +239,12 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoDefaultArgs {
 		args = append(args, "--no-default-args")
 	}
+	if trust := trustModeFromRecord(rec); trust != "" {
+		args = append(args, "--trust", trust)
+	}
+	if model := strings.TrimSpace(rec.Model); model != "" {
+		args = append(args, "--model", model)
+	}
 	// =VALUE form keeps the value glued to the flag so a literal "--" inside
 	// the binary args never reaches splitDashDash on replay.
 	if len(rec.CodexArgs) > 0 {
@@ -259,6 +273,15 @@ func restoreArgvFromRecord(rec launch.Record) []string {
 	if extras := launchExtraBinaryArgs(rec); len(extras) > 0 {
 		argv = removeContiguousSubsequence(argv, extras)
 	}
+	if model := strings.TrimSpace(rec.Model); model != "" {
+		argv = removeContiguousSubsequence(argv, []string{"--model", model})
+	}
+	if !rec.NoDefaultArgs {
+		trust := trustModeFromRecord(rec)
+		if defaults := defaultChildArgsForBinaryWithTrust(rec.Binary, trust); len(defaults) > 0 {
+			argv = removeContiguousSubsequence(argv, defaults)
+		}
+	}
 	return argv
 }
 
@@ -270,6 +293,32 @@ func launchExtraBinaryArgs(rec launch.Record) []string {
 		return rec.ClaudeArgs
 	}
 	return nil
+}
+
+// trustModeFromRecord returns the trust mode to re-emit on restore. If the
+// record has Trust set, it wins. Otherwise legacy codex records that contain
+// the bypass arg in argv (and did not opt out of defaults) are restored as
+// trusted; everything else is sandboxed.
+func trustModeFromRecord(rec launch.Record) string {
+	if t, err := normalizeTrustMode(rec.Trust); err == nil && rec.Trust != "" {
+		return t
+	}
+	if normalizedAgentBinary(rec.Binary) != "codex" {
+		return ""
+	}
+	if !rec.NoDefaultArgs && argvContainsBypass(rec.Argv) {
+		return trustModeTrusted
+	}
+	return trustModeSandboxed
+}
+
+func argvContainsBypass(argv []string) bool {
+	for _, a := range argv {
+		if a == "--dangerously-bypass-approvals-and-sandbox" {
+			return true
+		}
+	}
+	return false
 }
 
 func removeContiguousSubsequence(args, sub []string) []string {
@@ -298,11 +347,26 @@ func removeContiguousSubsequence(args, sub []string) []string {
 // It prefers 'amq-squad launch' so role + metadata round-trip cleanly;
 // callers who want the raw amq invocation can run with --dry-run to see it.
 func emitCommand(rec launch.Record) string {
+	return emitCommandWithOptions(rec, emitCommandOptions{})
+}
+
+// emitCommandOptions controls extra flags injected into the emitted
+// 'amq-squad launch' invocation. Force adds --force-duplicate so a planner
+// (e.g. team resume) can emit a command that matches the plan when a live
+// agent has been overridden.
+type emitCommandOptions struct {
+	Force bool
+}
+
+func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	var b strings.Builder
 	b.WriteString("cd ")
 	b.WriteString(shellQuote(rec.CWD))
 	b.WriteString(" && amq-squad launch")
 	b.WriteString(" --no-bootstrap")
+	if opts.Force {
+		b.WriteString(" --force-duplicate")
+	}
 	if rec.Role != "" {
 		b.WriteString(" --role ")
 		b.WriteString(shellQuote(rec.Role))
@@ -327,6 +391,14 @@ func emitCommand(rec launch.Record) string {
 	}
 	if rec.NoDefaultArgs {
 		b.WriteString(" --no-default-args")
+	}
+	if trust := trustModeFromRecord(rec); trust != "" {
+		b.WriteString(" --trust ")
+		b.WriteString(shellQuote(trust))
+	}
+	if model := strings.TrimSpace(rec.Model); model != "" {
+		b.WriteString(" --model ")
+		b.WriteString(shellQuote(model))
 	}
 	if len(rec.CodexArgs) > 0 {
 		b.WriteString(" --codex-args=")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -81,7 +81,7 @@ func TestEmitCommandIncludesConversationWithoutDuplicatingResumeArgs(t *testing.
 	cmd := emitCommand(rec)
 	for _, want := range []string{
 		"--conversation cto-thread",
-		"-- --dangerously-bypass-approvals-and-sandbox",
+		"--trust trusted",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("emitCommand missing %q in: %s", want, cmd)
@@ -89,6 +89,9 @@ func TestEmitCommandIncludesConversationWithoutDuplicatingResumeArgs(t *testing.
 	}
 	if strings.Contains(cmd, " resume cto-thread") {
 		t.Errorf("emitCommand should strip generated resume args when --conversation is present: %s", cmd)
+	}
+	if strings.Contains(cmd, " -- --dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("emitCommand should not duplicate trusted defaults after --: %s", cmd)
 	}
 }
 
@@ -149,6 +152,8 @@ func TestLaunchArgsFromRecord(t *testing.T) {
 		Root:         "/p/.agent-mail/stream1",
 	}
 	got := launchArgsFromRecord(rec)
+	// Built-in claude defaults are stripped from the -- block on emission;
+	// they are re-prepended on replay.
 	want := []string{
 		"--no-bootstrap",
 		"--role", "fullstack",
@@ -156,8 +161,6 @@ func TestLaunchArgsFromRecord(t *testing.T) {
 		"--conversation", "abc",
 		"--me", "fullstack",
 		"claude",
-		"--",
-		"--permission-mode", "auto",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
@@ -173,7 +176,9 @@ func TestLaunchArgsFromRecordPreservesSharedWorkstream(t *testing.T) {
 		Role:             "cto",
 	}
 	got := launchArgsFromRecord(rec)
-	want := []string{"--no-bootstrap", "--role", "cto", "--session", "cto", "--team-workstream", "--me", "cto", "codex"}
+	// codex defaults to sandboxed; --trust sandboxed is emitted explicitly so
+	// the trust boundary is visible on replay.
+	want := []string{"--no-bootstrap", "--role", "cto", "--session", "cto", "--team-workstream", "--trust", "sandboxed", "--me", "cto", "codex"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
 	}
@@ -189,7 +194,7 @@ func TestLaunchArgsFromRecordUsesRootWithoutSession(t *testing.T) {
 		Root:   "/p/.agent-mail",
 	}
 	got := launchArgsFromRecord(rec)
-	want := []string{"--no-bootstrap", "--root", "/p/.agent-mail", "--me", "codex", "codex"}
+	want := []string{"--no-bootstrap", "--root", "/p/.agent-mail", "--trust", "sandboxed", "--me", "codex", "codex"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
 	}
@@ -226,16 +231,18 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithCodexArgs(t *testing.T) {
 		CodexArgs:    []string{"--enable", "goals"},
 	}
 	got := launchArgsFromRecord(rec)
+	// Legacy record (Trust unset, bypass in argv) classifies as trusted; the
+	// trust default is re-prepended on replay so it is stripped from the
+	// emitted -- block.
 	want := []string{
 		"--no-bootstrap",
 		"--role", "cto",
 		"--session", "cto",
 		"--conversation", "X",
+		"--trust", "trusted",
 		"--codex-args=--enable goals",
 		"--me", "cto",
 		"codex",
-		"--",
-		"--dangerously-bypass-approvals-and-sandbox",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
@@ -256,6 +263,8 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithClaudeArgs(t *testing.T) 
 		ClaudeArgs:   []string{"--chrome"},
 	}
 	got := launchArgsFromRecord(rec)
+	// Built-in claude defaults are stripped on emission; replay re-prepends.
+	// claude has no trust concept so no --trust flag is emitted.
 	want := []string{
 		"--no-bootstrap",
 		"--role", "fullstack",
@@ -264,8 +273,6 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithClaudeArgs(t *testing.T) 
 		"--claude-args=--chrome",
 		"--me", "fullstack",
 		"claude",
-		"--",
-		"--permission-mode", "auto",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
@@ -274,7 +281,7 @@ func TestLaunchArgsFromRecordRoundTripsConversationWithClaudeArgs(t *testing.T) 
 }
 
 // joinedAgentArgs writes a value that parseAgentArgs must re-tokenize
-// identically — pin the round-trip for spaces, single quotes, double quotes,
+// identically; pin the round-trip for spaces, single quotes, double quotes,
 // and backslash escapes.
 func TestBinaryArgsJoinedRoundTripPreservesQuotingAndEscapes(t *testing.T) {
 	cases := [][]string{
@@ -297,7 +304,7 @@ func TestBinaryArgsJoinedRoundTripPreservesQuotingAndEscapes(t *testing.T) {
 	}
 }
 
-// --no-default-args must round-trip — without persistence the restore replay
+// --no-default-args must round-trip; without persistence the restore replay
 // silently re-injects the binary defaults the original launch opted out of.
 func TestLaunchArgsFromRecordPreservesNoDefaultArgs(t *testing.T) {
 	rec := launch.Record{
@@ -311,11 +318,14 @@ func TestLaunchArgsFromRecordPreservesNoDefaultArgs(t *testing.T) {
 		NoDefaultArgs: true,
 	}
 	got := launchArgsFromRecord(rec)
+	// NoDefaultArgs records have no bypass in argv, so trust classifies as
+	// sandboxed. --no-default-args is preserved.
 	want := []string{
 		"--no-bootstrap",
 		"--role", "cto",
 		"--session", "rt",
 		"--no-default-args",
+		"--trust", "sandboxed",
 		"--codex-args=--enable goals",
 		"--me", "cto",
 		"codex",
@@ -354,8 +364,10 @@ func TestLaunchArgsFromRecordEscapesLiteralDashDashInBinaryArgs(t *testing.T) {
 			t.Fatalf("--codex-args lost its value on replay: %#v", squadArgs)
 		}
 	}
-	if !reflect.DeepEqual(postDash, []string{"--dangerously-bypass-approvals-and-sandbox"}) {
-		t.Fatalf("postDash = %#v, want only the leftover default", postDash)
+	// Legacy record with bypass in argv classifies as trusted, so the bypass
+	// arg is stripped from the -- block (replay re-prepends via --trust).
+	if len(postDash) != 0 {
+		t.Fatalf("postDash = %#v, want empty for trusted-classified legacy record", postDash)
 	}
 	parsed, err := parseAgentArgs(extractFlagValue(squadArgs, "--codex-args"))
 	if err != nil {
@@ -398,12 +410,23 @@ func assertConversationReplayAccepted(t *testing.T, args []string) {
 	codexArgsRaw := fs.String("codex-args", "", "")
 	claudeArgsRaw := fs.String("claude-args", "", "")
 	conversation := fs.String("conversation", "", "")
+	trustRaw := fs.String("trust", "", "")
+	model := fs.String("model", "", "")
 	_ = fs.Bool("no-bootstrap", false, "")
+	_ = fs.Bool("no-default-args", false, "")
+	_ = fs.Bool("force-duplicate", false, "")
+	_ = fs.Bool("team-workstream", false, "")
 	_ = fs.String("role", "", "")
 	_ = fs.String("session", "", "")
+	_ = fs.String("root", "", "")
+	_ = fs.String("team-home", "", "")
 	_ = fs.String("me", "", "")
 	if err := fs.Parse(squadArgs); err != nil {
 		t.Fatalf("parse restore squadArgs: %v", err)
+	}
+	trustMode, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
+		t.Fatalf("normalizeTrustMode: %v", err)
 	}
 	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
@@ -416,7 +439,7 @@ func assertConversationReplayAccepted(t *testing.T, args []string) {
 	binary := remaining[0]
 	childArgs := append([]string(nil), remaining[1:]...)
 	childArgs = append(childArgs, postDash...)
-	defaultArgs := launchDefaultChildArgs(binary, true, binaryArgsFor(binary, binaryArgs))
+	defaultArgs := launchDefaultChildArgsWithTrust(binary, true, modelArgsForBinary(binary, *model), binaryArgsFor(binary, binaryArgs), trustMode)
 	childArgs = ensureLeadingChildArgs(defaultArgs, childArgs)
 	if _, err := applyConversationRestoreArgsWithDefaults(binary, childArgs, *conversation, defaultArgs); err != nil {
 		t.Fatalf("conversation restore rejected: %v", err)

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -30,6 +30,8 @@ func runTeam(args []string) error {
 		return runTeamShow(args[1:])
 	case "launch":
 		return runTeamLaunch(args[1:])
+	case "resume":
+		return runTeamResume(args[1:])
 	case "rules":
 		return runTeamRules(args[1:])
 	case "sync":
@@ -37,7 +39,7 @@ func runTeam(args []string) error {
 	default:
 		// Unknown subcommand. Treat as flags to the smart default so
 		// `amq-squad team --help` and similar still work.
-		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'show', 'launch', 'rules', or 'sync'.", args[0])
+		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'show', 'launch', 'resume', 'rules', or 'sync'.", args[0])
 	}
 }
 
@@ -49,7 +51,7 @@ func runTeamSmart() error {
 		return fmt.Errorf("getwd: %w", err)
 	}
 	if team.Exists(cwd) {
-		return emitTeamCommands(cwd, false, "", false, false, nil)
+		return emitTeamCommands(cwd, emitTeamOptions{})
 	}
 	fmt.Fprintln(os.Stderr, "No team configured for this project yet. Let's set one up.")
 	fmt.Fprintln(os.Stderr)
@@ -57,7 +59,7 @@ func runTeamSmart() error {
 		return err
 	}
 	fmt.Fprintln(os.Stderr)
-	return emitTeamCommands(cwd, false, "", false, false, nil)
+	return emitTeamCommands(cwd, emitTeamOptions{})
 }
 
 func runTeamInit(args []string) error {
@@ -67,6 +69,8 @@ func runTeamInit(args []string) error {
 	binaryFlag := fs.String("binary", "", "per-persona CLI overrides, e.g. fullstack=codex,qa=claude")
 	sessionFlag := fs.String("session", "", "AMQ workstream session name for all members (lowercase a-z, 0-9, -, _)")
 	cwdFlag := fs.String("cwd", "", "per-persona working directory overrides, e.g. qa=/path/to/sibling-project")
+	modelFlag := fs.String("model", "", "per-persona model overrides, e.g. cto=gpt-5,fullstack=sonnet")
+	trustRaw := fs.String("trust", "", "Codex trust profile for generated commands: sandboxed (default) or trusted")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for every Codex member, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for every Claude member, e.g. '--chrome'")
 	force := fs.Bool("force", false, "overwrite an existing team.json")
@@ -74,8 +78,8 @@ func runTeamInit(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
 
 Usage:
-  amq-squad team init [--personas id1,id2,...] [--binary persona=cli,...] [--session workstream] [--codex-args args] [--claude-args args] [--force]
-  amq-squad team init [--roles id1,id2,...] [--binary role=cli,...] [--session workstream] [--codex-args args] [--claude-args args] [--force]
+  amq-squad team init [--personas id1,id2,...] [--binary persona=cli,...] [--session workstream] [--model role=model,...] [--trust sandboxed|trusted] [--codex-args args] [--claude-args args] [--force]
+  amq-squad team init [--roles id1,id2,...] [--binary role=cli,...] [--session workstream] [--model role=model,...] [--trust sandboxed|trusted] [--codex-args args] [--claude-args args] [--force]
 
 Without --personas or --roles, prompts interactively: first choose personas,
 then choose the CLI for each persona. Writes <cwd>/.amq-squad/team.json and
@@ -91,6 +95,10 @@ Known personas:
 		}
 	}
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	trustMode, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
 		return err
 	}
 	if *rolesFlag != "" && *personasFlag != "" {
@@ -121,10 +129,22 @@ Known personas:
 	if err != nil {
 		return fmt.Errorf("parse --cwd: %w", err)
 	}
+	modelOverrides, err := parseKV(*modelFlag)
+	if err != nil {
+		return fmt.Errorf("parse --model: %w", err)
+	}
 	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
 		return err
 	}
+	// Validate trust + binary-args contradictions up-front so a team config
+	// never persists a setting that would fail at launch time.
+	if err := validateTrustCombination(trustMode, flagWasSet(fs, "trust"), false, binaryArgs); err != nil {
+		return err
+	}
+	// Normalize override keys to lowercase so we can match them against the
+	// chosen persona IDs without surprises.
+	modelOverrides = lowercaseKeys(modelOverrides)
 
 	var picked []string
 	interactive := *rolesFlag == "" && *personasFlag == ""
@@ -141,9 +161,36 @@ Known personas:
 		if err := promptBinarySelection(reader, os.Stderr, picked, binaryOverrides); err != nil {
 			return err
 		}
+		if err := promptModelSelection(reader, os.Stderr, modelOverrides); err != nil {
+			return err
+		}
+		if !flagWasSet(fs, "trust") {
+			chosen, err := promptTrustSelection(reader, os.Stderr, trustMode)
+			if err != nil {
+				return err
+			}
+			trustMode = chosen
+		}
+		if !flagWasSet(fs, "session") {
+			chosen, err := promptWorkstreamSelection(reader, os.Stderr, workstream)
+			if err != nil {
+				return err
+			}
+			workstream = chosen
+		}
 	}
 	if len(picked) == 0 {
 		return fmt.Errorf("no personas selected, aborting")
+	}
+
+	// Reject --model role=model where role is not a chosen persona, so a
+	// typo never silently drops a model override.
+	pickedSet := make(map[string]bool, len(picked))
+	for _, id := range picked {
+		pickedSet[strings.ToLower(strings.TrimSpace(id))] = true
+	}
+	if err := validateModelOverrideKeys(modelOverrides, pickedSet); err != nil {
+		return err
 	}
 
 	members := make([]team.Member, 0, len(picked))
@@ -171,6 +218,9 @@ Known personas:
 			Handle:  id,
 			Session: workstream,
 		}
+		if model, ok := modelOverrides[id]; ok {
+			m.Model = strings.TrimSpace(model)
+		}
 		if c, ok := cwdOverrides[id]; ok {
 			abs, err := expandPath(c)
 			if err != nil {
@@ -186,6 +236,7 @@ Known personas:
 	t := team.Team{
 		Project:    cwd,
 		Workstream: workstream,
+		Trust:      trustMode,
 		BinaryArgs: binaryArgs,
 		Members:    members,
 	}
@@ -204,6 +255,12 @@ Known personas:
 	if wroteRules {
 		fmt.Fprintf(os.Stderr, "Wrote %s.\n", rules.Path(cwd))
 	}
+	if interactive {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "Next:")
+		fmt.Fprintln(os.Stderr, "  amq-squad team launch          # open all members in the current tmux window")
+		fmt.Fprintln(os.Stderr, "  amq-squad team show            # print one launch command per member")
+	}
 	return nil
 }
 
@@ -212,18 +269,30 @@ func runTeamShow(args []string) error {
 	noBootstrap := fs.Bool("no-bootstrap", false, "emit launch commands that skip the generated bootstrap prompt")
 	session := fs.String("session", "", "AMQ workstream session name (default: sanitized team-home directory name; lowercase a-z, 0-9, -, _)")
 	fresh := fs.Bool("fresh", false, "fail if the selected workstream session already exists")
+	trustRaw := fs.String("trust", "", "Codex trust profile for this run: sandboxed or trusted")
+	modelFlag := fs.String("model", "", "per-persona model overrides for this run, e.g. cto=gpt-5,fullstack=sonnet")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'")
+	forceDuplicate := fs.Bool("force-duplicate", false, "include --force-duplicate in emitted launch commands")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
 
 Usage:
-  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--codex-args args] [--claude-args args]
+  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--trust sandboxed|trusted] [--model role=model,...] [--codex-args args] [--claude-args args] [--force-duplicate]
 `)
 	}
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	trustMode, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
+		return err
+	}
+	modelOverrides, err := parseKV(*modelFlag)
+	if err != nil {
+		return fmt.Errorf("parse --model: %w", err)
+	}
+	modelOverrides = lowercaseKeys(modelOverrides)
 	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
 		return err
@@ -235,10 +304,32 @@ Usage:
 	if !team.Exists(cwd) {
 		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
 	}
-	return emitTeamCommands(cwd, *noBootstrap, *session, flagWasSet(fs, "session"), *fresh, binaryArgs)
+	return emitTeamCommands(cwd, emitTeamOptions{
+		NoBootstrap:      *noBootstrap,
+		RequestedSession: *session,
+		ExplicitSession:  flagWasSet(fs, "session"),
+		Fresh:            *fresh,
+		ExtraBinaryArgs:  binaryArgs,
+		RequestedTrust:   trustMode,
+		ExplicitTrust:    flagWasSet(fs, "trust"),
+		ModelOverrides:   modelOverrides,
+		ForceDuplicate:   *forceDuplicate,
+	})
 }
 
-func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession string, explicitSession bool, fresh bool, extraBinaryArgs map[string][]string) error {
+type emitTeamOptions struct {
+	NoBootstrap      bool
+	RequestedSession string
+	ExplicitSession  bool
+	Fresh            bool
+	ExtraBinaryArgs  map[string][]string
+	RequestedTrust   string
+	ExplicitTrust    bool
+	ModelOverrides   map[string]string
+	ForceDuplicate   bool
+}
+
+func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 	t, err := team.Read(projectDir)
 	if err != nil {
 		return fmt.Errorf("read team: %w", err)
@@ -246,11 +337,11 @@ func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession stri
 	if len(t.Members) == 0 {
 		return fmt.Errorf("team has no members")
 	}
-	workstream, err := resolveTeamWorkstreamName(t, requestedSession, explicitSession)
+	workstream, err := resolveTeamWorkstreamName(t, opts.RequestedSession, opts.ExplicitSession)
 	if err != nil {
 		return err
 	}
-	if fresh {
+	if opts.Fresh {
 		exists, root, err := teamWorkstreamExists(t, workstream)
 		if err != nil {
 			return err
@@ -261,12 +352,34 @@ func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession stri
 	}
 
 	members := orderedTeamMembers(t.Members)
-	binaryArgs := mergeBinaryArgs(t.BinaryArgs, extraBinaryArgs)
+	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.ExtraBinaryArgs)
+	trustMode, err := resolveTeamTrustMode(t, opts.RequestedTrust, opts.ExplicitTrust)
+	if err != nil {
+		return err
+	}
+	// Apply the same trust-vs-binary-args contradiction check direct launch
+	// uses, after effective trust + merged binary args are known. A team
+	// config that combines sandboxed trust with bypass smuggled into
+	// --codex-args is rejected here rather than emitted as a launch command
+	// that would self-reject inside runLaunch.
+	if err := validateTrustCombination(trustMode, opts.ExplicitTrust || strings.TrimSpace(t.Trust) != "", false, binaryArgs); err != nil {
+		return err
+	}
+	// Reject --model role=model where role is not on the team, so a typo on
+	// team show / team launch never silently drops the override.
+	memberRoles := make(map[string]bool, len(members))
+	for _, m := range members {
+		memberRoles[strings.ToLower(m.Role)] = true
+	}
+	if err := validateModelOverrideKeys(opts.ModelOverrides, memberRoles); err != nil {
+		return err
+	}
 
 	fmt.Println("# amq-squad team - run each command in its own terminal tab")
 	fmt.Println("#")
 	fmt.Printf("# team-home: %s\n", t.Project)
 	fmt.Printf("# workstream: %s\n", workstream)
+	fmt.Printf("# trust:     %s\n", trustMode)
 	fmt.Printf("# members:   %d\n", len(members))
 	if formatted := formatBinaryArgs(binaryArgs); formatted != "" {
 		fmt.Printf("# binary args: %s\n", formatted)
@@ -295,12 +408,76 @@ func emitTeamCommands(projectDir string, noBootstrap bool, requestedSession stri
 		if r := catalog.Lookup(m.Role); r != nil {
 			label = r.Label
 		}
+		effectiveModel := memberEffectiveModel(m, opts.ModelOverrides)
 		cwd := m.EffectiveCWD(t.Project)
-		fmt.Printf("# %d. %s - %s (workstream: %s, cwd: %s)\n", i+1, label, m.Binary, workstream, cwd)
-		fmt.Println(emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream, binaryArgs))
+		modelLabel := effectiveModel
+		if modelLabel == "" {
+			modelLabel = "(default)"
+		}
+		fmt.Printf("# %d. %s - %s (workstream: %s, model: %s, cwd: %s)\n", i+1, label, m.Binary, workstream, modelLabel, cwd)
+		fmt.Println(emitTeamCommand(emitTeamCommandInput{
+			CWD:            cwd,
+			SquadBin:       squadBin,
+			TeamHome:       t.Project,
+			Member:         m,
+			NoBootstrap:    opts.NoBootstrap,
+			Workstream:     workstream,
+			BinaryArgs:     binaryArgs,
+			TrustMode:      trustMode,
+			Model:          effectiveModel,
+			ForceDuplicate: opts.ForceDuplicate,
+		}))
 		fmt.Println()
 	}
 	return nil
+}
+
+func resolveTeamTrustMode(t team.Team, requested string, explicit bool) (string, error) {
+	if explicit {
+		return normalizeTrustMode(requested)
+	}
+	if strings.TrimSpace(t.Trust) != "" {
+		return normalizeTrustMode(t.Trust)
+	}
+	return trustModeSandboxed, nil
+}
+
+func memberEffectiveModel(m team.Member, overrides map[string]string) string {
+	if v, ok := overrides[strings.ToLower(m.Role)]; ok {
+		return strings.TrimSpace(v)
+	}
+	return strings.TrimSpace(m.Model)
+}
+
+// validateModelOverrideKeys rejects --model role=model entries whose role is
+// not one of the known roles. Silent drops on typos are a DX trap; an error
+// makes the mistake visible.
+func validateModelOverrideKeys(overrides map[string]string, known map[string]bool) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+	var unknown []string
+	for k := range overrides {
+		if !known[strings.ToLower(strings.TrimSpace(k))] {
+			unknown = append(unknown, k)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("--model has unknown role(s): %s", strings.Join(unknown, ", "))
+}
+
+func lowercaseKeys(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[strings.ToLower(strings.TrimSpace(k))] = v
+	}
+	return out
 }
 
 func orderedTeamMembers(members []team.Member) []team.Member {
@@ -341,24 +518,49 @@ func uniqueMemberCWDs(projectDir string, members []team.Member) []string {
 	return out
 }
 
-func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap bool, workstream string, binaryArgs map[string][]string) string {
+type emitTeamCommandInput struct {
+	CWD            string
+	SquadBin       string
+	TeamHome       string
+	Member         team.Member
+	NoBootstrap    bool
+	Workstream     string
+	BinaryArgs     map[string][]string
+	TrustMode      string
+	Model          string
+	ForceDuplicate bool
+}
+
+func emitTeamCommand(in emitTeamCommandInput) string {
+	m := in.Member
 	var b strings.Builder
 	b.WriteString("cd ")
-	b.WriteString(shellQuote(cwd))
+	b.WriteString(shellQuote(in.CWD))
 	b.WriteString(" && ")
-	b.WriteString(shellQuote(squadBin))
+	b.WriteString(shellQuote(in.SquadBin))
 	b.WriteString(" launch")
 	b.WriteString(" --role ")
 	b.WriteString(shellQuote(m.Role))
 	b.WriteString(" --session ")
-	b.WriteString(shellQuote(workstream))
+	b.WriteString(shellQuote(in.Workstream))
 	b.WriteString(" --team-workstream")
-	if teamHome != "" {
-		b.WriteString(" --team-home ")
-		b.WriteString(shellQuote(teamHome))
+	if in.TrustMode != "" {
+		b.WriteString(" --trust ")
+		b.WriteString(shellQuote(in.TrustMode))
 	}
-	if noBootstrap {
+	if in.Model != "" {
+		b.WriteString(" --model ")
+		b.WriteString(shellQuote(in.Model))
+	}
+	if in.TeamHome != "" {
+		b.WriteString(" --team-home ")
+		b.WriteString(shellQuote(in.TeamHome))
+	}
+	if in.NoBootstrap {
 		b.WriteString(" --no-bootstrap")
+	}
+	if in.ForceDuplicate {
+		b.WriteString(" --force-duplicate")
 	}
 	if m.Handle != "" {
 		// Always explicit: a role-named handle avoids collisions when the
@@ -366,7 +568,7 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 		b.WriteString(" --me ")
 		b.WriteString(shellQuote(m.Handle))
 	}
-	extraDefaultArgs := binaryArgsFor(m.Binary, binaryArgs)
+	extraDefaultArgs := binaryArgsFor(m.Binary, in.BinaryArgs)
 	if len(extraDefaultArgs) > 0 {
 		switch normalizedAgentBinary(m.Binary) {
 		case "codex":
@@ -379,7 +581,8 @@ func emitTeamCommand(cwd, squadBin, teamHome string, m team.Member, noBootstrap 
 	}
 	b.WriteString(" ")
 	b.WriteString(shellQuote(m.Binary))
-	if defaultArgs := launchDefaultChildArgs(m.Binary, true, extraDefaultArgs); len(defaultArgs) > 0 {
+	modelArgs := modelArgsForBinary(m.Binary, in.Model)
+	if defaultArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, extraDefaultArgs, in.TrustMode); len(defaultArgs) > 0 {
 		b.WriteString(" --")
 		for _, arg := range defaultArgs {
 			b.WriteString(" ")
@@ -404,6 +607,83 @@ func promptPersonaSelection(reader *bufio.Reader, out io.Writer) ([]string, erro
 		return nil, fmt.Errorf("read selection: %w", err)
 	}
 	return parsePersonaSelection(line)
+}
+
+// promptModelSelection asks the user for per-role model overrides. Empty
+// input keeps current overrides untouched. Existing values from --model are
+// preserved and may be augmented.
+func promptModelSelection(reader *bufio.Reader, out io.Writer, overrides map[string]string) error {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Model overrides?")
+	fmt.Fprintln(out, "  Press Enter to keep binary defaults.")
+	fmt.Fprintln(out, "  Example: cto=gpt-5,fullstack=sonnet")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "> ")
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("read model overrides: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+	parsed, err := parseKV(line)
+	if err != nil {
+		return fmt.Errorf("parse model overrides: %w", err)
+	}
+	for k, v := range parsed {
+		overrides[strings.ToLower(k)] = strings.TrimSpace(v)
+	}
+	return nil
+}
+
+// promptWorkstreamSelection asks for the AMQ workstream session name with
+// the project default offered as Enter-to-accept. The chosen value is
+// validated to AMQ session naming rules.
+func promptWorkstreamSelection(reader *bufio.Reader, out io.Writer, defaultName string) (string, error) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Workstream / AMQ session?")
+	fmt.Fprintln(out, "  lowercase a-z, 0-9, -, _ only.")
+	fmt.Fprintf(out, "  Press Enter to use %q.\n", defaultName)
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "> ")
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("read workstream: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return defaultName, nil
+	}
+	if err := team.ValidateSessionName(line); err != nil {
+		return "", err
+	}
+	return line, nil
+}
+
+// promptTrustSelection asks for the Codex trust profile. Default is the
+// current trust mode (sandboxed). Returns the selected normalized trust mode.
+func promptTrustSelection(reader *bufio.Reader, out io.Writer, current string) (string, error) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Codex trust profile?")
+	fmt.Fprintln(out, "  sandboxed (recommended) - Codex prompts for approvals/sandbox")
+	fmt.Fprintln(out, "  trusted   (local power) - prepends --dangerously-bypass-approvals-and-sandbox")
+	fmt.Fprintf(out, "  Press Enter for %s.\n", current)
+	fmt.Fprintln(out)
+	fmt.Fprint(out, "> ")
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("read trust profile: %w", err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return current, nil
+	}
+	mode, err := normalizeTrustMode(strings.ToLower(line))
+	if err != nil {
+		return "", err
+	}
+	return mode, nil
 }
 
 func promptBinarySelection(reader *bufio.Reader, out io.Writer, personas []string, overrides map[string]string) error {
@@ -789,6 +1069,11 @@ Usage:
   amq-squad team show [--session name] [--fresh] [--no-bootstrap]
                                       Print launch commands for configured team
   amq-squad team launch [options]     Open the configured team in a terminal
+  amq-squad team resume [options]     Plan the safe path to bring the team back
+                                      after reboot/upgrade/terminal close.
+                                      Classifies each member as live/restore/
+                                      launch fresh/blocked and prints copy-
+                                      pasteable commands. Plan-only by default.
   amq-squad team rules init [--force] Seed or refresh team-rules.md
   amq-squad team sync [--apply]       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes)

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -23,6 +24,9 @@ type teamLaunchOptions struct {
 	DryRun          bool
 	SquadBin        string
 	BinaryArgs      map[string][]string
+	Trust           string
+	ModelOverrides  map[string]string
+	ForceDuplicate  bool
 }
 
 type teamLaunchPane struct {
@@ -63,8 +67,11 @@ func runTeamLaunch(args []string) error {
 	terminalSession := fs.String("terminal-session", "", "terminal session name when the backend creates one")
 	fresh := fs.Bool("fresh", false, "fail if the selected workstream session already exists")
 	noBootstrap := fs.Bool("no-bootstrap", false, "launch agents without the generated bootstrap prompt")
+	trustRaw := fs.String("trust", "", "Codex trust profile for this run: sandboxed or trusted")
+	modelFlag := fs.String("model", "", "per-persona model overrides for this run, e.g. cto=gpt-5,fullstack=sonnet")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'")
+	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent is detected for any member")
 	_ = fs.Bool("no-attach", false, "legacy no-op; new-session never attaches automatically")
 	stagger := fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes")
 	dryRun := fs.Bool("dry-run", false, "print terminal commands without executing them")
@@ -72,12 +79,18 @@ func runTeamLaunch(args []string) error {
 		fmt.Fprintf(os.Stderr, `amq-squad team launch - open the configured team in a terminal
 
 Usage:
-  amq-squad team launch [--session workstream] [--fresh] [--terminal tmux] [--target current-window|new-session] [--layout vertical|horizontal|tiled] [--terminal-session name] [--stagger 750ms] [--no-bootstrap] [--codex-args args] [--claude-args args] [--dry-run]
+  amq-squad team launch [--session workstream] [--fresh] [--terminal tmux]
+    [--target current-window|new-session] [--layout vertical|horizontal|tiled]
+    [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
+    [--trust sandboxed|trusted] [--model role=model,...]
+    [--codex-args args] [--claude-args args]
+    [--force-duplicate] [--dry-run]
 
 Supported terminal backends: %s
 
 tmux defaults to splitting the current tmux window. Use --target new-session
-to create a detached squad session.
+to create a detached squad session. The whole roster is preflighted for live
+duplicates before any tmux command runs; --force-duplicate overrides.
 `, strings.Join(registeredTeamLaunchTerminals(), ", "))
 	}
 	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
@@ -87,6 +100,15 @@ to create a detached squad session.
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	requestedTrust, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
+		return err
+	}
+	modelOverrides, err := parseKV(*modelFlag)
+	if err != nil {
+		return fmt.Errorf("parse --model: %w", err)
+	}
+	modelOverrides = lowercaseKeys(modelOverrides)
 	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
 	if err != nil {
 		return err
@@ -103,6 +125,9 @@ to create a detached squad session.
 		DryRun:          *dryRun,
 		SquadBin:        teamSquadBin(),
 		BinaryArgs:      binaryArgs,
+		Trust:           requestedTrust,
+		ModelOverrides:  modelOverrides,
+		ForceDuplicate:  *forceDuplicate,
 	}
 	backend, ok := teamLaunchBackends[opts.Terminal]
 	if !ok {
@@ -128,6 +153,26 @@ to create a detached squad session.
 		return err
 	}
 	opts.Workstream = workstream
+	trustMode, err := resolveTeamTrustMode(t, opts.Trust, flagWasSet(fs, "trust"))
+	if err != nil {
+		return err
+	}
+	opts.Trust = trustMode
+	// Apply the trust + binary-args contradiction check before opening any
+	// pane, so a misconfigured team never partially launches into runLaunch
+	// errors per pane.
+	mergedBinaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.BinaryArgs)
+	if err := validateTrustCombination(trustMode, flagWasSet(fs, "trust") || strings.TrimSpace(t.Trust) != "", false, mergedBinaryArgs); err != nil {
+		return err
+	}
+	// Reject --model role=model entries whose role is not on the team.
+	memberRoles := make(map[string]bool, len(t.Members))
+	for _, m := range t.Members {
+		memberRoles[strings.ToLower(m.Role)] = true
+	}
+	if err := validateModelOverrideKeys(opts.ModelOverrides, memberRoles); err != nil {
+		return err
+	}
 	if opts.Fresh {
 		exists, root, err := teamWorkstreamExists(t, opts.Workstream)
 		if err != nil {
@@ -138,10 +183,52 @@ to create a detached squad session.
 		}
 	}
 
+	// Preflight the whole roster before any tmux command (or dry-run output)
+	// so a partially-launched team never appears.
+	preflights, err := buildTeamPreflights(t, opts)
+	if err != nil {
+		return err
+	}
+	if err := preflightTeam(preflights, defaultDuplicateLaunchProbe); err != nil {
+		return err
+	}
+
 	if opts.DryRun {
 		return backend.DryRun(t, opts)
 	}
 	return backend.Launch(t, opts)
+}
+
+// buildTeamPreflights computes the agent-identity tuples team launch would
+// produce so preflightTeam can refuse before any pane is created. dryRun
+// passes through to each preflight so a --dry-run team launch never mutates
+// disk state during stale-artifact handling.
+func buildTeamPreflights(t team.Team, opts teamLaunchOptions) ([]agentLaunchPreflight, error) {
+	members := orderedTeamMembers(t.Members)
+	out := make([]agentLaunchPreflight, 0, len(members))
+	for _, m := range members {
+		cwd := m.EffectiveCWD(t.Project)
+		env, err := resolveAMQEnvInDir(cwd, "", opts.Workstream, m.Handle)
+		if err != nil {
+			return nil, fmt.Errorf("resolve amq env for %s: %w", m.Handle, err)
+		}
+		root := env.Root
+		handle := m.Handle
+		if env.Me != "" {
+			handle = env.Me
+		}
+		agentDir := filepath.Join(root, "agents", handle)
+		out = append(out, agentLaunchPreflight{
+			AgentDir:   agentDir,
+			Handle:     handle,
+			Workstream: env.SessionName,
+			Root:       root,
+			Binary:     m.Binary,
+			Force:      opts.ForceDuplicate,
+			DryRun:     opts.DryRun,
+		})
+	}
+	return out, nil
 }
 
 func registeredTeamLaunchTerminals() []string {
@@ -153,16 +240,27 @@ func registeredTeamLaunchTerminals() []string {
 	return names
 }
 
-func buildTeamLaunchPanes(t team.Team, squadBin string, noBootstrap bool, workstream string, extraBinaryArgs map[string][]string) []teamLaunchPane {
+func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane {
 	members := orderedTeamMembers(t.Members)
-	binaryArgs := mergeBinaryArgs(t.BinaryArgs, extraBinaryArgs)
+	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.BinaryArgs)
 	panes := make([]teamLaunchPane, 0, len(members))
 	for _, m := range members {
 		cwd := m.EffectiveCWD(t.Project)
 		panes = append(panes, teamLaunchPane{
-			Role:    m.Role,
-			CWD:     cwd,
-			Command: emitTeamCommand(cwd, squadBin, t.Project, m, noBootstrap, workstream, binaryArgs),
+			Role: m.Role,
+			CWD:  cwd,
+			Command: emitTeamCommand(emitTeamCommandInput{
+				CWD:            cwd,
+				SquadBin:       opts.SquadBin,
+				TeamHome:       t.Project,
+				Member:         m,
+				NoBootstrap:    opts.NoBootstrap,
+				Workstream:     opts.Workstream,
+				BinaryArgs:     binaryArgs,
+				TrustMode:      opts.Trust,
+				Model:          memberEffectiveModel(m, opts.ModelOverrides),
+				ForceDuplicate: opts.ForceDuplicate,
+			}),
 		})
 	}
 	return panes

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -18,7 +18,15 @@ func TestBuildTmuxLaunchPlanUsesCatalogOrderAndLaunchCommands(t *testing.T) {
 			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
 		},
 	}
-	plan := buildTmuxLaunchPlan(tm, "/bin/amq-squad", "amq-squad-repo", "new-session", "vertical", false, 750*time.Millisecond, "repo", nil)
+	plan := buildTmuxLaunchPlan(tm, teamLaunchOptions{
+		SquadBin:        "/bin/amq-squad",
+		TerminalSession: "amq-squad-repo",
+		Target:          "new-session",
+		Layout:          "vertical",
+		Stagger:         750 * time.Millisecond,
+		Workstream:      "repo",
+		Trust:           trustModeTrusted,
+	})
 	if plan.Session != "amq-squad-repo" {
 		t.Fatalf("Session = %q", plan.Session)
 	}
@@ -37,6 +45,20 @@ func TestBuildTmuxLaunchPlanUsesCatalogOrderAndLaunchCommands(t *testing.T) {
 	} {
 		if !strings.Contains(plan.Panes[0].Command, want) {
 			t.Errorf("cto command missing %q in %s", want, plan.Panes[0].Command)
+		}
+	}
+}
+
+func TestRunTeamLaunchHelpListsNewDXFlags(t *testing.T) {
+	_, stderr, err := captureOutput(t, func() error {
+		return runTeamLaunch([]string{"--help"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamLaunch --help: %v", err)
+	}
+	for _, want := range []string{"--trust", "--model", "--force-duplicate"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("team launch --help missing %q in:\n%s", want, stderr)
 		}
 	}
 }
@@ -155,7 +177,7 @@ func TestRunTeamLaunchDryRunDefaultsToCurrentWindow(t *testing.T) {
 		"tmux split-window",
 		" -h -c ",
 		"tmux select-layout -t \"$window\" even-horizontal",
-		"--no-bootstrap --me cto codex -- --dangerously-bypass-approvals-and-sandbox",
+		"--no-bootstrap --me cto codex",
 		"--no-bootstrap --me fullstack claude -- --permission-mode auto",
 		"--session ",
 		"# using current tmux window; no attach needed",
@@ -200,7 +222,7 @@ func TestRunTeamLaunchDryRunUsesExplicitSharedWorkstream(t *testing.T) {
 	}
 	for _, want := range []string{
 		"# workstream: issue-96",
-		"--session issue-96 --team-workstream --team-home",
+		"--session issue-96 --team-workstream",
 		"--no-bootstrap --me cto codex",
 		"--no-bootstrap --me fullstack claude",
 	} {
@@ -237,7 +259,7 @@ func TestRunTeamLaunchDryRunUsesBinaryArgs(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--dry-run", "--no-bootstrap", "--codex-args=--enable goals", "--claude-args=--chrome"})
+		return runTeamLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "trusted", "--codex-args=--enable goals", "--claude-args=--chrome"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -65,21 +65,20 @@ func (b tmuxTeamLaunchBackend) Launch(t team.Team, opts teamLaunchOptions) error
 }
 
 func (tmuxTeamLaunchBackend) buildPlan(t team.Team, opts teamLaunchOptions) tmuxLaunchPlan {
-	session := opts.TerminalSession
-	if session == "" {
-		session = defaultTmuxSessionName(t.Project)
+	if opts.TerminalSession == "" {
+		opts.TerminalSession = defaultTmuxSessionName(t.Project)
 	}
-	return buildTmuxLaunchPlan(t, opts.SquadBin, session, opts.Target, opts.Layout, opts.NoBootstrap, opts.Stagger, opts.Workstream, opts.BinaryArgs)
+	return buildTmuxLaunchPlan(t, opts)
 }
 
-func buildTmuxLaunchPlan(t team.Team, squadBin, sessionName, target, layout string, noBootstrap bool, startDelay time.Duration, workstream string, extraBinaryArgs map[string][]string) tmuxLaunchPlan {
+func buildTmuxLaunchPlan(t team.Team, opts teamLaunchOptions) tmuxLaunchPlan {
 	return tmuxLaunchPlan{
-		Session:    sessionName,
-		Workstream: workstream,
-		Target:     target,
-		Layout:     layout,
-		Panes:      buildTeamLaunchPanes(t, squadBin, noBootstrap, workstream, extraBinaryArgs),
-		StartDelay: startDelay,
+		Session:    opts.TerminalSession,
+		Workstream: opts.Workstream,
+		Target:     opts.Target,
+		Layout:     opts.Layout,
+		Panes:      buildTeamLaunchPanes(t, opts),
+		StartDelay: opts.Stagger,
 	}
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -1,0 +1,538 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+// resumeAction labels what `team resume` would do for one member.
+type resumeAction string
+
+const (
+	resumeLive    resumeAction = "live"
+	resumeRestore resumeAction = "restore"
+	resumeFresh   resumeAction = "launch fresh"
+	resumeBlocked resumeAction = "blocked"
+)
+
+type resumeMode string
+
+const (
+	resumeModeDefault         resumeMode = "default"
+	resumeModeRestoreExisting resumeMode = "restore-existing"
+	resumeModeFresh           resumeMode = "fresh"
+)
+
+// resumePlan is the per-member output row.
+type resumePlan struct {
+	Role    string
+	Action  resumeAction
+	Wake    string
+	Note    string
+	Command string
+	// HasRestoreRecord is true when a launch record matched this member's
+	// (cwd, role, handle, workstream). Tracked separately from Action so
+	// --restore-existing can verify record existence even when the final
+	// action came out as live.
+	HasRestoreRecord bool
+}
+
+func runTeamResume(args []string) error {
+	fs := flag.NewFlagSet("team resume", flag.ContinueOnError)
+	sessionFlag := fs.String("session", "", "AMQ workstream session name to resume into (defaults to the team workstream)")
+	restoreExisting := fs.Bool("restore-existing", false, "fail if no team member has restorable launch records for the workstream")
+	fresh := fs.Bool("fresh", false, "ignore restore history; plan every member from team.json (use with --session for a new workstream)")
+	dryRun := fs.Bool("dry-run", false, "plan-only; default behavior is already plan-only and exists for parity with other commands")
+	forceDuplicate := fs.Bool("force-duplicate", false, "include commands even when a live agent is detected for a member")
+	noBootstrap := fs.Bool("no-bootstrap", false, "emit fresh launch commands that skip the generated bootstrap prompt")
+	trustRaw := fs.String("trust", "", "Codex trust profile for fresh members: sandboxed (default) or trusted")
+	modelFlag := fs.String("model", "", "per-persona model overrides for fresh members, e.g. cto=gpt-5,fullstack=sonnet")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for fresh members, e.g. '--enable goals'")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad team resume - plan how to bring the team back
+
+Usage:
+  amq-squad team resume [--session name] [--fresh] [--restore-existing]
+                        [--dry-run] [--force-duplicate]
+                        [--no-bootstrap] [--trust sandboxed|trusted]
+                        [--model role=model,...]
+                        [--codex-args args] [--claude-args args]
+
+Inspects .amq-squad/team.json plus local launch history and live-agent
+signals (wake locks, agent PID liveness, presence) to print a per-member
+plan plus copy-pasteable commands.
+
+Per-member action labels:
+  live          Matching agent appears live; command suppressed unless
+                --force-duplicate is set.
+  restore       Restorable launch.json exists for this workstream; emits
+                'amq-squad launch ...' that replays the saved record.
+  launch fresh  No matching launch history; emits the same command shape
+                'amq-squad team launch' would use for this member.
+  blocked       Live signals present but no clear safe action; user must
+                pick --force-duplicate or narrow the workstream.
+
+Modes:
+  default              Prefer restore for the workstream; fall back to
+                       team intent for missing members.
+  --restore-existing   Same as default, but error when no member has a
+                       restorable record for the workstream.
+  --fresh --session X  Ignore restore; plan every member from team.json.
+                       Refuses if X already has live state unless
+                       --force-duplicate is set.
+
+team resume is plan-only. Run the printed commands in their own panes, or
+use 'amq-squad team launch' to open them in tmux from team intent.
+`)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	trustMode, err := normalizeTrustMode(*trustRaw)
+	if err != nil {
+		return err
+	}
+	modelOverrides, err := parseKV(*modelFlag)
+	if err != nil {
+		return fmt.Errorf("parse --model: %w", err)
+	}
+	modelOverrides = lowercaseKeys(modelOverrides)
+	binaryArgs, err := parseBinaryArgFlags(*codexArgsRaw, *claudeArgsRaw)
+	if err != nil {
+		return err
+	}
+
+	if *restoreExisting && *fresh {
+		return usageErrorf("--restore-existing and --fresh are mutually exclusive")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	if !team.Exists(cwd) {
+		return fmt.Errorf("no team configured. Run 'amq-squad team init' first.")
+	}
+	t, err := team.Read(cwd)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	if len(t.Members) == 0 {
+		return fmt.Errorf("team has no members")
+	}
+	workstream, err := resolveTeamWorkstreamName(t, *sessionFlag, flagWasSet(fs, "session"))
+	if err != nil {
+		return err
+	}
+	mergedBinaryArgs := mergeBinaryArgs(t.BinaryArgs, binaryArgs)
+	resolvedTrust, err := resolveTeamTrustMode(t, trustMode, flagWasSet(fs, "trust"))
+	if err != nil {
+		return err
+	}
+	if err := validateTrustCombination(resolvedTrust, flagWasSet(fs, "trust") || strings.TrimSpace(t.Trust) != "", false, mergedBinaryArgs); err != nil {
+		return err
+	}
+	memberRoles := make(map[string]bool, len(t.Members))
+	for _, m := range t.Members {
+		memberRoles[strings.ToLower(m.Role)] = true
+	}
+	if err := validateModelOverrideKeys(modelOverrides, memberRoles); err != nil {
+		return err
+	}
+
+	mode := resumeModeDefault
+	if *fresh {
+		mode = resumeModeFresh
+	} else if *restoreExisting {
+		mode = resumeModeRestoreExisting
+	}
+
+	force := *forceDuplicate
+	squadBin := teamSquadBin()
+	plans := make([]resumePlan, 0, len(t.Members))
+	recordCount := 0
+	for _, m := range orderedTeamMembers(t.Members) {
+		plan, err := planMemberResume(memberPlanInput{
+			Member:         m,
+			Team:           t,
+			Workstream:     workstream,
+			Mode:           mode,
+			Force:          force,
+			NoBootstrap:    *noBootstrap,
+			SquadBin:       squadBin,
+			BinaryArgs:     mergedBinaryArgs,
+			Trust:          resolvedTrust,
+			ModelOverrides: modelOverrides,
+		})
+		if err != nil {
+			return err
+		}
+		if plan.HasRestoreRecord {
+			recordCount++
+		}
+		plans = append(plans, plan)
+	}
+
+	// --restore-existing checks that restorable records EXIST for the
+	// workstream, independent of whether the final action is restore.
+	// Members that match a record but are currently live still satisfy
+	// the contract: the records are present and would replay if the live
+	// instance went away.
+	if mode == resumeModeRestoreExisting && recordCount == 0 {
+		return fmt.Errorf("--restore-existing: no team members have restorable launch records for workstream %q", workstream)
+	}
+
+	// --fresh into an existing workstream must refuse unless explicitly
+	// forced. A workstream is "existing" if either (a) at least one
+	// member has a matching restorable record, or (b) the workstream's
+	// AMQ root already contains mailbox state. Both shapes can be
+	// silently overwritten by emitting fresh launches; the second
+	// matches `team launch --fresh` semantics for parity.
+	if mode == resumeModeFresh && !force {
+		if recordCount > 0 {
+			return fmt.Errorf("--fresh --session %q: %d member(s) already have launch records for this workstream; rerun with --force-duplicate to overwrite", workstream, recordCount)
+		}
+		exists, root, err := teamWorkstreamExists(t, workstream)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("--fresh --session %q: workstream root %s already exists; rerun with --force-duplicate to reuse", workstream, root)
+		}
+	}
+
+	printResumePlan(t, workstream, mode, plans, *dryRun, force)
+	return nil
+}
+
+type memberPlanInput struct {
+	Member         team.Member
+	Team           team.Team
+	Workstream     string
+	Mode           resumeMode
+	Force          bool
+	NoBootstrap    bool
+	SquadBin       string
+	BinaryArgs     map[string][]string
+	Trust          string
+	ModelOverrides map[string]string
+}
+
+// planMemberResume classifies one team member and emits the appropriate
+// command. Disk state is never mutated: preflight runs in DryRun mode and
+// stale lock cleanup is deferred to the real launch path.
+func planMemberResume(in memberPlanInput) (resumePlan, error) {
+	m := in.Member
+	cwd := m.EffectiveCWD(in.Team.Project)
+	plan := resumePlan{Role: m.Role, Wake: "-"}
+
+	// Resolve the AMQ env per-member so multi-cwd teams work.
+	env, err := resolveAMQEnvInDir(cwd, "", in.Workstream, m.Handle)
+	if err != nil {
+		// Without the AMQ env we cannot inspect restore history, wake
+		// locks, presence, or duplicate risk. A safety-oriented planner
+		// must classify this as blocked, not silently emit fresh.
+		plan.Action = resumeBlocked
+		plan.Note = fmt.Sprintf("amq env unavailable: %v", err)
+		if in.Force {
+			plan.Action = resumeFresh
+			plan.Note = "force-duplicate: " + plan.Note
+			plan.Command = freshLaunchCommand(in)
+		}
+		return plan, nil
+	}
+	root := env.Root
+	handle := m.Handle
+	if env.Me != "" {
+		handle = env.Me
+	}
+	agentDir := filepath.Join(root, "agents", handle)
+
+	// Find a restorable launch record for this member in this workstream
+	// and current cwd. Without the cwd anchor a sibling repo with the
+	// same role/handle/session would let team resume emit the wrong
+	// repo's restore command.
+	rec, recFound := findMemberRestoreRecord(env.BaseRoot, in.Team.Project, cwd, env.SessionName, m.Role, handle)
+	plan.HasRestoreRecord = recFound
+	wakeLabel := wakeHealthForMember(agentDir, root, handle, rec, recFound)
+	plan.Wake = wakeLabel
+
+	// Run preflight in dry-run mode for live-signal classification.
+	pf := agentLaunchPreflight{
+		AgentDir:   agentDir,
+		Handle:     handle,
+		Workstream: env.SessionName,
+		Root:       root,
+		Binary:     m.Binary,
+		Force:      false,
+		DryRun:     true,
+	}
+	blocker, perr := pf.check(defaultDuplicateLaunchProbe)
+	if perr != nil {
+		// I/O error reading state: treat as blocked unless forced.
+		plan.Action = resumeBlocked
+		plan.Note = fmt.Sprintf("preflight error: %v", perr)
+		if in.Force {
+			plan.Action = resumeRestore
+			if !recFound || in.Mode == resumeModeFresh {
+				plan.Action = resumeFresh
+				plan.Command = freshLaunchCommand(in)
+			} else {
+				// Forced restore on preflight error path: same reason
+				// to inject --force-duplicate as the live+forced path.
+				plan.Command = emitCommandWithOptions(rec, emitCommandOptions{Force: true})
+			}
+			plan.Note = "force-duplicate: " + plan.Note
+		}
+		return plan, nil
+	}
+
+	if blocker != nil {
+		// Live signal detected.
+		if in.Force {
+			plan.Action = resumeLive
+			plan.Note = "force-duplicate: " + summarizeBlocker(blocker)
+			if in.Mode == resumeModeFresh || !recFound {
+				plan.Command = freshLaunchCommand(in)
+			} else {
+				// Forced restore must carry --force-duplicate so the
+				// printed command bypasses launch-time preflight.
+				plan.Command = emitCommandWithOptions(rec, emitCommandOptions{Force: true})
+			}
+			return plan, nil
+		}
+		plan.Action = resumeLive
+		plan.Note = summarizeBlocker(blocker)
+		// Suppress the command by default.
+		plan.Command = ""
+		return plan, nil
+	}
+
+	// No live signal. Choose restore vs fresh based on mode + record presence.
+	if in.Mode == resumeModeFresh {
+		plan.Action = resumeFresh
+		plan.Command = freshLaunchCommand(in)
+		return plan, nil
+	}
+	if recFound {
+		plan.Action = resumeRestore
+		plan.Command = emitCommand(rec)
+		return plan, nil
+	}
+	plan.Action = resumeFresh
+	plan.Command = freshLaunchCommand(in)
+	return plan, nil
+}
+
+// findMemberRestoreRecord returns the most recent launch.Record for the
+// given (member project, member cwd, workstream, role, handle) tuple under
+// baseRoot. memberCWD anchors identity to the current team member's
+// project; records whose CWD does not resolve to the same path are
+// rejected so a sibling repo with the same role/handle/session cannot
+// leak its restore command into this team's plan. Records with empty
+// CWD (legacy AMQ-only inference) are accepted as fallback only when no
+// CWD-matching record exists.
+func findMemberRestoreRecord(baseRoot, projectDir, memberCWD, workstream, role, handle string) (launch.Record, bool) {
+	if baseRoot == "" {
+		return launch.Record{}, false
+	}
+	entries, err := launch.ScanRestorableEntriesInRoot(projectDir, baseRoot)
+	if err != nil {
+		return launch.Record{}, false
+	}
+	wantCWD := canonicalPath(memberCWD)
+	var bestExact, bestLegacy *launch.Entry
+	for i := range entries {
+		rec := entries[i].Record
+		if !matchesRestoreFilters(rec, role, handle, workstream, "") {
+			continue
+		}
+		recCWD := canonicalPath(rec.CWD)
+		switch {
+		case recCWD != "" && recCWD == wantCWD:
+			if bestExact == nil || rec.StartedAt.After(bestExact.Record.StartedAt) {
+				bestExact = &entries[i]
+			}
+		case recCWD == "":
+			if bestLegacy == nil || rec.StartedAt.After(bestLegacy.Record.StartedAt) {
+				bestLegacy = &entries[i]
+			}
+		}
+	}
+	if bestExact != nil {
+		return bestExact.Record, true
+	}
+	if bestLegacy != nil {
+		return bestLegacy.Record, true
+	}
+	return launch.Record{}, false
+}
+
+// canonicalPath returns a normalized absolute path or "" when input is
+// empty. Symlink resolution is best effort: when EvalSymlinks fails (e.g.
+// the path no longer exists) the absolute clean form is returned.
+func canonicalPath(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
+// wakeHealthForMember returns the wake-health label for a member, using
+// the same wake-process matcher as v0.6 preflight so PID reuse by an
+// unrelated process never surfaces as pid:N. expectedRoot is the AMQ root
+// the member targets; it is used (along with the lock's recorded root)
+// to verify the live PID is actually an `amq wake` for this workstream.
+func wakeHealthForMember(agentDir, expectedRoot, handle string, rec launch.Record, recFound bool) string {
+	if recFound {
+		entry := launch.Entry{Record: rec, AgentDir: agentDir}
+		if label := wakeHealthForEntry(entry, defaultDuplicateLaunchProbe); label != "" {
+			return label
+		}
+	}
+	lockPath := wakeLockPath(agentDir)
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return "-"
+	}
+	var lock wakeLockFile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return "stale"
+	}
+	if lock.PID <= 0 || !defaultDuplicateLaunchProbe.PIDAlive(lock.PID) {
+		return "stale"
+	}
+	probeRoot := expectedRoot
+	if lock.Root != "" {
+		probeRoot = lock.Root
+	}
+	if !defaultDuplicateLaunchProbe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, probeRoot)) {
+		// PID reuse by an unrelated process or a foreign-root wake.
+		return "stale"
+	}
+	return fmt.Sprintf("pid:%d", lock.PID)
+}
+
+// summarizeBlocker compresses a duplicateBlocker into a one-line note.
+func summarizeBlocker(b *duplicateBlocker) string {
+	if b == nil || len(b.Reasons) == 0 {
+		return "live"
+	}
+	parts := make([]string, 0, len(b.Reasons))
+	for _, r := range b.Reasons {
+		parts = append(parts, r.Source)
+	}
+	return strings.Join(parts, "+")
+}
+
+// freshLaunchCommand emits the same command shape `team launch` would use
+// for this member, so trust/model/binary-args behavior matches.
+func freshLaunchCommand(in memberPlanInput) string {
+	cwd := in.Member.EffectiveCWD(in.Team.Project)
+	return emitTeamCommand(emitTeamCommandInput{
+		CWD:            cwd,
+		SquadBin:       in.SquadBin,
+		TeamHome:       in.Team.Project,
+		Member:         in.Member,
+		NoBootstrap:    in.NoBootstrap,
+		Workstream:     in.Workstream,
+		BinaryArgs:     in.BinaryArgs,
+		TrustMode:      in.Trust,
+		Model:          memberEffectiveModel(in.Member, in.ModelOverrides),
+		ForceDuplicate: in.Force,
+	})
+}
+
+func printResumePlan(t team.Team, workstream string, mode resumeMode, plans []resumePlan, dryRun, force bool) {
+	fmt.Println("# amq-squad team resume")
+	fmt.Println("#")
+	fmt.Printf("# team-home:  %s\n", t.Project)
+	fmt.Printf("# workstream: %s\n", workstream)
+	fmt.Printf("# mode:       %s\n", describeResumeMode(mode, dryRun))
+	fmt.Printf("# members:    %d\n", len(plans))
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ROLE\tACTION\tWAKE\tNOTE")
+	for _, p := range plans {
+		note := p.Note
+		if note == "" {
+			note = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Role, p.Action, p.Wake, note)
+	}
+	w.Flush()
+	fmt.Println()
+
+	for _, p := range plans {
+		if p.Command == "" {
+			fmt.Printf("# %s (%s) - no command (use --force-duplicate to override)\n", p.Role, p.Action)
+			continue
+		}
+		fmt.Printf("# %s (%s)\n", p.Role, p.Action)
+		fmt.Println(p.Command)
+		fmt.Println()
+	}
+
+	// The team-launch alternative replays from team intent (always fresh
+	// commands), not from the restore records the per-member plan may
+	// have used. The footer is only equivalent when every row is a
+	// fresh-from-team-intent row with a real command. Anything else --
+	// restore, live (including live+forced+recorded which emits a
+	// restore command), blocked, or suppressed -- means the footer would
+	// not reproduce the per-member plan, so suppress it conservatively.
+	allFresh := true
+	for _, p := range plans {
+		if p.Action != resumeFresh || p.Command == "" {
+			allFresh = false
+			break
+		}
+	}
+	if !allFresh {
+		fmt.Println("# Note: 'team launch' would re-emit fresh commands from team intent,")
+		fmt.Println("# which is not equivalent to the per-member plan above.")
+		return
+	}
+	fmt.Println("# Alternative: open the whole team in tmux from team intent")
+	suffix := ""
+	if force {
+		suffix = " --force-duplicate"
+	}
+	if mode == resumeModeFresh {
+		fmt.Printf("# %s team launch --fresh --session %s%s\n", filepath.Base(teamSquadBin()), shellQuote(workstream), suffix)
+	} else {
+		fmt.Printf("# %s team launch --session %s%s\n", filepath.Base(teamSquadBin()), shellQuote(workstream), suffix)
+	}
+}
+
+func describeResumeMode(mode resumeMode, dryRun bool) string {
+	suffix := ""
+	if dryRun {
+		suffix = " (--dry-run; plan-only)"
+	}
+	switch mode {
+	case resumeModeFresh:
+		return "fresh" + suffix
+	case resumeModeRestoreExisting:
+		return "restore-existing (require restorable records)" + suffix
+	default:
+		return "default (prefer restore, fall back to team intent)" + suffix
+	}
+}

--- a/internal/cli/team_resume_test.go
+++ b/internal/cli/team_resume_test.go
@@ -1,0 +1,716 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+// writeMemberLaunchRecord drops a v0.6 launch.json under the fake AMQ base
+// for the given session/handle so the resume planner can find it.
+func writeMemberLaunchRecord(t *testing.T, base, session, handle string, rec launch.Record) {
+	t.Helper()
+	agentDir := filepath.Join(base, session, "agents", handle)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec.Handle = handle
+	rec.Session = session
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatalf("write launch record: %v", err)
+	}
+}
+
+func resumeChdir(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+}
+
+func TestRunTeamResumeNoTeamConfigErrors(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	_, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err == nil {
+		t.Fatal("resume without team.json should fail")
+	}
+	if !strings.Contains(err.Error(), "no team configured") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunTeamResumeAllRestoreClassifiesEveryMember(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", Argv: nil,
+		StartedAt: time.Now(),
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "fullstack", launch.Record{
+		CWD: dir, Binary: "claude", Role: "fullstack",
+		Argv:      []string{"--permission-mode", "auto"},
+		StartedAt: time.Now(),
+	})
+
+	stdout, stderr, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"# amq-squad team resume",
+		"# workstream: issue-96",
+		"cto",
+		"fullstack",
+		"restore",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q in:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "launch fresh") {
+		t.Errorf("all-restore plan should not contain 'launch fresh':\n%s", stdout)
+	}
+}
+
+func TestRunTeamResumeAllFreshWhenNoRecords(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "launch fresh") {
+		t.Errorf("no-record team should plan launch fresh:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "  restore  ") || strings.Contains(stdout, "\trestore\t") {
+		t.Errorf("no-record team should not surface restore action:\n%s", stdout)
+	}
+}
+
+func TestRunTeamResumeMixedTeam(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	stdout, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v", err)
+	}
+	if !strings.Contains(stdout, "restore") {
+		t.Errorf("mixed team should mark cto as restore:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "launch fresh") {
+		t.Errorf("mixed team should mark fullstack as launch fresh:\n%s", stdout)
+	}
+}
+
+func TestRunTeamResumeLiveMemberSuppressesCommand(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Plant a wake.lock with our own PID so PIDAlive returns true and the
+	// process command matches the wake matcher.
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	myPID := os.Getpid()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: myPID, Root: filepath.Join(base, "issue-96")})
+
+	// Substitute the probe so we don't depend on ps args matching.
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == myPID },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto --root " + filepath.Join(base, "issue-96"))
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	stdout, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v", err)
+	}
+	if !strings.Contains(stdout, "live") {
+		t.Errorf("live wake should mark member as live:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "no command") {
+		t.Errorf("live member should suppress its launch command:\n%s", stdout)
+	}
+	// Lock must remain on disk: planning is non-mutating.
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Errorf("resume must not remove the live wake lock: %v", err)
+	}
+}
+
+func TestRunTeamResumeFreshIgnoresRestoreRecords(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--fresh", "--session", "issue-97"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamResume --fresh: %v", err)
+	}
+	if !strings.Contains(stdout, "launch fresh") {
+		t.Errorf("--fresh should plan launch fresh, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "restore") {
+		// The 'restore' substring will appear in the printed --restore-existing
+		// help text or other parts; check that the action column does not say
+		// restore. The action column is between two tabs in the planning row.
+		if strings.Contains(stdout, "\trestore\t") {
+			t.Errorf("--fresh should not classify member as restore:\n%s", stdout)
+		}
+	}
+}
+
+func TestRunTeamResumeRestoreExistingRequiresRecords(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--restore-existing"})
+	})
+	if err == nil {
+		t.Fatal("--restore-existing without records should error")
+	}
+	if !strings.Contains(err.Error(), "restorable") {
+		t.Fatalf("error should mention restorable: %v", err)
+	}
+}
+
+// Regression for #27 P1: a sibling repo with the same role/handle/session
+// must not leak its restore command into this team's plan. The newer foreign
+// record must be ignored in favor of the cwd-matching one (or fall through
+// to launch fresh when no cwd-matching record exists).
+func TestRunTeamResumeIgnoresForeignRepoRecordWithSameRoleHandleSession(t *testing.T) {
+	dir := t.TempDir()
+	foreignDir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Older record from THIS repo.
+	older := time.Now().Add(-1 * time.Hour)
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: older,
+	})
+	// Newer record from a foreign repo, same role/handle/session. Even
+	// though it is the most recent, planMemberResume must reject it on
+	// cwd grounds and fall back to the cwd-matching older record.
+	foreignAgentDir := filepath.Join(base, "issue-96", "agents", "cto-foreign")
+	if err := os.MkdirAll(foreignAgentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(foreignAgentDir, launch.Record{
+		CWD: foreignDir, Binary: "codex", Role: "cto", Handle: "cto", Session: "issue-96",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v", err)
+	}
+	if !strings.Contains(stdout, dir) {
+		t.Errorf("plan should reference current cwd %q, got:\n%s", dir, stdout)
+	}
+	if strings.Contains(stdout, foreignDir) {
+		t.Errorf("plan must not reference foreign cwd %q, got:\n%s", foreignDir, stdout)
+	}
+}
+
+// Regression for #27 P2: when no launch record exists, the wake-health
+// fallback must not report pid:N for a stale lock whose PID was reused by
+// an unrelated process.
+func TestWakeHealthForMemberRejectsForeignPIDReuse(t *testing.T) {
+	agentDir := t.TempDir()
+	expectedRoot := "/abs/proj/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4321, Root: expectedRoot})
+
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == 4321 },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			// Unrelated process: a node script that happens to have pid 4321.
+			return predicate("/usr/local/bin/node /path/to/some/server.js")
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	got := wakeHealthForMember(agentDir, expectedRoot, "cto", launch.Record{}, false)
+	if got != "stale" {
+		t.Errorf("PID-reused lock with unrelated command must classify as stale, got %q", got)
+	}
+}
+
+// Regression for #27 P2 (continued): a foreign-root wake (real `amq wake`
+// process but wrong workstream) must also classify as stale.
+func TestWakeHealthForMemberRejectsForeignRootWake(t *testing.T) {
+	agentDir := t.TempDir()
+	expectedRoot := "/abs/proj/.agent-mail/issue-96"
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 7777, Root: expectedRoot})
+
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == 7777 },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto --root /other/proj/.agent-mail/issue-96")
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	got := wakeHealthForMember(agentDir, expectedRoot, "cto", launch.Record{}, false)
+	if got != "stale" {
+		t.Errorf("foreign-root wake must classify as stale, got %q", got)
+	}
+}
+
+// Regression for #27 P3: a member whose AMQ env cannot be resolved must
+// classify as blocked, not silently 'launch fresh'. We trigger env failure
+// by pointing PATH at an empty dir so 'amq env --json' is unfindable.
+func TestRunTeamResumeBlockedOnEnvFailure(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	stdout, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v", err)
+	}
+	if !strings.Contains(stdout, "blocked") {
+		t.Errorf("env failure should classify as blocked, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "\tlaunch fresh\t") {
+		t.Errorf("env failure must not silently classify as launch fresh:\n%s", stdout)
+	}
+}
+
+// Regression for #27 P1 (addendum): --fresh --session <existing> must
+// reject when the workstream already has restorable launch records, unless
+// --force-duplicate is set. Without this guard, fresh would silently
+// overwrite saved launch.json metadata.
+func TestRunTeamResumeFreshRejectsExistingWorkstreamUnlessForced(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	_, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--fresh", "--session", "issue-96"})
+	})
+	if err == nil {
+		t.Fatal("--fresh into existing workstream should error without --force-duplicate")
+	}
+	if !strings.Contains(err.Error(), "force-duplicate") {
+		t.Fatalf("error should mention --force-duplicate, got %v", err)
+	}
+
+	// With --force-duplicate, the same call should succeed and emit fresh.
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--fresh", "--session", "issue-96", "--force-duplicate"})
+	})
+	if err != nil {
+		t.Fatalf("--fresh --force-duplicate should succeed: %v", err)
+	}
+	if !strings.Contains(stdout, "launch fresh") {
+		t.Errorf("--fresh --force-duplicate should still classify as launch fresh, got:\n%s", stdout)
+	}
+}
+
+// Regression: --fresh --session <existing-root> must reject when the
+// workstream's AMQ root already contains mailbox state, even if no
+// member has a matching launch record. Matches `team launch --fresh`
+// semantics so a fresh resume cannot silently reuse mailbox dirs.
+func TestRunTeamResumeFreshRejectsExistingWorkstreamRootWithoutRecords(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the workstream root with mailbox state but NO matching
+	// launch.json so the recordCount guard alone would not trip.
+	if err := os.MkdirAll(filepath.Join(base, "issue-96", "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--fresh", "--session", "issue-96"})
+	})
+	if err == nil {
+		t.Fatal("--fresh into existing workstream root should error without --force-duplicate")
+	}
+	if !strings.Contains(err.Error(), "force-duplicate") {
+		t.Fatalf("error should mention --force-duplicate, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error should mention existing workstream root, got %v", err)
+	}
+
+	// With --force-duplicate, the same call must succeed.
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--fresh", "--session", "issue-96", "--force-duplicate"})
+	})
+	if err != nil {
+		t.Fatalf("--fresh --force-duplicate should succeed: %v", err)
+	}
+	if !strings.Contains(stdout, "launch fresh") {
+		t.Errorf("forced resume should still classify member as launch fresh:\n%s", stdout)
+	}
+}
+
+// Regression for #27 P2 (addendum): --restore-existing must check for
+// restorable record existence, not whether the final action came out as
+// restore. A live member that matches a record still satisfies the
+// contract because the record exists and would replay if the live
+// instance went away.
+func TestRunTeamResumeRestoreExistingPassesWhenLiveMemberHasRecord(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	// Plant a live wake for this member so the final action is 'live',
+	// not 'restore'. The record still exists; --restore-existing must pass.
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	myPID := os.Getpid()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: myPID, Root: filepath.Join(base, "issue-96")})
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == myPID },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto --root " + filepath.Join(base, "issue-96"))
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--restore-existing"})
+	})
+	if err != nil {
+		t.Fatalf("--restore-existing with a recorded-but-live member should not fail: %v", err)
+	}
+	if !strings.Contains(stdout, "live") {
+		t.Errorf("plan should still classify the member as live:\n%s", stdout)
+	}
+}
+
+// Regression for #27 P1 (force-duplicate restore command must inject the
+// flag): when a member has both a restorable record and a live wake, the
+// emitted restore command under --force-duplicate must contain
+// --force-duplicate so it bypasses launch-time preflight on replay.
+func TestRunTeamResumeForceDuplicateRestoreCommandHasFlag(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	myPID := os.Getpid()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: myPID, Root: filepath.Join(base, "issue-96")})
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == myPID },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto --root " + filepath.Join(base, "issue-96"))
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--force-duplicate"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamResume --force-duplicate: %v", err)
+	}
+	if !strings.Contains(stdout, "force-duplicate:") {
+		t.Errorf("plan note should mark forced override:\n%s", stdout)
+	}
+	// The forced restore command MUST carry --force-duplicate so its
+	// own preflight does not refuse on replay against the same live agent.
+	if !strings.Contains(stdout, "amq-squad launch --no-bootstrap --force-duplicate") {
+		t.Errorf("forced restore command must inject --force-duplicate, got:\n%s", stdout)
+	}
+}
+
+// Regression for #27 P2 (footer must be option-aware or suppressed): when
+// the plan emits restore commands, the team-launch alternative footer
+// would NOT be equivalent (it always re-emits fresh from team intent), so
+// the footer must be suppressed and replaced with a clarifying note.
+func TestRunTeamResumeFooterSuppressedWhenAnyRestore(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	stdout, _, err := captureOutput(t, func() error { return runTeamResume(nil) })
+	if err != nil {
+		t.Fatalf("runTeamResume: %v", err)
+	}
+	if strings.Contains(stdout, "team launch --session") {
+		t.Errorf("footer alternative must be suppressed when any row is restore:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "not equivalent to the per-member plan") {
+		t.Errorf("footer should explain that team launch is not equivalent:\n%s", stdout)
+	}
+}
+
+// Combined regression for the live+forced+recorded case: action stays
+// 'live' but the emitted command is a forced restore. The footer must
+// still be suppressed because 'team launch' would re-emit fresh commands
+// from team intent and not reproduce the restore semantics above.
+func TestRunTeamResumeFooterSuppressedForLiveForcedRestore(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+	})
+
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	myPID := os.Getpid()
+	writeWakeLock(t, agentDir, wakeLockFile{PID: myPID, Root: filepath.Join(base, "issue-96")})
+	original := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == myPID },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return predicate("amq wake --me cto --root " + filepath.Join(base, "issue-96"))
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = original })
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--force-duplicate"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamResume --force-duplicate: %v", err)
+	}
+	// Sanity: the emitted command must be the forced restore.
+	if !strings.Contains(stdout, "amq-squad launch --no-bootstrap --force-duplicate") {
+		t.Errorf("forced live restore must include --force-duplicate, got:\n%s", stdout)
+	}
+	// Footer must be suppressed: 'team launch --session ...' would re-emit
+	// fresh from team intent and not reproduce the restore semantics.
+	if strings.Contains(stdout, "team launch --session") {
+		t.Errorf("footer must be suppressed for live+forced+recorded restore:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "not equivalent to the per-member plan") {
+		t.Errorf("footer note should still explain the non-equivalence:\n%s", stdout)
+	}
+}
+
+// Regression: when all rows are fresh and --force-duplicate was passed,
+// the footer alternative must propagate --force-duplicate.
+func TestRunTeamResumeFooterCarriesForceDuplicateOnAllFresh(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--force-duplicate"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamResume --force-duplicate: %v", err)
+	}
+	if !strings.Contains(stdout, "team launch --session 'issue-96' --force-duplicate") &&
+		!strings.Contains(stdout, "team launch --session issue-96 --force-duplicate") {
+		t.Errorf("footer should carry --force-duplicate, got:\n%s", stdout)
+	}
+}
+
+func TestRunTeamResumeHelpListsActions(t *testing.T) {
+	_, stderr, err := captureOutput(t, func() error { return Run([]string{"team", "resume", "--help"}, "test") })
+	if err != nil {
+		t.Fatalf("team resume --help: %v", err)
+	}
+	for _, want := range []string{
+		"amq-squad team resume",
+		"live",
+		"restore",
+		"launch fresh",
+		"blocked",
+		"--restore-existing",
+		"--fresh",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("team resume --help missing %q in:\n%s", want, stderr)
+		}
+	}
+}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -14,6 +14,49 @@ import (
 	"github.com/omriariav/amq-squad/internal/team"
 )
 
+// Persisted team args that contradict the trust profile must be caught
+// before launch commands are emitted, not surface as per-pane errors after
+// tmux panes are open.
+func TestEmitTeamCommandsRejectsPersistedSandboxedBypass(t *testing.T) {
+	dir := t.TempDir()
+	if err := team.Write(dir, team.Team{
+		Trust:      trustModeSandboxed,
+		BinaryArgs: map[string][]string{"codex": {"--dangerously-bypass-approvals-and-sandbox"}},
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := emitTeamCommands(dir, emitTeamOptions{})
+	if err == nil {
+		t.Fatal("sandboxed team with bypass in stored binary args should fail")
+	}
+	if !strings.Contains(err.Error(), "trusted") {
+		t.Fatalf("error should suggest trusted: %v", err)
+	}
+}
+
+func TestEmitTeamCommandsRejectsUnknownModelRoleKey(t *testing.T) {
+	dir := t.TempDir()
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := emitTeamCommands(dir, emitTeamOptions{
+		ModelOverrides: map[string]string{"ctoo": "gpt-5"},
+	})
+	if err == nil {
+		t.Fatal("unknown role key in --model should fail")
+	}
+	if !strings.Contains(err.Error(), "ctoo") {
+		t.Fatalf("error should name the bad key: %v", err)
+	}
+}
+
 func TestSplitCSV(t *testing.T) {
 	cases := map[string][]string{
 		"a,b,c":       {"a", "b", "c"},
@@ -73,7 +116,10 @@ func TestEmitTeamCommandShape(t *testing.T) {
 		Handle:  "designer",
 		Session: "designer",
 	}
-	cmd := emitTeamCommand("/home/u/proj", "amq-squad", "/home/u/proj", m, false, "proj", nil)
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/home/u/proj", SquadBin: "amq-squad", TeamHome: "/home/u/proj",
+		Member: m, Workstream: "proj", TrustMode: trustModeSandboxed,
+	})
 	for _, want := range []string{
 		"cd /home/u/proj",
 		"amq-squad launch",
@@ -91,18 +137,65 @@ func TestEmitTeamCommandShape(t *testing.T) {
 	}
 }
 
-func TestEmitTeamCommandAddsCodexDefaultArgs(t *testing.T) {
+func TestEmitTeamCommandSandboxedCodexOmitsBypass(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false, "p", nil)
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed,
+	})
+	if strings.Contains(cmd, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("sandboxed codex should not include bypass arg in: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--trust sandboxed") {
+		t.Errorf("expected --trust sandboxed in: %s", cmd)
+	}
+}
+
+func TestEmitTeamCommandTrustedCodexIncludesBypass(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeTrusted,
+	})
 	if !strings.Contains(cmd, "-- --dangerously-bypass-approvals-and-sandbox") {
-		t.Errorf("expected codex default args in: %s", cmd)
+		t.Errorf("trusted codex must include bypass arg in: %s", cmd)
+	}
+	if !strings.Contains(cmd, "--trust trusted") {
+		t.Errorf("expected --trust trusted in: %s", cmd)
+	}
+}
+
+func TestEmitTeamCommandIncludesModelOverride(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto", Model: "gpt-5"}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed, Model: m.Model,
+	})
+	if !strings.Contains(cmd, "--model gpt-5") {
+		t.Errorf("expected --model gpt-5 launch flag in: %s", cmd)
+	}
+	if !strings.Contains(cmd, "codex -- --model gpt-5") {
+		t.Errorf("expected codex native --model placement in: %s", cmd)
+	}
+}
+
+func TestEmitTeamCommandClaudeModelPlacement(t *testing.T) {
+	m := team.Member{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack", Model: "sonnet"}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed, Model: m.Model,
+	})
+	if !strings.Contains(cmd, "claude -- --permission-mode auto --model sonnet") {
+		t.Errorf("expected claude default + model placement in: %s", cmd)
 	}
 }
 
 func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "amq-squad", "/p", m, false, "p", map[string][]string{
-		"codex": {"--enable", "goals"},
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeTrusted,
+		BinaryArgs: map[string][]string{"codex": {"--enable", "goals"}},
 	})
 	for _, want := range []string{
 		"--codex-args='--enable goals'",
@@ -116,7 +209,10 @@ func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
 
 func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 	m := team.Member{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"}
-	cmd := emitTeamCommand("/home/user/my project", "amq-squad", "/home/user/my project", m, false, "my-project", nil)
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/home/user/my project", SquadBin: "amq-squad", TeamHome: "/home/user/my project",
+		Member: m, Workstream: "my-project", TrustMode: trustModeSandboxed,
+	})
 	if !strings.Contains(cmd, "'/home/user/my project'") {
 		t.Errorf("project path not quoted: %s", cmd)
 	}
@@ -124,7 +220,10 @@ func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 
 func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
-	cmd := emitTeamCommand("/p", "/usr/local/bin/amq-squad", "/p", m, false, "p", nil)
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "/usr/local/bin/amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed,
+	})
 	if !strings.Contains(cmd, "/usr/local/bin/amq-squad launch") {
 		t.Errorf("expected absolute binary path in: %s", cmd)
 	}
@@ -132,7 +231,10 @@ func TestEmitTeamCommandUsesBinaryPath(t *testing.T) {
 
 func TestEmitTeamCommandNoBootstrap(t *testing.T) {
 	m := team.Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "qa"}
-	cmd := emitTeamCommand("/p", "amq-squad", "/team", m, true, "team", nil)
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/team",
+		Member: m, NoBootstrap: true, Workstream: "team", TrustMode: trustModeSandboxed,
+	})
 	if !strings.Contains(cmd, "--no-bootstrap") {
 		t.Errorf("expected --no-bootstrap in: %s", cmd)
 	}
@@ -170,7 +272,7 @@ func TestRunTeamShowUsesDefaultSharedWorkstream(t *testing.T) {
 	workstream := defaultWorkstreamName(dir)
 	for _, want := range []string{
 		"# workstream: " + workstream,
-		"--session " + workstream + " --team-workstream --team-home",
+		"--session " + workstream + " --team-workstream",
 		"--no-bootstrap --me cto codex",
 		"--no-bootstrap --me fullstack claude",
 	} {
@@ -212,7 +314,7 @@ func TestRunTeamShowUsesStoredSharedWorkstream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runTeamShow: %v\nstderr:\n%s", err, stderr)
 	}
-	if !strings.Contains(stdout, "# workstream: issue-96") || !strings.Contains(stdout, "--session issue-96 --team-workstream --team-home") {
+	if !strings.Contains(stdout, "# workstream: issue-96") || !strings.Contains(stdout, "--session issue-96 --team-workstream") {
 		t.Fatalf("team show did not use stored shared workstream:\n%s", stdout)
 	}
 }
@@ -232,6 +334,7 @@ func TestRunTeamShowMergesStoredAndRunBinaryArgs(t *testing.T) {
 		}
 	})
 	if err := team.Write(dir, team.Team{
+		Trust:      trustModeTrusted,
 		BinaryArgs: map[string][]string{"codex": {"--enable", "goals"}},
 		Members: []team.Member{
 			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
@@ -387,17 +490,19 @@ printf '{"root":"%s"}\n' "$root"
 }
 
 func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
+	// Sandboxed Codex has no built-in default args, so bootstrap should still
+	// be appended on empty input. Trusted Codex behaves like the legacy default.
 	cases := []struct {
 		name      string
 		binary    string
 		childArgs []string
 		want      bool
 	}{
-		{name: "empty args", binary: "codex", want: true},
-		{name: "codex defaults", binary: "codex", childArgs: []string{"--dangerously-bypass-approvals-and-sandbox"}, want: true},
+		{name: "empty args codex", binary: "codex", want: true},
+		{name: "empty args claude", binary: "claude", want: true},
 		{name: "claude defaults", binary: "claude", childArgs: []string{"--permission-mode", "auto"}, want: true},
 		{name: "non-default args", binary: "claude", childArgs: []string{"--resume", "abc"}, want: false},
-		{name: "defaults plus custom args", binary: "codex", childArgs: []string{"--dangerously-bypass-approvals-and-sandbox", "--foo"}, want: false},
+		{name: "codex sandboxed has no defaults so bypass alone is non-default", binary: "codex", childArgs: []string{"--dangerously-bypass-approvals-and-sandbox"}, want: false},
 	}
 	for _, tc := range cases {
 		if got := shouldAppendBootstrap(tc.binary, tc.childArgs); got != tc.want {
@@ -414,30 +519,27 @@ func TestShouldAppendBootstrapWithDefaultChildArgs(t *testing.T) {
 }
 
 func TestEnsureDefaultChildArgs(t *testing.T) {
+	// Sandboxed Codex (the new default) has no built-in defaults to ensure.
 	got := ensureDefaultChildArgs("codex", nil)
-	want := []string{"--dangerously-bypass-approvals-and-sandbox"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("ensureDefaultChildArgs codex = %v, want %v", got, want)
+	if len(got) != 0 {
+		t.Errorf("ensureDefaultChildArgs sandboxed codex = %v, want []", got)
 	}
 	got = ensureDefaultChildArgs("claude", nil)
-	want = []string{"--permission-mode", "auto"}
+	want := []string{"--permission-mode", "auto"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ensureDefaultChildArgs claude = %v, want %v", got, want)
 	}
-	got = ensureDefaultChildArgs("codex", []string{"test-prompt"})
-	want = []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("ensureDefaultChildArgs should prepend defaults: got %v, want %v", got, want)
+	// Trusted codex still prepends the bypass arg.
+	trusted := defaultChildArgsForBinaryWithTrust("codex", trustModeTrusted)
+	if got := ensureLeadingChildArgs(trusted, nil); !reflect.DeepEqual(got, []string{"--dangerously-bypass-approvals-and-sandbox"}) {
+		t.Errorf("trusted codex defaults: got %v", got)
+	}
+	if got := ensureLeadingChildArgs(trusted, []string{"test-prompt"}); !reflect.DeepEqual(got, []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt"}) {
+		t.Errorf("trusted codex prepend: got %v", got)
 	}
 	explicit := []string{"--dangerously-bypass-approvals-and-sandbox", "--resume", "abc"}
-	got = ensureDefaultChildArgs("codex", explicit)
-	if !reflect.DeepEqual(got, explicit) {
-		t.Errorf("ensureDefaultChildArgs should not duplicate defaults: got %v, want %v", got, explicit)
-	}
-	got = ensureDefaultChildArgs("codex", []string{"test-prompt", "--dangerously-bypass-approvals-and-sandbox"})
-	want = []string{"--dangerously-bypass-approvals-and-sandbox", "test-prompt", "--dangerously-bypass-approvals-and-sandbox"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("ensureDefaultChildArgs should keep defaults before prompts: got %v, want %v", got, want)
+	if got := ensureLeadingChildArgs(trusted, explicit); !reflect.DeepEqual(got, explicit) {
+		t.Errorf("trusted codex idempotent: got %v", got)
 	}
 	got = ensureLeadingChildArgs([]string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals"}, []string{"--dangerously-bypass-approvals-and-sandbox", "prompt"})
 	want = []string{"--dangerously-bypass-approvals-and-sandbox", "--enable", "goals", "prompt"}

--- a/internal/cli/trust_model_test.go
+++ b/internal/cli/trust_model_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+)
+
+func TestDefaultChildArgsForBinaryWithTrust(t *testing.T) {
+	if got := defaultChildArgsForBinaryWithTrust("codex", trustModeSandboxed); len(got) != 0 {
+		t.Errorf("sandboxed codex defaults = %v, want []", got)
+	}
+	want := []string{"--dangerously-bypass-approvals-and-sandbox"}
+	if got := defaultChildArgsForBinaryWithTrust("codex", trustModeTrusted); !reflect.DeepEqual(got, want) {
+		t.Errorf("trusted codex defaults = %v, want %v", got, want)
+	}
+	wantClaude := []string{"--permission-mode", "auto"}
+	if got := defaultChildArgsForBinaryWithTrust("claude", trustModeSandboxed); !reflect.DeepEqual(got, wantClaude) {
+		t.Errorf("claude sandboxed defaults = %v, want %v", got, wantClaude)
+	}
+	if got := defaultChildArgsForBinaryWithTrust("claude", trustModeTrusted); !reflect.DeepEqual(got, wantClaude) {
+		t.Errorf("trust does not change claude defaults: %v", got)
+	}
+}
+
+func TestModelArgsForBinary(t *testing.T) {
+	cases := []struct {
+		binary string
+		model  string
+		want   []string
+	}{
+		{"codex", "gpt-5", []string{"--model", "gpt-5"}},
+		{"claude", "sonnet", []string{"--model", "sonnet"}},
+		{"codex", "  ", nil},
+		{"node", "x", nil},
+		{"/usr/local/bin/codex", "gpt-5", []string{"--model", "gpt-5"}},
+	}
+	for _, tc := range cases {
+		got := modelArgsForBinary(tc.binary, tc.model)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("modelArgsForBinary(%q, %q) = %v, want %v", tc.binary, tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestValidateTrustCombinationRejectsContradictions(t *testing.T) {
+	if err := validateTrustCombination(trustModeTrusted, true, true, nil); err == nil {
+		t.Fatal("trusted + no-default-args should fail")
+	}
+	if err := validateTrustCombination(trustModeSandboxed, true, false, map[string][]string{
+		"codex": {"--dangerously-bypass-approvals-and-sandbox"},
+	}); err == nil {
+		t.Fatal("sandboxed + bypass via codex-args should fail")
+	}
+	// Sandboxed without bypass is fine.
+	if err := validateTrustCombination(trustModeSandboxed, true, false, map[string][]string{"codex": {"--enable", "goals"}}); err != nil {
+		t.Fatalf("sandboxed + benign codex args should pass, got %v", err)
+	}
+	// Trusted + no-default-args still fine when both sides flow through naturally.
+	if err := validateTrustCombination(trustModeTrusted, true, false, nil); err != nil {
+		t.Fatalf("trusted alone should pass, got %v", err)
+	}
+}
+
+func TestTrustModeFromRecordLegacyBypassClassifiesAsTrusted(t *testing.T) {
+	rec := launch.Record{
+		Binary: "codex",
+		Argv:   []string{"--dangerously-bypass-approvals-and-sandbox", "prompt"},
+	}
+	if got := trustModeFromRecord(rec); got != trustModeTrusted {
+		t.Errorf("legacy codex bypass record = %q, want trusted", got)
+	}
+}
+
+func TestTrustModeFromRecordExplicitTrustWins(t *testing.T) {
+	rec := launch.Record{Binary: "codex", Trust: "sandboxed", Argv: []string{"--dangerously-bypass-approvals-and-sandbox"}}
+	if got := trustModeFromRecord(rec); got != trustModeSandboxed {
+		t.Errorf("explicit Trust should override argv inference: %q", got)
+	}
+}
+
+func TestTrustModeFromRecordNoDefaultArgsSandboxed(t *testing.T) {
+	rec := launch.Record{Binary: "codex", NoDefaultArgs: true, Argv: []string{"--enable", "goals"}}
+	if got := trustModeFromRecord(rec); got != trustModeSandboxed {
+		t.Errorf("no-default-args codex should classify as sandboxed: %q", got)
+	}
+}
+
+func TestTrustModeFromRecordClaudeReturnsEmpty(t *testing.T) {
+	rec := launch.Record{Binary: "claude", Argv: []string{"--permission-mode", "auto"}}
+	if got := trustModeFromRecord(rec); got != "" {
+		t.Errorf("claude should not get a trust label: %q", got)
+	}
+}
+
+func TestLaunchArgsFromRecordModelRoundTrips(t *testing.T) {
+	rec := launch.Record{
+		CWD:     "/p",
+		Binary:  "codex",
+		Argv:    []string{"--model", "gpt-5", "--enable", "goals"},
+		Session: "s",
+		Handle:  "cto",
+		Role:    "cto",
+		Model:   "gpt-5",
+		Trust:   trustModeSandboxed,
+	}
+	got := launchArgsFromRecord(rec)
+	want := []string{
+		"--no-bootstrap",
+		"--role", "cto",
+		"--session", "s",
+		"--trust", "sandboxed",
+		"--model", "gpt-5",
+		"--me", "cto",
+		"codex",
+		"--",
+		"--enable", "goals",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
+	}
+}
+
+func TestValidateModelOverrideKeysRejectsUnknownRole(t *testing.T) {
+	known := map[string]bool{"cto": true, "fullstack": true}
+	if err := validateModelOverrideKeys(map[string]string{"ctoo": "gpt-5"}, known); err == nil {
+		t.Fatal("expected error for unknown role key")
+	}
+	if err := validateModelOverrideKeys(map[string]string{"cto": "gpt-5"}, known); err != nil {
+		t.Fatalf("known role should not error: %v", err)
+	}
+	if err := validateModelOverrideKeys(map[string]string{"CTO": "gpt-5"}, known); err != nil {
+		t.Fatalf("case-insensitive match expected: %v", err)
+	}
+}
+
+func TestEmitCommandIncludesModel(t *testing.T) {
+	rec := launch.Record{
+		CWD:    "/p",
+		Binary: "claude",
+		Handle: "fullstack",
+		Role:   "fullstack",
+		Model:  "sonnet",
+	}
+	cmd := emitCommand(rec)
+	if !strings.Contains(cmd, "--model sonnet") {
+		t.Errorf("emitCommand missing --model sonnet: %s", cmd)
+	}
+}

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPromptModelSelectionEmptyKeepsOverrides(t *testing.T) {
+	overrides := map[string]string{}
+	r := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+	if err := promptModelSelection(r, &out, overrides); err != nil {
+		t.Fatal(err)
+	}
+	if len(overrides) != 0 {
+		t.Errorf("empty input should leave overrides untouched, got %v", overrides)
+	}
+}
+
+func TestPromptModelSelectionParsesKV(t *testing.T) {
+	overrides := map[string]string{}
+	r := bufio.NewReader(strings.NewReader("cto=gpt-5,fullstack=sonnet\n"))
+	var out bytes.Buffer
+	if err := promptModelSelection(r, &out, overrides); err != nil {
+		t.Fatal(err)
+	}
+	if overrides["cto"] != "gpt-5" || overrides["fullstack"] != "sonnet" {
+		t.Errorf("unexpected overrides: %v", overrides)
+	}
+}
+
+func TestPromptTrustSelectionEnterKeepsCurrent(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+	got, err := promptTrustSelection(r, &out, trustModeSandboxed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != trustModeSandboxed {
+		t.Errorf("Enter should keep sandboxed, got %q", got)
+	}
+}
+
+func TestPromptTrustSelectionAcceptsTrusted(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("trusted\n"))
+	var out bytes.Buffer
+	got, err := promptTrustSelection(r, &out, trustModeSandboxed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != trustModeTrusted {
+		t.Errorf("expected trusted, got %q", got)
+	}
+}
+
+func TestPromptTrustSelectionRejectsUnknown(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("yolo\n"))
+	var out bytes.Buffer
+	if _, err := promptTrustSelection(r, &out, trustModeSandboxed); err == nil {
+		t.Fatal("unknown trust mode should fail")
+	}
+}
+
+func TestPromptWorkstreamSelectionEnterKeepsDefault(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("\n"))
+	var out bytes.Buffer
+	got, err := promptWorkstreamSelection(r, &out, "issue-96")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "issue-96" {
+		t.Errorf("Enter should keep default, got %q", got)
+	}
+}
+
+func TestPromptWorkstreamSelectionRejectsInvalid(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("Has Spaces\n"))
+	var out bytes.Buffer
+	if _, err := promptWorkstreamSelection(r, &out, "issue-96"); err == nil {
+		t.Fatal("invalid workstream should fail")
+	}
+}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -42,7 +42,11 @@ type Record struct {
 	AMQVersion       string    `json:"amq_version,omitempty"`
 	CodexArgs        []string  `json:"codex_args,omitempty"`
 	ClaudeArgs       []string  `json:"claude_args,omitempty"`
+	Model            string    `json:"model,omitempty"`
+	Trust            string    `json:"trust,omitempty"`
 	NoDefaultArgs    bool      `json:"no_default_args,omitempty"`
+	AgentPID         int       `json:"agent_pid,omitempty"`
+	AgentTTY         string    `json:"agent_tty,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 }
 

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -31,6 +31,7 @@ type Member struct {
 	Binary  string `json:"binary"`  // "claude" or "codex"
 	Handle  string `json:"handle"`  // AMQ handle, defaults to Role
 	Session string `json:"session"` // AMQ workstream session name
+	Model   string `json:"model,omitempty"`
 	CWD     string `json:"cwd,omitempty"`
 }
 
@@ -50,12 +51,15 @@ func (m Member) EffectiveCWD(projectDir string) string {
 // would leak local paths into shared repos and break when the repo moves.
 // Workstream is the team's default shared AMQ session. CreatedAt is
 // informational. Member sessions are legacy/default workstream hints; the live
-// workstream can be overridden at launch time. BinaryArgs stores extra native
-// CLI args by binary name, for example codex or claude.
+// workstream can be overridden at launch time. Trust controls Codex trust
+// defaults for generated launch commands ("sandboxed" or "trusted"; empty
+// means sandboxed). BinaryArgs stores extra native CLI args by binary name,
+// for example codex or claude.
 type Team struct {
 	Schema     int                 `json:"schema"`
 	Project    string              `json:"-"`
 	Workstream string              `json:"workstream,omitempty"`
+	Trust      string              `json:"trust,omitempty"`
 	BinaryArgs map[string][]string `json:"binary_args,omitempty"`
 	Members    []Member            `json:"members"`
 	CreatedAt  time.Time           `json:"created_at"`
@@ -126,6 +130,9 @@ func Validate(t Team) error {
 			return fmt.Errorf("workstream: %w", err)
 		}
 	}
+	if t.Trust != "" && t.Trust != "sandboxed" && t.Trust != "trusted" {
+		return fmt.Errorf("trust: invalid trust mode %q: use sandboxed or trusted", t.Trust)
+	}
 	for binary, args := range t.BinaryArgs {
 		if err := ValidateDisplayValue("binary_args key", binary); err != nil {
 			return fmt.Errorf("binary_args[%q]: %w", binary, err)
@@ -176,6 +183,11 @@ func validateMember(prefix string, m Member) error {
 	if m.Binary != "" {
 		if err := ValidateDisplayValue("binary", m.Binary); err != nil {
 			return fmt.Errorf("%s.binary: %w", prefix, err)
+		}
+	}
+	if m.Model != "" {
+		if err := ValidateDisplayValue("model", m.Model); err != nil {
+			return fmt.Errorf("%s.model: %w", prefix, err)
 		}
 	}
 	if m.CWD != "" {


### PR DESCRIPTION
## Summary

Release v0.6.1 DX hardening for agent-team operation:

- Adds safer Codex trust defaults with explicit `--trust sandboxed|trusted` handling.
- Adds native model propagation for direct launch, team launch, and restore.
- Adds duplicate-launch preflight and wake-health reporting.
- Adds `amq-squad team resume` as the plan-only path for reboot, terminal close, and agent upgrade recovery.
- Updates README and HTML docs for v0.6.1.

## Review Notes

The release branch was reviewed through the v0-6-0-review AMQ workstream:

- CTO review passed for #25/#19/#22 DX hardening.
- CTO and senior-dev reviewed #27 `team resume` through multiple blocker fixes.
- Senior-dev pre-build review blockers were fixed and spot re-reviewed GO.

`.amq-squad/team.json` is intentionally excluded because it is live local routing state.

## Verification

- `make ci`
- `gofmt -l .`
- `git diff --cached --check`
- `rg -n -- '—' .`
- Local ldflags build: `amq-squad v0.6.1`
- Temporary binary smoke for setup, show, launch dry-run, resume, restore/list, trust/model guardrails, and fresh-existing workstream safety
