### PR TITLE
team-rules: post-release peer-notification norm (#81)

### DIFF
--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -62,7 +62,12 @@ func renderTeamRules(t team.Team) (string, error) {
 	b.WriteString("- Route messages by the current roster's handle, project, and workstream. Use `amq route explain` or `amq-squad amq route --to <handle>` when a cross-project or same-handle route is ambiguous.\n")
 	b.WriteString("- For important handoffs, use AMQ receipts such as `--wait-for drained --wait-timeout 60s` and report the message id when asking for follow-up.\n")
 	b.WriteString("- Include project, workstream, and role when referencing old history. Treat labels and integration metadata as debugging context, not as a fresh instruction by themselves.\n")
-	b.WriteString("- One concern per message when practical.\n")
+	b.WriteString("- One concern per message when practical.\n\n")
+
+	b.WriteString("## Lifecycle / Release Updates\n\n")
+	b.WriteString("- After an operator-approved lifecycle action (commit, PR open/ready, merge, tag, release, issue close, or a release-blocking decision), the owning/reviewer agent proactively posts a concise final-state update to the relevant peer thread. Do not wait to be pinged.\n")
+	b.WriteString("- Include what changed, the current repo/release/issue state, and whether any further implementation is needed, so the peer converges cleanly after the action.\n\n")
+
 	b.WriteString("## Operator Gates\n\n")
 	if team.SupportsOperatorGates(t) {
 		op := team.EffectiveOperator(t)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1181,6 +1181,8 @@ func TestRunTeamInitSeedsTeamRules(t *testing.T) {
 		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
 		"fullstack (Fullstack Developer)",
 		"Owns scoped end-to-end implementation",
+		"## Lifecycle / Release Updates",
+		"proactively posts a concise final-state update to the relevant peer thread",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("team-rules.md missing %q in:\n%s", want, body)

--- a/plugins/claude/skills/amq-squad/references/team-rules-template.md
+++ b/plugins/claude/skills/amq-squad/references/team-rules-template.md
@@ -81,6 +81,11 @@ Each agent should summarize the prior context it used before taking new work.
 - One concern per message when practical.
 - `amq send` reads stdin when `--body` is omitted. There is no `--body-file` flag.
 
+## Lifecycle / Release Updates
+
+- After an operator-approved lifecycle action (commit, PR open/ready, merge, tag, release, issue close, or a release-blocking decision), the owning/reviewer agent proactively posts a concise final-state update to the relevant peer thread. Do not wait to be pinged.
+- Include what changed, the current repo/release/issue state, and whether any further implementation is needed, so the peer converges cleanly after the action.
+
 ## Operator Gates
 
 If this profile enables operator gates, the human/operator is a virtual AMQ mailbox participant, not a runnable peer. Use the configured operator handle for human-only decisions or manual actions:

--- a/plugins/codex/skills/amq-squad/references/team-rules-template.md
+++ b/plugins/codex/skills/amq-squad/references/team-rules-template.md
@@ -81,6 +81,11 @@ Each agent should summarize the prior context it used before taking new work.
 - One concern per message when practical.
 - `amq send` reads stdin when `--body` is omitted. There is no `--body-file` flag.
 
+## Lifecycle / Release Updates
+
+- After an operator-approved lifecycle action (commit, PR open/ready, merge, tag, release, issue close, or a release-blocking decision), the owning/reviewer agent proactively posts a concise final-state update to the relevant peer thread. Do not wait to be pinged.
+- Include what changed, the current repo/release/issue state, and whether any further implementation is needed, so the peer converges cleanly after the action.
+
 ## Operator Gates
 
 If this profile enables operator gates, the human/operator is a virtual AMQ mailbox participant, not a runnable peer. Use the configured operator handle for human-only decisions or manual actions:


### PR DESCRIPTION
Closes #81. Adds a **Lifecycle / Release Updates** section to the default team-rules: after an operator-approved lifecycle action (commit/PR/merge/tag/release/issue-close/release-blocking decision), the owning/reviewer agent **proactively** posts a concise final-state update to the peer thread rather than waiting to be pinged — reducing stale peer state after CTO/operator actions.

Applied in all **three** places that must stay in lockstep (Codex flagged the drift risk): the generated default `internal/cli/team_rules.go` + both plugin reference templates (claude + codex). Substring test added. Full suite green.