### PR TITLE
Add per-member claude_args/codex_args overlay in team.json (#111)

### DIFF
--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -1,6 +1,11 @@
 package cli
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/team"
+)
 
 const (
 	trustModeSandboxed = "sandboxed"
@@ -69,6 +74,29 @@ func validateTrustCombination(trustMode string, trustExplicit, noDefaultArgs boo
 				}
 				return usageErrorf("--codex-args contains --dangerously-bypass-approvals-and-sandbox; pass --trust trusted instead so the trust boundary is explicit")
 			}
+		}
+	}
+	return nil
+}
+
+// validateMembersTrust applies the same trust-vs-args contradiction check to
+// each member's per-member native args (team.json claude_args/codex_args), so
+// a sandboxed team cannot smuggle the Codex bypass flag through one member's
+// codex_args. Runs at plan/launch time, next to the team-level check, so the
+// rejection happens before any pane exists instead of inside runLaunch.
+func validateMembersTrust(trustMode string, trustExplicit bool, members []team.Member) error {
+	for _, m := range members {
+		// ExtraArgs selects the field matching the member's binary, so a
+		// member can never be judged on args that don't apply to it (the
+		// schema validator rejects mismatched fields, but this helper must
+		// not depend on that having run).
+		extra := m.ExtraArgs()
+		if len(extra) == 0 {
+			continue
+		}
+		memberArgs := map[string][]string{normalizedAgentBinary(m.Binary): extra}
+		if err := validateTrustCombination(trustMode, trustExplicit, false, memberArgs); err != nil {
+			return fmt.Errorf("member %s: %w", m.Role, err)
 		}
 	}
 	return nil

--- a/internal/cli/json_envelopes_test.go
+++ b/internal/cli/json_envelopes_test.go
@@ -76,7 +76,8 @@ func TestRunUpDryRunJSONEnvelope(t *testing.T) {
 		Workstream: "issue-96",
 		Members: []team.Member{
 			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96",
+				ClaudeArgs: []string{"--settings", "overlay.json"}},
 		},
 	})
 	stdout, _, err := captureOutput(t, func() error {
@@ -118,6 +119,18 @@ func TestRunUpDryRunJSONEnvelope(t *testing.T) {
 	// Trust default must be present so callers can inspect it.
 	if env.Data.Trust == "" {
 		t.Errorf("trust missing from team_plan: %+v", env.Data)
+	}
+	// #111: per-member args surface on the plan member AND in its command.
+	for _, m := range env.Data.Plan {
+		if m.Role != "fullstack" {
+			continue
+		}
+		if len(m.ClaudeArgs) != 2 || m.ClaudeArgs[0] != "--settings" {
+			t.Errorf("plan member fullstack claude_args = %v, want the configured overlay args", m.ClaudeArgs)
+		}
+		if !strings.Contains(m.Command, "--claude-args='--settings overlay.json'") {
+			t.Errorf("plan member fullstack command missing member claude_args: %q", m.Command)
+		}
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -462,12 +462,14 @@ type teamInitDryRun struct {
 }
 
 type teamProfilePlanMember struct {
-	Role    string `json:"role"`
-	Handle  string `json:"handle"`
-	Binary  string `json:"binary"`
-	Model   string `json:"model,omitempty"`
-	CWD     string `json:"cwd"`
-	Session string `json:"session"`
+	Role       string   `json:"role"`
+	Handle     string   `json:"handle"`
+	Binary     string   `json:"binary"`
+	Model      string   `json:"model,omitempty"`
+	CWD        string   `json:"cwd"`
+	Session    string   `json:"session"`
+	ClaudeArgs []string `json:"claude_args,omitempty"`
+	CodexArgs  []string `json:"codex_args,omitempty"`
 }
 
 type teamProfilePlan struct {
@@ -547,12 +549,14 @@ func buildTeamProfilePlan(p teamInitDryRun) teamProfilePlan {
 	rows := make([]teamProfilePlanMember, 0, len(p.Team.Members))
 	for _, m := range orderedTeamMembers(p.Team.Members) {
 		rows = append(rows, teamProfilePlanMember{
-			Role:    m.Role,
-			Handle:  m.Handle,
-			Binary:  m.Binary,
-			Model:   m.Model,
-			CWD:     m.EffectiveCWD(p.Team.Project),
-			Session: m.Session,
+			Role:       m.Role,
+			Handle:     m.Handle,
+			Binary:     m.Binary,
+			Model:      m.Model,
+			CWD:        m.EffectiveCWD(p.Team.Project),
+			Session:    m.Session,
+			ClaudeArgs: m.ClaudeArgs,
+			CodexArgs:  m.CodexArgs,
 		})
 	}
 	return teamProfilePlan{
@@ -630,12 +634,14 @@ type emitTeamOptions struct {
 
 // teamPlanMember is the per-member entry inside a JSON team plan.
 type teamPlanMember struct {
-	Role    string `json:"role"`
-	Handle  string `json:"handle"`
-	Binary  string `json:"binary"`
-	Model   string `json:"model,omitempty"`
-	CWD     string `json:"cwd"`
-	Command string `json:"command"`
+	Role       string   `json:"role"`
+	Handle     string   `json:"handle"`
+	Binary     string   `json:"binary"`
+	Model      string   `json:"model,omitempty"`
+	CWD        string   `json:"cwd"`
+	ClaudeArgs []string `json:"claude_args,omitempty"`
+	CodexArgs  []string `json:"codex_args,omitempty"`
+	Command    string   `json:"command"`
 }
 
 // teamPlan is the JSON-friendly representation of a launch-plan preview.
@@ -693,6 +699,9 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 	if err := validateTrustCombination(trustMode, opts.ExplicitTrust || strings.TrimSpace(t.Trust) != "", false, binaryArgs); err != nil {
 		return err
 	}
+	if err := validateMembersTrust(trustMode, opts.ExplicitTrust || strings.TrimSpace(t.Trust) != "", members); err != nil {
+		return err
+	}
 	// Reject --model role=model where role is not on the team, so a typo on
 	// team show / team launch never silently drops the override.
 	memberRoles := make(map[string]bool, len(members))
@@ -736,11 +745,13 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 			effectiveModel := memberEffectiveModel(m, opts.ModelOverrides)
 			cwd := m.EffectiveCWD(t.Project)
 			plan.Plan = append(plan.Plan, teamPlanMember{
-				Role:   m.Role,
-				Handle: m.Handle,
-				Binary: m.Binary,
-				Model:  effectiveModel,
-				CWD:    cwd,
+				Role:       m.Role,
+				Handle:     m.Handle,
+				Binary:     m.Binary,
+				Model:      effectiveModel,
+				CWD:        cwd,
+				ClaudeArgs: m.ClaudeArgs,
+				CodexArgs:  m.CodexArgs,
 				Command: emitTeamCommand(emitTeamCommandInput{
 					CWD:            cwd,
 					SquadBin:       squadBin,
@@ -1004,7 +1015,12 @@ func emitTeamCommand(in emitTeamCommandInput) string {
 			b.WriteString(shellQuote(joinedAgentArgs(m.LauncherArgs)))
 		}
 	}
-	extraDefaultArgs := binaryArgsFor(m.Binary, in.BinaryArgs)
+	// Per-member native args (team.json claude_args/codex_args) come AFTER
+	// the team-level binary_args so the member-specific value wins by
+	// position. They ride the same --claude-args/--codex-args plumbing, so
+	// agent up persists them into the launch record and resume reproduces
+	// them like any other child args.
+	extraDefaultArgs := append(binaryArgsFor(m.Binary, in.BinaryArgs), m.ExtraArgs()...)
 	if len(extraDefaultArgs) > 0 {
 		switch normalizedAgentBinary(m.Binary) {
 		case "codex":

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -172,6 +172,9 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 	if err := validateTrustCombination(trustMode, explicitTrust || strings.TrimSpace(t.Trust) != "", false, mergedBinaryArgs); err != nil {
 		return err
 	}
+	if err := validateMembersTrust(trustMode, explicitTrust || strings.TrimSpace(t.Trust) != "", t.Members); err != nil {
+		return err
+	}
 	// Reject --model role=model entries whose role is not on the team.
 	memberRoles := make(map[string]bool, len(t.Members))
 	for _, m := range t.Members {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -284,6 +284,9 @@ func executeResume(r resumeExecution) error {
 	if err := validateTrustCombination(resolvedTrust, r.ExplicitTrust || strings.TrimSpace(t.Trust) != "", false, mergedBinaryArgs); err != nil {
 		return err
 	}
+	if err := validateMembersTrust(resolvedTrust, r.ExplicitTrust || strings.TrimSpace(t.Trust) != "", t.Members); err != nil {
+		return err
+	}
 	memberRoles := make(map[string]bool, len(t.Members))
 	for _, m := range t.Members {
 		memberRoles[strings.ToLower(m.Role)] = true

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -236,6 +236,65 @@ func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
 	}
 }
 
+func TestEmitTeamCommandAppendsPerMemberArgsAfterTeamArgs(t *testing.T) {
+	// #111: member claude_args ride after the team-level binary_args so the
+	// member-specific value wins by position, and they appear BOTH in the
+	// persisted --claude-args= flag and the explicit child args after --.
+	m := team.Member{
+		Role: "analyst", Binary: "claude", Handle: "analyst", Session: "s",
+		ClaudeArgs: []string{"--settings", ".claude/agent-overlays/analyst.json"},
+	}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed,
+		BinaryArgs: map[string][]string{"claude": {"--chrome"}},
+	})
+	for _, want := range []string{
+		"agent up claude",
+		"--claude-args='--chrome --settings .claude/agent-overlays/analyst.json'",
+		"-- --permission-mode auto --chrome --settings .claude/agent-overlays/analyst.json",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
+func TestEmitTeamCommandPerMemberArgsOnly(t *testing.T) {
+	// No team-level binary_args: a member's own args still emit.
+	m := team.Member{
+		Role: "cto", Binary: "codex", Handle: "cto", Session: "s",
+		CodexArgs: []string{"--profile", "fast"},
+	}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed,
+	})
+	if !strings.Contains(cmd, "--codex-args='--profile fast'") {
+		t.Errorf("member codex_args missing from emitted command: %s", cmd)
+	}
+}
+
+func TestValidateMembersTrustRejectsSmuggledBypass(t *testing.T) {
+	// A sandboxed team must not smuggle the Codex bypass flag through one
+	// member's codex_args; the rejection names the member.
+	members := []team.Member{
+		{Role: "cto", Binary: "codex", Handle: "cto", Session: "s",
+			CodexArgs: []string{"--dangerously-bypass-approvals-and-sandbox"}},
+	}
+	err := validateMembersTrust(trustModeSandboxed, false, members)
+	if err == nil {
+		t.Fatal("sandboxed trust + member bypass arg must be rejected")
+	}
+	if !strings.Contains(err.Error(), "member cto") {
+		t.Errorf("rejection should name the member: %v", err)
+	}
+	// Trusted mode allows it (the bypass is then the explicit default anyway).
+	if err := validateMembersTrust(trustModeTrusted, true, members); err != nil {
+		t.Errorf("trusted mode should accept the member bypass arg, got %v", err)
+	}
+}
+
 func TestEmitTeamCommandQuotesPathsWithSpaces(t *testing.T) {
 	m := team.Member{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "cpo"}
 	cmd := emitTeamCommand(emitTeamCommandInput{

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -49,6 +49,33 @@ type Member struct {
 	// expected to forward the trailing args to Binary so bootstrap survives.
 	Launcher     string   `json:"launcher,omitempty"`
 	LauncherArgs []string `json:"launcher_args,omitempty"`
+	// ClaudeArgs / CodexArgs are optional per-member native CLI args (e.g. a
+	// `--settings` overlay that trims a worker's plugin/hook surface). They
+	// are appended AFTER the team-level binary_args for the member's binary,
+	// so the member-specific value wins by position. Only the field matching
+	// the member's binary may be set — claude_args on a codex member (and
+	// vice versa) is rejected at validation so flipping a member's binary can
+	// never silently apply stale flags.
+	ClaudeArgs []string `json:"claude_args,omitempty"`
+	CodexArgs  []string `json:"codex_args,omitempty"`
+}
+
+// ExtraArgs returns the per-member native CLI args that match the member's
+// binary (claude_args for claude, codex_args for codex). Nil when the binary
+// matches neither or the matching field is empty; otherwise a copy, so
+// callers can append without mutating the profile.
+func (m Member) ExtraArgs() []string {
+	var args []string
+	switch strings.ToLower(strings.TrimSpace(m.Binary)) {
+	case "claude":
+		args = m.ClaudeArgs
+	case "codex":
+		args = m.CodexArgs
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	return append([]string(nil), args...)
 }
 
 // OperatorConfig describes the optional human/operator participant for a
@@ -514,6 +541,26 @@ func validateMember(prefix string, m Member) error {
 	}
 	if m.Launcher == "" && len(m.LauncherArgs) > 0 {
 		return fmt.Errorf("%s.launcher_args: set launcher before launcher_args", prefix)
+	}
+	for i, a := range m.ClaudeArgs {
+		if err := ValidateDisplayValue("claude_args", a); err != nil {
+			return fmt.Errorf("%s.claude_args[%d]: %w", prefix, i, err)
+		}
+	}
+	for i, a := range m.CodexArgs {
+		if err := ValidateDisplayValue("codex_args", a); err != nil {
+			return fmt.Errorf("%s.codex_args[%d]: %w", prefix, i, err)
+		}
+	}
+	// Binary-match contract: per-member args are bound to the binary they
+	// configure. Rejecting the mismatch (instead of silently ignoring it)
+	// means a member whose binary flips later can never carry stale flags.
+	bin := strings.ToLower(strings.TrimSpace(m.Binary))
+	if len(m.ClaudeArgs) > 0 && bin != "claude" {
+		return fmt.Errorf("%s.claude_args: member binary is %q; claude_args applies only to claude members", prefix, m.Binary)
+	}
+	if len(m.CodexArgs) > 0 && bin != "codex" {
+		return fmt.Errorf("%s.codex_args: member binary is %q; codex_args applies only to codex members", prefix, m.Binary)
 	}
 	return nil
 }

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -322,6 +322,67 @@ func TestValidateMemberLauncher(t *testing.T) {
 	}
 }
 
+func TestValidateMemberPerMemberArgs(t *testing.T) {
+	claude := Member{Role: "analyst", Binary: "claude", Handle: "analyst", Session: "s"}
+	codex := Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"}
+
+	ok := claude
+	ok.ClaudeArgs = []string{"--settings", ".claude/agent-overlays/analyst.json"}
+	if err := Validate(Team{Members: []Member{ok}}); err != nil {
+		t.Errorf("claude_args on a claude member should validate, got %v", err)
+	}
+
+	okCodex := codex
+	okCodex.CodexArgs = []string{"--enable", "goals"}
+	if err := Validate(Team{Members: []Member{okCodex}}); err != nil {
+		t.Errorf("codex_args on a codex member should validate, got %v", err)
+	}
+
+	// Binary mismatch is rejected, never silently ignored: stale flags must
+	// not survive a member's binary flip.
+	mismatch := codex
+	mismatch.ClaudeArgs = []string{"--settings", "x.json"}
+	if err := Validate(Team{Members: []Member{mismatch}}); err == nil || !strings.Contains(err.Error(), "claude_args applies only to claude members") {
+		t.Errorf("claude_args on codex member: want binary-match error, got %v", err)
+	}
+	mismatch2 := claude
+	mismatch2.CodexArgs = []string{"--enable", "goals"}
+	if err := Validate(Team{Members: []Member{mismatch2}}); err == nil || !strings.Contains(err.Error(), "codex_args applies only to codex members") {
+		t.Errorf("codex_args on claude member: want binary-match error, got %v", err)
+	}
+
+	// Entries are display-validated like every other persisted member field.
+	blank := claude
+	blank.ClaudeArgs = []string{"  "}
+	if err := Validate(Team{Members: []Member{blank}}); err == nil || !strings.Contains(err.Error(), "claude_args[0]") {
+		t.Errorf("blank claude_args entry: want display-value error, got %v", err)
+	}
+}
+
+func TestMemberExtraArgs(t *testing.T) {
+	m := Member{Role: "analyst", Binary: "claude", ClaudeArgs: []string{"--settings", "a.json"}, CodexArgs: nil}
+	got := m.ExtraArgs()
+	if len(got) != 2 || got[0] != "--settings" || got[1] != "a.json" {
+		t.Fatalf("ExtraArgs() = %v, want the claude_args", got)
+	}
+	// Returned slice is a copy: appending must not mutate the member.
+	_ = append(got, "--mutated")
+	if len(m.ClaudeArgs) != 2 {
+		t.Error("ExtraArgs must return a copy, member was mutated")
+	}
+	// Binary normalization: case/space-insensitive match.
+	m.Binary = " Claude "
+	if len(m.ExtraArgs()) != 2 {
+		t.Error("ExtraArgs should normalize the binary before matching")
+	}
+	// Unknown binary yields nil even when fields are set (validation rejects
+	// such configs, but loading them must stay non-destructive).
+	m.Binary = "other"
+	if m.ExtraArgs() != nil {
+		t.Error("ExtraArgs on an unmatched binary must be nil")
+	}
+}
+
 func TestEffectiveCapabilitiesAdvertisesRuntimeActions(t *testing.T) {
 	// Every v1.5.0+ build exposes the tmux runtime contract, so clients
 	// (amq-noc) can gate their runtime-action UI on capabilities.runtime_actions.

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -197,6 +197,15 @@ amq-squad agent up codex --role cto --session issue-96
 amq-squad agent resume fullstack
 ```
 
+Per-member native args (v1.8.0+): a `team.json` member may carry
+`claude_args` / `codex_args` (must match its binary; `team sync` rejects a
+mismatch). They append after the team-level `binary_args`, and `up`,
+`resume --exec`, `agent up`/`agent resume` apply them to that member only —
+e.g. a worker's `"claude_args": ["--settings", ".claude/agent-overlays/<role>.json"]`
+loads a settings overlay that trims the plugins/hooks it never uses in a
+same-cwd squad. No CLI flag: edit `team.json`, validate with
+`amq-squad team sync`; `up --dry-run` shows the args on each member's command.
+
 ## Exit codes
 
 - `0` success

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -101,6 +101,17 @@ You can also preview a candidate from a deterministic source with
   Keep the roster minimal; you can add roles later by re-running `team init`.
 - Choose the profile: default at `.amq-squad/team.json`, or a named profile at
   `.amq-squad/teams/<name>.json` for parallel team shapes (release vs research).
+- **Per-member native args** (v1.8.0+): a member entry in `team.json` may
+  carry `claude_args` / `codex_args` — extra native CLI args for that member
+  only, appended after the team-level `binary_args` so the member value wins.
+  The field must match the member's binary (`team sync` rejects a mismatch).
+  Flagship use: a same-cwd squad where only the lead needs the full
+  plugin/hook surface — give each worker
+  `"claude_args": ["--settings", ".claude/agent-overlays/<role>.json"]`
+  pointing at a Claude Code settings overlay (`enabledPlugins`,
+  `disableAllHooks`, ...) that trims plugins and hooks the worker never uses,
+  cutting its per-prompt context cost. There is no CLI flag for this field:
+  edit `team.json` after `new team`, then validate with `amq-squad team sync`.
 - Pick the team-home (where `.amq-squad/` lives): the cwd by default; for a
   monorepo, usually the repo root. Confirm if the choice is non-obvious.
 

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -193,6 +193,15 @@ amq-squad agent up codex --role cto --session issue-96
 amq-squad agent resume fullstack
 ```
 
+Per-member native args (v1.8.0+): a `team.json` member may carry
+`claude_args` / `codex_args` (must match its binary; `team sync` rejects a
+mismatch). They append after the team-level `binary_args`, and `up`,
+`resume --exec`, `agent up`/`agent resume` apply them to that member only —
+e.g. a worker's `"claude_args": ["--settings", ".claude/agent-overlays/<role>.json"]`
+loads a settings overlay that trims the plugins/hooks it never uses in a
+same-cwd squad. No CLI flag: edit `team.json`, validate with
+`amq-squad team sync`; `up --dry-run` shows the args on each member's command.
+
 ## Exit codes
 
 - `0` success

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -98,6 +98,17 @@ You can also preview a candidate from a deterministic source with
   Keep the roster minimal; you can add roles later by re-running `team init`.
 - Choose the profile: default at `.amq-squad/team.json`, or a named profile at
   `.amq-squad/teams/<name>.json` for parallel team shapes (release vs research).
+- **Per-member native args** (v1.8.0+): a member entry in `team.json` may
+  carry `claude_args` / `codex_args` — extra native CLI args for that member
+  only, appended after the team-level `binary_args` so the member value wins.
+  The field must match the member's binary (`team sync` rejects a mismatch).
+  Flagship use: a same-cwd squad where only the lead needs the full
+  plugin/hook surface — give each worker
+  `"claude_args": ["--settings", ".claude/agent-overlays/<role>.json"]`
+  pointing at a Claude Code settings overlay (`enabledPlugins`,
+  `disableAllHooks`, ...) that trims plugins and hooks the worker never uses,
+  cutting its per-prompt context cost. There is no CLI flag for this field:
+  edit `team.json` after `new team`, then validate with `amq-squad team sync`.
 - Pick the team-home (where `.amq-squad/` lives): the cwd by default; for a
   monorepo, usually the repo root. Confirm if the choice is non-obvious.
 


### PR DESCRIPTION
## Problem (#111 — HIGH, operator-requested)

All members of a same-cwd squad inherit identical Claude Code configuration (plugins, skills, hooks). In an orchestrated squad only the lead needs the full surface; workers on smaller-context models burn context and latency on plugins and per-prompt hook output they never use. Claude Code's `--settings <file>` overlay is the right primitive — amq-squad just had no per-member way to pass it (`--claude-args` is global; `agent up ... -- --settings x.json` defeats one-command `up`/`resume --exec`).

## Implementation

- **Schema**: `team.json` members accept `claude_args` / `codex_args` (omitempty, backward-compatible). The field must match the member's binary — a mismatch is **rejected** at validation (`team sync`, `up`, `resume`), so flipping a member's binary can never silently apply stale flags. Entries are display-validated like every persisted member field.
- **One merge point**: `emitTeamCommand` appends `Member.ExtraArgs()` after the team-level `binary_args` (member wins by position). Every launch surface — `up`, `up --dry-run`, `resume --exec`, the tmux team launch, generated `agent up` commands — funnels through it, and the args ride the existing `--claude-args`/`--codex-args` plumbing, so `agent up` persists them in the launch record and `agent resume` reproduces them. No new flags.
- **Trust boundary**: `validateMembersTrust` applies the existing trust-vs-args contradiction check to member args at plan time — sandboxed trust + bypass smuggled into one member's `codex_args` is rejected (naming the member) before any pane exists.
- **Visibility**: plan JSON (`team_plan` / `team_profile_plan`) exposes the fields per member; `--dry-run` command strings show them inline.
- **Docs**: `amq-squad` + `amq-team-setup` skills updated in both marketplace mirrors with the field and the `--settings` overlay pattern.

## Acceptance (from #111)

- [x] team.json member accepts `claude_args` (array of strings); `team sync` validates it
- [x] `up`, `resume --exec`, `agent up`, `agent resume` apply it to that member only
- [x] launch records persist it; `up --dry-run`/`resume` plan output displays it
- [x] docs: amq-squad + amq-team-setup skills mention the field and the `--settings` overlay pattern
- [x] (bonus) symmetric `codex_args` shipped now rather than as a follow-up

## Validation

- Unit: schema validation (match/mismatch/blank entries), `ExtraArgs()` copy semantics, emission ordering (team-level then member), member-named trust rejection, plan-JSON exposure.
- Smoke with the built binary: temp team → hand-edit member `claude_args` → `team sync` passes → `up --dry-run` emits `--claude-args='--settings .claude/agent-overlays/fullstack.json'` on that member only → mismatched field rejected by both `sync` and `up`.
- `make ci` green.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)