### PR TITLE
Fix tmux pane resolution for focus/send (symlinked cwd + wrong-agent guard)

### DIFF
--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -81,11 +81,20 @@ func (mr memberRuntime) recordedPaneID() string {
 // restart), otherwise the neutral resolver (title-first, then engine+cwd).
 // Returns the pane id plus a focus target.
 func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.TmuxPane) (paneID string, target tmuxpane.TmuxTarget, ok bool) {
+	// When we know the agent's exact recorded pane, it is the authoritative
+	// identity: use it only if that pane is still live and in the member's cwd.
+	// If the recorded pane is gone, the agent's pane is gone — do NOT fall back
+	// to the fuzzy cwd+engine resolver, which for `send` could deliver to the
+	// wrong agent (a same-cwd/engine peer whose pane is still alive). Report
+	// not-found so the verb errors clearly instead of guessing.
 	if id := mr.recordedPaneID(); id != "" {
-		if p, found := tmuxpane.FindPaneByID(id, panes); found && samePath(p.CWD, mr.CWD) {
+		if p, found := tmuxpane.FindPaneByID(id, panes); found && sameResolvedDir(p.CWD, mr.CWD) {
 			return id, tmuxpane.TargetFromPane(p), true
 		}
+		return "", tmuxpane.TmuxTarget{}, false
 	}
+	// No recorded pane id (a pre-1.5 record, or an agent launched outside tmux):
+	// best-effort resolve by title-first, then cwd+engine.
 	ag := state.Agent{Handle: mr.Handle, Role: mr.Member.Role, Engine: mr.Member.Binary}
 	if tgt, found := tmuxpane.ResolveTmuxTargetForSession(ag, workstream, mr.CWD, panes, nil); found {
 		// tgt.Pane is the pane INDEX; tmux would resolve a bare index relative
@@ -99,6 +108,28 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 		return paneTarget, tgt, true
 	}
 	return "", tmuxpane.TmuxTarget{}, false
+}
+
+// sameResolvedDir reports whether two paths refer to the same directory after
+// resolving symlinks, so a member cwd under a symlinked path (e.g. macOS
+// /var -> /private/var TMPDIR) matches tmux's resolved #{pane_current_path}.
+// Falls back to a plain absolute comparison when a side cannot be resolved.
+func sameResolvedDir(a, b string) bool {
+	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
+		return false
+	}
+	return resolveDir(a) == resolveDir(b)
+}
+
+func resolveDir(dir string) string {
+	abs := dir
+	if a, err := filepath.Abs(dir); err == nil {
+		abs = a
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 // paneIDForTarget returns the #{pane_id} of the live pane the resolver selected,

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -8,6 +10,50 @@ import (
 	"github.com/omriariav/amq-squad/internal/team"
 	"github.com/omriariav/amq-squad/internal/tmuxpane"
 )
+
+// TestResolveControlTargetSymlinkedCWD reproduces the live-test failure: the
+// member cwd is a symlinked path (like macOS /var/folders TMPDIR) while tmux
+// reports the resolved real path for the pane. The cwd guard must still match.
+func TestResolveControlTargetSymlinkedCWD(t *testing.T) {
+	real, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	// Member cwd is the symlink; tmux reports the resolved path for the pane.
+	mr := memberRuntime{
+		Member: team.Member{Role: "cto", Binary: "codex"}, Handle: "cto", CWD: link,
+		HasRecord: true, Record: launch.Record{Tmux: &launch.TmuxInfo{PaneID: "%104"}},
+	}
+	panes := []tmuxpane.TmuxPane{{PaneID: "%104", Session: "s", Window: "0", Pane: "0", CWD: real, Command: "codex"}}
+	id, _, ok := resolveControlTarget(mr, "issue-96", panes)
+	if !ok || id != "%104" {
+		t.Fatalf("symlinked member cwd must still resolve the recorded pane, got id=%q ok=%v", id, ok)
+	}
+}
+
+func TestSameResolvedDir(t *testing.T) {
+	real, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "lk")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	if !sameResolvedDir(link, real) {
+		t.Errorf("a symlink and its target must compare equal")
+	}
+	if sameResolvedDir(real, real+"-other") {
+		t.Errorf("different dirs must not compare equal")
+	}
+	if sameResolvedDir("", real) {
+		t.Errorf("empty path must not match")
+	}
+}
 
 func TestResolveControlTargetExactRecordedPane(t *testing.T) {
 	mr := memberRuntime{

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -254,7 +254,8 @@ func ResolveTmuxTargetForSession(a state.Agent, sessionName, projectDir string, 
 	// title match. This disambiguates agents that share the same cwd AND engine:
 	// the bug where cpo·codex and cto·codex in one repo both match the same panes
 	// under the cwd+engine scoring below and resolve to whichever pane comes first.
-	if want := expectedPaneToken(sessionName, a); want != "" {
+	want := expectedPaneToken(sessionName, a)
+	if want != "" {
 		for _, p := range panes {
 			if p.Title == want {
 				return targetFromPane(p), true
@@ -263,7 +264,7 @@ func ResolveTmuxTargetForSession(a state.Agent, sessionName, projectDir string, 
 	}
 
 	// Fallback: cwd+engine+pid scoring for panes launched before titles existed
-	// (or non-amq panes). Unchanged from the original resolver.
+	// (or non-amq panes).
 	wantCWD := cleanDir(projectDir)
 	engine := strings.ToLower(strings.TrimSpace(a.Engine))
 
@@ -272,6 +273,13 @@ func ResolveTmuxTargetForSession(a state.Agent, sessionName, projectDir string, 
 	ok := false
 
 	for _, p := range panes {
+		// A pane explicitly stamped for a DIFFERENT amq agent belongs to that
+		// agent's role only. The exact-token match already ran above; in the
+		// fallback, skip any other amq-tokened pane so a dead agent's request
+		// never resolves onto a live sibling that merely shares cwd+engine.
+		if want != "" && isAmqPaneToken(p.Title) && p.Title != want {
+			continue
+		}
 		if cleanDir(p.CWD) != wantCWD {
 			continue
 		}
@@ -301,6 +309,12 @@ func ResolveTmuxTargetForSession(a state.Agent, sessionName, projectDir string, 
 		return TmuxTarget{}, false
 	}
 	return targetFromPane(best), true
+}
+
+// isAmqPaneToken reports whether a pane title is a launcher-stamped amq token
+// ("amq:<session>:<role>"), i.e. the pane is explicitly owned by a known agent.
+func isAmqPaneToken(title string) bool {
+	return strings.HasPrefix(title, "amq:")
 }
 
 // targetFromPane builds a TmuxTarget from a resolved pane, carrying its title
@@ -391,10 +405,20 @@ func cleanDir(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	if abs, err := filepath.Abs(dir); err == nil {
-		return filepath.Clean(abs)
+	// Absolutize first, then resolve symlinks, so a member cwd like macOS
+	// /var/folders/... (a symlink to /private/var/folders/...) matches what tmux
+	// reports for the pane via #{pane_current_path} (the resolved real path).
+	// Without this, panes in a symlinked project dir never match and
+	// focus/jump/send silently miss. Falls back to Abs+Clean when the path can't
+	// be resolved (e.g. it does not exist, as in fake test fixtures).
+	abs := dir
+	if a, err := filepath.Abs(dir); err == nil {
+		abs = a
 	}
-	return filepath.Clean(dir)
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 // NotInTmuxError is returned by SwitchTo when invoked outside any tmux client

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -203,6 +203,24 @@ func TestParsePanes_ParsesPaneTitle(t *testing.T) {
 	}
 }
 
+func TestResolveTmuxTarget_DoesNotCrossAttributeTitledSibling(t *testing.T) {
+	ag := state.Agent{Handle: "cto", Role: "cto", Engine: "codex"}
+	// cto's pane is gone; only qa's amq-titled pane survives at the same
+	// cwd+engine. Resolving cto must NOT fall back onto qa's pane.
+	titledSibling := []TmuxPane{
+		{Session: "main", Window: "0", Pane: "1", CWD: "/repo", Command: "codex", Title: "amq:issue-96:qa"},
+	}
+	if _, ok := ResolveTmuxTargetForSession(ag, "issue-96", "/repo", titledSibling, nil); ok {
+		t.Fatal("must not attribute qa's titled pane to cto")
+	}
+	// An UNtitled sibling (older launch, no token) is still matchable by
+	// cwd+engine — the exclusion only applies to explicitly-tokened panes.
+	untitled := []TmuxPane{{Session: "main", Window: "0", Pane: "1", CWD: "/repo", Command: "codex"}}
+	if _, ok := ResolveTmuxTargetForSession(ag, "issue-96", "/repo", untitled, nil); !ok {
+		t.Fatal("untitled pane should still resolve by cwd+engine")
+	}
+}
+
 func TestSuggestJump_FormatsTarget(t *testing.T) {
 	got := SuggestJump(TmuxTarget{Session: "squad", Window: "1", Pane: "2"})
 	want := "tmux switch-client -t squad:1.2"

--- a/l2-smoke.sh
+++ b/l2-smoke.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# L2 smoke test — end-to-end verification of amq-squad v1.5.0 tmux runtime
+# control (issues #61/#62). Runs the 10-step walkthrough automatically.
+#
+# By default it uses a throwaway `bash` "agent" so the run is deterministic and
+# needs no real codex/claude. Set AGENT_BIN=codex (or claude) to drive real
+# agents instead (then the verbatim/multiline delivery is a manual eyeball).
+#
+#   ./l2-smoke.sh            # dummy bash agent (deterministic)
+#   AGENT_BIN=codex ./l2-smoke.sh
+set -uo pipefail
+
+REPO="${REPO:-/Users/omri.a/Code/amq-squad}"
+AGENT_BIN="${AGENT_BIN:-bash}"
+SESSION="${SESSION:-issue-96}"
+PASS=0; FAIL=0
+note(){ printf '\n\033[1m=== %s ===\033[0m\n' "$*"; }
+ok(){   printf '  \033[32mPASS\033[0m %s\n' "$*"; PASS=$((PASS+1)); }
+bad(){  printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); }
+
+note "Step 0 — build amq-squad from $REPO"
+BIN="$(mktemp -d)/amq-squad"
+( cd "$REPO" && go build -ldflags "-X main.version=v1.5.0-rc" -o "$BIN" ./cmd/amq-squad ) \
+  || { echo "build failed"; exit 1; }
+"$BIN" version
+
+PROJ="$(mktemp -d)"            # under /var/folders -> symlinked: exercises the cwd fix
+cd "$PROJ"; git init -q
+TMUX_SESSION=""
+cleanup(){
+  "$BIN" stop --all --project "$PROJ" >/dev/null 2>&1 || true
+  [ -n "$TMUX_SESSION" ] && tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  rm -rf "$PROJ"
+}
+trap cleanup EXIT
+
+note "Step 1 — create a 2-agent team (binary=$AGENT_BIN)"
+"$BIN" new team --roles cto,qa --binary "cto=$AGENT_BIN,qa=$AGENT_BIN" --session "$SESSION" >/dev/null \
+  && ok "team created" || bad "new team failed"
+
+note "Step 2 — launch agents into a new tmux session"
+UP_OUT="$("$BIN" up "$SESSION" --target new-session --no-bootstrap 2>&1)"
+if grep -q "Created tmux session" <<<"$UP_OUT"; then ok "agents launched"; else bad "up did not launch"; echo "$UP_OUT"; fi
+TMUX_SESSION="$(sed -n 's/.*Created tmux session \([A-Za-z0-9_-]*\).*/\1/p' <<<"$UP_OUT" | head -1)"
+echo "  tmux session: $TMUX_SESSION"
+sleep 2
+
+js(){ "$BIN" status --session "$SESSION" --json 2>/dev/null; }
+
+note "Step 3 — status --json carries tmux block + pane_alive + available actions"
+if js | python3 -c '
+import sys,json
+recs=json.load(sys.stdin)["data"]["records"]
+def good(r):
+    t=r.get("tmux") or {}
+    a={x["kind"]:x["available"] for x in r.get("actions",[])}
+    return bool(t.get("pane_id")) and t.get("pane_alive") and a.get("focus") and a.get("send")
+sys.exit(0 if recs and all(good(r) for r in recs) else 1)'; then
+  ok "both members: real pane_id, pane_alive=true, focus/send available"
+else
+  bad "tmux/pane_alive/actions missing or unavailable"; js | python3 -m json.tool
+fi
+
+CTO_PANE="$(js | python3 -c 'import sys,json;d=json.load(sys.stdin);print(next(r["tmux"]["pane_id"] for r in d["data"]["records"] if r["role"]=="cto"))' 2>/dev/null)"
+echo "  cto pane: $CTO_PANE"
+
+note "Step 4/5 — send delivers a prompt and submits Enter (in a symlinked cwd)"
+MARK="SMOKE${RANDOM}"
+# Single-quote the arithmetic so the AGENT's shell evaluates it, not this script.
+if "$BIN" send --session "$SESSION" --role cto --body 'echo '"$MARK"'_$((6*7))' >/dev/null 2>&1; then
+  ok "send returned success"
+else
+  bad "send failed (the bug we fixed: cwd guard rejecting a symlinked pane)"
+fi
+sleep 1
+if [ "$AGENT_BIN" = "bash" ] || [ "$AGENT_BIN" = "sh" ]; then
+  if tmux capture-pane -p -t "$CTO_PANE" 2>/dev/null | grep -q "${MARK}_42"; then
+    ok "prompt landed AND submitted (agent evaluated it -> ${MARK}_42)"
+  else
+    bad "prompt did not land/submit in the target pane"; tmux capture-pane -p -t "$CTO_PANE" 2>/dev/null | tail -5
+  fi
+fi
+
+note "Step 6 — quotes / shell metacharacters survive delivery verbatim"
+Q='q:a b|c;d&e'
+"$BIN" send --session "$SESSION" --role cto --body 'echo "'"$Q"'"' >/dev/null 2>&1 || true
+sleep 1
+if [ "$AGENT_BIN" = "bash" ] || [ "$AGENT_BIN" = "sh" ]; then
+  if tmux capture-pane -p -t "$CTO_PANE" 2>/dev/null | grep -qF "$Q"; then
+    ok "quoted text with | ; & delivered verbatim"
+  else
+    bad "special characters were mangled in delivery"
+  fi
+fi
+
+note "Step 7 — focus (best-effort; visible only when the session is attached)"
+if "$BIN" focus --session "$SESSION" --role qa >/dev/null 2>&1; then
+  ok "focus resolved the qa pane"
+else
+  echo "  (focus needs an attached client to switch view; resolution still ran)"
+fi
+
+note "Step 8 — dead pane errors clearly and pane_alive flips false"
+tmux kill-pane -t "$CTO_PANE" 2>/dev/null || true
+sleep 1
+DEAD_OUT="$("$BIN" send --session "$SESSION" --role cto --body "should fail" 2>&1)"
+echo "  send-after-kill output: [$DEAD_OUT]"
+if grep -qiE "not available|no live tmux pane" <<<"$DEAD_OUT"; then
+  ok "send to a dead pane errors clearly"
+else
+  bad "dead pane did not produce a clear error"
+fi
+if js | python3 -c 'import sys,json;d=json.load(sys.stdin);r=next(x for x in d["data"]["records"] if x["role"]=="cto");sys.exit(0 if not (r.get("tmux") or {}).get("pane_alive") else 1)'; then
+  ok "cto pane_alive flipped to false"
+else
+  bad "pane_alive did not flip after the pane died"
+fi
+
+note "Step 9 — resume --json emits a resume_plan envelope"
+if "$BIN" resume --session "$SESSION" --json 2>/dev/null | python3 -c 'import sys,json;sys.exit(0 if json.load(sys.stdin)["kind"]=="resume_plan" else 1)'; then
+  ok "resume --json -> kind=resume_plan"
+else
+  bad "resume --json shape wrong"
+fi
+
+note "Result"
+printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && echo "  ALL GREEN" || echo "  SOME CHECKS FAILED"
+exit "$FAIL"


### PR DESCRIPTION
Two real bugs in the v1.5.0 runtime control, found by running the **L2 live smoke** (real `up`/`status`/`send`/`focus` in tmux, project under macOS `/var/folders` → symlinked to `/private/var`). Static review (3 rounds + a holistic pass) missed both because they only surface against a real tmux server with a symlinked path and same-binary peers.

## Bug 1 — symlink-blind cwd matching (critical)
tmux reports `#{pane_current_path}` as the **resolved** real path (`/private/var/...`), but the member cwd was `/var/...`. `cleanDir`/`samePath` compared with `filepath.Abs` only (no symlink resolution), so the recorded pane **and** the resolver fallback never matched — `focus`/`send` failed with "no live tmux pane found" even though `status` reported `pane_alive: true` (an internal contradiction). Fix: `cleanDir` + new `sameResolvedDir` absolutize then `EvalSymlinks` (fallback `Abs+Clean` for nonexistent test fixtures).

## Bug 2 — wrong-agent delivery risk
When a member's recorded pane is gone, `resolveControlTarget` fuzzy-fell-back to cwd+engine, which for two same-cwd/engine agents could deliver `send` to a live **sibling**. Fix: a recorded `pane_id` is authoritative — used only if live and cwd-matching, else **not-found** (no fuzzy fallback; clear error). Fuzzy remains only for members with no recorded pane id (pre-1.5 / launched outside tmux). The resolver also no longer cross-attributes a pane explicitly titled for a different amq role.

## Validation harness
Adds `l2-smoke.sh` — a deterministic end-to-end check (dummy `bash` agent by default; `AGENT_BIN=codex` for real agents) covering capture, `pane_alive`, `actions`, **verbatim send delivery**, dead-pane error, and `resume_plan`. Currently **9/9 green**; it caught both bugs above.

## Tests / review
New unit tests: symlinked recorded-pane resolution, `sameResolvedDir`, titled-sibling cross-attribution. `go test ./...` green, `git diff --check` clean. **Codex-consulted → GOOD-TO-MERGE** (validated all three fixes incl. the refuse-fuzzy-fallback judgment call; one non-blocking note on relative paths already addressed by absolutizing first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)