### PR TITLE
Complete v1.7.0 marketplace packaging: codex orchestrator interface + manifest polish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "amq-squad",
+  "description": "Plugin marketplace for amq-squad: agent-team coordination skills for Claude Code, shipped from the amq-squad repo.",
   "owner": {
     "name": "Omri Ariav",
     "url": "https://github.com/omriariav"
@@ -8,7 +9,7 @@
     {
       "name": "amq-squad",
       "source": "./plugins/claude",
-      "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), and custom role authoring (amq-squad-role-creator).",
+      "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
       "category": "orchestration",
       "homepage": "https://github.com/omriariav/amq-squad"
     }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check docs-html docs-html-check html clean
+.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check docs-html docs-html-check html dogfood-claude clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -86,6 +86,12 @@ html: readme-html docs-html
 
 install: build
 	install amq-squad $(GOPATH)/bin/amq-squad 2>/dev/null || install amq-squad $(HOME)/go/bin/amq-squad
+
+# Launch Claude Code with the plugin loaded live from this working tree.
+# Shadows the marketplace-installed amq-squad plugin for this session only;
+# other folders keep the GitHub-marketplace version.
+dogfood-claude:
+	claude --plugin-dir plugins/claude
 
 release-smoke:
 	@test "$(VERSION)" != "dev" || (echo "VERSION is required, for example VERSION=v0.5.1" >&2; exit 1)

--- a/README.html
+++ b/README.html
@@ -365,6 +365,14 @@ binary-specific plugin under <code>plugins/claude</code> and
 plugin, e.g. <code>/amq-squad:amq-squad-role-creator</code>. In Codex,
 invoke them by skill name, e.g.
 <code>$amq-squad-role-creator</code>.</p>
+<p>To dogfood the skills from this working tree (instead of the
+marketplace snapshot), run <code>make dogfood-claude</code> here: it
+launches Claude Code with <code>--plugin-dir plugins/claude</code>,
+which loads the plugin live from disk and shadows the
+marketplace-installed copy for that session only. Codex has no
+per-session equivalent; it always serves the marketplace snapshot
+(refresh with <code>codex plugin marketplace upgrade</code> after
+merging skill changes).</p>
 <h2 id="using-amq-squad">Using amq-squad</h2>
 <p>amq-squad has two surfaces, and you use them at different times:</p>
 <ul>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Code, skills are namespaced by plugin, e.g.
 `/amq-squad:amq-squad-role-creator`. In Codex, invoke them by skill name, e.g.
 `$amq-squad-role-creator`.
 
+To dogfood the skills from this working tree (instead of the marketplace
+snapshot), run `make dogfood-claude` here: it launches Claude Code with
+`--plugin-dir plugins/claude`, which loads the plugin live from disk and
+shadows the marketplace-installed copy for that session only. Codex has no
+per-session equivalent; it always serves the marketplace snapshot (refresh
+with `codex plugin marketplace upgrade` after merging skill changes).
+
 ## Using amq-squad
 
 amq-squad has two surfaces, and you use them at different times:

--- a/plugins/codex/skills/amq-squad-orchestrator/agents/openai.yaml
+++ b/plugins/codex/skills/amq-squad-orchestrator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AMQ Squad Orchestrator"
+  short_description: "Lead-agent playbook to spawn, dispatch, and monitor an amq-squad"
+  default_prompt: "Use $amq-squad-orchestrator to run this squad as the lead: spawn child agents (`up <session> --target new-window` / `agent up`), dispatch tasks into their panes with the busy-guarded `send`, monitor liveness with `status --json`, drain the reports children push to you as AMQ messages, and recover stuck members with `resume`."


### PR DESCRIPTION
## Summary
- Add the missing `agents/openai.yaml` Codex interface file to the `amq-squad-orchestrator` skill — the other three codex skills already ship one, so the orchestrator was the only skill without a Codex display name / short description / default prompt.
- `.claude-plugin/marketplace.json`: add a marketplace-level `description` (clears the one warning from `claude plugin validate`) and fix the stale plugin entry description to list all four skills, matching `plugins/claude/.claude-plugin/plugin.json`.
- Add `make dogfood-claude` (`claude --plugin-dir plugins/claude`) plus a README note: dogfood the skills live from this working tree in this repo, while other folders use the GitHub marketplace install. Codex has no per-session equivalent (documented).
- Regenerate `README.html` (freshness check stays green).

## Validation
- `claude plugin validate` passes with no warnings.
- Installed from this tree via both CLIs: Claude `plugin details` inventory shows all 4 skills (~1.1k always-on tokens); Codex install snapshot contains all four `SKILL.md` + `openai.yaml` + `references/`.
- `claude --plugin-dir plugins/claude` resolves the plugin live from disk (`amq-squad@inline`) and shadows the marketplace install for that session only.
- `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)