### PR TITLE
Slice B: native pull-based task model (.amq-squad/tasks/)

### DIFF
--- a/docs/task-store-design.md
+++ b/docs/task-store-design.md
@@ -1,0 +1,100 @@
+# Native task store — design (v2.0 Slice B)
+
+The lead's dispatch mechanism becomes **task-pull**, not only pane-push: the
+lead decomposes the goal into tasks; workers claim them and self-schedule around
+dependencies. This is the binary-neutral, amq-squad-native analog of the
+`amq swarm` task list (which is Claude-Code-bound and, critically, has **no
+create verb**). Ours has `task add`, so an any-binary lead can decompose.
+
+## Storage
+
+- One directory per workstream: `.amq-squad/tasks/<session>/`.
+- **One JSON file per task**: `<session-tasks-dir>/<id>.json`. Per-file (vs a
+  single `tasks.json`) keeps writes small and lets `list` be a directory scan.
+- **Locking**: all mutations take an exclusive lock on a sidecar
+  `.amq-squad/tasks/<session>/.lock` (via `internal/flock`, the same helper
+  Slice A introduced). The lock is held across the whole read-modify-write so
+  concurrent `claim`s can't both win. `add` also serializes id allocation under
+  the lock.
+- **Atomic writes**: each task file is written `<id>.json.tmp` → `os.Rename`, so
+  a crash mid-write never leaves a partial/invalid task file. (Same pattern as
+  `team.WriteProfile`.)
+
+## Task schema (`<id>.json`)
+
+```json
+{
+  "id": "t1",
+  "title": "Wire the rate limiter",
+  "description": "…",                // optional
+  "status": "pending",               // pending|in_progress|completed|failed|blocked
+  "assigned_to": "",                 // handle of the claiming agent
+  "depends_on": ["t0"],              // ids that must be completed before claim
+  "created_at": "2026-06-13T…Z",
+  "updated_at": "2026-06-13T…Z",
+  "evidence": "",                    // set on done
+  "failure_reason": "",              // set on fail
+  "block_reason": ""                 // set on block
+}
+```
+
+amq-squad is the **sole writer** of `.amq-squad/tasks/` (unlike swarm, which
+shares `~/.claude/tasks/` with Claude Code), so tasks round-trip through the
+typed struct and unknown-field preservation is not needed in Slice B. If an
+interop adapter ever shares this store, switch to a `map[string]any` round-trip
+(as swarm does) to preserve foreign fields.
+
+## State machine
+
+```
+pending ──claim──▶ in_progress ──done──▶ completed
+                       │
+                       ├──fail──▶ failed
+                       └──block─▶ blocked
+```
+
+- `claim`: allowed only from `pending`, and only when **every** id in
+  `depends_on` is `completed` (dependency gating). Sets `assigned_to` and
+  `in_progress`; clears terminal fields.
+- `done` / `fail` / `block`: allowed only from `in_progress`. `done`→`completed`
+  (+ optional evidence); `fail`→`failed` (+ reason); `block`→`blocked`
+  (+ reason). A `blocked`/`failed` task can be re-`claim`ed only after it is
+  reset to `pending` (a later `task reset` verb; out of scope for Slice B —
+  blocked/failed are terminal here).
+- Any other transition is rejected with a clear error naming the current state.
+
+## ID allocation
+
+Under the store lock, scan existing task files, take the max `t<N>` suffix, and
+allocate `t<N+1>` (starts at `t1`). Deterministic, sortable, and race-free
+because allocation happens inside the lock.
+
+## Verbs (`amq-squad task …`, new `runTask` dispatcher)
+
+| Verb | Effect |
+| --- | --- |
+| `task add --title T [--desc D] [--depends-on id,…] [--assign role] --session S` | create a `pending` task; **the goal→task decomposition primitive** |
+| `task list [--status S] [--json] --session S` | list tasks (table or `tasks` JSON envelope) |
+| `task claim <id> --me handle --session S` | pending + deps-completed → in_progress, assigned to `handle` |
+| `task done <id> [--evidence E] --session S` | in_progress (by assignee) → completed |
+| `task fail <id> [--reason R] --session S` | in_progress → failed |
+| `task block <id> [--reason R] --session S` | in_progress → blocked |
+
+- `--session` resolves the workstream (required; tasks are per-workstream).
+- `claim`/`done`/`fail`/`block` operate on an existing id; transitions are
+  validated; ownership: `done`/`fail`/`block` require the task to be
+  `in_progress` (Slice B does not enforce assignee identity — a single-operator
+  convenience; assignee-only transitions are a Phase-1 hardening with the
+  seeded-approval work).
+
+## Not in Slice B (deferred)
+
+- `task reset` (blocked/failed → pending), a `task show <id>` read verb, and
+  assignee-only transition enforcement — Phase 1. (List is the only read
+  surface in Slice B; terminal states are one-way.)
+- Cycle detection is unnecessary: deps must reference already-created (lower-id)
+  tasks, so the graph is a DAG by construction — see `Add`.
+- Bridge of task changes to AMQ notifications (the swarm-bridge analog) — folds
+  into Slice C's orchestrate loop / Phase 1.
+- The lead's *judgment* about which tasks to create — that is Slice C (the
+  orchestrate-from-goal skill), validated at the Slice D eval gate.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -187,6 +187,8 @@ func dispatch(args []string) error {
 	switch args[0] {
 	case "team":
 		return runTeam(args[1:])
+	case "task":
+		return runTask(args[1:])
 	case "new":
 		return runNew(args[1:])
 	case "roles":
@@ -257,7 +259,8 @@ Usage:
 Commands:
   new       Create a team, named profile, or workstream session
   roles     List built-in role IDs and market numbers for team creation
-  team      Set up and manage the team (init, rules, sync, profiles)
+  team      Set up and manage the team (init, rules, member, sync, profiles)
+  task      Native pull-based task store (add/list/claim/done/fail/block)
   up        Bring the team up (use --dry-run to print the launch plan)
   stop      Stop configured team members (SIGTERM; --force = SIGKILL). State is
             preserved on disk, so the session stays resumable.

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -60,6 +60,7 @@ var completionTopCommands = []string{
 	"new",
 	"roles",
 	"team",
+	"task",
 	"up",
 	"stop",
 	"down",
@@ -123,6 +124,16 @@ var completionTeamMemberSubcommands = []string{
 	"remove",
 }
 
+// completionTaskSubcommands lists `amq-squad task` subcommands.
+var completionTaskSubcommands = []string{
+	"add",
+	"list",
+	"claim",
+	"done",
+	"fail",
+	"block",
+}
+
 // completionCommonFlags lists every flag registered by the current stdlib
 // CLI surfaces. The list is exhaustive on purpose: shell completion
 // shouldn't omit a flag just because it only appears on one command. Drift
@@ -150,6 +161,7 @@ var completionCommonFlags = []string{
 	"--apply",
 	"--as",
 	"--at-risk-wait",
+	"--assign",
 	"--binary",
 	"--body",
 	"--body-file",
@@ -159,10 +171,13 @@ var completionCommonFlags = []string{
 	"--conversation",
 	"--conversation-id",
 	"--cwd",
+	"--depends-on",
 	"--depth",
+	"--desc",
 	"--disable-all-hooks",
 	"--disable-plugins",
 	"--dry-run",
+	"--evidence",
 	"--exec",
 	"--filter",
 	"--force",
@@ -196,6 +211,7 @@ var completionCommonFlags = []string{
 	"--personas",
 	"--profile",
 	"--project",
+	"--reason",
 	"--refresh",
 	"--reset",
 	"--restore-existing",
@@ -212,6 +228,7 @@ var completionCommonFlags = []string{
 	"--stagger",
 	"--stage",
 	"--stale-after",
+	"--status",
 	"--sync",
 	"--target",
 	"--target-id",
@@ -222,6 +239,7 @@ var completionCommonFlags = []string{
 	"--team-workstream",
 	"--terminal",
 	"--terminal-session",
+	"--title",
 	"--tmp-older-than",
 	"--to",
 	"--tree",
@@ -288,6 +306,12 @@ func buildBashCompletionScript() string {
 	b.WriteString("    if [ \"${words[1]}\" = \"team\" ] && [ \"${words[2]}\" = \"member\" ] && [ \"$cword\" -eq 3 ]; then\n")
 	b.WriteString("        COMPREPLY=( $(compgen -W \"")
 	b.WriteString(strings.Join(completionTeamMemberSubcommands, " "))
+	b.WriteString("\" -- \"$cur\") )\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n\n")
+	b.WriteString("    if [ \"${words[1]}\" = \"task\" ] && [ \"$cword\" -eq 2 ]; then\n")
+	b.WriteString("        COMPREPLY=( $(compgen -W \"")
+	b.WriteString(strings.Join(completionTaskSubcommands, " "))
 	b.WriteString("\" -- \"$cur\") )\n")
 	b.WriteString("        return\n")
 	b.WriteString("    fi\n\n")
@@ -384,6 +408,17 @@ func buildZshCompletionScript() string {
 	b.WriteString("\n")
 	b.WriteString("        return\n")
 	b.WriteString("    fi\n\n")
+	b.WriteString("    if [[ \"${words[2]}\" == \"task\" && CURRENT -eq 3 ]]; then\n")
+	b.WriteString("        compadd -- ")
+	for i, s := range completionTaskSubcommands {
+		if i > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(zshQuote(s))
+	}
+	b.WriteString("\n")
+	b.WriteString("        return\n")
+	b.WriteString("    fi\n\n")
 	b.WriteString("    if [[ \"${words[2]}\" == \"agent\" && CURRENT -eq 3 ]]; then\n")
 	b.WriteString("        compadd -- ")
 	for i, s := range completionAgentSubcommands {
@@ -434,6 +469,10 @@ func buildFishCompletionScript() string {
 	b.WriteString("\n")
 	for _, sub := range completionTeamMemberSubcommands {
 		fmt.Fprintf(&b, "complete -c amq-squad -n \"__fish_seen_subcommand_from member\" -a %s\n", fishQuote(sub))
+	}
+	b.WriteString("\n")
+	for _, sub := range completionTaskSubcommands {
+		fmt.Fprintf(&b, "complete -c amq-squad -n \"__fish_seen_subcommand_from task\" -a %s\n", fishQuote(sub))
 	}
 	b.WriteString("\n")
 	for _, sub := range completionAgentSubcommands {

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -221,6 +221,7 @@ func TestCompletionTopCommandsMatchesDispatch(t *testing.T) {
 		"new":        true,
 		"roles":      true,
 		"team":       true,
+		"task":       true,
 		"up":         true,
 		"stop":       true,
 		"down":       true,

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/task"
+)
+
+// taskNow is overridable in tests for deterministic timestamps.
+var taskNow = func() time.Time { return time.Now().UTC() }
+
+// tasksEnvelopeData is the `task list --json` payload (typed, matching the
+// other JSON envelopes rather than a raw map).
+type tasksEnvelopeData struct {
+	Session string      `json:"session"`
+	Tasks   []task.Task `json:"tasks"`
+}
+
+// Deferred to Phase 1 (see docs/task-store-design.md): `task reset`
+// (blocked/failed → pending), assignee-only transition enforcement, and a
+// `task show <id>` read verb. Slice B is intentionally list-only + one-way
+// terminal transitions.
+
+// runTask dispatches `amq-squad task <add|list|claim|done|fail|block>`: the
+// native pull-based task store. The lead decomposes the goal into tasks; any
+// worker (Claude or Codex) claims them and self-schedules around dependencies.
+func runTask(args []string) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprint(os.Stderr, `amq-squad task - native pull-based task store for a workstream
+
+Usage:
+  amq-squad task add --title T [--desc D] [--depends-on id,…] [--assign role] --session S
+  amq-squad task list [--status S] [--json] --session S
+  amq-squad task claim <id> --me <handle> --session S
+  amq-squad task done  <id> [--evidence E] --session S
+  amq-squad task fail  <id> [--reason R] --session S
+  amq-squad task block <id> [--reason R] --session S
+
+Tasks live under .amq-squad/tasks/<session>/. A task is claimable only when all
+its --depends-on tasks are completed (dependency gating). All mutations are
+atomic and lock-serialized.
+`)
+		if len(args) == 0 {
+			return usageErrorf("task requires a subcommand (add, list, claim, done, fail, block)")
+		}
+		return nil
+	}
+	switch args[0] {
+	case "add":
+		return runTaskAdd(args[1:])
+	case "list", "ls":
+		return runTaskList(args[1:])
+	case "claim":
+		return runTaskTransition(args[1:], "claim")
+	case "done", "complete":
+		return runTaskTransition(args[1:], "done")
+	case "fail":
+		return runTaskTransition(args[1:], "fail")
+	case "block":
+		return runTaskTransition(args[1:], "block")
+	default:
+		return usageErrorf("unknown 'task' subcommand: %q. Try add, list, claim, done, fail, or block.", args[0])
+	}
+}
+
+// taskSessionProject resolves --session (required) and --project (default cwd).
+func taskSessionProject(sessionFlag, projectFlag string, fs *flag.FlagSet) (string, string, error) {
+	session := strings.TrimSpace(sessionFlag)
+	if session == "" {
+		return "", "", usageErrorf("--session is required (tasks are per-workstream)")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("getwd: %w", err)
+	}
+	projectDir, err := resolveProjectDirFlag(cwd, projectFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return "", "", err
+	}
+	return session, projectDir, nil
+}
+
+func runTaskAdd(args []string) error {
+	fs := flag.NewFlagSet("task add", flag.ContinueOnError)
+	title := fs.String("title", "", "task title (required)")
+	desc := fs.String("desc", "", "task description")
+	dependsOn := fs.String("depends-on", "", "comma-separated task ids that must complete first")
+	assign := fs.String("assign", "", "pre-assign to a role/handle (optional)")
+	sessionFlag := fs.String("session", "", "AMQ workstream session (required)")
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	session, projectDir, err := taskSessionProject(*sessionFlag, *projectFlag, fs)
+	if err != nil {
+		return err
+	}
+	t, err := task.Add(projectDir, session, task.AddInput{
+		Title:       *title,
+		Description: *desc,
+		DependsOn:   splitCommaList(*dependsOn),
+		AssignTo:    strings.TrimSpace(*assign),
+	}, taskNow())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("added %s: %s\n", t.ID, t.Title)
+	return nil
+}
+
+func runTaskList(args []string) error {
+	fs := flag.NewFlagSet("task list", flag.ContinueOnError)
+	statusFlag := fs.String("status", "", "filter by status (pending|in_progress|completed|failed|blocked)")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned tasks envelope")
+	sessionFlag := fs.String("session", "", "AMQ workstream session (required)")
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	session, projectDir, err := taskSessionProject(*sessionFlag, *projectFlag, fs)
+	if err != nil {
+		return err
+	}
+	tasks, err := task.List(projectDir, session)
+	if err != nil {
+		return err
+	}
+	if s := strings.TrimSpace(*statusFlag); s != "" {
+		filtered := tasks[:0:0]
+		for _, t := range tasks {
+			if t.Status == s {
+				filtered = append(filtered, t)
+			}
+		}
+		tasks = filtered
+	}
+	if *jsonOut {
+		return printJSONEnvelope("tasks", tasksEnvelopeData{Session: session, Tasks: tasks})
+	}
+	if len(tasks) == 0 {
+		fmt.Println("(no tasks)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSTATUS\tASSIGNED\tDEPENDS\tTITLE")
+	for _, t := range tasks {
+		deps := strings.Join(t.DependsOn, ",")
+		if deps == "" {
+			deps = "-"
+		}
+		assigned := t.AssignedTo
+		if assigned == "" {
+			assigned = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.ID, t.Status, assigned, deps, t.Title)
+	}
+	return w.Flush()
+}
+
+// runTaskTransition handles claim/done/fail/block: each takes a positional id.
+func runTaskTransition(args []string, verb string) error {
+	id, rest, ok := peelPositional(args)
+	if !ok {
+		return usageErrorf("task %s requires a task id, e.g. 'task %s t1 --session S'", verb, verb)
+	}
+	fs := flag.NewFlagSet("task "+verb, flag.ContinueOnError)
+	meFlag := fs.String("me", "", "claiming agent handle (claim only)")
+	evidenceFlag := fs.String("evidence", "", "evidence/result note (done only)")
+	reasonFlag := fs.String("reason", "", "reason (fail/block only)")
+	sessionFlag := fs.String("session", "", "AMQ workstream session (required)")
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	if err := parseFlags(fs, rest); err != nil {
+		return err
+	}
+	session, projectDir, err := taskSessionProject(*sessionFlag, *projectFlag, fs)
+	if err != nil {
+		return err
+	}
+	now := taskNow()
+	var t task.Task
+	switch verb {
+	case "claim":
+		t, err = task.Claim(projectDir, session, id, *meFlag, now)
+	case "done":
+		t, err = task.Done(projectDir, session, id, *evidenceFlag, now)
+	case "fail":
+		t, err = task.Fail(projectDir, session, id, *reasonFlag, now)
+	case "block":
+		t, err = task.Block(projectDir, session, id, *reasonFlag, now)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s is now %s", t.ID, t.Status)
+	if t.AssignedTo != "" {
+		fmt.Printf(" (%s)", t.AssignedTo)
+	}
+	fmt.Println()
+	return nil
+}

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func withFixedTaskNow(t *testing.T) {
+	t.Helper()
+	prev := taskNow
+	taskNow = func() time.Time { return time.Date(2026, 6, 13, 16, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { taskNow = prev })
+}
+
+func TestTaskAddListClaimDoneFlow(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	withFixedTaskNow(t)
+
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"add", "--title", "wire limiter", "--session", "s"})
+	}); err != nil {
+		t.Fatalf("task add: %v", err)
+	}
+	// list shows the task.
+	out, _, err := captureOutput(t, func() error {
+		return runTask([]string{"list", "--session", "s"})
+	})
+	if err != nil {
+		t.Fatalf("task list: %v", err)
+	}
+	if !strings.Contains(out, "t1") || !strings.Contains(out, "wire limiter") || !strings.Contains(out, "pending") {
+		t.Fatalf("list missing the task:\n%s", out)
+	}
+	// claim → done.
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"claim", "t1", "--me", "worker", "--session", "s"})
+	}); err != nil {
+		t.Fatalf("task claim: %v", err)
+	}
+	out, _, err = captureOutput(t, func() error {
+		return runTask([]string{"done", "t1", "--evidence", "PR#1", "--session", "s"})
+	})
+	if err != nil {
+		t.Fatalf("task done: %v", err)
+	}
+	if !strings.Contains(out, "t1 is now completed") {
+		t.Errorf("done output unexpected:\n%s", out)
+	}
+}
+
+func TestTaskRequiresSession(t *testing.T) {
+	chdir(t, t.TempDir())
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"add", "--title", "x"})
+	}); err == nil || !strings.Contains(err.Error(), "--session is required") {
+		t.Fatalf("want --session required, got %v", err)
+	}
+}
+
+func TestTaskListJSONEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	withFixedTaskNow(t)
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"add", "--title", "x", "--session", "s"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stdout, _, err := captureOutput(t, func() error {
+		return runTask([]string{"list", "--json", "--session", "s"})
+	})
+	if err != nil {
+		t.Fatalf("task list --json: %v", err)
+	}
+	if !strings.Contains(stdout, "\"kind\": \"tasks\"") && !strings.Contains(stdout, "\"kind\":\"tasks\"") {
+		t.Errorf("expected a tasks envelope, got:\n%s", stdout)
+	}
+}
+
+func TestTaskUnknownSubcommandErrors(t *testing.T) {
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"bogus", "--session", "s"})
+	}); err == nil || !strings.Contains(err.Error(), "unknown 'task' subcommand") {
+		t.Fatalf("want unknown-subcommand error, got %v", err)
+	}
+}
+
+func TestTaskClaimRequiresID(t *testing.T) {
+	chdir(t, t.TempDir())
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"claim", "--session", "s", "--me", "w"})
+	}); err == nil || !strings.Contains(err.Error(), "requires a task id") {
+		t.Fatalf("want task-id-required error, got %v", err)
+	}
+}
+
+// Ensure the task store path is project-scoped and discoverable on disk.
+func TestTaskStoreOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	withFixedTaskNow(t)
+	if _, _, err := captureOutput(t, func() error {
+		return runTask([]string{"add", "--title", "x", "--session", "issue-9"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir + "/.amq-squad/tasks/issue-9/t1.json"); err != nil {
+		t.Fatalf("task file not written to the expected path: %v", err)
+	}
+}

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -48,20 +48,21 @@ Examples:
 	}
 }
 
-// peelRole splits a leading positional role from the remaining flag args, so
-// `add <role> --binary x` parses (Go's flag stops at the first non-flag, so
-// the role must be peeled before flag parsing).
-func peelRole(args []string) (role string, rest []string, err error) {
+// peelPositional splits a leading positional argument from the remaining flag
+// args (Go's flag parser stops at the first non-flag, so a positional that
+// precedes flags must be peeled first). ok is false when the first arg is
+// missing or is itself a flag; the caller supplies the context-specific error.
+func peelPositional(args []string) (val string, rest []string, ok bool) {
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return "", nil, usageErrorf("a role is required, e.g. 'team member add researcher --binary codex'")
+		return "", nil, false
 	}
-	return args[0], args[1:], nil
+	return args[0], args[1:], true
 }
 
 func runTeamMemberAdd(args []string) error {
-	role, rest, err := peelRole(args)
-	if err != nil {
-		return err
+	role, rest, ok := peelPositional(args)
+	if !ok {
+		return usageErrorf("a role is required, e.g. 'team member add researcher --binary codex'")
 	}
 	fs := flag.NewFlagSet("team member add", flag.ContinueOnError)
 	binaryFlag := fs.String("binary", "", "agent CLI for this member: claude or codex (required)")
@@ -88,6 +89,7 @@ func runTeamMemberAdd(args []string) error {
 		return fmt.Errorf("role: %w", err)
 	}
 
+	var err error
 	var claudeArgs, codexArgs []string
 	if strings.TrimSpace(*claudeArgsRaw) != "" {
 		if claudeArgs, err = parseAgentArgs(*claudeArgsRaw); err != nil {
@@ -167,9 +169,9 @@ func runTeamMemberAdd(args []string) error {
 }
 
 func runTeamMemberRemove(args []string) error {
-	role, rest, err := peelRole(args)
-	if err != nil {
-		return err
+	role, rest, ok := peelPositional(args)
+	if !ok {
+		return usageErrorf("a role is required, e.g. 'team member add researcher --binary codex'")
 	}
 	role = strings.ToLower(strings.TrimSpace(role))
 	fs := flag.NewFlagSet("team member rm", flag.ContinueOnError)

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,0 +1,299 @@
+// Package task is amq-squad's native, binary-neutral pull-based task store:
+// the lead decomposes a goal into tasks under .amq-squad/tasks/<session>/, and
+// workers (any binary) claim them and self-schedule around dependencies. It is
+// the amq-squad-native analog of the amq swarm task list — but with a create
+// path (Add), so a Codex or Claude lead can decompose the goal. See
+// docs/task-store-design.md.
+package task
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/internal/flock"
+)
+
+// Status values for the five-state machine.
+const (
+	StatusPending    = "pending"
+	StatusInProgress = "in_progress"
+	StatusCompleted  = "completed"
+	StatusFailed     = "failed"
+	StatusBlocked    = "blocked"
+)
+
+// Task is one unit of work in a workstream's task store.
+type Task struct {
+	ID            string    `json:"id"`
+	Title         string    `json:"title"`
+	Description   string    `json:"description,omitempty"`
+	Status        string    `json:"status"`
+	AssignedTo    string    `json:"assigned_to,omitempty"`
+	DependsOn     []string  `json:"depends_on,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	Evidence      string    `json:"evidence,omitempty"`
+	FailureReason string    `json:"failure_reason,omitempty"`
+	BlockReason   string    `json:"block_reason,omitempty"`
+}
+
+// AddInput is the create payload for Add.
+type AddInput struct {
+	Title       string
+	Description string
+	DependsOn   []string
+	AssignTo    string
+}
+
+// Dir is the task directory for a workstream: .amq-squad/tasks/<session>.
+func Dir(projectDir, session string) string {
+	return filepath.Join(projectDir, ".amq-squad", "tasks", session)
+}
+
+// Add creates a new pending task and returns it. The id is allocated under the
+// store lock so concurrent adds never collide.
+func Add(projectDir, session string, in AddInput, now time.Time) (Task, error) {
+	if strings.TrimSpace(in.Title) == "" {
+		return Task{}, fmt.Errorf("task title is required")
+	}
+	var created Task
+	err := withLock(projectDir, session, func(dir string) error {
+		tasks, err := readAll(dir)
+		if err != nil {
+			return err
+		}
+		// Validate dependency ids exist now (a typo'd dep would otherwise gate
+		// the task forever). Because a dep must reference an already-created
+		// task and ids increase monotonically (allocID = max+1), every edge
+		// points from a higher id to a lower one — the dependency graph is a
+		// DAG by construction, so cycles and self-dependencies are impossible
+		// here (a self-dep references the not-yet-allocated id and fails this
+		// existence check).
+		byID := indexByID(tasks)
+		for _, dep := range in.DependsOn {
+			if _, ok := byID[dep]; !ok {
+				return fmt.Errorf("depends-on task %q does not exist", dep)
+			}
+		}
+		created = Task{
+			ID:          allocID(tasks),
+			Title:       strings.TrimSpace(in.Title),
+			Description: strings.TrimSpace(in.Description),
+			Status:      StatusPending,
+			AssignedTo:  strings.TrimSpace(in.AssignTo),
+			DependsOn:   dedupeNonEmpty(in.DependsOn),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		return writeTask(dir, created)
+	})
+	return created, err
+}
+
+// List returns all tasks in the workstream, sorted by id.
+func List(projectDir, session string) ([]Task, error) {
+	tasks, err := readAll(Dir(projectDir, session))
+	if err != nil {
+		return nil, err
+	}
+	sortTasks(tasks)
+	return tasks, nil
+}
+
+// Claim moves a pending task to in_progress for handle, but only when every
+// dependency is completed (dependency gating).
+func Claim(projectDir, session, id, handle string, now time.Time) (Task, error) {
+	if strings.TrimSpace(handle) == "" {
+		return Task{}, fmt.Errorf("--me handle is required to claim a task")
+	}
+	return mutate(projectDir, session, id, func(t *Task, all map[string]*Task) error {
+		if t.Status != StatusPending {
+			return fmt.Errorf("task %s is %s, not pending; only pending tasks can be claimed", id, t.Status)
+		}
+		for _, dep := range t.DependsOn {
+			d := all[dep]
+			if d == nil {
+				return fmt.Errorf("task %s depends on %s, which does not exist", id, dep)
+			}
+			if d.Status != StatusCompleted {
+				return fmt.Errorf("task %s is blocked on %s (%s); complete it first", id, dep, d.Status)
+			}
+		}
+		t.Status = StatusInProgress
+		t.AssignedTo = strings.TrimSpace(handle)
+		t.Evidence, t.FailureReason, t.BlockReason = "", "", ""
+		t.UpdatedAt = now
+		return nil
+	})
+}
+
+// Done / Fail / Block are the in_progress → terminal transitions.
+func Done(projectDir, session, id, evidence string, now time.Time) (Task, error) {
+	return terminal(projectDir, session, id, StatusCompleted, func(t *Task) { t.Evidence = strings.TrimSpace(evidence) }, now)
+}
+
+func Fail(projectDir, session, id, reason string, now time.Time) (Task, error) {
+	return terminal(projectDir, session, id, StatusFailed, func(t *Task) { t.FailureReason = strings.TrimSpace(reason) }, now)
+}
+
+func Block(projectDir, session, id, reason string, now time.Time) (Task, error) {
+	return terminal(projectDir, session, id, StatusBlocked, func(t *Task) { t.BlockReason = strings.TrimSpace(reason) }, now)
+}
+
+// terminal applies an in_progress → completed/failed/blocked transition.
+// Terminal states are final in Slice B: there is no reset path, so to re-attempt
+// a failed/blocked task, create a new one (`task reset` is deferred to Phase 1).
+func terminal(projectDir, session, id, to string, set func(*Task), now time.Time) (Task, error) {
+	return mutate(projectDir, session, id, func(t *Task, _ map[string]*Task) error {
+		if t.Status != StatusInProgress {
+			return fmt.Errorf("task %s is %s, not in_progress; claim it before marking it %s", id, t.Status, to)
+		}
+		t.Status = to
+		set(t)
+		t.UpdatedAt = now
+		return nil
+	})
+}
+
+// --- internals ---
+
+// mutate locks the store, loads all tasks, applies fn to the target task (with
+// the full set available for dependency checks), and persists just that task.
+func mutate(projectDir, session, id string, fn func(t *Task, all map[string]*Task) error) (Task, error) {
+	id = strings.TrimSpace(id)
+	var out Task
+	err := withLock(projectDir, session, func(dir string) error {
+		tasks, err := readAll(dir)
+		if err != nil {
+			return err
+		}
+		all := indexByID(tasks)
+		t := all[id]
+		if t == nil {
+			return fmt.Errorf("task %q not found in workstream %q", id, session)
+		}
+		if err := fn(t, all); err != nil {
+			return err
+		}
+		out = *t
+		return writeTask(dir, *t)
+	})
+	return out, err
+}
+
+func withLock(projectDir, session string, fn func(dir string) error) error {
+	dir := Dir(projectDir, session)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensure task dir %s: %w", dir, err)
+	}
+	return flock.WithLock(filepath.Join(dir, ".lock"), func() error { return fn(dir) })
+}
+
+func readAll(dir string) ([]Task, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read task dir: %w", err)
+	}
+	var tasks []Task
+	for _, e := range entries {
+		// Only finished task files. A crash leaves a "<id>.json.tmp" behind,
+		// which ends in .tmp (not .json) and is correctly skipped here; the
+		// real file only appears after the atomic rename, never partial.
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		var t Task
+		if err := json.Unmarshal(b, &t); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, nil
+}
+
+func writeTask(dir string, t Task) error {
+	b, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal task: %w", err)
+	}
+	path := filepath.Join(dir, t.ID+".json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// indexByID maps id → *Task pointing into the input slice. The pointers are
+// valid only for the lifetime of that slice (i.e. within the calling
+// mutate/Add scope); callers must not retain them past the lock callback.
+func indexByID(tasks []Task) map[string]*Task {
+	m := make(map[string]*Task, len(tasks))
+	for i := range tasks {
+		m[tasks[i].ID] = &tasks[i]
+	}
+	return m
+}
+
+// allocID returns t<N+1> where N is the max numeric suffix among t<N> ids.
+func allocID(tasks []Task) string {
+	max := 0
+	for _, t := range tasks {
+		if n, ok := parseTaskNum(t.ID); ok && n > max {
+			max = n
+		}
+	}
+	return "t" + strconv.Itoa(max+1)
+}
+
+func parseTaskNum(id string) (int, bool) {
+	if !strings.HasPrefix(id, "t") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(id[1:])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func dedupeNonEmpty(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+func sortTasks(tasks []Task) {
+	sort.Slice(tasks, func(i, j int) bool {
+		ni, oki := parseTaskNum(tasks[i].ID)
+		nj, okj := parseTaskNum(tasks[j].ID)
+		if oki && okj {
+			return ni < nj
+		}
+		return tasks[i].ID < tasks[j].ID
+	})
+}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,0 +1,125 @@
+package task
+
+import (
+	"testing"
+	"time"
+)
+
+var fixedNow = time.Date(2026, 6, 13, 16, 0, 0, 0, time.UTC)
+
+func TestAddAllocatesSequentialIDs(t *testing.T) {
+	dir := t.TempDir()
+	a, err := Add(dir, "s", AddInput{Title: "first"}, fixedNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Add(dir, "s", AddInput{Title: "second"}, fixedNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ID != "t1" || b.ID != "t2" {
+		t.Fatalf("ids = %s,%s want t1,t2", a.ID, b.ID)
+	}
+	if a.Status != StatusPending {
+		t.Errorf("new task status = %q, want pending", a.Status)
+	}
+	list, err := List(dir, "s")
+	if err != nil || len(list) != 2 {
+		t.Fatalf("list = %d (%v)", len(list), err)
+	}
+}
+
+func TestAddRequiresTitleAndValidatesDeps(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Add(dir, "s", AddInput{Title: "  "}, fixedNow); err == nil {
+		t.Error("empty title should be rejected")
+	}
+	if _, err := Add(dir, "s", AddInput{Title: "x", DependsOn: []string{"t99"}}, fixedNow); err == nil {
+		t.Error("dependency on a non-existent task should be rejected")
+	}
+}
+
+func TestClaimGatesOnDependencies(t *testing.T) {
+	dir := t.TempDir()
+	dep, _ := Add(dir, "s", AddInput{Title: "dep"}, fixedNow)
+	gated, _ := Add(dir, "s", AddInput{Title: "gated", DependsOn: []string{dep.ID}}, fixedNow)
+
+	// Cannot claim while the dependency is not completed.
+	if _, err := Claim(dir, "s", gated.ID, "worker", fixedNow); err == nil {
+		t.Fatal("claim should be gated until the dependency completes")
+	}
+	// Complete the dependency, then the gated task is claimable.
+	if _, err := Claim(dir, "s", dep.ID, "worker", fixedNow); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Done(dir, "s", dep.ID, "", fixedNow); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Claim(dir, "s", gated.ID, "worker2", fixedNow)
+	if err != nil {
+		t.Fatalf("claim after dep completed: %v", err)
+	}
+	if got.Status != StatusInProgress || got.AssignedTo != "worker2" {
+		t.Fatalf("claimed = %+v, want in_progress/worker2", got)
+	}
+}
+
+func TestStateMachineTransitions(t *testing.T) {
+	dir := t.TempDir()
+	tk, _ := Add(dir, "s", AddInput{Title: "x"}, fixedNow)
+
+	// done requires in_progress.
+	if _, err := Done(dir, "s", tk.ID, "ev", fixedNow); err == nil {
+		t.Error("done on a pending task should be rejected")
+	}
+	if _, err := Claim(dir, "s", tk.ID, "w", fixedNow); err != nil {
+		t.Fatal(err)
+	}
+	// claim twice rejected (no longer pending).
+	if _, err := Claim(dir, "s", tk.ID, "w2", fixedNow); err == nil {
+		t.Error("re-claiming an in_progress task should be rejected")
+	}
+	done, err := Done(dir, "s", tk.ID, "shipped", fixedNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.Status != StatusCompleted || done.Evidence != "shipped" {
+		t.Fatalf("done = %+v", done)
+	}
+	// terminal: cannot fail a completed task.
+	if _, err := Fail(dir, "s", tk.ID, "no", fixedNow); err == nil {
+		t.Error("fail on a completed task should be rejected")
+	}
+}
+
+func TestFailAndBlockCarryReasons(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		title string
+		fn    func(id string) (Task, error)
+		want  string
+		field func(Task) string
+	}{
+		{"a", func(id string) (Task, error) { return Fail(dir, "s", id, "boom", fixedNow) }, StatusFailed, func(t Task) string { return t.FailureReason }},
+		{"b", func(id string) (Task, error) { return Block(dir, "s", id, "waiting", fixedNow) }, StatusBlocked, func(t Task) string { return t.BlockReason }},
+	} {
+		tk, _ := Add(dir, "s", AddInput{Title: tc.title}, fixedNow)
+		if _, err := Claim(dir, "s", tk.ID, "w", fixedNow); err != nil {
+			t.Fatal(err)
+		}
+		got, err := tc.fn(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != tc.want || tc.field(got) == "" {
+			t.Fatalf("%s -> %+v, want %s with reason", tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestMutateUnknownIDErrors(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Claim(dir, "s", "t404", "w", fixedNow); err == nil {
+		t.Error("claiming an unknown id should error")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 0 Slice B of the [v2.0.0 plan](../blob/main/docs/v2.0.0.md): the binary-neutral, amq-squad-native **pull-based task store**. The lead decomposes a goal into tasks; workers (Claude *or* Codex) claim them and self-schedule around dependencies. It's the analog of the `amq swarm` task list — but **with a `task add` (create) verb**, which swarm lacks, so an any-binary lead can decompose the goal. Design doc: `docs/task-store-design.md`.

- **`internal/task`**: one JSON file per task under `.amq-squad/tasks/<session>/`, atomic `.tmp`+rename writes, all mutations serialized by the exclusive sidecar lock from Slice A (`internal/flock`). Five-state machine (`pending → in_progress → completed/failed/blocked`) with **dependency gating** (a claim is refused until every `depends_on` task is `completed`). Sequential `t<N>` ids allocated under the lock; `depends-on` ids validated at add time.
- **`amq-squad task <add|list|claim|done|fail|block>`** (new top-level verb), `--session`-scoped. Wired into dispatch, usage, and shell completion (bash/zsh/fish + the top-command and flag drift guards).

**Additive** — new package + new verb, no change to existing behavior or schema.

## Validation

- Package tests: id allocation, title/dep validation, dependency-gated claim, full state machine + terminal guards, fail/block reasons, unknown id.
- CLI tests: add/list/claim/done flow, `--session` required, JSON envelope, on-disk path, claim-needs-id.
- Real-binary smoke: `task add` two tasks with a dependency → claim of the gated task is refused (`blocked on t1 (pending)`) → after the dep completes, the claim succeeds.
- `make ci` green (exit code checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)