### PR TITLE
Slice A: team member add/rm — runtime roster mutation (v2.0 dynamic teams)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -5,6 +5,18 @@ the open issues by theme + status so the near-term path is legible at a glance.
 
 ## Release state
 
+- **v2.0.0 — in progress (goal-first dynamic teams).** A binary-neutral lead
+  composes its team from a goal (Codex can lead, not just be led); manual setup
+  stays the floor; spectrum manual → seeded (default) → autonomous (2.1). Full
+  plan + executable brief: `docs/v2.0.0.md`, `docs/v2.0.0-goal.md`. Proven
+  additively in the 1.x line first (Phase 0: A mutable roster → B native task
+  model → C orchestrate skill → D dogfood+eval gate) before the Phase 1 breaking
+  cut + `/v2`.
+  - **Slice A — `team member add/rm`** (runtime roster mutation): add/remove a
+    roster member at runtime via atomic, file-locked (`internal/flock`),
+    re-validated writes through `team.WriteProfile`, so a lead grows/shrinks its
+    team mid-session and the change persists for resume. Additive; no
+    removed/renamed verbs, no schema change.
 - **v1.5.0 — shipped.** tmux runtime contract (persisted pane/window ids,
   `pane_alive`, per-agent `actions[]`, `focus`/`open`/`send` verbs, `--target
   new-window`), custom roles, Claude + Codex plugin marketplaces.

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -103,6 +103,7 @@ var completionTeamSubcommands = []string{
 	"resume",
 	"rules",
 	"overlay",
+	"member",
 	"sync",
 	"profiles",
 	"rm",
@@ -113,6 +114,13 @@ var completionTeamSubcommands = []string{
 var completionTeamRulesSubcommands = []string{
 	"init",
 	"show",
+}
+
+// completionTeamMemberSubcommands lists `amq-squad team member` subcommands.
+var completionTeamMemberSubcommands = []string{
+	"add",
+	"rm",
+	"remove",
 }
 
 // completionCommonFlags lists every flag registered by the current stdlib
@@ -277,6 +285,12 @@ func buildBashCompletionScript() string {
 	b.WriteString("\" -- \"$cur\") )\n")
 	b.WriteString("        return\n")
 	b.WriteString("    fi\n\n")
+	b.WriteString("    if [ \"${words[1]}\" = \"team\" ] && [ \"${words[2]}\" = \"member\" ] && [ \"$cword\" -eq 3 ]; then\n")
+	b.WriteString("        COMPREPLY=( $(compgen -W \"")
+	b.WriteString(strings.Join(completionTeamMemberSubcommands, " "))
+	b.WriteString("\" -- \"$cur\") )\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n\n")
 	b.WriteString("    if [ \"${words[1]}\" = \"agent\" ] && [ \"$cword\" -eq 2 ]; then\n")
 	b.WriteString("        COMPREPLY=( $(compgen -W \"")
 	b.WriteString(strings.Join(completionAgentSubcommands, " "))
@@ -359,6 +373,17 @@ func buildZshCompletionScript() string {
 	b.WriteString("\n")
 	b.WriteString("        return\n")
 	b.WriteString("    fi\n\n")
+	b.WriteString("    if [[ \"${words[2]}\" == \"team\" && \"${words[3]}\" == \"member\" && CURRENT -eq 4 ]]; then\n")
+	b.WriteString("        compadd -- ")
+	for i, s := range completionTeamMemberSubcommands {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(zshQuote(s))
+	}
+	b.WriteString("\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n\n")
 	b.WriteString("    if [[ \"${words[2]}\" == \"agent\" && CURRENT -eq 3 ]]; then\n")
 	b.WriteString("        compadd -- ")
 	for i, s := range completionAgentSubcommands {
@@ -405,6 +430,10 @@ func buildFishCompletionScript() string {
 	b.WriteString("\n")
 	for _, sub := range completionTeamRulesSubcommands {
 		fmt.Fprintf(&b, "complete -c amq-squad -n \"__fish_seen_subcommand_from rules\" -a %s\n", fishQuote(sub))
+	}
+	b.WriteString("\n")
+	for _, sub := range completionTeamMemberSubcommands {
+		fmt.Fprintf(&b, "complete -c amq-squad -n \"__fish_seen_subcommand_from member\" -a %s\n", fishQuote(sub))
 	}
 	b.WriteString("\n")
 	for _, sub := range completionAgentSubcommands {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -40,6 +40,8 @@ func runTeam(args []string) error {
 		return runTeamRules(args[1:])
 	case "overlay":
 		return runTeamOverlay(args[1:])
+	case "member":
+		return runTeamMember(args[1:])
 	case "sync":
 		return runTeamSync(args[1:])
 	case "profiles":
@@ -49,7 +51,7 @@ func runTeam(args []string) error {
 	default:
 		// Unknown subcommand. Treat as flags to the smart default so
 		// `amq-squad team --help` and similar still work.
-		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'resume', 'rules', 'overlay', 'sync', 'profiles', or 'rm'.", args[0])
+		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'resume', 'rules', 'overlay', 'member', 'sync', 'profiles', or 'rm'.", args[0])
 	}
 }
 
@@ -1696,6 +1698,11 @@ Usage:
                                       Generate a per-member Claude settings
                                       overlay (trim plugins/hooks) and wire the
                                       member's claude_args to load it
+  amq-squad team member add <role> --binary <claude|codex> [options]
+  amq-squad team member rm <role>     Add or remove a roster member at runtime
+                                      (atomic + locked + re-validated). The new
+                                      member is not launched; an 'agent up' hint
+                                      is printed.
   amq-squad team sync [--apply] [--profile NAME]
                                       Sync CLAUDE.md and AGENTS.md from team-rules.md
                                       (default: preview; --apply writes; --profile

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/omriariav/amq-squad/internal/flock"
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+// runTeamMember dispatches `amq-squad team member <add|rm>`: runtime roster
+// mutation. This is the durable-roster primitive the goal-first composition
+// model rests on — a lead (any binary) grows or shrinks its team mid-session,
+// and the change persists to team.json so resume rebuilds the team it built.
+func runTeamMember(args []string) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprint(os.Stderr, `amq-squad team member - add or remove a roster member at runtime
+
+Usage:
+  amq-squad team member add <role> --binary <claude|codex> [--handle H]
+      [--session S] [--model M] [--claude-args "…"] [--codex-args "…"]
+      [--project DIR] [--profile NAME]
+  amq-squad team member rm <role> [--project DIR] [--profile NAME]
+
+Mutates the persisted team profile (team.json) atomically and under an
+exclusive lock, then re-validates it (orchestration constraints included).
+The new member is NOT launched; the printed 'agent up' command starts it.
+
+Examples:
+  amq-squad team member add researcher --binary codex
+  amq-squad team member add qa --binary claude --model sonnet
+  amq-squad team member rm researcher
+`)
+		if len(args) == 0 {
+			return usageErrorf("member requires a subcommand ('add' or 'rm')")
+		}
+		return nil
+	}
+	switch args[0] {
+	case "add":
+		return runTeamMemberAdd(args[1:])
+	case "rm", "remove":
+		return runTeamMemberRemove(args[1:])
+	default:
+		return usageErrorf("unknown 'team member' subcommand: %q. Try 'add' or 'rm'.", args[0])
+	}
+}
+
+// peelRole splits a leading positional role from the remaining flag args, so
+// `add <role> --binary x` parses (Go's flag stops at the first non-flag, so
+// the role must be peeled before flag parsing).
+func peelRole(args []string) (role string, rest []string, err error) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return "", nil, usageErrorf("a role is required, e.g. 'team member add researcher --binary codex'")
+	}
+	return args[0], args[1:], nil
+}
+
+func runTeamMemberAdd(args []string) error {
+	role, rest, err := peelRole(args)
+	if err != nil {
+		return err
+	}
+	fs := flag.NewFlagSet("team member add", flag.ContinueOnError)
+	binaryFlag := fs.String("binary", "", "agent CLI for this member: claude or codex (required)")
+	handleFlag := fs.String("handle", "", "AMQ handle (defaults to the role)")
+	sessionFlag := fs.String("session", "", "AMQ workstream session (defaults to the team's existing session)")
+	modelFlag := fs.String("model", "", "native model name passed to the binary")
+	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this member")
+	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this member")
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	profileFlag := fs.String("profile", "", "team profile to mutate (default: default profile)")
+	if err := parseFlags(fs, rest); err != nil {
+		return err
+	}
+
+	bin := normalizedAgentBinary(*binaryFlag)
+	if bin != "claude" && bin != "codex" {
+		return usageErrorf("--binary is required and must be claude or codex (got %q)", *binaryFlag)
+	}
+	// Normalize the role at the boundary so dedup and validation match the
+	// stored (always-lowercase) roles, and so 'Researcher' is accepted rather
+	// than failing the slug check with a confusing error.
+	role = strings.ToLower(strings.TrimSpace(role))
+	if err := team.ValidateRoleID(role); err != nil {
+		return fmt.Errorf("role: %w", err)
+	}
+
+	var claudeArgs, codexArgs []string
+	if strings.TrimSpace(*claudeArgsRaw) != "" {
+		if claudeArgs, err = parseAgentArgs(*claudeArgsRaw); err != nil {
+			return fmt.Errorf("parse --claude-args: %w", err)
+		}
+	}
+	if strings.TrimSpace(*codexArgsRaw) != "" {
+		if codexArgs, err = parseAgentArgs(*codexArgsRaw); err != nil {
+			return fmt.Errorf("parse --codex-args: %w", err)
+		}
+	}
+	// Per-member args are bound to the member's binary (matching the team.json
+	// binary-match rule). Reject a mismatch rather than silently dropping it.
+	if bin == "codex" && len(claudeArgs) > 0 {
+		return usageErrorf("--claude-args applies only to claude members")
+	}
+	if bin == "claude" && len(codexArgs) > 0 {
+		return usageErrorf("--codex-args applies only to codex members")
+	}
+
+	projectDir, profile, err := resolveExistingTeamProfile(*projectFlag, *profileFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return err
+	}
+
+	var added team.Member
+	if err := withProfileLock(projectDir, profile, func() error {
+		t, err := team.ReadProfile(projectDir, profile)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
+		}
+		for _, m := range t.Members {
+			if m.Role == role {
+				return fmt.Errorf("role %q is already on the team", role)
+			}
+		}
+		handle := strings.ToLower(strings.TrimSpace(*handleFlag))
+		if handle == "" {
+			handle = role
+		}
+		for _, m := range t.Members {
+			if m.Handle == handle {
+				return fmt.Errorf("handle %q is already in use; pass a distinct --handle", handle)
+			}
+		}
+		session := strings.ToLower(strings.TrimSpace(*sessionFlag))
+		if session == "" {
+			session = inheritedSession(t)
+		}
+		added = team.Member{
+			Role:    role,
+			Binary:  bin,
+			Handle:  handle,
+			Session: session,
+			Model:   strings.TrimSpace(*modelFlag),
+		}
+		if bin == "claude" {
+			added.ClaudeArgs = claudeArgs
+		} else {
+			added.CodexArgs = codexArgs
+		}
+		t.Members = append(t.Members, added)
+		// WriteProfile re-validates the whole team (orchestration, per-member
+		// binary-match, duplicate handles) before the atomic rename, so an
+		// invalid add never persists.
+		if err := team.WriteProfile(projectDir, profile, t); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("added %s (%s) to the team.\n", added.Role, added.Binary)
+	fmt.Printf("start it with:\n  %s\n", agentUpHint(added))
+	return nil
+}
+
+func runTeamMemberRemove(args []string) error {
+	role, rest, err := peelRole(args)
+	if err != nil {
+		return err
+	}
+	role = strings.ToLower(strings.TrimSpace(role))
+	fs := flag.NewFlagSet("team member rm", flag.ContinueOnError)
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	profileFlag := fs.String("profile", "", "team profile to mutate (default: default profile)")
+	if err := parseFlags(fs, rest); err != nil {
+		return err
+	}
+	projectDir, profile, err := resolveExistingTeamProfile(*projectFlag, *profileFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return err
+	}
+
+	var removed bool
+	if err := withProfileLock(projectDir, profile, func() error {
+		t, err := team.ReadProfile(projectDir, profile)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
+		}
+		// Removing the lead of an orchestrated team would leave a dangling
+		// lead reference that fails validation; refuse with a clear pointer.
+		if t.Orchestrated && t.Lead == role {
+			return fmt.Errorf("role %q is the orchestration lead; reassign the lead before removing it", role)
+		}
+		kept := t.Members[:0:0]
+		for _, m := range t.Members {
+			if m.Role == role {
+				removed = true
+				continue
+			}
+			kept = append(kept, m)
+		}
+		if !removed {
+			return fmt.Errorf("role %q is not a team member", role)
+		}
+		t.Members = kept
+		if err := team.WriteProfile(projectDir, profile, t); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("removed %s from the team.\n", role)
+	fmt.Printf("if it is live, stop it with:\n  amq-squad stop --role %s\n", role)
+	return nil
+}
+
+// resolveExistingTeamProfile resolves the project dir + profile (reusing the
+// shared resolver) and requires the profile to already exist — roster
+// mutation needs a team to mutate.
+func resolveExistingTeamProfile(projectFlag, profileFlag string, projectSet bool) (string, string, error) {
+	projectDir, profile, err := resolveProjectProfile(projectFlag, profileFlag, projectSet)
+	if err != nil {
+		return "", "", err
+	}
+	if !team.ExistsProfile(projectDir, profile) {
+		return "", "", fmt.Errorf("no team configured for profile %q. Run '%s' first.", profile, profileInitCommand(profile))
+	}
+	return projectDir, profile, nil
+}
+
+// withProfileLock serializes a read-modify-write of a team profile across
+// concurrent amq-squad processes via an exclusive lock on a sidecar file, so
+// a lead and a worker mutating the roster at once cannot lose an update.
+func withProfileLock(projectDir, profile string, fn func() error) error {
+	return flock.WithLock(team.ProfilePath(projectDir, profile)+".lock", fn)
+}
+
+// inheritedSession returns the workstream a new member should join: the
+// session shared by existing members (so the roster stays one workstream),
+// or empty when the team has no members or they disagree (resolved at launch).
+func inheritedSession(t team.Team) string {
+	session := ""
+	for _, m := range t.Members {
+		s := strings.TrimSpace(m.Session)
+		if s == "" {
+			continue
+		}
+		if session == "" {
+			session = s
+		} else if session != s {
+			return ""
+		}
+	}
+	return session
+}
+
+// agentUpHint builds the exact `agent up` command that launches a member with
+// its full roster config (binary, role, session, model, per-member args), so
+// the printed hint is copy-paste faithful until `--up` (a later slice) lands.
+func agentUpHint(m team.Member) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "amq-squad agent up %s --role %s", m.Binary, m.Role)
+	if s := strings.TrimSpace(m.Session); s != "" {
+		fmt.Fprintf(&b, " --session %s", s)
+	}
+	if model := strings.TrimSpace(m.Model); model != "" {
+		fmt.Fprintf(&b, " --model %s", model)
+	}
+	fmt.Fprintf(&b, " --me %s", m.Handle)
+	if len(m.ClaudeArgs) > 0 {
+		fmt.Fprintf(&b, " --claude-args %q", strings.Join(m.ClaudeArgs, " "))
+	}
+	if len(m.CodexArgs) > 0 {
+		fmt.Fprintf(&b, " --codex-args %q", strings.Join(m.CodexArgs, " "))
+	}
+	return b.String()
+}

--- a/internal/cli/team_member_test.go
+++ b/internal/cli/team_member_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/internal/team"
+)
+
+func teamMembers(t *testing.T, dir string) []team.Member {
+	t.Helper()
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	return cfg.Members
+}
+
+func TestTeamMemberAddAppendsAndPersists(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "issue-96"}},
+	})
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "researcher", "--binary", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("member add: %v", err)
+	}
+	ms := teamMembers(t, dir)
+	if len(ms) != 2 {
+		t.Fatalf("want 2 members, got %d: %+v", len(ms), ms)
+	}
+	got := ms[1]
+	if got.Role != "researcher" || got.Binary != "codex" || got.Handle != "researcher" {
+		t.Fatalf("appended member = %+v, want researcher/codex/researcher", got)
+	}
+	// Inherits the existing members' shared session so it joins one workstream.
+	if got.Session != "issue-96" {
+		t.Errorf("session = %q, want inherited issue-96", got.Session)
+	}
+	if !strings.Contains(out, "agent up codex --role researcher") {
+		t.Errorf("add should print the agent up hint, got:\n%s", out)
+	}
+}
+
+func TestTeamMemberAddNormalizesCaseAndPrintsFaithfulHint(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "issue-96"}},
+	})
+	// Mixed-case role + handle are normalized to lowercase slugs (not rejected
+	// by the slug validator), and the printed hint carries --model so it is
+	// copy-paste faithful.
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "Researcher", "--binary", "claude", "--handle", "Researcher", "--model", "sonnet"})
+	})
+	if err != nil {
+		t.Fatalf("member add (mixed case): %v", err)
+	}
+	got := teamMembers(t, dir)[1]
+	if got.Role != "researcher" || got.Handle != "researcher" {
+		t.Fatalf("role/handle not normalized: %+v", got)
+	}
+	if !strings.Contains(out, "agent up claude --role researcher --session issue-96 --model sonnet --me researcher") {
+		t.Errorf("hint should be a faithful copy-paste command with --model, got:\n%s", out)
+	}
+}
+
+func TestTeamMemberAddRequiresValidBinary(t *testing.T) {
+	seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}}})
+	for _, args := range [][]string{
+		{"add", "qa"},                    // no --binary
+		{"add", "qa", "--binary", "gpt"}, // invalid binary
+	} {
+		if _, _, err := captureOutput(t, func() error { return runTeamMember(args) }); err == nil ||
+			!strings.Contains(err.Error(), "binary") {
+			t.Errorf("runTeamMember(%v) = %v, want a --binary usage error", args, err)
+		}
+	}
+}
+
+func TestTeamMemberAddRejectsDuplicateRoleAndHandle(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "cto", "--binary", "codex"})
+	}); err == nil || !strings.Contains(err.Error(), "already on the team") {
+		t.Fatalf("duplicate role: want 'already on the team', got %v", err)
+	}
+	// Distinct role, but colliding handle.
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "qa", "--binary", "codex", "--handle", "cto"})
+	}); err == nil || !strings.Contains(err.Error(), "handle") {
+		t.Fatalf("duplicate handle: want a handle error, got %v", err)
+	}
+	if n := len(teamMembers(t, dir)); n != 1 {
+		t.Fatalf("rejected adds must not persist; got %d members", n)
+	}
+}
+
+func TestTeamMemberAddBinaryMismatchedArgsRejected(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}},
+	})
+	// codex member carrying claude_args must be rejected by team validation
+	// (WriteProfile re-validates), and must not persist.
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "worker", "--binary", "codex", "--claude-args", "--settings x.json"})
+	}); err == nil {
+		t.Fatal("codex member with claude_args should be rejected by validation")
+	}
+	if n := len(teamMembers(t, dir)); n != 1 {
+		t.Fatalf("invalid add must not persist; got %d members", n)
+	}
+}
+
+func TestTeamMemberRmRemovesAndPersists(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "s"},
+		},
+	})
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"rm", "qa"})
+	})
+	if err != nil {
+		t.Fatalf("member rm: %v", err)
+	}
+	ms := teamMembers(t, dir)
+	if len(ms) != 1 || ms[0].Role != "cto" {
+		t.Fatalf("after rm want [cto], got %+v", ms)
+	}
+	if !strings.Contains(out, "stop --role qa") {
+		t.Errorf("rm should print the stop hint, got:\n%s", out)
+	}
+}
+
+func TestTeamMemberRmUnknownRoleErrors(t *testing.T) {
+	seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}}})
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"rm", "ghost"})
+	}); err == nil || !strings.Contains(err.Error(), "not a team member") {
+		t.Fatalf("want 'not a team member', got %v", err)
+	}
+}
+
+func TestTeamMemberRmRefusesOrchestrationLead(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "s"},
+		},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"rm", "cto"})
+	}); err == nil || !strings.Contains(err.Error(), "lead") {
+		t.Fatalf("removing the lead should be refused, got %v", err)
+	}
+	if n := len(teamMembers(t, dir)); n != 2 {
+		t.Fatalf("refused rm must not persist; got %d members", n)
+	}
+}
+
+func TestTeamMemberRequiresExistingTeam(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "qa", "--binary", "claude"})
+	}); err == nil || !strings.Contains(err.Error(), "no team configured") {
+		t.Fatalf("want 'no team configured', got %v", err)
+	}
+}
+
+func TestTeamMemberRequiresSubcommandAndRole(t *testing.T) {
+	seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}}})
+	if _, _, err := captureOutput(t, func() error { return runTeamMember([]string{"add", "--binary", "codex"}) }); err == nil ||
+		!strings.Contains(err.Error(), "role is required") {
+		t.Errorf("add with no role: want 'role is required', got %v", err)
+	}
+	if _, _, err := captureOutput(t, func() error { return runTeamMember([]string{"bogus"}) }); err == nil ||
+		!strings.Contains(err.Error(), "unknown 'team member' subcommand") {
+		t.Errorf("bad subcommand: want unknown-subcommand error, got %v", err)
+	}
+}

--- a/internal/flock/flock.go
+++ b/internal/flock/flock.go
@@ -1,0 +1,30 @@
+// Package flock provides a tiny advisory exclusive file lock for serializing
+// read-modify-write cycles on a shared on-disk file (e.g. team.json) across
+// concurrent amq-squad processes. The lock is taken on a sidecar "<path>.lock"
+// file so it survives the atomic rename the writer does on the real file.
+package flock
+
+import (
+	"fmt"
+	"os"
+)
+
+// WithLock acquires an exclusive advisory lock on lockPath (creating it if
+// needed), runs fn, then releases the lock. The lock is held for the whole
+// fn, so a read-modify-write inside fn is serialized against other holders.
+// On platforms without flock it degrades to a best-effort no-op (fn still
+// runs) — the writer's atomic rename keeps the file valid regardless.
+func WithLock(lockPath string, fn func() error) error {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open lock %s: %w", lockPath, err)
+	}
+	defer f.Close()
+	if err := lockExclusive(f); err != nil {
+		return fmt.Errorf("lock %s: %w", lockPath, err)
+	}
+	// Explicit unlock for clarity; Close() would also release the advisory
+	// lock. Defers run LIFO, so unlock runs before Close — both are safe.
+	defer unlock(f)
+	return fn()
+}

--- a/internal/flock/flock_other.go
+++ b/internal/flock/flock_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package flock
+
+import "os"
+
+// Non-unix fallback: no advisory lock available, so concurrent
+// read-modify-write cycles are NOT serialized and can race (TOCTOU) — two
+// processes may both read, both write, and the last writer wins, silently
+// losing the other's update. The target file stays structurally valid (the
+// writer's atomic rename guarantees that), but its content may reflect only
+// one of the concurrent writers. amq-squad targets unix; this platform is
+// unsuitable for concurrent team mutations.
+func lockExclusive(_ *os.File) error { return nil }
+
+func unlock(_ *os.File) {}

--- a/internal/flock/flock_unix.go
+++ b/internal/flock/flock_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package flock
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockExclusive(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+}
+
+func unlock(f *os.File) {
+	_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}


### PR DESCRIPTION
## Summary

First slice of the [v2.0.0 plan](../blob/main/docs/v2.0.0.md) Phase 0 (A → B → C → D): the **durable-roster primitive** that lets a lead (any binary) compose its team at runtime. A Codex lead can grow/shrink its roster mid-session and the change persists, so resume rebuilds the team it built.

- `amq-squad team member add <role> --binary <claude|codex> [--handle] [--session] [--model] [--claude-args|--codex-args]` and `team member rm <role>` (new `case "member"` in `runTeam`).
- Read-modify-write through `team.WriteProfile` (atomic `.tmp`+rename), serialized by a new exclusive **sidecar file-lock** (`internal/flock`, unix `flock` + a no-op fallback). `WriteProfile` re-validates the whole team (orchestration, per-member binary-match, duplicate handles) before the rename, so an invalid add never persists.
- **add** rejects: duplicate role/handle, missing/invalid `--binary`, and binary-mismatched `--claude-args`/`--codex-args` (rejected, not silently dropped). New member inherits the team's shared session; prints the `agent up` command (not launched).
- **rm** refuses to remove the orchestration lead (would dangle the lead reference); prints the `stop --role` hint.

**Purely additive** — no removed/renamed verbs, no schema change.

## Validation

- 9 tests (append/persist + session inheritance, dup role, dup handle, invalid binary, mismatched-args non-persistence, rm/persist, unknown role, lead-removal refusal, missing-team, arg/subcommand validation).
- Real-binary smoke: Codex-led lead-only seed → `team member add researcher --binary codex` (inherits workstream) → add a claude worker → refuse removing the lead → prune the worker.
- `make ci` green (exit code checked; completion drift-guard passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)