### PR TITLE
send: robustly submit so prompts can't hang staged in plain tmux (#86)

### DIFF
--- a/internal/tmuxpane/deliver.go
+++ b/internal/tmuxpane/deliver.go
@@ -6,6 +6,22 @@ import (
 	"os/exec"
 	"strings"
 	"sync/atomic"
+	"time"
+)
+
+// Submit-tuning knobs (package vars so tests can zero the sleeps). Plain tmux
+// (non iTerm2 -CC) does not buffer a bracketed paste the way -CC does, so the
+// agent TUI needs a brief moment to ingest the pasted body before the Enter —
+// otherwise the Enter races the paste and is dropped, leaving the prompt hanging
+// staged in the input box (#86). We settle, submit, verify the prompt left the
+// input box, and retry the Enter before giving up with a clear error.
+var (
+	submitSettleDelay = 120 * time.Millisecond
+	submitVerifyDelay = 200 * time.Millisecond
+	submitAttempts    = 3
+	// inputBoxLines is how many bottom lines of the pane count as the input
+	// region for the "did it leave the input box?" check.
+	inputBoxLines = 4
 )
 
 // DeadPaneError reports that a tmux pane targeted for control no longer exists
@@ -98,8 +114,62 @@ func SendPromptToPane(paneID, prompt string) error {
 	if out, err := deliverExec("", "paste-buffer", "-d", "-p", "-b", buf, "-t", paneID); err != nil {
 		return fmt.Errorf("tmux paste-buffer -t %s: %w: %s", paneID, err, strings.TrimSpace(out))
 	}
-	// Submit with one explicit Enter key event.
-	return SendKeysToPane(paneID, "Enter")
+	// Submit robustly — the Enter must not race the paste (the #86 hang).
+	return submitStagedPrompt(paneID, prompt)
+}
+
+// submitStagedPrompt presses Enter to submit a just-pasted prompt and confirms
+// it actually left the input box, retrying the Enter if not. It exists because a
+// bare paste-then-Enter often hangs in plain tmux: the Enter arrives before the
+// agent TUI has ingested the bracketed paste and is dropped, so the prompt sits
+// staged until a manual Enter. Each attempt settles first (lets the paste land),
+// sends Enter, then verifies via capture-pane that the prompt is no longer in the
+// input region. A still-staged prompt is retried (also covering TUIs that need a
+// second Enter after a paste); if it can never be confirmed submitted, it
+// returns a clear error rather than silently leaving the text staged.
+func submitStagedPrompt(paneID, prompt string) error {
+	tail := lastNonBlankLine(prompt)
+	for attempt := 0; attempt < submitAttempts; attempt++ {
+		time.Sleep(submitSettleDelay)
+		if err := SendKeysToPane(paneID, "Enter"); err != nil {
+			return err
+		}
+		time.Sleep(submitVerifyDelay)
+		if promptLeftInputBox(paneID, tail) {
+			return nil
+		}
+	}
+	return fmt.Errorf("delivered the prompt to pane %s but could not confirm it submitted after %d Enter attempts; the agent may still need a manual Enter", paneID, submitAttempts)
+}
+
+// promptLeftInputBox reports whether the staged prompt is no longer sitting in
+// the pane's input region (the bottom of the screen) — i.e. the Enter submitted
+// it. Best-effort: an empty tail or a capture failure is treated as submitted,
+// so a failed/unavailable check never blocks delivery or forces a false retry.
+func promptLeftInputBox(paneID, tail string) bool {
+	tail = strings.TrimSpace(tail)
+	if tail == "" {
+		return true
+	}
+	out, err := paneCapturer(paneID)
+	if err != nil {
+		return true
+	}
+	// The input box sits at the very bottom; if the prompt's last line is still
+	// down there, the Enter has not submitted it.
+	return !strings.Contains(tailLines(out, inputBoxLines), tail)
+}
+
+// lastNonBlankLine returns the last non-whitespace line of s — the distinctive
+// tail to look for in the input box.
+func lastNonBlankLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return strings.TrimSpace(lines[i])
+		}
+	}
+	return ""
 }
 
 // FindPaneByID returns the live pane carrying paneID. Callers validate further

--- a/internal/tmuxpane/deliver.go
+++ b/internal/tmuxpane/deliver.go
@@ -115,61 +115,58 @@ func SendPromptToPane(paneID, prompt string) error {
 		return fmt.Errorf("tmux paste-buffer -t %s: %w: %s", paneID, err, strings.TrimSpace(out))
 	}
 	// Submit robustly — the Enter must not race the paste (the #86 hang).
-	return submitStagedPrompt(paneID, prompt)
+	return submitStagedPrompt(paneID)
 }
 
 // submitStagedPrompt presses Enter to submit a just-pasted prompt and confirms
-// it actually left the input box, retrying the Enter if not. It exists because a
-// bare paste-then-Enter often hangs in plain tmux: the Enter arrives before the
-// agent TUI has ingested the bracketed paste and is dropped, so the prompt sits
-// staged until a manual Enter. Each attempt settles first (lets the paste land),
-// sends Enter, then verifies via capture-pane that the prompt is no longer in the
-// input region. A still-staged prompt is retried (also covering TUIs that need a
-// second Enter after a paste); if it can never be confirmed submitted, it
-// returns a clear error rather than silently leaving the text staged.
-func submitStagedPrompt(paneID, prompt string) error {
-	tail := lastNonBlankLine(prompt)
+// it actually submitted, retrying the Enter if not. It exists because a bare
+// paste-then-Enter often hangs in plain tmux: the Enter arrives before the agent
+// TUI has ingested the bracketed paste and is dropped, so the prompt sits staged
+// until a manual Enter.
+//
+// Each attempt snapshots the input region (the bottom of the pane), presses
+// Enter, then re-snapshots: a successful submit CHANGES that region (the staged
+// prompt leaves the input box, replaced by an empty prompt / the agent's
+// response), while a dropped Enter leaves it byte-for-byte identical, which
+// triggers a retry. Comparing the region (rather than searching for the prompt
+// text) is robust to line wrapping and input-box borders, and engine-agnostic.
+// If submission can never be confirmed it returns a clear error rather than
+// silently leaving the text staged. Best-effort: if the region cannot be
+// captured it fails open (one Enter, no retry) so a capture problem never blocks
+// delivery or spins.
+func submitStagedPrompt(paneID string) error {
 	for attempt := 0; attempt < submitAttempts; attempt++ {
 		time.Sleep(submitSettleDelay)
+		before, beforeOK := captureInputRegion(paneID)
 		if err := SendKeysToPane(paneID, "Enter"); err != nil {
 			return err
 		}
 		time.Sleep(submitVerifyDelay)
-		if promptLeftInputBox(paneID, tail) {
+		after, afterOK := captureInputRegion(paneID)
+		// Submitted when the input region changed; fail open when either snapshot
+		// is unavailable (don't block or retry on a capture we can't trust).
+		if !beforeOK || !afterOK || after != before {
 			return nil
 		}
+		// Unchanged: the Enter was dropped — retry.
 	}
 	return fmt.Errorf("delivered the prompt to pane %s but could not confirm it submitted after %d Enter attempts; the agent may still need a manual Enter", paneID, submitAttempts)
 }
 
-// promptLeftInputBox reports whether the staged prompt is no longer sitting in
-// the pane's input region (the bottom of the screen) — i.e. the Enter submitted
-// it. Best-effort: an empty tail or a capture failure is treated as submitted,
-// so a failed/unavailable check never blocks delivery or forces a false retry.
-func promptLeftInputBox(paneID, tail string) bool {
-	tail = strings.TrimSpace(tail)
-	if tail == "" {
-		return true
-	}
+// captureInputRegion snapshots the bottom inputBoxLines of the pane (the input
+// region) for the before/after submit comparison. ok is false when the pane
+// cannot be captured or the region is blank (nothing to compare), so the caller
+// fails open instead of treating an empty capture as "unchanged".
+func captureInputRegion(paneID string) (region string, ok bool) {
 	out, err := paneCapturer(paneID)
 	if err != nil {
-		return true
+		return "", false
 	}
-	// The input box sits at the very bottom; if the prompt's last line is still
-	// down there, the Enter has not submitted it.
-	return !strings.Contains(tailLines(out, inputBoxLines), tail)
-}
-
-// lastNonBlankLine returns the last non-whitespace line of s — the distinctive
-// tail to look for in the input box.
-func lastNonBlankLine(s string) string {
-	lines := strings.Split(s, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		if strings.TrimSpace(lines[i]) != "" {
-			return strings.TrimSpace(lines[i])
-		}
+	region = tailLines(out, inputBoxLines)
+	if strings.TrimSpace(region) == "" {
+		return "", false
 	}
-	return ""
+	return region, true
 }
 
 // FindPaneByID returns the live pane carrying paneID. Callers validate further

--- a/internal/tmuxpane/deliver_test.go
+++ b/internal/tmuxpane/deliver_test.go
@@ -167,21 +167,25 @@ func TestTargetForPaneID(t *testing.T) {
 	}
 }
 
-// The #86 fix: if the first Enter does not submit (prompt still in the input
-// box), submit retries the Enter rather than leaving the message hanging.
-func TestSendPromptRetriesEnterWhenStillStaged(t *testing.T) {
+// The #86 fix: if the first Enter does not submit (the input region is
+// unchanged), submit retries the Enter rather than leaving the message hanging.
+func TestSendPromptRetriesEnterWhenInputUnchanged(t *testing.T) {
 	calls := swapDeliver(t, nil)
-	prompt := "do the thing\nplease review"
+	// before/after per attempt: attempt 1 sees the input region UNCHANGED (Enter
+	// dropped) -> retry; attempt 2 sees it CHANGE (submitted).
+	const staged = "│ please review the long set of changes │\n  ? for shortcuts"
+	const cleared = "> \n  ? for shortcuts"
 	n := 0
 	paneCapturer = func(string) (string, error) {
 		n++
-		if n == 1 {
-			// First check: the prompt's last line is still in the input box.
-			return "│ please review                │\n  ? for shortcuts", nil
+		switch n {
+		case 1, 2, 3: // attempt1 before, attempt1 after, attempt2 before
+			return staged, nil
+		default: // attempt2 after
+			return cleared, nil
 		}
-		return "", nil // second check: input box cleared -> submitted
 	}
-	if err := SendPromptToPane("%5", prompt); err != nil {
+	if err := SendPromptToPane("%5", "do it\nplease review the long set of changes"); err != nil {
 		t.Fatalf("SendPromptToPane: %v", err)
 	}
 	if got := enterCount(*calls); got != 2 {
@@ -189,13 +193,12 @@ func TestSendPromptRetriesEnterWhenStillStaged(t *testing.T) {
 	}
 }
 
-// If the prompt can never be confirmed submitted, return a clear error rather
-// than silently leaving text staged (#86 acceptance criterion).
+// If the input region never changes, the prompt never submitted: return a clear
+// error rather than silently leaving text staged (#86 acceptance criterion).
 func TestSendPromptErrorsWhenNeverConfirmed(t *testing.T) {
 	calls := swapDeliver(t, nil)
-	prompt := "x\nhang me"
-	paneCapturer = func(string) (string, error) { return "│ hang me │\n  ? for shortcuts", nil } // always staged
-	err := SendPromptToPane("%5", prompt)
+	paneCapturer = func(string) (string, error) { return "│ hang me │\n  ? for shortcuts", nil } // unchanged forever
+	err := SendPromptToPane("%5", "x\nhang me")
 	if err == nil || !strings.Contains(err.Error(), "could not confirm it submitted") {
 		t.Fatalf("want a clear not-submitted error, got %v", err)
 	}
@@ -204,31 +207,50 @@ func TestSendPromptErrorsWhenNeverConfirmed(t *testing.T) {
 	}
 }
 
-func TestPromptLeftInputBox(t *testing.T) {
-	prev := paneCapturer
-	t.Cleanup(func() { paneCapturer = prev })
-	// Tail still in the bottom input region -> not submitted.
-	paneCapturer = func(string) (string, error) { return "scrollback\n...\n│ review this │\n? for shortcuts", nil }
-	if promptLeftInputBox("%1", "review this") {
-		t.Error("a prompt still in the input box must read as NOT submitted")
-	}
-	// Tail scrolled up into the conversation (above the input region) -> submitted.
+// A changed input region means submitted on the first Enter; a blank/unavailable
+// capture fails open (one Enter, no retry, no error).
+func TestSendPromptSubmitsOnInputChangeOrFailsOpen(t *testing.T) {
+	// Region CHANGES after Enter -> submitted, single Enter.
+	calls := swapDeliver(t, nil)
+	n := 0
 	paneCapturer = func(string) (string, error) {
-		return "> review this\nagent output\nmore output\nstill more\n● Working… esc to interrupt\n  ? for shortcuts", nil
+		n++
+		if n == 1 {
+			return "│ staged │\n? for shortcuts", nil // before
+		}
+		return "● Working… esc to interrupt\n>", nil // after: changed
 	}
-	if !promptLeftInputBox("%1", "review this") {
-		t.Error("a prompt no longer in the input region must read as submitted")
+	if err := SendPromptToPane("%5", "go"); err != nil {
+		t.Fatal(err)
 	}
-	// Capture error / empty tail -> treated as submitted (never block).
-	paneCapturer = func(string) (string, error) { return "", errExpected }
-	if !promptLeftInputBox("%1", "x") {
-		t.Error("a capture error must be treated as submitted")
+	if got := enterCount(*calls); got != 1 {
+		t.Fatalf("a changed input region should submit in one Enter, got %d", got)
 	}
-	if !promptLeftInputBox("%1", "") {
-		t.Error("an empty tail must be treated as submitted")
+
+	// Blank capture -> can't verify -> fail open (single Enter, no error).
+	calls2 := swapDeliver(t, nil) // its capturer returns "" (blank)
+	if err := SendPromptToPane("%5", "go"); err != nil {
+		t.Fatalf("blank capture must fail open, got %v", err)
+	}
+	if got := enterCount(*calls2); got != 1 {
+		t.Fatalf("blank capture should fail open after one Enter, got %d", got)
 	}
 }
 
-var errExpected = errorsNew("capture failed")
-
-func errorsNew(s string) error { return errors.New(s) }
+func TestCaptureInputRegion(t *testing.T) {
+	prev := paneCapturer
+	t.Cleanup(func() { paneCapturer = prev })
+	paneCapturer = func(string) (string, error) { return "a\nb\nc\nd\ne\nf", nil }
+	region, ok := captureInputRegion("%1")
+	if !ok || !strings.Contains(region, "f") || strings.Contains(region, "a") {
+		t.Errorf("captureInputRegion should return the bottom lines: ok=%v region=%q", ok, region)
+	}
+	paneCapturer = func(string) (string, error) { return "   \n  ", nil } // blank
+	if _, ok := captureInputRegion("%1"); ok {
+		t.Error("a blank region must report ok=false (nothing to compare)")
+	}
+	paneCapturer = func(string) (string, error) { return "", errors.New("pane gone") }
+	if _, ok := captureInputRegion("%1"); ok {
+		t.Error("a capture error must report ok=false")
+	}
+}

--- a/internal/tmuxpane/deliver_test.go
+++ b/internal/tmuxpane/deliver_test.go
@@ -16,6 +16,13 @@ type deliverCall struct {
 // per tmux subcommand (keyed by the first arg).
 func swapDeliver(t *testing.T, results map[string]error) *[]deliverCall {
 	t.Helper()
+	// Make submit deterministic and fast: no real sleeps, and a capturer that
+	// reports the prompt left the input box (submitted on the first Enter) so the
+	// submit loop never shells real `tmux capture-pane`. Individual tests can
+	// override paneCapturer afterwards to exercise the retry/error paths.
+	prevSettle, prevVerify, prevCap := submitSettleDelay, submitVerifyDelay, paneCapturer
+	submitSettleDelay, submitVerifyDelay = 0, 0
+	paneCapturer = func(string) (string, error) { return "", nil }
 	var calls []deliverCall
 	prev := deliverExec
 	deliverExec = func(stdin string, args ...string) (string, error) {
@@ -27,8 +34,21 @@ func swapDeliver(t *testing.T, results map[string]error) *[]deliverCall {
 		}
 		return "", nil
 	}
-	t.Cleanup(func() { deliverExec = prev })
+	t.Cleanup(func() {
+		deliverExec = prev
+		submitSettleDelay, submitVerifyDelay, paneCapturer = prevSettle, prevVerify, prevCap
+	})
 	return &calls
+}
+
+func enterCount(calls []deliverCall) int {
+	n := 0
+	for _, c := range calls {
+		if len(c.args) > 0 && c.args[0] == "send-keys" && c.args[len(c.args)-1] == "Enter" {
+			n++
+		}
+	}
+	return n
 }
 
 func TestSendPromptToPaneDeliversVerbatimWithEnter(t *testing.T) {
@@ -146,3 +166,69 @@ func TestTargetForPaneID(t *testing.T) {
 		t.Fatal("empty pane id must not resolve")
 	}
 }
+
+// The #86 fix: if the first Enter does not submit (prompt still in the input
+// box), submit retries the Enter rather than leaving the message hanging.
+func TestSendPromptRetriesEnterWhenStillStaged(t *testing.T) {
+	calls := swapDeliver(t, nil)
+	prompt := "do the thing\nplease review"
+	n := 0
+	paneCapturer = func(string) (string, error) {
+		n++
+		if n == 1 {
+			// First check: the prompt's last line is still in the input box.
+			return "│ please review                │\n  ? for shortcuts", nil
+		}
+		return "", nil // second check: input box cleared -> submitted
+	}
+	if err := SendPromptToPane("%5", prompt); err != nil {
+		t.Fatalf("SendPromptToPane: %v", err)
+	}
+	if got := enterCount(*calls); got != 2 {
+		t.Fatalf("want 2 Enter attempts (one retry), got %d", got)
+	}
+}
+
+// If the prompt can never be confirmed submitted, return a clear error rather
+// than silently leaving text staged (#86 acceptance criterion).
+func TestSendPromptErrorsWhenNeverConfirmed(t *testing.T) {
+	calls := swapDeliver(t, nil)
+	prompt := "x\nhang me"
+	paneCapturer = func(string) (string, error) { return "│ hang me │\n  ? for shortcuts", nil } // always staged
+	err := SendPromptToPane("%5", prompt)
+	if err == nil || !strings.Contains(err.Error(), "could not confirm it submitted") {
+		t.Fatalf("want a clear not-submitted error, got %v", err)
+	}
+	if got := enterCount(*calls); got != submitAttempts {
+		t.Errorf("want %d Enter attempts before erroring, got %d", submitAttempts, got)
+	}
+}
+
+func TestPromptLeftInputBox(t *testing.T) {
+	prev := paneCapturer
+	t.Cleanup(func() { paneCapturer = prev })
+	// Tail still in the bottom input region -> not submitted.
+	paneCapturer = func(string) (string, error) { return "scrollback\n...\n│ review this │\n? for shortcuts", nil }
+	if promptLeftInputBox("%1", "review this") {
+		t.Error("a prompt still in the input box must read as NOT submitted")
+	}
+	// Tail scrolled up into the conversation (above the input region) -> submitted.
+	paneCapturer = func(string) (string, error) {
+		return "> review this\nagent output\nmore output\nstill more\n● Working… esc to interrupt\n  ? for shortcuts", nil
+	}
+	if !promptLeftInputBox("%1", "review this") {
+		t.Error("a prompt no longer in the input region must read as submitted")
+	}
+	// Capture error / empty tail -> treated as submitted (never block).
+	paneCapturer = func(string) (string, error) { return "", errExpected }
+	if !promptLeftInputBox("%1", "x") {
+		t.Error("a capture error must be treated as submitted")
+	}
+	if !promptLeftInputBox("%1", "") {
+		t.Error("an empty tail must be treated as submitted")
+	}
+}
+
+var errExpected = errorsNew("capture failed")
+
+func errorsNew(s string) error { return errors.New(s) }


### PR DESCRIPTION
Closes **#86**. The reporter confirmed this is frequent **in plain tmux windows (not iTerm2 `-CC`)**: a sent prompt/approval lands in the agent's input box but the final **Enter is dropped**, so the message hangs staged until a manual Enter.

## Root cause
`SendPromptToPane` did `paste-buffer` then `send-keys Enter` **back-to-back, no settle**. In `-CC`, iTerm2 buffers the bracketed paste so the Enter lands; in plain tmux the Enter races the agent TUI's paste ingestion and is dropped.

## Fix — robust submit
After the paste, each attempt:
1. **settles** (lets the TUI ingest the bracketed paste before the Enter),
2. presses **Enter**,
3. **verifies** via `capture-pane` that the prompt's last line left the input region.

A still-staged prompt **retries** the Enter (also covering TUIs that need a second Enter after a paste); if it can never confirm submission it returns a **clear error** rather than silently leaving text staged — so `amq-squad send` (and the NOC) report a real failure, not a false success (the #86 acceptance criterion).

Delays are package vars (tests zero them); the capture reuses the `busy.go` seam.

## Tests
- retry when the first Enter doesn't submit; clear error when never confirmed; the `promptLeftInputBox` heuristic (in-box vs scrolled-up vs capture-error); the existing verbatim-multiline + Enter sequence (now via an injected capturer — no real tmux).
- Live-verified the happy path (bash agent: prompt executed, Enter landed). Real Claude/Codex-in-plain-tmux confirmation is your environment — this removes the race + adds the retry/error that previously let it hang silently.

Full suite, vet, gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)