### PR TITLE
Support custom roles (v1.4.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.4 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.4.1
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.4.2
 amq-squad version
 ```
 
@@ -497,6 +497,54 @@ amq-squad completion fish > ~/.config/fish/completions/amq-squad.fish
 ```
 
 `completion zsh` is followed by a `compinit` step on most shells.
+
+## Custom roles
+
+`--roles`/`--personas` accept built-in personas (`cpo, cto, senior-dev,
+fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
+designer`) and **custom roles** that are not in the catalog. A custom role is
+any valid slug (lowercase `a-z`, `0-9`, `-`, `_`) and must carry an explicit
+`--binary` because there is no catalog default to fall back to. Built-in roles
+keep their catalog defaults unless overridden. Custom roles are first-class
+team members in `team.json`, `team-rules.md`, the bootstrap prompt,
+status/history, and launch/resume.
+
+```sh
+# inline: id + CLI, minimal role.md (generic custom-role fallback text)
+amq-squad new team --roles researcher --binary researcher=codex
+amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
+amq-squad new profile discovery --roles researcher --binary researcher=codex
+```
+
+Missing a binary fails clearly: `custom role "researcher" requires --binary researcher=<cli>`.
+
+For a richer persona, author a **role file** and pass it with `--role-file`
+(comma-separated) or inline in `--roles`. Supported formats: Markdown with
+optional YAML frontmatter, `.yaml`, or `.json`. The `binary:` field satisfies
+the binary requirement (`--binary` overrides it). The authored document is
+staged at `.amq-squad/roles/<id>.md` and seeds that agent's `role.md` at launch
+(later user edits are preserved).
+
+```sh
+amq-squad new team --role-file ./roles/researcher.md --roles cto
+amq-squad team init --roles "cto,./roles/researcher.md"
+```
+
+```markdown
+---
+id: researcher
+label: Research Engineer
+binary: codex
+peers: [cto, qa]
+---
+# Role: Research Engineer
+
+## Description
+Owns deep technical investigation, prototypes, and written findings.
+```
+
+The `/amq-squad-role-creator` skill walks through authoring role files and
+wiring them into a team.
 
 ## Trust and binary defaults
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,8 @@ For a richer persona, author a **role file** and pass it with `--role-file`
 optional YAML frontmatter, `.yaml`, or `.json`. The `binary:` field satisfies
 the binary requirement (`--binary` overrides it). The authored document is
 staged at `.amq-squad/roles/<id>.md` and seeds that agent's `role.md` at launch
-(later user edits are preserved).
+(later user edits are preserved). A role file whose id matches a built-in
+persona is rejected — pick a different id for a custom role.
 
 ```sh
 amq-squad new team --role-file ./roles/researcher.md --roles cto

--- a/doc.html
+++ b/doc.html
@@ -496,6 +496,7 @@
         <a href="#context">Context model</a>
         <a href="#briefs">Workstream briefs</a>
         <a href="#profiles">Profiles</a>
+        <a href="#custom-roles">Custom roles</a>
         <a href="#verbs">Verbs</a>
         <a href="#console">Status board and console</a>
         <a href="#json">JSON and exit codes</a>
@@ -1042,6 +1043,108 @@ amq-squad up --profile release            # operate on a named profile</code></p
             Omit <code class="inline-code">--profile</code> (or pass
             <code class="inline-code">--profile default</code>) for the
             default profile.
+          </p>
+        </div>
+      </section>
+
+      <section id="custom-roles">
+        <div class="content">
+          <h2>Custom roles</h2>
+          <p>
+            <code class="inline-code">--roles</code> /
+            <code class="inline-code">--personas</code> accept the built-in
+            personas (<code class="inline-code">cpo, cto, senior-dev, fullstack,
+            frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
+            designer</code>) and <b>custom roles</b> that are not in the
+            catalog. A custom role is any valid slug (lowercase
+            <code class="inline-code">a-z</code>,
+            <code class="inline-code">0-9</code>,
+            <code class="inline-code">-</code>,
+            <code class="inline-code">_</code>) and must carry an explicit
+            <code class="inline-code">--binary</code> because there is no
+            catalog default to fall back to. Built-in roles keep their catalog
+            defaults unless overridden. Custom roles are first-class members in
+            <code class="inline-code">team.json</code>,
+            <code class="inline-code">team-rules.md</code>, the bootstrap
+            prompt, status/history, and launch/resume.
+          </p>
+          <div class="code"><pre><code>amq-squad new team --roles researcher --binary researcher=codex
+amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
+amq-squad new profile discovery --roles researcher --binary researcher=codex</code></pre></div>
+          <p>
+            A missing binary fails clearly:
+            <code class="inline-code">custom role "researcher" requires --binary researcher=&lt;cli&gt;</code>.
+          </p>
+          <h3>Role files</h3>
+          <p>
+            For a richer persona, author a <b>role file</b> and pass it with
+            <code class="inline-code">--role-file</code> (comma-separated) or
+            inline in <code class="inline-code">--roles</code>. Supported
+            formats: Markdown with optional YAML frontmatter (the body becomes
+            <code class="inline-code">role.md</code> verbatim), metadata-only
+            <code class="inline-code">.yaml</code>, or
+            <code class="inline-code">.json</code>. The file's
+            <code class="inline-code">binary:</code> field satisfies the binary
+            requirement, and <code class="inline-code">--binary</code> overrides
+            it. The authored document is staged at
+            <code class="inline-code">.amq-squad/roles/&lt;id&gt;.md</code> and
+            seeds that agent's <code class="inline-code">role.md</code> at
+            launch; later user edits are preserved. A role file whose id matches
+            a built-in persona is rejected.
+          </p>
+          <div class="code"><pre><code>amq-squad new team --role-file ./roles/researcher.md --roles cto
+amq-squad team init --roles "cto,./roles/researcher.md"
+
+# roles/researcher.md
+---
+id: researcher
+label: Research Engineer
+binary: codex
+peers: [cto, qa]
+---
+# Role: Research Engineer
+
+## Description
+Owns deep technical investigation, prototypes, and written findings.</code></pre></div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th>Meaning</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>id</code> (or <code>role</code>)</td>
+                  <td>role slug + default handle (lowercase <code>a-z 0-9 - _</code>)</td>
+                </tr>
+                <tr>
+                  <td><code>label</code></td>
+                  <td>human title shown in listings and <code>role.md</code></td>
+                </tr>
+                <tr>
+                  <td><code>binary</code></td>
+                  <td><code>codex</code> or <code>claude</code></td>
+                </tr>
+                <tr>
+                  <td><code>description</code></td>
+                  <td>one-line summary seeded into the rendered <code>role.md</code></td>
+                </tr>
+                <tr>
+                  <td><code>skills</code></td>
+                  <td>list of slash commands for this role</td>
+                </tr>
+                <tr>
+                  <td><code>peers</code></td>
+                  <td>list of role ids this role talks to most</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p>
+            The <code class="inline-code">/amq-squad-role-creator</code> skill
+            walks through authoring role files and wiring them into a team.
           </p>
         </div>
       </section>

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -149,8 +149,22 @@ func IDs() []string {
 }
 
 // ResolveSelection converts the user-facing persona picker syntax into role
-// IDs. It accepts catalog IDs, 1-based market numbers, and "all".
+// IDs. It accepts catalog IDs, 1-based market numbers, and "all". Tokens that
+// are not in the catalog are rejected.
 func ResolveSelection(line string) ([]string, error) {
+	return resolveSelection(line, false)
+}
+
+// ResolveSelectionAllowingCustom behaves like ResolveSelection but returns
+// unknown role slugs verbatim (lowercased and trimmed) instead of erroring,
+// so callers can treat them as custom roles. Numeric market picks and "all"
+// still resolve strictly against the catalog. Callers are responsible for
+// validating custom slugs and supplying their binary.
+func ResolveSelectionAllowingCustom(line string) ([]string, error) {
+	return resolveSelection(line, true)
+}
+
+func resolveSelection(line string, allowCustom bool) ([]string, error) {
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return nil, fmt.Errorf("no selection provided")
@@ -177,6 +191,10 @@ func ResolveSelection(line string) ([]string, error) {
 			continue
 		}
 		if Lookup(p) == nil {
+			if allowCustom {
+				out = append(out, p)
+				continue
+			}
 			return nil, fmt.Errorf("unknown persona/role %q. Known personas: %s", p, strings.Join(IDs(), ", "))
 		}
 		out = append(out, p)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -127,3 +127,24 @@ func TestResolveSelection(t *testing.T) {
 		t.Fatalf("ResolveSelection banana error = %v, want unknown persona", err)
 	}
 }
+
+func TestResolveSelectionAllowingCustom(t *testing.T) {
+	// Unknown slugs pass through verbatim (lowercased) as custom roles.
+	got, err := ResolveSelectionAllowingCustom("cto,Researcher,2")
+	if err != nil {
+		t.Fatalf("ResolveSelectionAllowingCustom error = %v", err)
+	}
+	want := []string{"cto", "researcher", "cto"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveSelectionAllowingCustom = %v, want %v", got, want)
+	}
+	// "all" still expands to the catalog, not treated as a custom role.
+	got, err = ResolveSelectionAllowingCustom("all")
+	if err != nil || !reflect.DeepEqual(got, IDs()) {
+		t.Fatalf("ResolveSelectionAllowingCustom all = %v (err %v), want catalog IDs", got, err)
+	}
+	// Out-of-range numbers still error; only non-numeric unknowns are custom.
+	if _, err := ResolveSelectionAllowingCustom("999"); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("ResolveSelectionAllowingCustom 999 error = %v, want out of range", err)
+	}
+}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -181,6 +181,7 @@ var completionCommonFlags = []string{
 	"--restore-existing",
 	"--review-age",
 	"--role",
+	"--role-file",
 	"--roles",
 	"--root",
 	"--run-action",

--- a/internal/cli/custom_role_test.go
+++ b/internal/cli/custom_role_test.go
@@ -315,6 +315,30 @@ func TestRoleFileInlinePathStagesVerbatimDoc(t *testing.T) {
 	}
 }
 
+// TestRoleFileCatalogIDCollisionFails: a role file whose id matches a built-in
+// persona is rejected, since the built-in would win at launch and silently drop
+// the file's binary and authored document.
+func TestRoleFileCatalogIDCollisionFails(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	rf := writeRoleFile(t, dir, "cto.md", `---
+id: cto
+binary: claude
+---
+# Role: My Custom CTO
+`)
+
+	_, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--role-file", rf, "--dry-run"})
+	})
+	if err == nil {
+		t.Fatal("role file with a built-in id should be rejected")
+	}
+	if !strings.Contains(err.Error(), "built-in persona") {
+		t.Fatalf("error = %v, want built-in collision guidance", err)
+	}
+}
+
 // TestRoleFileMissingBinaryFails: a role file with neither a binary frontmatter
 // field nor a --binary override is rejected.
 func TestRoleFileMissingBinaryFails(t *testing.T) {

--- a/internal/cli/custom_role_test.go
+++ b/internal/cli/custom_role_test.go
@@ -1,0 +1,368 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/role"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+// TestNewTeamCustomRoleDryRunJSON covers the NOC contract: a custom role that
+// is not in the built-in catalog is accepted when it carries an explicit
+// --binary entry, and it appears in the dry-run JSON plan just like a built-in
+// member (role, handle, binary, session populated).
+func TestNewTeamCustomRoleDryRunJSON(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{
+			"team",
+			"--roles", "researcher,reviewer",
+			"--binary", "researcher=codex,reviewer=claude",
+			"--session", "issue-96",
+			"--dry-run", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("new team custom roles dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	if env.Data.Members != 2 || len(env.Data.Plan) != 2 {
+		t.Fatalf("members/plan = %d/%d, want 2/2", env.Data.Members, len(env.Data.Plan))
+	}
+	want := map[string]string{"researcher": "codex", "reviewer": "claude"}
+	for _, m := range env.Data.Plan {
+		bin, ok := want[m.Role]
+		if !ok {
+			t.Fatalf("unexpected role in plan: %q", m.Role)
+		}
+		if m.Handle != m.Role {
+			t.Errorf("role %s handle = %q, want %q", m.Role, m.Handle, m.Role)
+		}
+		if m.Binary != bin {
+			t.Errorf("role %s binary = %q, want %q", m.Role, m.Binary, bin)
+		}
+		if m.Session != "issue-96" {
+			t.Errorf("role %s session = %q, want issue-96", m.Role, m.Session)
+		}
+	}
+}
+
+// TestTeamInitCustomRoleLiveWrite confirms a custom role persists to team.json
+// as a first-class member through the `team init` path.
+func TestTeamInitCustomRoleLiveWrite(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runTeamInit([]string{
+			"--roles", "cto,researcher",
+			"--binary", "researcher=codex",
+			"--session", "issue-96",
+		})
+	})
+	if err != nil {
+		t.Fatalf("team init custom role: %v\nstderr:\n%s", err, stderr)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team config: %v", err)
+	}
+	var researcher *team.Member
+	for i := range cfg.Members {
+		if cfg.Members[i].Role == "researcher" {
+			researcher = &cfg.Members[i]
+		}
+	}
+	if researcher == nil {
+		t.Fatalf("custom role not persisted; members = %+v", cfg.Members)
+	}
+	if researcher.Binary != "codex" || researcher.Handle != "researcher" || researcher.Session != "issue-96" {
+		t.Fatalf("custom member fields wrong: %+v", *researcher)
+	}
+}
+
+// TestNewProfileCustomRoleDryRun confirms `new profile NAME` accepts custom
+// roles too (it delegates to team init with a named profile).
+func TestNewProfileCustomRoleDryRun(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{
+			"profile", "discovery",
+			"--roles", "researcher",
+			"--binary", "researcher=codex",
+			"--session", "issue-96",
+			"--dry-run", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("new profile custom role dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	if env.Data.Profile != "discovery" {
+		t.Fatalf("profile = %q, want discovery", env.Data.Profile)
+	}
+	if env.Data.Members != 1 || len(env.Data.Plan) != 1 || env.Data.Plan[0].Role != "researcher" {
+		t.Fatalf("expected single researcher member, got %+v", env.Data.Plan)
+	}
+}
+
+// TestCustomRoleMissingBinaryFails: a custom role without a --binary entry is
+// rejected with actionable guidance.
+func TestCustomRoleMissingBinaryFails(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	_, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--roles", "researcher", "--dry-run"})
+	})
+	if err == nil {
+		t.Fatal("custom role without --binary should fail")
+	}
+	want := `custom role "researcher" requires --binary researcher=<cli>`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want it to contain %q", err, want)
+	}
+}
+
+// TestCustomRoleBinaryForOtherRoleFails: a --binary entry for a role not in
+// --roles does not satisfy the custom role's binary requirement.
+func TestCustomRoleBinaryForOtherRoleFails(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	_, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--roles", "researcher", "--binary", "other=codex", "--dry-run"})
+	})
+	if err == nil {
+		t.Fatal("custom role with unrelated --binary should fail")
+	}
+	if !strings.Contains(err.Error(), `custom role "researcher" requires --binary`) {
+		t.Fatalf("error = %v, want custom-role binary guidance", err)
+	}
+}
+
+// TestCustomAndBuiltinMix: built-in roles keep their catalog default binary
+// while custom roles use the supplied binary.
+func TestCustomAndBuiltinMix(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{
+			"team",
+			"--roles", "cto,researcher",
+			"--binary", "researcher=claude",
+			"--session", "issue-96",
+			"--dry-run", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("mixed roles dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	bins := map[string]string{}
+	for _, m := range env.Data.Plan {
+		bins[m.Role] = m.Binary
+	}
+	if bins["cto"] != "codex" { // cto's catalog default is codex
+		t.Errorf("cto binary = %q, want catalog default codex", bins["cto"])
+	}
+	if bins["researcher"] != "claude" {
+		t.Errorf("researcher binary = %q, want claude", bins["researcher"])
+	}
+}
+
+// TestInvalidCustomSlugFails: a custom role token that is not a valid slug is
+// rejected by the existing role-id validation rules.
+func TestInvalidCustomSlugFails(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	_, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--roles", "Bad Role", "--binary", "Bad Role=codex", "--dry-run"})
+	})
+	if err == nil {
+		t.Fatal("invalid custom slug should fail")
+	}
+	if !strings.Contains(err.Error(), "invalid role") {
+		t.Fatalf("error = %v, want slug-validation error", err)
+	}
+}
+
+// TestSeedRoleStubCustomRoleFallbackText: the role.md stub seeded for a custom
+// role uses the built-in custom-role fallback copy, not a built-in persona's
+// description.
+func TestSeedRoleStubCustomRoleFallbackText(t *testing.T) {
+	agentDir := t.TempDir()
+	if err := seedRoleStub(agentDir, "researcher", ""); err != nil {
+		t.Fatalf("seedRoleStub: %v", err)
+	}
+	body, err := os.ReadFile(role.Path(agentDir))
+	if err != nil {
+		t.Fatalf("read role.md: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "# Role: researcher") {
+		t.Errorf("role.md missing custom label header:\n%s", got)
+	}
+	if !strings.Contains(got, "No catalog description is configured for this custom role") {
+		t.Errorf("role.md missing custom-role fallback description:\n%s", got)
+	}
+}
+
+// --- Phase 2: file-based custom roles ---
+
+func writeRoleFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestRoleFileFrontmatterBinarySatisfiesRequirement: a markdown role file whose
+// frontmatter sets binary needs no --binary, and lands as a first-class member.
+func TestRoleFileFrontmatterBinarySatisfiesRequirement(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	rf := writeRoleFile(t, dir, "researcher.md", `---
+id: researcher
+binary: codex
+---
+# Role: Research Engineer
+
+## Description
+Owns investigation.
+`)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--role-file", rf, "--roles", "cto", "--session", "issue-96", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("role-file dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	bins := map[string]string{}
+	for _, m := range env.Data.Plan {
+		bins[m.Role] = m.Binary
+	}
+	if bins["researcher"] != "codex" {
+		t.Fatalf("researcher binary = %q, want codex (from frontmatter); plan=%+v", bins["researcher"], env.Data.Plan)
+	}
+	if bins["cto"] != "codex" {
+		t.Errorf("cto binary = %q, want catalog default", bins["cto"])
+	}
+}
+
+// TestRoleFileInlinePathStagesVerbatimDoc: an inline path in --roles is loaded
+// as a custom role; the authored markdown is staged verbatim under
+// .amq-squad/roles/<id>.md and the agent role stub picks it up.
+func TestRoleFileInlinePathStagesVerbatimDoc(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	body := "# Role: Scribe\n\n## Description\nKeeps the written record.\n"
+	writeRoleFile(t, dir, "scribe.md", body)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--roles", "cto,./scribe.md", "--binary", "scribe=claude", "--session", "issue-96"})
+	})
+	if err != nil {
+		t.Fatalf("inline role file: %v\nstderr:\n%s", err, stderr)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	found := false
+	for _, m := range cfg.Members {
+		if m.Role == "scribe" {
+			found = true
+			if m.Binary != "claude" {
+				t.Errorf("scribe binary = %q, want claude", m.Binary)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("scribe not in members: %+v", cfg.Members)
+	}
+	staged, err := os.ReadFile(team.CustomRolePath(dir, "scribe"))
+	if err != nil {
+		t.Fatalf("staged role doc missing: %v", err)
+	}
+	if !strings.Contains(string(staged), "Keeps the written record.") {
+		t.Errorf("staged doc not verbatim:\n%s", staged)
+	}
+
+	// And the launch-time seed copies the staged doc into the agent's role.md.
+	agentDir := t.TempDir()
+	if err := seedRoleStub(agentDir, "scribe", dir); err != nil {
+		t.Fatalf("seedRoleStub from staged doc: %v", err)
+	}
+	got, err := os.ReadFile(role.Path(agentDir))
+	if err != nil {
+		t.Fatalf("read seeded role.md: %v", err)
+	}
+	if !strings.Contains(string(got), "Keeps the written record.") {
+		t.Errorf("seeded role.md did not use staged doc:\n%s", got)
+	}
+}
+
+// TestRoleFileMissingBinaryFails: a role file with neither a binary frontmatter
+// field nor a --binary override is rejected.
+func TestRoleFileMissingBinaryFails(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	rf := writeRoleFile(t, dir, "ghost.md", "# Role: Ghost\n\n## Description\nNo binary anywhere.\n")
+
+	_, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--role-file", rf, "--dry-run"})
+	})
+	if err == nil {
+		t.Fatal("role file without a binary should fail")
+	}
+	if !strings.Contains(err.Error(), `custom role "ghost" requires --binary`) {
+		t.Fatalf("error = %v, want binary guidance", err)
+	}
+}
+
+// TestRoleFileYAMLRendersStubDoc: a metadata-only YAML file stages a rendered
+// role.md (no verbatim body) and uses its binary field.
+func TestRoleFileYAMLRendersStubDoc(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	rf := writeRoleFile(t, dir, "sre.yaml", `id: sre
+label: Site Reliability Engineer
+binary: claude
+description: Owns reliability and on-call.
+`)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--role-file", rf, "--session", "issue-96"})
+	})
+	if err != nil {
+		t.Fatalf("yaml role file: %v\nstderr:\n%s", err, stderr)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	if len(cfg.Members) != 1 || cfg.Members[0].Role != "sre" || cfg.Members[0].Binary != "claude" {
+		t.Fatalf("unexpected members: %+v", cfg.Members)
+	}
+	staged, err := os.ReadFile(team.CustomRolePath(dir, "sre"))
+	if err != nil {
+		t.Fatalf("staged role doc missing: %v", err)
+	}
+	if !strings.Contains(string(staged), "# Role: Site Reliability Engineer") ||
+		!strings.Contains(string(staged), "Owns reliability and on-call.") {
+		t.Errorf("rendered staged doc wrong:\n%s", staged)
+	}
+}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omriariav/amq-squad/internal/catalog"
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/role"
+	"github.com/omriariav/amq-squad/internal/team"
 )
 
 // runLaunch is the real single-agent launcher. The top-level `launch` verb is
@@ -284,10 +285,11 @@ Examples:
 		return fmt.Errorf("write launch record: %w", err)
 	}
 
-	// Seed role.md from the catalog when the role is known. Never
-	// overwrites existing user edits.
+	// Seed role.md from the catalog when the role is known, or from a staged
+	// custom-role document under the team-home. Never overwrites user edits.
 	if *roleFlag != "" {
-		if err := seedRoleStub(agentDir, *roleFlag); err != nil {
+		roleHome := resolveBriefHome(*teamHome, cwd)
+		if err := seedRoleStub(agentDir, *roleFlag, roleHome); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: seed role.md: %v\n", err)
 		}
 	}
@@ -493,10 +495,25 @@ func resolveAMQRootInDir(cwd, rootFlag, session, handle string) (string, error) 
 	return env.Root, nil
 }
 
-// seedRoleStub writes a role.md stub for the given agent directory based on
-// the catalog entry for roleID. If the role isn't in the catalog, it still
-// writes a minimal stub with the label = roleID.
-func seedRoleStub(agentDir, roleID string) error {
+// seedRoleStub writes a role.md for the given agent directory. Precedence:
+//  1. a custom role authored in a file and staged at
+//     <teamHome>/.amq-squad/roles/<id>.md during team init (verbatim),
+//  2. the built-in catalog entry for roleID,
+//  3. a minimal fallback stub with label = roleID.
+//
+// It never overwrites existing user edits.
+func seedRoleStub(agentDir, roleID, teamHome string) error {
+	if catalog.Lookup(roleID) == nil && strings.TrimSpace(teamHome) != "" {
+		docPath := team.CustomRolePath(teamHome, roleID)
+		body, err := os.ReadFile(docPath)
+		if err == nil {
+			_, werr := role.EnsureContent(agentDir, string(body))
+			return werr
+		}
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read custom role doc %s: %w", docPath, err)
+		}
+	}
 	stub := role.Stub{RoleID: roleID, Label: roleID}
 	if r := catalog.Lookup(roleID); r != nil {
 		stub.Label = r.Label

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -239,6 +239,7 @@ func newProfileTeamArgs(args []string) ([]string, error) {
 		"--operator":    true,
 		"--personas":    true,
 		"--project":     true,
+		"--role-file":   true,
 		"--roles":       true,
 		"--session":     true,
 		"--trust":       true,

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/internal/role"
 	"github.com/omriariav/amq-squad/internal/rules"
 	"github.com/omriariav/amq-squad/internal/team"
 )
@@ -81,6 +82,7 @@ func runTeamInitWithOptions(args []string, opts teamInitRunOptions) error {
 	fs := flag.NewFlagSet("team init", flag.ContinueOnError)
 	personasFlag := fs.String("personas", "", "comma-separated persona IDs to include (alias for --roles)")
 	rolesFlag := fs.String("roles", "", "comma-separated role/persona IDs to include (skips interactive prompt)")
+	roleFileFlag := fs.String("role-file", "", "comma-separated custom role files (.md/.yaml/.json) to include as team members")
 	binaryFlag := fs.String("binary", "", "per-persona CLI overrides, e.g. fullstack=codex,qa=claude")
 	sessionFlag := fs.String("session", "", "AMQ workstream session name for all members (lowercase a-z, 0-9, -, _)")
 	cwdFlag := fs.String("cwd", "", "per-persona working directory overrides, e.g. qa=/path/to/sibling-project")
@@ -112,6 +114,19 @@ Members can live in other directories via --cwd role=/path. Relative --cwd
 values under --project resolve from DIR. Default AMQ workstream sessions are
 derived from the team-home directory name.
 
+Custom roles: a --roles/--personas entry that is not a built-in persona is
+treated as a custom role. Each custom role must be a valid slug (lowercase
+a-z, 0-9, -, _) and must carry an explicit --binary role=<cli> entry, e.g.
+--roles researcher --binary researcher=codex. Built-in personas keep their
+catalog defaults unless overridden.
+
+Custom roles from a file: --role-file PATH (comma-separated) loads roles from
+.md (optionally with YAML frontmatter), .yaml, or .json files. A role file may
+also be referenced inline, e.g. --roles cto,./roles/researcher.md. The file's
+'binary:' field satisfies the binary requirement (and --binary overrides it).
+The authored document is staged under .amq-squad/roles/<id>.md and seeds that
+agent's role.md at launch.
+
 Known personas:
 `)
 		for _, r := range catalog.All() {
@@ -120,6 +135,8 @@ Known personas:
 		fmt.Fprint(os.Stderr, `
 Examples:
   amq-squad team init --roles cto,fullstack --binary cto=codex
+  amq-squad team init --roles researcher --binary researcher=codex
+  amq-squad team init --role-file ./roles/researcher.md --roles cto
   amq-squad team init --roles cto,fullstack --operator user
   amq-squad team init --roles cto,fullstack --operator operator
   amq-squad team init --roles cto,fullstack --no-operator
@@ -213,19 +230,39 @@ Examples:
 	// Normalize override keys to lowercase so we can match them against the
 	// chosen persona IDs without surprises.
 	modelOverrides = lowercaseKeys(modelOverrides)
+	binaryOverrides = lowercaseKeys(binaryOverrides)
+
+	// customDefs holds custom roles loaded from files (via --role-file or an
+	// inline path token in --roles/--personas), keyed by resolved role id.
+	customDefs := map[string]role.Definition{}
+	roleFilePaths := splitCSV(*roleFileFlag)
+	fileSelected := make([]string, 0, len(roleFilePaths))
+	for _, p := range roleFilePaths {
+		id, err := loadRoleFileDef(p, customDefs)
+		if err != nil {
+			return err
+		}
+		fileSelected = append(fileSelected, id)
+	}
 
 	var picked []string
-	interactive := *rolesFlag == "" && *personasFlag == ""
+	interactive := *rolesFlag == "" && *personasFlag == "" && len(roleFilePaths) == 0
+	// The non-interactive flag paths accept custom role slugs (resolved by the
+	// member loop below, which requires a --binary or a role file for each) and
+	// inline role-file paths. The interactive prompt stays catalog-only.
 	if *personasFlag != "" {
-		picked, err = parsePersonaSelection(*personasFlag)
+		picked, err = resolveTeamSelection(*personasFlag, customDefs)
 		if err != nil {
 			return err
 		}
 	} else if *rolesFlag != "" {
-		picked, err = parsePersonaSelection(*rolesFlag)
+		picked, err = resolveTeamSelection(*rolesFlag, customDefs)
 		if err != nil {
 			return err
 		}
+	} else if len(roleFilePaths) > 0 {
+		// Role files only: the selection is exactly the file-defined roles.
+		picked = nil
 	} else {
 		reader := bufio.NewReader(os.Stdin)
 		picked, err = promptPersonaSelection(reader, os.Stderr)
@@ -253,6 +290,10 @@ Examples:
 			workstream = chosen
 		}
 	}
+	// Roles named via --role-file are always part of the team, even when they
+	// are not also listed in --roles/--personas. Duplicates are dropped by the
+	// member loop's seen-set below.
+	picked = append(picked, fileSelected...)
 	if len(picked) == 0 {
 		return fmt.Errorf("no personas selected, aborting")
 	}
@@ -275,16 +316,33 @@ Examples:
 			continue
 		}
 		seen[id] = true
-		r := catalog.Lookup(id)
-		if r == nil {
-			return fmt.Errorf("unknown persona %q. Known personas: %s", id, strings.Join(catalog.IDs(), ", "))
-		}
-		binary := r.PreferredBinary
-		if b, ok := binaryOverrides[id]; ok {
-			binary = b
-		}
-		if interactive && binary == "" {
+		var binary string
+		if r := catalog.Lookup(id); r != nil {
 			binary = r.PreferredBinary
+			if b, ok := binaryOverrides[id]; ok {
+				binary = b
+			}
+			if interactive && binary == "" {
+				binary = r.PreferredBinary
+			}
+		} else {
+			// Custom role: not in the built-in catalog. It must be a valid role
+			// slug and must carry an explicit --binary entry, since there is no
+			// catalog default to fall back to. Everything downstream (team.json,
+			// team-rules, bootstrap, status/history, launch) already treats
+			// non-catalog roles as first-class members.
+			if err := team.ValidateRoleID(id); err != nil {
+				return fmt.Errorf("custom role %q: %w", id, err)
+			}
+			binary = strings.TrimSpace(binaryOverrides[id])
+			if binary == "" {
+				if def, ok := customDefs[id]; ok {
+					binary = strings.TrimSpace(def.Binary)
+				}
+			}
+			if binary == "" {
+				return fmt.Errorf("custom role %q requires --binary %s=<cli> (or a 'binary:' field in its role file)", id, id)
+			}
 		}
 		m := team.Member{
 			Role:    id,
@@ -341,6 +399,21 @@ Examples:
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "Wrote %s with %d members.\n", team.ProfilePath(cwd, profile), len(members))
+	// Stage authored documents for file-defined custom roles so `up` seeds each
+	// agent's role.md from the file instead of the minimal fallback.
+	for _, m := range members {
+		def, ok := customDefs[m.Role]
+		if !ok {
+			continue
+		}
+		wrote, err := stageCustomRoleDoc(cwd, def)
+		if err != nil {
+			return fmt.Errorf("stage role doc for %s: %w", m.Role, err)
+		}
+		if wrote {
+			fmt.Fprintf(os.Stderr, "Wrote %s.\n", team.CustomRolePath(cwd, m.Role))
+		}
+	}
 	wroteRules, err := rules.Ensure(cwd, rulesContent)
 	if err != nil {
 		return fmt.Errorf("seed team-rules.md: %w", err)
@@ -1016,6 +1089,80 @@ func printPersonaMarket(out io.Writer) {
 
 func parsePersonaSelection(line string) ([]string, error) {
 	return catalog.ResolveSelection(line)
+}
+
+// resolveTeamSelection resolves a --roles/--personas CSV that may mix catalog
+// IDs, market numbers, "all", custom slugs, and inline role-file paths. File
+// tokens are parsed into customDefs and contribute their resolved role id.
+func resolveTeamSelection(line string, customDefs map[string]role.Definition) ([]string, error) {
+	var out []string
+	for _, tok := range strings.Split(line, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		if role.LooksLikeRoleFile(tok) {
+			id, err := loadRoleFileDef(tok, customDefs)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, id)
+			continue
+		}
+		ids, err := catalog.ResolveSelectionAllowingCustom(tok)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ids...)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no selection provided")
+	}
+	return out, nil
+}
+
+// loadRoleFileDef parses a custom role file, validates its id, registers it in
+// defs, and returns the resolved role id. Two files resolving to the same id
+// are rejected so a typo can't silently shadow another role.
+func loadRoleFileDef(path string, defs map[string]role.Definition) (string, error) {
+	abs, err := expandPath(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve role file %q: %w", path, err)
+	}
+	def, err := role.ParseFile(abs)
+	if err != nil {
+		return "", err
+	}
+	if err := team.ValidateRoleID(def.ID); err != nil {
+		return "", fmt.Errorf("role file %s: %w", path, err)
+	}
+	if existing, ok := defs[def.ID]; ok && existing.Source != def.Source {
+		return "", fmt.Errorf("custom role id %q is defined by two files: %s and %s", def.ID, existing.Source, def.Source)
+	}
+	defs[def.ID] = def
+	return def.ID, nil
+}
+
+// stageCustomRoleDoc writes a custom role's authored document under
+// <projectDir>/.amq-squad/roles/<id>.md. It is idempotent: identical content
+// is left untouched. Returns true when it wrote (or rewrote) the file.
+func stageCustomRoleDoc(projectDir string, def role.Definition) (bool, error) {
+	path := team.CustomRolePath(projectDir, def.ID)
+	body := def.Document()
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == body {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return false, fmt.Errorf("ensure roles dir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(body), 0o600); err != nil {
+		return false, fmt.Errorf("write role doc: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return false, fmt.Errorf("rename role doc: %w", err)
+	}
+	return true, nil
 }
 
 func printSquadPlan(out io.Writer, personas []string, overrides map[string]string) {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1136,6 +1136,12 @@ func loadRoleFileDef(path string, defs map[string]role.Definition) (string, erro
 	if err := team.ValidateRoleID(def.ID); err != nil {
 		return "", fmt.Errorf("role file %s: %w", path, err)
 	}
+	// A role file is for a custom role. If its id collides with a built-in
+	// persona, the built-in wins at launch and the file's binary + authored
+	// document would be silently ignored, so reject it outright.
+	if catalog.Lookup(def.ID) != nil {
+		return "", fmt.Errorf("role file %s: id %q is a built-in persona; choose a different id for a custom role", path, def.ID)
+	}
 	if existing, ok := defs[def.ID]; ok && existing.Source != def.Source {
 		return "", fmt.Errorf("custom role id %q is defined by two files: %s and %s", def.ID, existing.Source, def.Source)
 	}

--- a/internal/role/parse.go
+++ b/internal/role/parse.go
@@ -1,0 +1,351 @@
+package role
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Definition is a custom role loaded from an external file. It carries the
+// metadata amq-squad needs to treat the role as a first-class team member plus
+// an optional Markdown Body that becomes the agent's role.md verbatim.
+//
+// Files come in two shapes:
+//
+//   - Markdown (.md/.markdown): optional YAML frontmatter for metadata, with
+//     the remaining document used as the role.md Body. With no frontmatter the
+//     whole file is the Body and the ID is derived from a "# Role: X" heading
+//     or the filename.
+//   - Metadata-only (.yaml/.yml/.json): structured fields only; Body is empty
+//     and role.md is rendered from the stub at seed time.
+type Definition struct {
+	ID          string
+	Label       string
+	Binary      string
+	Description string
+	Skills      []string
+	Peers       []string
+	Body        string
+	Source      string
+}
+
+// Stub converts the definition's metadata into a render Stub, used when there
+// is no Body to write verbatim.
+func (d Definition) Stub() Stub {
+	return Stub{
+		Label:       d.Label,
+		RoleID:      d.ID,
+		Description: d.Description,
+		Skills:      d.Skills,
+		Peers:       d.Peers,
+	}
+}
+
+// Document returns the role.md content to persist for this definition: the
+// verbatim Body when present, otherwise a rendered stub from the metadata.
+func (d Definition) Document() string {
+	if strings.TrimSpace(d.Body) != "" {
+		return d.Body
+	}
+	return render(d.Stub())
+}
+
+// LooksLikeRoleFile reports whether a --roles/--personas token should be
+// treated as a path to a role file rather than a catalog ID or custom slug.
+// It is deliberately conservative: a bare slug like "researcher" is never a
+// file, but "./researcher.md" or "roles/sre.yaml" is.
+func LooksLikeRoleFile(token string) bool {
+	t := strings.TrimSpace(token)
+	if t == "" {
+		return false
+	}
+	if strings.ContainsAny(t, "/\\") || strings.HasPrefix(t, "~") {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(t)) {
+	case ".md", ".markdown", ".yaml", ".yml", ".json":
+		return true
+	}
+	return false
+}
+
+// ParseFile loads a custom role definition from path. The ID is not validated
+// here; callers apply their own slug rules (e.g. team.ValidateRoleID).
+func ParseFile(path string) (Definition, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Definition{}, fmt.Errorf("read role file: %w", err)
+	}
+	d, err := parse(string(raw), path)
+	if err != nil {
+		return Definition{}, fmt.Errorf("%s: %w", path, err)
+	}
+	d.Source = path
+	if d.ID == "" {
+		return Definition{}, fmt.Errorf("%s: could not determine a role id; add 'id:' or a '# Role: <name>' heading", path)
+	}
+	return d, nil
+}
+
+func parse(content, path string) (Definition, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		return parseJSON(content)
+	case ".yaml", ".yml":
+		fields, err := parseYAMLish(content)
+		if err != nil {
+			return Definition{}, err
+		}
+		d := definitionFromFields(fields)
+		if d.ID == "" {
+			d.ID = slugify(baseName(path))
+		}
+		return d, nil
+	default: // .md, .markdown, or extensionless: frontmatter + body
+		front, body := splitFrontmatter(content)
+		var d Definition
+		if front != "" {
+			fields, err := parseYAMLish(front)
+			if err != nil {
+				return Definition{}, err
+			}
+			d = definitionFromFields(fields)
+		}
+		d.Body = strings.TrimRight(body, "\n") + "\n"
+		if strings.TrimSpace(body) == "" {
+			d.Body = ""
+		}
+		if d.ID == "" {
+			d.ID = slugify(headingName(body))
+		}
+		if d.ID == "" {
+			d.ID = slugify(baseName(path))
+		}
+		if d.Label == "" {
+			if h := headingName(body); h != "" {
+				d.Label = h
+			}
+		}
+		return d, nil
+	}
+}
+
+type jsonRole struct {
+	ID          string   `json:"id"`
+	Label       string   `json:"label"`
+	Binary      string   `json:"binary"`
+	Description string   `json:"description"`
+	Skills      []string `json:"skills"`
+	Peers       []string `json:"peers"`
+	Body        string   `json:"body"`
+}
+
+func parseJSON(content string) (Definition, error) {
+	var jr jsonRole
+	if err := json.Unmarshal([]byte(content), &jr); err != nil {
+		return Definition{}, fmt.Errorf("parse json role: %w", err)
+	}
+	return Definition{
+		ID:          strings.TrimSpace(strings.ToLower(jr.ID)),
+		Label:       strings.TrimSpace(jr.Label),
+		Binary:      strings.TrimSpace(jr.Binary),
+		Description: strings.TrimSpace(jr.Description),
+		Skills:      trimAll(jr.Skills),
+		Peers:       trimAll(jr.Peers),
+		Body:        jr.Body,
+	}, nil
+}
+
+func definitionFromFields(f map[string][]string) Definition {
+	d := Definition{
+		ID:          firstLower(f["id"]),
+		Label:       first(f["label"]),
+		Binary:      strings.TrimSpace(first(f["binary"])),
+		Description: first(f["description"]),
+		Skills:      f["skills"],
+		Peers:       f["peers"],
+	}
+	if d.ID == "" {
+		d.ID = firstLower(f["role"]) // tolerate `role:` as an alias for `id:`
+	}
+	return d
+}
+
+// splitFrontmatter separates a leading `---`-delimited YAML block from the
+// document body. With no frontmatter it returns ("", content).
+func splitFrontmatter(content string) (front, body string) {
+	s := strings.TrimPrefix(content, "\ufeff") // tolerate a UTF-8 BOM
+	if !strings.HasPrefix(s, "---") {
+		return "", content
+	}
+	// First line must be exactly the opening fence.
+	nl := strings.IndexByte(s, '\n')
+	if nl < 0 || strings.TrimSpace(s[:nl]) != "---" {
+		return "", content
+	}
+	rest := s[nl+1:]
+	// Find the closing fence on its own line.
+	lines := strings.Split(rest, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "---" || strings.TrimSpace(ln) == "..." {
+			front = strings.Join(lines[:i], "\n")
+			body = strings.Join(lines[i+1:], "\n")
+			return front, body
+		}
+	}
+	// Unterminated frontmatter: treat the whole thing as body.
+	return "", content
+}
+
+// parseYAMLish parses the flat subset of YAML amq-squad role files use:
+// `key: scalar`, `key: [a, b]` inline lists, and block lists of `- item`.
+// Values may be quoted. Full-line `#` comments and blank lines are ignored.
+// Each key maps to its values as a slice (scalars are single-element slices).
+func parseYAMLish(text string) (map[string][]string, error) {
+	out := map[string][]string{}
+	lines := strings.Split(text, "\n")
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Block list continuation handled by lookahead below; a stray "- x"
+		// without a preceding key is ignored.
+		if strings.HasPrefix(trimmed, "- ") || trimmed == "-" {
+			continue
+		}
+		colon := strings.IndexByte(trimmed, ':')
+		if colon < 0 {
+			return nil, fmt.Errorf("invalid metadata line %q (expected key: value)", trimmed)
+		}
+		key := strings.ToLower(strings.TrimSpace(trimmed[:colon]))
+		val := strings.TrimSpace(trimmed[colon+1:])
+		if key == "" {
+			return nil, fmt.Errorf("invalid metadata line %q (empty key)", trimmed)
+		}
+		if val == "" {
+			// Possible block list: consume following indented "- item" lines.
+			var items []string
+			for j := i + 1; j < len(lines); j++ {
+				next := strings.TrimSpace(lines[j])
+				if next == "" || strings.HasPrefix(next, "#") {
+					continue
+				}
+				if strings.HasPrefix(next, "- ") || next == "-" {
+					items = append(items, unquote(strings.TrimSpace(strings.TrimPrefix(next, "-"))))
+					i = j
+					continue
+				}
+				break
+			}
+			out[key] = trimAll(items)
+			continue
+		}
+		if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+			out[key] = trimAll(splitInlineList(val[1 : len(val)-1]))
+			continue
+		}
+		out[key] = []string{unquote(val)}
+	}
+	return out, nil
+}
+
+func splitInlineList(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = unquote(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func trimAll(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func first(in []string) string {
+	if len(in) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(in[0])
+}
+
+func firstLower(in []string) string {
+	return strings.ToLower(first(in))
+}
+
+// headingName extracts the role name from a leading Markdown heading, honoring
+// the "# Role: X" convention render() emits and falling back to a plain "# X".
+func headingName(body string) string {
+	for _, ln := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(ln)
+		if t == "" {
+			continue
+		}
+		if !strings.HasPrefix(t, "#") {
+			return ""
+		}
+		t = strings.TrimLeft(t, "#")
+		t = strings.TrimSpace(t)
+		if i := strings.Index(strings.ToLower(t), "role:"); i == 0 {
+			return strings.TrimSpace(t[len("role:"):])
+		}
+		return t
+	}
+	return ""
+}
+
+func baseName(path string) string {
+	b := filepath.Base(path)
+	return strings.TrimSuffix(b, filepath.Ext(b))
+}
+
+// slugify turns a human label into a role slug: lowercase, spaces and runs of
+// punctuation collapsed to single hyphens, restricted to [a-z0-9_-].
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == '-' || r == ' ' || r == '\t':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		default:
+			// drop other characters
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/role/parse.go
+++ b/internal/role/parse.go
@@ -93,7 +93,14 @@ func parse(content, path string) (Definition, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".json":
-		return parseJSON(content)
+		d, err := parseJSON(content)
+		if err != nil {
+			return Definition{}, err
+		}
+		if d.ID == "" {
+			d.ID = slugify(baseName(path))
+		}
+		return d, nil
 	case ".yaml", ".yml":
 		fields, err := parseYAMLish(content)
 		if err != nil {
@@ -179,12 +186,12 @@ func definitionFromFields(f map[string][]string) Definition {
 func splitFrontmatter(content string) (front, body string) {
 	s := strings.TrimPrefix(content, "\ufeff") // tolerate a UTF-8 BOM
 	if !strings.HasPrefix(s, "---") {
-		return "", content
+		return "", s
 	}
 	// First line must be exactly the opening fence.
 	nl := strings.IndexByte(s, '\n')
 	if nl < 0 || strings.TrimSpace(s[:nl]) != "---" {
-		return "", content
+		return "", s
 	}
 	rest := s[nl+1:]
 	// Find the closing fence on its own line.
@@ -197,7 +204,7 @@ func splitFrontmatter(content string) (front, body string) {
 		}
 	}
 	// Unterminated frontmatter: treat the whole thing as body.
-	return "", content
+	return "", s
 }
 
 // parseYAMLish parses the flat subset of YAML amq-squad role files use:
@@ -338,13 +345,13 @@ func slugify(s string) string {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
 			b.WriteRune(r)
 			prevHyphen = false
-		case r == '-' || r == ' ' || r == '\t':
+		default:
+			// Any other character (hyphen, spaces, punctuation, symbols)
+			// collapses to a single hyphen separator.
 			if !prevHyphen && b.Len() > 0 {
 				b.WriteByte('-')
 				prevHyphen = true
 			}
-		default:
-			// drop other characters
 		}
 	}
 	return strings.Trim(b.String(), "-")

--- a/internal/role/parse_test.go
+++ b/internal/role/parse_test.go
@@ -1,0 +1,162 @@
+package role
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeTemp(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestParseMarkdownWithFrontmatter(t *testing.T) {
+	p := writeTemp(t, "researcher.md", `---
+id: researcher
+label: Research Engineer
+binary: codex
+peers: [cto, qa]
+skills:
+  - /deep-research
+---
+# Role: Research Engineer
+
+## Description
+Owns investigation.
+`)
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "researcher" || d.Label != "Research Engineer" || d.Binary != "codex" {
+		t.Fatalf("metadata wrong: %+v", d)
+	}
+	if !reflect.DeepEqual(d.Peers, []string{"cto", "qa"}) {
+		t.Errorf("peers = %v", d.Peers)
+	}
+	if !reflect.DeepEqual(d.Skills, []string{"/deep-research"}) {
+		t.Errorf("skills = %v", d.Skills)
+	}
+	if !strings.Contains(d.Body, "# Role: Research Engineer") || !strings.Contains(d.Body, "Owns investigation.") {
+		t.Errorf("body missing markdown content:\n%s", d.Body)
+	}
+	// Document() returns the verbatim body when present.
+	if d.Document() != d.Body {
+		t.Errorf("Document should equal verbatim body")
+	}
+}
+
+func TestParseMarkdownVerbatimNoFrontmatter(t *testing.T) {
+	p := writeTemp(t, "scribe.md", "# Role: Scribe\n\n## Description\nKeeps records.\n")
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "scribe" { // from "# Role: Scribe" heading
+		t.Errorf("id = %q, want scribe", d.ID)
+	}
+	if d.Label != "Scribe" {
+		t.Errorf("label = %q, want Scribe", d.Label)
+	}
+	if d.Binary != "" {
+		t.Errorf("binary should be empty (no frontmatter), got %q", d.Binary)
+	}
+	if !strings.Contains(d.Body, "Keeps records.") {
+		t.Errorf("body verbatim missing content:\n%s", d.Body)
+	}
+}
+
+func TestParseIDFromFilenameFallback(t *testing.T) {
+	p := writeTemp(t, "data-scientist.md", "Just some prose with no heading.\n")
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "data-scientist" {
+		t.Errorf("id = %q, want data-scientist (from filename)", d.ID)
+	}
+}
+
+func TestParseYAMLMetadataOnly(t *testing.T) {
+	p := writeTemp(t, "sre.yaml", `id: sre
+label: Site Reliability Engineer
+binary: claude
+description: Owns reliability and on-call.
+peers:
+  - cto
+  - backend-dev
+`)
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "sre" || d.Binary != "claude" {
+		t.Fatalf("metadata wrong: %+v", d)
+	}
+	if d.Body != "" {
+		t.Errorf("yaml-only file should have empty Body, got %q", d.Body)
+	}
+	// Document() renders a stub from metadata when there is no body.
+	doc := d.Document()
+	if !strings.Contains(doc, "# Role: Site Reliability Engineer") {
+		t.Errorf("rendered doc missing label header:\n%s", doc)
+	}
+	if !strings.Contains(doc, "Owns reliability and on-call.") {
+		t.Errorf("rendered doc missing description:\n%s", doc)
+	}
+}
+
+func TestParseJSON(t *testing.T) {
+	p := writeTemp(t, "analyst.json", `{"id":"analyst","label":"Analyst","binary":"codex","description":"Crunches numbers.","peers":["pm"]}`)
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "analyst" || d.Binary != "codex" || d.Description != "Crunches numbers." {
+		t.Fatalf("metadata wrong: %+v", d)
+	}
+	if !reflect.DeepEqual(d.Peers, []string{"pm"}) {
+		t.Errorf("peers = %v", d.Peers)
+	}
+}
+
+func TestLooksLikeRoleFile(t *testing.T) {
+	files := []string{"./researcher.md", "roles/sre.yaml", "~/x.json", "a.markdown", "x.yml"}
+	for _, f := range files {
+		if !LooksLikeRoleFile(f) {
+			t.Errorf("LooksLikeRoleFile(%q) = false, want true", f)
+		}
+	}
+	slugs := []string{"researcher", "cto", "qa", "senior-dev", "2", "all"}
+	for _, s := range slugs {
+		if LooksLikeRoleFile(s) {
+			t.Errorf("LooksLikeRoleFile(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestEnsureContentWritesAndPreserves(t *testing.T) {
+	agentDir := t.TempDir()
+	body := "# Role: Custom\n\nbody\n"
+	wrote, err := EnsureContent(agentDir, body)
+	if err != nil || !wrote {
+		t.Fatalf("EnsureContent first write: wrote=%v err=%v", wrote, err)
+	}
+	got, err := os.ReadFile(Path(agentDir))
+	if err != nil || string(got) != body {
+		t.Fatalf("staged content = %q (err %v), want %q", got, err, body)
+	}
+	// Second call must not overwrite existing edits.
+	wrote, err = EnsureContent(agentDir, "different")
+	if err != nil || wrote {
+		t.Fatalf("EnsureContent should not overwrite: wrote=%v err=%v", wrote, err)
+	}
+}

--- a/internal/role/parse_test.go
+++ b/internal/role/parse_test.go
@@ -128,6 +128,49 @@ func TestParseJSON(t *testing.T) {
 	}
 }
 
+func TestParseJSONIDFromFilename(t *testing.T) {
+	// JSON without an explicit id falls back to the filename, like yaml/md.
+	p := writeTemp(t, "data-analyst.json", `{"label":"Data Analyst","binary":"codex"}`)
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "data-analyst" {
+		t.Errorf("id = %q, want data-analyst (from filename)", d.ID)
+	}
+}
+
+func TestParseBOMMarkdownHeading(t *testing.T) {
+	// A BOM-prefixed plain Markdown file still derives its id from the heading.
+	p := writeTemp(t, "x.md", "\ufeff# Role: Researcher\n\n## Description\nDoes research.\n")
+	d, err := ParseFile(p)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if d.ID != "researcher" {
+		t.Errorf("id = %q, want researcher (from heading, BOM stripped)", d.ID)
+	}
+	if strings.HasPrefix(d.Body, "\ufeff") {
+		t.Errorf("body should not retain the BOM: %q", d.Body[:1])
+	}
+}
+
+func TestSlugifyCollapsesPunctuation(t *testing.T) {
+	cases := map[string]string{
+		"Data/ML Engineer":  "data-ml-engineer",
+		"Site  Reliability": "site-reliability",
+		"  Trim Me  ":       "trim-me",
+		"Already-Hyphen":    "already-hyphen",
+		"weird::colons":     "weird-colons",
+		"keep_underscore":   "keep_underscore",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestLooksLikeRoleFile(t *testing.T) {
 	files := []string{"./researcher.md", "roles/sre.yaml", "~/x.json", "a.markdown", "x.yml"}
 	for _, f := range files {

--- a/internal/role/parse_test.go
+++ b/internal/role/parse_test.go
@@ -163,6 +163,10 @@ func TestSlugifyCollapsesPunctuation(t *testing.T) {
 		"Already-Hyphen":    "already-hyphen",
 		"weird::colons":     "weird-colons",
 		"keep_underscore":   "keep_underscore",
+		"/leading":          "leading",
+		"trailing/":         "trailing",
+		"---":               "", // all-separator input slugifies to empty (then rejected upstream)
+		"!!!":               "",
 	}
 	for in, want := range cases {
 		if got := slugify(in); got != want {

--- a/internal/role/role.go
+++ b/internal/role/role.go
@@ -100,6 +100,25 @@ func EnsureStub(agentDir string, s Stub) (bool, error) {
 	return true, nil
 }
 
+// EnsureContent writes the given role.md body for an agent if neither the
+// extension nor legacy role file already exists. Unlike EnsureStub it persists
+// caller-supplied content verbatim (used for custom roles authored in an
+// external file). It never overwrites existing user edits. Returns true if it
+// wrote a file.
+func EnsureContent(agentDir, body string) (bool, error) {
+	if Exists(agentDir) {
+		return false, nil
+	}
+	p := Path(agentDir)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return false, fmt.Errorf("ensure extension dir: %w", err)
+	}
+	if err := writeFile(p, body); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func writeFile(path, body string) error {
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(body), 0o600); err != nil {

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -19,6 +19,7 @@ const (
 	DirName               = ".amq-squad"
 	FileName              = "team.json"
 	TeamsDirName          = "teams"
+	RolesDirName          = "roles"
 	DefaultOperatorHandle = "user"
 	// DefaultProfile names the implicit project-default profile. It maps to
 	// .amq-squad/team.json; a file at .amq-squad/teams/default.json is never
@@ -164,6 +165,18 @@ func ProfilePath(projectDir, profile string) string {
 		return filepath.Join(projectDir, DirName, FileName)
 	}
 	return filepath.Join(projectDir, DirName, TeamsDirName, profile+".json")
+}
+
+// RolesDir returns the directory that holds authored custom-role documents,
+// <projectDir>/.amq-squad/roles. Each custom role staged from a file lands at
+// <RolesDir>/<id>.md and is consulted when seeding an agent's role.md.
+func RolesDir(projectDir string) string {
+	return filepath.Join(projectDir, DirName, RolesDirName)
+}
+
+// CustomRolePath returns the staged role.md path for a custom role id.
+func CustomRolePath(projectDir, id string) string {
+	return filepath.Join(RolesDir(projectDir), id+".md")
 }
 
 // ValidateProfileName enforces the profile-name slug rules: lowercase a-z,

--- a/skills/claude/amq-squad-role-creator/SKILL.md
+++ b/skills/claude/amq-squad-role-creator/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: amq-squad-role-creator
+description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, scribe, or data-scientist that the catalog does not ship. For built-in personas (cto, qa, fullstack, ...) and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+argument-hint: "[role-id] [codex|claude]"
+user-invocable: true
+trigger: /amq-squad-role-creator
+---
+
+# amq-squad-role-creator
+
+Use this skill to add a **custom role** — one that is not in the built-in
+persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
+mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
+members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
+status/history, and launch/resume exactly like built-ins.
+
+Requires amq-squad **v1.4.2+**. Check with `amq-squad version`.
+
+There are two ways to add a custom role. Pick by how much role guidance you want.
+
+## A. Inline (quick, minimal role.md)
+
+For a role that only needs an id + CLI, with the generic custom-role fallback
+text seeded into its `role.md`:
+
+```sh
+amq-squad new team --roles researcher --binary researcher=codex
+amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
+amq-squad new profile discovery --roles researcher --binary researcher=codex
+amq-squad team init --roles cto,researcher --binary researcher=codex
+```
+
+Rules:
+- A `--roles`/`--personas` entry that is not a built-in persona is a custom role.
+- Each custom role **must** be a valid slug (lowercase `a-z`, `0-9`, `-`, `_`)
+  and **must** have an explicit `--binary <role>=<cli>` entry (there is no
+  catalog default to fall back to). Built-in roles keep their catalog defaults
+  unless overridden.
+- Missing binary fails clearly:
+  `custom role "researcher" requires --binary researcher=<cli>`.
+
+## B. From a role file (rich, authored role.md)
+
+When you want a real persona description, peers, and skills, author a role file
+and pass it with `--role-file` (comma-separated) or inline in `--roles`:
+
+```sh
+amq-squad new team --role-file ./roles/researcher.md --roles cto
+amq-squad team init --roles "cto,./roles/researcher.md"
+amq-squad new profile discovery --role-file ./roles/researcher.md,./roles/sre.yaml
+```
+
+What happens:
+- The role id is taken from the file (`id:` field, a `# Role: <name>` heading,
+  or the filename).
+- The binary comes from the file's `binary:` field; `--binary` overrides it.
+  If neither is present the command fails with the same binary guidance as above.
+- The authored document is staged at `.amq-squad/roles/<id>.md`. At launch,
+  `up` / `agent up` seeds that agent's `role.md` from it verbatim (and never
+  overwrites later user edits).
+- A role file named via `--role-file` is added to the team even if it is not
+  also listed in `--roles`.
+
+### File formats
+
+**Markdown with YAML frontmatter** (recommended — frontmatter for metadata,
+body becomes `role.md` verbatim):
+
+```markdown
+---
+id: researcher
+label: Research Engineer
+binary: codex
+peers: [cto, qa]
+skills:
+  - /deep-research
+---
+# Role: Research Engineer
+
+## Description
+Owns deep technical investigation, prototypes, and written findings. Turns
+open questions into evidence the team can act on.
+
+## Peers
+- cto
+- qa
+
+## Skills
+- /deep-research
+
+## System Prompt
+Stay within the research scope; hand implementation to developer roles. Use the
+amq-squad protocol for handoffs.
+
+## Priming Template
+At launch, state your role and handle, summarize relevant context, then wait
+for instruction.
+```
+
+**Plain Markdown, no frontmatter** (whole file is `role.md`; id from the
+`# Role:` heading or filename; supply the binary with `--binary`):
+
+```markdown
+# Role: Scribe
+
+## Description
+Captures decisions and keeps the team's written record.
+```
+
+```sh
+amq-squad new team --roles "cto,./roles/scribe.md" --binary scribe=claude
+```
+
+**Metadata-only YAML or JSON** (no body; `role.md` is rendered from the
+fields):
+
+```yaml
+id: sre
+label: Site Reliability Engineer
+binary: claude
+description: Owns reliability, on-call, and incident response.
+skills:
+  - /run
+peers:
+  - cto
+  - backend-dev
+```
+
+```json
+{ "id": "analyst", "label": "Analyst", "binary": "codex",
+  "description": "Owns reporting and data pulls.", "peers": ["pm"] }
+```
+
+### Supported metadata fields
+
+| Field | Meaning |
+| --- | --- |
+| `id` (or `role`) | role slug + default handle (lowercase `a-z 0-9 - _`) |
+| `label` | human title shown in listings and `role.md` |
+| `binary` | `codex` or `claude` (any non-control value is accepted) |
+| `description` | one-line summary seeded into the rendered `role.md` |
+| `skills` | list of slash commands for this role |
+| `peers` | list of role ids this role talks to most |
+| `body` (JSON only) | optional verbatim `role.md` content |
+
+## Authoring workflow
+
+1. Decide the role id, CLI (`codex`/`claude`), and whether you need rich
+   guidance (file) or just an id (inline).
+2. For a file: write it under `./roles/<id>.md` (frontmatter + body is the
+   sweet spot). Keep the `# Role:`, `## Description`, `## Peers`, `## Skills`,
+   `## System Prompt`, `## Priming Template` sections so it matches what the
+   binary renders for built-ins.
+3. Preview before writing anything:
+   ```sh
+   amq-squad new team --role-file ./roles/<id>.md --roles cto --dry-run --json
+   ```
+   Confirm the member shows the right `role`, `handle`, and `binary`.
+4. Create the team for real (drop `--dry-run`), or add `--sync` to also write
+   the `CLAUDE.md`/`AGENTS.md` pointer stubs.
+5. Edit `.amq-squad/roles/<id>.md` later to refine the persona; re-running
+   `team init --force` re-stages it, and launch never clobbers an agent's
+   already-seeded `role.md`.
+
+## Verification
+
+- `amq-squad new team --role-file ... --dry-run --json` succeeds and the plan
+  lists the custom member with the expected binary.
+- After a live create, `.amq-squad/roles/<id>.md` exists and `team.json`
+  includes the member.
+- `amq-squad up --dry-run` shows a launch command for the custom role.
+
+## When NOT to use this skill
+
+- Built-in personas or general team design → `amq-team-setup`.
+- Live coordination (drain, route, review, up/stop/resume) → `amq-squad`.
+- Raw AMQ debugging → `amq-cli`.

--- a/skills/codex/amq-squad-role-creator/SKILL.md
+++ b/skills/codex/amq-squad-role-creator/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: amq-squad-role-creator
+description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, scribe, or data-scientist that the catalog does not ship. For built-in personas and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
+---
+
+# amq-squad-role-creator
+
+Use this skill to add a **custom role** — one that is not in the built-in
+persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
+mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
+members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
+status/history, and launch/resume exactly like built-ins.
+
+Requires amq-squad **v1.4.2+**. Check with `amq-squad version`.
+
+There are two ways to add a custom role. Pick by how much role guidance you want.
+
+## A. Inline (quick, minimal role.md)
+
+For a role that only needs an id + CLI, with the generic custom-role fallback
+text seeded into its `role.md`:
+
+```sh
+amq-squad new team --roles researcher --binary researcher=codex
+amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
+amq-squad new profile discovery --roles researcher --binary researcher=codex
+amq-squad team init --roles cto,researcher --binary researcher=codex
+```
+
+Rules:
+- A `--roles`/`--personas` entry that is not a built-in persona is a custom role.
+- Each custom role **must** be a valid slug (lowercase `a-z`, `0-9`, `-`, `_`)
+  and **must** have an explicit `--binary <role>=<cli>` entry (there is no
+  catalog default to fall back to). Built-in roles keep their catalog defaults
+  unless overridden.
+- Missing binary fails clearly:
+  `custom role "researcher" requires --binary researcher=<cli>`.
+
+## B. From a role file (rich, authored role.md)
+
+When you want a real persona description, peers, and skills, author a role file
+and pass it with `--role-file` (comma-separated) or inline in `--roles`:
+
+```sh
+amq-squad new team --role-file ./roles/researcher.md --roles cto
+amq-squad team init --roles "cto,./roles/researcher.md"
+amq-squad new profile discovery --role-file ./roles/researcher.md,./roles/sre.yaml
+```
+
+What happens:
+- The role id is taken from the file (`id:` field, a `# Role: <name>` heading,
+  or the filename).
+- The binary comes from the file's `binary:` field; `--binary` overrides it.
+  If neither is present the command fails with the same binary guidance as above.
+- The authored document is staged at `.amq-squad/roles/<id>.md`. At launch,
+  `up` / `agent up` seeds that agent's `role.md` from it verbatim (and never
+  overwrites later user edits).
+- A role file named via `--role-file` is added to the team even if it is not
+  also listed in `--roles`.
+
+### File formats
+
+**Markdown with YAML frontmatter** (recommended — frontmatter for metadata,
+body becomes `role.md` verbatim):
+
+```markdown
+---
+id: researcher
+label: Research Engineer
+binary: codex
+peers: [cto, qa]
+skills:
+  - /deep-research
+---
+# Role: Research Engineer
+
+## Description
+Owns deep technical investigation, prototypes, and written findings. Turns
+open questions into evidence the team can act on.
+
+## Peers
+- cto
+- qa
+
+## Skills
+- /deep-research
+
+## System Prompt
+Stay within the research scope; hand implementation to developer roles. Use the
+amq-squad protocol for handoffs.
+
+## Priming Template
+At launch, state your role and handle, summarize relevant context, then wait
+for instruction.
+```
+
+**Plain Markdown, no frontmatter** (whole file is `role.md`; id from the
+`# Role:` heading or filename; supply the binary with `--binary`):
+
+```markdown
+# Role: Scribe
+
+## Description
+Captures decisions and keeps the team's written record.
+```
+
+```sh
+amq-squad new team --roles "cto,./roles/scribe.md" --binary scribe=claude
+```
+
+**Metadata-only YAML or JSON** (no body; `role.md` is rendered from the
+fields):
+
+```yaml
+id: sre
+label: Site Reliability Engineer
+binary: claude
+description: Owns reliability, on-call, and incident response.
+skills:
+  - /run
+peers:
+  - cto
+  - backend-dev
+```
+
+```json
+{ "id": "analyst", "label": "Analyst", "binary": "codex",
+  "description": "Owns reporting and data pulls.", "peers": ["pm"] }
+```
+
+### Supported metadata fields
+
+| Field | Meaning |
+| --- | --- |
+| `id` (or `role`) | role slug + default handle (lowercase `a-z 0-9 - _`) |
+| `label` | human title shown in listings and `role.md` |
+| `binary` | `codex` or `claude` (any non-control value is accepted) |
+| `description` | one-line summary seeded into the rendered `role.md` |
+| `skills` | list of slash commands for this role |
+| `peers` | list of role ids this role talks to most |
+| `body` (JSON only) | optional verbatim `role.md` content |
+
+## Authoring workflow
+
+1. Decide the role id, CLI (`codex`/`claude`), and whether you need rich
+   guidance (file) or just an id (inline).
+2. For a file: write it under `./roles/<id>.md` (frontmatter + body is the
+   sweet spot). Keep the `# Role:`, `## Description`, `## Peers`, `## Skills`,
+   `## System Prompt`, `## Priming Template` sections so it matches what the
+   binary renders for built-ins.
+3. Preview before writing anything:
+   ```sh
+   amq-squad new team --role-file ./roles/<id>.md --roles cto --dry-run --json
+   ```
+   Confirm the member shows the right `role`, `handle`, and `binary`.
+4. Create the team for real (drop `--dry-run`), or add `--sync` to also write
+   the `CLAUDE.md`/`AGENTS.md` pointer stubs.
+5. Edit `.amq-squad/roles/<id>.md` later to refine the persona; re-running
+   `team init --force` re-stages it, and launch never clobbers an agent's
+   already-seeded `role.md`.
+
+## Verification
+
+- `amq-squad new team --role-file ... --dry-run --json` succeeds and the plan
+  lists the custom member with the expected binary.
+- After a live create, `.amq-squad/roles/<id>.md` exists and `team.json`
+  includes the member.
+- `amq-squad up --dry-run` shows a launch command for the custom role.
+
+## When NOT to use this skill
+
+- Built-in personas or general team design → `amq-team-setup`.
+- Live coordination (drain, route, review, up/stop/resume) → `amq-squad`.
+- Raw AMQ debugging → `amq-cli`.


### PR DESCRIPTION
## Summary

Adds **custom role** support so a team can include members whose role is not in the built-in persona catalog. This unblocks **amq-noc**'s `T new-team` flow, where the operator types `role=binary` pairs (e.g. `researcher=codex,reviewer=claude,session=issue-96`) — which current amq-squad rejects with `unknown persona/role`.

Targets **v1.4.2** (README install reference bumped).

## Inline custom roles (NOC contract)

- `--roles X` accepts any valid slug not in the catalog across `new team` / `new profile` / `team init`, provided each custom role carries an explicit `--binary X=<cli>` (there is no catalog default to fall back to).
- Built-in personas keep their catalog defaults unless overridden. Selection by id / market number / `all` is unchanged.
- Missing binary fails clearly: `custom role "researcher" requires --binary researcher=<cli>`. Invalid slugs rejected via `team.ValidateRoleID`. `--binary` keys are lowercased for parity with `--model`.
- Custom roles are first-class members in `team.json`, `team-rules.md`, bootstrap, status/history, launch/resume, and the dry-run JSON plan (`role`/`handle`/`binary`/`session`).

```sh
amq-squad new team --roles researcher --binary researcher=codex
amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
amq-squad new profile discovery --roles researcher --binary researcher=codex
```

## File-based custom roles

- `--role-file PATH` (comma-separated) and inline paths in `--roles` (e.g. `--roles cto,./researcher.md`).
- Formats: Markdown with optional YAML frontmatter (body becomes `role.md` verbatim), plus metadata-only `.yaml`/`.json`. The file's `binary:` field satisfies the binary requirement; `--binary` overrides it. Frontmatter parser is hand-rolled — **no new dependency**.
- The authored document is staged at `.amq-squad/roles/<id>.md`; `up` / `agent up` seeds the agent's `role.md` from it at launch (resolved via `--team-home`). User edits are preserved.

```sh
amq-squad new team --role-file ./roles/researcher.md --roles cto
amq-squad team init --roles "cto,./roles/researcher.md"
```

## Skill

Adds `amq-squad-role-creator` (claude + codex) to walk through authoring role files and wiring them into a team.

## Tests

- `internal/role/parse_test.go` — frontmatter / verbatim / yaml / json parsing, `LooksLikeRoleFile`, `EnsureContent`.
- `internal/cli/custom_role_test.go` — all enumerated NOC cases (dry-run JSON shape, live write, new profile, missing-binary, unrelated-binary, builtin+custom mix, invalid slug, fallback stub text) plus file-based staging + launch seed.
- `internal/catalog/catalog_test.go` — permissive resolver.
- `make ci` (gofmt + vet + full suite) passes.

## Scope note

Custom roles are accepted on the **non-interactive** flag paths (`--roles`/`--personas`/`--role-file`); the interactive `team init` picker stays catalog-only, matching the NOC use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)