### PR TITLE
Add `team member list` — roster-read companion to add/rm (Slice D finding)

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -120,6 +120,8 @@ var completionTeamRulesSubcommands = []string{
 // completionTeamMemberSubcommands lists `amq-squad team member` subcommands.
 var completionTeamMemberSubcommands = []string{
 	"add",
+	"list",
+	"ls",
 	"rm",
 	"remove",
 }

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -15,7 +15,7 @@ const JSONSchemaVersion = 1
 
 // jsonEnvelope is the wrapping shape every --json output uses. Kind names
 // the produced view (e.g. "brief", "brief_seed", "status", "history", "team_plan",
-// "team_profile_plan", "version", "roles", "team_profiles",
+// "team_profile_plan", "team_roster", "tasks", "version", "roles", "team_profiles",
 // "brief_candidate"); Data is the kind-specific payload. Stdout receives the
 // envelope alone; diagnostics stay on stderr.
 type jsonEnvelope struct {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1699,7 +1699,8 @@ Usage:
                                       overlay (trim plugins/hooks) and wire the
                                       member's claude_args to load it
   amq-squad team member add <role> --binary <claude|codex> [options]
-  amq-squad team member rm <role>     Add or remove a roster member at runtime
+  amq-squad team member rm <role>
+  amq-squad team member list          Add/remove/list roster members at runtime
                                       (atomic + locked + re-validated). The new
                                       member is not launched; an 'agent up' hint
                                       is printed.

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/omriariav/amq-squad/internal/flock"
 	"github.com/omriariav/amq-squad/internal/team"
 )
 
-// runTeamMember dispatches `amq-squad team member <add|rm>`: runtime roster
+// runTeamMember dispatches `amq-squad team member <add|rm|list>`: runtime roster
 // mutation. This is the durable-roster primitive the goal-first composition
 // model rests on — a lead (any binary) grows or shrinks its team mid-session,
 // and the change persists to team.json so resume rebuilds the team it built.
@@ -23,6 +24,7 @@ Usage:
       [--session S] [--model M] [--claude-args "…"] [--codex-args "…"]
       [--project DIR] [--profile NAME]
   amq-squad team member rm <role> [--project DIR] [--profile NAME]
+  amq-squad team member list [--json] [--project DIR] [--profile NAME]
 
 Mutates the persisted team profile (team.json) atomically and under an
 exclusive lock, then re-validates it (orchestration constraints included).
@@ -34,7 +36,7 @@ Examples:
   amq-squad team member rm researcher
 `)
 		if len(args) == 0 {
-			return usageErrorf("member requires a subcommand ('add' or 'rm')")
+			return usageErrorf("member requires a subcommand ('add', 'list', or 'rm')")
 		}
 		return nil
 	}
@@ -43,9 +45,81 @@ Examples:
 		return runTeamMemberAdd(args[1:])
 	case "rm", "remove":
 		return runTeamMemberRemove(args[1:])
+	case "list", "ls":
+		return runTeamMemberList(args[1:])
 	default:
-		return usageErrorf("unknown 'team member' subcommand: %q. Try 'add' or 'rm'.", args[0])
+		return usageErrorf("unknown 'team member' subcommand: %q. Try 'add', 'list', or 'rm'.", args[0])
 	}
+}
+
+// runTeamMemberList prints the current roster — the read companion to add/rm,
+// so a lead can see the team it has built without opening team.json.
+func runTeamMemberList(args []string) error {
+	fs := flag.NewFlagSet("team member list", flag.ContinueOnError)
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	profileFlag := fs.String("profile", "", "team profile to read (default: default profile)")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned roster envelope")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return usageErrorf("unexpected argument %q", fs.Arg(0))
+	}
+	projectDir, profile, err := resolveExistingTeamProfile(*projectFlag, *profileFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return err
+	}
+	t, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	members := orderedTeamMembers(t.Members)
+	if *jsonOut {
+		return printJSONEnvelope("team_roster", teamRosterData{
+			Profile: profile, Orchestrated: t.Orchestrated, Lead: t.Lead, Members: members,
+		})
+	}
+	if len(members) == 0 {
+		fmt.Println("(no members)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	// The LEAD column only carries information for an orchestrated team; omit it
+	// entirely for a flat team rather than printing an always-blank column.
+	if t.Orchestrated {
+		fmt.Fprintln(w, "ROLE\tBINARY\tHANDLE\tMODEL\tSESSION\tLEAD")
+	} else {
+		fmt.Fprintln(w, "ROLE\tBINARY\tHANDLE\tMODEL\tSESSION")
+	}
+	for _, m := range members {
+		model := orDash(m.Model)
+		session := orDash(m.Session)
+		if t.Orchestrated {
+			lead := ""
+			if m.Role == t.Lead {
+				lead = "lead"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", m.Role, m.Binary, m.Handle, model, session, lead)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", m.Role, m.Binary, m.Handle, model, session)
+		}
+	}
+	return w.Flush()
+}
+
+func orDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+// teamRosterData is the `team member list --json` payload.
+type teamRosterData struct {
+	Profile      string        `json:"profile"`
+	Orchestrated bool          `json:"orchestrated"`
+	Lead         string        `json:"lead,omitempty"`
+	Members      []team.Member `json:"members"`
 }
 
 // peelPositional splits a leading positional argument from the remaining flag

--- a/internal/cli/team_member_test.go
+++ b/internal/cli/team_member_test.go
@@ -164,6 +164,67 @@ func TestTeamMemberRmRefusesOrchestrationLead(t *testing.T) {
 	}
 }
 
+func TestTeamMemberListShowsRoster(t *testing.T) {
+	seedTeam(t, team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "s", Model: "sonnet"},
+		},
+	})
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"list"})
+	})
+	if err != nil {
+		t.Fatalf("member list: %v", err)
+	}
+	for _, want := range []string{"cto", "qa", "sonnet", "lead"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("roster table missing %q in:\n%s", want, out)
+		}
+	}
+	// JSON envelope.
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"list", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member list --json: %v", err)
+	}
+	if !strings.Contains(stdout, "team_roster") || !strings.Contains(stdout, "\"lead\": \"cto\"") {
+		t.Errorf("roster json unexpected:\n%s", stdout)
+	}
+}
+
+func TestTeamMemberListFlatTeamAndEmptyAndAlias(t *testing.T) {
+	// Flat (non-orchestrated) team: no LEAD column, and --json omits "lead".
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}},
+	})
+	out, _, err := captureOutput(t, func() error { return runTeamMember([]string{"ls"}) }) // ls alias
+	if err != nil {
+		t.Fatalf("member ls: %v", err)
+	}
+	if strings.Contains(out, "LEAD") {
+		t.Errorf("flat team should not show a LEAD column:\n%s", out)
+	}
+	stdout, _, err := captureOutput(t, func() error { return runTeamMember([]string{"list", "--json"}) })
+	if err != nil {
+		t.Fatalf("member list --json: %v", err)
+	}
+	if strings.Contains(stdout, "\"lead\"") {
+		t.Errorf("flat team json should omit the lead key:\n%s", stdout)
+	}
+}
+
+func TestTeamMemberListEmptyRoster(t *testing.T) {
+	seedTeam(t, team.Team{Members: nil})
+	out, _, err := captureOutput(t, func() error { return runTeamMember([]string{"list"}) })
+	if err != nil || !strings.Contains(out, "(no members)") {
+		t.Fatalf("empty roster: want '(no members)', got %q / %v", out, err)
+	}
+}
+
 func TestTeamMemberRequiresExistingTeam(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)


### PR DESCRIPTION
## Summary

The Slice-D eval found that **all 5 Codex leads reached for `team member list`** to see the roster they'd built, hit "unknown subcommand," and fell back to reading `team.json` by hand. This adds the read companion to `add`/`rm`:

- `amq-squad team member list [--json]` — a table (role, binary, handle, model, session, **lead** marker) or a `team_roster` JSON envelope.
- New `case "list"`/`ls` in `runTeamMember`, reusing `resolveExistingTeamProfile` + `orderedTeamMembers`; rejects stray positionals.
- Usage, `printTeamUsage`, and shell completion (bash/zsh/fish) updated.
- Tests for the table (incl. lead marker + model) and the JSON envelope.

Additive, no breaking changes. Closes one of the two Slice-D follow-up findings (the other is the `scribe` role). `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)