### PR TITLE
Advertise capabilities.runtime_actions (L3 consumer-contract gap)

### DIFF
--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -70,6 +70,12 @@ type OperatorView struct {
 // in team.json so hand-edited configs cannot drift.
 type Capabilities struct {
 	OperatorGates bool `json:"operator_gates"`
+	// RuntimeActions advertises that this amq-squad build exposes the tmux
+	// runtime contract clients (amq-noc) consume: per-member tmux identity +
+	// pane_alive in status/history/resume --json, the status `actions` array,
+	// and the focus/open/send control verbs. Always true since v1.5.0; a client
+	// can gate its runtime-action UI on it instead of sniffing for fields.
+	RuntimeActions bool `json:"runtime_actions"`
 }
 
 // EffectiveCWD returns the member's working directory, falling back to the
@@ -146,7 +152,10 @@ func SupportsOperatorGates(t Team) bool {
 }
 
 func EffectiveCapabilities(t Team) Capabilities {
-	return Capabilities{OperatorGates: SupportsOperatorGates(t)}
+	return Capabilities{
+		OperatorGates:  SupportsOperatorGates(t),
+		RuntimeActions: true, // every v1.5.0+ build exposes the runtime contract
+	}
 }
 
 // Path returns the team.json path for the default profile under projectDir.

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -264,5 +265,22 @@ func TestValidateMemberLauncher(t *testing.T) {
 	orphanArgs.LauncherArgs = []string{"--pull"}
 	if err := Validate(Team{Members: []Member{orphanArgs}}); err == nil || !strings.Contains(err.Error(), "set launcher before launcher_args") {
 		t.Errorf("launcher_args without launcher: want guard error, got %v", err)
+	}
+}
+
+func TestEffectiveCapabilitiesAdvertisesRuntimeActions(t *testing.T) {
+	// Every v1.5.0+ build exposes the tmux runtime contract, so clients
+	// (amq-noc) can gate their runtime-action UI on capabilities.runtime_actions.
+	caps := EffectiveCapabilities(Team{Schema: SchemaVersion}) // unconditional since v1.5.0
+	if !caps.RuntimeActions {
+		t.Error("EffectiveCapabilities must advertise RuntimeActions=true")
+	}
+	// It must serialize as the stable `runtime_actions` key the consumer reads.
+	b, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"runtime_actions":true`) {
+		t.Errorf("capabilities JSON missing runtime_actions:true, got %s", b)
 	}
 }


### PR DESCRIPTION
**Found by L3 validation against the real amq-noc consumer.** amq-noc's forked `team.Capabilities` struct has a `runtime_actions` field it uses to gate the runtime-action UI, but amq-squad only ever emitted `{"operator_gates": true}` — it never advertised the tmux runtime contract it now exposes (pane ids + `pane_alive` + `actions[]` + focus/open/send).

## Fix
Add `RuntimeActions` to `team.Capabilities`, set `true` in `EffectiveCapabilities` (unconditional — every v1.5.0+ build has the contract). It now appears wherever capabilities are emitted (`status`, `team_plan`, `team_profiles`, `up --dry-run --json`) as `"runtime_actions": true`, so a client can gate on the capability instead of sniffing for the `actions[]` field.

Backward-compatible (additive; `operator_gates` unchanged). Verified live: `capabilities = {"operator_gates": true, "runtime_actions": true}`, and amq-noc's struct unmarshals `RuntimeActions = true`. Test added; `go test ./...` green.

Candidate for **v1.5.1** (v1.5.0 is already tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)