### PR TITLE
Release prep v1.9.0: roadmap + version bumps

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -59,6 +59,24 @@ the open issues by theme + status so the near-term path is legible at a glance.
     spawn / dispatch (busy-guarded `send`) / monitor (`status --json`) / the
     `[AGENT-EVENT]`-over-AMQ reporting protocol / recover. Plus the corrected
     `send` busy-guard note in the `amq-squad` skill.
+- **v1.9.0 — shipped. Context-budget + operator-steering release.**
+  - **`team overlay` primitive (#111 follow-up).** `amq-squad team overlay
+    init (--role R | --workers)` generates `.amq-squad/overlays/
+    <role>.claude.json` and wires the member's `claude_args` to load it via
+    `--settings` — one command to trim a worker's plugin/hook surface in a
+    same-cwd squad. No-clobber + idempotent + `--force`-gated replacement;
+    `--workers` excludes the orchestration lead; plan emission (up / resume /
+    tmux launch) fails fast when a referenced `--settings` file is missing.
+    (PR #120; skills wizard beat + docs in PR #122, both marketplaces.)
+  - **#117 — operator DIRECTIVE convention.** The squad-side contract for
+    amq-noc v0.8.0's direct-lead flow: an "Operator directives" section in the
+    `amq-squad-orchestrator` skill (arrival shapes, priority over child
+    reports, ack on the same p2p thread, never clears `gate/<topic>`), plus a
+    generated line in the orchestrated `## Orchestration` team-rules norm
+    naming the lead handle (the #81/#101 generated-norm pattern). (PR #121)
+  - **Triage:** closed #46 (amq env identity strip + stderr surfacing both
+    shipped earlier) and #11 (role.md stubs already actionable, TODO text
+    survives only as the upgrade-path test fixture).
 - **v1.8.0 — shipped. The dogfooding release: every item came out of the first
   real-world orchestrated-squad run (pm-copilot, 2026-06-10).**
   - **#109 — stop → rm refused for the 90s presence-freshness window.** A fresh
@@ -151,6 +169,7 @@ the open issues by theme + status so the near-term path is legible at a glance.
 - #19 — Rework Codex trust defaults for generated launches. ✅ shipped
   (sandboxed-by-default trust profiles) — closed in the v1.8.0 triage.
 - #11 — Replace placeholder `role.md` stubs with actionable role guidance.
+  ✅ closed in the v1.9.0 triage (already shipped; pinned by tests).
 
 ### AMQ integration & operator
 
@@ -163,8 +182,9 @@ the open issues by theme + status so the near-term path is legible at a glance.
 
 ### Bugs
 
-- #46 — `amq env` failures are opaque; the launch path leaks shell
-  `AM_ROOT`/`AM_ME` identity.
+- #46 — `amq env` failures are opaque; identity leak. ✅ closed in the v1.9.0
+  triage (envWithoutAMQIdentity at both resolution and exec; stderr folded
+  into errors).
 - #45 — Exiting agent leaves an orphan `amq wake` that blocks relaunch.
   ✅ closed in the v1.8.0 triage (v1.5.x preflight auto-clean + actionable
   blocker; prevention shipped as `--require-wake` in v1.8.0).

--- a/README.html
+++ b/README.html
@@ -337,8 +337,8 @@ workstream)</li>
 (<code>launch.json</code> + <code>role.md</code> inside the AMQ
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
-<p>Install the 1.8 line:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.8.0</span>
+<p>Install the 1.9 line:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.9.0</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 1.x build:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@latest</span></code></pre></div>
@@ -767,6 +767,15 @@ amq-squad team rules init [--project DIR] [--force]
                                   Seed or refresh .amq-squad/team-rules.md.
 amq-squad team rules show [--project DIR]
                                   Print .amq-squad/team-rules.md.
+amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]
+                        [--disable-all-hooks] [--force] [--dry-run]
+                                  Generate .amq-squad/overlays/&lt;role&gt;.claude.json
+                                  and wire the member&#39;s claude_args to load it
+                                  via --settings: trim a worker&#39;s plugin/hook
+                                  surface in a same-cwd squad. --workers targets
+                                  every claude member (orchestration lead
+                                  excluded). Plan emission fails fast when a
+                                  referenced --settings file is missing.
 amq-squad team sync [--project DIR] [--apply] [--allow-outside]
                                   Sync the pointer stub into CLAUDE.md and AGENTS.md.
                                   Exit 1 on drift when --apply is not set.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.8 line:
+Install the 1.9 line:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.8.0
+go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.9.0
 amq-squad version
 ```
 
@@ -368,6 +368,15 @@ amq-squad team rules init [--project DIR] [--force]
                                   Seed or refresh .amq-squad/team-rules.md.
 amq-squad team rules show [--project DIR]
                                   Print .amq-squad/team-rules.md.
+amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]
+                        [--disable-all-hooks] [--force] [--dry-run]
+                                  Generate .amq-squad/overlays/<role>.claude.json
+                                  and wire the member's claude_args to load it
+                                  via --settings: trim a worker's plugin/hook
+                                  surface in a same-cwd squad. --workers targets
+                                  every claude member (orchestration lead
+                                  excluded). Plan emission fails fast when a
+                                  referenced --settings file is missing.
 amq-squad team sync [--project DIR] [--apply] [--allow-outside]
                                   Sync the pointer stub into CLAUDE.md and AGENTS.md.
                                   Exit 1 on drift when --apply is not set.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- **PLAN.md**: v1.9.0 release-state entry — context-budget + operator-steering release: `team overlay` primitive (#120) + skills wizard beat (#122), operator DIRECTIVE convention (#117 via #121), triage closes (#46, #11).
- **README**: `go install` tag → v1.9.0; `team overlay init` documented in the verbs list; README.html regenerated.
- **Plugin manifests** (both marketplaces) → 1.9.0.

`make ci` green (exit code checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)