### PR TITLE
Fix #109: stop → rm no longer refuses for the 90s presence-freshness window

### DIFF
--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/omriariav/amq-squad/internal/state"
 )
@@ -126,7 +128,8 @@ By default archive PREVIEWS exactly what will move and prompts for confirmation
 the prompt for automation.
 
 A session with any LIVE agent is refused unless --force; archive never stops
-running agents. Stop the team first with 'amq-squad down --all --force'.
+running agents. Stop the team first with
+'amq-squad stop --all [--session <session>] --force'.
 
 Examples:
   amq-squad archive issue-96
@@ -153,7 +156,8 @@ filesystem changes. Pass --yes/-y to skip the prompt for automation. To keep the
 data recoverable, use 'amq-squad archive <session>' instead.
 
 A session with any LIVE agent is refused unless --force; rm never stops running
-agents. Stop the team first with 'amq-squad down --all --force'.
+agents. Stop the team first with
+'amq-squad stop --all [--session <session>] --force'.
 
 Examples:
   amq-squad rm issue-96
@@ -307,13 +311,25 @@ func executeRmReportDeclined(e rmExecution) (bool, error) {
 	// SAFETY 3: refuse a running session unless --force. Reuse the repo's
 	// liveness (internal/state) so this agrees with status/down about "live".
 	if target.RootExists {
-		live, err := liveAgentsInSession(e.ProjectDir, baseRoot, session, e.Probe)
+		live, mailboxWindow, err := liveAgentsInSession(e.ProjectDir, baseRoot, session, e.Probe)
 		if err != nil {
 			return false, fmt.Errorf("check liveness for session %q: %w", session, err)
 		}
 		if len(live) > 0 && !e.Force {
-			return false, fmt.Errorf("session %q has live agents (%s); stop it first with 'amq-squad down --all --force', or pass --force to %s anyway",
-				session, strings.Join(live, ", "), verb)
+			msg := fmt.Sprintf("session %q has live agents (%s); stop it first with 'amq-squad stop --all --session %s --force', or pass --force to %s anyway",
+				session, strings.Join(live, ", "), session, verb)
+			if mailboxWindow > 0 {
+				// Some refusing agents are only "live" via a fresh presence
+				// write, not a verified process. Tell the operator the window
+				// so waiting is a known option, not folklore.
+				display := mailboxWindow.Round(time.Second)
+				if display < time.Second {
+					display = time.Second // never render a confusing "~0s"
+				}
+				msg += fmt.Sprintf(" (some presence files were written within the %s freshness window; it clears in ~%s)",
+					state.PresenceFreshness, display)
+			}
+			return false, errors.New(msg)
 		}
 	}
 
@@ -337,24 +353,37 @@ func executeRmReportDeclined(e rmExecution) (bool, error) {
 // liveAgentsInSession returns the handles of agents the repo's liveness
 // classifier considers operational (alive, wake-live, or dead-mailbox-live) in
 // the named session. An empty slice means the session is safe to tear down.
-func liveAgentsInSession(projectDir, baseRoot, session string, probe state.Probe) ([]string, error) {
+//
+// The second return is the longest remaining presence-freshness window among
+// the dead-mailbox-live agents (zero when none): how long until their fresh
+// presence writes expire and they stop counting as live. The refusal message
+// uses it so the operator knows waiting is an option (#109).
+func liveAgentsInSession(projectDir, baseRoot, session string, probe state.Probe) ([]string, time.Duration, error) {
 	snap, err := state.Build(projectDir, baseRoot, probe)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var live []string
+	var mailboxWindow time.Duration
 	for _, sess := range snap.Sessions {
 		if sess.Name != session {
 			continue
 		}
 		for _, a := range sess.Agents {
 			switch a.Liveness {
-			case state.LivenessAlive, state.LivenessWakeLive, state.LivenessDeadMailboxLive:
+			case state.LivenessAlive, state.LivenessWakeLive:
 				live = append(live, a.Handle)
+			case state.LivenessDeadMailboxLive:
+				live = append(live, a.Handle)
+				if !a.LastSeen.IsZero() {
+					if rem := state.PresenceFreshness - probe.Now().Sub(a.LastSeen); rem > mailboxWindow {
+						mailboxWindow = rem
+					}
+				}
 			}
 		}
 	}
-	return live, nil
+	return live, mailboxWindow, nil
 }
 
 // countAgentMailboxes counts the agent subdirectories under <root>/agents so

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -327,6 +327,81 @@ func TestArchiveRefusesLiveSessionWithoutForce(t *testing.T) {
 	}
 }
 
+// TestRmProceedsAfterCleanStop is the #109 regression: stop's last act writes
+// presence.json with status "offline" and a fresh last_seen. That terminal
+// write must NOT hold rm's live-agents gate closed — the documented stop→rm
+// sequence has to work back-to-back, not after a 90s wait.
+func TestRmProceedsAfterCleanStop(t *testing.T) {
+	base := t.TempDir()
+	projectDir := t.TempDir()
+	root := filepath.Join(base, "first-run")
+	seedAgentRecord(t, base, "first-run", "copilot", launch.Record{
+		Binary: "claude", Handle: "copilot", AgentPID: 4242,
+		Root: root, Session: "first-run",
+	})
+	// Exactly what stop leaves behind: dead agent PID + a seconds-old
+	// presence write with status "offline".
+	seedBoardPresence(t, base, "first-run", "copilot", "offline", time.Now().Add(-5*time.Second))
+	deadPID := rmStateProbe(map[int]bool{4242: false}, map[int]bool{4242: false})
+
+	out, err := runRmExec(t, rmExecution{
+		ProjectDir: projectDir,
+		Session:    "first-run",
+		Mode:       rmModeDelete,
+		Yes:        true,
+		BaseRoot:   base,
+		Probe:      deadPID,
+	})
+	if err != nil {
+		t.Fatalf("rm right after a clean stop must proceed, got: %v\n%s", err, out)
+	}
+	if _, statErr := os.Stat(root); !os.IsNotExist(statErr) {
+		t.Errorf("rm should have removed the root; stat err = %v", statErr)
+	}
+}
+
+// TestRmRefusalNamesFreshnessWindow: when the only "live" evidence is a fresh
+// non-terminal presence write behind a dead PID (a genuine zombie writer), rm
+// still refuses — but the error must name the freshness window and suggest the
+// non-deprecated stop verb, so the operator knows waiting is an option (#109).
+func TestRmRefusalNamesFreshnessWindow(t *testing.T) {
+	base := t.TempDir()
+	projectDir := t.TempDir()
+	root := filepath.Join(base, "first-run")
+	seedAgentRecord(t, base, "first-run", "copilot", launch.Record{
+		Binary: "claude", Handle: "copilot", AgentPID: 4242,
+		Root: root, Session: "first-run",
+	})
+	// Zombie writer: dead agent PID, but presence still reads "active" and
+	// fresh — the dead-mailbox-live case that must keep refusing.
+	seedBoardPresence(t, base, "first-run", "copilot", "active", time.Now().Add(-5*time.Second))
+	deadPID := rmStateProbe(map[int]bool{4242: false}, map[int]bool{4242: false})
+
+	_, err := runRmExec(t, rmExecution{
+		ProjectDir: projectDir,
+		Session:    "first-run",
+		Mode:       rmModeDelete,
+		Yes:        true,
+		BaseRoot:   base,
+		Probe:      deadPID,
+	})
+	if err == nil {
+		t.Fatal("a zombie-writer session must still refuse rm without --force")
+	}
+	if !strings.Contains(err.Error(), "freshness window") {
+		t.Errorf("refusal should name the presence freshness window: %v", err)
+	}
+	if !strings.Contains(err.Error(), "amq-squad stop --all") {
+		t.Errorf("refusal should suggest the stop verb, not the deprecated down alias: %v", err)
+	}
+	if strings.Contains(err.Error(), "amq-squad down") {
+		t.Errorf("refusal must not suggest the deprecated down alias: %v", err)
+	}
+	if _, statErr := os.Stat(root); statErr != nil {
+		t.Errorf("refused rm must leave the root intact: %v", statErr)
+	}
+}
+
 // TestRmConfinedToSessionRoot is the highest-risk property: deleting session X
 // must leave a sibling session Y (and the brief for Y) completely intact.
 func TestRmConfinedToSessionRoot(t *testing.T) {

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -192,7 +192,14 @@ func classifyAgent(e launch.Entry, probe Probe) Agent {
 	if presErr == nil && !pres.LastSeen.IsZero() {
 		recent := probe.Now().Sub(pres.LastSeen) <= PresenceFreshness
 		handleOK := pres.Handle == "" || pres.Handle == rec.Handle
-		if recent && handleOK {
+		// A fresh write whose status is explicitly "offline" is the expected
+		// terminal act of a clean stop (stop/down flip presence offline as
+		// their last step), NOT evidence that something is still writing.
+		// Counting it as a live-ish touch made the documented stop→rm
+		// sequence deterministically refuse for PresenceFreshness (#109), so
+		// an offline write classifies exactly like an expired one.
+		terminal := strings.EqualFold(pres.Status, "offline")
+		if recent && handleOK && !terminal {
 			mailboxRecentlyTouched = true
 			if strings.EqualFold(pres.Status, "active") {
 				presenceActiveFresh = true
@@ -222,9 +229,11 @@ func classifyAgent(e launch.Entry, probe Probe) Agent {
 			a.Liveness = LivenessAlive
 		}
 	case mailboxRecentlyTouched && rec.AgentPID > 0:
-		// Mailbox touched recently (presence not "active", e.g. "offline"/"idle")
-		// yet the recorded agent PID is dead: something is still writing while
-		// the agent is gone. Distinct dead-mailbox-live signal.
+		// Mailbox touched recently with a non-active, non-terminal status
+		// (e.g. "idle"; "offline" never reaches here, see the terminal
+		// carve-out above) yet the recorded agent PID is dead: something is
+		// still writing while the agent is gone. Distinct dead-mailbox-live
+		// signal.
 		a.Liveness = LivenessDeadMailboxLive
 	case !hasAnyDiskSignal:
 		a.Liveness = LivenessMissing

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -69,6 +69,11 @@ const (
 	// still writing to the mailbox while the agent process is gone. This MUST
 	// NOT collapse into "stale" or "alive": it is its own signal that the
 	// operator likely has a zombie heartbeat or a detached wake.
+	//
+	// One carve-out: a fresh presence write whose status is explicitly
+	// "offline" never classifies here. That write is the terminal act of a
+	// clean stop, not a zombie writer; treating it as live-ish made stop→rm
+	// refuse for the whole freshness window (#109).
 	LivenessDeadMailboxLive Liveness = "dead-mailbox-live"
 )
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -256,10 +256,10 @@ func TestClassifyDeadMailboxLiveNonActiveStatus(t *testing.T) {
 	agentDir := seedAgent(t, base, "s", "cto", launch.Record{
 		Binary: "codex", Handle: "cto", Session: "s", AgentPID: 1234,
 	})
-	// Mailbox touched recently but status is "offline": still a live mailbox
-	// behind a dead process — the inverse lie (running-looking writes, status
-	// says offline). Must surface as dead-mailbox-live, not dead.
-	seedPresence(t, agentDir, "cto", "offline", testNow.Add(-5*time.Second))
+	// Mailbox touched recently with a non-active, non-terminal status ("idle"):
+	// still a live mailbox behind a dead process — something keeps writing
+	// while the agent is gone. Must surface as dead-mailbox-live, not dead.
+	seedPresence(t, agentDir, "cto", "idle", testNow.Add(-5*time.Second))
 	probe := fakeProbe(map[int]bool{1234: false}, map[int]bool{1234: false}, nil)
 
 	snap, err := Build(proj, base, probe)
@@ -269,6 +269,33 @@ func TestClassifyDeadMailboxLiveNonActiveStatus(t *testing.T) {
 	a := findAgent(t, snap, "cto")
 	if a.Liveness != LivenessDeadMailboxLive {
 		t.Fatalf("Liveness = %q, want dead-mailbox-live (fresh mailbox, dead pid)", a.Liveness)
+	}
+}
+
+func TestClassifyFreshOfflinePresenceIsNotMailboxLive(t *testing.T) {
+	base := t.TempDir()
+	proj := t.TempDir()
+	agentDir := seedAgent(t, base, "s", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", Session: "s", AgentPID: 1234,
+	})
+	// The post-stop state (#109): stop killed the agent and flipped presence
+	// to "offline" seconds ago. That write is a terminal signal, not a zombie
+	// heartbeat — it must classify exactly like an expired one (stale via the
+	// recorded-PID signal), NOT dead-mailbox-live, or the documented stop→rm
+	// sequence refuses for the whole PresenceFreshness window.
+	seedPresence(t, agentDir, "cto", "offline", testNow.Add(-5*time.Second))
+	probe := fakeProbe(map[int]bool{1234: false}, map[int]bool{1234: false}, nil)
+
+	snap, err := Build(proj, base, probe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := findAgent(t, snap, "cto")
+	if a.Liveness == LivenessDeadMailboxLive {
+		t.Fatal("fresh offline presence + dead pid must not classify dead-mailbox-live (#109)")
+	}
+	if a.Liveness != LivenessStale {
+		t.Fatalf("Liveness = %q, want stale (same as after the freshness window expires)", a.Liveness)
 	}
 }
 


### PR DESCRIPTION
## Problem (#109)

`stop`'s last act per agent writes `presence.json` with `status: "offline"` and a fresh `last_seen`. The shared liveness classifier counted **any** fresh presence write as "mailbox recently touched", so a cleanly stopped agent classified as `dead-mailbox-live` for the whole `PresenceFreshness` window (90s) — and `rm`'s live-agents gate deterministically refused the documented `stop` → `rm` sequence. The error then suggested `down --all --force`, the deprecated alias of `stop`, which goes through the same presence write and could never resolve the refusal.

## Fix (issue's option 1, classifier-level)

- **internal/state**: a fresh presence write with `status == "offline"` is a *terminal* signal (the expected end of a clean stop), not a zombie writer. It no longer counts as a mailbox touch, so the post-stop state classifies exactly like it does after the window expires (`stale` via the recorded-PID signal) — the 90s window no longer changes classification for offline writes. Genuine zombie writers (fresh `active`/`idle` + dead PID) still classify `dead-mailbox-live`. Fixes every consumer of the shared classifier at once: rm, status, stop, and the NOC snapshots.
- **internal/cli/rm**: refusal message now suggests `amq-squad stop --all --session <s> --force` (not the deprecated `down` alias — also fixed in both help texts), and when the refusal is held by `dead-mailbox-live` agents it names the freshness window and how long until it clears (issue's option 3).

## Tests

- Classifier: post-stop offline state must read `stale`, never `dead-mailbox-live`; the genuine zombie-writer regression moved to `idle` status so it keeps covering the non-active case.
- rm: proceeds back-to-back after a clean stop (the exact #109 repro shape); zombie-writer sessions still refuse, with the window named and no deprecated verb in the message.
- `make ci` green.

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)