### PR TITLE
Release prep v1.5.3 (Closes #85, #86)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -23,6 +23,19 @@ the open issues by theme + status so the near-term path is legible at a glance.
     resume_new_session / stop) — closes amq-noc#7's producer side. Board/
     project-scope actions deferred (the board envelope carries no per-session
     profile).
+- **v1.5.3 — shipped.**
+  - **#86 — prompt delivery dropped the Enter.** `send` now submits robustly in
+    plain tmux: settle, Enter, verify the input region changed, retry, and a
+    clear error instead of silently leaving text staged.
+  - **#85 — iTerm2 `tmux -CC`.** An `attach_control` session action
+    (`tmux -CC attach -t <session>`) when the workstream has a live tmux session;
+    opening under `-CC` also makes Shift+Enter work natively.
+  - **shift+enter doctor hint** — `doctor` warns (informational) when tmux
+    `extended-keys` is off, with the opt-in fix; amq-squad never mutates the
+    user's tmux server.
+  - **#87** — plain `resume` vs `--json` was a cross-invocation race, not a code
+    bug; pinned with a consistency regression test.
+  - **#81** — post-release peer-notification norm in the default team-rules.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.2
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.3
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
v1.5.3 ships:
- **#86** — `send` submit-hang fix: robust settle/verify/retry/clear-error so prompts can't hang staged in plain tmux (PR #88).
- **#85** — iTerm2 `tmux -CC` `attach_control` session action + a `doctor` shift+enter hint for tmux `extended-keys` (PR #91).
- **#87** — plain `resume` vs `--json` diagnosed as a cross-invocation race; pinned with a consistency regression test (PR #90).
- **#81** — post-release peer-notification norm in the default team-rules (PR #89, already closed).

This PR: PLAN.md (mark v1.5.3 shipped) + bump install reference + plugin manifests to v1.5.3. Docs/version only.

Closes #85
Closes #86