### PR TITLE
resume --exec: reject non-tmux --terminal (final v1.5.0 review)

### DIFF
--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -191,6 +191,22 @@ func TestReadPromptBody(t *testing.T) {
 	}
 }
 
+func TestResumeExecRejectsNonTmuxTerminal(t *testing.T) {
+	// resume --exec runs the built-in tmux plan; it must reject --terminal
+	// tmux-session (rather than validating it and silently running the default
+	// tmux backend). Window-per-agent on resume is via --target new-window.
+	tm := team.Team{Project: "/p", Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto"}}}
+	plans := []resumePlan{{Role: "cto", Action: resumeRestore, Command: "cd /p && amq-squad agent up codex --role cto"}}
+	err := execResumePlan(tm, "issue-96", plans,
+		resumeExecOptions{Enabled: true, Terminal: "tmux-session", Target: "current-window", Layout: "vertical"}, false)
+	if err == nil || !strings.Contains(err.Error(), "not supported on resume") {
+		t.Fatalf("want rejection of tmux-session terminal on resume --exec, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "new-window") {
+		t.Errorf("error should point to --target new-window: %v", err)
+	}
+}
+
 func TestSendRequiresRole(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
 		return runSend([]string{"--session", "issue-96", "--body", "hi"})

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -367,6 +367,14 @@ func execResumePlan(t team.Team, workstream string, plans []resumePlan, exec res
 	if !ok {
 		return fmt.Errorf("unsupported terminal %q: supported terminals: %s", exec.Terminal, strings.Join(registeredTeamLaunchTerminals(), ", "))
 	}
+	// resume --exec runs the built-in tmux plan (runTmuxLaunchPlan) directly from
+	// restore records; it does not drive the external window-per-agent
+	// `tmux-session` backend. Reject any non-tmux terminal here rather than
+	// validating it and silently running the tmux backend instead. Window-per-
+	// agent on resume is available natively via `--target new-window`.
+	if exec.Terminal != "tmux" {
+		return fmt.Errorf("resume --exec runs the built-in tmux backend; --terminal %q is not supported on resume. For one window per agent, use --target new-window.", exec.Terminal)
+	}
 
 	var (
 		panes   []teamLaunchPane


### PR DESCRIPTION
The final holistic Codex review of v1.5.0 found one more issue on the `resume --exec` path.

## Problem (pre-existing)
`execResumePlan` looked up the selected `--terminal` backend and validated it, but then **always** ran `runTmuxLaunchPlan` (the built-in tmux backend). So `resume --exec --terminal tmux-session` validated `tmux-session` and then silently ran the default tmux split/window code — the wrong backend. (Pre-existing: resume --exec builds a `tmuxLaunchPlan` directly from restore records and never drove the external `tmux-session` backend.)

The v1.5.0 feature itself is unaffected: `resume --exec --target new-window` works, because it routes through `runTmuxLaunchPlan` → `runTmuxWindowsPlan`.

## Fix
Reject any non-tmux `--terminal` on `resume --exec` with a clear error pointing at the supported native path:
> `resume --exec runs the built-in tmux backend; --terminal "tmux-session" is not supported on resume. For one window per agent, use --target new-window.`

Verified: `--terminal tmux-session` is rejected; `--target new-window` passes the guard. New unit test. `go test ./...` green (the one status flake was a leftover tmux pane from a smoke, since cleaned — the test itself is unmocked-tmux-dependent, noted as separate test-hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)