### PR TITLE
Add native window-per-agent tmux backend (--target new-window)

### DIFF
--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -25,7 +25,7 @@ func runResume(args []string) error {
 	execMode := fs.Bool("exec", false, "open the planned launch commands in the terminal backend (tmux) instead of printing them")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (with tmux runtime metadata) instead of the human plan")
 	terminal := fs.String("terminal", "tmux", "terminal backend to use with --exec")
-	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window or new-session)")
+	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window, new-window, or new-session)")
 	layout := fs.String("layout", "vertical", "terminal layout with --exec (tmux: vertical, horizontal, or tiled)")
 	terminalSession := fs.String("terminal-session", "", "terminal session name when --exec --target new-session")
 	stagger := fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes with --exec")
@@ -38,7 +38,7 @@ Usage:
                    [--no-bootstrap] [--trust sandboxed|trusted]
                    [--model role=model,...]
                    [--codex-args args] [--claude-args args]
-                   [--exec [--terminal tmux] [--target current-window|new-session]
+                   [--exec [--terminal tmux] [--target current-window|new-window|new-session]
                            [--layout vertical|horizontal|tiled]
                            [--terminal-session name] [--stagger 750ms]]
 

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -92,7 +92,7 @@ func runTeamLaunch(args []string) error {
 
 Usage:
   amq-squad team launch [--profile NAME] [--session workstream] [--fresh] [--terminal tmux]
-    [--target current-window|new-session] [--layout vertical|horizontal|tiled]
+    [--target current-window|new-window|new-session] [--layout vertical|horizontal|tiled]
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|trusted] [--model role=model,...]
     [--codex-args args] [--claude-args args]
@@ -100,8 +100,10 @@ Usage:
 
 Supported terminal backends: %s
 
-tmux defaults to splitting the current tmux window. Use --target new-session
-to create a detached squad session. The whole roster is preflighted for live
+tmux defaults to splitting the current tmux window into one pane per agent. Use
+--target new-window for one tmux window (iTerm2 tab under -CC) per agent — a
+full-size terminal each, better for many agents. Use --target new-session to
+create a detached squad session. The whole roster is preflighted for live
 duplicates before any tmux command runs; --force-duplicate overrides.
 
 Examples:

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -177,9 +177,16 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 // into its own tmux window (in the current session when run from inside tmux,
 // otherwise a new session). Control still targets exact pane ids.
 func tmuxWindowsDryRunLines(plan tmuxLaunchPlan) []string {
+	// This preview shows the inside-tmux path (add a window per agent to the
+	// current session) — the common way to use --target new-window. Launched
+	// LIVE outside tmux, the backend instead creates a new detached
+	// '<session>' session whose first window hosts the first agent; that path
+	// isn't copy-pasteable as a one-liner, so the `:?` guard fails loudly here
+	// rather than emitting a command against a session that doesn't exist.
 	lines := []string{
-		`session=$(tmux display-message -p -t "${TMUX_PANE:-}" '#{session_name}' 2>/dev/null || echo ` + shellQuote(plan.Session) + `)`,
-		"# one tmux window per agent in $session (a new '" + plan.Session + "' session is created when launched outside tmux)",
+		"# one tmux window per agent, added to your current tmux session",
+		"# (launched live outside tmux, a new detached '" + plan.Session + "' session is created instead)",
+		`session=$(tmux display-message -p -t "${TMUX_PANE:?run from inside tmux, or launch live with: amq-squad up --target new-window}" '#{session_name}')`,
 	}
 	targets := make([]string, 0, len(plan.Panes))
 	for i, pane := range plan.Panes {
@@ -196,7 +203,11 @@ func tmuxWindowsDryRunLines(plan tmuxLaunchPlan) []string {
 			lines = append(lines, sleepDryRunLine(plan.StartDelay))
 		}
 	}
-	lines = append(lines, "# switch between agents with: tmux select-window -t \"$session:<role>\" (or click the iTerm2 tab under -CC)")
+	if plan.Workstream != "" {
+		// Switch to an agent by pane id, not window name (names can collide):
+		// amq-squad focus resolves the exact pane.
+		lines = append(lines, "# focus an agent with: "+shellCommand("amq-squad", "focus", "--session", plan.Workstream, "--role", "<role>"))
+	}
 	return lines
 }
 

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -38,8 +38,8 @@ func (tmuxTeamLaunchBackend) Name() string {
 }
 
 func (tmuxTeamLaunchBackend) Validate(opts teamLaunchOptions) error {
-	if opts.Target != "new-session" && opts.Target != "current-window" {
-		return fmt.Errorf("unsupported tmux target %q: use new-session or current-window", opts.Target)
+	if opts.Target != "new-session" && opts.Target != "current-window" && opts.Target != "new-window" {
+		return fmt.Errorf("unsupported tmux target %q: use current-window, new-window, or new-session", opts.Target)
 	}
 	if opts.Layout != "vertical" && opts.Layout != "horizontal" && opts.Layout != "tiled" {
 		return fmt.Errorf("unsupported tmux layout %q: use vertical, horizontal, or tiled", opts.Layout)
@@ -130,6 +130,9 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 	if len(plan.Panes) == 0 {
 		return nil
 	}
+	if plan.Target == "new-window" {
+		return tmuxWindowsDryRunLines(plan)
+	}
 	windowTarget := plan.Session + ":0"
 	firstTarget := plan.Session + ":0.0"
 	lines := []string{}
@@ -167,6 +170,33 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 	} else {
 		lines = append(lines, "# attach later with: "+shellCommand("tmux", "attach-session", "-t", plan.Session))
 	}
+	return lines
+}
+
+// tmuxWindowsDryRunLines previews the window-per-agent launch: each agent goes
+// into its own tmux window (in the current session when run from inside tmux,
+// otherwise a new session). Control still targets exact pane ids.
+func tmuxWindowsDryRunLines(plan tmuxLaunchPlan) []string {
+	lines := []string{
+		`session=$(tmux display-message -p -t "${TMUX_PANE:-}" '#{session_name}' 2>/dev/null || echo ` + shellQuote(plan.Session) + `)`,
+		"# one tmux window per agent in $session (a new '" + plan.Session + "' session is created when launched outside tmux)",
+	}
+	targets := make([]string, 0, len(plan.Panes))
+	for i, pane := range plan.Panes {
+		v := fmt.Sprintf("win_%d", i)
+		targets = append(targets, "$"+v)
+		lines = append(lines,
+			v+`=$(tmux new-window -d -P -F '#{pane_id}' -t "$session:" -n `+shellQuote(tmuxWindowName(pane.Role))+" -c "+shellQuote(pane.CWD)+")",
+			tmuxSelectPaneDryRunLine("$"+v, paneTitleToken(plan.Session, pane.Role)),
+		)
+	}
+	for i, pane := range plan.Panes {
+		lines = append(lines, tmuxSendKeysDryRunLine(targets[i], pane.Command))
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			lines = append(lines, sleepDryRunLine(plan.StartDelay))
+		}
+	}
+	lines = append(lines, "# switch between agents with: tmux select-window -t \"$session:<role>\" (or click the iTerm2 tab under -CC)")
 	return lines
 }
 
@@ -217,6 +247,9 @@ func tmuxSendKeysDryRunLine(target, command string) string {
 func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 	if len(plan.Panes) == 0 {
 		return fmt.Errorf("tmux plan has no panes")
+	}
+	if plan.Target == "new-window" {
+		return runTmuxWindowsPlan(plan)
 	}
 	windowTarget := plan.Session + ":0"
 	firstTarget := plan.Session + ":0.0"
@@ -287,6 +320,94 @@ func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 	quietNotice("Created tmux session %s. Attach with: tmux attach -t %s\n", plan.Session, shellQuote(plan.Session))
 	verbosePolicyEcho()
 	return nil
+}
+
+// runTmuxWindowsPlan launches one tmux WINDOW per agent (Sagi-style window-per-
+// agent), so each agent gets a full-size terminal instead of a cramped split
+// pane. The host session is the current tmux session when launched from inside
+// tmux, otherwise a new detached session whose first window hosts the first
+// agent. Each agent's pane carries the same amq pane-title token and is driven
+// by send-keys exactly like the pane backends, so the runtime metadata/control
+// layer (pane-id capture, status, focus, send) works unchanged.
+func runTmuxWindowsPlan(plan tmuxLaunchPlan) error {
+	session, firstPaneID, err := tmuxWindowsHostSession(plan)
+	if err != nil {
+		return err
+	}
+	targets := make([]string, 0, len(plan.Panes))
+	for i, pane := range plan.Panes {
+		paneID := ""
+		if i == 0 && firstPaneID != "" {
+			// First agent reuses the window the new session was created with.
+			paneID = firstPaneID
+		} else {
+			out, werr := outputCommand("tmux", "new-window", "-d", "-P", "-F", "#{pane_id}",
+				"-t", session+":", "-n", tmuxWindowName(pane.Role), "-c", pane.CWD)
+			if werr != nil {
+				return werr
+			}
+			paneID = strings.TrimSpace(out)
+		}
+		if paneID == "" {
+			return fmt.Errorf("tmux returned an empty pane id for window %q", pane.Role)
+		}
+		if err := runCommand("tmux", "select-pane", "-t", paneID, "-T", paneTitleToken(plan.Session, pane.Role)); err != nil {
+			return err
+		}
+		targets = append(targets, paneID)
+	}
+	for i, pane := range plan.Panes {
+		if err := runCommand("tmux", "send-keys", "-t", targets[i], withTmuxTargetEnv("new-window", pane.Command), "C-m"); err != nil {
+			return err
+		}
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			time.Sleep(plan.StartDelay)
+		}
+	}
+	if firstPaneID != "" {
+		quietNotice("Created tmux session %s with one window per agent. Attach with: tmux attach -t %s\n", plan.Session, shellQuote(plan.Session))
+	} else {
+		quietNotice("Added %d agent window(s) to the current tmux session.\n", len(plan.Panes))
+	}
+	verbosePolicyEcho()
+	return nil
+}
+
+// tmuxWindowsHostSession resolves the session to add agent windows to. Inside
+// tmux it is the current session (firstPaneID empty: every agent gets a fresh
+// window). Outside tmux it creates a new detached session whose initial window
+// hosts the first agent (firstPaneID is that window's pane).
+func tmuxWindowsHostSession(plan tmuxLaunchPlan) (session, firstPaneID string, err error) {
+	if os.Getenv("TMUX") != "" {
+		pane := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+		if pane == "" {
+			return "", "", fmt.Errorf("--target new-window inside tmux requires TMUX_PANE; launch from a tmux pane, or use --target new-session")
+		}
+		s, derr := outputCommand("tmux", "display-message", "-p", "-t", pane, "#{session_name}")
+		if derr != nil {
+			return "", "", derr
+		}
+		return strings.TrimSpace(s), "", nil
+	}
+	if err := tmuxEnsureSessionAbsent(plan.Session); err != nil {
+		return "", "", err
+	}
+	out, err := outputCommand("tmux", "new-session", "-d", "-P", "-F", "#{pane_id}",
+		"-s", plan.Session, "-n", tmuxWindowName(plan.Panes[0].Role), "-c", plan.Panes[0].CWD)
+	if err != nil {
+		return "", "", err
+	}
+	return plan.Session, strings.TrimSpace(out), nil
+}
+
+// tmuxWindowName is the human-facing window label for an agent (the role).
+// Window names are labels only — control always targets the exact pane id — so
+// duplicates across the user's session are harmless.
+func tmuxWindowName(role string) string {
+	if strings.TrimSpace(role) == "" {
+		return "agent"
+	}
+	return sanitizeTmuxSessionName(role)
 }
 
 func tmuxSplitDirection(layout string) string {

--- a/internal/cli/team_launch_tmux_window_test.go
+++ b/internal/cli/team_launch_tmux_window_test.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTmuxBackendAcceptsNewWindowTarget(t *testing.T) {
+	b := tmuxTeamLaunchBackend{}
+	for _, tgt := range []string{"current-window", "new-window", "new-session"} {
+		if err := b.Validate(teamLaunchOptions{Target: tgt, Layout: "vertical"}); err != nil {
+			t.Errorf("target %q should be valid: %v", tgt, err)
+		}
+	}
+	if err := b.Validate(teamLaunchOptions{Target: "bogus", Layout: "vertical"}); err == nil {
+		t.Error("an unknown target must be rejected")
+	}
+}
+
+func TestTmuxDryRunNewWindowOneWindowPerAgent(t *testing.T) {
+	plan := tmuxLaunchPlan{
+		Session:    "amq-squad-proj",
+		Workstream: "issue-96",
+		Target:     "new-window",
+		Layout:     "vertical",
+		Panes: []teamLaunchPane{
+			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"},
+			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role qa"},
+		},
+	}
+	joined := strings.Join(tmuxDryRunLines(plan), "\n")
+
+	// Window-per-agent: a new-window per role, and NO pane splitting/layout.
+	if strings.Contains(joined, "split-window") {
+		t.Errorf("new-window must not split panes:\n%s", joined)
+	}
+	if strings.Contains(joined, "select-layout") {
+		t.Errorf("new-window has no pane-layout step:\n%s", joined)
+	}
+	if c := strings.Count(joined, "new-window"); c != 2 {
+		t.Errorf("expected 2 new-window invocations (one per agent), got %d:\n%s", c, joined)
+	}
+	if c := strings.Count(joined, "send-keys"); c != 2 {
+		t.Errorf("expected one send-keys per agent, got %d:\n%s", c, joined)
+	}
+	// Each agent still gets its deterministic pane-title token (so focus/send
+	// resolve identically to the pane backends) and a human window name.
+	for _, role := range []string{"cto", "qa"} {
+		token := "amq:amq-squad-proj:" + role
+		if !strings.Contains(joined, "-T '"+token+"'") && !strings.Contains(joined, "-T "+token) {
+			t.Errorf("missing pane title token for %q:\n%s", role, joined)
+		}
+		if !strings.Contains(joined, "-n '"+role+"'") && !strings.Contains(joined, "-n "+role) {
+			t.Errorf("missing window name for %q:\n%s", role, joined)
+		}
+	}
+}
+
+func TestTmuxWindowName(t *testing.T) {
+	if got := tmuxWindowName("cto"); got != "cto" {
+		t.Errorf("tmuxWindowName(cto) = %q, want cto", got)
+	}
+	if got := tmuxWindowName(""); got != "agent" {
+		t.Errorf("empty role should fall back to %q, got %q", "agent", got)
+	}
+}

--- a/internal/cli/team_launch_tmux_window_test.go
+++ b/internal/cli/team_launch_tmux_window_test.go
@@ -37,10 +37,10 @@ func TestTmuxDryRunNewWindowOneWindowPerAgent(t *testing.T) {
 	if strings.Contains(joined, "select-layout") {
 		t.Errorf("new-window has no pane-layout step:\n%s", joined)
 	}
-	if c := strings.Count(joined, "new-window"); c != 2 {
-		t.Errorf("expected 2 new-window invocations (one per agent), got %d:\n%s", c, joined)
+	if c := strings.Count(joined, "tmux new-window"); c != 2 {
+		t.Errorf("expected 2 tmux new-window invocations (one per agent), got %d:\n%s", c, joined)
 	}
-	if c := strings.Count(joined, "send-keys"); c != 2 {
+	if c := strings.Count(joined, "tmux send-keys"); c != 2 {
 		t.Errorf("expected one send-keys per agent, got %d:\n%s", c, joined)
 	}
 	// Each agent still gets its deterministic pane-title token (so focus/send

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -38,7 +38,7 @@ func runUp(args []string) error {
 Usage:
   amq-squad up [<session>] [--project DIR] [--profile NAME] [--session workstream]
     [--reset [--yes|-y] [--force]]
-    [--terminal tmux] [--target current-window|new-session]
+    [--terminal tmux] [--target current-window|new-window|new-session]
     [--layout vertical|horizontal|tiled]
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|trusted] [--model role=model,...]


### PR DESCRIPTION
Adds **`--target new-window`** to the default tmux terminal: **one tmux window per agent** (an iTerm2 native tab under `-CC`) instead of split panes — so each agent gets a full-size terminal. This is the Sagi-style window-per-agent model we compared against (motivation for #61/#62), now **native** (no external `tmux-session` CLI).

## Why
Full-screen agent TUIs (Claude/Codex) want the whole terminal; splitting N agents into N panes of one window gives each ~1/N height — fine for 2, unusable at 3–4+. Window-per-agent gives each a full tab.

## How
- **Inside tmux:** agent windows are added to the **current** session.
- **Outside tmux:** a new detached session is created; its first window hosts the first agent, the rest get their own windows.
- Each window's pane carries the same **amq pane-title token** and is driven by `send-keys` exactly like the pane backends — so the **entire v1.5.0 runtime layer works unchanged**: pane-id capture, `status` `pane_alive`, `focus`, `send`. That's the payoff of the pane-id-addressed design: switching topology is nearly free.

## Live-verified
Real launch: agents landed in their **own windows** (window names `cto`/`qa`), pane ids captured (`%125`/`%126`), `target: new-window` recorded in the launch record, and `send --role cto` **resolved and delivered across windows** (`WINDOW_OK_42` via `capture-pane`). The user's real tmux sessions were untouched (separate detached session).

## Tests
`Validate` accepts `new-window`; dry-run emits one `new-window` per agent (no `split-window`/`select-layout`) with the title token + window name; `tmuxWindowName`. Help updated (`up` / `team launch` / `resume --exec`). `go test ./...` green, `git diff --check` clean.

Also files the busy-pane idle-check follow-up as #68 (the one remaining gap from the Sagi comparison; (b) — multiline submit to real Claude — passed, so no issue needed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)