### PR TITLE
Adopt amq coop exec --require-wake on the launch path (#30 item 1)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -198,9 +198,9 @@ func launchKnownFlag(name string) string {
 		"-conversation", "-conversation-id", "-trust", "-model", "-launcher":
 		return "string"
 	case "--team-workstream", "--no-bootstrap", "--no-default-args",
-		"--force-duplicate", "--dry-run",
+		"--force-duplicate", "--dry-run", "--no-require-wake",
 		"-team-workstream", "-no-bootstrap", "-no-default-args",
-		"-force-duplicate", "-dry-run",
+		"-force-duplicate", "-dry-run", "-no-require-wake",
 		// Help flags after the binary should fall through to runLaunch
 		// (which prints amq-squad launch help) rather than flow to the
 		// child binary as `-- --help`. Native child help is still

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -27,6 +27,23 @@ func resolveAMQEnv(rootFlag, session, handle string) (amqEnv, error) {
 	return resolveAMQEnvInDir("", rootFlag, session, handle)
 }
 
+// minRequireWakeAMQVersion is the first AMQ release whose `coop exec` accepts
+// --require-wake (refuse to launch unless the wake sidecar acquires its lock).
+const minRequireWakeAMQVersion = "0.34.1"
+
+// amqSupportsRequireWake reports whether the amq version string from `amq env`
+// is new enough for `coop exec --require-wake`. Empty or unparseable versions
+// return false: passing an unknown flag to an old amq would fail every
+// launch, so the gate only engages on a positively verified version.
+func amqSupportsRequireWake(version string) bool {
+	got, ok := parseSemverParts(strings.TrimSpace(version))
+	if !ok {
+		return false
+	}
+	min, _ := parseSemverParts(minRequireWakeAMQVersion)
+	return compareSemverParts(got, min) >= 0
+}
+
 func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {
 	args := []string{"env", "--json"}
 	if handle != "" {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -176,6 +176,7 @@ var completionCommonFlags = []string{
 	"--no-bootstrap",
 	"--no-default-args",
 	"--no-operator",
+	"--no-require-wake",
 	"--once",
 	"--older-than",
 	"--operator",

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -237,6 +237,7 @@ func TestTranslateAgentUpArgs(t *testing.T) {
 		{"codex-args consumes dash-prefixed value", []string{"codex", "--dry-run", "--no-bootstrap", "--codex-args", "--enable goals"}, []string{"--dry-run", "--no-bootstrap", "--codex-args", "--enable goals", "codex"}},
 		{"claude-args consumes dash-prefixed value", []string{"claude", "--dry-run", "--no-bootstrap", "--claude-args", "--chrome"}, []string{"--dry-run", "--no-bootstrap", "--claude-args", "--chrome", "claude"}},
 		{"trailing codex-args with no value is child", []string{"codex", "--dry-run", "--no-bootstrap", "--codex-args"}, []string{"--dry-run", "--no-bootstrap", "codex", "--", "--codex-args"}},
+		{"post-binary --no-require-wake is a launch flag", []string{"codex", "--dry-run", "--no-require-wake"}, []string{"--dry-run", "--no-require-wake", "codex"}},
 		{"post-binary --help routes to runLaunch help", []string{"codex", "--dry-run", "--help"}, []string{"--dry-run", "--help", "codex"}},
 		{"post-binary -h routes to runLaunch help", []string{"codex", "--dry-run", "-h"}, []string{"--dry-run", "-h", "codex"}},
 		{"explicit -- --help is child", []string{"codex", "--dry-run", "--", "--help"}, []string{"--dry-run", "codex", "--", "--help"}},

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -50,6 +50,7 @@ func runLaunch(args []string) error {
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args to treat as launch defaults, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args to treat as launch defaults, e.g. '--chrome'")
 	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent for the same handle/workstream is detected")
+	noRequireWake := fs.Bool("no-require-wake", false, "do not pass --require-wake to amq coop exec (allows launching when the wake sidecar cannot acquire its lock)")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 	launcherRaw := fs.String("launcher", "", "custom launcher to exec instead of <binary> (still receives AMQ env/identity, bootstrap, and a launch record)")
 	launcherArgsRaw := fs.String("launcher-args", "", "args passed to --launcher before the agent's child args; the launcher must forward trailing args to <binary>")
@@ -82,6 +83,10 @@ Side effects before exec:
   9. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
  10. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+     With amq 0.34.1+, --require-wake is passed so the launch fails at the
+     door when the wake sidecar cannot start and acquire its lock (instead
+     of surfacing as a stale/orphaned wake later). --no-require-wake opts
+     out for environments where wake cannot run but the agent should.
 
 With --dry-run, the resolved coop exec command is printed and amq-squad exits.
 Disk state is untouched and no exec occurs.
@@ -203,6 +208,7 @@ Examples:
 		Model:            strings.TrimSpace(*model),
 		Trust:            trustMode,
 		NoDefaultArgs:    *noDefaultArgs,
+		NoRequireWake:    *noRequireWake,
 		AgentPID:         os.Getpid(),
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
@@ -250,6 +256,16 @@ Examples:
 	}
 	if *me != "" {
 		coopArgs = append(coopArgs, "--me", *me)
+	}
+	// Fail the launch at the door when the wake sidecar cannot start and
+	// acquire its lock, instead of detecting a missing/orphaned wake later
+	// (#30). Version-gated: amq grew --require-wake in 0.34.1, and an empty
+	// or unparseable reported version omits the flag so older amq builds
+	// never see an unknown flag. --no-require-wake is the escape hatch for
+	// TIOCSTI-hostile environments where wake can't acquire its lock but the
+	// operator wants the agent anyway.
+	if !*noRequireWake && amqSupportsRequireWake(env.AMQVersion) {
+		coopArgs = append(coopArgs, "--require-wake")
 	}
 	// A custom launcher is exec'd in place of the binary. Launcher args precede
 	// the agent's normal child args; the launcher is expected to forward the

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omriariav/amq-squad/internal/launch"
 )
 
 func TestRunLaunchDryRunSandboxedCodexOmitsBypassDefault(t *testing.T) {
@@ -23,6 +25,99 @@ func TestRunLaunchDryRunSandboxedCodexOmitsBypassDefault(t *testing.T) {
 	want := "amq coop exec codex -- test-prompt"
 	if !strings.Contains(stdout, want) {
 		t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+	}
+}
+
+func TestAMQSupportsRequireWake(t *testing.T) {
+	for version, want := range map[string]bool{
+		"":         false, // very old amq: env reports no version
+		"garbage":  false, // unparseable: never pass an unverified flag
+		"0.33.9":   false,
+		"0.34.0":   false, // --require-wake landed in 0.34.1
+		"0.35":     false, // two-part versions don't parse; pinned so a parser change is visible
+		"0.34.1":   true,
+		"v0.34.1":  true,
+		"0.35.0":   true,
+		"1.0.0":    true,
+		" 0.34.1 ": true,
+	} {
+		if got := amqSupportsRequireWake(version); got != want {
+			t.Errorf("amqSupportsRequireWake(%q) = %v, want %v", version, got, want)
+		}
+	}
+}
+
+func TestRunLaunchDryRunRequireWakeVersionGate(t *testing.T) {
+	// amq 0.34.1+ launches fail at the door when the wake sidecar cannot
+	// acquire its lock (#30): coop exec gains --require-wake by default.
+	setupFakeAMQWithVersion(t, "0.34.1")
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "amq coop exec --require-wake codex -- test-prompt") {
+		t.Fatalf("amq 0.34.1 launch should pass --require-wake:\n%s", stdout)
+	}
+}
+
+func TestRunLaunchDryRunRequireWakeWithSessionShape(t *testing.T) {
+	// Pin the full production argv shape: --session before --require-wake,
+	// both before the binary positional (amq rejects misplaced flags).
+	setupFakeAMQWithVersion(t, "0.34.1")
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--session", "issue-96", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "amq coop exec --session issue-96 --require-wake codex -- test-prompt") {
+		t.Fatalf("session + require-wake argv shape drifted:\n%s", stdout)
+	}
+}
+
+func TestLaunchArgsFromRecordReplaysNoRequireWake(t *testing.T) {
+	// The opt-out answers an environment constraint (wake cannot acquire its
+	// lock), so resume/replay must reproduce it, not silently re-enable the
+	// gate. Compare with NoDefaultArgs, the precedent it follows.
+	rec := launch.Record{Binary: "codex", Handle: "cto", Session: "issue-96", NoRequireWake: true}
+	args := launchArgsFromRecord(rec)
+	found := false
+	for _, a := range args {
+		if a == "--no-require-wake" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("replay args missing --no-require-wake: %v", args)
+	}
+}
+
+func TestRunLaunchDryRunNoRequireWakeOptOut(t *testing.T) {
+	setupFakeAMQWithVersion(t, "0.34.1")
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-require-wake", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "--require-wake") {
+		t.Fatalf("--no-require-wake must omit the flag:\n%s", stdout)
+	}
+}
+
+func TestRunLaunchDryRunOldAMQOmitsRequireWake(t *testing.T) {
+	// 0.34.0 predates the flag; passing it would fail every launch.
+	setupFakeAMQWithVersion(t, "0.34.0")
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "codex", "test-prompt"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "--require-wake") {
+		t.Fatalf("amq 0.34.0 must not receive --require-wake:\n%s", stdout)
 	}
 }
 
@@ -372,6 +467,13 @@ func TestApplyConversationRestoreArgsRejectsConflicts(t *testing.T) {
 
 func setupFakeAMQ(t *testing.T) {
 	t.Helper()
+	setupFakeAMQWithVersion(t, "")
+}
+
+// setupFakeAMQWithVersion installs a fake amq whose `env --json` reports the
+// given amq_version (empty omits the field, matching very old amq builds).
+func setupFakeAMQWithVersion(t *testing.T, version string) {
+	t.Helper()
 	dir := t.TempDir()
 	binDir := filepath.Join(dir, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -380,7 +482,11 @@ func setupFakeAMQ(t *testing.T) {
 	root := filepath.Join(dir, ".agent-mail")
 	script := `#!/bin/sh
 if [ "$1" = "env" ]; then
-  printf '{"root":"%s"}\n' "$AMQ_FAKE_ROOT"
+  if [ -n "$AMQ_FAKE_VERSION" ]; then
+    printf '{"root":"%s","amq_version":"%s"}\n' "$AMQ_FAKE_ROOT" "$AMQ_FAKE_VERSION"
+  else
+    printf '{"root":"%s"}\n' "$AMQ_FAKE_ROOT"
+  fi
   exit 0
 fi
 echo "unexpected amq command: $*" >&2
@@ -390,6 +496,7 @@ exit 1
 		t.Fatal(err)
 	}
 	t.Setenv("AMQ_FAKE_ROOT", root)
+	t.Setenv("AMQ_FAKE_VERSION", version)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -243,6 +243,9 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoDefaultArgs {
 		args = append(args, "--no-default-args")
 	}
+	if rec.NoRequireWake {
+		args = append(args, "--no-require-wake")
+	}
 	if trust := trustModeFromRecord(rec); trust != "" {
 		args = append(args, "--trust", trust)
 	}
@@ -417,6 +420,9 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	}
 	if rec.NoDefaultArgs {
 		b.WriteString(" --no-default-args")
+	}
+	if rec.NoRequireWake {
+		b.WriteString(" --no-require-wake")
 	}
 	if trust := trustModeFromRecord(rec); trust != "" {
 		b.WriteString(" --trust ")

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -47,7 +47,12 @@ type Record struct {
 	Model            string    `json:"model,omitempty"`
 	Trust            string    `json:"trust,omitempty"`
 	NoDefaultArgs    bool      `json:"no_default_args,omitempty"`
-	AgentPID         int       `json:"agent_pid,omitempty"`
+	// NoRequireWake records the --no-require-wake opt-out so resume/replay
+	// reproduces it: the constraint it answers (wake cannot acquire its lock
+	// in this environment) is a property of the execution environment, not a
+	// one-shot launch decision.
+	NoRequireWake bool      `json:"no_require_wake,omitempty"`
+	AgentPID      int       `json:"agent_pid,omitempty"`
 	AgentTTY         string    `json:"agent_tty,omitempty"`
 	StartedAt        time.Time `json:"started_at"`
 	// TeamProfile names the profile the launch was emitted from. Empty


### PR DESCRIPTION
## Summary

Promotes wake health from "detected later" to "launch failed at the door" (#30 item 1): `agent up` now passes `--require-wake` to `amq coop exec`, so a launch refuses when the wake sidecar cannot start and acquire its lock. This is the prevention half of the orphan-wake bug class — #44/#45 were closed on the detection/cleanup half shipped in v1.5.x.

- **Version-gated default-on**: the flag is appended only when `amq env` reports a version ≥ 0.34.1 (where amq introduced it). Empty/unparseable versions omit it, so older amq builds never receive an unknown flag. Reuses doctor's semver helpers.
- **Escape hatch**: `--no-require-wake` (the issue's suggested opt-out for TIOCSTI-hostile environments), wired through the agent-up arg translator allowlist and shell completion.
- **One funnel**: every launch surface (emitted team commands, `up` tmux backend, resume replay) execs through `agent up`, so they all inherit the gate without changes.

## Found-by-smoke bug fixed in the same PR

The real-binary smoke caught that `--no-require-wake` placed after the binary positional (`agent up codex --no-require-wake`) was silently folded into child args — the `translateAgentUpArgs` allowlist (`launchKnownFlag`) needed the new flag, same registry pattern as shell completion. A translator regression case now pins it.

## Validation

- Unit: version-gate table test (empty/garbage/0.33.9/0.34.0 → off; 0.34.1/v0.34.1/0.35/1.0 → on); fake-amq dry-run tests for default-on, opt-out, and old-amq downgrade; translator case.
- Smoke with real amq 0.34.1: default emits `amq coop exec --session <s> --require-wake <binary>`; opt-out omits it (both flag positions).
- `make ci` green.

Part of #30 — items 2–3 (`wake --inject-via`, `from-session`) remain open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)