### PR TITLE
Release amq-squad v1.7.0

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -59,19 +59,34 @@ the open issues by theme + status so the near-term path is legible at a glance.
     spawn / dispatch (busy-guarded `send`) / monitor (`status --json`) / the
     `[AGENT-EVENT]`-over-AMQ reporting protocol / recover. Plus the corrected
     `send` busy-guard note in the `amq-squad` skill.
+- **v1.7.0 — shipped. Closes #101 (one-setup orchestrated squad).**
+  - **#101 — `amq-team-setup` wizard.** A wizard-style 5-step flow in both
+    marketplaces (Claude + Codex): (A) capture a goal from ANY source — inline
+    prompt, local `.md`, GitHub issue or PR (`gh`), Jira key (Atlassian MCP /
+    `jira` CLI), or doc URL (Confluence / fetch) — fetched agent-side so core
+    stays tracker-neutral; (B) normalize into a canonical per-session brief
+    (`references/briefs-template.md`: Goal / Source / Scope / Out of scope /
+    Acceptance), drafted then confirmed (a raw ticket is not a brief); (C) an
+    orchestration opt-in driven by a STRUCTURED CLI primitive — `team.json`
+    gains `orchestrated`/`lead`, `amq-squad new team --orchestrated [--lead
+    ROLE]` records the lead and injects the orchestration reporting norm into
+    the generated `team-rules.md` (mirrors the #81 norm pattern, generated +
+    tested, never pasted prose), default off, exactly one lead, never the NOC.
+    Shipped as PR #103 (CLI primitive) + PR #104 (wizard skill).
 
 ## Themes
 
 ### Runtime orchestration (the v1.5.x arc)
 
 - **#101 — `amq-team-setup` wizard: goal→brief + orchestration opt-in**
-  *(planned, v1.7.0 headline).* A wizard-style flow that captures a goal from any
-  source (Jira / GitHub issue or PR / `.md` / URL / inline prompt) and normalizes
-  it into a canonical brief, then optionally wires the squad for orchestration via
-  a structured `new team --orchestrated --lead <role>` primitive (injects the
-  team-rules reporting norm; never pasted prose). Tracker-neutral core (the skill
-  fetches), default off, Claude + Codex, **never in the NOC**. Makes a one-setup
-  orchestrated squad — the amq-squad analog of Sagi's always-on protocol.
+  ✅ **shipped in v1.7.0** (PR #103 CLI primitive + #104 wizard skill). A
+  wizard-style flow that captures a goal from any source (Jira / GitHub issue or
+  PR / `.md` / URL / inline prompt) and normalizes it into a canonical brief,
+  then optionally wires the squad for orchestration via a structured `new team
+  --orchestrated --lead <role>` primitive (injects the team-rules reporting norm;
+  never pasted prose). Tracker-neutral core (the skill fetches), default off,
+  Claude + Codex, **never in the NOC**. Makes a one-setup orchestrated squad —
+  the amq-squad analog of Sagi's always-on protocol.
 - **#76 — Agent orchestrator.** ✅ shipped in v1.6.0: the `amq-squad-orchestrator`
   skill (lead spawns/dispatches/monitors child agents over the tmux contract; the
   `[AGENT-EVENT]`-over-AMQ reporting protocol) plus #95 external-pane adoption. The

--- a/README.html
+++ b/README.html
@@ -338,7 +338,7 @@ workstream)</li>
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
 <p>Install the 1.6 line:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.6.0</span>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.7.0</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 1.x build:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@latest</span></code></pre></div>
@@ -424,8 +424,11 @@ to use each</h3>
 <tr>
 <td><strong><code>amq-team-setup</code></strong></td>
 <td>designing a team</td>
-<td>first-time setup: personas, profile choice, team rules, pointer
-stubs, brief authoring, <code>sync</code>, validation.</td>
+<td>wizard-style first-time setup: capture a goal from any source
+(prompt / <code>.md</code> / GitHub issue or PR / Jira / URL) into a
+canonical brief, pick personas + profile, optionally wire orchestration
+(who leads), team rules, pointer stubs, <code>sync</code>,
+validation.</td>
 </tr>
 <tr>
 <td><strong><code>amq-squad-role-creator</code></strong></td>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 1.6 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.6.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.7.0
 amq-squad version
 ```
 
@@ -97,7 +97,7 @@ and **control targets the recorded pane id**, never window names. Full surface:
 | Skill | Audience | Reach for it when |
 | --- | --- | --- |
 | **`amq-squad`** | an agent on a live team | day-to-day coordination: inbox drains, routing, review/handoff, `status`/`console`/`history`, `up`/`stop`/`resume`/`fork`, `agent up`/`resume`, and tmux runtime control (`focus`/`send`). |
-| **`amq-team-setup`** | designing a team | first-time setup: personas, profile choice, team rules, pointer stubs, brief authoring, `sync`, validation. |
+| **`amq-team-setup`** | designing a team | wizard-style first-time setup: capture a goal from any source (prompt / `.md` / GitHub issue or PR / Jira / URL) into a canonical brief, pick personas + profile, optionally wire orchestration (who leads), team rules, pointer stubs, `sync`, validation. |
 | **`amq-squad-role-creator`** | adding a role type | authoring a new custom role (persona + `role.md`), inline or as a reusable role file. |
 | **`amq-squad-orchestrator`** | a **lead** agent | running a squad as a *driver*: spawn child agents, dispatch tasks into their panes with the busy-guarded `send`, monitor liveness via `status --json`, collect children's `[AGENT-EVENT]`-over-AMQ reports, and recover. The amq-squad-native equivalent of a hand-rolled tmux spawn protocol. |
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
Release prep for **v1.7.0** — closes #101 (the `amq-team-setup` wizard / one-setup orchestrated squad).

Shipped in this minor (already merged to main):
- **#103** — orchestration opt-in primitive: `team.json` `orchestrated`/`lead` + `new team --orchestrated [--lead ROLE]` injecting a tested `## Orchestration` norm into the generated `team-rules.md`.
- **#104** — `amq-team-setup` wizard in both marketplaces: source-agnostic goal→brief capture, canonical `briefs-template.md`, and the orchestration opt-in step driving the flag.

This PR: PLAN.md "v1.7.0 — shipped", install reference + plugin manifests → v1.7.0, README skills-table description refresh, regenerated README.html. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)