### PR TITLE
Release prep v1.5.2: roadmap + version bumps (Closes #79)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -81,5 +81,8 @@ the open issues by theme + status so the near-term path is legible at a glance.
 
 - Several issues above are implemented but still open (marked *pending close*);
   they're listed for an accurate picture and should be triaged closed.
-- Roadmap order is theme-grouped, not strictly sequenced; the active line is
-  v1.5.1 → the #7 status-actions follow-up → (when there's demand) #76.
+- Roadmap order is theme-grouped, not strictly sequenced. v1.5.2 shipped the
+  #79 liveness unification and the session-scope `status --json` actions
+  (amq-noc#7 producer side). Remaining near-term: board/project-scope actions
+  (deferred — needs per-session profile in the board envelope); then, when
+  there's demand, #76 (the agent orchestrator).

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,9 +11,18 @@ the open issues by theme + status so the near-term path is legible at a glance.
 - **v1.5.1 — shipped.** `capabilities.runtime_actions` (#73), `send` busy-pane
   idle-check (#74 / #68), structured action metadata
   `label`/`scope`/`mutates`/`needs_confirmation`/`reason` (#75).
-- **Next (v1.5.2 candidate):** session/project-scope actions in `status --json`
-  to fully close amq-noc#7 (resume-current-window / resume-new-session / stop /
-  restart) — extend the status envelope, no new command.
+- **v1.5.2 — shipped.**
+  - **#79 — NOC runtime JSON contract gaps.** Unified `status`/`resume` liveness
+    behind one shared classifier so `resume --json` can't contradict `status
+    --json` (incl. a zombie-heartbeat guard that also fixes the latent #44
+    "stale live presence" bug); a `liveness` block on `resume.plan[]`; honest
+    `resume --help`; regression coverage. (Ask #1, `runtime_actions`, shipped in
+    v1.5.1.)
+  - **Session-scope action catalog** on single-session `status --json`
+    (`data.actions`: status / resume_preview / resume_current_window /
+    resume_new_session / stop) — closes amq-noc#7's producer side. Board/
+    project-scope actions deferred (the board envelope carries no per-session
+    profile).
 
 ## Themes
 
@@ -26,6 +35,9 @@ the open issues by theme + status so the near-term path is legible at a glance.
   addressing); new binary work is `spawn` / `emit-event` / `watch`. **Never in
   the NOC** — at most the NOC observes an orchestration. This is the headline
   forward item.
+- #79 — NOC runtime JSON contract gaps in v1.5.0. ✅ shipped in v1.5.2 (shared
+  liveness classifier + `resume.plan[].liveness` + session-scope `status --json`
+  actions) — *pending close.*
 - #61 — Expose first-class tmux orchestration metadata for NOC clients.
   ✅ shipped in v1.5.0 — *pending close.*
 - #62 — Make tmux prompt delivery deterministic for launched agents.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.1
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.2
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
v1.5.2 ships:
- **#79** runtime-JSON contract unification — shared `status`/`resume` liveness classifier (+ zombie-heartbeat guard, also fixing latent #44), `resume.plan[].liveness`, honest `resume --help` (PRs #80, #82).
- **Session-scope action catalog** on `status --json` (`data.actions`) — closes amq-noc#7's producer side (PR #83).

This PR: PLAN.md (mark v1.5.2 + #79 shipped) + bump install reference + plugin manifests to v1.5.2. Docs/version only. **Closes #79** on merge.