### PR TITLE
Release prep v1.6.0: roadmap + version bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.txt
 # Local scratch / RC build artifacts (never commit)
 amq-squad-rc-*
 .pm-os/
+.claude/worktrees/

--- a/PLAN.md
+++ b/PLAN.md
@@ -47,6 +47,18 @@ the open issues by theme + status so the near-term path is legible at a glance.
     unified into one shared `internal/procinfo` probe consumed by BOTH
     `internal/cli` and `internal/state` (the status board + NOC snapshots), so
     every surface reads liveness identically.
+- **v1.6.0 — shipped. Closes the Sagi-spawn gap.**
+  - **#95 — Adopt externally-launched panes.** Agents launched outside
+    amq-squad's tmux backend (raw `tmux new-window`, Sagi-style) now have their
+    live pane adopted by PID lineage (a fork-free `procinfo.ChildrenIndex`
+    snapshot), so `focus`/`send`/`attach_control` and `pane_alive` work for them.
+    A PID-lineage match is definitive and bypasses the cwd/engine heuristics, but
+    only for a verified live agent pid (guards stale/reused pids).
+  - **#76 — Agent-orchestrator skill** in both marketplaces: a lead-agent
+    playbook (the Sagi `spawn.md` equivalent) over the shipped primitives —
+    spawn / dispatch (busy-guarded `send`) / monitor (`status --json`) / the
+    `[AGENT-EVENT]`-over-AMQ reporting protocol / recover. Plus the corrected
+    `send` busy-guard note in the `amq-squad` skill.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Requires Go 1.25+, the `amq` binary on `PATH` (v0.34+), and `tmux` on `PATH` for
 ### Skills (plugin marketplaces)
 
 This repo doubles as a plugin marketplace that ships the amq-squad skills
-(`amq-squad`, `amq-team-setup`, `amq-squad-role-creator`) for both Claude Code
-and Codex. The CLI and the skills are versioned together.
+(`amq-squad`, `amq-squad-orchestrator`, `amq-team-setup`, `amq-squad-role-creator`)
+for both Claude Code and Codex. The CLI and the skills are versioned together.
 
 Claude Code:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.5 line:
+Install the 1.6 line:
 
 ```sh
 go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.6.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.5 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.5.4
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.6.0
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
**v1.6.0** closes the Sagi-spawn gap:
- **#95** — adopt externally-launched panes by PID lineage (fork-free `procinfo.ChildrenIndex`), so `focus`/`send`/`attach_control` work for agents launched outside amq-squad's tmux backend. Verified-pid guarded (PR #96).
- **#76** — the `amq-squad-orchestrator` skill in both marketplaces (lead-agent playbook + `[AGENT-EVENT]`-over-AMQ) + corrected `send` busy-guard note (PR #97).

This PR: PLAN.md (mark v1.6.0 shipped) + bump install reference + plugin manifests to v1.6.0 (minor) + gitignore `.claude/worktrees/`. Docs/version only. #95/#76 already closed by their squash-merges.