### PR TITLE
resume --json: liveness block + honest help (#79 PR B)

### DIFF
--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -465,5 +467,44 @@ func TestResumeLiveNoteListsAllLiveSources(t *testing.T) {
 	repl := agentLiveness{Verdict: livenessReplacementLive, ReplacementTarget: "%5"}
 	if got := resumeLiveNote(repl, "codex"); !strings.Contains(got, "%5") || !strings.Contains(got, "recorded pid dead") {
 		t.Errorf("replacement note = %q, want it to mention the dead pid + target", got)
+	}
+}
+
+// resume --json must expose a `liveness` block carrying the SAME verdict status
+// status reports, so a client compares liveness.status to status's status
+// instead of inferring liveness from the planning `action` (#79 PR B).
+func TestResumePlanJSONCarriesLiveness(t *testing.T) {
+	var buf bytes.Buffer
+	plans := []resumePlan{{
+		Role: "cto", Handle: "cto", Action: resumeRestore,
+		Command:  "amq-squad agent up codex --role cto",
+		Liveness: &agentLiveness{Status: statusStateStale, Detail: "agent pid dead", Signals: statusSignals{AgentPID: 7777}},
+	}}
+	if err := writeResumeJSON(&buf, team.Team{Project: "/p"}, "issue-96", resumeModeDefault, "", plans); err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Data struct {
+			Plan []struct {
+				Action   string `json:"action"`
+				Liveness *struct {
+					Status string `json:"status"`
+					Detail string `json:"detail"`
+				} `json:"liveness"`
+			} `json:"plan"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatal(err)
+	}
+	p := env.Data.Plan[0]
+	if p.Liveness == nil {
+		t.Fatal("resume_plan member must carry a liveness block")
+	}
+	if p.Liveness.Status != "stale" {
+		t.Errorf("liveness.status = %q, want %q (the shared verdict status)", p.Liveness.Status, "stale")
+	}
+	if p.Action != "restore" {
+		t.Errorf("a stale verdict should restore, got action %q", p.Action)
 	}
 }

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -101,9 +101,16 @@ func TestStatusAndResumeAgreeOnStaleAgent(t *testing.T) {
 		t.Fatalf("restore action must emit a non-empty command, got empty")
 	}
 
-	// 4) Agreement: status stale <-> resume not-live.
+	// 4) Agreement: status stale <-> resume not-live, AND the resume plan carries
+	// the shared liveness verdict matching status (what resume --json exposes).
 	if rec.Status == statusStateStale && plan.Action == resumeLive {
 		t.Fatalf("status and resume disagree: status=stale but resume=live")
+	}
+	if plan.Liveness == nil {
+		t.Fatal("resume plan must carry a liveness verdict")
+	}
+	if plan.Liveness.Status != rec.Status {
+		t.Errorf("resume liveness.status %q != status %q (must agree)", plan.Liveness.Status, rec.Status)
 	}
 }
 

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -23,7 +23,7 @@ func runResume(args []string) error {
 	projectFlag := fs.String("project", "", "project/team-home directory to resume (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to resume (default: default profile)")
 	execMode := fs.Bool("exec", false, "open the planned launch commands in the terminal backend (tmux) instead of printing them")
-	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (with tmux runtime metadata) instead of the human plan")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (liveness + tmux metadata) instead of the human plan")
 	terminal := fs.String("terminal", "tmux", "terminal backend to use with --exec")
 	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window, new-window, or new-session)")
 	layout := fs.String("layout", "vertical", "terminal layout with --exec (tmux: vertical, horizontal, or tiled)")
@@ -58,9 +58,11 @@ copy-pasteable commands. With --exec, opens those commands through the
 selected terminal backend (same path as 'up'), skipping members that are
 already live and refusing to start if any member is in the 'blocked'
 action without --force-duplicate. With --json, emits a schema-versioned
-resume_plan envelope (per-member action, command, and tmux runtime metadata
-including pane_alive) for clients; --json is a read-only preview and cannot be
-combined with --exec.
+resume_plan envelope for clients: per-member action plus a liveness block
+(status/detail/signals) consistent with 'status --json', and -- where available
+-- the copy-ready command (omitted for members already live) and tmux runtime
+metadata including pane_alive (present only for members launched in tmux).
+--json is a read-only preview and cannot be combined with --exec.
 
 Fresh / new-session behavior belongs to 'amq-squad fork --from S --as T'.
 

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -156,6 +156,20 @@ type resumeMemberJSON struct {
 	Note             string           `json:"note,omitempty"`
 	Command          string           `json:"command,omitempty"`
 	Tmux             *tmuxRuntimeJSON `json:"tmux,omitempty"`
+	// Liveness is the shared liveness verdict (status + detail + signals), the
+	// SAME classification `status --json` reports. A client compares
+	// liveness.status to status's status instead of inferring liveness from the
+	// planning `action`. Omitted only on the blocked paths where no verdict ran.
+	Liveness *resumeLivenessJSON `json:"liveness,omitempty"`
+}
+
+// resumeLivenessJSON exposes the shared liveness verdict on a resume_plan member
+// so `resume --json` and `status --json` carry identical liveness for the same
+// agent. status is the same statusState string status emits.
+type resumeLivenessJSON struct {
+	Status  string        `json:"status"`
+	Detail  string        `json:"detail,omitempty"`
+	Signals statusSignals `json:"signals"`
 }
 
 // resumeEnvelopeData is the `resume_plan` envelope body: the same per-member
@@ -183,6 +197,14 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 			}
 			fillPaneAlive(rt, livePanes)
 		}
+		var liveness *resumeLivenessJSON
+		if p.Liveness != nil {
+			liveness = &resumeLivenessJSON{
+				Status:  string(p.Liveness.Status),
+				Detail:  p.Liveness.Detail,
+				Signals: p.Liveness.Signals,
+			}
+		}
 		rows = append(rows, resumeMemberJSON{
 			Role:             p.Role,
 			Handle:           p.Handle,
@@ -192,6 +214,7 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 			Note:             p.Note,
 			Command:          p.Command,
 			Tmux:             rt,
+			Liveness:         liveness,
 		})
 	}
 	profile = strings.TrimSpace(profile)

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -584,6 +584,10 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		// must classify this as blocked, not silently emit fresh.
 		plan.Action = resumeBlocked
 		plan.Note = fmt.Sprintf("amq env unavailable: %v", err)
+		// Carry a liveness verdict even here so --json always has one (and so it
+		// agrees with status, which also reports missing when the env is
+		// unresolvable). The env failure means we cannot inspect any signal.
+		plan.Liveness = &agentLiveness{Verdict: livenessMissing, Status: statusStateMissing, Detail: plan.Note}
 		if in.Force {
 			plan.Action = resumeFresh
 			plan.Note = "force-duplicate: " + plan.Note
@@ -617,11 +621,17 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		probe = defaultDuplicateLaunchProbe
 	}
 
+	// Single shared liveness verdict — the same classifier status consumes (the
+	// #79 fix: status and resume can never disagree). Computed up front so EVERY
+	// return path below — including the forced preflight-error path — carries a
+	// liveness block.
+	live := classifyAgentLiveness(agentDir, root, handle, m.Role, m.Binary, env.SessionName, cwd, probe)
+	plan.Liveness = &live
+
 	// Surface a real I/O inspection error as blocked, preserving the prior
 	// safety contract. The preflight is still the authority on read errors; we
 	// run it in dry-run mode purely to catch perr (it reaps nothing on disk in
-	// dry-run). The live/stale DECISION, however, comes from the shared
-	// classifier below so status and resume can never disagree.
+	// dry-run). The live/stale DECISION comes from the shared classifier above.
 	pf := agentLaunchPreflight{
 		AgentDir:   agentDir,
 		Handle:     handle,
@@ -649,12 +659,6 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		}
 		return plan, nil
 	}
-
-	// Single shared liveness verdict — the same classifier status consumes.
-	// This is the fix for #79: a genuinely-stale agent is no longer mislabeled
-	// live by resume; the two surfaces now share one verdict.
-	live := classifyAgentLiveness(agentDir, root, handle, m.Role, m.Binary, env.SessionName, cwd, probe)
-	plan.Liveness = &live
 
 	if live.Live() {
 		// Live signal detected (agent / wake / presence / replacement). Same

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -50,6 +50,11 @@ type resumePlan struct {
 	// any. Surfaced for `resume --json` so clients know which pane a restore
 	// targets and whether that pane is still alive.
 	Tmux *launch.TmuxInfo
+	// Liveness is the shared liveness verdict (the SAME classifier status uses),
+	// captured so `resume --json` can expose a `liveness` block a client compares
+	// to `status --json` instead of inferring from the planning `Action`. nil on
+	// the early blocked paths (amq env / preflight error) where no verdict ran.
+	Liveness *agentLiveness
 }
 
 func runTeamResume(args []string) error {
@@ -66,7 +71,7 @@ func runTeamResume(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
 	projectFlag := fs.String("project", "", "project/team-home directory to plan (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to plan (default: default profile)")
-	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (with tmux runtime metadata) instead of the human plan")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (liveness + tmux metadata) instead of the human plan")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team resume - plan how to bring the team back
@@ -649,6 +654,7 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	// This is the fix for #79: a genuinely-stale agent is no longer mislabeled
 	// live by resume; the two surfaces now share one verdict.
 	live := classifyAgentLiveness(agentDir, root, handle, m.Role, m.Binary, env.SessionName, cwd, probe)
+	plan.Liveness = &live
 
 	if live.Live() {
 		// Live signal detected (agent / wake / presence / replacement). Same


### PR DESCRIPTION
PR B of v1.5.2 for **#79**, on top of the shared classifier (PR A #80). Closes #79's asks #2 (consistency, now observable) and #3 (help honesty).

## What
- **`liveness` block on `resume.plan[]`** — exposes the unified verdict (`status`/`detail`/`signals`, the SAME classification `status --json` reports) so a client compares `resume.plan[].liveness.status` to `status`'s status **instead of inferring liveness from the planning `action`** (which is a launch-planning label, not operational liveness). Captured right after `classifyAgentLiveness`; omitted only on the blocked paths where no verdict ran.
- **Honest help** — `resume`/`team resume --help` no longer claim the JSON *always* carries `command` + tmux/`pane_alive`. It now says: per-member `action` + a `liveness` block consistent with `status --json`, plus `command` (omitted for members already live) and tmux metadata incl. `pane_alive` (only for members launched in tmux). Flag descriptions updated too.

## Example
```json
{"kind":"resume_plan","data":{"plan":[
  {"role":"cto","action":"restore","has_restore_record":true,
   "command":"amq-squad agent up codex --role cto",
   "liveness":{"status":"stale","detail":"…","signals":{"agent_pid":7777}}}
]}}
```
A stale verdict now yields `action: restore` with a command (the PR A fix) **and** a `liveness.status: "stale"` that matches `status --json`.

## Tests
Cross-consistency: `resume_plan` JSON carries a `liveness` block whose status is the shared verdict (`stale` ⇒ `action: restore`). Full suite, vet, gofmt green. Additive/backward-compatible (`action` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)