### PR TITLE
Release amq-squad v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.3 line:
+Install the 1.4 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.3.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.4.1
 amq-squad version
 ```
 


### PR DESCRIPTION
Patch release after the final v1.4.0 review fix.

Includes:
- PR #56 fix already on main: legacy schema 1/2 profiles now reject runnable `user` members when `user` is the implicit non-runnable operator handle.
- README install snippet updated to `v1.4.1`.

Validation:
- `make ci`
- `git diff --check`