### PR TITLE
v1.5.0 Phase B: tmux runtime contract in status/history/resume JSON (#61, noc#6)

### DIFF
--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -31,6 +31,10 @@ type historyRecord struct {
 	Source       string    `json:"source"`
 	CWD          string    `json:"cwd"`
 	StartedAt    time.Time `json:"started_at,omitempty"`
+	// Tmux is the persisted tmux runtime identity for the launch, plus a
+	// computed pane_alive, so clients can tell which historical launches still
+	// have a live pane to focus/resume. Omitted for records without tmux.
+	Tmux *tmuxRuntimeJSON `json:"tmux,omitempty"`
 }
 
 func runHistory(args []string) error {
@@ -149,7 +153,18 @@ func historyRecordsFromEntries(entries []launch.Entry) []historyRecord {
 			Source:       sourceLabel(e.Source),
 			CWD:          r.CWD,
 			StartedAt:    r.StartedAt,
+			Tmux:         tmuxRuntimeFromInfo(r.Tmux),
 		})
+	}
+	// Resolve pane liveness once across all rows that recorded a tmux pane.
+	var livePanes map[string]bool
+	for i := range rows {
+		if rows[i].Tmux != nil {
+			if livePanes == nil {
+				livePanes = livePaneIDSet(statusPaneLister)
+			}
+			fillPaneAlive(rows[i].Tmux, livePanes)
+		}
 	}
 	return rows
 }

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -23,6 +23,7 @@ func runResume(args []string) error {
 	projectFlag := fs.String("project", "", "project/team-home directory to resume (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to resume (default: default profile)")
 	execMode := fs.Bool("exec", false, "open the planned launch commands in the terminal backend (tmux) instead of printing them")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (with tmux runtime metadata) instead of the human plan")
 	terminal := fs.String("terminal", "tmux", "terminal backend to use with --exec")
 	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window or new-session)")
 	layout := fs.String("layout", "vertical", "terminal layout with --exec (tmux: vertical, horizontal, or tiled)")
@@ -33,7 +34,7 @@ func runResume(args []string) error {
 
 Usage:
   amq-squad resume [--project DIR] [--profile NAME] [--session name] [--restore-existing]
-                   [--dry-run] [--force-duplicate]
+                   [--dry-run] [--json] [--force-duplicate]
                    [--no-bootstrap] [--trust sandboxed|trusted]
                    [--model role=model,...]
                    [--codex-args args] [--claude-args args]
@@ -56,7 +57,10 @@ Default behavior is plan-only: prints the per-member action table plus
 copy-pasteable commands. With --exec, opens those commands through the
 selected terminal backend (same path as 'up'), skipping members that are
 already live and refusing to start if any member is in the 'blocked'
-action without --force-duplicate.
+action without --force-duplicate. With --json, emits a schema-versioned
+resume_plan envelope (per-member action, command, and tmux runtime metadata
+including pane_alive) for clients; --json is a read-only preview and cannot be
+combined with --exec.
 
 Fresh / new-session behavior belongs to 'amq-squad fork --from S --as T'.
 
@@ -64,6 +68,7 @@ Examples:
   amq-squad resume
   amq-squad resume --project ~/Code/app --session issue-96
   amq-squad resume --session issue-96 --restore-existing
+  amq-squad resume --session issue-96 --json
   amq-squad resume --exec
   amq-squad resume --exec --target new-session --terminal-session squad
 `)
@@ -73,6 +78,9 @@ Examples:
 	}
 	if *execMode && *dryRun {
 		return usageErrorf("--exec and --dry-run are mutually exclusive")
+	}
+	if *jsonOut && *execMode {
+		return usageErrorf("--json is a read-only plan preview; it cannot be combined with --exec")
 	}
 
 	profile, err := resolveProfileFlag(*profileFlag)
@@ -119,6 +127,7 @@ Examples:
 		ClaudeArgsRaw:    *claudeArgsRaw,
 		DryRun:           *dryRun,
 		Profile:          profile,
+		JSON:             *jsonOut,
 		Style:            resumePrinterStyle{Label: "resume", FooterVerb: "up"},
 		Exec:             exec,
 	})

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -34,12 +34,38 @@ func tmuxRuntimeFromInfo(info *launch.TmuxInfo) *tmuxRuntimeJSON {
 	if info == nil {
 		return nil
 	}
+	// Defensive: a record with an empty tmux object (malformed or externally
+	// written) carries no identity, so omit the block rather than emitting
+	// {"pane_alive": false} with no ids.
+	if info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.Target == "" {
+		return nil
+	}
 	return &tmuxRuntimeJSON{
 		Session:    info.Session,
 		WindowID:   info.WindowID,
 		WindowName: info.WindowName,
 		PaneID:     info.PaneID,
 		Target:     info.Target,
+	}
+}
+
+// memoizePaneLister wraps a pane lister so the underlying `tmux list-panes`
+// runs at most once; the cached (panes, error) is returned on every call. A
+// command installs this for its duration so independent readers (e.g. status's
+// live-replacement detection and pane_alive resolution) share one snapshot and
+// one tmux call instead of re-listing per member.
+func memoizePaneLister(list tmuxpane.PaneLister) tmuxpane.PaneLister {
+	var (
+		done  bool
+		panes []tmuxpane.TmuxPane
+		err   error
+	)
+	return func() ([]tmuxpane.TmuxPane, error) {
+		if !done {
+			panes, err = list()
+			done = true
+		}
+		return panes, err
 	}
 }
 

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"io"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
+)
+
+// tmuxRuntimeJSON is the stable tmux runtime-identity block that amq-noc (and
+// other JSON clients) consume to make a launched agent actionable: target
+// follow-up control by exact pane id, and know whether that pane is still
+// valid. It mirrors launch.TmuxInfo plus a computed pane_alive. It is nil (and
+// omitted) when the launch record carried no tmux identity, so clients detect
+// runtime-control availability by presence.
+type tmuxRuntimeJSON struct {
+	Session    string `json:"session,omitempty"`
+	WindowID   string `json:"window_id,omitempty"`
+	WindowName string `json:"window_name,omitempty"`
+	PaneID     string `json:"pane_id,omitempty"`
+	Target     string `json:"target,omitempty"`
+	// PaneAlive reports whether the recorded pane_id is still present in the
+	// live tmux server. Always serialized so clients can branch on it without
+	// guessing. False when the pane is gone or tmux is unavailable.
+	PaneAlive bool `json:"pane_alive"`
+}
+
+// tmuxRuntimeFromInfo converts a persisted launch.TmuxInfo into the JSON block,
+// leaving PaneAlive false for the caller to fill from a live-pane set. Returns
+// nil when there is no tmux identity.
+func tmuxRuntimeFromInfo(info *launch.TmuxInfo) *tmuxRuntimeJSON {
+	if info == nil {
+		return nil
+	}
+	return &tmuxRuntimeJSON{
+		Session:    info.Session,
+		WindowID:   info.WindowID,
+		WindowName: info.WindowName,
+		PaneID:     info.PaneID,
+		Target:     info.Target,
+	}
+}
+
+// livePaneIDSet returns the set of #{pane_id} for every live tmux pane via the
+// injectable lister. It degrades to an empty set (never an error) when tmux is
+// unavailable, so pane_alive resolves to false rather than failing the command.
+func livePaneIDSet(list tmuxpane.PaneLister) map[string]bool {
+	set := map[string]bool{}
+	panes, err := list()
+	if err != nil {
+		return set
+	}
+	for _, p := range panes {
+		if p.PaneID != "" {
+			set[p.PaneID] = true
+		}
+	}
+	return set
+}
+
+// fillPaneAlive sets PaneAlive on a runtime block from a live-pane set. A nil
+// block (no tmux identity) is left untouched.
+func fillPaneAlive(rt *tmuxRuntimeJSON, live map[string]bool) {
+	if rt == nil {
+		return
+	}
+	rt.PaneAlive = rt.PaneID != "" && live[rt.PaneID]
+}
+
+// resumeMemberJSON is one member row in the resume_plan envelope. It mirrors the
+// human plan (role/action/note/command) and adds the runtime identity so a
+// client can decide whether to focus a live pane or re-open one.
+type resumeMemberJSON struct {
+	Role             string           `json:"role"`
+	Handle           string           `json:"handle,omitempty"`
+	Action           string           `json:"action"`
+	HasRestoreRecord bool             `json:"has_restore_record"`
+	Wake             string           `json:"wake,omitempty"`
+	Note             string           `json:"note,omitempty"`
+	Command          string           `json:"command,omitempty"`
+	Tmux             *tmuxRuntimeJSON `json:"tmux,omitempty"`
+}
+
+// resumeEnvelopeData is the `resume_plan` envelope body: the same per-member
+// classification `resume` prints, in a stable shape clients can render as
+// actions. It is a read-only preview (never executes).
+type resumeEnvelopeData struct {
+	TeamHome   string             `json:"team_home"`
+	Workstream string             `json:"workstream"`
+	Profile    string             `json:"profile,omitempty"`
+	Mode       string             `json:"mode"`
+	Members    int                `json:"members"`
+	Plan       []resumeMemberJSON `json:"plan"`
+}
+
+// writeResumeJSON emits the resume_plan envelope. Pane liveness is resolved once
+// across every member that carries a tmux identity.
+func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeMode, profile string, plans []resumePlan) error {
+	rows := make([]resumeMemberJSON, 0, len(plans))
+	var livePanes map[string]bool
+	for _, p := range plans {
+		rt := tmuxRuntimeFromInfo(p.Tmux)
+		if rt != nil {
+			if livePanes == nil {
+				livePanes = livePaneIDSet(statusPaneLister)
+			}
+			fillPaneAlive(rt, livePanes)
+		}
+		rows = append(rows, resumeMemberJSON{
+			Role:             p.Role,
+			Handle:           p.Handle,
+			Action:           string(p.Action),
+			HasRestoreRecord: p.HasRestoreRecord,
+			Wake:             wakeForJSON(p.Wake),
+			Note:             p.Note,
+			Command:          p.Command,
+			Tmux:             rt,
+		})
+	}
+	profile = strings.TrimSpace(profile)
+	if profile == team.DefaultProfile {
+		profile = ""
+	}
+	return writeJSONEnvelope(out, "resume_plan", resumeEnvelopeData{
+		TeamHome:   t.Project,
+		Workstream: workstream,
+		Profile:    profile,
+		Mode:       string(mode),
+		Members:    len(rows),
+		Plan:       rows,
+	})
+}
+
+// wakeForJSON normalizes the human "-" placeholder to an empty (omitted) field.
+func wakeForJSON(w string) string {
+	w = strings.TrimSpace(w)
+	if w == "-" {
+		return ""
+	}
+	return w
+}

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -28,6 +28,30 @@ func TestTmuxRuntimeFromInfo(t *testing.T) {
 	}
 }
 
+func TestTmuxRuntimeFromEmptyInfoIsNil(t *testing.T) {
+	// A record with an empty tmux object carries no identity -> omit the block.
+	if rt := tmuxRuntimeFromInfo(&launch.TmuxInfo{}); rt != nil {
+		t.Fatalf("empty tmux info should map to nil, got %+v", rt)
+	}
+}
+
+func TestMemoizePaneListerCallsUnderlyingOnce(t *testing.T) {
+	calls := 0
+	memo := memoizePaneLister(func() ([]tmuxpane.TmuxPane, error) {
+		calls++
+		return []tmuxpane.TmuxPane{{PaneID: "%1"}}, nil
+	})
+	for i := 0; i < 3; i++ {
+		panes, _ := memo()
+		if len(panes) != 1 || panes[0].PaneID != "%1" {
+			t.Fatalf("memoized lister returned wrong snapshot: %+v", panes)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("underlying lister called %d times, want exactly 1", calls)
+	}
+}
+
 func TestFillPaneAlive(t *testing.T) {
 	live := map[string]bool{"%5": true}
 	rt := &tmuxRuntimeJSON{PaneID: "%5"}

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
+)
+
+// swapStatusPaneLister installs a fake pane lister for the duration of a test.
+func swapStatusPaneLister(t *testing.T, panes []tmuxpane.TmuxPane, err error) {
+	t.Helper()
+	prev := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return panes, err }
+	t.Cleanup(func() { statusPaneLister = prev })
+}
+
+func TestTmuxRuntimeFromInfo(t *testing.T) {
+	if rt := tmuxRuntimeFromInfo(nil); rt != nil {
+		t.Fatalf("nil info should map to nil runtime, got %+v", rt)
+	}
+	rt := tmuxRuntimeFromInfo(&launch.TmuxInfo{Session: "main", WindowID: "@1", PaneID: "%5", Target: "current-window"})
+	if rt == nil || rt.PaneID != "%5" || rt.Target != "current-window" || rt.PaneAlive {
+		t.Fatalf("unexpected runtime block: %+v", rt)
+	}
+}
+
+func TestFillPaneAlive(t *testing.T) {
+	live := map[string]bool{"%5": true}
+	rt := &tmuxRuntimeJSON{PaneID: "%5"}
+	fillPaneAlive(rt, live)
+	if !rt.PaneAlive {
+		t.Error("pane %5 should be alive")
+	}
+	dead := &tmuxRuntimeJSON{PaneID: "%9"}
+	fillPaneAlive(dead, live)
+	if dead.PaneAlive {
+		t.Error("pane %9 should be dead")
+	}
+	fillPaneAlive(nil, live) // must not panic
+}
+
+func TestLivePaneIDSetDegradesOnError(t *testing.T) {
+	set := livePaneIDSet(func() ([]tmuxpane.TmuxPane, error) { return nil, errors.New("no tmux server") })
+	if len(set) != 0 {
+		t.Fatalf("tmux error should yield empty set, got %v", set)
+	}
+	set = livePaneIDSet(func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%1"}, {PaneID: ""}, {PaneID: "%2"}}, nil
+	})
+	if !set["%1"] || !set["%2"] || set[""] {
+		t.Fatalf("unexpected live set: %v", set)
+	}
+}
+
+func TestWriteResumeJSONShapeAndPaneAlive(t *testing.T) {
+	// One restore member whose recorded pane is live, one fresh member with no
+	// tmux identity.
+	swapStatusPaneLister(t, []tmuxpane.TmuxPane{{PaneID: "%265"}}, nil)
+	plans := []resumePlan{
+		{
+			Role: "cto", Handle: "cto", Action: resumeRestore, HasRestoreRecord: true,
+			Wake: "-", Command: "cd /r && amq-squad agent up codex --role cto",
+			Tmux: &launch.TmuxInfo{Session: "main", WindowID: "@42", PaneID: "%265", Target: "current-window"},
+		},
+		{Role: "qa", Handle: "qa", Action: resumeFresh, Wake: "-", Command: "cd /r && amq-squad agent up claude --role qa"},
+	}
+	var buf bytes.Buffer
+	if err := writeResumeJSON(&buf, team.Team{Project: "/r"}, "issue-96", resumeModeDefault, team.DefaultProfile, plans); err != nil {
+		t.Fatalf("writeResumeJSON: %v", err)
+	}
+	env := decodeJSONEnvelope[resumeEnvelopeData](t, buf.String())
+	if env.Kind != "resume_plan" {
+		t.Fatalf("kind = %q, want resume_plan", env.Kind)
+	}
+	if env.Data.Profile != "" {
+		t.Errorf("default profile should be omitted, got %q", env.Data.Profile)
+	}
+	if env.Data.Members != 2 || len(env.Data.Plan) != 2 {
+		t.Fatalf("members/plan = %d/%d, want 2/2", env.Data.Members, len(env.Data.Plan))
+	}
+	cto := env.Data.Plan[0]
+	if cto.Action != "restore" || !cto.HasRestoreRecord {
+		t.Errorf("cto plan wrong: %+v", cto)
+	}
+	if cto.Wake != "" {
+		t.Errorf("wake '-' should normalize to empty, got %q", cto.Wake)
+	}
+	if cto.Tmux == nil || cto.Tmux.PaneID != "%265" || !cto.Tmux.PaneAlive {
+		t.Errorf("cto tmux/pane_alive wrong: %+v", cto.Tmux)
+	}
+	qa := env.Data.Plan[1]
+	if qa.Action != "launch fresh" || qa.Tmux != nil {
+		t.Errorf("qa plan should be fresh with no tmux: %+v", qa)
+	}
+}
+
+func TestHistoryRecordsCarryTmuxAndPaneAlive(t *testing.T) {
+	swapStatusPaneLister(t, []tmuxpane.TmuxPane{{PaneID: "%7"}}, nil)
+	entries := []launch.Entry{
+		{Source: "x", Record: launch.Record{
+			Role: "cto", Handle: "cto", Binary: "codex", Session: "issue-96", CWD: "/r",
+			Tmux: &launch.TmuxInfo{PaneID: "%7", Session: "main"},
+		}},
+		{Source: "x", Record: launch.Record{Role: "qa", Handle: "qa", Binary: "claude", Session: "issue-96", CWD: "/r"}},
+	}
+	rows := historyRecordsFromEntries(entries)
+	if rows[0].Tmux == nil || !rows[0].Tmux.PaneAlive {
+		t.Errorf("history cto should carry live tmux: %+v", rows[0].Tmux)
+	}
+	if rows[1].Tmux != nil {
+		t.Errorf("history qa should have no tmux: %+v", rows[1].Tmux)
+	}
+}
+
+func TestResumeJSONRejectsExec(t *testing.T) {
+	_, _, err := captureOutput(t, func() error {
+		return runResume([]string{"--json", "--exec"})
+	})
+	if err == nil {
+		t.Fatal("--json --exec should be rejected")
+	}
+	if _, ok := err.(UsageError); !ok {
+		t.Fatalf("want UsageError, got %T: %v", err, err)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -74,6 +74,10 @@ type statusRecord struct {
 	Status   statusState   `json:"status"`
 	Detail   string        `json:"detail,omitempty"`
 	Signals  statusSignals `json:"signals"`
+	// Tmux is the persisted tmux runtime identity (exact pane/window ids) plus
+	// a computed pane_alive, so clients can target follow-up control. Omitted
+	// when the agent's launch record carried no tmux identity.
+	Tmux *tmuxRuntimeJSON `json:"tmux,omitempty"`
 }
 
 func runStatus(args []string) error {
@@ -168,6 +172,17 @@ func executeStatus(s statusExecution) error {
 	for _, m := range members {
 		rows = append(rows, classifyMemberStatus(t, m, workstream, s.Probe))
 	}
+	// Resolve pane liveness once for every member that recorded a tmux pane, so
+	// clients can tell a still-valid pane from a stale launch record.
+	var livePanes map[string]bool
+	for i := range rows {
+		if rows[i].Tmux != nil {
+			if livePanes == nil {
+				livePanes = livePaneIDSet(statusPaneLister)
+			}
+			fillPaneAlive(rows[i].Tmux, livePanes)
+		}
+	}
 	if s.JSON {
 		return writeJSONEnvelope(s.Out, "status", statusEnvelopeData{
 			TeamHome:     t.Project,
@@ -223,6 +238,9 @@ func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe d
 	rec.AgentDir = filepath.Join(root, "agents", rec.Handle)
 
 	launchRec, launchErr := launch.Read(rec.AgentDir)
+	if launchErr == nil {
+		rec.Tmux = tmuxRuntimeFromInfo(launchRec.Tmux)
+	}
 	wakeLock, wakeErr := readWakeLock(rec.AgentDir)
 	presence, presenceErr := readPresenceForEntry(rec.AgentDir)
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -167,13 +167,23 @@ func executeStatus(s statusExecution) error {
 		return err
 	}
 
+	// Share one tmux pane snapshot across this whole command: live-replacement
+	// detection inside classifyMemberStatus and pane_alive resolution below
+	// both read statusPaneLister, so memoize it for the command's duration —
+	// `tmux list-panes` runs at most once and both readings see the same
+	// snapshot (avoiding N+1 calls and snapshot skew).
+	restoreLister := statusPaneLister
+	statusPaneLister = memoizePaneLister(restoreLister)
+	defer func() { statusPaneLister = restoreLister }()
+
 	members := orderedTeamMembers(t.Members)
 	rows := make([]statusRecord, 0, len(members))
 	for _, m := range members {
 		rows = append(rows, classifyMemberStatus(t, m, workstream, s.Probe))
 	}
-	// Resolve pane liveness once for every member that recorded a tmux pane, so
-	// clients can tell a still-valid pane from a stale launch record.
+	// Resolve pane liveness for every member that recorded a tmux pane, so
+	// clients can tell a still-valid pane from a stale launch record. Uses the
+	// same memoized snapshot as classification above.
 	var livePanes map[string]bool
 	for i := range rows {
 		if rows[i].Tmux != nil {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -36,6 +36,7 @@ const (
 // resumePlan is the per-member output row.
 type resumePlan struct {
 	Role    string
+	Handle  string
 	Action  resumeAction
 	Wake    string
 	Note    string
@@ -45,6 +46,10 @@ type resumePlan struct {
 	// --restore-existing can verify record existence even when the final
 	// action came out as live.
 	HasRestoreRecord bool
+	// Tmux is the persisted tmux identity of the matched restore record, when
+	// any. Surfaced for `resume --json` so clients know which pane a restore
+	// targets and whether that pane is still alive.
+	Tmux *launch.TmuxInfo
 }
 
 func runTeamResume(args []string) error {
@@ -61,13 +66,14 @@ func runTeamResume(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
 	projectFlag := fs.String("project", "", "project/team-home directory to plan (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to plan (default: default profile)")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (with tmux runtime metadata) instead of the human plan")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team resume - plan how to bring the team back
 
 Usage:
   amq-squad team resume [--project DIR] [--profile NAME] [--session name] [--fresh]
-                        [--restore-existing] [--dry-run] [--force-duplicate]
+                        [--restore-existing] [--dry-run] [--json] [--force-duplicate]
                         [--no-bootstrap] [--trust sandboxed|trusted]
                         [--model role=model,...]
                         [--codex-args args] [--claude-args args]
@@ -146,6 +152,7 @@ Examples:
 		ClaudeArgsRaw:    *claudeArgsRaw,
 		DryRun:           *dryRun,
 		Profile:          profile,
+		JSON:             *jsonOut,
 	})
 }
 
@@ -166,6 +173,9 @@ type resumeExecution struct {
 	ClaudeArgsRaw    string
 	DryRun           bool
 	Profile          string
+	// JSON emits a schema-versioned resume_plan envelope instead of the human
+	// plan. It is a read-only preview, so it is mutually exclusive with Exec.
+	JSON bool
 	// Style controls the printer header label and footer verb so the same
 	// planner can present its output as team resume, resume, or fork without
 	// duplicating logic.
@@ -322,6 +332,14 @@ func executeResume(r resumeExecution) error {
 		if exists {
 			return fmt.Errorf("--fresh --session %q: workstream root %s already exists; rerun with --force-duplicate to reuse", workstream, root)
 		}
+	}
+
+	if r.JSON {
+		out := r.Out
+		if out == nil {
+			out = os.Stdout
+		}
+		return writeResumeJSON(out, t, workstream, r.Mode, r.Profile, plans)
 	}
 
 	if r.Exec.Enabled {
@@ -553,6 +571,10 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	baseRoot := absoluteAMQRoot(cwd, env.BaseRoot)
 	rec, recFound := findMemberRestoreRecord(baseRoot, in.Team.Project, cwd, env.SessionName, m.Role, handle)
 	plan.HasRestoreRecord = recFound
+	plan.Handle = handle
+	if recFound {
+		plan.Tmux = rec.Tmux
+	}
 	wakeLabel := wakeHealthForMember(agentDir, root, handle, rec, recFound)
 	plan.Wake = wakeLabel
 


### PR DESCRIPTION
Second slice of the **v1.5.0 tmux runtime orchestration** milestone. Implements #61 item 3 and gives amq-noc the stable JSON contract it consumes in amq-noc#6.

Stacked on #63 (Phase A). Base is `v1.5.0-phase-a-tmux-metadata`; retarget to `main` after #63 merges.

## What lands

A shared runtime block — `{ session, window_id, window_name, pane_id, target, pane_alive }` — surfaces in three JSON outputs:

- **`status --json`** (`statusRecord.tmux`)
- **`history --json`** (`historyRecord.tmux`)
- **`resume --json` / `team resume --json`** — NEW `--json` flag emitting a schema-versioned `resume_plan` envelope (per-member `role`/`handle`/`action`/`has_restore_record`/`command` + the tmux block). Read-only preview; rejected with `--exec`.

`pane_alive` is computed once per command by matching the recorded `pane_id` against the live tmux pane set; it **degrades to `false`** when tmux is unavailable rather than failing. The block is **omitted** when a record has no tmux identity, so clients detect runtime-control availability by presence.

NOC can now answer (per #61 item 3 / noc#6): is this agent's recorded pane still alive? which command resumes it? — without inferring tmux state itself.

## Notes
- Shared converters in `runtime_json.go` keep the three surfaces consistent.
- Envelope `schema_version` stays 1 (additive fields inside `data`); new `kind: "resume_plan"`.
- Verified end-to-end: planted a launch record with a tmux block; confirmed the block + `pane_alive` in all three outputs.

## Tests
Converters; pane_alive (live / dead / nil / tmux-error degradation); `resume_plan` envelope shape + default-profile omission + wake normalization; history tmux rows; `--json`/`--exec` conflict. `make ci` green, `git diff --check` clean.

## Heads-up on #47
While mapping resume I confirmed **`resume --exec` already exists** (shipped v1.2.0). So #47's core is done; the v1.5.0 tie-in is that relaunched agents now capture tmux metadata automatically (Phase A). Phase C will fold the remaining #62 (deterministic prompt delivery) + focus/open/send verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)