### PR TITLE
build: make readme-html + ci freshness guard (README.html never drifts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ readme-html-check:
 		echo "pandoc not found; skipping README.html freshness check"; \
 	else \
 		tmp="$$(mktemp)"; \
+		trap 'rm -f "$$tmp"' EXIT; \
 		$(PANDOC_CMD) -o "$$tmp"; \
 		if ! diff -q "$$tmp" README.html >/dev/null 2>&1; then \
 			echo "README.html is stale: run 'make readme-html' and commit it" >&2; \
-			rm -f "$$tmp"; exit 1; \
+			exit 1; \
 		fi; \
-		rm -f "$$tmp"; \
 		echo "README.html is in sync with README.md"; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: build test fmt fmt-check vet ci install release-smoke clean
+.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+
+# README.html is a generated render of README.md. PANDOC_CMD is the single
+# source of truth for how it is built, shared by the regenerate and freshness
+# targets so they cannot diverge.
+PANDOC_CMD = pandoc README.md -f gfm -t html5 -s --toc --toc-depth=2 \
+	--metadata title="amq-squad — role-aware agent team launcher" \
+	--include-in-header=docs/readme-head.html
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o amq-squad ./cmd/amq-squad
@@ -18,7 +25,31 @@ fmt-check:
 vet:
 	go vet ./...
 
-ci: fmt-check vet test
+ci: fmt-check vet test readme-html-check
+
+# Regenerate the browsable README.html from README.md. Run this whenever
+# README.md changes (the release process bumps README.md, so it runs here).
+readme-html:
+	@command -v pandoc >/dev/null 2>&1 || { echo "pandoc is required: brew install pandoc" >&2; exit 1; }
+	$(PANDOC_CMD) -o README.html
+	@echo "regenerated README.html"
+
+# Fail if README.html is stale relative to README.md (drift guard, part of ci so
+# a release PR cannot merge a README.md change without the matching README.html).
+# Skips cleanly when pandoc is absent so pandoc-less CI is not blocked.
+readme-html-check:
+	@if ! command -v pandoc >/dev/null 2>&1; then \
+		echo "pandoc not found; skipping README.html freshness check"; \
+	else \
+		tmp="$$(mktemp)"; \
+		$(PANDOC_CMD) -o "$$tmp"; \
+		if ! diff -q "$$tmp" README.html >/dev/null 2>&1; then \
+			echo "README.html is stale: run 'make readme-html' and commit it" >&2; \
+			rm -f "$$tmp"; exit 1; \
+		fi; \
+		rm -f "$$tmp"; \
+		echo "README.html is in sync with README.md"; \
+	fi
 
 install: build
 	install amq-squad $(GOPATH)/bin/amq-squad 2>/dev/null || install amq-squad $(HOME)/go/bin/amq-squad

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,15 @@
 # Releasing amq-squad
 
-Release changes must go through a PR and `make ci` before merge.
+Release changes must go through a PR and `make ci` before merge. `make ci`
+includes a README.html freshness check, so a release that touches `README.md`
+cannot merge without the matching regenerated `README.html` (see step 1).
 
 ## Patch Release Checklist
 
-1. Update user-facing install references, usually the README `go install` tag.
+1. Update user-facing install references (usually the README `go install` tag).
+   Any time you change `README.md`, run `make readme-html` to regenerate
+   `README.html` (requires `pandoc`) and commit both; `make ci` fails if
+   `README.html` is out of sync.
 2. Merge the release PR.
 3. Tag the merge commit:
 

--- a/docs/readme-head.html
+++ b/docs/readme-head.html
@@ -1,0 +1,27 @@
+<style>
+  :root { --fg:#1f2328; --muted:#656d76; --bg:#ffffff; --code-bg:#f6f8fa; --border:#d0d7de; --link:#0969da; --accent:#0550ae; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg:#e6edf3; --muted:#9198a1; --bg:#0d1117; --code-bg:#161b22; --border:#30363d; --link:#4493f8; --accent:#79c0ff; }
+  }
+  * { box-sizing: border-box; }
+  body { color:var(--fg); background:var(--bg); font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;
+         max-width:920px; margin:0 auto; padding:2rem 1.25rem 5rem; }
+  h1,h2,h3,h4 { line-height:1.25; margin-top:1.8em; margin-bottom:.6em; font-weight:600; }
+  h1 { font-size:2rem; border-bottom:1px solid var(--border); padding-bottom:.3em; }
+  h2 { font-size:1.5rem; border-bottom:1px solid var(--border); padding-bottom:.3em; }
+  h3 { font-size:1.2rem; } h4 { font-size:1rem; }
+  a { color:var(--link); text-decoration:none; } a:hover { text-decoration:underline; }
+  p,li { color:var(--fg); }
+  code { background:var(--code-bg); border-radius:6px; padding:.15em .4em; font:13.5px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  pre { background:var(--code-bg); border:1px solid var(--border); border-radius:8px; padding:1rem; overflow:auto; }
+  pre code { background:none; padding:0; }
+  table { border-collapse:collapse; width:100%; margin:1em 0; display:block; overflow:auto; }
+  th,td { border:1px solid var(--border); padding:.5em .8em; text-align:left; vertical-align:top; }
+  th { background:var(--code-bg); }
+  blockquote { color:var(--muted); border-left:4px solid var(--border); margin:1em 0; padding:.2em 1em; }
+  hr { border:none; border-top:1px solid var(--border); margin:2em 0; }
+  #TOC { background:var(--code-bg); border:1px solid var(--border); border-radius:8px; padding:1rem 1.25rem; margin:1.5rem 0; }
+  #TOC > ul { margin:.3em 0; } #TOC ul { list-style:none; padding-left:1.1em; } #TOC > ul { padding-left:0; }
+  #TOC a { color:var(--accent); }
+  .toc-title { font-weight:600; }
+</style>


### PR DESCRIPTION
Per the request: keep README.html in sync as part of the **release process**, not a manual step.

- **`make readme-html`** regenerates `README.html` from `README.md` (pandoc/GFM, TOC, committed CSS header `docs/readme-head.html`). A single `PANDOC_CMD` is shared by the regenerate + check targets so they can't diverge.
- **`make readme-html-check`** regenerates to a temp file and **fails if `README.html` is stale**, wired into **`make ci`** — which `RELEASING.md` already mandates before every release merge. So a release that touches `README.md` cannot merge without the matching `README.html`. It **skips cleanly when pandoc is absent** so pandoc-less CI isn't blocked.
- `RELEASING.md` documents the step.

Verified: regen is deterministic (no diff vs committed README.html), the check passes in sync, and **fails** when README.md is edited without regenerating.