### PR TITLE
Adopt externally-launched agent panes by PID lineage (#95)

### DIFF
--- a/internal/cli/pane_adopt.go
+++ b/internal/cli/pane_adopt.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/internal/procinfo"
+	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
+)
+
+// childrenPidTree returns a best-effort, fork-free pid->children function for
+// the tmux resolver's PID-lineage matching (#95: adopt externally-launched
+// panes). Returns nil when the process table cannot be read, in which case the
+// resolver degrades to title/cwd/engine matching rather than failing.
+func childrenPidTree() func(int) []int {
+	tree, err := procinfo.ChildrenIndex()
+	if err != nil {
+		return nil
+	}
+	return tree
+}
+
+// adoptLivePane resolves a LIVE tmux pane for an agent that has no usable
+// recorded pane — e.g. one launched OUTSIDE amq-squad's tmux backend
+// (Sagi-style raw `tmux new-window`), whose launch record carries no tmux
+// block. It resolves by title token, then cwd+engine, anchored by PID lineage
+// (agentPID must live in the pane's process subtree) so an externally-launched
+// pane is attributed to the right agent even when peers share cwd+engine.
+// Returns a synthesized tmux identity (no Target — it was not amq-launched) or
+// nil when no pane resolves. This is what lets focus/send/attach_control work
+// for adopted agents.
+func adoptLivePane(role, handle, binary, cwd, workstream string, agentPID int, panes []tmuxpane.TmuxPane, pidTree func(int) []int) *launch.TmuxInfo {
+	if len(panes) == 0 {
+		return nil
+	}
+	ag := state.Agent{Handle: handle, Role: role, Engine: binary, AgentPID: agentPID}
+	tgt, ok := tmuxpane.ResolveTmuxTargetForSession(ag, workstream, cwd, panes, pidTree)
+	if !ok {
+		return nil
+	}
+	paneID := paneIDForTarget(tgt, panes)
+	if paneID == "" {
+		return nil
+	}
+	p, found := tmuxpane.FindPaneByID(paneID, panes)
+	if !found {
+		return nil
+	}
+	return &launch.TmuxInfo{
+		Session:    p.Session,
+		WindowID:   p.WindowID,
+		WindowName: p.WindowName,
+		PaneID:     p.PaneID,
+	}
+}

--- a/internal/cli/pane_adopt.go
+++ b/internal/cli/pane_adopt.go
@@ -1,11 +1,31 @@
 package cli
 
 import (
+	"strings"
+
 	"github.com/omriariav/amq-squad/internal/launch"
 	"github.com/omriariav/amq-squad/internal/procinfo"
 	"github.com/omriariav/amq-squad/internal/state"
 	"github.com/omriariav/amq-squad/internal/tmuxpane"
 )
+
+// verifiedAgentPID returns pid only when it is a LIVE process running the
+// expected binary. PID-lineage pane resolution treats a match as definitive and
+// bypasses the cwd/engine heuristics, so the pid MUST be verified first or a
+// stale/reused pid from an old launch record could resolve onto an unrelated
+// pane. Callers that read a record directly (focus/send) must pass the result
+// of this; callers that already hold a verified agent-live verdict (status /
+// resume) may pass the verified Signals.AgentPID directly.
+func verifiedAgentPID(pid int, binary string) int {
+	if pid <= 0 || !procinfo.Alive(pid) {
+		return 0
+	}
+	b := strings.TrimSpace(binary)
+	if b == "" || !procinfo.Match(pid, agentProcessMatcher(b)) {
+		return 0
+	}
+	return pid
+}
 
 // childrenPidTree returns a best-effort, fork-free pid->children function for
 // the tmux resolver's PID-lineage matching (#95: adopt externally-launched
@@ -28,6 +48,10 @@ func childrenPidTree() func(int) []int {
 // Returns a synthesized tmux identity (no Target — it was not amq-launched) or
 // nil when no pane resolves. This is what lets focus/send/attach_control work
 // for adopted agents.
+//
+// agentPID MUST be a VERIFIED live agent pid (caller's responsibility: a verdict
+// of agent-live, or verifiedAgentPID for record-only callers). Passing an
+// unverified/stale pid risks resolving onto an unrelated pane via reuse.
 func adoptLivePane(role, handle, binary, cwd, workstream string, agentPID int, panes []tmuxpane.TmuxPane, pidTree func(int) []int) *launch.TmuxInfo {
 	if len(panes) == 0 {
 		return nil

--- a/internal/cli/pane_adopt_test.go
+++ b/internal/cli/pane_adopt_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/omriariav/amq-squad/internal/tmuxpane"
@@ -59,5 +60,25 @@ func TestAdoptLivePaneByPidWhenCommandMismatches(t *testing.T) {
 	}
 	if got := adoptLivePane("fullstack", "fullstack", "claude", "/repo", "main", 62277, panes, nil); got != nil {
 		t.Errorf("without PID lineage, a mismatched command must NOT adopt; got %+v", got)
+	}
+}
+
+// #95 review: PID-lineage adoption bypasses cwd+engine, so the anchoring pid
+// MUST be verified live + correct-binary; a stale/reused or wrong-binary pid is
+// rejected (returns 0 -> no lineage anchor).
+func TestVerifiedAgentPID(t *testing.T) {
+	if verifiedAgentPID(0, "codex") != 0 || verifiedAgentPID(-5, "codex") != 0 {
+		t.Error("non-positive pid must be 0")
+	}
+	if verifiedAgentPID(os.Getpid(), "") != 0 {
+		t.Error("empty binary must be 0")
+	}
+	// This live process is not running a binary named like this -> rejected.
+	if verifiedAgentPID(os.Getpid(), "definitely-not-this-binary-xyz") != 0 {
+		t.Error("a live pid running a DIFFERENT binary must be rejected (reuse guard)")
+	}
+	// A (very likely) dead pid -> rejected.
+	if verifiedAgentPID(2147483646, "codex") != 0 {
+		t.Error("a dead pid must be rejected")
 	}
 }

--- a/internal/cli/pane_adopt_test.go
+++ b/internal/cli/pane_adopt_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/tmuxpane"
+)
+
+// #95: adoptLivePane must resolve an externally-launched agent's live pane, and
+// PID lineage must disambiguate peers that share cwd+engine.
+func TestAdoptLivePane(t *testing.T) {
+	panes := []tmuxpane.TmuxPane{
+		{Session: "main", Pane: "1", PID: 100, Command: "codex", CWD: "/repo", PaneID: "%5", WindowID: "@1", WindowName: "w0"},
+		{Session: "main", Pane: "2", PID: 200, Command: "codex", CWD: "/repo", PaneID: "%6", WindowID: "@1", WindowName: "w0"},
+	}
+	// agent 62195 runs under pane %5's shell (pid 100); 62277 under %6 (pid 200).
+	tree := func(pid int) []int {
+		return map[int][]int{100: {62195}, 200: {62277}}[pid]
+	}
+
+	if got := adoptLivePane("cto", "cto", "codex", "/repo", "main", 62277, panes, tree); got == nil || got.PaneID != "%6" {
+		t.Fatalf("agent 62277 lives under %%6; got %+v", got)
+	}
+	if got := adoptLivePane("cto", "cto", "codex", "/repo", "main", 62195, panes, tree); got == nil || got.PaneID != "%5" {
+		t.Fatalf("agent 62195 lives under %%5; got %+v", got)
+	}
+	// Adopted identity carries the pane's session/window/pane so focus/send/attach work.
+	got := adoptLivePane("cto", "cto", "codex", "/repo", "main", 62195, panes, tree)
+	if got.Session != "main" || got.WindowID != "@1" || got.PaneID != "%5" {
+		t.Errorf("adopted identity incomplete: %+v", got)
+	}
+	// No PID-lineage match (pid 999 is in no pane's tree) AND no cwd match: the
+	// heuristic gate applies and rejects. A PID match would bypass cwd since it
+	// is definitive (exercised above).
+	if got := adoptLivePane("cto", "cto", "codex", "/elsewhere", "main", 999, panes, tree); got != nil {
+		t.Errorf("no pid match + no cwd match must yield nil, got %+v", got)
+	}
+	// No panes at all -> nil.
+	if got := adoptLivePane("cto", "cto", "codex", "/repo", "main", 62195, nil, tree); got != nil {
+		t.Errorf("no panes must yield nil, got %+v", got)
+	}
+}
+
+// #95 regression: claude/codex rename their process, so a pane's foreground
+// command may not match the engine name (e.g. "2.1.169"). A definitive PID
+// lineage must adopt the pane anyway; without it, the engine gate rejects.
+func TestAdoptLivePaneByPidWhenCommandMismatches(t *testing.T) {
+	panes := []tmuxpane.TmuxPane{
+		{Session: "main", Pane: "1", PID: 61773, Command: "2.1.169", CWD: "/repo", PaneID: "%145", WindowID: "@2"},
+	}
+	tree := func(pid int) []int {
+		if pid == 61773 {
+			return []int{62277}
+		}
+		return nil
+	}
+	if got := adoptLivePane("fullstack", "fullstack", "claude", "/repo", "main", 62277, panes, tree); got == nil || got.PaneID != "%145" {
+		t.Fatalf("PID lineage must adopt despite a mismatched foreground command; got %+v", got)
+	}
+	if got := adoptLivePane("fullstack", "fullstack", "claude", "/repo", "main", 62277, panes, nil); got != nil {
+		t.Errorf("without PID lineage, a mismatched command must NOT adopt; got %+v", got)
+	}
+}

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -95,10 +95,16 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 		}
 		return "", tmuxpane.TmuxTarget{}, false
 	}
-	// No recorded pane id (a pre-1.5 record, or an agent launched outside tmux):
-	// best-effort resolve by title-first, then cwd+engine.
+	// No recorded pane id (a pre-1.5 record, or an agent launched outside
+	// amq-squad's tmux backend): best-effort resolve by title-first, then
+	// cwd+engine, anchored by PID lineage so an externally-launched pane resolves
+	// to the right agent even when peers share cwd+engine (#95). The recorded
+	// agent pid (present even when no tmux block was captured) anchors the match.
 	ag := state.Agent{Handle: mr.Handle, Role: mr.Member.Role, Engine: mr.Member.Binary}
-	if tgt, found := tmuxpane.ResolveTmuxTargetForSession(ag, workstream, mr.CWD, panes, nil); found {
+	if mr.HasRecord {
+		ag.AgentPID = mr.Record.AgentPID
+	}
+	if tgt, found := tmuxpane.ResolveTmuxTargetForSession(ag, workstream, mr.CWD, panes, childrenPidTree()); found {
 		// tgt.Pane is the pane INDEX; tmux would resolve a bare index relative
 		// to the current client/window, not the agent's pane. Resolve to the
 		// exact pane_id, falling back to a fully-qualified session:window.pane

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -102,7 +102,10 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 	// agent pid (present even when no tmux block was captured) anchors the match.
 	ag := state.Agent{Handle: mr.Handle, Role: mr.Member.Role, Engine: mr.Member.Binary}
 	if mr.HasRecord {
-		ag.AgentPID = mr.Record.AgentPID
+		// Trust PID lineage only for a VERIFIED live agent pid: focus/send read
+		// the record without a liveness verdict, so a stale/reused pid must not
+		// anchor a cwd/engine-bypassing match (#95 review).
+		ag.AgentPID = verifiedAgentPID(mr.Record.AgentPID, mr.Member.Binary)
 	}
 	if tgt, found := tmuxpane.ResolveTmuxTargetForSession(ag, workstream, mr.CWD, panes, childrenPidTree()); found {
 		// tgt.Pane is the pane INDEX; tmux would resolve a bare index relative

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -188,6 +188,20 @@ func executeStatus(s statusExecution) error {
 	for _, m := range members {
 		rows = append(rows, classifyMemberStatus(t, m, workstream, s.Probe))
 	}
+	// #95: adopt a live tmux pane for live agents with no recorded tmux identity
+	// (launched outside amq-squad's tmux backend, e.g. a raw `tmux new-window`),
+	// so focus/send/attach_control and pane_alive work for them too. Resolved by
+	// PID lineage + cwd/engine from the memoized pane snapshot.
+	pidTree := childrenPidTree()
+	for i := range rows {
+		if rows[i].Tmux == nil && isLiveStatusState(rows[i].Status) {
+			if panes, perr := statusPaneLister(); perr == nil {
+				if adopted := adoptLivePane(rows[i].Role, rows[i].Handle, rows[i].Binary, rows[i].CWD, workstream, rows[i].Signals.AgentPID, panes, pidTree); adopted != nil {
+					rows[i].Tmux = tmuxRuntimeFromInfo(adopted)
+				}
+			}
+		}
+	}
 	// Resolve pane liveness for every member that recorded a tmux pane, so
 	// clients can tell a still-valid pane from a stale launch record. Uses the
 	// same memoized snapshot as classification above.
@@ -237,6 +251,13 @@ func firstStatusRoot(rows []statusRecord) string {
 		}
 	}
 	return ""
+}
+
+// isLiveStatusState reports whether a status state counts as a live agent
+// (verified agent pid, or a verified wake helper). Used to decide whether to
+// attempt live-pane adoption for an agent with no recorded tmux identity.
+func isLiveStatusState(s statusState) bool {
+	return s == statusStateLive || s == statusStateWakeLive
 }
 
 func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe duplicateLaunchProbe) statusRecord {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -194,7 +194,11 @@ func executeStatus(s statusExecution) error {
 	// PID lineage + cwd/engine from the memoized pane snapshot.
 	pidTree := childrenPidTree()
 	for i := range rows {
-		if rows[i].Tmux == nil && isLiveStatusState(rows[i].Status) {
+		// Only verified AGENT-live agents adopt by PID lineage: Signals.AgentPID
+		// is then a confirmed live process of the right binary. wake-live /
+		// presence-live have no verified agent pid, so do not trust lineage there
+		// (#95 review).
+		if rows[i].Tmux == nil && rows[i].Signals.AgentAlive && rows[i].Signals.BinaryMatch {
 			if panes, perr := statusPaneLister(); perr == nil {
 				if adopted := adoptLivePane(rows[i].Role, rows[i].Handle, rows[i].Binary, rows[i].CWD, workstream, rows[i].Signals.AgentPID, panes, pidTree); adopted != nil {
 					rows[i].Tmux = tmuxRuntimeFromInfo(adopted)
@@ -251,13 +255,6 @@ func firstStatusRoot(rows []statusRecord) string {
 		}
 	}
 	return ""
-}
-
-// isLiveStatusState reports whether a status state counts as a live agent
-// (verified agent pid, or a verified wake helper). Used to decide whether to
-// attempt live-pane adoption for an agent with no recorded tmux identity.
-func isLiveStatusState(s statusState) bool {
-	return s == statusStateLive || s == statusStateWakeLive
 }
 
 func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe duplicateLaunchProbe) statusRecord {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -630,9 +630,11 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 
 	// #95: a live agent launched outside amq-squad's tmux backend has no recorded
 	// tmux block; adopt its live pane so resume --json exposes the same pane
-	// identity status does (focus/attach parity across surfaces). Live agents
-	// only — a dead agent's pane is handled by the replacement path/classifier.
-	if live.Live() && plan.Tmux == nil {
+	// identity status does (focus/attach parity across surfaces). Verified
+	// AGENT-live only: that verdict proves Signals.AgentPID is a live process of
+	// the right binary, so PID lineage is safe. wake-live/presence-live have no
+	// verified agent pid (#95 review).
+	if live.Verdict == livenessAgentLive && plan.Tmux == nil {
 		if panes, perr := statusPaneLister(); perr == nil {
 			if adopted := adoptLivePane(m.Role, handle, m.Binary, cwd, env.SessionName, live.Signals.AgentPID, panes, childrenPidTree()); adopted != nil {
 				plan.Tmux = adopted

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -628,6 +628,18 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	live := classifyAgentLiveness(agentDir, root, handle, m.Role, m.Binary, env.SessionName, cwd, probe)
 	plan.Liveness = &live
 
+	// #95: a live agent launched outside amq-squad's tmux backend has no recorded
+	// tmux block; adopt its live pane so resume --json exposes the same pane
+	// identity status does (focus/attach parity across surfaces). Live agents
+	// only — a dead agent's pane is handled by the replacement path/classifier.
+	if live.Live() && plan.Tmux == nil {
+		if panes, perr := statusPaneLister(); perr == nil {
+			if adopted := adoptLivePane(m.Role, handle, m.Binary, cwd, env.SessionName, live.Signals.AgentPID, panes, childrenPidTree()); adopted != nil {
+				plan.Tmux = adopted
+			}
+		}
+	}
+
 	// Surface a real I/O inspection error as blocked, preserving the prior
 	// safety contract. The preflight is still the authority on read errors; we
 	// run it in dry-run mode purely to catch perr (it reaps nothing on disk in

--- a/internal/procinfo/native_darwin.go
+++ b/internal/procinfo/native_darwin.go
@@ -13,3 +13,22 @@ func readArgsNative(pid int) (string, bool) {
 	}
 	return parseKernProcArgs2(buf)
 }
+
+// parentChildIndex builds a parent-pid -> child-pids map from the KERN_PROC_ALL
+// sysctl (no fork), so the tmux resolver can walk a pane's process subtree to a
+// recorded agent pid without shelling `ps`.
+func parentChildIndex() (map[int][]int, error) {
+	procs, err := unix.SysctlKinfoProcSlice("kern.proc.all")
+	if err != nil {
+		return nil, err
+	}
+	index := make(map[int][]int, len(procs))
+	for i := range procs {
+		pid := int(procs[i].Proc.P_pid)
+		ppid := int(procs[i].Eproc.Ppid)
+		if pid > 0 && ppid > 0 {
+			index[ppid] = append(index[ppid], pid)
+		}
+	}
+	return index, nil
+}

--- a/internal/procinfo/native_linux.go
+++ b/internal/procinfo/native_linux.go
@@ -5,6 +5,7 @@ package procinfo
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // readArgsNative reads pid's full command line from /proc/<pid>/cmdline — no
@@ -15,4 +16,49 @@ func readArgsNative(pid int) (string, bool) {
 		return "", false
 	}
 	return parseProcCmdline(buf)
+}
+
+// parentChildIndex builds a parent-pid -> child-pids map by scanning
+// /proc/<pid>/stat (no fork). The comm field (2) is parenthesized and may
+// contain spaces, so ppid is read relative to the LAST ')'.
+func parentChildIndex() (map[int][]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	index := make(map[int][]int, len(entries))
+	for _, e := range entries {
+		pid, perr := strconv.Atoi(e.Name())
+		if perr != nil || pid <= 0 {
+			continue
+		}
+		buf, rerr := os.ReadFile("/proc/" + e.Name() + "/stat")
+		if rerr != nil {
+			continue
+		}
+		ppid, ok := ppidFromStat(string(buf))
+		if ok && ppid > 0 {
+			index[ppid] = append(index[ppid], pid)
+		}
+	}
+	return index, nil
+}
+
+// ppidFromStat extracts the parent pid (field 4) from a /proc/<pid>/stat line,
+// parsing after the comm field's closing paren.
+func ppidFromStat(stat string) (int, bool) {
+	close := strings.LastIndexByte(stat, ')')
+	if close < 0 || close+1 >= len(stat) {
+		return 0, false
+	}
+	fields := strings.Fields(stat[close+1:])
+	// fields[0] = state, fields[1] = ppid
+	if len(fields) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, false
+	}
+	return ppid, true
 }

--- a/internal/procinfo/native_other.go
+++ b/internal/procinfo/native_other.go
@@ -2,6 +2,13 @@
 
 package procinfo
 
+import "errors"
+
 // readArgsNative has no fork-free implementation on this platform; callers fall
 // back to ps.
 func readArgsNative(pid int) (string, bool) { return "", false }
+
+// parentChildIndex has no fork-free implementation on this platform.
+func parentChildIndex() (map[int][]int, error) {
+	return nil, errors.New("procinfo: no fork-free process table on this platform")
+}

--- a/internal/procinfo/procinfo.go
+++ b/internal/procinfo/procinfo.go
@@ -62,6 +62,21 @@ func Match(pid int, predicate func(args string) bool) bool {
 	return predicate(args)
 }
 
+// ChildrenIndex takes one fork-free snapshot of the process table and returns a
+// function mapping a pid to its IMMEDIATE child pids (suitable as the pidTree
+// seam for tmux pane resolution: walking a pane's pane_pid down to an agent
+// pid). The returned function is a closure over the snapshot, so repeated
+// lookups do not re-read the table. err is non-nil when the table cannot be
+// read (e.g. unsupported platform); callers should treat that as "no pid tree"
+// and degrade to non-pid resolution rather than failing.
+func ChildrenIndex() (func(pid int) []int, error) {
+	index, err := parentChildIndex()
+	if err != nil {
+		return nil, err
+	}
+	return func(pid int) []int { return index[pid] }, nil
+}
+
 // Args returns pid's full command line, fork-free where possible (darwin sysctl
 // / linux /proc), falling back to ps (with retry on transient fork failures)
 // otherwise. ok=false means it could not be read at all.

--- a/internal/procinfo/procinfo_test.go
+++ b/internal/procinfo/procinfo_test.go
@@ -2,6 +2,7 @@ package procinfo
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"syscall"
 	"testing"
@@ -121,5 +122,29 @@ func TestParseProcCmdline(t *testing.T) {
 	}
 	if _, ok := parseProcCmdline(nil); ok {
 		t.Error("empty cmdline must be not-ok")
+	}
+}
+
+// ChildrenIndex must build a real, fork-free parent->children map: this test
+// process is a child of its own parent (os.Getppid).
+func TestChildrenIndexFindsRealChild(t *testing.T) {
+	ci, err := ChildrenIndex()
+	if err != nil {
+		t.Skipf("no fork-free process table on this platform: %v", err)
+	}
+	ppid := os.Getppid()
+	self := os.Getpid()
+	found := false
+	for _, c := range ci(ppid) {
+		if c == self {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ChildrenIndex(%d) did not include this process %d; children=%v", ppid, self, ci(ppid))
+	}
+	// A pid with no children returns an empty slice, not a panic.
+	if got := ci(-1); len(got) != 0 {
+		t.Errorf("ci(-1) = %v, want empty", got)
 	}
 }

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -280,15 +280,25 @@ func ResolveTmuxTargetForSession(a state.Agent, sessionName, projectDir string, 
 		if want != "" && isAmqPaneToken(p.Title) && p.Title != want {
 			continue
 		}
-		if cleanDir(p.CWD) != wantCWD {
-			continue
-		}
-		if !commandMatchesEngine(p.Command, engine) {
-			continue
+
+		// A PID-lineage match is DEFINITIVE: the agent process literally lives in
+		// this pane's process subtree, so this is the agent's pane regardless of
+		// the pane's foreground command name (e.g. claude/codex rename their
+		// process) or a changed cwd. It therefore BYPASSES the cwd+engine
+		// heuristics, which only gate the non-pid fallback for agents launched
+		// outside amq-squad's tmux backend (#95).
+		pidMatch := a.AgentPID > 0 && pidTree != nil && subtreeContains(pidTree, p.PID, a.AgentPID)
+		if !pidMatch {
+			if cleanDir(p.CWD) != wantCWD {
+				continue
+			}
+			if !commandMatchesEngine(p.Command, engine) {
+				continue
+			}
 		}
 
 		score := 0
-		if a.AgentPID > 0 && pidTree != nil && subtreeContains(pidTree, p.PID, a.AgentPID) {
+		if pidMatch {
 			score += 100
 		}
 		if sessionName != "" && p.Session == sessionName {


### PR DESCRIPTION
Closes **#95**. Agents launched **outside** amq-squad's tmux backend (raw `tmux new-window`, Sagi-style) carry no recorded tmux identity, so `focus`/`send` were unavailable and `attach_control` omitted — even though the agent runs in a live pane. Now amq-squad **adopts** the live pane.

## How
- **`procinfo.ChildrenIndex()`** — one **fork-free** snapshot of the process table (darwin `KERN_PROC_ALL` sysctl, linux `/proc`) → a `pid → children` function. This is the resolver's `pidTree` seam, which callers previously always passed `nil`.
- **PID-lineage match is definitive** in `ResolveTmuxTargetForSession`: the agent process lives in exactly one pane's process subtree, so that pane is the agent's **regardless of the foreground command name** (claude/codex rename their process — fullstack's pane showed `cmd=2.1.169`) or a changed cwd. A PID match **bypasses the cwd+engine heuristics**, which still gate the non-pid fallback.
- **`focus`/`send`** (`resolveControlTarget`), **`status`**, and **`resume`** now feed a real `pidTree` and adopt a live pane for live agents lacking a recorded one, synthesizing the tmux identity so `focus`/`send`/`attach_control` and `pane_alive` work.

## Verified live
On the externally-launched amq-noc squad: **both** agents adopt their panes (cto `%144`, fullstack `%145`, `pane_alive: true`), `focus`/`send` become **available**, and **`attach_control` is published**. Before: `tmux: none`, focus/send unavailable, no attach_control.

## Tests
`ChildrenIndex` (finds a real child, fork-free), `adoptLivePane` PID-lineage **disambiguation** of cwd+engine peers, and the **command-mismatch-but-PID-match** regression (the `2.1.169` case). Fork-free (consistent with the #87 fix); additive; cross-builds darwin/linux/other. Full suite, vet, gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)