### PR TITLE
Fix pane-title identity: stamp workstream, not terminal session (v1.5.0 blockers)

### DIFF
--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -88,7 +88,9 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 	// wrong agent (a same-cwd/engine peer whose pane is still alive). Report
 	// not-found so the verb errors clearly instead of guessing.
 	if id := mr.recordedPaneID(); id != "" {
-		if p, found := tmuxpane.FindPaneByID(id, panes); found && sameResolvedDir(p.CWD, mr.CWD) {
+		if p, found := tmuxpane.FindPaneByID(id, panes); found &&
+			sameResolvedDir(p.CWD, mr.CWD) &&
+			!paneTitledForDifferentAgent(p.Title, workstream, mr.Member.Role) {
 			return id, tmuxpane.TargetFromPane(p), true
 		}
 		return "", tmuxpane.TmuxTarget{}, false
@@ -130,6 +132,21 @@ func resolveDir(dir string) string {
 		return resolved
 	}
 	return filepath.Clean(abs)
+}
+
+// paneTitledForDifferentAgent reports whether a pane carries an amq title token
+// (amq:<workstream>:<role>) for a role OTHER than the expected one — i.e. the
+// recorded pane id was reused by a sibling agent (e.g. after a tmux server
+// restart) in the same repo. Such a pane must not be trusted for the recorded
+// agent even when its cwd matches, or `send` could deliver to the wrong agent.
+// An untitled or clobbered (non-amq) title is not second-guessed: the recorded
+// pane id + cwd match stand.
+func paneTitledForDifferentAgent(title, workstream, role string) bool {
+	title = strings.TrimSpace(title)
+	if !strings.HasPrefix(title, "amq:") {
+		return false
+	}
+	return title != paneTitleToken(workstream, role)
 }
 
 // paneIDForTarget returns the #{pane_id} of the live pane the resolver selected,

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -74,6 +74,29 @@ func TestResolveControlTargetExactRecordedPane(t *testing.T) {
 	}
 }
 
+func TestResolveControlTargetRejectsReusedPaneTitledForOther(t *testing.T) {
+	// The recorded pane id is alive and in the right cwd, but tmux restarted and
+	// %42 is now a SIBLING agent's pane (titled for qa, same repo). cto's send
+	// must NOT target it.
+	mr := memberRuntime{
+		Member: team.Member{Role: "cto", Binary: "codex"}, Handle: "cto", CWD: "/repo",
+		HasRecord: true, Record: launch.Record{Tmux: &launch.TmuxInfo{PaneID: "%42"}},
+	}
+	reused := []tmuxpane.TmuxPane{
+		{PaneID: "%42", Session: "main", Window: "0", Pane: "1", CWD: "/repo", Command: "codex", Title: "amq:issue-96:qa"},
+	}
+	if _, _, ok := resolveControlTarget(mr, "issue-96", reused); ok {
+		t.Fatal("a recorded pane reused by a different agent (amq title for another role) must be rejected")
+	}
+	// Same pane id, but titled for cto (or untitled) -> trusted.
+	for _, title := range []string{"amq:issue-96:cto", "", "zsh"} {
+		ours := []tmuxpane.TmuxPane{{PaneID: "%42", CWD: "/repo", Command: "codex", Title: title}}
+		if _, _, ok := resolveControlTarget(mr, "issue-96", ours); !ok {
+			t.Errorf("pane titled %q (ours / untitled) should be trusted", title)
+		}
+	}
+}
+
 func TestResolveControlTargetFallbackReturnsPaneID(t *testing.T) {
 	// No recorded pane; the neutral resolver matches by cwd+engine. The returned
 	// target must be the exact pane_id, NOT the pane index (which tmux would

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -95,9 +95,10 @@ func TestRunTeamLaunchRejectsUnsupportedTerminalWithRegistry(t *testing.T) {
 
 func TestTmuxDryRunLinesShowPaneFlow(t *testing.T) {
 	plan := tmuxLaunchPlan{
-		Session: "amq-squad-repo",
-		Target:  "new-session",
-		Layout:  "vertical",
+		Session:    "amq-squad-repo", // tmux session name (targets)
+		Workstream: "repo",           // AMQ workstream (pane-title identity)
+		Target:     "new-session",
+		Layout:     "vertical",
 		Panes: []teamLaunchPane{
 			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex"},
 			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up claude"},
@@ -107,13 +108,14 @@ func TestTmuxDryRunLinesShowPaneFlow(t *testing.T) {
 	got := strings.Join(tmuxDryRunLines(plan), "\n")
 	for _, want := range []string{
 		"tmux new-session -d -s amq-squad-repo -n squad -c /repo",
-		// Pane titles carry the deterministic name-first jump token amq:<session>:<role>.
-		"tmux select-pane -t 'amq-squad-repo:0.0' -T 'amq:amq-squad-repo:cto'",
+		// Pane titles carry the name-first jump token amq:<workstream>:<role> —
+		// the WORKSTREAM, not the tmux session name, so it matches the resolver.
+		"tmux select-pane -t 'amq-squad-repo:0.0' -T 'amq:repo:cto'",
 		"tmux send-keys -t 'amq-squad-repo:0.0'",
 		"sleep 0.75",
 		"pane_1=$(tmux split-window -P -F '#{pane_id}' -t 'amq-squad-repo:0' -h -c /repo)",
 		"tmux select-layout -t 'amq-squad-repo:0' even-horizontal",
-		`tmux select-pane -t "$pane_1" -T 'amq:amq-squad-repo:qa'`,
+		`tmux select-pane -t "$pane_1" -T 'amq:repo:qa'`,
 		`tmux send-keys -t "$pane_1"`,
 		"# attach later with: tmux attach-session -t amq-squad-repo",
 	} {
@@ -125,9 +127,10 @@ func TestTmuxDryRunLinesShowPaneFlow(t *testing.T) {
 
 func TestTmuxDryRunLinesCanTargetCurrentWindow(t *testing.T) {
 	plan := tmuxLaunchPlan{
-		Session: "ignored",
-		Target:  "current-window",
-		Layout:  "vertical",
+		Session:    "ignored", // current-window ignores the session name
+		Workstream: "repo",    // but the pane-title identity is the workstream
+		Target:     "current-window",
+		Layout:     "vertical",
 		Panes: []teamLaunchPane{
 			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex"},
 			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up claude"},
@@ -140,8 +143,8 @@ func TestTmuxDryRunLinesCanTargetCurrentWindow(t *testing.T) {
 		// focused window, so panes never hijack an unrelated tab (#40).
 		`window=$(tmux display-message -p -t "${TMUX_PANE:?run amq-squad up from inside a tmux pane}" '#{session_name}:#{window_index}')`,
 		`first_pane="$TMUX_PANE"`,
-		// Pane titles carry the deterministic name-first jump token amq:<session>:<role>.
-		`tmux select-pane -t "$first_pane" -T 'amq:ignored:cto'`,
+		// Pane titles carry the name-first jump token amq:<workstream>:<role>.
+		`tmux select-pane -t "$first_pane" -T 'amq:repo:cto'`,
 		`pane_1=$(tmux split-window -P -F '#{pane_id}' -t "$window" -h -c /repo)`,
 		`tmux send-keys -t "$first_pane"`,
 		`tmux send-keys -t "$pane_1"`,

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -147,13 +147,13 @@ func tmuxDryRunLines(plan tmuxLaunchPlan) []string {
 		lines = append(lines, shellCommand("tmux", "new-session", "-d", "-s", plan.Session, "-n", "squad", "-c", plan.Panes[0].CWD))
 	}
 	targets := []string{firstTarget}
-	lines = append(lines, tmuxSelectPaneDryRunLine(firstTarget, paneTitleToken(plan.Session, plan.Panes[0].Role)))
+	lines = append(lines, tmuxSelectPaneDryRunLine(firstTarget, paneTitleToken(plan.Workstream, plan.Panes[0].Role)))
 	for i, pane := range plan.Panes[1:] {
 		paneVar := fmt.Sprintf("pane_%d", i+1)
 		targets = append(targets, "$"+paneVar)
 		lines = append(lines,
 			tmuxSplitDryRunLine(paneVar, windowTarget, pane.CWD, plan.Layout),
-			tmuxSelectPaneDryRunLine("$"+paneVar, paneTitleToken(plan.Session, pane.Role)),
+			tmuxSelectPaneDryRunLine("$"+paneVar, paneTitleToken(plan.Workstream, pane.Role)),
 		)
 	}
 	if len(plan.Panes) > 1 {
@@ -194,7 +194,7 @@ func tmuxWindowsDryRunLines(plan tmuxLaunchPlan) []string {
 		targets = append(targets, "$"+v)
 		lines = append(lines,
 			v+`=$(tmux new-window -d -P -F '#{pane_id}' -t "$session:" -n `+shellQuote(tmuxWindowName(pane.Role))+" -c "+shellQuote(pane.CWD)+")",
-			tmuxSelectPaneDryRunLine("$"+v, paneTitleToken(plan.Session, pane.Role)),
+			tmuxSelectPaneDryRunLine("$"+v, paneTitleToken(plan.Workstream, pane.Role)),
 		)
 	}
 	for i, pane := range plan.Panes {
@@ -240,15 +240,17 @@ func tmuxSelectPaneDryRunLine(target, title string) string {
 }
 
 // paneTitleToken builds the deterministic, machine-parseable pane title that the
-// Tmux pane resolution is name-first: "amq:<session>:<role>". The role is unique per
-// agent within a session, so two agents that share a repo AND an engine (the
-// bug: cpo·codex + cto·codex in the same dir) still get distinct titles. The
-// token doubles as a human-facing label since it carries the role. When the role
-// is empty it is omitted, leaving "amq:<session>:" — callers always pass a role
-// for real members, but this stays parseable. MUST stay in lockstep with the
-// resolver's expectedPaneToken in internal/tmuxpane/tmux.go.
-func paneTitleToken(session, role string) string {
-	return "amq:" + session + ":" + role
+// name-first tmux pane resolution matches: "amq:<workstream>:<role>". The
+// session component is the AMQ WORKSTREAM (not the tmux/terminal session name),
+// because that is the agent identity every resolver caller (status, focus, send)
+// keys off — stamping the terminal-session name here would make the title never
+// match the resolver's expectedPaneToken and break name-first/exclusion. The
+// role is unique per agent within a workstream, so two agents that share a repo
+// AND an engine (cpo·codex + cto·codex in one dir) still get distinct titles.
+// MUST stay in lockstep with expectedPaneToken in internal/tmuxpane/tmux.go,
+// which is called with the workstream.
+func paneTitleToken(workstream, role string) string {
+	return "amq:" + workstream + ":" + role
 }
 
 func tmuxSendKeysDryRunLine(target, command string) string {
@@ -292,7 +294,7 @@ func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 	default:
 		return fmt.Errorf("unsupported tmux target %q", plan.Target)
 	}
-	if err := runCommand("tmux", "select-pane", "-t", firstTarget, "-T", paneTitleToken(plan.Session, plan.Panes[0].Role)); err != nil {
+	if err := runCommand("tmux", "select-pane", "-t", firstTarget, "-T", paneTitleToken(plan.Workstream, plan.Panes[0].Role)); err != nil {
 		return err
 	}
 	targets := []string{firstTarget}
@@ -306,7 +308,7 @@ func runTmuxLaunchPlan(plan tmuxLaunchPlan) error {
 			return fmt.Errorf("tmux split-window returned empty pane id")
 		}
 		targets = append(targets, paneID)
-		if err := runCommand("tmux", "select-pane", "-t", paneID, "-T", paneTitleToken(plan.Session, pane.Role)); err != nil {
+		if err := runCommand("tmux", "select-pane", "-t", paneID, "-T", paneTitleToken(plan.Workstream, pane.Role)); err != nil {
 			return err
 		}
 	}
@@ -362,7 +364,7 @@ func runTmuxWindowsPlan(plan tmuxLaunchPlan) error {
 		if paneID == "" {
 			return fmt.Errorf("tmux returned an empty pane id for window %q", pane.Role)
 		}
-		if err := runCommand("tmux", "select-pane", "-t", paneID, "-T", paneTitleToken(plan.Session, pane.Role)); err != nil {
+		if err := runCommand("tmux", "select-pane", "-t", paneID, "-T", paneTitleToken(plan.Workstream, pane.Role)); err != nil {
 			return err
 		}
 		targets = append(targets, paneID)

--- a/internal/cli/team_launch_tmux_session_test.go
+++ b/internal/cli/team_launch_tmux_session_test.go
@@ -189,9 +189,10 @@ func TestTmuxSessionBackendRegistered(t *testing.T) {
 // backend did not perturb the default path.
 func TestDefaultTmuxBackendStillEmitsSplitPanePlan(t *testing.T) {
 	plan := tmuxLaunchPlan{
-		Session: "amq-squad-repo",
-		Target:  "new-session",
-		Layout:  "vertical",
+		Session:    "amq-squad-repo",
+		Workstream: "repo",
+		Target:     "new-session",
+		Layout:     "vertical",
 		Panes: []teamLaunchPane{
 			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex"},
 			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up claude"},
@@ -203,7 +204,7 @@ func TestDefaultTmuxBackendStillEmitsSplitPanePlan(t *testing.T) {
 		"tmux new-session -d -s amq-squad-repo -n squad -c /repo",
 		"pane_1=$(tmux split-window -P -F '#{pane_id}' -t 'amq-squad-repo:0' -h -c /repo)",
 		"tmux select-layout -t 'amq-squad-repo:0' even-horizontal",
-		"tmux select-pane -t 'amq-squad-repo:0.0' -T 'amq:amq-squad-repo:cto'",
+		"tmux select-pane -t 'amq-squad-repo:0.0' -T 'amq:repo:cto'",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("default tmux plan regressed, missing %q in:\n%s", want, got)

--- a/internal/cli/team_launch_tmux_title_test.go
+++ b/internal/cli/team_launch_tmux_title_test.go
@@ -12,9 +12,10 @@ import (
 // same repo+engine still resolve to distinct panes.
 func TestTmuxDryRunLines_StampsDeterministicPaneTitles(t *testing.T) {
 	plan := tmuxLaunchPlan{
-		Session: "beta",
-		Target:  "new-session",
-		Layout:  "tiled",
+		Session:    "beta-tmux",
+		Workstream: "beta",
+		Target:     "new-session",
+		Layout:     "tiled",
 		Panes: []teamLaunchPane{
 			{Role: "cpo", CWD: "/repo", Command: "codex"},
 			{Role: "cto", CWD: "/repo", Command: "codex"},

--- a/internal/cli/team_launch_tmux_window_test.go
+++ b/internal/cli/team_launch_tmux_window_test.go
@@ -46,7 +46,9 @@ func TestTmuxDryRunNewWindowOneWindowPerAgent(t *testing.T) {
 	// Each agent still gets its deterministic pane-title token (so focus/send
 	// resolve identically to the pane backends) and a human window name.
 	for _, role := range []string{"cto", "qa"} {
-		token := "amq:amq-squad-proj:" + role
+		// Title uses the WORKSTREAM (issue-96), not the terminal session name
+		// (amq-squad-proj) — so it matches what the resolver expects.
+		token := "amq:issue-96:" + role
 		if !strings.Contains(joined, "-T '"+token+"'") && !strings.Contains(joined, "-T "+token) {
 			t.Errorf("missing pane title token for %q:\n%s", role, joined)
 		}


### PR DESCRIPTION
The final holistic Codex review of v1.5.0 found **two release blockers**, both rooted in the pane-title token being stamped with the wrong session name.

## Blocker 1 — title-session mismatch (High)
The launcher stamped titles as `amq:<terminal-session>:<role>` (e.g. `amq:amq-squad-proj:cto`), but every resolver caller (`status` live-replacement, `focus`, `send` fuzzy path) expects `amq:<workstream>:<role>` (e.g. `amq:issue-96:cto`). When they differ:
- name-first title match fails, and
- the #67 titled-sibling exclusion **skips the real pane** — so legitimate targets become unreachable in fallback paths.

**Fix:** stamp `paneTitleToken(plan.Workstream, role)` at all pane/window/dry-run sites. `plan.Workstream` is the resolved workstream (`team_launch.go:162`) — the exact value the resolver receives.

## Blocker 2 — fast path didn't check title (High)
`resolveControlTarget` trusted a recorded `%pane_id` on a cwd match alone, so after a tmux restart that reuses `%N` for a **sibling** agent in the same repo, `send` could hit the wrong agent. **Fix:** also reject a live recorded pane whose title is an `amq:` token for a *different* role (`paneTitledForDifferentAgent`); untitled/clobbered titles still trust id+cwd.

## Verified
- **Live:** pane titles are now `amq:issue-96:<role>` (not the terminal-session name); `send` still delivers (`TITLEFIX_42` via capture-pane); `l2-smoke.sh` **9/9**.
- Tests: dry-run title assertions now distinguish `Session` (tmux target) from `Workstream` (title identity); new reused-pane-titled-for-other rejection test. `go test ./...` green, `git diff --check` clean.

These were not caught by L1/L2 because `focus`/`send` via the recorded pane-id fast path worked (masking the fuzzy/title paths). This is the fix that makes the resolver/title contract internally consistent before a v1.5.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)