### PR TITLE
v1.5.0 Phase D: document tmux runtime control

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Team discovery payloads include derived operator metadata for external clients: 
 ```sh
 amq-squad status --json | jq .
 amq-squad history --json | jq .
+amq-squad resume --session issue-96 --json | jq .
 amq-squad doctor --json | jq .
 amq-squad team profiles --json | jq .
 amq-squad roles --json | jq .
@@ -505,6 +506,58 @@ Envelope shape:
   "data": { /* verb-specific payload */ }
 }
 ```
+
+## Runtime control (tmux)
+
+amq-squad owns the tmux execution/control contract for a team so external
+clients (such as amq-noc) can make agents actionable without scraping tmux or
+reconstructing pane layouts themselves.
+
+When an agent is launched inside tmux, its launch record persists the **exact
+tmux identity** of its pane — `session`, `window_id`, `window_name`, `pane_id`,
+and how the pane was created (`target`). Pane and window ids (`%265`, `@42`) are
+stable control addresses; window names are labels and are never used to target
+control.
+
+`status --json`, `history --json`, and `resume --json` expose that identity as a
+`tmux` block plus a computed `pane_alive` (does the recorded pane still exist?).
+`status --json` members also carry an `actions` array of stable, project-scoped
+commands a client can render or copy, each with an `available` flag:
+
+```json
+{
+  "role": "cto",
+  "status": "live",
+  "tmux": { "session": "main", "window_id": "@42", "pane_id": "%265",
+            "target": "current-window", "pane_alive": true },
+  "actions": [
+    { "kind": "focus",  "available": true, "command": "amq-squad focus --project DIR --session issue-96 --role cto" },
+    { "kind": "send",   "available": true, "command": "amq-squad send --project DIR --session issue-96 --role cto --body-file -" },
+    { "kind": "resume", "available": true, "command": "amq-squad resume --project DIR --session issue-96 --exec" }
+  ]
+}
+```
+
+The `tmux` block is omitted for agents launched outside tmux, so clients detect
+runtime-control availability by presence.
+
+High-level control verbs target the exact pane id (falling back to a neutral
+title/cwd resolver) and are all project-scoped:
+
+```sh
+amq-squad focus --session issue-96 --role cto   # bring the agent's pane into view
+amq-squad focus --session issue-96              # focus the session
+amq-squad open --session issue-96               # alias for focus
+amq-squad send  --session issue-96 --role cto --body "please review PR #65"
+amq-squad send  --session issue-96 --role qa --body-file ./prompt.md
+cat prompt.md | amq-squad send --session issue-96 --role cto --body-file -
+amq-squad resume --session issue-96 --exec      # relaunch the team's panes
+```
+
+`send` delivers the prompt deterministically: it stages the text in a tmux paste
+buffer (via stdin, never a shell string) and pastes it into the exact pane, then
+submits a single Enter — so multi-line prompts and text with quotes or shell
+metacharacters arrive verbatim. It errors clearly if the target pane is gone.
 
 ## Exit codes
 

--- a/doc.html
+++ b/doc.html
@@ -500,6 +500,7 @@
         <a href="#verbs">Verbs</a>
         <a href="#console">Status board and console</a>
         <a href="#json">JSON and exit codes</a>
+        <a href="#runtime">Runtime control</a>
         <a href="#completion">Shell completions</a>
         <a href="#workstreams">Sessions and threads</a>
         <a href="#cross">Cross-project teams</a>
@@ -1372,6 +1373,65 @@ amq-squad version --json | jq .</code></pre></div>
               </tbody>
             </table>
           </div>
+        </div>
+      </section>
+
+      <section id="runtime">
+        <div class="content">
+          <h2>Runtime control (tmux)</h2>
+          <p>
+            amq-squad owns the tmux execution/control contract for a team, so
+            clients (such as amq-noc) make agents actionable without scraping
+            tmux or reconstructing pane layouts. When an agent launches inside
+            tmux, its launch record persists the exact tmux identity of its
+            pane: <code class="inline-code">session</code>,
+            <code class="inline-code">window_id</code>,
+            <code class="inline-code">window_name</code>,
+            <code class="inline-code">pane_id</code>, and how the pane was
+            created (<code class="inline-code">target</code>). Pane and window
+            ids (<code class="inline-code">%265</code>,
+            <code class="inline-code">@42</code>) are stable control addresses;
+            window names are labels and are never used as addresses.
+          </p>
+          <p>
+            <code class="inline-code">status --json</code>,
+            <code class="inline-code">history --json</code>, and
+            <code class="inline-code">resume --json</code> expose a
+            <code class="inline-code">tmux</code> block plus a computed
+            <code class="inline-code">pane_alive</code>. Status members also
+            carry an <code class="inline-code">actions</code> array of stable,
+            project-scoped commands a client can render or copy, each with an
+            <code class="inline-code">available</code> flag. The
+            <code class="inline-code">tmux</code> block is omitted for agents
+            launched outside tmux, so clients detect availability by presence.
+          </p>
+          <div class="code"><pre><code>{
+  "role": "cto",
+  "tmux": { "session": "main", "pane_id": "%265", "target": "current-window", "pane_alive": true },
+  "actions": [
+    { "kind": "focus",  "available": true, "command": "amq-squad focus --session issue-96 --role cto" },
+    { "kind": "send",   "available": true, "command": "amq-squad send --session issue-96 --role cto --body-file -" },
+    { "kind": "resume", "available": true, "command": "amq-squad resume --session issue-96 --exec" }
+  ]
+}</code></pre></div>
+          <p>
+            High-level control verbs target the exact pane id (falling back to a
+            neutral title/cwd resolver) and are project-scoped:
+          </p>
+          <div class="code"><pre><code>amq-squad focus --session issue-96 --role cto   # bring the agent's pane into view
+amq-squad focus --session issue-96              # focus the session ('open' is an alias)
+amq-squad send  --session issue-96 --role cto --body "please review PR #65"
+amq-squad send  --session issue-96 --role qa --body-file ./prompt.md
+cat prompt.md | amq-squad send --session issue-96 --role cto --body-file -
+amq-squad resume --session issue-96 --exec      # relaunch the team's panes</code></pre></div>
+          <p>
+            <code class="inline-code">send</code> delivers the prompt
+            deterministically: it stages the text in a tmux paste buffer (via
+            stdin, never a shell string) and pastes it into the exact pane, then
+            submits a single Enter — so multi-line prompts and text with quotes
+            or shell metacharacters arrive verbatim. It errors clearly if the
+            target pane is gone.
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
Final slice of the **v1.5.0 tmux runtime orchestration** milestone — documentation.

Adds a **"Runtime control (tmux)"** section to both the README and the 2.0 guide (`doc.html`) covering:
- the persisted tmux identity per agent (exact `pane_id`/`window_id`, never window names);
- the `tmux` block + `pane_alive` + `actions` array in `status`/`history`/`resume --json`;
- the `focus` / `open` / `send` verbs and deterministic prompt delivery (paste-buffer via stdin + explicit Enter, verbatim multiline/quoted/metachar text, clear dead-pane errors).

`resume --json` is added to the JSON examples. `doc.html` keeps its v2.0.0 version refs (it's the 2.0 guide); nav + tag balance verified (18/18 sections).

Docs-only — no code changes. `make ci` green.

## Milestone wrap-up
- #61 (items 1–4) ✅ · #62 ✅ · amq-noc#6 contract ✅ · #47 already shipped (`resume --exec`, v1.2.0).
- v1.5.0-rc binary built for amq-noc validation (local `amq-squad-rc-150` + `amq-squad-rc-150-prompt.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)