### PR TITLE
Release prep v1.5.1: roadmap PLAN.md + version bumps

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,73 @@
+# amq-squad roadmap
+
+Living roadmap. The GitHub issue tracker is the source of truth; this file groups
+the open issues by theme + status so the near-term path is legible at a glance.
+
+## Release state
+
+- **v1.5.0 — shipped.** tmux runtime contract (persisted pane/window ids,
+  `pane_alive`, per-agent `actions[]`, `focus`/`open`/`send` verbs, `--target
+  new-window`), custom roles, Claude + Codex plugin marketplaces.
+- **v1.5.1 — in progress.** `capabilities.runtime_actions` (#73), `send`
+  busy-pane idle-check (#74 / #68), structured action metadata
+  `label`/`scope`/`mutates`/`needs_confirmation`/`reason` (#75).
+- **Next (v1.5.2 candidate):** session/project-scope actions in `status --json`
+  to fully close amq-noc#7 (resume-current-window / resume-new-session / stop /
+  restart) — extend the status envelope, no new command.
+
+## Themes
+
+### Runtime orchestration (the v1.5.x arc)
+
+- **#76 — Agent orchestrator** *(roadmap; substrate shipped).* A lead agent
+  spawns, drives, monitors child agents over the tmux contract; children push
+  `[AGENT-EVENT]` envelopes back. Mostly a protocol + skill on top of the shipped
+  primitives (`send`/`focus`/`--target new-window`/`PaneBusy`/pane-id
+  addressing); new binary work is `spawn` / `emit-event` / `watch`. **Never in
+  the NOC** — at most the NOC observes an orchestration. This is the headline
+  forward item.
+- #61 — Expose first-class tmux orchestration metadata for NOC clients.
+  ✅ shipped in v1.5.0 — *pending close.*
+- #62 — Make tmux prompt delivery deterministic for launched agents.
+  ✅ shipped in v1.5.0 — *pending close.*
+- #47 — Batch execute mode for resume (`up --restore`).
+  ✅ `resume --exec` shipped in v1.2.0 — *pending close.*
+
+### Team lifecycle & DX
+
+- #31 — *(epic, breaking)* Unify team lifecycle verbs; separate team identity
+  from workstream. Largely realized by the 2.0 reshape — *audit & close/refile.*
+- #27 — Unified team resume UX (fresh launch vs restore). *Likely addressed by
+  the resume rework — verify.*
+- #26 — Team rules template library for modern agent squads.
+- #22 — Support a per-member target model in team config.
+- #39 — `team init --roles` rejects custom names. ✅ custom roles shipped in
+  v1.5.0 — *pending close.*
+- #25 — Prevent launching duplicate live agents for the same role/handle/
+  workstream. ✅ roster preflight + duplicate detection shipped — *pending close.*
+- #19 — Rework Codex trust defaults for generated launches.
+- #11 — Replace placeholder `role.md` stubs with actionable role guidance.
+
+### AMQ integration & operator
+
+- #53 — Support a virtual operator participant in squad teams. *Partially
+  addressed by the schema-3 operator (`user` handle / `--operator`) — verify
+  scope vs close.*
+- #30 — Adopt new AMQ features (require-wake, inject-via, from-session); drop
+  stale acks.
+- #58 — Clarify the AMQ message-kind enum in the skill routing docs. *Largely
+  addressed in the v1.5.0 skill update (#70) — verify & close.*
+
+### Bugs
+
+- #46 — `amq env` failures are opaque; the launch path leaks shell
+  `AM_ROOT`/`AM_ME` identity.
+- #45 — Exiting agent leaves an orphan `amq wake` process that blocks relaunch.
+- #44 — `down` leaves an orphaned `amq wake` process and stale live presence.
+
+## Notes
+
+- Several issues above are implemented but still open (marked *pending close*);
+  they're listed for an accurate picture and should be triaged closed.
+- Roadmap order is theme-grouped, not strictly sequenced; the active line is
+  v1.5.1 → the #7 status-actions follow-up → (when there's demand) #76.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.1
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
Adds PLAN.md (themed roadmap of all open issues, headlined by #76 the agent orchestrator) and bumps the install reference + plugin manifests to v1.5.1. v1.5.1 ships #73 (capabilities.runtime_actions), #74/#68 (send idle-check), #75 (action metadata). Docs/version only.