### PR TITLE
Enrich runtime actions with structured metadata (amq-noc#7)

### DIFF
--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -129,6 +129,23 @@ func TestMemberActions(t *testing.T) {
 	if !byKind["resume"].Available || !byKind["status"].Available {
 		t.Errorf("resume/status should always be available")
 	}
+	// #7 schema: each action carries a label, an agent scope, and mutate/confirm
+	// metadata so a client can render a confirm-gated executable action.
+	wantMeta := map[string]struct{ mutates, confirm bool }{
+		"focus":  {false, false},
+		"send":   {true, true},
+		"resume": {true, true},
+		"status": {false, false},
+	}
+	for k, want := range wantMeta {
+		a := byKind[k]
+		if a.Label == "" || a.Scope != "agent" {
+			t.Errorf("%s action missing label/scope: %+v", k, a)
+		}
+		if a.Mutates != want.mutates || a.NeedsConfirmation != want.confirm {
+			t.Errorf("%s mutates/needs_confirmation = %v/%v, want %v/%v", k, a.Mutates, a.NeedsConfirmation, want.mutates, want.confirm)
+		}
+	}
 	for _, k := range []string{"focus", "send", "resume", "status"} {
 		cmd := byKind[k].Command
 		if !strings.HasPrefix(cmd, "amq-squad "+k) {
@@ -146,11 +163,22 @@ func TestMemberActions(t *testing.T) {
 	if !strings.Contains(named[0].Command, "--profile review") {
 		t.Errorf("named profile not in command: %q", named[0].Command)
 	}
-	// Dead pane -> focus/send unavailable.
+	// Dead pane -> focus/send unavailable WITH a reason; resume/status stay
+	// available with no reason.
 	dead := memberActions("/Code/app", team.DefaultProfile, "issue-96", "cto", false)
 	for _, a := range dead {
-		if (a.Kind == "focus" || a.Kind == "send") && a.Available {
-			t.Errorf("%s should be unavailable for a dead pane", a.Kind)
+		switch a.Kind {
+		case "focus", "send":
+			if a.Available {
+				t.Errorf("%s should be unavailable for a dead pane", a.Kind)
+			}
+			if a.Reason == "" {
+				t.Errorf("%s should carry a reason when unavailable", a.Kind)
+			}
+		default:
+			if !a.Available || a.Reason != "" {
+				t.Errorf("%s should stay available with no reason: %+v", a.Kind, a)
+			}
 		}
 	}
 }

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -131,19 +131,31 @@ func TestMemberActions(t *testing.T) {
 	}
 	// #7 schema: each action carries a label, an agent scope, and mutate/confirm
 	// metadata so a client can render a confirm-gated executable action.
-	wantMeta := map[string]struct{ mutates, confirm bool }{
-		"focus":  {false, false},
-		"send":   {true, true},
-		"resume": {true, true},
-		"status": {false, false},
+	wantMeta := map[string]struct {
+		mutates, confirm bool
+		scope            string
+	}{
+		"focus":  {false, false, "agent"},   // has --role
+		"send":   {true, true, "agent"},     // has --role
+		"resume": {true, true, "session"},   // session resume (no --role)
+		"status": {false, false, "session"}, // session board (no --role)
 	}
 	for k, want := range wantMeta {
 		a := byKind[k]
-		if a.Label == "" || a.Scope != "agent" {
-			t.Errorf("%s action missing label/scope: %+v", k, a)
+		if a.Label == "" || a.Scope != want.scope {
+			t.Errorf("%s action label/scope wrong: got scope %q label %q", k, a.Scope, a.Label)
 		}
 		if a.Mutates != want.mutates || a.NeedsConfirmation != want.confirm {
 			t.Errorf("%s mutates/needs_confirmation = %v/%v, want %v/%v", k, a.Mutates, a.NeedsConfirmation, want.mutates, want.confirm)
+		}
+		// Scope accuracy: an agent-scoped action's command must carry --role; a
+		// session-scoped one must not.
+		hasRole := strings.Contains(a.Command, "--role ")
+		if want.scope == "agent" && !hasRole {
+			t.Errorf("%s is agent-scoped but command lacks --role: %q", k, a.Command)
+		}
+		if want.scope == "session" && hasRole {
+			t.Errorf("%s is session-scoped but command has --role: %q", k, a.Command)
 		}
 	}
 	for _, k := range []string{"focus", "send", "resume", "status"} {

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -95,19 +95,32 @@ func fillPaneAlive(rt *tmuxRuntimeJSON, live map[string]bool) {
 	rt.PaneAlive = rt.PaneID != "" && live[rt.PaneID]
 }
 
-// runtimeActionJSON is one stable, project-scoped command a client (amq-noc)
-// can render or copy for a member. Emitting the exact command keeps the control
-// contract in amq-squad: clients call/copy these instead of assembling tmux or
-// amq-squad invocations themselves.
+// runtimeActionJSON is one stable, project-scoped operator action a client
+// (amq-noc) can render, copy, or execute for a member. Emitting the exact
+// command keeps the control contract in amq-squad: clients call/copy these
+// instead of assembling tmux or amq-squad invocations themselves. The structured
+// metadata (mutates / needs_confirmation / available / reason) lets a client
+// gate an EXECUTABLE action deterministically without hard-coding policy.
 type runtimeActionJSON struct {
-	Kind      string `json:"kind"` // focus | send | resume | status
-	Command   string `json:"command"`
-	Available bool   `json:"available"`
+	// Kind is the stable id of the action (focus | send | resume | status).
+	Kind string `json:"kind"`
+	// Label is a short human-facing name for the action.
+	Label string `json:"label"`
+	// Scope is the action's target granularity (currently always "agent").
+	Scope             string `json:"scope"`
+	Command           string `json:"command"`
+	Mutates           bool   `json:"mutates"`            // changes squad/agent state
+	NeedsConfirmation bool   `json:"needs_confirmation"` // a client should confirm first
+	Available         bool   `json:"available"`
+	// Reason explains why an action is unavailable in the current context;
+	// empty when available.
+	Reason string `json:"reason,omitempty"`
 }
 
-// memberActions builds the per-member action commands. focus/send require a
-// live pane (paneAlive); resume and status are always available. The project
-// flag is included so the command is runnable from anywhere.
+// memberActions builds the per-member action catalog. focus/send require a live
+// pane (paneAlive); resume and status are always available. Each action carries
+// the metadata a client needs to render a confirm-gated executable action. The
+// project flag is included so the command is runnable from anywhere.
 func memberActions(projectDir, profile, session, role string, paneAlive bool) []runtimeActionJSON {
 	base := "amq-squad"
 	scope := " --project " + shellQuote(projectDir)
@@ -116,11 +129,15 @@ func memberActions(projectDir, profile, session, role string, paneAlive bool) []
 	}
 	scope += " --session " + shellQuote(session)
 	roleArg := " --role " + shellQuote(role)
+	deadReason := ""
+	if !paneAlive {
+		deadReason = "agent pane is not live"
+	}
 	return []runtimeActionJSON{
-		{Kind: "focus", Available: paneAlive, Command: base + " focus" + scope + roleArg},
-		{Kind: "send", Available: paneAlive, Command: base + " send" + scope + roleArg + " --body-file -"},
-		{Kind: "resume", Available: true, Command: base + " resume" + scope + " --exec"},
-		{Kind: "status", Available: true, Command: base + " status" + scope + " --json"},
+		{Kind: "focus", Label: "focus pane", Scope: "agent", Mutates: false, NeedsConfirmation: false, Available: paneAlive, Reason: deadReason, Command: base + " focus" + scope + roleArg},
+		{Kind: "send", Label: "send a prompt", Scope: "agent", Mutates: true, NeedsConfirmation: true, Available: paneAlive, Reason: deadReason, Command: base + " send" + scope + roleArg + " --body-file -"},
+		{Kind: "resume", Label: "resume agent", Scope: "agent", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec"},
+		{Kind: "status", Label: "show status", Scope: "agent", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " status" + scope + " --json"},
 	}
 }
 

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -133,11 +133,14 @@ func memberActions(projectDir, profile, session, role string, paneAlive bool) []
 	if !paneAlive {
 		deadReason = "agent pane is not live"
 	}
+	// focus/send carry --role (agent scope); resume/status as commanded here act
+	// on the whole session (no --role), so their scope is "session". A per-agent
+	// dedicated catalog with agent-scoped resume/restart is a follow-up.
 	return []runtimeActionJSON{
 		{Kind: "focus", Label: "focus pane", Scope: "agent", Mutates: false, NeedsConfirmation: false, Available: paneAlive, Reason: deadReason, Command: base + " focus" + scope + roleArg},
 		{Kind: "send", Label: "send a prompt", Scope: "agent", Mutates: true, NeedsConfirmation: true, Available: paneAlive, Reason: deadReason, Command: base + " send" + scope + roleArg + " --body-file -"},
-		{Kind: "resume", Label: "resume agent", Scope: "agent", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec"},
-		{Kind: "status", Label: "show status", Scope: "agent", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " status" + scope + " --json"},
+		{Kind: "resume", Label: "resume session", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec"},
+		{Kind: "status", Label: "show session status", Scope: "session", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " status" + scope + " --json"},
 	}
 }
 


### PR DESCRIPTION
Advances **amq-noc#7**: a structured action catalog so the NOC can render **confirm-gated executable** actions deterministically rather than copy a string or hard-code policy.

Enriches the per-member `actions[]` in **`status --json`** (the only envelope that carries `actions[]`; `history`/`resume_plan` carry the `tmux` block but no actions) with the exact fields #7 specifies — **additively**:

| field | meaning |
|---|---|
| `label` | short human name |
| `scope` | `agent` (focus/send — carry `--role`) or `session` (resume/status — no `--role`) |
| `mutates` | changes squad/agent state — `send`/`resume` true, `focus`/`status` false |
| `needs_confirmation` | a client should confirm first — `send`/`resume` true |
| `reason` | why unavailable (e.g. `agent pane is not live`); empty when available |

`kind` stays the stable id; `command`/`available` unchanged. **Backward-compatible** — existing consumers ignore the new fields. `TestMemberActions` covers the metadata + a `--role`/`scope` invariant.

## Scope / follow-up
Agent + session actions on the **agent record**. A proper **project/session-scope catalog** (resume-current-window / resume-new-session / stop / restart, agent-scoped resume) via a dedicated `amq-squad actions --json` command is a deliberate follow-up pending your call on the API shape.

Candidate for **v1.5.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)