### PR TITLE
Fix legacy operator handle conflict

### DIFF
--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -335,7 +335,9 @@ func Validate(t Team) error {
 		return fmt.Errorf("trust: invalid trust mode %q: use sandboxed or trusted", t.Trust)
 	}
 	operatorHandle := ""
-	if t.Operator != nil {
+	if t.Operator == nil {
+		operatorHandle = DefaultOperatorHandle
+	} else {
 		if t.Operator.Enabled {
 			operatorHandle = strings.TrimSpace(t.Operator.Handle)
 			if operatorHandle == "" {

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -130,6 +130,26 @@ func TestReadSchema2AdvertisesImplicitOperatorGates(t *testing.T) {
 	}
 }
 
+func TestReadSchema2RejectsRunnableImplicitOperatorHandle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{
+  "schema": 2,
+  "members": [
+    {"role": "cto", "binary": "codex", "handle": "user", "session": "issue-96"}
+  ]
+}`
+	if err := os.WriteFile(Path(dir), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Read(dir)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with non-runnable operator") {
+		t.Fatalf("Read schema 2 runnable user error = %v, want implicit operator conflict", err)
+	}
+}
+
 func TestWriteDisabledOperator(t *testing.T) {
 	dir := t.TempDir()
 	op := DisabledOperator()


### PR DESCRIPTION
Final 1.4.0 quality fix from post-merge review.

Schema 1/2 profiles without an explicit operator field are treated as implicit non-runnable `user` operator-gate teams. The validator now applies the same runnable-handle conflict check to that implicit operator path, so a legacy runnable member using handle `user` is rejected instead of being advertised as both a runnable agent and a non-runnable operator.

Validation:
- `go test ./internal/team`
- `make ci`
- `git diff --check`