### PR TITLE
1.2.1: fix --session + --root collision in emitted commands

### DIFF
--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -31,11 +31,15 @@ func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 	if handle != "" {
 		args = append(args, "--me", handle)
 	}
-	if rootFlag != "" {
-		args = append(args, "--root", rootFlag)
-	}
+	// amq treats --session NAME as shorthand for --root .agent-mail/<name>
+	// and refuses both together. Prefer --session when both are supplied,
+	// since session is the more specific selector. Callers like restore
+	// historically passed both; we filter at the boundary so any other
+	// future caller cannot trip the same trap.
 	if session != "" {
 		args = append(args, "--session", session)
+	} else if rootFlag != "" {
+		args = append(args, "--root", rootFlag)
 	}
 	cmd := exec.Command("amq", args...)
 	// Strip AMQ identity vars unconditionally: the operator has already passed

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -36,6 +36,14 @@ func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 	// since session is the more specific selector. Callers like restore
 	// historically passed both; we filter at the boundary so any other
 	// future caller cannot trip the same trap.
+	//
+	// When BOTH are supplied (e.g. an operator typed `agent up --session X
+	// --root Y` directly), warn so the dropped --root is visible: silently
+	// launching into the session-derived root when the operator passed an
+	// explicit conflicting --root would be worse than the old failure.
+	if session != "" && rootFlag != "" {
+		fmt.Fprintf(os.Stderr, "warning: amq-squad: --session %q implies --root .agent-mail/%s; ignoring conflicting --root %q.\n", session, session, rootFlag)
+	}
 	if session != "" {
 		args = append(args, "--session", session)
 	} else if rootFlag != "" {

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -73,6 +73,37 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 	}
 }
 
+// TestResolveAMQEnvDropsRootWhenSessionProvided covers the boundary fix
+// for the mutual-exclusion bug: amq treats --session NAME as shorthand
+// for --root .agent-mail/<name> and rejects the call when both are set.
+// resolveAMQEnvInDir must forward only --session in that case. The fake
+// amq exits 2 with a recognizable error when it sees --root, so a regress
+// would fail this test.
+func TestResolveAMQEnvDropsRootWhenSessionProvided(t *testing.T) {
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"env\" ] && [ \"$2\" = \"--json\" ]; then\n" +
+		"  for arg in \"$@\"; do\n" +
+		"    if [ \"$arg\" = \"--root\" ]; then\n" +
+		"      echo 'fake amq: --session and --root are mutually exclusive' >&2\n" +
+		"      exit 2\n" +
+		"    fi\n" +
+		"  done\n" +
+		"  printf '%s\\n' '{\"root\":\"/p/.agent-mail/stream1\",\"base_root\":\"/p/.agent-mail\",\"session_name\":\"stream1\",\"me\":\"cto\"}'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"unexpected amq command: $*\" >&2\n" +
+		"exit 1\n"
+	setupFakeAMQScript(t, script)
+
+	got, err := resolveAMQEnv("/p/.agent-mail", "stream1", "cto")
+	if err != nil {
+		t.Fatalf("resolveAMQEnv with both flags must drop --root: %v", err)
+	}
+	if got.SessionName != "stream1" || got.Me != "cto" {
+		t.Fatalf("resolveAMQEnv = %+v", got)
+	}
+}
+
 // TestResolveAMQEnvIncludesStderrOnFailure covers #46: amq env failures
 // must surface stderr text in the wrapped error. Previously cmd.Output()
 // dropped stderr and operators only saw "amq env: exit status N".

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,14 +81,26 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 // amq exits 2 with a recognizable error when it sees --root, so a regress
 // would fail this test.
 func TestResolveAMQEnvDropsRootWhenSessionProvided(t *testing.T) {
+	// Fake amq: exit 2 if --root is seen, exit 2 if --session is missing,
+	// success otherwise. The two-sided check proves resolveAMQEnvInDir
+	// both drops --root AND forwards --session — dropping both would also
+	// fail without the missing-session guard.
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"env\" ] && [ \"$2\" = \"--json\" ]; then\n" +
+		"  saw_session=0\n" +
 		"  for arg in \"$@\"; do\n" +
 		"    if [ \"$arg\" = \"--root\" ]; then\n" +
 		"      echo 'fake amq: --session and --root are mutually exclusive' >&2\n" +
 		"      exit 2\n" +
 		"    fi\n" +
+		"    if [ \"$arg\" = \"--session\" ]; then\n" +
+		"      saw_session=1\n" +
+		"    fi\n" +
 		"  done\n" +
+		"  if [ \"$saw_session\" != \"1\" ]; then\n" +
+		"    echo 'fake amq: --session must be forwarded' >&2\n" +
+		"    exit 2\n" +
+		"  fi\n" +
 		"  printf '%s\\n' '{\"root\":\"/p/.agent-mail/stream1\",\"base_root\":\"/p/.agent-mail\",\"session_name\":\"stream1\",\"me\":\"cto\"}'\n" +
 		"  exit 0\n" +
 		"fi\n" +
@@ -97,10 +110,38 @@ func TestResolveAMQEnvDropsRootWhenSessionProvided(t *testing.T) {
 
 	got, err := resolveAMQEnv("/p/.agent-mail", "stream1", "cto")
 	if err != nil {
-		t.Fatalf("resolveAMQEnv with both flags must drop --root: %v", err)
+		t.Fatalf("resolveAMQEnv with both flags must drop --root and keep --session: %v", err)
 	}
 	if got.SessionName != "stream1" || got.Me != "cto" {
 		t.Fatalf("resolveAMQEnv = %+v", got)
+	}
+}
+
+// TestResolveAMQEnvWarnsWhenBothFlagsPresent: silent override of
+// operator-supplied --root would be worse than the prior failure, so the
+// boundary policy emits a stderr warning naming the dropped flag.
+func TestResolveAMQEnvWarnsWhenBothFlagsPresent(t *testing.T) {
+	setupFakeAMQEnv(t, `{"root":"/p/.agent-mail/stream1","session_name":"stream1","me":"cto"}`)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	if _, err := resolveAMQEnv("/p/.agent-mail/some/override", "stream1", "cto"); err != nil {
+		t.Fatalf("resolveAMQEnv: %v", err)
+	}
+	w.Close()
+	out, _ := io.ReadAll(r)
+	got := string(out)
+	if !strings.Contains(got, "ignoring conflicting --root") {
+		t.Errorf("expected stderr warning when both --session and --root supplied; got: %q", got)
+	}
+	if !strings.Contains(got, "stream1") {
+		t.Errorf("warning should name the session: %q", got)
 	}
 }
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -156,9 +156,12 @@ Examples:
 		return fmt.Errorf("getwd: %w", err)
 	}
 
-	// Resolve the AMQ env via the amq CLI. This respects .amqrc, --session,
-	// --root, and AMQ's validated sender identity exactly as coop exec will, so
-	// launch.json and the actual mailbox agree.
+	// Resolve the AMQ env via the amq CLI so launch.json and the actual
+	// mailbox agree. resolveAMQEnv respects .amqrc and AMQ's validated
+	// sender identity exactly as coop exec will. If both --session and
+	// --root were passed, the boundary policy in amq_env.go drops --root
+	// (and warns), since amq treats --session NAME as shorthand for
+	// --root .agent-mail/<name> and rejects the pair.
 	env, err := resolveAMQEnv(*rootFlag, *session, handle)
 	if err != nil {
 		return fmt.Errorf("resolve amq env: %w", err)
@@ -210,7 +213,9 @@ Examples:
 	// --dry-run is a true preview with zero side effects. --session NAME
 	// is amq shorthand for --root .agent-mail/<name>; passing both is
 	// rejected by amq, so prefer --session when callers supplied both
-	// (matching the resolveAMQEnvInDir boundary policy).
+	// (matching the resolveAMQEnvInDir boundary policy). The same warning
+	// fires once at env resolution time, so this branch stays silent to
+	// avoid duplicating the message.
 	coopArgs := []string{"coop", "exec"}
 	if *session != "" {
 		coopArgs = append(coopArgs, "--session", *session)

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -207,12 +207,14 @@ Examples:
 	}
 
 	// Build the coop exec invocation. Done before any disk writes so
-	// --dry-run is a true preview with zero side effects.
+	// --dry-run is a true preview with zero side effects. --session NAME
+	// is amq shorthand for --root .agent-mail/<name>; passing both is
+	// rejected by amq, so prefer --session when callers supplied both
+	// (matching the resolveAMQEnvInDir boundary policy).
 	coopArgs := []string{"coop", "exec"}
 	if *session != "" {
 		coopArgs = append(coopArgs, "--session", *session)
-	}
-	if *rootFlag != "" {
+	} else if *rootFlag != "" {
 		coopArgs = append(coopArgs, "--root", *rootFlag)
 	}
 	if *me != "" {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -428,3 +428,32 @@ func captureOutput(t *testing.T, fn func() error) (string, string, error) {
 	}
 	return string(stdout), string(stderr), runErr
 }
+
+// TestRunLaunchDryRunSessionAndRootDropsRoot covers the third call site of
+// the session+root mutual-exclusion fix: the coopArgs builder in
+// runLaunch must not pass --root to `amq coop exec` when --session is
+// already set, matching the boundary policy in resolveAMQEnvInDir. Without
+// this, even after restore.go stops emitting both, a caller who passes
+// both flags to `agent up` directly would still trip the same rejection
+// when launch.go re-builds the coop exec invocation.
+func TestRunLaunchDryRunSessionAndRootDropsRoot(t *testing.T) {
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{
+			"--dry-run", "--no-bootstrap",
+			"--session", "stream1",
+			"--root", "/p/.agent-mail",
+			"codex",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "--session stream1") {
+		t.Fatalf("coop exec must keep --session stream1:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "--root") {
+		t.Fatalf("coop exec must not emit --root alongside --session (amq rejects the combo):\n%s", stdout)
+	}
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -243,11 +243,11 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.Role != "" {
 		args = append(args, "--role", rec.Role)
 	}
+	// amq treats --session NAME as shorthand for --root .agent-mail/<name>,
+	// so passing both is a hard "mutually exclusive" rejection. Emit one or
+	// the other, never both. The same rule applies in emitCommandWithOptions.
 	if rec.Session != "" {
 		args = append(args, "--session", rec.Session)
-		if rec.BaseRoot != "" {
-			args = append(args, "--root", rec.BaseRoot)
-		}
 	} else if rec.Root != "" {
 		args = append(args, "--root", rec.Root)
 	}
@@ -403,13 +403,11 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 		b.WriteString(" --role ")
 		b.WriteString(shellQuote(rec.Role))
 	}
+	// amq treats --session NAME as shorthand for --root .agent-mail/<name>,
+	// so passing both is rejected by `amq env`. Emit one or the other.
 	if rec.Session != "" {
 		b.WriteString(" --session ")
 		b.WriteString(shellQuote(rec.Session))
-		if rec.BaseRoot != "" {
-			b.WriteString(" --root ")
-			b.WriteString(shellQuote(rec.BaseRoot))
-		}
 	} else if rec.Root != "" {
 		b.WriteString(" --root ")
 		b.WriteString(shellQuote(rec.Root))

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -171,7 +171,12 @@ func TestEmitCommandIncludesRootWhenSessionMissing(t *testing.T) {
 	}
 }
 
-func TestEmitCommandIncludesBaseRootWithSession(t *testing.T) {
+// TestEmitCommandOmitsRootWhenSessionPresent locks the fix for the
+// `--session and --root are mutually exclusive` regression: amq treats
+// --session NAME as shorthand for --root .agent-mail/<name>, so the
+// emitted plan must drop --root whenever --session is set, regardless of
+// what BaseRoot the record carries.
+func TestEmitCommandOmitsRootWhenSessionPresent(t *testing.T) {
 	rec := launch.Record{
 		CWD:      "/p",
 		Binary:   "claude",
@@ -181,10 +186,11 @@ func TestEmitCommandIncludesBaseRootWithSession(t *testing.T) {
 		BaseRoot: "/tmp/mail",
 	}
 	cmd := emitCommand(rec)
-	for _, want := range []string{"--root /tmp/mail", "--session stream1"} {
-		if !strings.Contains(cmd, want) {
-			t.Errorf("emitCommand missing %q in: %s", want, cmd)
-		}
+	if !strings.Contains(cmd, "--session stream1") {
+		t.Errorf("emitCommand should keep --session stream1 in: %s", cmd)
+	}
+	if strings.Contains(cmd, "--root") {
+		t.Errorf("emitCommand must not emit --root alongside --session (amq rejects the combo): %s", cmd)
 	}
 }
 
@@ -248,7 +254,11 @@ func TestLaunchArgsFromRecordUsesRootWithoutSession(t *testing.T) {
 	}
 }
 
-func TestLaunchArgsFromRecordPreservesBaseRootWithSession(t *testing.T) {
+// TestLaunchArgsFromRecordOmitsRootWhenSessionPresent locks the same
+// session/root mutual-exclusion fix on the --exec replay path. Without
+// this, `resume --exec` replays a saved record into amq env with both
+// flags and amq rejects the call before the agent can launch.
+func TestLaunchArgsFromRecordOmitsRootWhenSessionPresent(t *testing.T) {
 	rec := launch.Record{
 		Binary:   "claude",
 		Session:  "stream1",
@@ -257,7 +267,7 @@ func TestLaunchArgsFromRecordPreservesBaseRootWithSession(t *testing.T) {
 		BaseRoot: "/tmp/mail",
 	}
 	got := launchArgsFromRecord(rec)
-	want := []string{"--no-bootstrap", "--session", "stream1", "--root", "/tmp/mail", "--me", "claude", "claude"}
+	want := []string{"--no-bootstrap", "--session", "stream1", "--me", "claude", "claude"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("launchArgsFromRecord = %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary

Ancient bug, finally visible: amq treats `--session NAME` as shorthand for `--root .agent-mail/<name>` and rejects the call when both are passed. `amq-squad`'s restore code has been emitting both together since v0.x. The failure was invisible until v1.2.0 — `amq_env.go` was using `cmd.Output()` which dropped stderr, so the only signal was opaque `amq env: exit status 2`. The #46 stderr-capture fix made the underlying error visible:

\`\`\`
error: resolve amq env: amq env: exit status 2: --session and --root are mutually exclusive
\`\`\`

And v1.2.0's `resume --exec` then dutifully fed the broken commands into 4 tmux panes that all immediately errored.

## Fix

Three call sites, same rule: when `--session NAME` is set, drop `--root` (session is the more specific selector).

- **`restore.go emitCommandWithOptions`** — the printed plan
- **`restore.go launchArgsFromRecord`** — the `resume --exec` replay
- **`amq_env.go resolveAMQEnvInDir`** — defensive boundary fix so any future caller cannot trip the same trap
- **`launch.go` coopArgs builder** — same rule on the final `amq coop exec` invocation

## Tests

New:
- `TestEmitCommandOmitsRootWhenSessionPresent` — locks the printed plan
- `TestLaunchArgsFromRecordOmitsRootWhenSessionPresent` — locks the replay path
- `TestResolveAMQEnvDropsRootWhenSessionProvided` — fake amq exits 2 if `--root` shows up; proves the boundary
- `TestRunLaunchDryRunSessionAndRootDropsRoot` — locks the coopArgs change

Renamed + inverted (they pinned the buggy behavior):
- `TestEmitCommandIncludesBaseRootWithSession` → `TestEmitCommandOmitsRootWhenSessionPresent`
- `TestLaunchArgsFromRecordPreservesBaseRootWithSession` → `TestLaunchArgsFromRecordOmitsRootWhenSessionPresent`

## Test plan

- [x] `make ci` green
- [ ] Manual repro from the v1.2.0 transcript: `resume --exec` on `taboola-pm-os/beta-vault-context` should now launch all 4 panes without the "mutually exclusive" rejection
- [ ] `release-smoke VERSION=v1.2.1` after merge + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)