### PR TITLE
v1.5.0 Phase A: persist exact tmux runtime metadata (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.4 line:
+Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.4.2
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.0
 amq-squad version
 ```
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -14,7 +14,15 @@ import (
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/role"
 	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
 )
+
+// envTmuxTarget carries the tmux launch target (current-window / new-window /
+// new-session) from a team-launch backend into each agent's launcher process,
+// so the per-agent launch record can persist how its pane was created. It is
+// set only on the live tmux launch paths; manual `agent up` launches leave it
+// unset and record an empty target.
+const envTmuxTarget = "AMQ_SQUAD_TMUX_TARGET"
 
 // runLaunch is the real single-agent launcher. The top-level `launch` verb is
 // legacy; this body now backs `agent up` (via runAgentUp -> translateAgentUpArgs)
@@ -199,6 +207,21 @@ Examples:
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
 		TeamProfile:      strings.TrimSpace(*teamProfile),
+	}
+
+	// Capture exact tmux identity (session/window/pane ids) when launched
+	// inside tmux, so clients can target follow-up control by stable pane id
+	// instead of re-inferring from window names. Best-effort: a capture failure
+	// must never block the launch. This runs before exec while $TMUX/$TMUX_PANE
+	// still describe this agent's pane.
+	if id, err := tmuxpane.CurrentPaneIdentity(); err == nil && id != nil {
+		rec.Tmux = &launch.TmuxInfo{
+			Session:    id.Session,
+			WindowID:   id.WindowID,
+			WindowName: id.WindowName,
+			PaneID:     id.PaneID,
+			Target:     strings.TrimSpace(os.Getenv(envTmuxTarget)),
+		}
 	}
 
 	// Keep generated bootstrap out of launch.json so restore stays compact

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -321,6 +321,20 @@ func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane 
 	return panes
 }
 
+// withTmuxTargetEnv prefixes a per-pane launch command with an exported
+// AMQ_SQUAD_TMUX_TARGET assignment so the launched agent's record can persist
+// how its pane was created (current-window / new-window / new-session). target
+// is a controlled enum, never user text, and is shell-quoted defensively. An
+// empty target returns the command unchanged. Only the live tmux send-keys
+// paths use this, so dry-run / copy-paste commands stay clean.
+func withTmuxTargetEnv(target, command string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return command
+	}
+	return "export " + envTmuxTarget + "=" + shellQuote(target) + "; " + command
+}
+
 func teamSquadBin() string {
 	if p, err := os.Executable(); err == nil {
 		return p

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -321,18 +321,21 @@ func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane 
 	return panes
 }
 
-// withTmuxTargetEnv prefixes a per-pane launch command with an exported
-// AMQ_SQUAD_TMUX_TARGET assignment so the launched agent's record can persist
-// how its pane was created (current-window / new-window / new-session). target
-// is a controlled enum, never user text, and is shell-quoted defensively. An
-// empty target returns the command unchanged. Only the live tmux send-keys
+// withTmuxTargetEnv wraps a per-pane launch command so the launched agent's
+// record can persist how its pane was created (current-window / new-window /
+// new-session). The assignment is exported inside a subshell so it reaches the
+// amq-squad process (a plain `VAR=val cmd` would scope it to `cd` only) but
+// does NOT leak into the operator's pane shell after the agent exits — a leak
+// would make a later manual `agent up` in that pane record a stale target.
+// target is a controlled enum, never user text, and is shell-quoted defensively.
+// An empty target returns the command unchanged. Only the live tmux send-keys
 // paths use this, so dry-run / copy-paste commands stay clean.
 func withTmuxTargetEnv(target, command string) string {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return command
 	}
-	return "export " + envTmuxTarget + "=" + shellQuote(target) + "; " + command
+	return "(export " + envTmuxTarget + "=" + shellQuote(target) + "; " + command + ")"
 }
 
 func teamSquadBin() string {

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -272,7 +272,7 @@ func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 		}
 	}
 	for i, pane := range plan.Panes {
-		if err := runCommand("tmux", "send-keys", "-t", targets[i], pane.Command, "C-m"); err != nil {
+		if err := runCommand("tmux", "send-keys", "-t", targets[i], withTmuxTargetEnv(plan.Target, pane.Command), "C-m"); err != nil {
 			return err
 		}
 		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {

--- a/internal/cli/team_launch_tmux_session.go
+++ b/internal/cli/team_launch_tmux_session.go
@@ -152,7 +152,7 @@ func runTmuxSessionLaunchPlan(plan tmuxSessionLaunchPlan) error {
 		if err := runCommand(tmuxSessionBinary, tmuxSessionCreateArgv(plan.Workstream, pane.Role, pane.CWD)...); err != nil {
 			return err
 		}
-		if err := runCommand("tmux", "send-keys", "-t", plan.Workstream+":"+pane.Role, pane.Command, "C-m"); err != nil {
+		if err := runCommand("tmux", "send-keys", "-t", plan.Workstream+":"+pane.Role, withTmuxTargetEnv("new-window", pane.Command), "C-m"); err != nil {
 			return err
 		}
 		if err := runCommand(tmuxSessionBinary, tmuxSessionRenameArgv(plan.Workstream, pane.Role)...); err != nil {

--- a/internal/cli/tmux_target_env_test.go
+++ b/internal/cli/tmux_target_env_test.go
@@ -8,14 +8,15 @@ import (
 func TestWithTmuxTargetEnvPrefixesExportedTarget(t *testing.T) {
 	cmd := "cd /repo && amq-squad agent up codex --role cto"
 	got := withTmuxTargetEnv("current-window", cmd)
-	want := "export " + envTmuxTarget + "=current-window; " + cmd
+	want := "(export " + envTmuxTarget + "=current-window; " + cmd + ")"
 	if got != want {
 		t.Fatalf("withTmuxTargetEnv = %q, want %q", got, want)
 	}
-	// The exported assignment must precede the command so the amq-squad process
-	// inherits it (a plain `VAR=val cmd` would scope it to `cd` only).
-	if !strings.HasPrefix(got, "export "+envTmuxTarget+"=") {
-		t.Fatalf("target env not exported before command: %q", got)
+	// The assignment is exported (so the amq-squad process inherits it; a plain
+	// `VAR=val cmd` would scope it to `cd` only) but wrapped in a subshell so it
+	// does not leak into the operator's pane shell after the agent exits.
+	if !strings.HasPrefix(got, "(export "+envTmuxTarget+"=") || !strings.HasSuffix(got, ")") {
+		t.Fatalf("target env not wrapped in an exported subshell: %q", got)
 	}
 }
 
@@ -33,7 +34,7 @@ func TestWithTmuxTargetEnvQuotesValue(t *testing.T) {
 	// Defense in depth: the value is a controlled enum, but it is shell-quoted
 	// so it can never inject shell syntax into the sent command.
 	got := withTmuxTargetEnv("new-session", "cmd")
-	if !strings.Contains(got, envTmuxTarget+"=new-session;") {
+	if !strings.Contains(got, envTmuxTarget+"=new-session; ") {
 		t.Fatalf("unexpected quoting/shape: %q", got)
 	}
 }

--- a/internal/cli/tmux_target_env_test.go
+++ b/internal/cli/tmux_target_env_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWithTmuxTargetEnvPrefixesExportedTarget(t *testing.T) {
+	cmd := "cd /repo && amq-squad agent up codex --role cto"
+	got := withTmuxTargetEnv("current-window", cmd)
+	want := "export " + envTmuxTarget + "=current-window; " + cmd
+	if got != want {
+		t.Fatalf("withTmuxTargetEnv = %q, want %q", got, want)
+	}
+	// The exported assignment must precede the command so the amq-squad process
+	// inherits it (a plain `VAR=val cmd` would scope it to `cd` only).
+	if !strings.HasPrefix(got, "export "+envTmuxTarget+"=") {
+		t.Fatalf("target env not exported before command: %q", got)
+	}
+}
+
+func TestWithTmuxTargetEnvEmptyTargetUnchanged(t *testing.T) {
+	cmd := "cd /repo && amq-squad agent up codex"
+	if got := withTmuxTargetEnv("", cmd); got != cmd {
+		t.Fatalf("empty target must leave command unchanged, got %q", got)
+	}
+	if got := withTmuxTargetEnv("   ", cmd); got != cmd {
+		t.Fatalf("blank target must leave command unchanged, got %q", got)
+	}
+}
+
+func TestWithTmuxTargetEnvQuotesValue(t *testing.T) {
+	// Defense in depth: the value is a controlled enum, but it is shell-quoted
+	// so it can never inject shell syntax into the sent command.
+	got := withTmuxTargetEnv("new-session", "cmd")
+	if !strings.Contains(got, envTmuxTarget+"=new-session;") {
+		t.Fatalf("unexpected quoting/shape: %q", got)
+	}
+}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -54,6 +54,27 @@ type Record struct {
 	// means the implicit default profile. Captured so status / bootstrap
 	// routing can reuse the same profile without rereading flags.
 	TeamProfile string `json:"team_profile,omitempty"`
+	// Tmux is the tmux runtime identity captured at launch time when
+	// amq-squad runs inside tmux. nil when launched outside tmux (or when
+	// tmux metadata could not be resolved). Clients detect runtime-control
+	// availability by the presence of this object, not by Schema.
+	Tmux *TmuxInfo `json:"tmux,omitempty"`
+}
+
+// TmuxInfo is the exact tmux identity of the pane an agent was launched into.
+// Pane and window ids (e.g. "%265", "@42") are stable tmux control addresses
+// and are the only values that should be used to target follow-up control.
+// WindowName is a human label that can collide and must never be treated as an
+// address.
+type TmuxInfo struct {
+	Session    string `json:"session,omitempty"`
+	WindowID   string `json:"window_id,omitempty"`
+	WindowName string `json:"window_name,omitempty"`
+	PaneID     string `json:"pane_id,omitempty"`
+	// Target records how the pane was created relative to the launching
+	// environment: "current-window", "new-window", or "new-session". Empty
+	// when not known to the launcher.
+	Target string `json:"target,omitempty"`
 }
 
 // Entry is a launch record plus the mailbox directory it was discovered in.

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -68,6 +68,74 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestWriteReadTmuxMetadata(t *testing.T) {
+	dir := t.TempDir()
+	in := Record{
+		CWD:       "/some/project",
+		Binary:    "codex",
+		Handle:    "cto",
+		Role:      "cto",
+		Root:      dir,
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+		Tmux: &TmuxInfo{
+			Session:    "main",
+			WindowID:   "@42",
+			WindowName: "amq-squad-issue-96",
+			PaneID:     "%265",
+			Target:     "current-window",
+		},
+	}
+	if err := Write(dir, in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Tmux == nil {
+		t.Fatal("tmux metadata lost on round-trip")
+	}
+	if *out.Tmux != *in.Tmux {
+		t.Fatalf("tmux round-trip mismatch: got %+v, want %+v", *out.Tmux, *in.Tmux)
+	}
+
+	// The on-disk JSON must nest the runtime identity under "tmux" with the
+	// exact field names the NOC contract depends on.
+	raw, err := os.ReadFile(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe struct {
+		Tmux *TmuxInfo `json:"tmux"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if probe.Tmux == nil || probe.Tmux.PaneID != "%265" {
+		t.Fatalf("json tmux block missing/wrong: %s", raw)
+	}
+}
+
+func TestReadLegacyRecordHasNilTmux(t *testing.T) {
+	// A pre-1.5 record (no "tmux" key) must read back with a nil Tmux pointer,
+	// so clients detect runtime-control availability by presence, not schema.
+	dir := t.TempDir()
+	legacy := `{"schema":1,"cwd":"/p","binary":"codex","handle":"cto","root":"` + dir + `","started_at":"2026-01-01T00:00:00Z"}`
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(dir), []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Tmux != nil {
+		t.Fatalf("legacy record should have nil Tmux, got %+v", out.Tmux)
+	}
+}
+
 func TestReadMissing(t *testing.T) {
 	dir := t.TempDir()
 	_, err := Read(dir)

--- a/internal/tmuxpane/capture_test.go
+++ b/internal/tmuxpane/capture_test.go
@@ -1,0 +1,117 @@
+package tmuxpane
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// swapCapture replaces the captureExec seam and returns a restore func plus a
+// pointer to the recorded argv of the last call.
+func swapCapture(t *testing.T, out string, retErr error) *[]string {
+	t.Helper()
+	var got []string
+	prev := captureExec
+	captureExec = func(args ...string) (string, error) {
+		got = append([]string(nil), args...)
+		return out, retErr
+	}
+	t.Cleanup(func() { captureExec = prev })
+	return &got
+}
+
+func swapEnv(t *testing.T, server, pane string) {
+	t.Helper()
+	ps, pp := tmuxServerEnv, tmuxPaneEnv
+	tmuxServerEnv = func() string { return server }
+	tmuxPaneEnv = func() string { return pane }
+	t.Cleanup(func() { tmuxServerEnv, tmuxPaneEnv = ps, pp })
+}
+
+func TestCurrentPaneIdentityResolvesExactIDs(t *testing.T) {
+	swapEnv(t, "/tmp/tmux-1000/default,123,0", "%5")
+	got := swapCapture(t, "main\t@42\tamq-squad-issue-96\t%5\n", nil)
+
+	id, err := CurrentPaneIdentity()
+	if err != nil {
+		t.Fatalf("CurrentPaneIdentity: %v", err)
+	}
+	if id == nil {
+		t.Fatal("expected identity, got nil")
+	}
+	want := &PaneIdentity{Session: "main", WindowID: "@42", WindowName: "amq-squad-issue-96", PaneID: "%5"}
+	if !reflect.DeepEqual(id, want) {
+		t.Fatalf("identity = %+v, want %+v", id, want)
+	}
+	// It must target the explicit $TMUX_PANE, never the active pane.
+	wantArgs := []string{"display-message", "-p", "-t", "%5", "#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}"}
+	if !reflect.DeepEqual(*got, wantArgs) {
+		t.Fatalf("capture argv = %v, want %v", *got, wantArgs)
+	}
+}
+
+func TestCurrentPaneIdentityNotInTmux(t *testing.T) {
+	swapEnv(t, "", "%5") // $TMUX empty
+	got := swapCapture(t, "", nil)
+	id, err := CurrentPaneIdentity()
+	if err != nil || id != nil {
+		t.Fatalf("outside tmux want (nil,nil), got (%v,%v)", id, err)
+	}
+	if len(*got) != 0 {
+		t.Fatalf("must not query tmux when $TMUX unset; argv=%v", *got)
+	}
+}
+
+func TestCurrentPaneIdentityNoPaneEnv(t *testing.T) {
+	swapEnv(t, "/tmp/tmux-1000/default", "") // in tmux but no $TMUX_PANE
+	got := swapCapture(t, "", nil)
+	id, err := CurrentPaneIdentity()
+	if err != nil || id != nil {
+		t.Fatalf("no pane env want (nil,nil), got (%v,%v)", id, err)
+	}
+	if len(*got) != 0 {
+		t.Fatalf("must not query tmux when $TMUX_PANE unset; argv=%v", *got)
+	}
+}
+
+func TestPaneIdentityForPropagatesError(t *testing.T) {
+	swapCapture(t, "", errors.New("no server running"))
+	if _, err := PaneIdentityFor("%5"); err == nil {
+		t.Fatal("expected error when tmux query fails")
+	}
+}
+
+func TestPaneIdentityForRejectsShortOutput(t *testing.T) {
+	swapCapture(t, "main\t@42\n", nil) // only 2 fields
+	if _, err := PaneIdentityFor("%5"); err == nil {
+		t.Fatal("expected error on malformed display-message output")
+	}
+}
+
+func TestParsePanesCapturesExactIDs(t *testing.T) {
+	// 10-field row including pane_id (#{pane_id}) and window_id (#{window_id}).
+	row := "main\t0\t1\t4242\tcodex\t/repo\tamq:issue-96:cto\tsquad\t%5\t@42"
+	panes := parsePanes(row)
+	if len(panes) != 1 {
+		t.Fatalf("want 1 pane, got %d", len(panes))
+	}
+	p := panes[0]
+	if p.PaneID != "%5" || p.WindowID != "@42" {
+		t.Fatalf("exact ids not parsed: PaneID=%q WindowID=%q", p.PaneID, p.WindowID)
+	}
+	if p.Session != "main" || p.Title != "amq:issue-96:cto" || p.WindowName != "squad" {
+		t.Fatalf("row fields wrong: %+v", p)
+	}
+}
+
+func TestParsePanesToleratesOldEightFieldRow(t *testing.T) {
+	// Older 8-field row (no pane_id/window_id) must still parse, with empty ids.
+	row := "main\t0\t1\t4242\tcodex\t/repo\tamq:issue-96:cto\tsquad"
+	panes := parsePanes(row)
+	if len(panes) != 1 {
+		t.Fatalf("want 1 pane, got %d", len(panes))
+	}
+	if panes[0].PaneID != "" || panes[0].WindowID != "" {
+		t.Fatalf("old row should have empty exact ids, got PaneID=%q WindowID=%q", panes[0].PaneID, panes[0].WindowID)
+	}
+}

--- a/internal/tmuxpane/capture_test.go
+++ b/internal/tmuxpane/capture_test.go
@@ -30,7 +30,9 @@ func swapEnv(t *testing.T, server, pane string) {
 
 func TestCurrentPaneIdentityResolvesExactIDs(t *testing.T) {
 	swapEnv(t, "/tmp/tmux-1000/default,123,0", "%5")
-	got := swapCapture(t, "main\t@42\tamq-squad-issue-96\t%5\n", nil)
+	// Output order matches the ids-first format: pane_id, window_id, session,
+	// window_name.
+	got := swapCapture(t, "%5\t@42\tmain\tamq-squad-issue-96\n", nil)
 
 	id, err := CurrentPaneIdentity()
 	if err != nil {
@@ -43,10 +45,26 @@ func TestCurrentPaneIdentityResolvesExactIDs(t *testing.T) {
 	if !reflect.DeepEqual(id, want) {
 		t.Fatalf("identity = %+v, want %+v", id, want)
 	}
-	// It must target the explicit $TMUX_PANE, never the active pane.
-	wantArgs := []string{"display-message", "-p", "-t", "%5", "#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}"}
+	// It must target the explicit $TMUX_PANE, never the active pane, and request
+	// the stable ids before the (possibly tab-bearing) window name.
+	wantArgs := []string{"display-message", "-p", "-t", "%5", "#{pane_id}\t#{window_id}\t#{session_name}\t#{window_name}"}
 	if !reflect.DeepEqual(*got, wantArgs) {
 		t.Fatalf("capture argv = %v, want %v", *got, wantArgs)
+	}
+}
+
+func TestPaneIdentityToleratesTabInWindowName(t *testing.T) {
+	// A window name containing a tab must corrupt only the label, never the ids.
+	swapCapture(t, "%9\t@7\tmain\tweird\tname\n", nil)
+	id, err := PaneIdentityFor("%9")
+	if err != nil {
+		t.Fatalf("PaneIdentityFor: %v", err)
+	}
+	if id.PaneID != "%9" || id.WindowID != "@7" || id.Session != "main" {
+		t.Fatalf("ids corrupted by tab in name: %+v", id)
+	}
+	if id.WindowName != "weird\tname" {
+		t.Fatalf("window name = %q, want the joined remainder", id.WindowName)
 	}
 }
 
@@ -89,8 +107,9 @@ func TestPaneIdentityForRejectsShortOutput(t *testing.T) {
 }
 
 func TestParsePanesCapturesExactIDs(t *testing.T) {
-	// 10-field row including pane_id (#{pane_id}) and window_id (#{window_id}).
-	row := "main\t0\t1\t4242\tcodex\t/repo\tamq:issue-96:cto\tsquad\t%5\t@42"
+	// Full 10-field row: session, window, pane, pid, command, cwd, pane_id,
+	// window_id, pane_title, window_name (ids before the labels).
+	row := "main\t0\t1\t4242\tcodex\t/repo\t%5\t@42\tamq:issue-96:cto\tsquad"
 	panes := parsePanes(row)
 	if len(panes) != 1 {
 		t.Fatalf("want 1 pane, got %d", len(panes))
@@ -104,14 +123,28 @@ func TestParsePanesCapturesExactIDs(t *testing.T) {
 	}
 }
 
-func TestParsePanesToleratesOldEightFieldRow(t *testing.T) {
-	// Older 8-field row (no pane_id/window_id) must still parse, with empty ids.
-	row := "main\t0\t1\t4242\tcodex\t/repo\tamq:issue-96:cto\tsquad"
-	panes := parsePanes(row)
-	if len(panes) != 1 {
-		t.Fatalf("want 1 pane, got %d", len(panes))
+func TestParsePanesTabInWindowNameDoesNotCorruptIDs(t *testing.T) {
+	// A tab inside the trailing window_name must not shift the ids; it is
+	// absorbed into WindowName.
+	row := "main\t0\t1\t4242\tcodex\t/repo\t%5\t@42\tamq:issue-96:cto\tweird\tname"
+	p := parsePanes(row)[0]
+	if p.PaneID != "%5" || p.WindowID != "@42" || p.Title != "amq:issue-96:cto" {
+		t.Fatalf("ids/title corrupted by tab in window name: %+v", p)
 	}
-	if panes[0].PaneID != "" || panes[0].WindowID != "" {
-		t.Fatalf("old row should have empty exact ids, got PaneID=%q WindowID=%q", panes[0].PaneID, panes[0].WindowID)
+	if p.WindowName != "weird\tname" {
+		t.Fatalf("window name = %q, want joined remainder", p.WindowName)
+	}
+}
+
+func TestParsePanesToleratesShortRows(t *testing.T) {
+	// A 6-field row (no ids/labels) parses the core fields with empty extras.
+	short := parsePanes("main\t0\t1\t4242\tcodex\t/repo")[0]
+	if short.PaneID != "" || short.WindowID != "" || short.Title != "" || short.WindowName != "" {
+		t.Fatalf("short row should have empty extras, got %+v", short)
+	}
+	// An 8-field row (through window_id, no labels) parses the ids.
+	ids := parsePanes("main\t0\t1\t4242\tcodex\t/repo\t%5\t@42")[0]
+	if ids.PaneID != "%5" || ids.WindowID != "@42" || ids.Title != "" {
+		t.Fatalf("8-field row should parse ids with empty labels, got %+v", ids)
 	}
 }

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -31,6 +31,12 @@ type TmuxPane struct {
 	// name when no pane-title token is present. Optional (older tmux output may
 	// omit it; the parser tolerates its absence).
 	WindowName string
+	// PaneID is the pane's #{pane_id} (e.g. "%265") — the exact, stable tmux
+	// control address for the pane. WindowID is #{window_id} (e.g. "@42").
+	// Both are optional in parsing (older callers/output may omit them) but the
+	// production lister always requests them.
+	PaneID   string
+	WindowID string
 }
 
 // TmuxTarget identifies a single pane for the jump action. Title carries the
@@ -80,6 +86,68 @@ func defaultOsaRunner(name string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), err
 }
 
+// PaneIdentity is the exact tmux identity of a single pane, resolved at launch
+// time so follow-up control can target stable ids rather than re-inferring from
+// names. PaneID/WindowID are tmux control addresses; WindowName is a label.
+type PaneIdentity struct {
+	Session    string
+	WindowID   string
+	WindowName string
+	PaneID     string
+}
+
+// captureExec is the seam for the read-only `tmux display-message` query used to
+// resolve a pane's identity. Production runs the real tmux binary; tests inject
+// a recorder. It returns raw stdout so the caller parses the tab-separated row.
+var captureExec = func(args ...string) (string, error) {
+	out, err := exec.Command("tmux", args...).Output()
+	return string(out), err
+}
+
+// tmuxPaneEnv reads $TMUX_PANE (the pane hosting the current process). Seam for
+// tests. tmuxServerEnv reads $TMUX (presence of a tmux client).
+var (
+	tmuxPaneEnv   = func() string { return os.Getenv("TMUX_PANE") }
+	tmuxServerEnv = func() string { return os.Getenv("TMUX") }
+)
+
+// CurrentPaneIdentity resolves the exact tmux identity of the pane hosting the
+// current process. It returns (nil, nil) when not running inside tmux (so
+// callers persist nothing rather than guessing). A non-nil error means tmux was
+// present but the query failed; callers may treat that as best-effort and skip.
+func CurrentPaneIdentity() (*PaneIdentity, error) {
+	if strings.TrimSpace(tmuxServerEnv()) == "" {
+		return nil, nil
+	}
+	pane := strings.TrimSpace(tmuxPaneEnv())
+	if pane == "" {
+		return nil, nil
+	}
+	return PaneIdentityFor(pane)
+}
+
+// PaneIdentityFor resolves the identity of an explicit pane id via
+// `tmux display-message -p -t <pane> ...`. Targeting an explicit pane (not the
+// active one) is deliberate: control must not depend on which client/window is
+// currently focused.
+func PaneIdentityFor(paneID string) (*PaneIdentity, error) {
+	const format = "#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}"
+	out, err := captureExec("display-message", "-p", "-t", paneID, format)
+	if err != nil {
+		return nil, fmt.Errorf("tmux display-message -t %s: %w", paneID, err)
+	}
+	fields := strings.Split(strings.TrimRight(out, "\r\n"), "\t")
+	if len(fields) < 4 {
+		return nil, fmt.Errorf("unexpected tmux display-message output %q", out)
+	}
+	return &PaneIdentity{
+		Session:    fields[0],
+		WindowID:   fields[1],
+		WindowName: fields[2],
+		PaneID:     fields[3],
+	}, nil
+}
+
 // DefaultPaneLister shells `tmux list-panes -a` with a tab-separated format and
 // parses each row into a TmuxPane. It is strictly READ-ONLY. A missing tmux
 // binary or no server is reported as an error so callers can degrade.
@@ -88,7 +156,7 @@ func DefaultPaneLister() ([]TmuxPane, error) {
 	// panes) leaves a trailing tab the parser tolerates; pane_title carries the
 	// name-first resolution token and window_name the cross-session focus
 	// fallback.
-	const format = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_title}\t#{window_name}"
+	const format = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_title}\t#{window_name}\t#{pane_id}\t#{window_id}"
 	out, err := exec.Command("tmux", "list-panes", "-a", "-F", format).Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
@@ -126,6 +194,15 @@ func parsePanes(out string) []TmuxPane {
 		// window_name is the optional 8th field; tolerate its absence too.
 		if len(fields) >= 8 {
 			pane.WindowName = fields[7]
+		}
+		// pane_id (#{pane_id}) and window_id (#{window_id}) are the optional 9th
+		// and 10th fields — the exact tmux control addresses. Tolerate absence
+		// for callers/tests still on the older 8-field format.
+		if len(fields) >= 9 {
+			pane.PaneID = strings.TrimSpace(fields[8])
+		}
+		if len(fields) >= 10 {
+			pane.WindowID = strings.TrimSpace(fields[9])
 		}
 		panes = append(panes, pane)
 	}

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -131,7 +131,11 @@ func CurrentPaneIdentity() (*PaneIdentity, error) {
 // active one) is deliberate: control must not depend on which client/window is
 // currently focused.
 func PaneIdentityFor(paneID string) (*PaneIdentity, error) {
-	const format = "#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}"
+	// Stable ids (pane_id, window_id, session_name) come first because they can
+	// never contain a tab; window_name is a user-settable label that can, so it
+	// is parsed last as the joined remainder. This guarantees a weird window
+	// name can corrupt only the label, never the control addresses.
+	const format = "#{pane_id}\t#{window_id}\t#{session_name}\t#{window_name}"
 	out, err := captureExec("display-message", "-p", "-t", paneID, format)
 	if err != nil {
 		return nil, fmt.Errorf("tmux display-message -t %s: %w", paneID, err)
@@ -141,10 +145,10 @@ func PaneIdentityFor(paneID string) (*PaneIdentity, error) {
 		return nil, fmt.Errorf("unexpected tmux display-message output %q", out)
 	}
 	return &PaneIdentity{
-		Session:    fields[0],
+		PaneID:     fields[0],
 		WindowID:   fields[1],
-		WindowName: fields[2],
-		PaneID:     fields[3],
+		Session:    fields[2],
+		WindowName: strings.Join(fields[3:], "\t"),
 	}, nil
 }
 
@@ -156,7 +160,11 @@ func DefaultPaneLister() ([]TmuxPane, error) {
 	// panes) leaves a trailing tab the parser tolerates; pane_title carries the
 	// name-first resolution token and window_name the cross-session focus
 	// fallback.
-	const format = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_title}\t#{window_name}\t#{pane_id}\t#{window_id}"
+	// pane_id + window_id (exact control addresses, tab-free) are placed before
+	// the trailing human labels pane_title + window_name so a label containing a
+	// tab can never shift the ids. window_name remains the last field so the
+	// parser can absorb any embedded tabs into it.
+	const format = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_id}\t#{window_id}\t#{pane_title}\t#{window_name}"
 	out, err := exec.Command("tmux", "list-panes", "-a", "-F", format).Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
@@ -186,23 +194,23 @@ func parsePanes(out string) []TmuxPane {
 			Command: fields[4],
 			CWD:     fields[5],
 		}
-		// pane_title is the optional 7th field; tolerate panes captured without
-		// it (older tmux output, or rows that simply have no title).
+		// Field order is: session, window_index, pane_index, pane_pid,
+		// pane_current_command, pane_current_path, pane_id, window_id,
+		// pane_title, window_name. The exact ids (6,7) precede the human labels
+		// (8,9) so a tab in a label cannot shift them. All four trailing fields
+		// are optional; rows shorter than the current format still parse.
 		if len(fields) >= 7 {
-			pane.Title = fields[6]
+			pane.PaneID = strings.TrimSpace(fields[6])
 		}
-		// window_name is the optional 8th field; tolerate its absence too.
 		if len(fields) >= 8 {
-			pane.WindowName = fields[7]
+			pane.WindowID = strings.TrimSpace(fields[7])
 		}
-		// pane_id (#{pane_id}) and window_id (#{window_id}) are the optional 9th
-		// and 10th fields — the exact tmux control addresses. Tolerate absence
-		// for callers/tests still on the older 8-field format.
 		if len(fields) >= 9 {
-			pane.PaneID = strings.TrimSpace(fields[8])
+			pane.Title = fields[8]
 		}
+		// window_name is last; absorb any embedded tabs into it.
 		if len(fields) >= 10 {
-			pane.WindowID = strings.TrimSpace(fields[9])
+			pane.WindowName = strings.Join(fields[9:], "\t")
 		}
 		panes = append(panes, pane)
 	}

--- a/internal/tmuxpane/tmux_focus_test.go
+++ b/internal/tmuxpane/tmux_focus_test.go
@@ -284,12 +284,13 @@ func TestITermFocusToken_PrefersTitleThenWindowName(t *testing.T) {
 	}
 }
 
-// TestParsePanes_ParsesWindowName proves the 8th field (window_name) is parsed
-// and carried, and that older 7-field rows still parse (window name empty).
+// TestParsePanes_ParsesWindowName proves the trailing window_name field is
+// parsed and carried, and that shorter rows without it still parse (window name
+// empty). Field order: ...,cwd,pane_id,window_id,pane_title,window_name.
 func TestParsePanes_ParsesWindowName(t *testing.T) {
 	out := "" +
-		"beta\t0\t0\t100\tcodex\t/repo\tamq:beta:cpo\tcpo-win\n" + // 8 fields
-		"beta\t0\t1\t200\tcodex\t/repo\tamq:beta:cto\n" // 7 fields (no window name)
+		"beta\t0\t0\t100\tcodex\t/repo\t%0\t@0\tamq:beta:cpo\tcpo-win\n" + // 10 fields
+		"beta\t0\t1\t200\tcodex\t/repo\t%1\t@0\tamq:beta:cto\n" // 9 fields (no window name)
 	panes := parsePanes(out)
 	if len(panes) != 2 {
 		t.Fatalf("expected 2 panes, got %d: %+v", len(panes), panes)

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -182,10 +182,12 @@ func TestResolveTmuxTargetForSession_FallsBackWhenNoTitles(t *testing.T) {
 }
 
 func TestParsePanes_ParsesPaneTitle(t *testing.T) {
-	// 7-field rows: one with a title token, one with an empty title (trailing tab).
+	// Field order: session,window,pane,pid,command,cwd,pane_id,window_id,
+	// pane_title,window_name. One row with a title token, one with an empty
+	// title (trailing tabs).
 	out := "" +
-		"beta\t0\t0\t100\tcodex\t/repo\tamq:beta:cpo\n" +
-		"beta\t0\t1\t200\tcodex\t/repo\t\n"
+		"beta\t0\t0\t100\tcodex\t/repo\t%0\t@0\tamq:beta:cpo\n" +
+		"beta\t0\t1\t200\tcodex\t/repo\t%1\t@0\t\n"
 	panes := parsePanes(out)
 	if len(panes) != 2 {
 		t.Fatalf("expected 2 panes, got %d: %+v", len(panes), panes)

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -15,7 +15,7 @@ mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 
-Requires amq-squad **v1.4.2+**. Check with `amq-squad version`.
+Requires amq-squad **v1.5.0+**. Check with `amq-squad version`.
 
 There are two ways to add a custom role. Pick by how much role guidance you want.
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -11,7 +11,7 @@ mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 
-Requires amq-squad **v1.4.2+**. Check with `amq-squad version`.
+Requires amq-squad **v1.5.0+**. Check with `amq-squad version`.
 
 There are two ways to add a custom role. Pick by how much role guidance you want.
 


### PR DESCRIPTION
First slice of the **v1.5.0 tmux runtime orchestration** milestone (goal: amq-squad owns the tmux execution/control contract; amq-noc consumes it). Implements #61 items 1–2 (persist tmux identity; use exact ids).

Also folds in the **1.4.2 → 1.5.0** version bump (first commit) now that #59/#60 ship as part of 1.5.0.

## What lands

- **`launch.Record.Tmux`** — optional `{ session, window_id, window_name, pane_id, target }`. Captured in `runLaunch` **before** `syscall.Exec`, while `$TMUX`/`$TMUX_PANE` still name the agent's own pane. Best-effort (never blocks a launch). Pre-1.5 records read back with `nil` tmux, so clients detect availability by **presence, not schema**.
- **`tmuxpane.CurrentPaneIdentity` / `PaneIdentityFor`** — resolve exact ids via `tmux display-message -p -t <pane> '#{session_name}\t#{window_id}\t#{window_name}\t#{pane_id}'`, always targeting the **explicit pane** (not the active one). Injectable `captureExec`/env seams.
- **`DefaultPaneLister` + `TmuxPane`** now carry `#{pane_id}` / `#{window_id}`; parser tolerates older 8-field rows (so existing callers/tests are unaffected).
- **Live tmux backends** export `AMQ_SQUAD_TMUX_TARGET` so each agent records how its pane was created (`current-window` / `new-window` / `new-session`). Dry-run / copy-paste commands stay clean (no flag pollution, no `--` argv issues).

## Why this shape

Window names are human labels that collide; pane/window ids are the stable control addresses (per #61). Capturing in `runLaunch` covers single-agent and all team-launch targets uniformly, because every agent's command runs *inside* its target pane via `send-keys`.

## Tests

- record tmux round-trip + legacy-nil-tmux
- capture argv construction + parse + not-in-tmux / no-`$TMUX_PANE`
- pane-list exact-id parse + 8-field tolerance
- target env-prefix construction (exported before command, empty-unchanged, quoting)
- `make ci` green; `git diff --check` clean

## Next in the milestone

- Phase B: expose this via `status --json` / `history --json` / new `resume --json` (NOC contract, amq-noc#6).
- Phase C: `SendPromptToPane` + `focus`/`open`/`send` + `resume --exec` (#62, #47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)