### PR TITLE
iTerm2 tmux -CC attach action (#85) + extended-keys doctor hint (shift+enter)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -72,6 +72,14 @@ type doctorExecution struct {
 	WakeOverride   func(t team.Team, workstream string) []doctorCheck
 	WorkstreamHint string
 	Profile        string
+	// Getenv reads process environment (injectable so the tmux extended-keys
+	// check can be driven deterministically in tests). Defaults to os.Getenv.
+	Getenv func(name string) string
+	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
+	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
+	// false when the option is unset or tmux is unavailable. Injectable so the
+	// extended-keys check never shells real tmux in tests.
+	TmuxShowOptions func(name string) (value string, ok bool)
 }
 
 func defaultDoctorExecution(projectDir string) doctorExecution {
@@ -81,10 +89,29 @@ func defaultDoctorExecution(projectDir string) doctorExecution {
 		ResolveAMQEnv: func(projectDir string) (amqEnv, error) {
 			return resolveAMQEnvInDir(projectDir, "", "", "amq-squad")
 		},
-		RunAMQOps: defaultDoctorAMQOps,
-		LookPath:  exec.LookPath,
-		Probe:     defaultDuplicateLaunchProbe,
+		RunAMQOps:       defaultDoctorAMQOps,
+		LookPath:        exec.LookPath,
+		Probe:           defaultDuplicateLaunchProbe,
+		Getenv:          os.Getenv,
+		TmuxShowOptions: defaultTmuxShowServerOption,
 	}
+}
+
+// defaultTmuxShowServerOption reads a server-scoped tmux option via
+// `tmux show-options -s <name>`. tmux prints "<name> <value>"; we return the
+// value. ok is false when tmux is unavailable or the option is unset (tmux
+// exits non-zero / prints nothing), so the caller treats it as off/unknown.
+// READ-ONLY: amq-squad never runs `tmux set-option`.
+func defaultTmuxShowServerOption(name string) (string, bool) {
+	out, err := exec.Command("tmux", "show-options", "-s", name).Output()
+	if err != nil {
+		return "", false
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) < 2 {
+		return "", false
+	}
+	return fields[len(fields)-1], true
 }
 
 func runDoctor(args []string) error {
@@ -317,6 +344,7 @@ func runDoctorChecks(d doctorExecution) ([]doctorCheck, string) {
 	checks = append(checks, doctorCheckAMQOps(d))
 	checks = append(checks, doctorCheckTeamConfig(d))
 	checks = append(checks, doctorCheckTmux(d))
+	checks = append(checks, doctorCheckTmuxExtendedKeys(d))
 	checks = append(checks, doctorCheckMarkerIntegrity(d)...)
 	checks = append(checks, doctorCheckPointerSync(d)...)
 	wakeChecks, workstream := doctorCheckWake(d)
@@ -459,6 +487,60 @@ func doctorCheckTmux(d doctorExecution) doctorCheck {
 		}
 	}
 	return doctorCheck{Name: "tmux", Status: doctorOK, Detail: path}
+}
+
+// doctorCheckTmuxExtendedKeys is an INFORMATIONAL hint (never fail) about plain
+// tmux dropping modified keys. When running inside tmux ($TMUX set) with the
+// server-wide `extended-keys` option off or unset, modified keys like
+// Shift+Enter (used for newline-in-input by some agents) don't reach the agent.
+// We surface the opt-in tmux settings the operator can apply themselves, and
+// note that iTerm2's tmux -CC (the attach_control action) avoids this entirely.
+//
+// amq-squad does NOT change the tmux server for you: this check only READS
+// `tmux show-options -s extended-keys` and PRINTS the hint. It is a no-op (ok)
+// when not inside tmux or when extended-keys is already on.
+func doctorCheckTmuxExtendedKeys(d doctorExecution) doctorCheck {
+	const name = "tmux extended-keys"
+	getenv := d.Getenv
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	if strings.TrimSpace(getenv("TMUX")) == "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "not running inside tmux; skipped",
+		}
+	}
+	if d.TmuxShowOptions == nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "extended-keys probe unavailable; skipped",
+		}
+	}
+	value, ok := d.TmuxShowOptions("extended-keys")
+	value = strings.TrimSpace(value)
+	if ok && value != "" && value != "off" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "extended-keys " + value + " (modified keys like Shift+Enter reach agents)",
+		}
+	}
+	state := "unset"
+	if ok && value != "" {
+		state = value
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: "extended-keys " + state + ": modified keys (e.g. Shift+Enter) may not reach agents in plain tmux. " +
+			"This is a server-wide tmux setting you opt into (amq-squad does not change it for you); enable with: " +
+			"tmux set-option -s extended-keys on; tmux set-option -s extended-keys-format csi-u; " +
+			"tmux set-option -as terminal-features 'xterm*:extkeys'. " +
+			"iTerm2 tmux -CC (the attach_control action) avoids this entirely.",
+	}
 }
 
 func doctorCheckMarkerIntegrity(d doctorExecution) []doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -438,6 +438,78 @@ func TestExecuteDoctorTmuxMissingFails(t *testing.T) {
 	}
 }
 
+func TestDoctorCheckTmuxExtendedKeys(t *testing.T) {
+	// Not inside tmux -> skipped, OK, no hint.
+	t.Run("not in tmux", func(t *testing.T) {
+		d := doctorExecution{
+			Getenv:          func(string) string { return "" },
+			TmuxShowOptions: func(string) (string, bool) { t.Fatal("must not probe tmux when $TMUX is unset"); return "", false },
+		}
+		c := doctorCheckTmuxExtendedKeys(d)
+		if c.Status != doctorOK {
+			t.Errorf("not-in-tmux status = %q, want ok", c.Status)
+		}
+		if !strings.Contains(c.Detail, "skipped") || strings.Contains(c.Detail, "Shift+Enter") {
+			t.Errorf("not-in-tmux detail should be a skip with no hint: %q", c.Detail)
+		}
+	})
+
+	// Inside tmux, extended-keys off -> OK (never fails) WITH the hint.
+	t.Run("off shows hint", func(t *testing.T) {
+		d := doctorExecution{
+			Getenv:          func(name string) string { return map[string]string{"TMUX": "/tmp/tmux-1/default,1,0"}[name] },
+			TmuxShowOptions: func(string) (string, bool) { return "off", true },
+		}
+		c := doctorCheckTmuxExtendedKeys(d)
+		if c.Status != doctorOK {
+			t.Errorf("extended-keys off must NOT fail doctor; status = %q", c.Status)
+		}
+		for _, want := range []string{
+			"Shift+Enter",
+			"tmux set-option -s extended-keys on",
+			"extended-keys-format csi-u",
+			"xterm*:extkeys",
+			"tmux -CC",
+			"amq-squad does not change it for you",
+		} {
+			if !strings.Contains(c.Detail, want) {
+				t.Errorf("hint missing %q: %q", want, c.Detail)
+			}
+		}
+	})
+
+	// Inside tmux, extended-keys unset (ok=false) -> OK with the hint too.
+	t.Run("unset shows hint", func(t *testing.T) {
+		d := doctorExecution{
+			Getenv:          func(string) string { return "/tmp/tmux-1/default,1,0" },
+			TmuxShowOptions: func(string) (string, bool) { return "", false },
+		}
+		c := doctorCheckTmuxExtendedKeys(d)
+		if c.Status != doctorOK || !strings.Contains(c.Detail, "Shift+Enter") {
+			t.Errorf("unset extended-keys should be ok with hint, got %+v", c)
+		}
+		if !strings.Contains(c.Detail, "unset") {
+			t.Errorf("unset detail should name the unset state: %q", c.Detail)
+		}
+	})
+
+	// Inside tmux, extended-keys on -> OK, no hint.
+	t.Run("on no hint", func(t *testing.T) {
+		d := doctorExecution{
+			Getenv:          func(string) string { return "/tmp/tmux-1/default,1,0" },
+			TmuxShowOptions: func(string) (string, bool) { return "on", true },
+		}
+		c := doctorCheckTmuxExtendedKeys(d)
+		if c.Status != doctorOK {
+			t.Errorf("extended-keys on status = %q, want ok", c.Status)
+		}
+		// The remediation hint (set-option commands) must be absent when on.
+		if strings.Contains(c.Detail, "set-option") || strings.Contains(c.Detail, "may not reach agents") {
+			t.Errorf("extended-keys on must not print the hint: %q", c.Detail)
+		}
+	})
+}
+
 func TestExecuteDoctorMarkerIntegrity(t *testing.T) {
 	cases := map[string]struct {
 		body   string

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -260,7 +260,7 @@ func TestSendRequiresRole(t *testing.T) {
 }
 
 func TestSessionActions(t *testing.T) {
-	acts := sessionActions("/Code/app", team.DefaultProfile, "issue-96")
+	acts := sessionActions("/Code/app", team.DefaultProfile, "issue-96", "")
 	byKind := map[string]runtimeActionJSON{}
 	for _, a := range acts {
 		byKind[a.Kind] = a
@@ -304,7 +304,76 @@ func TestSessionActions(t *testing.T) {
 	if strings.Contains(byKind["status"].Command, "--profile") {
 		t.Errorf("default profile must be omitted: %q", byKind["status"].Command)
 	}
-	if !strings.Contains(sessionActions("/Code/app", "review", "issue-96")[0].Command, "--profile review") {
+	if !strings.Contains(sessionActions("/Code/app", "review", "issue-96", "")[0].Command, "--profile review") {
 		t.Error("named profile must appear in session action commands")
+	}
+	// With no live tmux session, attach_control is ABSENT (no target to attach).
+	if _, ok := byKind["attach_control"]; ok {
+		t.Errorf("attach_control must be omitted when tmuxSession is empty: %+v", acts)
+	}
+
+	// With a live tmux session, attach_control is APPENDED: it is a raw
+	// `tmux -CC attach -t <session>` command, session-scoped, non-mutating, and
+	// carries no --role.
+	withTmux := sessionActions("/Code/app", team.DefaultProfile, "issue-96", "main")
+	var attach *runtimeActionJSON
+	for i := range withTmux {
+		if withTmux[i].Kind == "attach_control" {
+			attach = &withTmux[i]
+		}
+	}
+	if attach == nil {
+		t.Fatalf("attach_control must be present when tmuxSession is non-empty: %+v", withTmux)
+	}
+	if attach.Command != "tmux -CC attach -t main" {
+		t.Errorf("attach_control command = %q, want %q", attach.Command, "tmux -CC attach -t main")
+	}
+	if attach.Scope != "session" {
+		t.Errorf("attach_control scope = %q, want session", attach.Scope)
+	}
+	if attach.Mutates || attach.NeedsConfirmation {
+		t.Errorf("attach_control must not mutate or need confirmation: %+v", attach)
+	}
+	if !attach.Available {
+		t.Errorf("attach_control must be available when tmuxSession is non-empty: %+v", attach)
+	}
+	if attach.Label == "" {
+		t.Errorf("attach_control must carry a label")
+	}
+	if strings.Contains(attach.Command, "--role") {
+		t.Errorf("attach_control is session-scoped and must not carry --role: %q", attach.Command)
+	}
+	// A session token needing shell quoting is quoted consistently.
+	quoted := sessionActions("/Code/app", team.DefaultProfile, "issue-96", "my session")
+	var quotedAttach string
+	for _, a := range quoted {
+		if a.Kind == "attach_control" {
+			quotedAttach = a.Command
+		}
+	}
+	if quotedAttach != "tmux -CC attach -t 'my session'" {
+		t.Errorf("attach_control should shell-quote the session token: %q", quotedAttach)
+	}
+}
+
+func TestFirstLiveTmuxSession(t *testing.T) {
+	// No rows / no tmux identity -> "".
+	if got := firstLiveTmuxSession(nil); got != "" {
+		t.Errorf("nil rows: got %q, want empty", got)
+	}
+	rows := []statusRecord{
+		{Role: "cto"}, // no tmux block
+		{Role: "qa", Tmux: &tmuxRuntimeJSON{Session: "dead", PaneID: "%1", PaneAlive: false}},
+	}
+	if got := firstLiveTmuxSession(rows); got != "" {
+		t.Errorf("no live pane: got %q, want empty", got)
+	}
+	// First live-pane row's session wins, even if a later row is also live.
+	rows = append(rows,
+		statusRecord{Role: "fs", Tmux: &tmuxRuntimeJSON{Session: "alpha", PaneID: "%2", PaneAlive: true}},
+		statusRecord{Role: "be", Tmux: &tmuxRuntimeJSON{Session: "beta", PaneID: "%3", PaneAlive: true}},
+	)
+	if got := firstLiveTmuxSession(rows); got != "alpha" {
+		t.Errorf("first live-pane session: got %q, want alpha", got)
 	}
 }

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -162,16 +162,52 @@ func commandScope(projectDir, profile, session string) string {
 // from stop + a resume). resume_new_session lets amq-squad derive the tmux
 // session name (omitting --terminal-session). All are runnable commands, so
 // available is true; the mutating ones request confirmation.
-func sessionActions(projectDir, profile, session string) []runtimeActionJSON {
+//
+// tmuxSession is the live tmux session the workstream's agents run in (derived
+// from the status rows). When non-empty, an attach_control action is appended
+// so a client can open/attach the session in iTerm2's tmux -CC control mode;
+// when empty it is omitted (no attach target to point at).
+func sessionActions(projectDir, profile, session, tmuxSession string) []runtimeActionJSON {
 	base := "amq-squad"
 	scope := commandScope(projectDir, profile, session)
-	return []runtimeActionJSON{
+	actions := []runtimeActionJSON{
 		{Kind: "status", Label: "show session status", Scope: "session", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " status" + scope + " --json"},
 		{Kind: "resume_preview", Label: "preview resume plan", Scope: "session", Mutates: false, NeedsConfirmation: false, Available: true, Command: base + " resume" + scope + " --json"},
 		{Kind: "resume_current_window", Label: "resume in current window", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec --target current-window"},
 		{Kind: "resume_new_session", Label: "resume in new tmux session", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " resume" + scope + " --exec --target new-session"},
 		{Kind: "stop", Label: "stop the session", Scope: "session", Mutates: true, NeedsConfirmation: true, Available: true, Command: base + " stop" + scope + " --all"},
 	}
+	// attach_control is a raw tmux command for the OPERATOR/NOC to run (NOT an
+	// amq-squad subcommand): `tmux -CC attach` is an interactive foreground
+	// client attach, so it is print/copy-oriented and amq-squad never execs it.
+	// Under iTerm2's tmux -CC control mode it gets native rendering and lets
+	// modified keys (e.g. Shift+Enter) reach the agent. It only makes sense when
+	// the workstream has a live tmux session, so it is appended only then.
+	if tmuxSession != "" {
+		actions = append(actions, runtimeActionJSON{
+			Kind:              "attach_control",
+			Label:             "open in iTerm2 (tmux -CC)",
+			Scope:             "session",
+			Mutates:           false,
+			NeedsConfirmation: false,
+			Available:         true,
+			Command:           "tmux -CC attach -t " + shellQuote(tmuxSession),
+		})
+	}
+	return actions
+}
+
+// firstLiveTmuxSession returns the tmux session name of the first status row
+// that carries a live tmux pane (Tmux != nil && Tmux.PaneAlive), or "" when no
+// row has a live pane. It is how the status write site derives the attach
+// target for the session-scope attach_control action.
+func firstLiveTmuxSession(rows []statusRecord) string {
+	for _, r := range rows {
+		if r.Tmux != nil && r.Tmux.PaneAlive {
+			return r.Tmux.Session
+		}
+	}
+	return ""
 }
 
 // resumeMemberJSON is one member row in the resume_plan envelope. It mirrors the

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -213,7 +213,7 @@ func executeStatus(s statusExecution) error {
 			Operator:     team.EffectiveOperator(t),
 			Capabilities: team.EffectiveCapabilities(t),
 			Records:      rows,
-			Actions:      sessionActions(t.Project, s.Profile, workstream),
+			Actions:      sessionActions(t.Project, s.Profile, workstream, firstLiveTmuxSession(rows)),
 		})
 	}
 	policy := outputPolicyCurrent()


### PR DESCRIPTION
Two related "make plain tmux behave like iTerm2 -CC" changes for v1.5.3.

## #85 — `attach_control` session-scope action
Single-session \`status --json\` now also emits an \`attach_control\` action when the workstream has a **live** tmux session:
\`\`\`json
{"kind":"attach_control","label":"open in iTerm2 (tmux -CC)","scope":"session",
 "mutates":false,"needs_confirmation":false,"available":true,
 "command":"tmux -CC attach -t <tmux-session>"}
\`\`\`
- Derived target: \`firstLiveTmuxSession(rows)\` = the \`Tmux.Session\` of the first row with a live pane; **omitted** when there's no live tmux session (never an empty target).
- It's a raw operator/NOC command (print/copy-oriented) — \`tmux -CC attach\` is an interactive foreground attach, so amq-squad never execs it (Codex-recommended shape; *not* a \`--target\`).
- Opening the workstream under \`-CC\` gives native iTerm2 windows/panes **and** makes Shift+Enter work natively.

## shift+enter — doctor hint (no server mutation)
\`amq-squad doctor\` adds a \`tmux extended-keys\` check: when inside tmux with \`extended-keys off\`/unset, it prints an **informational** hint (doctor still passes) that modified keys like Shift+Enter may not reach agents in plain tmux, the opt-in \`set-option\` commands to enable it, and that iTerm2 \`tmux -CC\` avoids it. **amq-squad never changes the user's tmux server** — it only prints the hint (extended-keys is server-wide + terminal-dependent, so it must be the operator's choice).

## Tests / safety
- \`TestSessionActions\` updated (new 4-arg signature + attach present/absent + quoting), \`TestFirstLiveTmuxSession\`, \`TestDoctorCheckTmuxExtendedKeys\` (off→hint, unset→hint, on→none, not-in-tmux→skip; seams injected, no real tmux).
- Additive/backward-compatible; board envelope unchanged. Full suite, vet, gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)