### PR TITLE
Add `scribe` (Technical Writer) role to the catalog (Slice D finding)

### DIFF
--- a/README.html
+++ b/README.html
@@ -1140,7 +1140,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb26-1"><a href="#
 step on most shells.</p>
 <h2 id="custom-roles">Custom roles</h2>
 <p><code>--roles</code>/<code>--personas</code> accept built-in personas
-(<code>cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm, designer</code>)
+(<code>cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm, designer, scribe</code>)
 and <strong>custom roles</strong> that are not in the catalog. A custom
 role is any valid slug (lowercase <code>a-z</code>, <code>0-9</code>,
 <code>-</code>, <code>_</code>) and must carry an explicit

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ amq-squad completion fish > ~/.config/fish/completions/amq-squad.fish
 
 `--roles`/`--personas` accept built-in personas (`cpo, cto, senior-dev,
 fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
-designer`) and **custom roles** that are not in the catalog. A custom role is
+designer, scribe`) and **custom roles** that are not in the catalog. A custom role is
 any valid slug (lowercase `a-z`, `0-9`, `-`, `_`) and must carry an explicit
 `--binary` because there is no catalog default to fall back to. Built-in roles
 keep their catalog defaults unless overridden. Custom roles are first-class

--- a/docs/eval-results.md
+++ b/docs/eval-results.md
@@ -40,12 +40,10 @@ borderline; #3 and #4 both cover their critical category.
    reading `.amq-squad/team.json` directly. Bare `amq-squad team` shows the
    roster, but a lead naturally reaches for `team member list`. **Recommended
    follow-up:** add `team member list` (or point the error at `amq-squad team`).
-2. **Role library lacks a docs/writer role** (catalog is cpo, cto, senior-dev,
-   fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
-   designer). For the docs goal (#4) the lead reached for `backend-dev` as the
-   API SME — defensible, but it's why #4 is borderline. **Recommended
-   follow-up:** add a `scribe`/`technical-writer` role so docs goals compose
-   cleanly without an implementer.
+2. **Role library lacks a docs/writer role** (catalog at eval time lacked a docs role). For the docs goal (#4) the lead
+   reached for `backend-dev` as the API SME — defensible, but it is why #4 is
+   borderline. **Resolved:** a `scribe` (Technical Writer) role was added to the
+   catalog so docs goals compose cleanly without an implementer.
 
 Neither finding blocks the gate; both are good iteration before/with Phase 1.
 

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -364,7 +364,7 @@ and monitors the others and owns the deliverable.</td>
 <td>Custom roles</td>
 <td><strong><code>amq-squad-role-creator</code></strong></td>
 <td>when you need a role the built-in catalog doesn't ship (researcher,
-sre, scribe, ...).</td>
+sre, archivist, ...).</td>
 </tr>
 </tbody>
 </table>
@@ -767,7 +767,7 @@ id="amq-squad-role-creator--author-a-custom-role"><code>amq-squad-role-creator</
 <code>/amq-squad:amq-squad-role-creator</code> (Claude) ·
 <code>$amq-squad-role-creator</code> (Codex) <strong>Use when:</strong>
 you need a role the built-in catalog doesn't ship
-(<code>researcher</code>, <code>sre</code>, <code>scribe</code>,
+(<code>researcher</code>, <code>sre</code>, <code>archivist</code>,
 <code>data-scientist</code>, ...). Custom roles are first-class — they
 appear in <code>team.json</code>, <code>team-rules.md</code>, the
 bootstrap prompt, and status/launch exactly like built-ins.</p>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,7 +30,7 @@ A fourth skill exists only when you need a **role the catalog doesn't ship**.
 | Design / setup | **`amq-team-setup`** | once, before the team runs: capture the goal, draft the brief, pick roles, optionally wire orchestration, write `team.json` + `team-rules.md` + the brief + pointer stubs. |
 | Live coordination | **`amq-squad`** | every day after the team exists: bring members up, drain inboxes, route handoffs, request reviews, check status, stop/resume/fork. |
 | Lead orchestration | **`amq-squad-orchestrator`** | when one agent is the **lead** that spawns, dispatches, and monitors the others and owns the deliverable. |
-| Custom roles | **`amq-squad-role-creator`** | when you need a role the built-in catalog doesn't ship (researcher, sre, scribe, ...). |
+| Custom roles | **`amq-squad-role-creator`** | when you need a role the built-in catalog doesn't ship (researcher, sre, archivist, ...). |
 
 They sit on top of three durable layers that setup creates and coordination
 consumes:
@@ -319,7 +319,7 @@ amq-squad agent resume fullstack         # revive one child from its saved recor
 **Invoke:** `/amq-squad:amq-squad-role-creator` (Claude) ·
 `$amq-squad-role-creator` (Codex)
 **Use when:** you need a role the built-in catalog doesn't ship (`researcher`,
-`sre`, `scribe`, `data-scientist`, ...). Custom roles are first-class — they
+`sre`, `archivist`, `data-scientist`, ...). Custom roles are first-class — they
 appear in `team.json`, `team-rules.md`, the bootstrap prompt, and status/launch
 exactly like built-ins.
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -108,7 +108,7 @@ var roles = []Role{
 		PreferredBinary: "claude",
 		Profile:         "Keeps work ordered, unblocked, and shippable.",
 		Description:     "Translates product strategy into ordered work. Tracks scope, unblocks, and keeps the team aligned on what ships next.",
-		DefaultPeers:    []string{"cpo", "fullstack", "frontend-dev", "mobile-dev", "junior-dev", "qa", "designer"},
+		DefaultPeers:    []string{"cpo", "fullstack", "frontend-dev", "mobile-dev", "junior-dev", "qa", "designer", "scribe"},
 	},
 	{
 		ID:              "designer",
@@ -118,6 +118,14 @@ var roles = []Role{
 		Description:     "Designs the product surface. Produces UI components, flows, and visual assets, leaning on /frontend-design and /canvas-design.",
 		Skills:          []string{"/frontend-design", "/canvas-design"},
 		DefaultPeers:    []string{"cpo", "fullstack", "pm"},
+	},
+	{
+		ID:              "scribe",
+		Label:           "Technical Writer",
+		PreferredBinary: "claude",
+		Profile:         "Docs, references, guides, the written record.",
+		Description:     "Owns the written deliverable: API references, guides, READMEs, and the team's written record. The right author for a docs goal — does not implement product code.",
+		DefaultPeers:    []string{"cto", "backend-dev", "frontend-dev", "pm"},
 	},
 }
 

--- a/internal/cli/custom_role_test.go
+++ b/internal/cli/custom_role_test.go
@@ -268,11 +268,11 @@ Owns investigation.
 func TestRoleFileInlinePathStagesVerbatimDoc(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
-	body := "# Role: Scribe\n\n## Description\nKeeps the written record.\n"
-	writeRoleFile(t, dir, "scribe.md", body)
+	body := "# Role: Archivist\n\n## Description\nKeeps the written record.\n"
+	writeRoleFile(t, dir, "archivist.md", body)
 
 	_, stderr, err := captureOutput(t, func() error {
-		return runNew([]string{"team", "--roles", "cto,./scribe.md", "--binary", "scribe=claude", "--session", "issue-96"})
+		return runNew([]string{"team", "--roles", "cto,./archivist.md", "--binary", "archivist=claude", "--session", "issue-96"})
 	})
 	if err != nil {
 		t.Fatalf("inline role file: %v\nstderr:\n%s", err, stderr)
@@ -283,17 +283,17 @@ func TestRoleFileInlinePathStagesVerbatimDoc(t *testing.T) {
 	}
 	found := false
 	for _, m := range cfg.Members {
-		if m.Role == "scribe" {
+		if m.Role == "archivist" {
 			found = true
 			if m.Binary != "claude" {
-				t.Errorf("scribe binary = %q, want claude", m.Binary)
+				t.Errorf("archivist binary = %q, want claude", m.Binary)
 			}
 		}
 	}
 	if !found {
-		t.Fatalf("scribe not in members: %+v", cfg.Members)
+		t.Fatalf("archivist not in members: %+v", cfg.Members)
 	}
-	staged, err := os.ReadFile(team.CustomRolePath(dir, "scribe"))
+	staged, err := os.ReadFile(team.CustomRolePath(dir, "archivist"))
 	if err != nil {
 		t.Fatalf("staged role doc missing: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestRoleFileInlinePathStagesVerbatimDoc(t *testing.T) {
 
 	// And the launch-time seed copies the staged doc into the agent's role.md.
 	agentDir := t.TempDir()
-	if err := seedRoleStub(agentDir, "scribe", dir); err != nil {
+	if err := seedRoleStub(agentDir, "archivist", dir); err != nil {
 		t.Fatalf("seedRoleStub from staged doc: %v", err)
 	}
 	got, err := os.ReadFile(role.Path(agentDir))

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -151,6 +151,8 @@ func roleScope(roleID string) string {
 		return "Owns work ordering, clarification, coordination, status, and handoffs. Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user."
 	case "designer":
 		return "Owns product flows, UX, visual shape, and design assets. Does not implement production code unless explicitly assigned by the user."
+	case "scribe":
+		return "Owns the written deliverable and record: API references, guides, READMEs, and docs. Does not implement product code unless explicitly assigned by the user."
 	default:
 		return "Owns the responsibilities described in role.md. Ask before taking implementation work outside this role."
 	}

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-squad-role-creator
-description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, scribe, or data-scientist that the catalog does not ship. For built-in personas (cto, qa, fullstack, ...) and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
+description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, or data-scientist that the catalog does not ship. For built-in personas (cto, qa, fullstack, ...) and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true
@@ -11,7 +11,7 @@ trigger: /amq-squad-role-creator
 
 Use this skill to add a **custom role** — one that is not in the built-in
 persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
-mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
+mobile-dev, junior-dev, qa, pm, designer, scribe`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 
@@ -102,14 +102,14 @@ for instruction.
 `# Role:` heading or filename; supply the binary with `--binary`):
 
 ```markdown
-# Role: Scribe
+# Role: Archivist
 
 ## Description
 Captures decisions and keeps the team's written record.
 ```
 
 ```sh
-amq-squad new team --roles "cto,./roles/scribe.md" --binary scribe=claude
+amq-squad new team --roles "cto,./roles/archivist.md" --binary archivist=claude
 ```
 
 **Metadata-only YAML or JSON** (no body; `role.md` is rendered from the

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: amq-squad-role-creator
-description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, scribe, or data-scientist that the catalog does not ship. For built-in personas and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
+description: Author custom amq-squad roles that are not in the built-in persona catalog, then wire them into a team. Covers writing a role file (Markdown with optional YAML frontmatter, .yaml, or .json), the required binary, and adding the role via `team init`/`new team`/`new profile` with `--role-file` or an inline path in `--roles`, plus the inline `--roles X --binary X=<cli>` shortcut. Use when someone wants a role like researcher, sre, or data-scientist that the catalog does not ship. For built-in personas and general team design, use `amq-team-setup`; for live coordination use `amq-squad`.
 ---
 
 # amq-squad-role-creator
 
 Use this skill to add a **custom role** — one that is not in the built-in
 persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
-mobile-dev, junior-dev, qa, pm, designer`). Custom roles are first-class team
+mobile-dev, junior-dev, qa, pm, designer, scribe`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 
@@ -98,14 +98,14 @@ for instruction.
 `# Role:` heading or filename; supply the binary with `--binary`):
 
 ```markdown
-# Role: Scribe
+# Role: Archivist
 
 ## Description
 Captures decisions and keeps the team's written record.
 ```
 
 ```sh
-amq-squad new team --roles "cto,./roles/scribe.md" --binary scribe=claude
+amq-squad new team --roles "cto,./roles/archivist.md" --binary archivist=claude
 ```
 
 **Metadata-only YAML or JSON** (no body; `role.md` is rendered from the


### PR DESCRIPTION
## Summary

The Slice-D eval found docs goals had no clean role to compose from — the Codex lead reached for `backend-dev` as the API SME (why the docs goal scored *borderline*). This adds a **`scribe` (Technical Writer)** built-in role so docs goals compose without an implementer.

- **catalog**: `scribe` — claude default; owns API references, guides, READMEs, the written record; does not implement product code.
- **team_rules `roleScope`**: scribe's scope sentence.
- **Persona-list enumerations** updated: `amq-squad-role-creator` skill (both mirrors), README (+ regenerated README.html).
- **`custom_role_test`**: its fixture used `scribe` as an arbitrary *custom* role id — repointed to `archivist` (the built-in collision guard correctly rejected the old fixture, which is proof the reservation works).
- **eval-results**: the docs-role finding is marked resolved.

Additive, no breaking changes. Closes the second of the two Slice-D follow-up findings. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)