### PR TITLE
status --json: session-scope action catalog (amq-noc#7)

### DIFF
--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -258,3 +258,53 @@ func TestSendRequiresRole(t *testing.T) {
 		t.Fatalf("want UsageError, got %T: %v", err, err)
 	}
 }
+
+func TestSessionActions(t *testing.T) {
+	acts := sessionActions("/Code/app", team.DefaultProfile, "issue-96")
+	byKind := map[string]runtimeActionJSON{}
+	for _, a := range acts {
+		byKind[a.Kind] = a
+	}
+	want := []string{"status", "resume_preview", "resume_current_window", "resume_new_session", "stop"}
+	if len(acts) != len(want) {
+		t.Fatalf("want %d session actions, got %d", len(want), len(acts))
+	}
+	for _, k := range want {
+		a, ok := byKind[k]
+		if !ok {
+			t.Fatalf("missing session action %q", k)
+		}
+		if a.Scope != "session" || a.Label == "" {
+			t.Errorf("%s scope/label wrong: scope=%q label=%q", k, a.Scope, a.Label)
+		}
+		if !strings.Contains(a.Command, "--session issue-96") || !strings.Contains(a.Command, "--project /Code/app") {
+			t.Errorf("%s command missing scope: %q", k, a.Command)
+		}
+		if strings.Contains(a.Command, "--role") {
+			t.Errorf("a session action must not carry --role: %q", a.Command)
+		}
+	}
+	// Read-only vs mutating + confirmation.
+	if byKind["status"].Mutates || byKind["resume_preview"].Mutates {
+		t.Error("status/resume_preview must not mutate")
+	}
+	for _, k := range []string{"resume_current_window", "resume_new_session", "stop"} {
+		if !byKind[k].Mutates || !byKind[k].NeedsConfirmation {
+			t.Errorf("%s must mutate and need confirmation", k)
+		}
+	}
+	// Commands map to real verbs; new-session omits --terminal-session (derived).
+	if byKind["stop"].Command != "amq-squad stop --project /Code/app --session issue-96 --all" {
+		t.Errorf("stop command = %q", byKind["stop"].Command)
+	}
+	if !strings.HasSuffix(byKind["resume_new_session"].Command, "--exec --target new-session") {
+		t.Errorf("resume_new_session should omit --terminal-session: %q", byKind["resume_new_session"].Command)
+	}
+	// Profile: default omitted, named included.
+	if strings.Contains(byKind["status"].Command, "--profile") {
+		t.Errorf("default profile must be omitted: %q", byKind["status"].Command)
+	}
+	if !strings.Contains(sessionActions("/Code/app", "review", "issue-96")[0].Command, "--profile review") {
+		t.Error("named profile must appear in session action commands")
+	}
+}

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -144,6 +144,36 @@ func memberActions(projectDir, profile, session, role string, paneAlive bool) []
 	}
 }
 
+// commandScope renders the shared "--project D [--profile P] --session S" tail
+// for project-scoped runtime commands, so member and session actions stay in
+// lockstep.
+func commandScope(projectDir, profile, session string) string {
+	scope := " --project " + shellQuote(projectDir)
+	if profile != "" && profile != team.DefaultProfile {
+		scope += " --profile " + shellQuote(profile)
+	}
+	scope += " --session " + shellQuote(session)
+	return scope
+}
+
+// sessionActions builds the SESSION-scope operator action catalog for a
+// workstream: the lifecycle controls a client renders for a session row. They
+// map to real amq-squad verbs (no synthetic "restart" — a client composes that
+// from stop + a resume). resume_new_session lets amq-squad derive the tmux
+// session name (omitting --terminal-session). All are runnable commands, so
+// available is true; the mutating ones request confirmation.
+func sessionActions(projectDir, profile, session string) []runtimeActionJSON {
+	base := "amq-squad"
+	scope := commandScope(projectDir, profile, session)
+	return []runtimeActionJSON{
+		{Kind: "status", Label: "show session status", Scope: "session", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " status" + scope + " --json"},
+		{Kind: "resume_preview", Label: "preview resume plan", Scope: "session", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " resume" + scope + " --json"},
+		{Kind: "resume_current_window", Label: "resume in current window", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec --target current-window"},
+		{Kind: "resume_new_session", Label: "resume in new tmux session", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec --target new-session"},
+		{Kind: "stop", Label: "stop the session", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " stop" + scope + " --all"},
+	}
+}
+
 // resumeMemberJSON is one member row in the resume_plan envelope. It mirrors the
 // human plan (role/action/note/command) and adds the runtime identity so a
 // client can decide whether to focus a live pane or re-open one.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -60,6 +60,11 @@ type statusEnvelopeData struct {
 	Operator     team.OperatorView `json:"operator"`
 	Capabilities team.Capabilities `json:"capabilities"`
 	Records      []statusRecord    `json:"records"`
+	// Actions are the SESSION-scope operator actions (status / resume preview /
+	// resume in current window / resume in new tmux session / stop), the catalog
+	// counterpart to each record's agent-scope actions. A client renders these
+	// for the session row instead of constructing the commands itself.
+	Actions []runtimeActionJSON `json:"actions"`
 }
 
 type statusRecord struct {
@@ -208,6 +213,7 @@ func executeStatus(s statusExecution) error {
 			Operator:     team.EffectiveOperator(t),
 			Capabilities: team.EffectiveCapabilities(t),
 			Records:      rows,
+			Actions:      sessionActions(t.Project, s.Profile, workstream),
 		})
 	}
 	policy := outputPolicyCurrent()


### PR DESCRIPTION
Closes the remaining producer side of **amq-noc#7**: single-session `status --session X --json` now carries a top-level **`data.actions`** array of **session-scope** operator actions — the catalog counterpart to each record's agent-scope `actions[]` — so the NOC renders session-row controls from the contract instead of generating them locally (v0.4.0's fallback).

## Actions (real verbs, #75 rich schema)
| kind | command | mutates | confirm |
|---|---|---|---|
| `status` | `amq-squad status … --json` | no | no |
| `resume_preview` | `amq-squad resume … --json` | no | no |
| `resume_current_window` | `amq-squad resume … --exec --target current-window` | yes | yes |
| `resume_new_session` | `amq-squad resume … --exec --target new-session` (name auto-derived) | yes | yes |
| `stop` | `amq-squad stop … --all` | yes | yes |

Each carries `label`/`scope:"session"`/`mutates`/`needs_confirmation`/`available` (#75 schema). No synthetic `restart` — a client composes stop + resume.

## Notes
- **Additive/backward-compatible**: the bare `status --json` board envelope (`kind: sessions`) is unchanged; agent-scope `records[].actions` unchanged.
- **Project/board-scope deferred**: the board's `sessionBoardRow` carries no per-session profile, so correct per-session commands there need profile resolution — a follow-up (and the NOC fetches single-session `status --json` for a selected session anyway).

Live-verified the JSON shape; `TestSessionActions` pins scope/flags/commands/profile. Full suite, vet, gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)