### PR TITLE
Unify status/resume liveness behind one shared classifier (#79)

### DIFF
--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -132,8 +132,14 @@ func classifyAgentLiveness(agentDir, root, handle, role, binary, workstream, cwd
 		}
 	}
 
-	// Presence freshness/active/handle rules, identical to the prior status
-	// logic (and to preflight/list).
+	// Presence freshness/active/handle rules, plus the preflight's
+	// zombie-heartbeat guard (#38/#44). A fresh presence only proves SOMETHING
+	// wrote the file in the last 90s; if both the launch and wake writer records
+	// exist and both PIDs are confirmed dead, the file is a leftover heartbeat,
+	// not a live agent. presenceWriterIsKnownDead is the SAME guard the launch
+	// preflight applies, so status, resume, and preflight agree. It is
+	// conservative: only a both-records-present, both-dead case demotes
+	// presence; a missing/unknown writer keeps presence as live (unchanged).
 	presenceLive := false
 	presenceMismatched := false
 	if presenceErr == nil {
@@ -143,7 +149,7 @@ func classifyAgentLiveness(agentDir, root, handle, role, binary, workstream, cwd
 		active := strings.EqualFold(presence.Status, "active")
 		handleOK := presence.Handle == "" || presence.Handle == handle
 		switch {
-		case fresh && active && handleOK:
+		case fresh && active && handleOK && !presenceWriterIsKnownDead(agentDir, root, handle, binary, probe):
 			presenceLive = true
 		case fresh && active && !handleOK:
 			presenceMismatched = true

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -54,6 +54,12 @@ type agentLiveness struct {
 	// Signals is the populated status signal block (agent pid/alive/match,
 	// wake pid/alive, presence/last-seen).
 	Signals statusSignals
+	// PresenceLive is true when a fresh, active, same-handle presence is a real
+	// live signal (i.e. it passed the zombie-heartbeat guard). It is kept
+	// separate from the single Verdict so resume can list EVERY live source in
+	// its note (e.g. "wake+launch+presence"), matching the pre-unification
+	// blocker summary.
+	PresenceLive bool
 	// LaunchRecord is the parsed launch.json (zero value when none/unreadable).
 	LaunchRecord launch.Record
 	// LaunchFound is true when launch.json parsed successfully.
@@ -155,6 +161,7 @@ func classifyAgentLiveness(agentDir, root, handle, role, binary, workstream, cwd
 			presenceMismatched = true
 		}
 	}
+	out.PresenceLive = presenceLive
 
 	if out.Signals.AgentAlive && out.Signals.BinaryMatch {
 		out.Verdict = livenessAgentLive

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+// agentLivenessVerdict is the single shared liveness vocabulary that BOTH
+// `status` and `resume` consume so they can never disagree about whether an
+// agent is alive. It is finer-grained than statusState (it distinguishes the
+// three "live" sub-reasons) so callers can map it to their own surface:
+// status collapses agent/presence/replacement to "live"; resume treats all
+// four live verdicts as "skip-live".
+type agentLivenessVerdict string
+
+const (
+	// livenessAgentLive: the launch-record AgentPID is alive AND its binary
+	// matches. The agent process itself is verified running.
+	livenessAgentLive agentLivenessVerdict = "agent-live"
+	// livenessWakeLive: the wake helper is verified live for this handle/root,
+	// but the agent PID itself is not verified.
+	livenessWakeLive agentLivenessVerdict = "wake-live"
+	// livenessPresenceLive: a fresh, active presence.json for this handle, with
+	// no verified PID. The agent is heartbeating even though no PID is proven.
+	livenessPresenceLive agentLivenessVerdict = "presence-live"
+	// livenessReplacementLive: the recorded PID is dead, but a live tmux pane
+	// resolves to this member (the relaunched-outside-amq-squad case).
+	livenessReplacementLive agentLivenessVerdict = "replacement-live"
+	// livenessStale: live-pointing disk signals exist (launch record, wake
+	// lock, or mismatched fresh presence) but none verify as usable for this
+	// handle.
+	livenessStale agentLivenessVerdict = "stale"
+	// livenessMissing: no launch record, no wake lock, no usable presence for
+	// this handle. The member is configured but has never run (or its artifacts
+	// are gone) in the resolved session.
+	livenessMissing agentLivenessVerdict = "missing"
+)
+
+// agentLiveness is the shared classifier's output: the verdict plus everything
+// status and resume need to render their respective surfaces without
+// re-reading disk or re-running the probe.
+type agentLiveness struct {
+	Verdict agentLivenessVerdict
+	// Status is the statusState this verdict maps to, so classifyMemberStatus
+	// can adopt it directly.
+	Status statusState
+	// Detail is the human-readable one-line explanation, identical to the
+	// detail string status emitted before unification.
+	Detail string
+	// Signals is the populated status signal block (agent pid/alive/match,
+	// wake pid/alive, presence/last-seen).
+	Signals statusSignals
+	// LaunchRecord is the parsed launch.json (zero value when none/unreadable).
+	LaunchRecord launch.Record
+	// LaunchFound is true when launch.json parsed successfully.
+	LaunchFound bool
+	// Tmux is the persisted tmux runtime identity from the launch record, when
+	// any. nil when the record carried no tmux block or no record was found.
+	Tmux *launch.TmuxInfo
+	// ReplacementTarget is the live tmux pane jump target when the verdict is
+	// replacement-live; empty otherwise.
+	ReplacementTarget string
+}
+
+// Live reports whether the verdict is any of the live sub-states. Both status
+// (live/wake-live) and resume (skip-live) branch on this.
+func (l agentLiveness) Live() bool {
+	switch l.Verdict {
+	case livenessAgentLive, livenessWakeLive, livenessPresenceLive, livenessReplacementLive:
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyAgentLiveness performs ONE read of launch.json / wake.lock /
+// presence plus the probe checks and returns the single shared verdict that
+// status and resume both consume. It reproduces the exact signal+state logic
+// that classifyMemberStatus used before unification, including:
+//   - agent: launch AgentPID alive AND binary matches,
+//   - wake: wake-lock PID alive AND an `amq wake` for this handle/root,
+//   - presence: fresh + active + handle rules (the zombie-writer guard is
+//     applied by the caller's freshness check exactly as before — see below),
+//   - the live-replacement-pane fallback (relaunched-outside-amq-squad).
+//
+// agentDir is the resolved mailbox dir; root is its AMQ root; handle is the
+// resolved handle; role/binary/workstream identify the member for the
+// replacement-pane resolver. probe abstracts liveness/process inspection so
+// tests inject deterministic behavior.
+func classifyAgentLiveness(agentDir, root, handle, role, binary, workstream, cwd string, probe duplicateLaunchProbe) agentLiveness {
+	out := agentLiveness{}
+
+	launchRec, launchErr := launch.Read(agentDir)
+	if launchErr == nil {
+		out.LaunchFound = true
+		out.LaunchRecord = launchRec
+		out.Tmux = launchRec.Tmux
+	}
+	wakeLock, wakeErr := readWakeLock(agentDir)
+	presence, presenceErr := readPresenceForEntry(agentDir)
+
+	hasLaunchPID := launchErr == nil && launchRec.AgentPID > 0
+	hasWakePID := wakeErr == nil && wakeLock.PID > 0
+
+	if hasLaunchPID {
+		out.Signals.AgentPID = launchRec.AgentPID
+		if probe.PIDAlive(launchRec.AgentPID) {
+			out.Signals.AgentAlive = true
+			b := strings.TrimSpace(launchRec.Binary)
+			if b == "" {
+				b = binary
+			}
+			if b != "" && probe.ProcessMatch(launchRec.AgentPID, agentProcessMatcher(b)) {
+				out.Signals.BinaryMatch = true
+			}
+		}
+	}
+	if hasWakePID {
+		out.Signals.WakePID = wakeLock.PID
+		if probe.PIDAlive(wakeLock.PID) {
+			expectedRoot := root
+			if wakeLock.Root != "" {
+				expectedRoot = wakeLock.Root
+			}
+			if probe.ProcessMatch(wakeLock.PID, wakeProcessMatcher(handle, expectedRoot)) {
+				out.Signals.WakeAlive = true
+			}
+		}
+	}
+
+	// Presence freshness/active/handle rules, identical to the prior status
+	// logic (and to preflight/list).
+	presenceLive := false
+	presenceMismatched := false
+	if presenceErr == nil {
+		out.Signals.Presence = presence.Status
+		out.Signals.LastSeen = presence.LastSeen
+		fresh := !presence.LastSeen.IsZero() && probe.Now().Sub(presence.LastSeen) <= presenceFreshness
+		active := strings.EqualFold(presence.Status, "active")
+		handleOK := presence.Handle == "" || presence.Handle == handle
+		switch {
+		case fresh && active && handleOK:
+			presenceLive = true
+		case fresh && active && !handleOK:
+			presenceMismatched = true
+		}
+	}
+
+	if out.Signals.AgentAlive && out.Signals.BinaryMatch {
+		out.Verdict = livenessAgentLive
+		out.Status = statusStateLive
+		out.Detail = fmt.Sprintf("agent pid %d alive (%s)", out.Signals.AgentPID, binary)
+		return out
+	}
+	if presenceLive {
+		out.Verdict = livenessPresenceLive
+		out.Status = statusStateLive
+		out.Detail = fmt.Sprintf("fresh active presence, no verified pid (last seen %s)", presence.LastSeen.UTC().Format(time.RFC3339))
+		return out
+	}
+	if out.Signals.WakeAlive {
+		out.Verdict = livenessWakeLive
+		out.Status = statusStateWakeLive
+		out.Detail = wakeLiveDetail(out.Signals)
+		return out
+	}
+
+	// Not live. Stale requires a live-pointing disk signal for this handle.
+	// Lone stale/inactive/old presence does not count; it collapses to missing.
+	hasLiveSignal := hasLaunchPID || hasWakePID || presenceMismatched
+	if !hasLiveSignal {
+		out.Verdict = livenessMissing
+		out.Status = statusStateMissing
+		out.Detail = "no live signals for this handle"
+		return out
+	}
+
+	// Before settling on stale: the recorded PID may be dead because the agent
+	// was relaunched OUTSIDE amq-squad, leaving a live replacement process the
+	// launch record never learned about. Look for a live tmux pane that
+	// resolves to this member.
+	if target, ok := classifierReplacementPane(role, handle, binary, cwd, workstream); ok {
+		out.Verdict = livenessReplacementLive
+		out.Status = statusStateLive
+		out.ReplacementTarget = target
+		out.Detail = fmt.Sprintf("recorded pid dead; live %s at %s — relaunch via amq-squad to re-register", binary, target)
+		return out
+	}
+
+	out.Verdict = livenessStale
+	out.Status = statusStateStale
+	out.Detail = staleDetail(out.Signals, presenceMismatched) + "; relaunch via amq-squad to re-register"
+	return out
+}
+
+// classifierReplacementPane is the verdict-level live-replacement detector. It
+// delegates to liveReplacementPane (the single neutral tmux resolver shared
+// with status) so there is exactly one replacement-detection implementation and
+// its existing tests stay authoritative. The classifier carries bare identity
+// fields, so it assembles the minimal team.Member + statusRecord the resolver
+// needs.
+func classifierReplacementPane(role, handle, binary, cwd, workstream string) (string, bool) {
+	m := team.Member{Role: role, Handle: handle, Binary: binary}
+	rec := statusRecord{Role: role, Handle: handle, Binary: binary, CWD: cwd}
+	return liveReplacementPane(m, rec, workstream)
+}

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -314,3 +314,128 @@ func TestClassifierReplacementLive(t *testing.T) {
 		t.Fatalf("replacement detail should mention recorded pid dead, got %q", live.Detail)
 	}
 }
+
+// TestStatusAndResumeAgreeOnZombiePresence is the #44 zombie-heartbeat
+// regression carried into the shared classifier: a FRESH active same-handle
+// presence.json whose launch+wake writer PIDs are BOTH confirmed dead is a
+// leftover heartbeat, not a live agent. The classifier must apply the same
+// zombie guard the launch preflight does, so the verdict is stale (not
+// presence-live). Status then correctly reports stale (previously it wrongly
+// said live -- the latent #44 bug), and resume offers restore with a command
+// (previously it would have reported action=live with no command). Both
+// surfaces must agree on stale.
+func TestStatusAndResumeAgreeOnZombiePresence(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	root := filepath.Join(base, "issue-96")
+	agentDir := filepath.Join(root, "agents", "cto")
+
+	// Both writer records present with dead PIDs.
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 7777, StartedAt: time.Now(),
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 8888, Root: root, Started: time.Now()})
+
+	// A fresh, active, same-handle presence -- the zombie heartbeat.
+	now := time.Now()
+	writeStatusPresence(t, base, "issue-96", "cto", presenceFile{
+		Handle:   "cto",
+		Status:   "active",
+		LastSeen: now.Add(-10 * time.Second),
+	})
+
+	// No live tmux pane, so the replacement-live fallback never fires.
+	withStubPaneLister(t, nil, nil)
+
+	// Both writer PIDs dead; neither matches.
+	probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+	// 1) Classifier: zombie presence demotes to stale (NOT presence-live).
+	live := classifyAgentLiveness(agentDir, root, "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessStale {
+		t.Fatalf("zombie presence verdict = %q, want stale", live.Verdict)
+	}
+	if live.Status != statusStateStale {
+		t.Fatalf("zombie presence status = %q, want stale (detail %q)", live.Status, live.Detail)
+	}
+	if live.Live() {
+		t.Fatalf("zombie presence must not report Live()")
+	}
+
+	// 2) classifyMemberStatus reports stale (the #44 fix at the status layer).
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateStale {
+		t.Fatalf("status = %q, want stale (detail %q)", rec.Status, rec.Detail)
+	}
+
+	// 3) resume offers restore with a command -- NOT live-with-no-command.
+	plan, err := planMemberResume(memberPlanInput{
+		Member:     tm.Members[0],
+		Team:       tm,
+		Workstream: "issue-96",
+		Mode:       resumeModeDefault,
+		SquadBin:   teamSquadBin(),
+		Probe:      probe,
+	})
+	if err != nil {
+		t.Fatalf("planMemberResume: %v", err)
+	}
+	if plan.Action == resumeLive {
+		t.Fatalf("zombie-presence resume action = live; want restore. note=%q", plan.Note)
+	}
+	if plan.Action != resumeRestore {
+		t.Fatalf("zombie-presence resume action = %q, want restore", plan.Action)
+	}
+	if strings.TrimSpace(plan.Command) == "" {
+		t.Fatalf("zombie-presence restore must emit a non-empty command, got empty")
+	}
+
+	// 4) Agreement: status stale <-> resume not-live.
+	if rec.Status == statusStateStale && plan.Action == resumeLive {
+		t.Fatalf("status and resume disagree on zombie presence: status=stale but resume=live")
+	}
+}
+
+// TestClassifierPresenceLiveWhenWriterUnknown pins the conservative half of the
+// zombie guard: a fresh active presence with NO writer records (or a missing
+// one) still counts as presence-live, exactly as before. Only a both-present,
+// both-dead case demotes it. This guards against the guard over-reaching.
+func TestClassifierPresenceLiveWhenWriterUnknown(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	root := filepath.Join(base, "issue-96")
+	agentDir := filepath.Join(root, "agents", "cto")
+
+	// Fresh active presence, but NO launch.json and NO wake.lock: writers are
+	// unknown, so presence must still count as live.
+	now := time.Now()
+	writeStatusPresence(t, base, "issue-96", "cto", presenceFile{
+		Handle:   "cto",
+		Status:   "active",
+		LastSeen: now.Add(-10 * time.Second),
+	})
+	withStubPaneLister(t, nil, nil)
+	probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+	live := classifyAgentLiveness(agentDir, root, "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessPresenceLive {
+		t.Fatalf("presence with unknown writers verdict = %q, want presence-live", live.Verdict)
+	}
+	if live.Status != statusStateLive {
+		t.Fatalf("presence with unknown writers status = %q, want live", live.Status)
+	}
+}

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
+)
+
+// livenessProbe builds a deterministic probe for the unification tests: a PID
+// is alive iff it is in alive, and ProcessMatch is true iff the pid is in
+// match. Now is fixed so presence freshness is reproducible.
+func livenessProbe(alive, match map[int]bool, now time.Time) duplicateLaunchProbe {
+	return duplicateLaunchProbe{
+		PIDAlive:     func(pid int) bool { return alive[pid] },
+		ProcessMatch: func(pid int, _ func(args string) bool) bool { return match[pid] },
+		Now:          func() time.Time { return now },
+	}
+}
+
+// TestStatusAndResumeAgreeOnStaleAgent is the core #79 regression: a genuinely
+// stale agent on disk (dead launch AgentPID + dead/unrelated wake PID, with no
+// fresh active presence and no live replacement pane) must be deemed stale by
+// the single shared classifier, render as `stale` in status, and resume to a
+// RESTORE action (with a real command) -- never `live`. Before unification,
+// status and resume classified liveness independently and could disagree
+// (status stale, resume live). Now they consume one verdict and must agree.
+func TestStatusAndResumeAgreeOnStaleAgent(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	// Stale launch record: a captured AgentPID that is no longer alive.
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 7777, StartedAt: time.Now(),
+	})
+	// Stale wake lock: a wake PID that is dead/unrelated.
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 8888, Root: filepath.Join(base, "issue-96")})
+
+	// No tmux panes, so the replacement-live fallback never fires (and the test
+	// never shells real tmux).
+	withStubPaneLister(t, nil, nil)
+
+	now := time.Now()
+	// Both pids dead, neither matches.
+	probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+	// 1) The shared classifier verdict is stale.
+	live := classifyAgentLiveness(agentDir, filepath.Join(base, "issue-96"), "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessStale {
+		t.Fatalf("classifier verdict = %q, want %q", live.Verdict, livenessStale)
+	}
+	if live.Status != statusStateStale {
+		t.Fatalf("classifier status = %q, want stale", live.Status)
+	}
+	if live.Live() {
+		t.Fatalf("stale verdict must not report Live()")
+	}
+
+	// 2) classifyMemberStatus maps it to stale.
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateStale {
+		t.Fatalf("status = %q, want stale (detail %q)", rec.Status, rec.Detail)
+	}
+
+	// 3) planMemberResume must restore (record exists), NOT live, and emit a
+	//    non-empty command. This is the fix: the stale agent resumes.
+	plan, err := planMemberResume(memberPlanInput{
+		Member:     tm.Members[0],
+		Team:       tm,
+		Workstream: "issue-96",
+		Mode:       resumeModeDefault,
+		SquadBin:   teamSquadBin(),
+		Probe:      probe,
+	})
+	if err != nil {
+		t.Fatalf("planMemberResume: %v", err)
+	}
+	if plan.Action == resumeLive {
+		t.Fatalf("resume action = live for a stale agent; want restore. note=%q", plan.Note)
+	}
+	if plan.Action != resumeRestore {
+		t.Fatalf("resume action = %q, want restore", plan.Action)
+	}
+	if strings.TrimSpace(plan.Command) == "" {
+		t.Fatalf("restore action must emit a non-empty command, got empty")
+	}
+
+	// 4) Agreement: status stale <-> resume not-live.
+	if rec.Status == statusStateStale && plan.Action == resumeLive {
+		t.Fatalf("status and resume disagree: status=stale but resume=live")
+	}
+}
+
+// TestStatusAndResumeAgreeOnMissingAgent: with no records at all, the verdict
+// is missing, status renders missing, and resume launches fresh (no record to
+// restore) -- never live.
+func TestStatusAndResumeAgreeOnMissingAgent(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	withStubPaneLister(t, nil, nil)
+
+	now := time.Now()
+	probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+	live := classifyAgentLiveness(agentDir, filepath.Join(base, "issue-96"), "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessMissing {
+		t.Fatalf("classifier verdict = %q, want missing", live.Verdict)
+	}
+
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateMissing {
+		t.Fatalf("status = %q, want missing", rec.Status)
+	}
+
+	plan, err := planMemberResume(memberPlanInput{
+		Member:     tm.Members[0],
+		Team:       tm,
+		Workstream: "issue-96",
+		Mode:       resumeModeDefault,
+		SquadBin:   teamSquadBin(),
+		Probe:      probe,
+	})
+	if err != nil {
+		t.Fatalf("planMemberResume: %v", err)
+	}
+	if plan.Action == resumeLive {
+		t.Fatalf("resume action = live for a missing agent; want launch fresh")
+	}
+	if plan.Action != resumeFresh {
+		t.Fatalf("resume action = %q, want launch fresh", plan.Action)
+	}
+	if strings.TrimSpace(plan.Command) == "" {
+		t.Fatalf("fresh action must emit a non-empty command, got empty")
+	}
+}
+
+// TestStatusAndResumeAgreeOnLiveAgentPID: a live agent PID (alive + binary
+// match) must be agent-live in the classifier, `live` in status, and `live`
+// (command suppressed) in resume.
+func TestStatusAndResumeAgreeOnLiveAgentPID(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	withStubPaneLister(t, nil, nil)
+
+	now := time.Now()
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, now)
+
+	live := classifyAgentLiveness(agentDir, filepath.Join(base, "issue-96"), "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessAgentLive {
+		t.Fatalf("classifier verdict = %q, want agent-live", live.Verdict)
+	}
+	if !live.Live() {
+		t.Fatalf("agent-live verdict must report Live()")
+	}
+
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateLive {
+		t.Fatalf("status = %q, want live", rec.Status)
+	}
+
+	plan, err := planMemberResume(memberPlanInput{
+		Member:     tm.Members[0],
+		Team:       tm,
+		Workstream: "issue-96",
+		Mode:       resumeModeDefault,
+		SquadBin:   teamSquadBin(),
+		Probe:      probe,
+	})
+	if err != nil {
+		t.Fatalf("planMemberResume: %v", err)
+	}
+	if plan.Action != resumeLive {
+		t.Fatalf("resume action = %q, want live", plan.Action)
+	}
+	if plan.Command != "" {
+		t.Fatalf("live member must suppress its command by default, got %q", plan.Command)
+	}
+}
+
+// TestStatusAndResumeAgreeOnLiveWakeOnly: a live wake lock with no launch
+// record is wake-live in the classifier, `wake-live` in status, and `live`
+// (command suppressed) in resume. The wake matcher must verify the live PID is
+// an amq wake for this handle/root, so this probe matches on a real-looking arg
+// string.
+func TestStatusAndResumeAgreeOnLiveWakeOnly(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	root := filepath.Join(base, "issue-96")
+	agentDir := filepath.Join(root, "agents", "cto")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4321, Root: root, Started: time.Now()})
+	withStubPaneLister(t, nil, nil)
+
+	now := time.Now()
+	probe := duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == 4321 },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return pid == 4321 && predicate("amq wake --me cto --root "+root)
+		},
+		Now: func() time.Time { return now },
+	}
+
+	live := classifyAgentLiveness(agentDir, root, "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessWakeLive {
+		t.Fatalf("classifier verdict = %q, want wake-live", live.Verdict)
+	}
+	if live.Status != statusStateWakeLive {
+		t.Fatalf("classifier status = %q, want wake-live", live.Status)
+	}
+
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateWakeLive {
+		t.Fatalf("status = %q, want wake-live", rec.Status)
+	}
+
+	plan, err := planMemberResume(memberPlanInput{
+		Member:     tm.Members[0],
+		Team:       tm,
+		Workstream: "issue-96",
+		Mode:       resumeModeDefault,
+		SquadBin:   teamSquadBin(),
+		Probe:      probe,
+	})
+	if err != nil {
+		t.Fatalf("planMemberResume: %v", err)
+	}
+	if plan.Action != resumeLive {
+		t.Fatalf("resume action = %q, want live (wake-live should suppress relaunch)", plan.Action)
+	}
+	if plan.Command != "" {
+		t.Fatalf("wake-live member must suppress its command by default, got %q", plan.Command)
+	}
+}
+
+// TestClassifierReplacementLive: a dead recorded PID but a live SAME-ENGINE
+// pane in the member cwd yields the replacement-live verdict (status live),
+// proving the verdict-level replacement detector delegates to the shared
+// resolver.
+func TestClassifierReplacementLive(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 4242, StartedAt: time.Now(),
+	})
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	withStubPaneLister(t, []tmuxpane.TmuxPane{
+		{Session: "main", Window: "0", Pane: "3", Command: "codex", CWD: canonicalPath(dir)},
+	}, nil)
+
+	now := time.Now()
+	probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+	live := classifyAgentLiveness(agentDir, filepath.Join(base, "issue-96"), "cto", "cto", "codex", "issue-96", dir, probe)
+	if live.Verdict != livenessReplacementLive {
+		t.Fatalf("classifier verdict = %q, want replacement-live", live.Verdict)
+	}
+	if live.Status != statusStateLive {
+		t.Fatalf("classifier status = %q, want live", live.Status)
+	}
+	if !strings.Contains(live.Detail, "recorded pid dead") {
+		t.Fatalf("replacement detail should mention recorded pid dead, got %q", live.Detail)
+	}
+}

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -439,3 +439,31 @@ func TestClassifierPresenceLiveWhenWriterUnknown(t *testing.T) {
 		t.Fatalf("presence with unknown writers status = %q, want live", live.Status)
 	}
 }
+
+// resumeLiveNote must list EVERY live source (not just the highest-precedence
+// verdict) in preflight blocker order wake+launch+presence, matching the
+// pre-unification summarizeBlocker output the resume contract promised.
+func TestResumeLiveNoteListsAllLiveSources(t *testing.T) {
+	all := agentLiveness{
+		Verdict:      livenessAgentLive, // highest-precedence verdict...
+		Signals:      statusSignals{AgentAlive: true, BinaryMatch: true, WakeAlive: true},
+		PresenceLive: true, // ...but every source is live
+	}
+	if got := resumeLiveNote(all, "codex"); got != "wake+launch+presence" {
+		t.Errorf("multi-signal note = %q, want %q", got, "wake+launch+presence")
+	}
+	// A subset (wake + presence, no live agent pid).
+	sub := agentLiveness{Verdict: livenessPresenceLive, Signals: statusSignals{WakeAlive: true}, PresenceLive: true}
+	if got := resumeLiveNote(sub, "codex"); got != "wake+presence" {
+		t.Errorf("subset note = %q, want %q", got, "wake+presence")
+	}
+	// Single source.
+	if got := resumeLiveNote(agentLiveness{Verdict: livenessWakeLive, Signals: statusSignals{WakeAlive: true}}, "codex"); got != "wake" {
+		t.Errorf("wake-only note = %q, want wake", got)
+	}
+	// Replacement keeps its distinct phrasing + target.
+	repl := agentLiveness{Verdict: livenessReplacementLive, ReplacementTarget: "%5"}
+	if got := resumeLiveNote(repl, "codex"); !strings.Contains(got, "%5") || !strings.Contains(got, "recorded pid dead") {
+		t.Errorf("replacement note = %q, want it to mention the dead pid + target", got)
+	}
+}

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -305,18 +305,32 @@ func (p agentLaunchPreflight) inspectPresence(probe duplicateLaunchProbe) (*bloc
 	}, nil
 }
 
+// presenceWriterIsKnownDead delegates to the shared free function so the
+// zombie-heartbeat guard has ONE implementation used by both the preflight and
+// the shared liveness classifier (classifyAgentLiveness). The preflight has no
+// distinct Binary in this guard (launchWriterDead falls back to the record's
+// own binary, then p.Binary), so it is passed through.
+func (p agentLaunchPreflight) presenceWriterIsKnownDead(probe duplicateLaunchProbe) bool {
+	return presenceWriterIsKnownDead(p.AgentDir, p.Root, p.Handle, p.Binary, probe)
+}
+
 // presenceWriterIsKnownDead reports whether the on-disk wake.lock and
 // launch.json both point at processes that are gone (dead PID or PID-reuse
 // by an unrelated process). When either record is missing we cannot prove
 // the writer is dead, so we keep the conservative behavior (presence
-// blocks). Only when both records exist and both are confirmed dead do we
-// treat the presence file as a zombie heartbeat.
-func (p agentLaunchPreflight) presenceWriterIsKnownDead(probe duplicateLaunchProbe) bool {
-	lockDead, lockKnown := p.wakeWriterDead(probe)
+// counts as live / preflight blocks). Only when both records exist and both
+// are confirmed dead do we treat the presence file as a zombie heartbeat.
+//
+// This is the single shared guard: agentLaunchPreflight.inspectPresence and
+// classifyAgentLiveness both call it so status, resume, and the launch
+// preflight agree about what a fresh-but-dead-writer presence means. fallbackBinary
+// is the agent binary to assume when the launch record itself carries none.
+func presenceWriterIsKnownDead(agentDir, root, handle, fallbackBinary string, probe duplicateLaunchProbe) bool {
+	lockDead, lockKnown := wakeWriterDead(agentDir, root, handle, probe)
 	if !lockKnown {
 		return false
 	}
-	launchDead, launchKnown := p.launchWriterDead(probe)
+	launchDead, launchKnown := launchWriterDead(agentDir, fallbackBinary, probe)
 	if !launchKnown {
 		return false
 	}
@@ -328,10 +342,11 @@ func (p agentLaunchPreflight) presenceWriterIsKnownDead(probe duplicateLaunchPro
 // when the PID is gone or the live PID does not match an amq wake for this
 // handle/root. A corrupt or unparseable lock is reported as unknown (not
 // dead): we have no evidence either way and the conservative answer for
-// the zombie-presence guard is to keep blocking. The stale-cleanup path in
-// inspectWakeLock still removes the corrupt file on its own.
-func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, known bool) {
-	data, err := os.ReadFile(wakeLockPath(p.AgentDir))
+// the zombie-presence guard is to keep counting presence as live. The
+// stale-cleanup path in inspectWakeLock still removes the corrupt file on its
+// own.
+func wakeWriterDead(agentDir, root, handle string, probe duplicateLaunchProbe) (dead, known bool) {
+	data, err := os.ReadFile(wakeLockPath(agentDir))
 	if err != nil {
 		return false, false
 	}
@@ -345,11 +360,11 @@ func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, 
 	if !probe.PIDAlive(lock.PID) {
 		return true, true
 	}
-	expectedRoot := p.Root
+	expectedRoot := root
 	if lock.Root != "" {
 		expectedRoot = lock.Root
 	}
-	if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(p.Handle, expectedRoot)) {
+	if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, expectedRoot)) {
 		return true, true
 	}
 	return false, true
@@ -358,9 +373,10 @@ func (p agentLaunchPreflight) wakeWriterDead(probe duplicateLaunchProbe) (dead, 
 // launchWriterDead inspects launch.json. Returns (dead, known): "known" is
 // true when the record existed and parsed and carries a captured AgentPID;
 // "dead" is true when that PID is gone or the live PID does not match the
-// expected agent binary.
-func (p agentLaunchPreflight) launchWriterDead(probe duplicateLaunchProbe) (dead, known bool) {
-	rec, err := launch.Read(p.AgentDir)
+// expected agent binary. fallbackBinary is used only when the record itself
+// recorded no binary.
+func launchWriterDead(agentDir, fallbackBinary string, probe duplicateLaunchProbe) (dead, known bool) {
+	rec, err := launch.Read(agentDir)
 	if err != nil {
 		return false, false
 	}
@@ -374,7 +390,7 @@ func (p agentLaunchPreflight) launchWriterDead(probe duplicateLaunchProbe) (dead
 	}
 	binary := strings.TrimSpace(rec.Binary)
 	if binary == "" {
-		binary = p.Binary
+		binary = fallbackBinary
 	}
 	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
 		return true, true

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -11,7 +11,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/state"
 	"github.com/omriariav/amq-squad/internal/team"
 	"github.com/omriariav/amq-squad/internal/tmuxpane"
@@ -255,97 +254,16 @@ func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe d
 	rec.Root = root
 	rec.AgentDir = filepath.Join(root, "agents", rec.Handle)
 
-	launchRec, launchErr := launch.Read(rec.AgentDir)
-	if launchErr == nil {
-		rec.Tmux = tmuxRuntimeFromInfo(launchRec.Tmux)
-	}
-	wakeLock, wakeErr := readWakeLock(rec.AgentDir)
-	presence, presenceErr := readPresenceForEntry(rec.AgentDir)
-
-	hasLaunchPID := launchErr == nil && launchRec.AgentPID > 0
-	hasWakePID := wakeErr == nil && wakeLock.PID > 0
-
-	if hasLaunchPID {
-		rec.Signals.AgentPID = launchRec.AgentPID
-		if probe.PIDAlive(launchRec.AgentPID) {
-			rec.Signals.AgentAlive = true
-			binary := strings.TrimSpace(launchRec.Binary)
-			if binary == "" {
-				binary = m.Binary
-			}
-			if binary != "" && probe.ProcessMatch(launchRec.AgentPID, agentProcessMatcher(binary)) {
-				rec.Signals.BinaryMatch = true
-			}
-		}
-	}
-	if hasWakePID {
-		rec.Signals.WakePID = wakeLock.PID
-		if probe.PIDAlive(wakeLock.PID) {
-			expectedRoot := rec.Root
-			if wakeLock.Root != "" {
-				expectedRoot = wakeLock.Root
-			}
-			if probe.ProcessMatch(wakeLock.PID, wakeProcessMatcher(rec.Handle, expectedRoot)) {
-				rec.Signals.WakeAlive = true
-			}
-		}
-	}
-	// Apply the same freshness/active/handle rules preflight and list use so
-	// status agrees with them about what counts as a live presence signal.
-	presenceLive := false
-	presenceMismatched := false
-	if presenceErr == nil {
-		rec.Signals.Presence = presence.Status
-		rec.Signals.LastSeen = presence.LastSeen
-		fresh := !presence.LastSeen.IsZero() && probe.Now().Sub(presence.LastSeen) <= presenceFreshness
-		active := strings.EqualFold(presence.Status, "active")
-		handleOK := presence.Handle == "" || presence.Handle == rec.Handle
-		switch {
-		case fresh && active && handleOK:
-			presenceLive = true
-		case fresh && active && !handleOK:
-			presenceMismatched = true
-		}
-	}
-
-	if rec.Signals.AgentAlive && rec.Signals.BinaryMatch {
-		rec.Status = statusStateLive
-		rec.Detail = fmt.Sprintf("agent pid %d alive (%s)", rec.Signals.AgentPID, m.Binary)
-		return rec
-	}
-	if presenceLive {
-		rec.Status = statusStateLive
-		rec.Detail = fmt.Sprintf("fresh active presence, no verified pid (last seen %s)", presence.LastSeen.UTC().Format(time.RFC3339))
-		return rec
-	}
-	if rec.Signals.WakeAlive {
-		rec.Status = statusStateWakeLive
-		rec.Detail = wakeLiveDetail(rec.Signals)
-		return rec
-	}
-	// Not live. Stale requires a live-pointing disk signal for this handle.
-	// Lone stale/inactive/old presence does not count; it collapses to missing
-	// so old presence files don't lock a member into "stale" forever.
-	hasLiveSignal := hasLaunchPID || hasWakePID || presenceMismatched
-	if !hasLiveSignal {
-		rec.Status = statusStateMissing
-		rec.Detail = "no live signals for this handle"
-		return rec
-	}
-	// Before settling on stale: the recorded PID may be dead because the agent
-	// was relaunched OUTSIDE amq-squad (e.g. "relaunching as dogfood QA"), leaving
-	// a live replacement process the launch record never learned about. Look for a
-	// live tmux pane that resolves to this member (same engine + cwd, title-first,
-	// via the same neutral tmux resolver). If found, report live with a
-	// re-register hint rather than a misleading stale.
-	if target, ok := liveReplacementPane(m, rec, workstream); ok {
-		rec.Status = statusStateLive
-		rec.Detail = fmt.Sprintf("recorded pid dead; live %s at %s — relaunch via amq-squad to re-register", m.Binary, target)
-		return rec
-	}
-
-	rec.Status = statusStateStale
-	rec.Detail = staleDetail(rec.Signals, presenceMismatched) + "; relaunch via amq-squad to re-register"
+	// Consume the single shared liveness classifier so status and resume can
+	// never disagree. classifyAgentLiveness does the one disk read + probe
+	// checks and returns the verdict, signals, detail, status state, and the
+	// persisted tmux identity. classifyMemberStatus then just adopts them; the
+	// verdict->statusState mapping lives in the classifier (Status field).
+	live := classifyAgentLiveness(rec.AgentDir, root, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe)
+	rec.Tmux = tmuxRuntimeFromInfo(live.Tmux)
+	rec.Signals = live.Signals
+	rec.Status = live.Status
+	rec.Detail = live.Detail
 	return rec
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -153,6 +153,7 @@ Examples:
 		DryRun:           *dryRun,
 		Profile:          profile,
 		JSON:             *jsonOut,
+		Probe:            defaultDuplicateLaunchProbe,
 	})
 }
 
@@ -176,6 +177,12 @@ type resumeExecution struct {
 	// JSON emits a schema-versioned resume_plan envelope instead of the human
 	// plan. It is a read-only preview, so it is mutually exclusive with Exec.
 	JSON bool
+	// Probe abstracts liveness/process inspection for the per-member live-signal
+	// classification (mirrors how statusExecution takes a probe). Defaults to
+	// defaultDuplicateLaunchProbe when unset; tests inject a deterministic probe.
+	// It does NOT govern the exec-time launch preflight, which stays on the
+	// authoritative defaultDuplicateLaunchProbe (see execResumePlan).
+	Probe duplicateLaunchProbe
 	// Style controls the printer header label and footer verb so the same
 	// planner can present its output as team resume, resume, or fork without
 	// duplicating logic.
@@ -280,6 +287,15 @@ func executeResume(r resumeExecution) error {
 		return err
 	}
 
+	// Default the probe so callers that build a resumeExecution without one
+	// (older entry points, fork) still classify against real liveness, while
+	// tests can inject a deterministic probe. This mirrors how status takes a
+	// probe and is independent of the exec-time launch preflight.
+	probe := r.Probe
+	if probe.PIDAlive == nil {
+		probe = defaultDuplicateLaunchProbe
+	}
+
 	squadBin := teamSquadBin()
 	plans := make([]resumePlan, 0, len(t.Members))
 	recordCount := 0
@@ -296,6 +312,7 @@ func executeResume(r resumeExecution) error {
 			Trust:          resolvedTrust,
 			ModelOverrides: modelOverrides,
 			Profile:        r.Profile,
+			Probe:          probe,
 		})
 		if err != nil {
 			return err
@@ -540,6 +557,10 @@ type memberPlanInput struct {
 	Trust          string
 	ModelOverrides map[string]string
 	Profile        string
+	// Probe abstracts liveness/process inspection for live-signal
+	// classification. Zero value falls back to defaultDuplicateLaunchProbe so
+	// direct callers and tests that omit it still get real liveness checks.
+	Probe duplicateLaunchProbe
 }
 
 // planMemberResume classifies one team member and emits the appropriate
@@ -586,7 +607,16 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	wakeLabel := wakeHealthForMember(agentDir, root, handle, rec, recFound)
 	plan.Wake = wakeLabel
 
-	// Run preflight in dry-run mode for live-signal classification.
+	probe := in.Probe
+	if probe.PIDAlive == nil {
+		probe = defaultDuplicateLaunchProbe
+	}
+
+	// Surface a real I/O inspection error as blocked, preserving the prior
+	// safety contract. The preflight is still the authority on read errors; we
+	// run it in dry-run mode purely to catch perr (it reaps nothing on disk in
+	// dry-run). The live/stale DECISION, however, comes from the shared
+	// classifier below so status and resume can never disagree.
 	pf := agentLaunchPreflight{
 		AgentDir:   agentDir,
 		Handle:     handle,
@@ -596,8 +626,7 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		Force:      false,
 		DryRun:     true,
 	}
-	blocker, perr := pf.check(defaultDuplicateLaunchProbe)
-	if perr != nil {
+	if _, perr := pf.check(probe); perr != nil {
 		// I/O error reading state: treat as blocked unless forced.
 		plan.Action = resumeBlocked
 		plan.Note = fmt.Sprintf("preflight error: %v", perr)
@@ -616,11 +645,18 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		return plan, nil
 	}
 
-	if blocker != nil {
-		// Live signal detected.
+	// Single shared liveness verdict — the same classifier status consumes.
+	// This is the fix for #79: a genuinely-stale agent is no longer mislabeled
+	// live by resume; the two surfaces now share one verdict.
+	live := classifyAgentLiveness(agentDir, root, handle, m.Role, m.Binary, env.SessionName, cwd, probe)
+
+	if live.Live() {
+		// Live signal detected (agent / wake / presence / replacement). Same
+		// contract as before: suppress the command unless --force-duplicate.
+		note := resumeLiveNote(live, m.Binary)
 		if in.Force {
 			plan.Action = resumeLive
-			plan.Note = "force-duplicate: " + summarizeBlocker(blocker)
+			plan.Note = "force-duplicate: " + note
 			if in.Mode == resumeModeFresh || !recFound {
 				plan.Command = freshLaunchCommand(in)
 			} else {
@@ -631,41 +667,14 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 			return plan, nil
 		}
 		plan.Action = resumeLive
-		plan.Note = summarizeBlocker(blocker)
+		plan.Note = note
 		// Suppress the command by default.
 		plan.Command = ""
 		return plan, nil
 	}
 
-	if recFound && rec.AgentPID > 0 {
-		statusRec := statusRecord{
-			Role:     m.Role,
-			Handle:   handle,
-			Binary:   m.Binary,
-			Session:  env.SessionName,
-			CWD:      cwd,
-			Root:     root,
-			AgentDir: agentDir,
-		}
-		if target, ok := liveReplacementPane(m, statusRec, env.SessionName); ok {
-			note := fmt.Sprintf("recorded pid dead; live %s at %s; relaunch via amq-squad to re-register", m.Binary, target)
-			plan.Action = resumeLive
-			if in.Force {
-				plan.Note = "force-duplicate: " + note
-				if in.Mode == resumeModeFresh {
-					plan.Command = freshLaunchCommand(in)
-				} else {
-					plan.Command = emitCommandWithOptions(rec, emitCommandOptions{Force: true, NoBootstrap: in.NoBootstrap})
-				}
-				return plan, nil
-			}
-			plan.Note = note
-			plan.Command = ""
-			return plan, nil
-		}
-	}
-
-	// No live signal. Choose restore vs fresh based on mode + record presence.
+	// No live signal (verdict stale or missing). Choose restore vs fresh based
+	// on mode + record presence.
 	if in.Mode == resumeModeFresh {
 		plan.Action = resumeFresh
 		plan.Command = freshLaunchCommand(in)
@@ -786,16 +795,26 @@ func wakeHealthForMember(agentDir, expectedRoot, handle string, rec launch.Recor
 	return fmt.Sprintf("pid:%d", lock.PID)
 }
 
-// summarizeBlocker compresses a duplicateBlocker into a one-line note.
-func summarizeBlocker(b *duplicateBlocker) string {
-	if b == nil || len(b.Reasons) == 0 {
+// resumeLiveNote produces the per-member plan Note for a live verdict,
+// preserving the wording resume emitted before the classifier unification:
+//   - replacement-live keeps resume's "recorded pid dead; live <bin> at
+//     <target>; relaunch..." phrasing (the form its tests assert), and
+//   - the agent/wake/presence verdicts collapse to the short source label
+//     summarizeBlocker produced from the preflight blocker (e.g. "launch",
+//     "wake", "presence"), so the table note is unchanged for those cases.
+func resumeLiveNote(live agentLiveness, binary string) string {
+	switch live.Verdict {
+	case livenessReplacementLive:
+		return fmt.Sprintf("recorded pid dead; live %s at %s; relaunch via amq-squad to re-register", binary, live.ReplacementTarget)
+	case livenessAgentLive:
+		return "launch"
+	case livenessWakeLive:
+		return "wake"
+	case livenessPresenceLive:
+		return "presence"
+	default:
 		return "live"
 	}
-	parts := make([]string, 0, len(b.Reasons))
-	for _, r := range b.Reasons {
-		parts = append(parts, r.Source)
-	}
-	return strings.Join(parts, "+")
 }
 
 // freshLaunchCommand emits the same command shape `team launch` would use

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -796,25 +796,31 @@ func wakeHealthForMember(agentDir, expectedRoot, handle string, rec launch.Recor
 }
 
 // resumeLiveNote produces the per-member plan Note for a live verdict,
-// preserving the wording resume emitted before the classifier unification:
+// preserving the exact wording resume emitted before the classifier unification:
 //   - replacement-live keeps resume's "recorded pid dead; live <bin> at
 //     <target>; relaunch..." phrasing (the form its tests assert), and
-//   - the agent/wake/presence verdicts collapse to the short source label
-//     summarizeBlocker produced from the preflight blocker (e.g. "launch",
-//     "wake", "presence"), so the table note is unchanged for those cases.
+//   - the agent/wake/presence verdicts list EVERY live source (not just the
+//     highest-precedence verdict) in the preflight blocker order wake+launch+
+//     presence, joined with "+", exactly as summarizeBlocker did (so a
+//     multi-signal live agent still reads "wake+launch+presence").
 func resumeLiveNote(live agentLiveness, binary string) string {
-	switch live.Verdict {
-	case livenessReplacementLive:
+	if live.Verdict == livenessReplacementLive {
 		return fmt.Sprintf("recorded pid dead; live %s at %s; relaunch via amq-squad to re-register", binary, live.ReplacementTarget)
-	case livenessAgentLive:
-		return "launch"
-	case livenessWakeLive:
-		return "wake"
-	case livenessPresenceLive:
-		return "presence"
-	default:
+	}
+	var parts []string
+	if live.Signals.WakeAlive {
+		parts = append(parts, "wake")
+	}
+	if live.Signals.AgentAlive && live.Signals.BinaryMatch {
+		parts = append(parts, "launch")
+	}
+	if live.PresenceLive {
+		parts = append(parts, "presence")
+	}
+	if len(parts) == 0 {
 		return "live"
 	}
+	return strings.Join(parts, "+")
 }
 
 // freshLaunchCommand emits the same command shape `team launch` would use


### PR DESCRIPTION
PR A of v1.5.2 for **#79** (NOC runtime JSON contract gaps). `status` and `resume` independently classified agent liveness and could **contradict** each other (status `stale`, resume `action: live` for the same agent). This unifies them.

## What
- **New `internal/cli/liveness.go`** — a single `classifyAgentLiveness(...)` that does ONE read of launch.json/wake.lock/presence + the probe checks and returns a shared `{Verdict, Status, Detail, Signals, …}`. Both surfaces consume it, so they can't disagree on the underlying verdict.
- **`classifyMemberStatus` consumes it** and maps verdict→`statusState` (byte-for-byte unchanged for existing cases — status's logic was *extracted*, not rewritten; `status.go` −102 lines).
- **`planMemberResume` consumes it** and maps verdict→`resumeAction`: live verdicts → `live` (command suppressed unless `--force-duplicate`, same contract); **`stale`/`missing` → `restore`/`fresh` with a command** — the fix (a genuinely-dead agent is no longer mislabeled `live`). The probe is now injected into resume planning (was a hardcoded global) for deterministic tests.

## Zombie-heartbeat guard (the subtle correctness point)
The shared classifier applies the preflight's **zombie guard** (`presenceWriterIsKnownDead`, #44): a fresh `presence.json` whose launch+wake writers are *both confirmed dead* is a leftover heartbeat, not a live agent. Extracted into ONE shared implementation used by both the classifier and `agentLaunchPreflight` (the preflight keeps a thin delegating wrapper, behaviorally unchanged). This **fixes a latent #44 status bug** (status used to call such a zombie `live`) and **prevents a resume regression** (resume now correctly offers `restore`, not `live`).

## Safety — duplicate-launch protection unchanged
The exec-time guard (`agentLaunchPreflight.check`) is untouched: `launch.go`, `team_launch.go`, and the `resume --exec` roster preflight still gate launches non-dry-run on `defaultDuplicateLaunchProbe`. The classifier is for classification/display; the preflight stays the execution gate.

## Tests
`internal/cli/liveness_test.go`: status and resume **agree** on a stale agent, on a zombie-presence agent (the #44 case), on missing, on a live agent pid (both live), on live-wake-only (status `wake-live`, resume `live`), and replacement-live. **No existing test needed changing** — all status/resume/preflight/down/list/doctor tests pass unmodified. `go build`/`vet`/`gofmt`/`go test ./...` green.

## Scope
PR A is the internal unification + action-classification fix. **PR B** (follow-up) exposes a `liveness` object on `resume.plan[]` so the NOC compares `liveness.status` (not `action`) to `status.status`, and fixes `resume --help` honesty.

Implemented by a fresh-context agent over two passes; I independently re-verified green, reviewed the classifier/mapping/exec-gate/extraction, and caught + directed the zombie-guard fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)