### PR TITLE
test: pin plain resume == resume --json action (#87)

### DIFF
--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -516,16 +516,20 @@ func TestResumePlanJSONCarriesLiveness(t *testing.T) {
 	}
 }
 
-// #87: plain `resume` and `resume --json` MUST render the same action — they
+// #87: plain `resume` and `resume --json` MUST render the same action. They
 // both branch from the SAME []resumePlan in executeResume, so they cannot
-// diverge by code (the report was a cross-invocation race). This pins it: if a
-// future change makes the plain renderer re-derive the action, this fails.
+// diverge by code (the report was a cross-invocation race). This pins it: the
+// fixture sets Action DELIBERATELY mismatched against Liveness.Status, so a
+// renderer that (wrongly) re-derived the action from liveness would emit a
+// different string and fail. Both renderers must echo resumePlan.Action.
 func TestPlainAndJSONResumeRenderSameAction(t *testing.T) {
 	plans := []resumePlan{
+		// Action=restore but liveness says live: output must show "restore".
 		{Role: "cto", Handle: "cto", Action: resumeRestore, Command: "amq-squad agent up codex --role cto",
-			Liveness: &agentLiveness{Status: statusStateStale, Detail: "stale"}},
+			Liveness: &agentLiveness{Status: statusStateLive, Detail: "live"}},
+		// Action=live but liveness says stale: output must show "live".
 		{Role: "qa", Handle: "qa", Action: resumeLive, Note: "wake+launch",
-			Liveness: &agentLiveness{Status: statusStateWakeLive}},
+			Liveness: &agentLiveness{Status: statusStateStale}},
 	}
 	tm := team.Team{Project: "/p"}
 	var plain, jsonBuf bytes.Buffer

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -515,3 +515,56 @@ func TestResumePlanJSONCarriesLiveness(t *testing.T) {
 		t.Errorf("a stale verdict should restore, got action %q", p.Action)
 	}
 }
+
+// #87: plain `resume` and `resume --json` MUST render the same action — they
+// both branch from the SAME []resumePlan in executeResume, so they cannot
+// diverge by code (the report was a cross-invocation race). This pins it: if a
+// future change makes the plain renderer re-derive the action, this fails.
+func TestPlainAndJSONResumeRenderSameAction(t *testing.T) {
+	plans := []resumePlan{
+		{Role: "cto", Handle: "cto", Action: resumeRestore, Command: "amq-squad agent up codex --role cto",
+			Liveness: &agentLiveness{Status: statusStateStale, Detail: "stale"}},
+		{Role: "qa", Handle: "qa", Action: resumeLive, Note: "wake+launch",
+			Liveness: &agentLiveness{Status: statusStateWakeLive}},
+	}
+	tm := team.Team{Project: "/p"}
+	var plain, jsonBuf bytes.Buffer
+	writeResumePlan(&plain, tm, "issue-96", resumeModeDefault, plans, false, false, resumePrinterStyle{Label: "resume", FooterVerb: "up"})
+	if err := writeResumeJSON(&jsonBuf, tm, "issue-96", resumeModeDefault, "", plans); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plain: the row for each role shows that member's action.
+	plainRow := map[string]string{}
+	for _, line := range strings.Split(plain.String(), "\n") {
+		if f := strings.Fields(line); len(f) >= 2 {
+			plainRow[f[0]] = line
+		}
+	}
+	// JSON: action per role.
+	var env struct {
+		Data struct {
+			Plan []struct{ Role, Action string } `json:"plan"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(jsonBuf.Bytes(), &env); err != nil {
+		t.Fatal(err)
+	}
+	jsonAction := map[string]string{}
+	for _, p := range env.Data.Plan {
+		jsonAction[p.Role] = p.Action
+	}
+
+	for _, p := range plans {
+		if row, ok := plainRow[p.Role]; !ok || !strings.Contains(row, string(p.Action)) {
+			t.Errorf("plain resume row for %s = %q, must show action %q", p.Role, row, p.Action)
+		}
+		if jsonAction[p.Role] != string(p.Action) {
+			t.Errorf("json action for %s = %q, want %q", p.Role, jsonAction[p.Role], p.Action)
+		}
+		// And the two renderers must agree.
+		if got := jsonAction[p.Role]; !strings.Contains(plainRow[p.Role], got) {
+			t.Errorf("plain (%q) and json (%q) disagree on %s's action", plainRow[p.Role], got, p.Role)
+		}
+	}
+}


### PR DESCRIPTION
Addresses **#87** (plain `resume` showed ACTION=live while `resume --json`/`status --json` showed restore/stale).

**Root cause = a cross-invocation race**, not a code bug: `executeResume` builds the plan **once** and renders plain *or* `--json` from the same `[]resumePlan`, so they can't diverge by code; neither re-derives liveness (Codex confirmed: `writeResumePlan` prints `p.Action`, `writeResumeJSON` serializes `p.Action`). Re-running all three now shows them consistent. The reporter caught three separate invocations mid-transition (wake pids flapping).

This adds a **regression test** that renders both surfaces from one plan and asserts the same per-member action — so a future change that makes the plain renderer re-derive liveness fails loudly. No logic change. (Will close #87 in the v1.5.3 release with this explanation.)