### PR TITLE
Release prep v1.5.4: roadmap + version bumps

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -33,9 +33,20 @@ the open issues by theme + status so the near-term path is legible at a glance.
   - **shift+enter doctor hint** — `doctor` warns (informational) when tmux
     `extended-keys` is off, with the opt-in fix; amq-squad never mutates the
     user's tmux server.
-  - **#87** — plain `resume` vs `--json` was a cross-invocation race, not a code
-    bug; pinned with a consistency regression test.
+  - **#87** — plain `resume` vs `--json`: shipped a consistency regression test
+    (the same-invocation paths share one plan). NOTE: #87 was later **reopened**
+    with a deterministic repro and the real cause fixed in v1.5.4.
   - **#81** — post-release peer-notification norm in the default team-rules.
+- **v1.5.4 — shipped.**
+  - **#87 (reopened)** — `status`/`doctor` called live launch records stale
+    while `resume` saw them live, with `ps` proving the PIDs alive. Root cause:
+    `ProcessMatch` forked `ps`, which returns `EAGAIN` under fork pressure (a
+    large process table), demoting a live agent/wake to stale on some surfaces
+    but not others. Fix: read process command lines **fork-free** (darwin
+    `KERN_PROCARGS2` / linux `/proc`, `ps -ww` fallback) and `EPERM`⇒alive,
+    unified into one shared `internal/procinfo` probe consumed by BOTH
+    `internal/cli` and `internal/state` (the status board + NOC snapshots), so
+    every surface reads liveness identically.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.3
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.4
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
v1.5.4 ships the **#87 (reopened)** fix — a unified, **fork-free** liveness probe (`internal/procinfo`) consumed by both `internal/cli` and `internal/state`, so status/doctor/resume/preflight + the status board + NOC snapshots can't demote a live PID to stale under fork pressure (was: `ProcessMatch` forked `ps`, `EAGAIN` under load). The code landed via squash-merge of #93 (which already `Closes #87`).

This PR: PLAN.md (annotate the v1.5.3 #87 entry as reopened + mark v1.5.4 shipped) + bump install reference + plugin manifests to v1.5.4. Docs/version only.

amq-noc dev re-validated rc2 → **GO for #87** (60/60 under load + sabotaged-`ps` across status/resume/doctor/board/NOC).