### PR TITLE
1.2.0: down/up reliability + amq env diagnostics + resume --exec

### DIFF
--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -37,12 +38,20 @@ func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 		args = append(args, "--session", session)
 	}
 	cmd := exec.Command("amq", args...)
+	// Strip AMQ identity vars unconditionally: the operator has already passed
+	// --root/--session/--me on the wire, and a stale AM_ROOT/AM_ME from a
+	// previous shell session must not silently override them.
+	cmd.Env = envWithoutAMQIdentity(os.Environ())
 	if cwd != "" {
 		cmd.Dir = cwd
-		cmd.Env = envWithoutAMQIdentity(os.Environ())
 	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return amqEnv{}, fmt.Errorf("amq env: %w: %s", err, msg)
+		}
 		return amqEnv{}, fmt.Errorf("amq env: %w", err)
 	}
 	var parsed amqEnv

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -69,6 +70,27 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 	if got.Root != "/target/session" || got.BaseRoot != "/target" ||
 		got.Me != "amq-squad" || got.Project != "target-project" {
 		t.Fatalf("resolveAMQEnvInDir = %+v", got)
+	}
+}
+
+// TestResolveAMQEnvIncludesStderrOnFailure covers #46: amq env failures
+// must surface stderr text in the wrapped error. Previously cmd.Output()
+// dropped stderr and operators only saw "amq env: exit status N".
+func TestResolveAMQEnvIncludesStderrOnFailure(t *testing.T) {
+	script := "#!/bin/sh\n" +
+		"echo 'error: cannot resolve workstream \"ghost\" under .agent-mail/' >&2\n" +
+		"exit 2\n"
+	setupFakeAMQScript(t, script)
+
+	_, err := resolveAMQEnv("", "ghost", "cto")
+	if err == nil {
+		t.Fatal("expected error from amq env exit 2")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve workstream") {
+		t.Errorf("error should include stderr text from amq; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 2") {
+		t.Errorf("error should still include exit status; got: %v", err)
 	}
 }
 

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -22,6 +23,10 @@ const (
 	downStatusNotLive   downStatus = "not-live"
 	downStatusMaybeLive downStatus = "maybe-live"
 	downStatusFailed    downStatus = "failed"
+	// downStatusCleaned means the agent PID was already dead but stale
+	// runtime artifacts (orphan wake process, wake.lock, active presence)
+	// were reaped so the next `up` cannot collide with them.
+	downStatusCleaned downStatus = "cleaned"
 )
 
 type downReport struct {
@@ -212,11 +217,23 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
 			return report
 		}
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.any() {
+			report.Status = downStatusCleaned
+			report.Detail = "no pid captured at launch; " + cleaned.summary()
+			return report
+		}
 		report.Status = downStatusNotLive
 		report.Detail = "no pid captured at launch and presence is not fresh — treating as not live"
 		return report
 	}
 	if !probe.PIDAlive(rec.AgentPID) {
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.any() {
+			report.Status = downStatusCleaned
+			report.Detail = fmt.Sprintf("recorded pid %d is not alive; %s", rec.AgentPID, cleaned.summary())
+			return report
+		}
 		report.Status = downStatusNotLive
 		report.Detail = fmt.Sprintf("recorded pid %d is not alive", rec.AgentPID)
 		return report
@@ -226,6 +243,12 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 		binary = m.Binary
 	}
 	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.any() {
+			report.Status = downStatusCleaned
+			report.Detail = fmt.Sprintf("pid %d does not match expected binary %q (PID reuse); %s", rec.AgentPID, binary, cleaned.summary())
+			return report
+		}
 		report.Status = downStatusNotLive
 		report.Detail = fmt.Sprintf("pid %d does not match expected binary %q (PID reuse)", rec.AgentPID, binary)
 		return report
@@ -235,9 +258,115 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 		report.Detail = fmt.Sprintf("terminate pid %d: %v", rec.AgentPID, err)
 		return report
 	}
+	// The agent itself just received SIGTERM. Reap the wake sidecar and
+	// flip presence offline up front so a racing `up` cannot collide on
+	// artifacts whose owner is in the process of exiting.
+	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
 	report.Status = downStatusForceSent
 	report.Detail = fmt.Sprintf("SIGTERM sent to pid %d", rec.AgentPID)
+	if cleaned.any() {
+		report.Detail += "; " + cleaned.summary()
+	}
 	return report
+}
+
+// reapResult records which orphan artifacts were cleaned during teardown so
+// the per-member report can surface them.
+type reapResult struct {
+	WakeKilled   int
+	LockRemoved  bool
+	PresenceFlip bool
+}
+
+func (r reapResult) any() bool {
+	return r.WakeKilled > 0 || r.LockRemoved || r.PresenceFlip
+}
+
+func (r reapResult) summary() string {
+	parts := make([]string, 0, 3)
+	if r.WakeKilled > 0 {
+		parts = append(parts, fmt.Sprintf("SIGTERM sent to wake pid %d", r.WakeKilled))
+	}
+	if r.LockRemoved {
+		parts = append(parts, "removed stale .wake.lock")
+	}
+	if r.PresenceFlip {
+		parts = append(parts, "flipped presence to offline")
+	}
+	if len(parts) == 0 {
+		return "no orphan artifacts found"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// reapStaleArtifacts cleans up the runtime side-effects an agent leaves
+// behind when its process dies but its wake sidecar and/or presence file
+// survive. Returns a reapResult describing what was done so the caller can
+// include it in user-visible reports. Errors during cleanup are best-effort
+// and do not propagate: the goal is to unblock the next launch, not to
+// guarantee atomicity.
+func reapStaleArtifacts(agentDir, handle, root string, term processTerminator, probe duplicateLaunchProbe) reapResult {
+	var result reapResult
+	if agentDir == "" {
+		return result
+	}
+
+	lockPath := wakeLockPath(agentDir)
+	if data, err := os.ReadFile(lockPath); err == nil {
+		var lock wakeLockFile
+		if jsonErr := json.Unmarshal(data, &lock); jsonErr == nil && lock.PID > 0 && probe.PIDAlive(lock.PID) {
+			expectedRoot := root
+			if lock.Root != "" {
+				expectedRoot = lock.Root
+			}
+			if probe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, expectedRoot)) {
+				if termErr := term.Terminate(lock.PID); termErr == nil {
+					result.WakeKilled = lock.PID
+				}
+			}
+		}
+		// Remove the lock unconditionally once we've made our SIGTERM decision:
+		// either it's a verified-stale lock (PID dead / unrelated process) and
+		// preflight would have stripped it anyway, or we just SIGTERMed the wake
+		// and the next `up` should not have to wait for the wake's own teardown
+		// to delete it.
+		if rmErr := os.Remove(lockPath); rmErr == nil {
+			result.LockRemoved = true
+		}
+	}
+
+	presencePath := filepath.Join(agentDir, "presence.json")
+	if data, err := os.ReadFile(presencePath); err == nil {
+		var pres presenceFile
+		if jsonErr := json.Unmarshal(data, &pres); jsonErr == nil {
+			if pres.Handle != "" && pres.Handle != handle {
+				// Foreign handle wrote this file; leave it alone.
+				return result
+			}
+			// Only flip ACTIVE+FRESH presence: a stale "active" file is not
+			// blocking anyone (preflight ignores anything past the freshness
+			// window), so touching it is pure noise. A fresh active file with
+			// a dead agent/wake is the zombie-heartbeat case #38 / #44 — that
+			// is what needs flipping so the next `up` is not blocked.
+			if strings.EqualFold(pres.Status, "active") && !pres.LastSeen.IsZero() && probe.Now().Sub(pres.LastSeen) <= presenceFreshness {
+				pres.Status = "offline"
+				pres.LastSeen = probe.Now().UTC()
+				if pres.Schema == 0 {
+					pres.Schema = 1
+				}
+				if pres.Handle == "" {
+					pres.Handle = handle
+				}
+				if newData, marshErr := json.Marshal(pres); marshErr == nil {
+					if writeErr := os.WriteFile(presencePath, newData, 0o600); writeErr == nil {
+						result.PresenceFlip = true
+					}
+				}
+			}
+		}
+	}
+
+	return result
 }
 
 // presenceFreshFor reports the agent's last heartbeat and whether it is recent
@@ -268,7 +397,7 @@ func renderDownReports(out io.Writer, workstream string, reports []downReport) e
 	fmt.Fprintf(out, "# targets:    %d\n", len(reports))
 	fmt.Fprintln(out)
 	policy := outputPolicyCurrent()
-	var sent, notLive, maybeLive, failed int
+	var sent, notLive, maybeLive, failed, cleaned int
 	for _, r := range reports {
 		fmt.Fprintf(out, "%-12s %-10s %s\n", r.Role, colorStatus(policy, string(r.Status)), r.Detail)
 		switch r.Status {
@@ -280,10 +409,12 @@ func renderDownReports(out io.Writer, workstream string, reports []downReport) e
 			maybeLive++
 		case downStatusFailed:
 			failed++
+		case downStatusCleaned:
+			cleaned++
 		}
 	}
 	fmt.Fprintln(out)
-	fmt.Fprintf(out, "# summary: %d force-sent, %d not-live, %d maybe-live, %d failed\n", sent, notLive, maybeLive, failed)
+	fmt.Fprintf(out, "# summary: %d force-sent, %d cleaned, %d not-live, %d maybe-live, %d failed\n", sent, cleaned, notLive, maybeLive, failed)
 	if maybeLive > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintf(out, "WARN: %d member(s) had no pid to signal but still report fresh presence — they may still be running.\n", maybeLive)
@@ -295,10 +426,11 @@ func renderDownReports(out io.Writer, workstream string, reports []downReport) e
 		if maybeLive > 0 {
 			msg += fmt.Sprintf("; %d may still be live (no pid to signal)", maybeLive)
 		}
-		// Partial (exit 3) when there is either progress (a SIGTERM was sent) or
-		// an unconfirmed stop (maybe-live): neither is a clean success nor a
-		// wholesale breakage. Only a pure all-failed run stays a plain error.
-		if sent > 0 || maybeLive > 0 {
+		// Partial (exit 3) when there is either progress (a SIGTERM was sent,
+		// an orphan was reaped) or an unconfirmed stop (maybe-live): neither
+		// is a clean success nor a wholesale breakage. Only a pure all-failed
+		// run stays a plain error.
+		if sent > 0 || cleaned > 0 || maybeLive > 0 {
 			return &PartialError{Message: msg}
 		}
 		return errors.New(msg)

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -218,6 +218,11 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 			return report
 		}
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.failed() {
+			report.Status = downStatusFailed
+			report.Detail = "no pid captured at launch; " + cleaned.summary()
+			return report
+		}
 		if cleaned.any() {
 			report.Status = downStatusCleaned
 			report.Detail = "no pid captured at launch; " + cleaned.summary()
@@ -229,6 +234,11 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 	}
 	if !probe.PIDAlive(rec.AgentPID) {
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.failed() {
+			report.Status = downStatusFailed
+			report.Detail = fmt.Sprintf("recorded pid %d is not alive; %s", rec.AgentPID, cleaned.summary())
+			return report
+		}
 		if cleaned.any() {
 			report.Status = downStatusCleaned
 			report.Detail = fmt.Sprintf("recorded pid %d is not alive; %s", rec.AgentPID, cleaned.summary())
@@ -244,6 +254,11 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 	}
 	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		if cleaned.failed() {
+			report.Status = downStatusFailed
+			report.Detail = fmt.Sprintf("pid %d does not match expected binary %q (PID reuse); %s", rec.AgentPID, binary, cleaned.summary())
+			return report
+		}
 		if cleaned.any() {
 			report.Status = downStatusCleaned
 			report.Detail = fmt.Sprintf("pid %d does not match expected binary %q (PID reuse); %s", rec.AgentPID, binary, cleaned.summary())
@@ -260,32 +275,47 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 	}
 	// The agent itself just received SIGTERM. Reap the wake sidecar and
 	// flip presence offline up front so a racing `up` cannot collide on
-	// artifacts whose owner is in the process of exiting.
+	// artifacts whose owner is in the process of exiting. A reap-side
+	// failure does not retract the SIGTERM we just sent to the agent;
+	// surface it as a partial-progress detail line so the operator can see
+	// the wake survived without rolling back the agent kill.
 	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
 	report.Status = downStatusForceSent
 	report.Detail = fmt.Sprintf("SIGTERM sent to pid %d", rec.AgentPID)
-	if cleaned.any() {
+	if cleaned.any() || cleaned.failed() {
 		report.Detail += "; " + cleaned.summary()
 	}
 	return report
 }
 
 // reapResult records which orphan artifacts were cleaned during teardown so
-// the per-member report can surface them.
+// the per-member report can surface them. WakeSignalFailed is set when a
+// matching live wake was found but Terminate returned an error; in that
+// case the lock and presence are preserved so the next preflight still sees
+// the live writer.
 type reapResult struct {
-	WakeKilled   int
-	LockRemoved  bool
-	PresenceFlip bool
+	WakeKilled       int
+	WakeSignalFailed int
+	WakeSignalError  string
+	LockRemoved      bool
+	PresenceFlip     bool
 }
 
 func (r reapResult) any() bool {
 	return r.WakeKilled > 0 || r.LockRemoved || r.PresenceFlip
 }
 
+func (r reapResult) failed() bool {
+	return r.WakeSignalFailed > 0
+}
+
 func (r reapResult) summary() string {
 	parts := make([]string, 0, 3)
 	if r.WakeKilled > 0 {
 		parts = append(parts, fmt.Sprintf("SIGTERM sent to wake pid %d", r.WakeKilled))
+	}
+	if r.WakeSignalFailed > 0 {
+		parts = append(parts, fmt.Sprintf("failed to signal wake pid %d (%s); lock and presence left intact", r.WakeSignalFailed, r.WakeSignalError))
 	}
 	if r.LockRemoved {
 		parts = append(parts, "removed stale .wake.lock")
@@ -312,26 +342,47 @@ func reapStaleArtifacts(agentDir, handle, root string, term processTerminator, p
 	}
 
 	lockPath := wakeLockPath(agentDir)
+	// canRemoveLock tracks whether we've confirmed the lock is safe to
+	// remove: confirmed stale (dead PID / PID-reused / corrupt), or we
+	// successfully signaled the live matching wake. If a matching wake is
+	// live and we FAIL to signal it, leaving the lock in place keeps the
+	// next preflight honest — operators must not be told the system is
+	// clean when a foreign-uid wake is still running.
+	canRemoveLock := false
 	if data, err := os.ReadFile(lockPath); err == nil {
 		var lock wakeLockFile
-		if jsonErr := json.Unmarshal(data, &lock); jsonErr == nil && lock.PID > 0 && probe.PIDAlive(lock.PID) {
+		switch jsonErr := json.Unmarshal(data, &lock); {
+		case jsonErr != nil:
+			// Corrupt lock: no PID to verify, safe to remove.
+			canRemoveLock = true
+		case lock.PID <= 0:
+			canRemoveLock = true
+		case !probe.PIDAlive(lock.PID):
+			canRemoveLock = true
+		default:
 			expectedRoot := root
 			if lock.Root != "" {
 				expectedRoot = lock.Root
 			}
-			if probe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, expectedRoot)) {
-				if termErr := term.Terminate(lock.PID); termErr == nil {
-					result.WakeKilled = lock.PID
-				}
+			if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, expectedRoot)) {
+				// PID-reuse by an unrelated process: lock is stale.
+				canRemoveLock = true
+			} else if termErr := term.Terminate(lock.PID); termErr == nil {
+				result.WakeKilled = lock.PID
+				canRemoveLock = true
+			} else {
+				// Live matching wake we could not signal. Surface the
+				// failure and leave both lock and presence intact so
+				// preflight keeps blocking the next `up`.
+				result.WakeSignalFailed = lock.PID
+				result.WakeSignalError = termErr.Error()
+				return result
 			}
 		}
-		// Remove the lock unconditionally once we've made our SIGTERM decision:
-		// either it's a verified-stale lock (PID dead / unrelated process) and
-		// preflight would have stripped it anyway, or we just SIGTERMed the wake
-		// and the next `up` should not have to wait for the wake's own teardown
-		// to delete it.
-		if rmErr := os.Remove(lockPath); rmErr == nil {
-			result.LockRemoved = true
+		if canRemoveLock {
+			if rmErr := os.Remove(lockPath); rmErr == nil {
+				result.LockRemoved = true
+			}
 		}
 	}
 

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -275,14 +275,22 @@ func terminateMember(t team.Team, m team.Member, workstream string, term process
 	}
 	// The agent itself just received SIGTERM. Reap the wake sidecar and
 	// flip presence offline up front so a racing `up` cannot collide on
-	// artifacts whose owner is in the process of exiting. A reap-side
-	// failure does not retract the SIGTERM we just sent to the agent;
-	// surface it as a partial-progress detail line so the operator can see
-	// the wake survived without rolling back the agent kill.
+	// artifacts whose owner is in the process of exiting. A reap failure
+	// (live matching wake we could not signal) is itself a partial-down:
+	// the agent is dying but the wake is still running and the on-disk
+	// lock + presence are intentionally preserved. Surface that as
+	// downStatusFailed so renderDownReports counts it correctly; without
+	// this, the per-member detail says "wake survived" but the summary
+	// still reads as a clean success.
 	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+	if cleaned.failed() {
+		report.Status = downStatusFailed
+		report.Detail = fmt.Sprintf("SIGTERM sent to pid %d; %s", rec.AgentPID, cleaned.summary())
+		return report
+	}
 	report.Status = downStatusForceSent
 	report.Detail = fmt.Sprintf("SIGTERM sent to pid %d", rec.AgentPID)
-	if cleaned.any() || cleaned.failed() {
+	if cleaned.any() {
 		report.Detail += "; " + cleaned.summary()
 	}
 	return report

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -586,3 +586,125 @@ func TestExecuteDownAllScopedToConfiguredMembers(t *testing.T) {
 		t.Fatalf("--all targeted unconfigured handles: calls = %v, want [11]", term.calls)
 	}
 }
+
+// TestExecuteDownReapKeepsLockOnSignalFailure covers the case where a
+// matching live wake exists but Terminate returns an error (e.g. EPERM on
+// a wake owned by another uid). The lock must NOT be removed and presence
+// must NOT flip — otherwise the next `up` would see clean state and
+// duplicate-launch on top of a still-running wake.
+func TestExecuteDownReapKeepsLockOnSignalFailure(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "qa", launch.Record{
+		Binary: "claude", Handle: "qa", AgentPID: 1111,
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 3476, Root: filepath.Join(base, "issue-96")})
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	term := &recordingTerminator{failOn: map[int]error{3476: errors.New("operation not permitted")}}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "qa",
+		Terminator:       term,
+		// Agent dead, wake alive + matching.
+		Probe: downFakeProbe(
+			map[int]bool{1111: false, 3476: true},
+			map[int]bool{1111: false, 3476: true},
+		),
+	})
+	if err == nil {
+		t.Fatalf("signal failure should not return nil:\n%s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); statErr != nil {
+		t.Errorf(".wake.lock must be preserved when SIGTERM fails: %v", statErr)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "active") {
+		t.Errorf("presence must not flip to offline when wake signal failed; got %q", pres.Status)
+	}
+	for _, want := range []string{"failed", "failed to signal wake pid 3476", "operation not permitted"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestExecuteDownReapRejectsForeignRootWake covers PID reuse where the
+// live PID belongs to a wake for a different workstream root. The lock
+// must be removed (stale for this dir) and the foreign wake must NOT be
+// signaled.
+func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 7000,
+	})
+	// Lock claims our root; the live PID actually belongs to a wake for a
+	// sibling root. wakeProcessMatcher will reject; reap must classify the
+	// lock as stale and not signal.
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 9000, Root: filepath.Join(base, "issue-96")})
+
+	term := &recordingTerminator{}
+	_, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "cto",
+		Terminator:       term,
+		// PID alive but ProcessMatch returns false (foreign root).
+		Probe: downFakeProbe(
+			map[int]bool{7000: false, 9000: true},
+			map[int]bool{7000: false, 9000: false},
+		),
+	})
+	if err != nil {
+		t.Fatalf("foreign-root reap should be exit 0: %v", err)
+	}
+	if len(term.calls) != 0 {
+		t.Fatalf("foreign-root wake must not be signaled; got %v", term.calls)
+	}
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
+		t.Errorf("foreign-root lock should be removed as stale; stat err = %v", statErr)
+	}
+}
+
+// TestRenderDownReportsCleanedAndFailedStaysPartial covers the reporting
+// contract for the new cleaned status mixed with a failed teardown: the
+// combined exit must be partial so the operator sees both that work was
+// done AND that something needs attention.
+func TestRenderDownReportsCleanedAndFailedStaysPartial(t *testing.T) {
+	var buf bytes.Buffer
+	reports := []downReport{
+		{Role: "cto", Root: "/tmp/root", Status: downStatusCleaned, Detail: "recorded pid 1 is not alive; flipped presence to offline"},
+		{Role: "qa", Root: "/tmp/root", Status: downStatusFailed, Detail: "terminate pid 5: boom"},
+	}
+	err := renderDownReports(&buf, "issue-96", reports)
+	pe, ok := err.(*PartialError)
+	if !ok {
+		t.Fatalf("cleaned+failed must be *PartialError, got %T: %v", err, err)
+	}
+	for _, want := range []string{"1 of 2", "1 force-sent, 1 cleaned"} {
+		if want == "1 force-sent, 1 cleaned" {
+			// summary line literal: 0 force-sent, 1 cleaned, ...
+			if !strings.Contains(buf.String(), "0 force-sent, 1 cleaned") {
+				t.Errorf("summary line missing cleaned counter:\n%s", buf.String())
+			}
+			continue
+		}
+		if !strings.Contains(pe.Message, want) {
+			t.Errorf("partial message missing %q: %q", want, pe.Message)
+		}
+	}
+}

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -42,6 +42,25 @@ func downFakeProbe(alive map[int]bool, match map[int]bool) duplicateLaunchProbe 
 	}
 }
 
+// downRealMatcherProbe returns a probe whose ProcessMatch actually invokes
+// the predicate against synthetic ps args, so reapStaleArtifacts is
+// exercised through wakeProcessMatcher rather than through a canned
+// pass/fail map. The pidArgs map maps each live PID to the string `ps`
+// would return for it.
+func downRealMatcherProbe(alive map[int]bool, pidArgs map[int]string) duplicateLaunchProbe {
+	return duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return alive[pid] },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			args, ok := pidArgs[pid]
+			if !ok {
+				return false
+			}
+			return predicate(args)
+		},
+		Now: time.Now,
+	}
+}
+
 // seedAgentRecord writes a launch.json under the AMQ fake-root layout for a
 // given workstream and handle. Returns the agent dir so tests can assert on
 // resolution side effects.
@@ -642,7 +661,8 @@ func TestExecuteDownReapKeepsLockOnSignalFailure(t *testing.T) {
 // TestExecuteDownReapRejectsForeignRootWake covers PID reuse where the
 // live PID belongs to a wake for a different workstream root. The lock
 // must be removed (stale for this dir) and the foreign wake must NOT be
-// signaled.
+// signaled. Uses the real wakeProcessMatcher predicate via synthetic ps
+// args so a future refactor that calls the wrong matcher is caught here.
 func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{
@@ -651,10 +671,11 @@ func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
 	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
 		Binary: "codex", Handle: "cto", AgentPID: 7000,
 	})
+	ourRoot := filepath.Join(base, "issue-96")
 	// Lock claims our root; the live PID actually belongs to a wake for a
-	// sibling root. wakeProcessMatcher will reject; reap must classify the
-	// lock as stale and not signal.
-	writeWakeLock(t, agentDir, wakeLockFile{PID: 9000, Root: filepath.Join(base, "issue-96")})
+	// foreign root with the same handle. wakeProcessMatcher must reject on
+	// root mismatch; reap must classify the lock as stale and not signal.
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 9000, Root: ourRoot})
 
 	term := &recordingTerminator{}
 	_, err := runDownExec(t, downExecution{
@@ -663,10 +684,12 @@ func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
 		ExplicitSession:  true,
 		Role:             "cto",
 		Terminator:       term,
-		// PID alive but ProcessMatch returns false (foreign root).
-		Probe: downFakeProbe(
+		Probe: downRealMatcherProbe(
 			map[int]bool{7000: false, 9000: true},
-			map[int]bool{7000: false, 9000: false},
+			map[int]string{
+				// Same --me cto, but --root points to a foreign workstream.
+				9000: "amq wake --me cto --root /tmp/foreign-root/other-session",
+			},
 		),
 	})
 	if err != nil {
@@ -677,6 +700,73 @@ func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
 		t.Errorf("foreign-root lock should be removed as stale; stat err = %v", statErr)
+	}
+}
+
+// TestExecuteDownAgentKilledButWakeReapFailsIsFailed covers the contract
+// surfaced in Codex pass 2: when the agent SIGTERM succeeds but the
+// matching live wake cannot be signaled, the per-member status must be
+// downStatusFailed so renderDownReports counts it as a failure. Without
+// this, the summary would read "1 force-sent" and exit 0 even though the
+// wake is still running and the lock is intentionally preserved.
+func TestExecuteDownAgentKilledButWakeReapFailsIsFailed(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "qa", launch.Record{
+		Binary: "claude", Handle: "qa", AgentPID: 1111,
+	})
+	ourRoot := filepath.Join(base, "issue-96")
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 3476, Root: ourRoot})
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	term := &recordingTerminator{
+		// Agent SIGTERM succeeds; wake SIGTERM fails (EPERM-shaped).
+		failOn: map[int]error{3476: errors.New("operation not permitted")},
+	}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "qa",
+		Terminator:       term,
+		Probe: downRealMatcherProbe(
+			map[int]bool{1111: true, 3476: true},
+			map[int]string{
+				1111: "claude",
+				3476: "amq wake --me qa --root " + ourRoot,
+			},
+		),
+	})
+	if err == nil {
+		t.Fatalf("wake-reap failure on force-sent path must produce non-zero exit:\n%s", out)
+	}
+	if _, ok := err.(*PartialError); ok {
+		// Per current contract this returns a plain error (1 of 1 failed,
+		// no other sent). Either is acceptable as "not clean success", but
+		// guard against a future regression to nil.
+		t.Logf("note: returned PartialError (also acceptable): %v", err)
+	}
+	for _, want := range []string{"failed", "SIGTERM sent to pid 1111", "failed to signal wake pid 3476", "operation not permitted"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The wake-lock and presence must remain so the next preflight still sees
+	// the live writer.
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); statErr != nil {
+		t.Errorf(".wake.lock must be preserved after wake signal failure: %v", statErr)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "active") {
+		t.Errorf("presence must not flip when wake signal failed; got %q", pres.Status)
 	}
 }
 

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -387,6 +387,179 @@ func TestExecuteDownResolvesDefaultWorkstream(t *testing.T) {
 	}
 }
 
+// TestExecuteDownReapsOrphanWakeOnDeadAgent covers #44: agent PID dead,
+// wake sidecar still alive + heartbeating presence. down --force must
+// SIGTERM the wake, drop the lock, and flip presence offline so the next
+// `up` does not collide.
+func TestExecuteDownReapsOrphanWakeOnDeadAgent(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "qa", launch.Record{
+		Binary: "claude", Handle: "qa", AgentPID: 1111,
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 3476, Root: filepath.Join(base, "issue-96")})
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	term := &recordingTerminator{}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "qa",
+		Terminator:       term,
+		// Agent pid dead, wake pid alive; both pass process-match.
+		Probe: downFakeProbe(
+			map[int]bool{1111: false, 3476: true},
+			map[int]bool{1111: false, 3476: true},
+		),
+	})
+	if err != nil {
+		t.Fatalf("cleaned reap should be exit 0: got %v\n%s", err, out)
+	}
+	if len(term.calls) != 1 || term.calls[0] != 3476 {
+		t.Fatalf("expected SIGTERM to orphan wake pid 3476; got %v", term.calls)
+	}
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
+		t.Errorf("stale .wake.lock should be removed; stat err = %v", statErr)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "offline") {
+		t.Errorf("presence should be flipped to offline; got %q", pres.Status)
+	}
+	for _, want := range []string{"cleaned", "recorded pid 1111 is not alive", "SIGTERM sent to wake pid 3476", "removed stale .wake.lock", "flipped presence to offline"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestExecuteDownReapsZombiePresenceWhenWakeDead covers the case where the
+// agent and wake are both dead but presence is still "active" within the
+// freshness window (zombie heartbeat from a long-running orphan that died
+// recently). down should flip it offline so preflight cannot block.
+func TestExecuteDownReapsZombiePresenceWhenWakeDead(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "cpo", launch.Record{
+		Binary: "codex", Handle: "cpo", AgentPID: 6139,
+	})
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cpo", Status: "active",
+		LastSeen: time.Now().Add(-30 * time.Second),
+	})
+
+	term := &recordingTerminator{}
+	out, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "cpo",
+		Terminator:       term,
+		Probe:            downFakeProbe(map[int]bool{6139: false}, map[int]bool{6139: false}),
+	})
+	if err != nil {
+		t.Fatalf("zombie-presence reap should be exit 0: got %v\n%s", err, out)
+	}
+	if len(term.calls) != 0 {
+		t.Fatalf("no terminator calls expected when no live PID; got %v", term.calls)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "offline") {
+		t.Errorf("presence should be flipped to offline; got %q", pres.Status)
+	}
+	if !strings.Contains(out, "cleaned") || !strings.Contains(out, "flipped presence to offline") {
+		t.Errorf("output missing cleaned+flip detail:\n%s", out)
+	}
+}
+
+// TestExecuteDownReapDoesNotTouchForeignPresence guards against clobbering
+// a presence file written by a different handle that happens to live under
+// this agent dir (defense in depth: shouldn't happen, but if it does we
+// must not silently flip another agent's heartbeat).
+func TestExecuteDownReapDoesNotTouchForeignPresence(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "qa", launch.Record{
+		Binary: "claude", Handle: "qa", AgentPID: 5555,
+	})
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "someone-else", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	term := &recordingTerminator{}
+	_, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "qa",
+		Terminator:       term,
+		Probe:            downFakeProbe(map[int]bool{5555: false}, map[int]bool{5555: false}),
+	})
+	if err != nil {
+		t.Fatalf("down: %v", err)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if pres.Handle != "someone-else" || !strings.EqualFold(pres.Status, "active") {
+		t.Errorf("foreign presence must not be modified; got handle=%q status=%q", pres.Handle, pres.Status)
+	}
+}
+
+// TestExecuteDownReapsLockOnPIDReuse covers a stale .wake.lock whose PID
+// has been recycled by an unrelated process. The lock must be removed but
+// the reused-PID process must not be SIGTERMed.
+func TestExecuteDownReapsLockOnPIDReuse(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 7000,
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 8888, Root: filepath.Join(base, "issue-96")})
+
+	term := &recordingTerminator{}
+	_, err := runDownExec(t, downExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Role:             "cto",
+		Terminator:       term,
+		// Agent dead; wake PID alive but process-match returns false (unrelated process).
+		Probe: downFakeProbe(
+			map[int]bool{7000: false, 8888: true},
+			map[int]bool{7000: false, 8888: false},
+		),
+	})
+	if err != nil {
+		t.Fatalf("lock cleanup should be exit 0: got %v", err)
+	}
+	if len(term.calls) != 0 {
+		t.Fatalf("reused PID must not receive SIGTERM; got %v", term.calls)
+	}
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
+		t.Errorf("stale lock should still be removed even on PID reuse; stat err = %v", statErr)
+	}
+}
+
 // TestExecuteDownAllScopedToConfiguredMembers proves --all does not sweep
 // every launch record on disk; only configured team members are targeted.
 func TestExecuteDownAllScopedToConfiguredMembers(t *testing.T) {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -287,7 +287,11 @@ Examples:
 	if err != nil {
 		return fmt.Errorf("amq not found in PATH: %w", err)
 	}
-	return syscall.Exec(amqBin, append([]string{"amq"}, coopArgs...), os.Environ())
+	// Strip inherited AMQ identity vars before exec'ing coop exec. We already
+	// resolved the right --root/--session/--me on the command line; passing a
+	// stale AM_ROOT/AM_ME from the launching shell along to the agent would
+	// re-create the identity-leak asymmetry #46 closed for env resolution.
+	return syscall.Exec(amqBin, append([]string{"amq"}, coopArgs...), envWithoutAMQIdentity(os.Environ()))
 }
 
 // ensureLauncherExecutable verifies a custom --launcher path exists and is an

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -128,25 +128,36 @@ func (p agentLaunchPreflight) check(probe duplicateLaunchProbe) (*duplicateBlock
 		AgentDir:   p.AgentDir,
 	}
 
+	// Presence first, before wake-lock cleanup runs. inspectPresence consults
+	// the wake.lock and launch.json writer-liveness to decide whether the
+	// presence file is a zombie heartbeat; inspectWakeLock will rewrite the
+	// disk by removing stale locks, which would otherwise make wake writer
+	// status look "unknown" instead of "known dead" to the presence check.
+	if reason, err := p.inspectPresence(probe); err != nil {
+		return nil, err
+	} else if reason != nil {
+		blocker.Reasons = append(blocker.Reasons, *reason)
+	}
+
 	// Wake lock.
 	if reason, err := p.inspectWakeLock(probe); err != nil {
 		return nil, err
 	} else if reason != nil {
-		blocker.Reasons = append(blocker.Reasons, *reason)
+		// Wake comes first in the reported blocker list for stable
+		// ordering with prior versions.
+		blocker.Reasons = append([]blockerReason{*reason}, blocker.Reasons...)
 	}
 
 	// Prior launch record (PID alive + plausible command).
 	if reason, err := p.inspectLaunchRecord(probe); err != nil {
 		return nil, err
 	} else if reason != nil {
-		blocker.Reasons = append(blocker.Reasons, *reason)
-	}
-
-	// Presence (secondary signal).
-	if reason, err := p.inspectPresence(probe); err != nil {
-		return nil, err
-	} else if reason != nil {
-		blocker.Reasons = append(blocker.Reasons, *reason)
+		// Launch slots in between wake and presence.
+		idx := 0
+		if len(blocker.Reasons) > 0 && blocker.Reasons[0].Source == "wake" {
+			idx = 1
+		}
+		blocker.Reasons = append(blocker.Reasons[:idx], append([]blockerReason{*reason}, blocker.Reasons[idx:]...)...)
 	}
 
 	if len(blocker.Reasons) == 0 {
@@ -273,6 +284,18 @@ func (p agentLaunchPreflight) inspectPresence(probe duplicateLaunchProbe) (*bloc
 	if pres.Handle != "" && pres.Handle != p.Handle {
 		return nil, nil
 	}
+	// Zombie-heartbeat guard (#38, #44): presence "fresh" only means SOMETHING
+	// has written the file in the last 90s. If we have launch+wake records on
+	// disk and both their recorded PIDs are dead (or PID-reused by an unrelated
+	// process), the file is a leftover from a writer that has since died — not
+	// a live agent. inspectWakeLock and inspectLaunchRecord will (a) already
+	// surface a blocker themselves when a live writer is present, and (b)
+	// remove the stale lock/record so a subsequent up succeeds. We must not
+	// keep the presence-only block once both signals are confirmed dead, or
+	// the operator hits the same wall a clean down → up would otherwise clear.
+	if p.presenceWriterIsKnownDead(probe) {
+		return nil, nil
+	}
 	msg := fmt.Sprintf("active presence updated %s", pres.LastSeen.UTC().Format(time.RFC3339))
 	msg += "; presence " + path
 	return &blockerReason{
@@ -280,6 +303,76 @@ func (p agentLaunchPreflight) inspectPresence(probe duplicateLaunchProbe) (*bloc
 		Message: msg,
 		Hint:    "wait for presence to expire, stop the running agent, or use --force-duplicate",
 	}, nil
+}
+
+// presenceWriterIsKnownDead reports whether the on-disk wake.lock and
+// launch.json both point at processes that are gone (dead PID or PID-reuse
+// by an unrelated process). When either record is missing we cannot prove
+// the writer is dead, so we keep the conservative behavior (presence
+// blocks). Only when both records exist and both are confirmed dead do we
+// treat the presence file as a zombie heartbeat.
+func (p agentLaunchPreflight) presenceWriterIsKnownDead(probe duplicateLaunchProbe) bool {
+	lockDead, lockKnown := p.wakeWriterDead(probe)
+	if !lockKnown {
+		return false
+	}
+	launchDead, launchKnown := p.launchWriterDead(probe)
+	if !launchKnown {
+		return false
+	}
+	return lockDead && launchDead
+}
+
+// wakeWriterDead inspects .wake.lock. Returns (dead, known): "known" is true
+// when the file existed and parsed; "dead" is true when the PID is gone or
+// the live PID does not match an amq wake for this handle/root.
+func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, known bool) {
+	data, err := os.ReadFile(wakeLockPath(p.AgentDir))
+	if err != nil {
+		return false, false
+	}
+	var lock wakeLockFile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return true, true
+	}
+	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {
+		return true, true
+	}
+	expectedRoot := p.Root
+	if lock.Root != "" {
+		expectedRoot = lock.Root
+	}
+	if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(p.Handle, expectedRoot)) {
+		return true, true
+	}
+	return false, true
+}
+
+// launchWriterDead inspects launch.json. Returns (dead, known): "known" is
+// true when the record existed and parsed and carries a captured AgentPID;
+// "dead" is true when that PID is gone or the live PID does not match the
+// expected agent binary.
+func (p agentLaunchPreflight) launchWriterDead(probe duplicateLaunchProbe) (dead, known bool) {
+	rec, err := launch.Read(p.AgentDir)
+	if err != nil {
+		return false, false
+	}
+	if rec.AgentPID <= 0 {
+		// No pid was captured at launch (e.g. codex seats). We cannot prove
+		// the writer is dead from this record alone.
+		return false, false
+	}
+	if !probe.PIDAlive(rec.AgentPID) {
+		return true, true
+	}
+	binary := strings.TrimSpace(rec.Binary)
+	if binary == "" {
+		binary = p.Binary
+	}
+	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
+		return true, true
+	}
+	return false, true
 }
 
 // wakeLockFile mirrors AMQ's wake.lock JSON shape.

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -324,8 +324,12 @@ func (p agentLaunchPreflight) presenceWriterIsKnownDead(probe duplicateLaunchPro
 }
 
 // wakeWriterDead inspects .wake.lock. Returns (dead, known): "known" is true
-// when the file existed and parsed; "dead" is true when the PID is gone or
-// the live PID does not match an amq wake for this handle/root.
+// when the file existed, parsed, and carried a usable PID; "dead" is true
+// when the PID is gone or the live PID does not match an amq wake for this
+// handle/root. A corrupt or unparseable lock is reported as unknown (not
+// dead): we have no evidence either way and the conservative answer for
+// the zombie-presence guard is to keep blocking. The stale-cleanup path in
+// inspectWakeLock still removes the corrupt file on its own.
 func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, known bool) {
 	data, err := os.ReadFile(wakeLockPath(p.AgentDir))
 	if err != nil {
@@ -333,9 +337,12 @@ func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, 
 	}
 	var lock wakeLockFile
 	if err := json.Unmarshal(data, &lock); err != nil {
-		return true, true
+		return false, false
 	}
-	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {
+	if lock.PID <= 0 {
+		return false, false
+	}
+	if !probe.PIDAlive(lock.PID) {
 		return true, true
 	}
 	expectedRoot := p.Root

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -680,21 +680,26 @@ func TestPreflightZombiePresenceDoesNotBlock(t *testing.T) {
 
 // TestPreflightFreshPresenceWithLiveAgentStillBlocks ensures the guard does
 // not over-correct: a live launch.json PID means there's a real agent that
-// could legitimately be writing presence.
+// could legitimately be writing presence. Includes both .wake.lock and
+// launch.json so the both-record evaluation path is exercised, and asserts
+// the blocker reasons keep their stable wake → launch → presence order.
 func TestPreflightFreshPresenceWithLiveAgentStillBlocks(t *testing.T) {
 	agentDir := t.TempDir()
 	writePresence(t, agentDir, presenceFile{
 		Schema: 1, Handle: "cto", Status: "active",
 		LastSeen: time.Now().Add(-5 * time.Second),
 	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1111, Root: "/r"})
 	if err := launch.Write(agentDir, launch.Record{
 		Binary: "codex", Handle: "cto", AgentPID: 4242, StartedAt: time.Now(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
+	// Wake dead but matching, launch alive: presenceWriterIsKnownDead must
+	// return false because the launch writer is alive.
 	probe := fakeProbe(
-		map[int]bool{4242: true},
+		map[int]bool{1111: false, 4242: true},
 		map[int]string{4242: "codex"},
 		time.Now(),
 	)
@@ -707,6 +712,96 @@ func TestPreflightFreshPresenceWithLiveAgentStillBlocks(t *testing.T) {
 	}
 	if blocker == nil {
 		t.Fatal("fresh presence with live agent must still block")
+	}
+	sources := make([]string, 0, len(blocker.Reasons))
+	for _, r := range blocker.Reasons {
+		sources = append(sources, r.Source)
+	}
+	// Wake is stale so inspectWakeLock won't emit a blocker, but launch is
+	// alive and presence is fresh: both must appear, launch before presence.
+	if got := strings.Join(sources, ","); got != "launch,presence" {
+		t.Errorf("blocker source order = %q, want launch,presence", got)
+	}
+}
+
+// TestPreflightLiveWakeAndDeadLaunchStillBlocks: wake is the writer, agent
+// is gone. Wake itself raises a blocker; presence must NOT short-circuit
+// to "writer dead" since the wake writer is alive.
+func TestPreflightLiveWakeAndDeadLaunchStillBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cto", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1111, Root: "/r"})
+	if err := launch.Write(agentDir, launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 4242, StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := fakeProbe(
+		map[int]bool{1111: true, 4242: false},
+		map[int]string{1111: "amq wake --me cto --root /r"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("live wake + dead launch + fresh presence must still block")
+	}
+	sources := make([]string, 0, len(blocker.Reasons))
+	for _, r := range blocker.Reasons {
+		sources = append(sources, r.Source)
+	}
+	if got := strings.Join(sources, ","); got != "wake,presence" {
+		t.Errorf("blocker source order = %q, want wake,presence", got)
+	}
+}
+
+// TestPreflightCorruptWakeLockKeepsPresenceConservative: corrupt lock has
+// no usable PID, so wakeWriterDead must report unknown — and presence must
+// keep blocking rather than treat the corrupt file as "writer dead."
+func TestPreflightCorruptWakeLockKeepsPresenceConservative(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cto", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+	if err := os.WriteFile(wakeLockPath(agentDir), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 4242, StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := fakeProbe(map[int]bool{4242: false}, nil, time.Now())
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("corrupt lock must not let presence pass: no proven dead writer")
+	}
+	sawPresence := false
+	for _, r := range blocker.Reasons {
+		if r.Source == "presence" {
+			sawPresence = true
+			break
+		}
+	}
+	if !sawPresence {
+		t.Errorf("expected presence in blocker reasons; got %+v", blocker.Reasons)
 	}
 }
 

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -644,3 +644,119 @@ func TestWakeHealthForEntry(t *testing.T) {
 		t.Errorf("inactive: got %q, want empty", got)
 	}
 }
+
+// TestPreflightZombiePresenceDoesNotBlock covers #38/#44: a fresh active
+// presence file written by an orphan wake that has since died (and a
+// launch.json whose AgentPID is also dead) must not keep `up` from
+// relaunching. Before the fix, presence freshness alone blocked even
+// after both writers were gone.
+func TestPreflightZombiePresenceDoesNotBlock(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cto", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 1111, Root: "/r"})
+	if err := launch.Write(agentDir, launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 2222, StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both writers dead. Presence is fresh purely because of a recently
+	// killed orphan that updated the file before exit.
+	probe := fakeProbe(map[int]bool{1111: false, 2222: false}, nil, time.Now())
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker != nil {
+		t.Fatalf("zombie presence (both writers dead) should not block: %v", blocker)
+	}
+}
+
+// TestPreflightFreshPresenceWithLiveAgentStillBlocks ensures the guard does
+// not over-correct: a live launch.json PID means there's a real agent that
+// could legitimately be writing presence.
+func TestPreflightFreshPresenceWithLiveAgentStillBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cto", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+	if err := launch.Write(agentDir, launch.Record{
+		Binary: "codex", Handle: "cto", AgentPID: 4242, StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := fakeProbe(
+		map[int]bool{4242: true},
+		map[int]string{4242: "codex"},
+		time.Now(),
+	)
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Binary: "codex",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("fresh presence with live agent must still block")
+	}
+}
+
+// TestPreflightFreshPresenceWithCodexSeatStillBlocks: codex seats often
+// have no captured AgentPID. The launch record exists but cannot prove the
+// writer dead, so presence still blocks (conservative).
+func TestPreflightFreshPresenceWithCodexSeatStillBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "cpo", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+	if err := launch.Write(agentDir, launch.Record{
+		Binary: "codex", Handle: "cpo", AgentPID: 0, StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "cpo", Workstream: "w", Root: "/r", Binary: "codex",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("no captured pid means we cannot prove writer dead; presence must still block")
+	}
+}
+
+// TestPreflightFreshPresenceWithoutLockOrRecordStillBlocks: when neither
+// .wake.lock nor launch.json exist on disk, we cannot prove the writer is
+// dead. Presence keeps the conservative block.
+func TestPreflightFreshPresenceWithoutLockOrRecordStillBlocks(t *testing.T) {
+	agentDir := t.TempDir()
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	probe := fakeProbe(map[int]bool{}, nil, time.Now())
+	pf := agentLaunchPreflight{
+		AgentDir: agentDir, Handle: "qa", Workstream: "w", Root: "/r", Binary: "claude",
+	}
+	blocker, err := pf.check(probe)
+	if err != nil {
+		t.Fatalf("check: %v", err)
+	}
+	if blocker == nil {
+		t.Fatal("with no on-disk writer records, presence must still block (cannot prove writer dead)")
+	}
+}

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/omriariav/amq-squad/internal/team"
 )
@@ -20,8 +21,14 @@ func runResume(args []string) error {
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for fresh members, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
 	profileFlag := fs.String("profile", "", "team profile to resume (default: default profile)")
+	execMode := fs.Bool("exec", false, "open the planned launch commands in the terminal backend (tmux) instead of printing them")
+	terminal := fs.String("terminal", "tmux", "terminal backend to use with --exec")
+	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window or new-session)")
+	layout := fs.String("layout", "vertical", "terminal layout with --exec (tmux: vertical, horizontal, or tiled)")
+	terminalSession := fs.String("terminal-session", "", "terminal session name when --exec --target new-session")
+	stagger := fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes with --exec")
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, `amq-squad resume - plan how to bring the team back
+		fmt.Fprint(os.Stderr, `amq-squad resume - bring the team back from launch records
 
 Usage:
   amq-squad resume [--profile NAME] [--session name] [--restore-existing]
@@ -29,21 +36,35 @@ Usage:
                    [--no-bootstrap] [--trust sandboxed|trusted]
                    [--model role=model,...]
                    [--codex-args args] [--claude-args args]
+                   [--exec [--terminal tmux] [--target current-window|new-session]
+                           [--layout vertical|horizontal|tiled]
+                           [--terminal-session name] [--stagger 750ms]]
 
 Inspects .amq-squad/team.json plus local launch history and live-agent
-signals (wake locks, agent PID liveness, presence) to print a per-member
-plan plus copy-pasteable commands.
+signals (wake locks, agent PID liveness, presence) to choose a per-member
+action: restore from launch.json, launch fresh from team intent, skip if
+live, or refuse if blocked.
+
+Default behavior is plan-only: prints the per-member action table plus
+copy-pasteable commands. With --exec, opens those commands through the
+selected terminal backend (same path as 'up'), skipping members that are
+already live and refusing to start if any member is in the 'blocked'
+action without --force-duplicate.
 
 Fresh / new-session behavior belongs to 'amq-squad fork --from S --as T'.
-Use 'amq-squad up' to open the planned team in tmux from team intent.
 
 Examples:
   amq-squad resume
   amq-squad resume --session issue-96 --restore-existing
+  amq-squad resume --exec
+  amq-squad resume --exec --target new-session --terminal-session squad
 `)
 	}
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	if *execMode && *dryRun {
+		return usageErrorf("--exec and --dry-run are mutually exclusive")
 	}
 
 	profile, err := resolveProfileFlag(*profileFlag)
@@ -61,6 +82,17 @@ Examples:
 	if *restoreExisting {
 		mode = resumeModeRestoreExisting
 	}
+	exec := resumeExecOptions{}
+	if *execMode {
+		exec = resumeExecOptions{
+			Enabled:         true,
+			Terminal:        *terminal,
+			Target:          *target,
+			Layout:          *layout,
+			TerminalSession: *terminalSession,
+			Stagger:         *stagger,
+		}
+	}
 	return executeResume(resumeExecution{
 		ProjectDir:       cwd,
 		RequestedSession: *sessionFlag,
@@ -76,5 +108,6 @@ Examples:
 		DryRun:           *dryRun,
 		Profile:          profile,
 		Style:            resumePrinterStyle{Label: "resume", FooterVerb: "up"},
+		Exec:             exec,
 	})
 }

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -196,6 +196,94 @@ func walkFiles(root string, visit func(path string, mode os.FileMode, size int64
 	})
 }
 
+// TestRunResumeRejectsExecWithDryRun guards the mutually-exclusive surface
+// so the operator does not get a silent no-op when they pass both.
+func TestRunResumeRejectsExecWithDryRun(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members:    []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := captureOutput(t, func() error { return runResume([]string{"--exec", "--dry-run"}) })
+	if err == nil {
+		t.Fatal("--exec --dry-run together should be a usage error")
+	}
+	if _, ok := err.(UsageError); !ok {
+		t.Fatalf("want UsageError, got %T: %v", err, err)
+	}
+}
+
+// TestExecResumePlanRefusesBlockedMembersUnlessForced covers the contract
+// that resume --exec is not a backdoor around live-agent protection: any
+// member in action=blocked aborts the run unless --force-duplicate.
+func TestExecResumePlanRefusesBlockedMembersUnlessForced(t *testing.T) {
+	t.Run("blocked aborts without force", func(t *testing.T) {
+		err := execResumePlan(
+			team.Team{Project: t.TempDir(), Members: []team.Member{{Role: "cto"}}},
+			"issue-96",
+			[]resumePlan{
+				{Role: "cto", Action: resumeBlocked, Note: "wake+presence", Command: ""},
+			},
+			resumeExecOptions{Enabled: true, Terminal: "tmux", Target: "current-window", Layout: "vertical"},
+			false,
+		)
+		if err == nil || !strings.Contains(err.Error(), "blocked") {
+			t.Fatalf("blocked member should abort: %v", err)
+		}
+		if !strings.Contains(err.Error(), "--force-duplicate") {
+			t.Errorf("error should mention escape hatch: %v", err)
+		}
+	})
+}
+
+// TestExecResumePlanNothingToLaunch covers the all-live scenario: every
+// member is already running, so there is nothing to send through the
+// terminal backend. Exit cleanly with a notice rather than opening an
+// empty pane.
+func TestExecResumePlanNothingToLaunch(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, err := captureOutput(t, func() error {
+		return execResumePlan(
+			team.Team{Project: dir, Members: []team.Member{{Role: "cto"}, {Role: "qa"}}},
+			"issue-96",
+			[]resumePlan{
+				{Role: "cto", Action: resumeLive, Note: "wake"},
+				{Role: "qa", Action: resumeLive, Note: "wake+presence"},
+			},
+			resumeExecOptions{Enabled: true, Terminal: "tmux", Target: "current-window", Layout: "vertical"},
+			false,
+		)
+	})
+	if err != nil {
+		t.Fatalf("all-live execResumePlan should succeed: %v", err)
+	}
+	for _, want := range []string{"resume --exec", "nothing to launch", "2 live"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestExecResumePlanRejectsUnknownTerminal makes sure the operator gets a
+// clear error rather than a downstream nil-map panic when the terminal
+// flag value is wrong.
+func TestExecResumePlanRejectsUnknownTerminal(t *testing.T) {
+	err := execResumePlan(
+		team.Team{Project: t.TempDir(), Members: []team.Member{{Role: "cto"}}},
+		"issue-96",
+		[]resumePlan{{Role: "cto", Action: resumeRestore, Command: "echo hi"}},
+		resumeExecOptions{Enabled: true, Terminal: "screen", Target: "current-window", Layout: "vertical"},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported terminal") {
+		t.Fatalf("expected unsupported-terminal error; got %v", err)
+	}
+}
+
 // walkDir is a tiny wrapper around filepath.Walk used by the disk-mutation
 // fingerprint test. Kept local so the existing helpers stay focused on the
 // planner inputs.

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -343,6 +343,19 @@ func execResumePlan(t team.Team, workstream string, plans []resumePlan, exec res
 	for _, p := range plans {
 		switch p.Action {
 		case resumeLive:
+			// planMemberResume emits a non-empty Command for live members
+			// only when the operator passed --force-duplicate; otherwise the
+			// command is suppressed. Honor that distinction here: relaunch
+			// live+forced members through the backend (parity with the
+			// printed plan) and skip the others with a clear notice.
+			if p.Command != "" {
+				panes = append(panes, teamLaunchPane{
+					Role:    p.Role,
+					CWD:     planMemberCWD(t, p.Role),
+					Command: p.Command,
+				})
+				continue
+			}
 			skipped = append(skipped, p)
 		case resumeBlocked:
 			blocked = append(blocked, p)
@@ -401,10 +414,63 @@ func execResumePlan(t team.Team, workstream string, plans []resumePlan, exec res
 		plan.Session = defaultTmuxSessionName(t.Project)
 	}
 
+	// Roster-level preflight before any pane opens, mirroring `up`'s
+	// contract (team_launch.go:243). Without this, each per-pane `agent up`
+	// preflights at exec time — but the operator only sees the refusal
+	// AFTER tmux has split panes. Run the same aggregate check now so a
+	// blocked member aborts cleanly before any backend side effects, and
+	// honor --force-duplicate by stamping it into each plan.
+	preflights, err := buildResumeExecPreflights(t, panes, workstream, force)
+	if err != nil {
+		return err
+	}
+	if err := preflightTeam(preflights, defaultDuplicateLaunchProbe); err != nil {
+		return err
+	}
+
 	for _, p := range skipped {
 		fmt.Fprintf(os.Stderr, "skipping %s: %s\n", p.Role, p.Note)
 	}
 	return runTmuxLaunchPlan(plan)
+}
+
+// buildResumeExecPreflights resolves the AMQ identity for each runnable
+// pane and constructs an agentLaunchPreflight tuple that preflightTeam can
+// use to refuse a blocked roster before tmux opens any pane.
+func buildResumeExecPreflights(t team.Team, panes []teamLaunchPane, workstream string, force bool) ([]agentLaunchPreflight, error) {
+	byRole := make(map[string]team.Member, len(t.Members))
+	for _, m := range t.Members {
+		byRole[strings.ToLower(m.Role)] = m
+	}
+	out := make([]agentLaunchPreflight, 0, len(panes))
+	for _, pane := range panes {
+		m, ok := byRole[strings.ToLower(pane.Role)]
+		if !ok {
+			// Pane built from a role we cannot resolve back to team.json:
+			// preflight cannot inspect identity, so skip it rather than
+			// fabricate a tuple that would block on the wrong agent dir.
+			continue
+		}
+		cwd := m.EffectiveCWD(t.Project)
+		env, err := resolveAMQEnvInDir(cwd, "", workstream, m.Handle)
+		if err != nil {
+			return nil, fmt.Errorf("resolve amq env for %s: %w", m.Handle, err)
+		}
+		root := env.Root
+		handle := m.Handle
+		if env.Me != "" {
+			handle = env.Me
+		}
+		out = append(out, agentLaunchPreflight{
+			AgentDir:   filepath.Join(root, "agents", handle),
+			Handle:     handle,
+			Workstream: env.SessionName,
+			Root:       root,
+			Binary:     m.Binary,
+			Force:      force,
+		})
+	}
+	return out, nil
 }
 
 // planMemberCWD resolves the effective cwd for a planned role by looking up

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/team"
@@ -161,6 +162,25 @@ type resumeExecution struct {
 	// planner can present its output as team resume, resume, or fork without
 	// duplicating logic.
 	Style resumePrinterStyle
+	// Exec opts in to the terminal-backend execution path: instead of
+	// printing the per-member plan, the planner converts restore/launch-fresh
+	// commands into a teamLaunchPlan and runs it through the chosen backend.
+	// Members with action=live are skipped; action=blocked aborts the run
+	// unless Force is also set.
+	Exec resumeExecOptions
+}
+
+// resumeExecOptions carries the live-launch backend flags surfaced by
+// `resume --exec`. They mirror the subset of liveLaunchFlags that resume
+// needs, which keeps the resume entry point free of preview-flag plumbing
+// that does not apply (no --fresh, no --json envelope).
+type resumeExecOptions struct {
+	Enabled         bool
+	Terminal        string
+	Target          string
+	Layout          string
+	TerminalSession string
+	Stagger         time.Duration
 }
 
 // resumePrinterStyle parameterizes the per-entry-point output surface. The
@@ -293,10 +313,112 @@ func executeResume(r resumeExecution) error {
 		}
 	}
 
+	if r.Exec.Enabled {
+		return execResumePlan(t, workstream, plans, r.Exec, r.Force)
+	}
+
 	style := r.Style
 	style.Profile = r.Profile
 	printResumePlan(t, workstream, r.Mode, plans, r.DryRun, r.Force, style)
 	return nil
+}
+
+// execResumePlan converts the per-member resume plan into a team launch
+// plan and runs it through the selected backend. Members already live are
+// skipped; members in the blocked action abort the run unless force was
+// requested. The contract matches operator expectation that `resume --exec`
+// is the inverse of `down`: it brings what is down back, leaves what is up
+// alone, and refuses to silently sidestep duplicate-launch protection.
+func execResumePlan(t team.Team, workstream string, plans []resumePlan, exec resumeExecOptions, force bool) error {
+	backend, ok := teamLaunchBackends[exec.Terminal]
+	if !ok {
+		return fmt.Errorf("unsupported terminal %q: supported terminals: %s", exec.Terminal, strings.Join(registeredTeamLaunchTerminals(), ", "))
+	}
+
+	var (
+		panes   []teamLaunchPane
+		skipped []resumePlan
+		blocked []resumePlan
+	)
+	for _, p := range plans {
+		switch p.Action {
+		case resumeLive:
+			skipped = append(skipped, p)
+		case resumeBlocked:
+			blocked = append(blocked, p)
+		case resumeRestore, resumeFresh:
+			if p.Command == "" {
+				// Defensive: planner emitted no command for a runnable
+				// action. Treat as blocked rather than silently dropping.
+				blocked = append(blocked, p)
+				continue
+			}
+			panes = append(panes, teamLaunchPane{
+				Role:    p.Role,
+				CWD:     planMemberCWD(t, p.Role),
+				Command: p.Command,
+			})
+		}
+	}
+
+	if len(blocked) > 0 && !force {
+		roles := make([]string, 0, len(blocked))
+		for _, p := range blocked {
+			roles = append(roles, fmt.Sprintf("%s (%s)", p.Role, p.Note))
+		}
+		return fmt.Errorf("refusing to exec resume: %d member(s) blocked: %s. Resolve manually or rerun with --force-duplicate.", len(blocked), strings.Join(roles, ", "))
+	}
+	if len(panes) == 0 {
+		// Nothing to do is success: all members are live or there is no
+		// recoverable plan. Tell the operator explicitly rather than
+		// silently opening an empty tmux window.
+		fmt.Printf("# amq-squad resume --exec\n# workstream: %s\n# nothing to launch (%d live, %d blocked)\n", workstream, len(skipped), len(blocked))
+		return nil
+	}
+
+	opts := teamLaunchOptions{
+		Terminal:        exec.Terminal,
+		Target:          exec.Target,
+		Layout:          exec.Layout,
+		Workstream:      workstream,
+		TerminalSession: exec.TerminalSession,
+		Stagger:         exec.Stagger,
+		SquadBin:        teamSquadBin(),
+	}
+	if err := backend.Validate(opts); err != nil {
+		return err
+	}
+
+	plan := tmuxLaunchPlan{
+		Session:    opts.TerminalSession,
+		Workstream: opts.Workstream,
+		Target:     opts.Target,
+		Layout:     opts.Layout,
+		Panes:      panes,
+		StartDelay: opts.Stagger,
+	}
+	if plan.Session == "" {
+		plan.Session = defaultTmuxSessionName(t.Project)
+	}
+
+	for _, p := range skipped {
+		fmt.Fprintf(os.Stderr, "skipping %s: %s\n", p.Role, p.Note)
+	}
+	return runTmuxLaunchPlan(plan)
+}
+
+// planMemberCWD resolves the effective cwd for a planned role by looking up
+// the team member. Falls back to the team project when the role is no
+// longer in team.json (which should not happen because the planner derives
+// its members from team.json, but it keeps execResumePlan robust against
+// future planner changes).
+func planMemberCWD(t team.Team, role string) string {
+	for _, m := range t.Members {
+		if strings.EqualFold(m.Role, role) {
+			return m.EffectiveCWD(t.Project)
+		}
+	}
+	return t.Project
 }
 
 type memberPlanInput struct {


### PR DESCRIPTION
## Summary

Closes #38, #44, #46, #47 and addresses the symptoms behind #45.

Four tightly-coupled fixes for the down → up cycle that surfaced again on 1.1.0:

- **`down --force` reaps orphan wake + cleans state (#44).** When the recorded agent PID is dead, `terminateMember` no longer short-circuits to `not-live`. It now consults `.wake.lock`, SIGTERMs the wake process if it is alive and matches `amq wake --me <handle>` for this root, removes the stale lock unconditionally, and flips fresh-active `presence.json` to `offline`. New `cleaned` status surfaces the work that was done.
- **Preflight presence requires a live writer (#38/#44).** `inspectPresence` previously blocked purely on `lastSeen` within 90s. Now it consults `.wake.lock` and `launch.json` — if both have records whose PIDs are dead (or PID-reused by an unrelated process), presence is treated as a zombie heartbeat and does not block. The conservative behavior (block) stays when records are missing or evidence is ambiguous.
- **`amq env` diagnostics (#46).** `amq_env.go` now captures stderr into the wrapped error so `amq env: exit status N` failures are diagnosable, and identity stripping (`AM_ROOT` / `AM_ME` / `AM_BASE_ROOT`) is unconditional. This removes the launch-vs-planner asymmetry where stale shell env leaked into `agent up` but not `resume`.
- **`resume --exec` (#47).** Adds an execute mode to the resume planner: instead of printing N commands for the operator to paste into N panes, `--exec` routes them through the same terminal backend `up` uses. Live members are skipped with a notice; blocked members abort the run unless `--force-duplicate` is also set.

## Test plan

- [x] `make ci` (fmt + vet + test) clean on this branch
- [ ] Manual repro from the original failure: `down --force` on a workstream with dead agent + live wake → status flips, lock removed, presence offline, next `up` succeeds
- [ ] `resume --exec` against a workstream with restorable records → tmux panes open with the saved commands
- [ ] `amq env: exit status 2` reproduction now includes stderr text
- [ ] `release-smoke VERSION=v1.2.0` after merge + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)