### PR TITLE
Release prep v1.8.0: roadmap + version bumps

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -59,6 +59,39 @@ the open issues by theme + status so the near-term path is legible at a glance.
     spawn / dispatch (busy-guarded `send`) / monitor (`status --json`) / the
     `[AGENT-EVENT]`-over-AMQ reporting protocol / recover. Plus the corrected
     `send` busy-guard note in the `amq-squad` skill.
+- **v1.8.0 — shipped. The dogfooding release: every item came out of the first
+  real-world orchestrated-squad run (pm-copilot, 2026-06-10).**
+  - **#109 — stop → rm refused for the 90s presence-freshness window.** A fresh
+    presence write with `status:"offline"` is the terminal act of a clean stop,
+    not a zombie writer: it no longer counts as a mailbox touch, so the
+    post-stop state classifies stale immediately (same as after the window) and
+    the documented `stop` → `rm` sequence works back-to-back. rm's refusal now
+    suggests `stop` (not the deprecated `down` alias) and names the freshness
+    window + time remaining when dead-mailbox-live agents hold the gate.
+    (PR #112)
+  - **#111 — per-member `claude_args`/`codex_args` overlay in team.json.**
+    Same-cwd squads can trim each worker's plugin/hook surface via a Claude
+    `--settings` overlay without touching the lead: member args append after
+    team-level `binary_args` (member wins by position), must match the
+    member's binary (validated), ride the existing `--claude-args`/`--codex-args`
+    plumbing (persisted in launch records, replayed on resume), are
+    trust-checked per member at plan time, and surface in plan JSON +
+    `--dry-run`. Skills in both marketplaces document the pattern. (PR #113)
+  - **#110 — amq-team-setup wizard doc gaps** from the same run, both mirrors:
+    `--binary` one-comma-list semantics, `--session` in the step-5 create
+    examples (+ the dir-name default warning), a launch-name consistency
+    warning in the handoff (a `--session` override at launch boots a new
+    workstream with a stub brief), role-file staging normalization, and the
+    show-role-bodies-before-create gate. (PR #114)
+  - **#30 item 1 — `coop exec --require-wake` adoption.** Launches fail at the
+    door when the wake sidecar cannot acquire its lock, version-gated on amq
+    0.34.1+ (empty/unparseable versions omit the flag), with a
+    `--no-require-wake` escape hatch that persists in the launch record so
+    resume reproduces it. The prevention half of the orphan-wake class.
+    (PR #115; #30 items 2–3 remain open)
+  - **Triage sweep:** closed shipped-but-open issues #22 (per-member model),
+    #19 (codex trust profiles), #53 (virtual operator), #27 (resume UX), #44 +
+    #45 (orphan wake detection/cleanup), and the #31 lifecycle epic.
 - **v1.7.0 — shipped. Closes #101 (one-setup orchestrated squad).**
   - **#101 — `amq-team-setup` wizard.** A wizard-style 5-step flow in both
     marketplaces (Claude + Codex): (A) capture a goal from ANY source — inline
@@ -105,25 +138,26 @@ the open issues by theme + status so the near-term path is legible at a glance.
 ### Team lifecycle & DX
 
 - #31 — *(epic, breaking)* Unify team lifecycle verbs; separate team identity
-  from workstream. Largely realized by the 2.0 reshape — *audit & close/refile.*
-- #27 — Unified team resume UX (fresh launch vs restore). *Likely addressed by
-  the resume rework — verify.*
+  from workstream. ✅ realized by the 2.0 reshape — closed in the v1.8.0 triage.
+- #27 — Unified team resume UX (fresh launch vs restore). ✅ shipped via the
+  resume planner — closed in the v1.8.0 triage.
 - #26 — Team rules template library for modern agent squads.
-- #22 — Support a per-member target model in team config.
+- #22 — Support a per-member target model in team config. ✅ shipped
+  (`Member.Model` + `--model role=model`) — closed in the v1.8.0 triage.
 - #39 — `team init --roles` rejects custom names. ✅ custom roles shipped in
   v1.5.0 — *pending close.*
 - #25 — Prevent launching duplicate live agents for the same role/handle/
   workstream. ✅ roster preflight + duplicate detection shipped — *pending close.*
-- #19 — Rework Codex trust defaults for generated launches.
+- #19 — Rework Codex trust defaults for generated launches. ✅ shipped
+  (sandboxed-by-default trust profiles) — closed in the v1.8.0 triage.
 - #11 — Replace placeholder `role.md` stubs with actionable role guidance.
 
 ### AMQ integration & operator
 
-- #53 — Support a virtual operator participant in squad teams. *Partially
-  addressed by the schema-3 operator (`user` handle / `--operator`) — verify
-  scope vs close.*
-- #30 — Adopt new AMQ features (require-wake, inject-via, from-session); drop
-  stale acks.
+- #53 — Support a virtual operator participant in squad teams. ✅ shipped as the
+  schema-3 operator — closed in the v1.8.0 triage.
+- #30 — Adopt new AMQ features; drop stale acks. Item 1 (`--require-wake`) ✅
+  shipped in v1.8.0; items 2–3 (`wake --inject-via`, from-session) remain.
 - #58 — Clarify the AMQ message-kind enum in the skill routing docs. *Largely
   addressed in the v1.5.0 skill update (#70) — verify & close.*
 
@@ -131,8 +165,11 @@ the open issues by theme + status so the near-term path is legible at a glance.
 
 - #46 — `amq env` failures are opaque; the launch path leaks shell
   `AM_ROOT`/`AM_ME` identity.
-- #45 — Exiting agent leaves an orphan `amq wake` process that blocks relaunch.
-- #44 — `down` leaves an orphaned `amq wake` process and stale live presence.
+- #45 — Exiting agent leaves an orphan `amq wake` that blocks relaunch.
+  ✅ closed in the v1.8.0 triage (v1.5.x preflight auto-clean + actionable
+  blocker; prevention shipped as `--require-wake` in v1.8.0).
+- #44 — `down` leaves an orphaned wake and stale live presence. ✅ closed in
+  the v1.8.0 triage (v1.5.2 classifier + v1.5.4 probe + stop-side reaping).
 
 ## Notes
 

--- a/README.html
+++ b/README.html
@@ -337,8 +337,8 @@ workstream)</li>
 (<code>launch.json</code> + <code>role.md</code> inside the AMQ
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
-<p>Install the 1.6 line:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.7.0</span>
+<p>Install the 1.8 line:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.8.0</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 1.x build:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@latest</span></code></pre></div>

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.6 line:
+Install the 1.8 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.7.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.8.0
 amq-squad version
 ```
 

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -32,29 +32,29 @@ type Record struct {
 	Session string   `json:"session"`
 	// SharedWorkstream means Session was chosen as the team-wide workstream,
 	// even if the name happens to equal this agent's role or handle.
-	SharedWorkstream bool      `json:"shared_workstream,omitempty"`
-	Conversation     string    `json:"conversation,omitempty"`
-	Handle           string    `json:"handle"`
-	Role             string    `json:"role,omitempty"`
-	Root             string    `json:"root"`
-	BaseRoot         string    `json:"base_root,omitempty"`
-	RootSource       string    `json:"root_source,omitempty"`
-	AMQVersion       string    `json:"amq_version,omitempty"`
-	CodexArgs        []string  `json:"codex_args,omitempty"`
-	ClaudeArgs       []string  `json:"claude_args,omitempty"`
-	Launcher         string    `json:"launcher,omitempty"`
-	LauncherArgs     []string  `json:"launcher_args,omitempty"`
-	Model            string    `json:"model,omitempty"`
-	Trust            string    `json:"trust,omitempty"`
-	NoDefaultArgs    bool      `json:"no_default_args,omitempty"`
+	SharedWorkstream bool     `json:"shared_workstream,omitempty"`
+	Conversation     string   `json:"conversation,omitempty"`
+	Handle           string   `json:"handle"`
+	Role             string   `json:"role,omitempty"`
+	Root             string   `json:"root"`
+	BaseRoot         string   `json:"base_root,omitempty"`
+	RootSource       string   `json:"root_source,omitempty"`
+	AMQVersion       string   `json:"amq_version,omitempty"`
+	CodexArgs        []string `json:"codex_args,omitempty"`
+	ClaudeArgs       []string `json:"claude_args,omitempty"`
+	Launcher         string   `json:"launcher,omitempty"`
+	LauncherArgs     []string `json:"launcher_args,omitempty"`
+	Model            string   `json:"model,omitempty"`
+	Trust            string   `json:"trust,omitempty"`
+	NoDefaultArgs    bool     `json:"no_default_args,omitempty"`
 	// NoRequireWake records the --no-require-wake opt-out so resume/replay
 	// reproduces it: the constraint it answers (wake cannot acquire its lock
 	// in this environment) is a property of the execution environment, not a
 	// one-shot launch decision.
 	NoRequireWake bool      `json:"no_require_wake,omitempty"`
 	AgentPID      int       `json:"agent_pid,omitempty"`
-	AgentTTY         string    `json:"agent_tty,omitempty"`
-	StartedAt        time.Time `json:"started_at"`
+	AgentTTY      string    `json:"agent_tty,omitempty"`
+	StartedAt     time.Time `json:"started_at"`
 	// TeamProfile names the profile the launch was emitted from. Empty
 	// means the implicit default profile. Captured so status / bootstrap
 	// routing can reuse the same profile without rereading flags.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- **PLAN.md**: v1.8.0 release-state entry — the dogfooding release: #109 (stop→rm freshness-window fix), #111 (per-member `claude_args`/`codex_args` overlay), #110 (wizard skill doc gaps), #30 item 1 (`--require-wake` adoption) — plus triage annotations for the closed issues (#22 #19 #53 #27 #44 #45 #31).
- **README**: `go install` tag → `v1.8.0`, "Install the 1.8 line", README.html regenerated.
- **Plugin manifests** (both marketplaces) → 1.8.0 so `claude plugin update` / `codex plugin marketplace upgrade` pick up this release's skill changes (#110 fixes + #111 docs).
- **gofmt fix** for `internal/launch/record.go` (slipped through #115; fmt-check failure was masked by a piped CI run).

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)