### PR TITLE
1.1.0: down honesty (#38), tmux pane targeting (#40), handoff kind guidance (#41), custom launchers (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ amq-squad resume                     # plan recovery after reboot / upgrade / cl
 amq-squad fork --from <cur> --as <new>  # branch a fresh workstream
 ```
 
+### tmux targets
+
+`amq-squad up` defaults to `--target current-window`, which splits the tmux
+window where you run the command. To bring a team up inside an existing tmux
+session such as `main`, switch or attach to the desired window first, then run
+`up` from that pane:
+
+```sh
+tmux switch-client -t main:6
+cd ~/Code/my-project
+amq-squad up --session v1-0-0-qa --terminal tmux --target current-window --layout tiled
+```
+
+Use `--target new-session --terminal-session NAME` only when you want
+amq-squad to create a separate tmux session. `--terminal-session` names the new
+session; it does not select an existing tmux session for `current-window`.
+
+Panes are anchored to the pane you launch from (`$TMUX_PANE`), not to whatever
+window happens to be focused, so a `current-window` launch is safe even under
+iTerm2's `tmux -CC` integration: changing tabs mid-launch will not rehome the
+panes onto an unrelated window. If you launch from outside tmux, `current-window`
+refuses with a hint rather than guessing a target.
+
+If the AMQ workstream already exists, omit `--fresh`. Stop the old team first
+with `amq-squad down --all --force --session <workstream>`, then run `up` again
+from the target tmux window. Add `--force-duplicate` only when stale live-agent
+signals remain after the old panes are stopped.
+
 Single-agent primitives:
 
 ```sh
@@ -53,6 +81,24 @@ amq-squad agent resume fullstack
 ```
 
 Legacy 1.x verbs still work and emit a one-line deprecation warning. See [Deprecated 1.x verbs](#deprecated-1x-verbs).
+
+### Custom launchers
+
+A managed member can be launched through a project-specific wrapper script while
+still receiving AMQ identity, bootstrap, a launch record, and status/resume. Pass
+`--launcher` (and optional `--launcher-args`) on `agent up`, or set `launcher` /
+`launcher_args` on the member in `team.json`:
+
+```sh
+amq-squad agent up claude --role qa --session beta --team-workstream \
+  --launcher /path/claude-pm-os-dev.sh --launcher-args "--pull --workspace /ws"
+```
+
+The launcher is exec'd in place of the binary. `--launcher-args` come first, then
+amq-squad appends the agent's normal child args (bootstrap + defaults), so **the
+launcher script must forward its trailing args to the agent** (e.g. end with
+`exec claude "$@"`). amq-squad refuses with a clear error if the launcher path is
+missing or not executable. `up --dry-run` prints the resolved launcher command.
 
 ## Context model
 

--- a/doc.html
+++ b/doc.html
@@ -655,11 +655,80 @@ amq-squad down --all --force         # SIGTERM the team
 amq-squad resume                     # plan recovery after reboot / upgrade / close
 amq-squad fork --from &lt;cur&gt; --as &lt;new&gt;  # branch a fresh workstream</code></pre></div>
 
+          <h3>tmux targets</h3>
+          <p>
+            <code class="inline-code">amq-squad up</code> defaults to
+            <code class="inline-code">--target current-window</code>, which
+            splits the tmux window where you run the command. To bring a team
+            up inside an existing tmux session such as
+            <code class="inline-code">main</code>, switch or attach to the
+            desired window first, then run
+            <code class="inline-code">up</code> from that pane.
+          </p>
+          <div class="code"><pre><code>tmux switch-client -t main:6
+cd ~/Code/my-project
+amq-squad up --session v1-0-0-qa --terminal tmux --target current-window --layout tiled</code></pre></div>
+          <p>
+            Use
+            <code class="inline-code">--target new-session --terminal-session NAME</code>
+            only when you want amq-squad to create a separate tmux session.
+            <code class="inline-code">--terminal-session</code> names the new
+            session; it does not select an existing tmux session for
+            <code class="inline-code">current-window</code>.
+          </p>
+          <p>
+            Panes are anchored to the pane you launch from
+            (<code class="inline-code">$TMUX_PANE</code>), not to whatever window
+            happens to be focused, so a
+            <code class="inline-code">current-window</code> launch is safe even
+            under iTerm2's <code class="inline-code">tmux -CC</code> integration:
+            changing tabs mid-launch will not rehome the panes onto an unrelated
+            window. If you launch from outside tmux,
+            <code class="inline-code">current-window</code> refuses with a hint
+            rather than guessing a target.
+          </p>
+          <p>
+            If the AMQ workstream already exists, omit
+            <code class="inline-code">--fresh</code>. Stop the old team first
+            with
+            <code class="inline-code">amq-squad down --all --force --session &lt;workstream&gt;</code>,
+            then run <code class="inline-code">up</code> again from the target
+            tmux window. Add
+            <code class="inline-code">--force-duplicate</code> only when stale
+            live-agent signals remain after the old panes are stopped.
+          </p>
+
           <p>
             Single-agent primitives:
           </p>
           <div class="code"><pre><code>amq-squad agent up codex --role cto --session issue-96
 amq-squad agent resume fullstack</code></pre></div>
+
+          <h3>Custom launchers</h3>
+          <p>
+            A managed member can be launched through a project-specific wrapper
+            script while still receiving AMQ identity, bootstrap, a launch
+            record, and status/resume. Pass
+            <code class="inline-code">--launcher</code> (and optional
+            <code class="inline-code">--launcher-args</code>) on
+            <code class="inline-code">agent up</code>, or set
+            <code class="inline-code">launcher</code> /
+            <code class="inline-code">launcher_args</code> on the member in
+            <code class="inline-code">team.json</code>.
+          </p>
+          <div class="code"><pre><code>amq-squad agent up claude --role qa --session beta --team-workstream \
+  --launcher /path/claude-pm-os-dev.sh --launcher-args "--pull --workspace /ws"</code></pre></div>
+          <p>
+            The launcher is exec'd in place of the binary.
+            <code class="inline-code">--launcher-args</code> come first, then
+            amq-squad appends the agent's normal child args (bootstrap +
+            defaults), so <strong>the launcher script must forward its trailing
+            args to the agent</strong> (e.g. end with
+            <code class="inline-code">exec claude "$@"</code>). amq-squad refuses
+            with a clear error if the launcher path is missing or not
+            executable. <code class="inline-code">up --dry-run</code> prints the
+            resolved launcher command.
+          </p>
 
           <h3>Non-interactive setup</h3>
           <div class="code"><pre><code>amq-squad team init \

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -190,13 +190,13 @@ walk:
 // given.
 func launchKnownFlag(name string) string {
 	switch name {
-	case "--codex-args", "--claude-args",
-		"-codex-args", "-claude-args":
+	case "--codex-args", "--claude-args", "--launcher-args",
+		"-codex-args", "-claude-args", "-launcher-args":
 		return "string-accepts-dash"
 	case "--role", "--session", "--me", "--root", "--team-home", "--team-profile",
-		"--conversation", "--conversation-id", "--trust", "--model",
+		"--conversation", "--conversation-id", "--trust", "--model", "--launcher",
 		"-role", "-session", "-me", "-root", "-team-home", "-team-profile",
-		"-conversation", "-conversation-id", "-trust", "-model":
+		"-conversation", "-conversation-id", "-trust", "-model", "-launcher":
 		return "string"
 	case "--team-workstream", "--no-bootstrap", "--no-default-args",
 		"--force-duplicate", "--dry-run",

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -130,6 +130,8 @@ var completionCommonFlags = []string{
 	"--from",
 	"--handle",
 	"--json",
+	"--launcher",
+	"--launcher-args",
 	"--layout",
 	"--me",
 	"--model",

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -207,7 +207,7 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 		// No pid was captured at launch (e.g. codex seats never recorded one).
 		// There is nothing to signal, so consult presence before implying the
 		// member is gone: a fresh heartbeat means it may well still be running.
-		if lastSeen, fresh := presenceFreshFor(report.AgentDir, probe); fresh {
+		if lastSeen, fresh := presenceFreshFor(report.AgentDir, handle, probe); fresh {
 			report.Status = downStatusMaybeLive
 			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
 			return report
@@ -243,9 +243,14 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 // presenceFreshFor reports the agent's last heartbeat and whether it is recent
 // enough to treat the member as possibly still running. It mirrors the
 // freshness rule status and preflight use, so down agrees with them.
-func presenceFreshFor(agentDir string, probe duplicateLaunchProbe) (time.Time, bool) {
+func presenceFreshFor(agentDir, handle string, probe duplicateLaunchProbe) (time.Time, bool) {
 	pres, err := readPresenceForEntry(agentDir)
 	if err != nil {
+		return time.Time{}, false
+	}
+	// Honor the same handle rule status and preflight use: a presence file
+	// written for a different handle is not evidence this member is live.
+	if pres.Handle != "" && pres.Handle != handle {
 		return time.Time{}, false
 	}
 	if !strings.EqualFold(pres.Status, "active") || pres.LastSeen.IsZero() {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -287,11 +287,13 @@ func renderDownReports(out io.Writer, workstream string, reports []downReport) e
 	}
 	if failed > 0 {
 		msg := fmt.Sprintf("down: %d of %d target(s) failed", failed, len(reports))
-		// Partial success requires at least one target genuinely terminated AND
-		// at least one target failed. All-failed (or failed + not-live only)
-		// stays a system/runtime error so wrappers do not treat a wholesale
-		// breakage as "progress made".
-		if sent > 0 {
+		if maybeLive > 0 {
+			msg += fmt.Sprintf("; %d may still be live (no pid to signal)", maybeLive)
+		}
+		// Partial (exit 3) when there is either progress (a SIGTERM was sent) or
+		// an unconfirmed stop (maybe-live): neither is a clean success nor a
+		// wholesale breakage. Only a pure all-failed run stays a plain error.
+		if sent > 0 || maybeLive > 0 {
 			return &PartialError{Message: msg}
 		}
 		return errors.New(msg)

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/team"
@@ -19,6 +20,7 @@ type downStatus string
 const (
 	downStatusForceSent downStatus = "force-sent"
 	downStatusNotLive   downStatus = "not-live"
+	downStatusMaybeLive downStatus = "maybe-live"
 	downStatusFailed    downStatus = "failed"
 )
 
@@ -27,6 +29,7 @@ type downReport struct {
 	Handle   string
 	Binary   string
 	AgentDir string
+	Root     string
 	PID      int
 	Status   downStatus
 	Detail   string
@@ -186,6 +189,7 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 		handle = env.Me
 	}
 	report.Handle = handle
+	report.Root = env.Root
 	report.AgentDir = filepath.Join(env.Root, "agents", handle)
 	rec, err := launch.Read(report.AgentDir)
 	if err != nil {
@@ -199,7 +203,20 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 		return report
 	}
 	report.PID = rec.AgentPID
-	if rec.AgentPID <= 0 || !probe.PIDAlive(rec.AgentPID) {
+	if rec.AgentPID <= 0 {
+		// No pid was captured at launch (e.g. codex seats never recorded one).
+		// There is nothing to signal, so consult presence before implying the
+		// member is gone: a fresh heartbeat means it may well still be running.
+		if lastSeen, fresh := presenceFreshFor(report.AgentDir, probe); fresh {
+			report.Status = downStatusMaybeLive
+			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
+			return report
+		}
+		report.Status = downStatusNotLive
+		report.Detail = "no pid captured at launch and presence is not fresh — treating as not live"
+		return report
+	}
+	if !probe.PIDAlive(rec.AgentPID) {
 		report.Status = downStatusNotLive
 		report.Detail = fmt.Sprintf("recorded pid %d is not alive", rec.AgentPID)
 		return report
@@ -223,13 +240,30 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 	return report
 }
 
+// presenceFreshFor reports the agent's last heartbeat and whether it is recent
+// enough to treat the member as possibly still running. It mirrors the
+// freshness rule status and preflight use, so down agrees with them.
+func presenceFreshFor(agentDir string, probe duplicateLaunchProbe) (time.Time, bool) {
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if !strings.EqualFold(pres.Status, "active") || pres.LastSeen.IsZero() {
+		return time.Time{}, false
+	}
+	return pres.LastSeen, probe.Now().Sub(pres.LastSeen) <= presenceFreshness
+}
+
 func renderDownReports(out io.Writer, workstream string, reports []downReport) error {
 	fmt.Fprintln(out, "# amq-squad down")
 	fmt.Fprintf(out, "# workstream: %s\n", workstream)
+	if root := firstDownRoot(reports); root != "" {
+		fmt.Fprintf(out, "# AM_ROOT:    %s\n", root)
+	}
 	fmt.Fprintf(out, "# targets:    %d\n", len(reports))
 	fmt.Fprintln(out)
 	policy := outputPolicyCurrent()
-	var sent, notLive, failed int
+	var sent, notLive, maybeLive, failed int
 	for _, r := range reports {
 		fmt.Fprintf(out, "%-12s %-10s %s\n", r.Role, colorStatus(policy, string(r.Status)), r.Detail)
 		switch r.Status {
@@ -237,22 +271,44 @@ func renderDownReports(out io.Writer, workstream string, reports []downReport) e
 			sent++
 		case downStatusNotLive:
 			notLive++
+		case downStatusMaybeLive:
+			maybeLive++
 		case downStatusFailed:
 			failed++
 		}
 	}
 	fmt.Fprintln(out)
-	fmt.Fprintf(out, "# summary: %d force-sent, %d not-live, %d failed\n", sent, notLive, failed)
-	if failed == 0 {
-		return nil
+	fmt.Fprintf(out, "# summary: %d force-sent, %d not-live, %d maybe-live, %d failed\n", sent, notLive, maybeLive, failed)
+	if maybeLive > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "WARN: %d member(s) had no pid to signal but still report fresh presence — they may still be running.\n", maybeLive)
+		fmt.Fprintln(out, "      down can only signal pids it recorded at launch. Stop the underlying tmux pane / terminal")
+		fmt.Fprintln(out, "      manually, then re-run 'amq-squad status' to confirm (AM_ROOT above shows where presence lives).")
 	}
-	msg := fmt.Sprintf("down: %d of %d target(s) failed", failed, len(reports))
-	// Partial success requires at least one target genuinely terminated AND
-	// at least one target failed. All-failed (or failed + not-live only)
-	// stays a system/runtime error so wrappers do not treat a wholesale
-	// breakage as "progress made".
-	if sent > 0 {
-		return &PartialError{Message: msg}
+	if failed > 0 {
+		msg := fmt.Sprintf("down: %d of %d target(s) failed", failed, len(reports))
+		// Partial success requires at least one target genuinely terminated AND
+		// at least one target failed. All-failed (or failed + not-live only)
+		// stays a system/runtime error so wrappers do not treat a wholesale
+		// breakage as "progress made".
+		if sent > 0 {
+			return &PartialError{Message: msg}
+		}
+		return errors.New(msg)
 	}
-	return errors.New(msg)
+	// Members we could not confirm stopped must not read as a clean success:
+	// surface them as partial so the exit code (3) signals "not fully down".
+	if maybeLive > 0 {
+		return &PartialError{Message: fmt.Sprintf("down: %d member(s) may still be live (no pid to signal)", maybeLive)}
+	}
+	return nil
+}
+
+func firstDownRoot(reports []downReport) string {
+	for _, r := range reports {
+		if r.Root != "" {
+			return r.Root
+		}
+	}
+	return ""
 }

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -229,6 +229,24 @@ func TestExecuteDownMaybeLiveForNoPIDWithFreshPresence(t *testing.T) {
 	}
 }
 
+func TestRenderDownReportsMaybeLiveWithFailureStaysPartial(t *testing.T) {
+	var buf bytes.Buffer
+	reports := []downReport{
+		{Role: "cto", Root: "/tmp/root", Status: downStatusFailed, Detail: "terminate pid 5: boom"},
+		{Role: "qa", Root: "/tmp/root", Status: downStatusMaybeLive, Detail: "no pid captured at launch — may still be live"},
+	}
+	// failed + maybe-live with zero sent must still be partial (exit 3), not a
+	// plain error that hides the unconfirmed-stop members.
+	err := renderDownReports(&buf, "issue-96", reports)
+	pe, ok := err.(*PartialError)
+	if !ok {
+		t.Fatalf("want *PartialError, got %T: %v", err, err)
+	}
+	if !strings.Contains(pe.Message, "may still be live") {
+		t.Errorf("partial message should mention maybe-live members: %q", pe.Message)
+	}
+}
+
 func TestExecuteDownNotLiveForNoPIDStalePresence(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -196,6 +196,66 @@ func TestExecuteDownNotLiveForDeadPID(t *testing.T) {
 	}
 }
 
+func TestExecuteDownMaybeLiveForNoPIDWithFreshPresence(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	// Codex seats can finish launch without ever recording a pid; a fresh
+	// heartbeat means the agent may well still be running.
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 0,
+	})
+	writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now().Add(-5 * time.Second)})
+	term := &recordingTerminator{}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "cto",
+		Terminator:       term,
+		Probe:            downFakeProbe(nil, nil),
+	})
+	if len(term.calls) != 0 {
+		t.Fatalf("terminator must not be called when no pid was captured; got %v", term.calls)
+	}
+	if _, ok := err.(*PartialError); !ok {
+		t.Fatalf("maybe-live member must not read as clean success; want *PartialError, got %T: %v", err, err)
+	}
+	for _, want := range []string{"maybe-live", "no pid captured", "WARN:", "# AM_ROOT:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExecuteDownNotLiveForNoPIDStalePresence(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 0,
+	})
+	// Presence exists but is stale, so there is no reason to suspect liveness.
+	writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now().Add(-1 * time.Hour)})
+	term := &recordingTerminator{}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "cto",
+		Terminator:       term,
+		Probe:            downFakeProbe(nil, nil),
+	})
+	if err != nil {
+		t.Fatalf("down: %v", err)
+	}
+	if !strings.Contains(out, "not-live") || !strings.Contains(out, "no pid captured") {
+		t.Errorf("expected not-live with no-pid detail:\n%s", out)
+	}
+}
+
 func TestExecuteDownNotLiveForMissingRecord(t *testing.T) {
 	setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -50,6 +50,8 @@ func runLaunch(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args to treat as launch defaults, e.g. '--chrome'")
 	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent for the same handle/workstream is detected")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
+	launcherRaw := fs.String("launcher", "", "custom launcher to exec instead of <binary> (still receives AMQ env/identity, bootstrap, and a launch record)")
+	launcherArgsRaw := fs.String("launcher-args", "", "args passed to --launcher before the agent's child args; the launcher must forward trailing args to <binary>")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad launch - launch an agent with role metadata
@@ -112,6 +114,17 @@ Examples:
 	if err := validateTrustCombination(trustMode, trustExplicit, *noDefaultArgs, binaryArgs); err != nil {
 		return err
 	}
+	launcher := strings.TrimSpace(*launcherRaw)
+	var launcherArgs []string
+	if strings.TrimSpace(*launcherArgsRaw) != "" {
+		launcherArgs, err = parseAgentArgs(*launcherArgsRaw)
+		if err != nil {
+			return fmt.Errorf("parse --launcher-args: %w", err)
+		}
+	}
+	if launcher == "" && len(launcherArgs) > 0 {
+		return usageErrorf("--launcher-args requires --launcher")
+	}
 	remaining := fs.Args()
 	if len(remaining) == 0 {
 		return usageErrorf("launch requires a binary (e.g. 'amq-squad launch --role cpo codex')")
@@ -171,6 +184,8 @@ Examples:
 		AMQVersion:       env.AMQVersion,
 		CodexArgs:        binaryArgs["codex"],
 		ClaudeArgs:       binaryArgs["claude"],
+		Launcher:         launcher,
+		LauncherArgs:     launcherArgs,
 		Model:            strings.TrimSpace(*model),
 		Trust:            trustMode,
 		NoDefaultArgs:    *noDefaultArgs,
@@ -203,10 +218,19 @@ Examples:
 	if *me != "" {
 		coopArgs = append(coopArgs, "--me", *me)
 	}
-	coopArgs = append(coopArgs, binary)
-	if len(effectiveChildArgs) > 0 {
+	// A custom launcher is exec'd in place of the binary. Launcher args precede
+	// the agent's normal child args; the launcher is expected to forward the
+	// trailing args to the binary so bootstrap and default args still reach it.
+	target := binary
+	trailing := effectiveChildArgs
+	if launcher != "" {
+		target = launcher
+		trailing = append(append([]string(nil), launcherArgs...), effectiveChildArgs...)
+	}
+	coopArgs = append(coopArgs, target)
+	if len(trailing) > 0 {
 		coopArgs = append(coopArgs, "--")
-		coopArgs = append(coopArgs, effectiveChildArgs...)
+		coopArgs = append(coopArgs, trailing...)
 	}
 
 	if *dryRun {
@@ -214,6 +238,12 @@ Examples:
 		quietNotice("(dry run - no files written, not execing)\n")
 		verbosePolicyEcho()
 		return nil
+	}
+
+	if launcher != "" {
+		if err := ensureLauncherExecutable(launcher); err != nil {
+			return err
+		}
 	}
 
 	preflight := agentLaunchPreflight{
@@ -258,6 +288,26 @@ Examples:
 		return fmt.Errorf("amq not found in PATH: %w", err)
 	}
 	return syscall.Exec(amqBin, append([]string{"amq"}, coopArgs...), os.Environ())
+}
+
+// ensureLauncherExecutable verifies a custom --launcher path exists and is an
+// executable file before exec, so a missing or non-executable wrapper fails
+// with a clear message instead of an opaque coop exec error.
+func ensureLauncherExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("launcher %q not found", path)
+		}
+		return fmt.Errorf("launcher %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("launcher %q is a directory, not an executable", path)
+	}
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("launcher %q is not executable (chmod +x it)", path)
+	}
+	return nil
 }
 
 func conversationRefFromFlags(conversation, conversationID string) (string, error) {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -26,6 +26,57 @@ func TestRunLaunchDryRunSandboxedCodexOmitsBypassDefault(t *testing.T) {
 	}
 }
 
+func TestRunLaunchDryRunCustomLauncherWrapsBinary(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{
+			"--dry-run", "--no-bootstrap", "--no-default-args",
+			"--launcher", "/opt/launch.sh",
+			"--launcher-args=--pull --workspace /x",
+			"claude", "test-prompt",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	// The launcher is exec'd in place of the binary; launcher args precede the
+	// agent's child args so the wrapper can forward the trailing ones to claude.
+	want := "amq coop exec /opt/launch.sh -- --pull --workspace /x test-prompt"
+	if !strings.Contains(stdout, want) {
+		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestEnsureLauncherExecutable(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := filepath.Join(dir, "nope.sh")
+	if err := ensureLauncherExecutable(missing); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("missing launcher: want 'not found' error, got %v", err)
+	}
+
+	notExec := filepath.Join(dir, "plain.sh")
+	if err := os.WriteFile(notExec, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureLauncherExecutable(notExec); err == nil || !strings.Contains(err.Error(), "not executable") {
+		t.Errorf("non-executable launcher: want 'not executable' error, got %v", err)
+	}
+
+	if err := ensureLauncherExecutable(dir); err == nil || !strings.Contains(err.Error(), "directory") {
+		t.Errorf("directory launcher: want 'directory' error, got %v", err)
+	}
+
+	okExec := filepath.Join(dir, "good.sh")
+	if err := os.WriteFile(okExec, []byte("#!/bin/sh\nexec claude \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureLauncherExecutable(okExec); err != nil {
+		t.Errorf("executable launcher: want nil, got %v", err)
+	}
+}
+
 func TestRunLaunchDryRunTrustedCodexPrependsBypass(t *testing.T) {
 	setupFakeAMQ(t)
 

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -274,6 +274,12 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if len(rec.ClaudeArgs) > 0 {
 		args = append(args, "--claude-args="+joinedAgentArgs(rec.ClaudeArgs))
 	}
+	if rec.Launcher != "" {
+		args = append(args, "--launcher", rec.Launcher)
+		if len(rec.LauncherArgs) > 0 {
+			args = append(args, "--launcher-args="+joinedAgentArgs(rec.LauncherArgs))
+		}
+	}
 	if rec.Handle != "" {
 		args = append(args, "--me", rec.Handle)
 	}
@@ -433,6 +439,14 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	if len(rec.ClaudeArgs) > 0 {
 		b.WriteString(" --claude-args=")
 		b.WriteString(shellQuote(joinedAgentArgs(rec.ClaudeArgs)))
+	}
+	if rec.Launcher != "" {
+		b.WriteString(" --launcher ")
+		b.WriteString(shellQuote(rec.Launcher))
+		if len(rec.LauncherArgs) > 0 {
+			b.WriteString(" --launcher-args=")
+			b.WriteString(shellQuote(joinedAgentArgs(rec.LauncherArgs)))
+		}
 	}
 	if rec.Handle != "" && rec.Handle != defaultHandleFor(rec.Binary) {
 		b.WriteString(" --me ")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -14,16 +14,22 @@ func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
 		Binary: "claude", Handle: "qa", Role: "qa", Session: "beta",
 		Launcher: "/opt/launch.sh", LauncherArgs: []string{"--pull", "--workspace", "/x"},
 	}
-	// Resume/restore must reconstruct the wrapper, not relaunch the raw binary.
-	joined := strings.Join(launchArgsFromRecord(rec), " ")
-	if !strings.Contains(joined, "--launcher /opt/launch.sh") {
-		t.Errorf("resume args missing --launcher: %s", joined)
+	// Resume/restore must reconstruct the wrapper as pre-binary launch flags, in
+	// order — not relaunch the raw binary. Pin the exact arg slice so a reorder
+	// (e.g. a launcher flag leaking past the binary positional or the "--"
+	// child boundary) fails loudly rather than passing a substring check.
+	want := []string{
+		"--no-bootstrap", "--role", "qa", "--session", "beta",
+		"--launcher", "/opt/launch.sh", "--launcher-args=--pull --workspace /x",
+		"--me", "qa", "claude",
 	}
-	if !strings.Contains(joined, "--launcher-args=--pull --workspace /x") {
-		t.Errorf("resume args missing exact --launcher-args value: %s", joined)
+	if got := launchArgsFromRecord(rec); !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord(rec)\n got: %v\nwant: %v", got, want)
 	}
-	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh") || !strings.Contains(cmd, "--launcher-args=") {
-		t.Errorf("emit command missing launcher flags: %s", cmd)
+	// emitCommandWithOptions: the launcher flag must be immediately followed by
+	// its args flag (ordering pinned; quoting of the value is left to shellQuote).
+	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh --launcher-args=") {
+		t.Errorf("emit command missing ordered launcher segment: %s", cmd)
 	}
 
 	// A launcher with no args must not emit an empty --launcher-args=.

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -19,11 +19,22 @@ func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
 	if !strings.Contains(joined, "--launcher /opt/launch.sh") {
 		t.Errorf("resume args missing --launcher: %s", joined)
 	}
-	if !strings.Contains(joined, "--launcher-args=") || !strings.Contains(joined, "--pull") {
-		t.Errorf("resume args missing --launcher-args: %s", joined)
+	if !strings.Contains(joined, "--launcher-args=--pull --workspace /x") {
+		t.Errorf("resume args missing exact --launcher-args value: %s", joined)
 	}
-	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh") {
-		t.Errorf("emit command missing --launcher: %s", cmd)
+	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh") || !strings.Contains(cmd, "--launcher-args=") {
+		t.Errorf("emit command missing launcher flags: %s", cmd)
+	}
+
+	// A launcher with no args must not emit an empty --launcher-args=.
+	noArgs := rec
+	noArgs.LauncherArgs = nil
+	jn := strings.Join(launchArgsFromRecord(noArgs), " ")
+	if !strings.Contains(jn, "--launcher /opt/launch.sh") {
+		t.Errorf("no-args case missing --launcher: %s", jn)
+	}
+	if strings.Contains(jn, "--launcher-args") {
+		t.Errorf("no-args case should not emit --launcher-args: %s", jn)
 	}
 }
 

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -26,21 +26,32 @@ func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
 	if got := launchArgsFromRecord(rec); !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord(rec)\n got: %v\nwant: %v", got, want)
 	}
-	// emitCommandWithOptions: the launcher flag must be immediately followed by
-	// its args flag (ordering pinned; quoting of the value is left to shellQuote).
-	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh --launcher-args=") {
-		t.Errorf("emit command missing ordered launcher segment: %s", cmd)
+	// emitCommandWithOptions: pin the exact launcher segment, value included.
+	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh --launcher-args='--pull --workspace /x'") {
+		t.Errorf("emit command missing exact launcher segment: %s", cmd)
 	}
 
-	// A launcher with no args must not emit an empty --launcher-args=.
+	// With child argv present, the launcher flags must stay before the "--"
+	// passthrough boundary rather than leaking into the child args.
+	argvRec := rec
+	argvRec.NoDefaultArgs = true
+	argvRec.Argv = []string{"hello-prompt"}
+	ac := emitCommandWithOptions(argvRec, emitCommandOptions{})
+	li, di := strings.Index(ac, "--launcher /opt/launch.sh"), strings.Index(ac, " -- ")
+	if li < 0 || di < 0 || li > di {
+		t.Errorf("launcher segment must precede the -- child boundary: %s", ac)
+	}
+
+	// A launcher with no args must not emit an empty --launcher-args=, in either
+	// the replay arg slice or the emitted command.
 	noArgs := rec
 	noArgs.LauncherArgs = nil
 	jn := strings.Join(launchArgsFromRecord(noArgs), " ")
-	if !strings.Contains(jn, "--launcher /opt/launch.sh") {
-		t.Errorf("no-args case missing --launcher: %s", jn)
+	if !strings.Contains(jn, "--launcher /opt/launch.sh") || strings.Contains(jn, "--launcher-args") {
+		t.Errorf("no-args replay should have --launcher without --launcher-args: %s", jn)
 	}
-	if strings.Contains(jn, "--launcher-args") {
-		t.Errorf("no-args case should not emit --launcher-args: %s", jn)
+	if nc := emitCommandWithOptions(noArgs, emitCommandOptions{}); !strings.Contains(nc, "--launcher /opt/launch.sh") || strings.Contains(nc, "--launcher-args") {
+		t.Errorf("no-args emit should have --launcher without --launcher-args: %s", nc)
 	}
 }
 

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/omriariav/amq-squad/internal/launch"
 )
 
+func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
+	rec := launch.Record{
+		Binary: "claude", Handle: "qa", Role: "qa", Session: "beta",
+		Launcher: "/opt/launch.sh", LauncherArgs: []string{"--pull", "--workspace", "/x"},
+	}
+	// Resume/restore must reconstruct the wrapper, not relaunch the raw binary.
+	joined := strings.Join(launchArgsFromRecord(rec), " ")
+	if !strings.Contains(joined, "--launcher /opt/launch.sh") {
+		t.Errorf("resume args missing --launcher: %s", joined)
+	}
+	if !strings.Contains(joined, "--launcher-args=") || !strings.Contains(joined, "--pull") {
+		t.Errorf("resume args missing --launcher-args: %s", joined)
+	}
+	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--launcher /opt/launch.sh") {
+		t.Errorf("emit command missing --launcher: %s", cmd)
+	}
+}
+
 func TestShellQuoteSafeString(t *testing.T) {
 	cases := map[string]string{
 		"claude":          "claude",

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -37,9 +37,12 @@ func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
 	argvRec.NoDefaultArgs = true
 	argvRec.Argv = []string{"hello-prompt"}
 	ac := emitCommandWithOptions(argvRec, emitCommandOptions{})
-	li, di := strings.Index(ac, "--launcher /opt/launch.sh"), strings.Index(ac, " -- ")
+	li, di := strings.Index(ac, "--launcher /opt/launch.sh --launcher-args='--pull --workspace /x'"), strings.Index(ac, " -- ")
 	if li < 0 || di < 0 || li > di {
-		t.Errorf("launcher segment must precede the -- child boundary: %s", ac)
+		t.Errorf("full launcher segment must precede the -- child boundary: %s", ac)
+	}
+	if after := ac[di:]; strings.Contains(after, "--launcher") {
+		t.Errorf("launcher flags must not appear after the -- child boundary: %s", ac)
 	}
 
 	// A launcher with no args must not emit an empty --launcher-args=, in either

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -145,12 +145,26 @@ func executeStatus(s statusExecution) error {
 		})
 	}
 	policy := outputPolicyCurrent()
+	fmt.Fprintf(s.Out, "# workstream: %s\n", workstream)
+	if root := firstStatusRoot(rows); root != "" {
+		fmt.Fprintf(s.Out, "# AM_ROOT:    %s\n", root)
+	}
+	fmt.Fprintln(s.Out)
 	w := tabwriter.NewWriter(s.Out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ROLE\tHANDLE\tBINARY\tSESSION\tSTATUS\tDETAIL")
 	for _, r := range rows {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.Role, r.Handle, r.Binary, r.Session, colorStatus(policy, string(r.Status)), r.Detail)
 	}
 	return w.Flush()
+}
+
+func firstStatusRoot(rows []statusRecord) string {
+	for _, r := range rows {
+		if r.Root != "" {
+			return r.Root
+		}
+	}
+	return ""
 }
 
 func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe duplicateLaunchProbe) statusRecord {
@@ -230,7 +244,7 @@ func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe d
 	}
 	if presenceLive {
 		rec.Status = statusStateLive
-		rec.Detail = fmt.Sprintf("fresh active presence (last seen %s)", presence.LastSeen.UTC().Format(time.RFC3339))
+		rec.Detail = fmt.Sprintf("fresh active presence, no verified pid (last seen %s)", presence.LastSeen.UTC().Format(time.RFC3339))
 		return rec
 	}
 	// Not live. Stale requires a live-pointing disk signal for this handle.

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -181,6 +181,36 @@ func TestExecuteStatusLiveOnFreshActivePresence(t *testing.T) {
 	}
 }
 
+func TestExecuteStatusSurfacesRootAndPresenceOnlyDetail(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	now := time.Now()
+	writeStatusPresence(t, base, "issue-96", "cto", presenceFile{
+		Handle:   "cto",
+		Status:   "active",
+		LastSeen: now.Add(-10 * time.Second),
+	})
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             false,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	// AM_ROOT must be discoverable, and a presence-only live member must say so
+	// (no verified pid) so it reconciles with down's "no pid to signal".
+	for _, want := range []string{"# AM_ROOT:", "no verified pid"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("status output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestExecuteStatusStalePresenceCollapsesToMissing(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -650,6 +650,14 @@ func emitTeamCommand(in emitTeamCommandInput) string {
 		b.WriteString(" --me ")
 		b.WriteString(shellQuote(m.Handle))
 	}
+	if m.Launcher != "" {
+		b.WriteString(" --launcher ")
+		b.WriteString(shellQuote(m.Launcher))
+		if len(m.LauncherArgs) > 0 {
+			b.WriteString(" --launcher-args=")
+			b.WriteString(shellQuote(joinedAgentArgs(m.LauncherArgs)))
+		}
+	}
 	extraDefaultArgs := binaryArgsFor(m.Binary, in.BinaryArgs)
 	if len(extraDefaultArgs) > 0 {
 		switch normalizedAgentBinary(m.Binary) {

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -247,6 +247,17 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 	if opts.DryRun {
 		return backend.DryRun(t, opts)
 	}
+	// Validate every configured custom launcher up front so a missing or
+	// non-executable wrapper aborts the whole launch before any pane opens,
+	// rather than failing mid-roster after other members have already started.
+	for _, m := range t.Members {
+		if m.Launcher == "" {
+			continue
+		}
+		if err := ensureLauncherExecutable(m.Launcher); err != nil {
+			return fmt.Errorf("%s: %w", m.Role, err)
+		}
+	}
 	// Live launch. If the caller (up --seed-from) requested a seeded brief,
 	// write it now: all team-launch validations and preflight have passed,
 	// so we are committed to opening backend panes. Doing the write here

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -128,7 +128,7 @@ func TestTmuxDryRunLinesCanTargetCurrentWindow(t *testing.T) {
 	for _, want := range []string{
 		// Anchored on the launching shell's own pane ($TMUX_PANE), not the
 		// focused window, so panes never hijack an unrelated tab (#40).
-		`window=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}:#{window_index}')`,
+		`window=$(tmux display-message -p -t "${TMUX_PANE:?run amq-squad up from inside a tmux pane}" '#{session_name}:#{window_index}')`,
 		`first_pane="$TMUX_PANE"`,
 		`tmux select-pane -t "$first_pane" -T cto`,
 		`pane_1=$(tmux split-window -P -F '#{pane_id}' -t "$window" -h -c /repo)`,

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -126,8 +126,10 @@ func TestTmuxDryRunLinesCanTargetCurrentWindow(t *testing.T) {
 	}
 	got := strings.Join(tmuxDryRunLines(plan), "\n")
 	for _, want := range []string{
-		"window=$(tmux display-message -p '#{session_name}:#{window_index}')",
-		"first_pane=$(tmux display-message -p '#{session_name}:#{window_index}.#{pane_index}')",
+		// Anchored on the launching shell's own pane ($TMUX_PANE), not the
+		// focused window, so panes never hijack an unrelated tab (#40).
+		`window=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}:#{window_index}')`,
+		`first_pane="$TMUX_PANE"`,
 		`tmux select-pane -t "$first_pane" -T cto`,
 		`pane_1=$(tmux split-window -P -F '#{pane_id}' -t "$window" -h -c /repo)`,
 		`tmux send-keys -t "$first_pane"`,

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -137,7 +137,7 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 		windowTarget = "$window"
 		firstTarget = "$first_pane"
 		lines = append(lines,
-			`window=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}:#{window_index}')`,
+			`window=$(tmux display-message -p -t "${TMUX_PANE:?run amq-squad up from inside a tmux pane}" '#{session_name}:#{window_index}')`,
 			`first_pane="$TMUX_PANE"`,
 		)
 	} else {

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -137,8 +137,8 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 		windowTarget = "$window"
 		firstTarget = "$first_pane"
 		lines = append(lines,
-			"window=$(tmux display-message -p '#{session_name}:#{window_index}')",
-			"first_pane=$(tmux display-message -p '#{session_name}:#{window_index}.#{pane_index}')",
+			`window=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}:#{window_index}')`,
+			`first_pane="$TMUX_PANE"`,
 		)
 	} else {
 		lines = append(lines, shellCommand("tmux", "new-session", "-d", "-s", plan.Session, "-n", "squad", "-c", plan.Panes[0].CWD))
@@ -210,20 +210,22 @@ func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 	firstTarget := plan.Session + ":0.0"
 	switch plan.Target {
 	case "current-window":
-		if os.Getenv("TMUX") == "" {
-			return fmt.Errorf("--target current-window requires running inside tmux")
+		paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+		if os.Getenv("TMUX") == "" || paneID == "" {
+			return fmt.Errorf("--target current-window requires running inside tmux (TMUX_PANE unset); attach a tmux session and launch from one of its panes, or use --target new-session")
 		}
+		// Anchor on the launching shell's own pane ($TMUX_PANE), never tmux's
+		// focused pane. `tmux display-message -p` without -t reports whichever
+		// window is active *now*, so under iTerm2 -CC a focus change mid-launch
+		// rehomes the panes onto an unrelated tab (#40). Resolving the window
+		// from TMUX_PANE with -t makes targeting deterministic regardless of focus.
 		var err error
-		windowTarget, err = outputCommand("tmux", "display-message", "-p", "#{session_name}:#{window_index}")
-		if err != nil {
-			return err
-		}
-		firstTarget, err = outputCommand("tmux", "display-message", "-p", "#{session_name}:#{window_index}.#{pane_index}")
+		windowTarget, err = outputCommand("tmux", "display-message", "-p", "-t", paneID, "#{session_name}:#{window_index}")
 		if err != nil {
 			return err
 		}
 		windowTarget = strings.TrimSpace(windowTarget)
-		firstTarget = strings.TrimSpace(firstTarget)
+		firstTarget = paneID
 	case "new-session":
 		if err := tmuxEnsureSessionAbsent(plan.Session); err != nil {
 			return err

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -53,7 +53,7 @@ func renderTeamRules(t team.Team) (string, error) {
 
 	b.WriteString("## Communication\n\n")
 	b.WriteString("- Use focused AMQ threads.\n")
-	b.WriteString("- Use p2p threads for role-to-role handoffs.\n")
+	b.WriteString("- Use p2p threads for role-to-role handoffs; send them as `--kind review_request` (or `--kind todo` for a queued task). There is no `handoff` message kind.\n")
 	b.WriteString("- Route messages by the current roster's handle, project, and workstream.\n")
 	b.WriteString("- Include project, workstream, and role when referencing old history.\n")
 	b.WriteString("- One concern per message when practical.\n\n")

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -136,6 +136,29 @@ func TestEmitTeamCommandShape(t *testing.T) {
 	}
 }
 
+func TestEmitTeamCommandIncludesCustomLauncher(t *testing.T) {
+	m := team.Member{
+		Role:         "qa",
+		Binary:       "claude",
+		Handle:       "qa",
+		Launcher:     "/opt/scripts/pm-os-dev.sh",
+		LauncherArgs: []string{"--pull", "--workspace", "/x"},
+	}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/repo", SquadBin: "amq-squad", Member: m, Workstream: "issue-96", TrustMode: trustModeSandboxed,
+	})
+	for _, want := range []string{
+		"--launcher /opt/scripts/pm-os-dev.sh",
+		"--launcher-args=",
+		"--pull",
+		"--workspace",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
 func TestEmitTeamCommandSandboxedCodexOmitsBypass(t *testing.T) {
 	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
 	cmd := emitTeamCommand(emitTeamCommandInput{

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -42,6 +42,8 @@ type Record struct {
 	AMQVersion       string    `json:"amq_version,omitempty"`
 	CodexArgs        []string  `json:"codex_args,omitempty"`
 	ClaudeArgs       []string  `json:"claude_args,omitempty"`
+	Launcher         string    `json:"launcher,omitempty"`
+	LauncherArgs     []string  `json:"launcher_args,omitempty"`
 	Model            string    `json:"model,omitempty"`
 	Trust            string    `json:"trust,omitempty"`
 	NoDefaultArgs    bool      `json:"no_default_args,omitempty"`

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -41,6 +41,12 @@ type Member struct {
 	Session string `json:"session"` // AMQ workstream session name
 	Model   string `json:"model,omitempty"`
 	CWD     string `json:"cwd,omitempty"`
+	// Launcher is an optional wrapper command exec'd in place of Binary while
+	// the member still receives AMQ identity, bootstrap, and a launch record.
+	// LauncherArgs precede the agent's normal child args; the launcher is
+	// expected to forward the trailing args to Binary so bootstrap survives.
+	Launcher     string   `json:"launcher,omitempty"`
+	LauncherArgs []string `json:"launcher_args,omitempty"`
 }
 
 // EffectiveCWD returns the member's working directory, falling back to the
@@ -286,6 +292,22 @@ func validateMember(prefix string, m Member) error {
 		if !filepath.IsAbs(m.CWD) {
 			return fmt.Errorf("%s.cwd: must be absolute", prefix)
 		}
+	}
+	if m.Launcher != "" {
+		if err := ValidateDisplayValue("launcher", m.Launcher); err != nil {
+			return fmt.Errorf("%s.launcher: %w", prefix, err)
+		}
+		if !filepath.IsAbs(m.Launcher) {
+			return fmt.Errorf("%s.launcher: must be absolute", prefix)
+		}
+	}
+	for i, a := range m.LauncherArgs {
+		if err := ValidateDisplayValue("launcher_args", a); err != nil {
+			return fmt.Errorf("%s.launcher_args[%d]: %w", prefix, i, err)
+		}
+	}
+	if m.Launcher == "" && len(m.LauncherArgs) > 0 {
+		return fmt.Errorf("%s.launcher_args: set launcher before launcher_args", prefix)
 	}
 	return nil
 }

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -45,7 +46,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		t.Fatalf("Members len = %d, want %d", len(out.Members), len(in.Members))
 	}
 	for i, m := range out.Members {
-		if m != in.Members[i] {
+		if !reflect.DeepEqual(m, in.Members[i]) {
 			t.Errorf("Members[%d] = %+v, want %+v", i, m, in.Members[i])
 		}
 	}
@@ -139,5 +140,28 @@ func TestValidateRejectsDuplicateHandles(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "duplicate handle") {
 		t.Fatalf("Validate error = %v, want duplicate handle", err)
+	}
+}
+
+func TestValidateMemberLauncher(t *testing.T) {
+	base := Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}
+
+	ok := base
+	ok.Launcher = "/opt/scripts/pm-os-dev.sh"
+	ok.LauncherArgs = []string{"--pull", "--workspace", "/x"}
+	if err := Validate(Team{Members: []Member{ok}}); err != nil {
+		t.Errorf("absolute launcher with args should validate, got %v", err)
+	}
+
+	rel := base
+	rel.Launcher = "scripts/pm-os-dev.sh"
+	if err := Validate(Team{Members: []Member{rel}}); err == nil || !strings.Contains(err.Error(), "launcher: must be absolute") {
+		t.Errorf("relative launcher: want 'must be absolute', got %v", err)
+	}
+
+	orphanArgs := base
+	orphanArgs.LauncherArgs = []string{"--pull"}
+	if err := Validate(Team{Members: []Member{orphanArgs}}); err == nil || !strings.Contains(err.Error(), "set launcher before launcher_args") {
+		t.Errorf("launcher_args without launcher: want guard error, got %v", err)
 	}
 }

--- a/skills/claude/amq-squad/SKILL.md
+++ b/skills/claude/amq-squad/SKILL.md
@@ -95,6 +95,7 @@ Global output flags work before or after the subcommand: `--quiet`, `--verbose`,
        --subject "Review: X" --body "Please review."
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
+   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). `amq` rejects `--kind handoff` before sending, so it silently degrades to `status`.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 

--- a/skills/claude/amq-squad/SKILL.md
+++ b/skills/claude/amq-squad/SKILL.md
@@ -95,7 +95,7 @@ Global output flags work before or after the subcommand: `--quiet`, `--verbose`,
        --subject "Review: X" --body "Please review."
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
-   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). `amq` rejects `--kind handoff` before sending, so it silently degrades to `status`.
+   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). Emitting `--kind handoff` fails validation and falls back to `status`, losing the intended label.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 

--- a/skills/codex/amq-squad/SKILL.md
+++ b/skills/codex/amq-squad/SKILL.md
@@ -92,6 +92,7 @@ Global output flags work before or after the subcommand: `--quiet`, `--verbose`,
        --subject "Review: X" --body "Please review."
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
+   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). `amq` rejects `--kind handoff` before sending, so it silently degrades to `status`.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 

--- a/skills/codex/amq-squad/SKILL.md
+++ b/skills/codex/amq-squad/SKILL.md
@@ -92,7 +92,7 @@ Global output flags work before or after the subcommand: `--quiet`, `--verbose`,
        --subject "Review: X" --body "Please review."
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
-   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). `amq` rejects `--kind handoff` before sending, so it silently degrades to `status`.
+   - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). Emitting `--kind handoff` fails validation and falls back to `status`, losing the intended label.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 


### PR DESCRIPTION
Bundled 1.1.0 release: the post-v1.0.0 stabilization fixes plus the custom-launcher feature.

## Changes

- **#41 — handoff kind guidance.** Skills (Claude + Codex) and generated `team-rules.md` now spell out the valid `--kind` enum and map role handoffs to `--kind review_request` / `--kind todo`. `amq` has no `handoff` kind; this stops agents emitting it and getting silently downgraded to `status`. (amq-squad can't change the enum — `avivsinai/agent-message-queue` owns it and isn't a dependency — so guidance is the lever.)
- **#38 — down honesty + presence/pid reconciliation.** `down` now reports `maybe-live` for members with no captured pid but fresh presence (instead of a misleading `not-live`), reconciles presence against the recorded pid, surfaces `AM_ROOT` in `down`/`status` headers, and exits partial (3) when it can't confirm a stop. `status` annotates presence-only liveness as "no verified pid." Deferred to a later release: `doctor --reap`, `resume` plain-language polish.
- **#40 — deterministic tmux pane targeting.** `current-window` now anchors on the launching shell's `$TMUX_PANE` (passes `-t`), so a focus change mid-launch under iTerm2 `tmux -CC` no longer rehomes panes onto an unrelated tab. Refuses cleanly when launched outside tmux. Deferred: a `--target-window` flag.
- **#42 — custom launchers for managed agents.** New `--launcher` / `--launcher-args` flags and `launcher` / `launcher_args` member config. The launcher is exec'd in place of the binary while still receiving AMQ identity/env, bootstrap, a launch record, and status/resume. Path is validated (clear errors for missing/non-executable). The launcher must forward its trailing args to the agent binary (documented). `up --dry-run` prints the resolved command.

## Tests / docs

- New tests for all four; `make ci` (fmt-check, vet, test) green.
- README + doc.html updated for #40 and #42.

Closes #38
Closes #40
Closes #41
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)