### PR TITLE
[2.0 Phase 1a — HOLD] Remove deprecated verbs (down + launch/restore/list, team show/launch)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -197,10 +197,6 @@ func dispatch(args []string) error {
 		return runUp(args[1:])
 	case "stop":
 		return runStop(args[1:])
-	case "down":
-		// Deprecated alias for `stop`, kept for one release. runDown prints a
-		// one-line stderr hint then runs the identical stop logic.
-		return runDown(args[1:])
 	case "brief":
 		return runBrief(args[1:])
 	case "threads":
@@ -227,18 +223,6 @@ func dispatch(args []string) error {
 		return runRm(args[1:], rmModeDelete)
 	case "archive":
 		return runRm(args[1:], rmModeArchive)
-	case "launch":
-		// Legacy verb. Kept as an explicit hint (not unknown-command) for one
-		// release so muscle-memory invocations get a pointer.
-		return usageErrorf("'launch' is a legacy verb; use 'agent up <binary>' to launch a single agent.")
-	case "restore":
-		// Legacy verb. Print mode maps to 'history'; exec mode maps to
-		// 'agent resume <role>'. Surface both so either intent is covered.
-		return usageErrorf("'restore' is a legacy verb; use 'history' to list restorable records or 'agent resume <role>' to re-launch one.")
-	case "list":
-		// Legacy verb in favor of 'status' (live agents) / 'history'
-		// (restorable records).
-		return usageErrorf("'list' is a legacy verb; use 'status' for live agents or 'history' for restorable records.")
 	case "completion":
 		return runCompletion(args[1:])
 	case "doctor":
@@ -264,7 +248,6 @@ Commands:
   up        Bring the team up (use --dry-run to print the launch plan)
   stop      Stop configured team members (SIGTERM; --force = SIGKILL). State is
             preserved on disk, so the session stays resumable.
-  down      Deprecated alias for 'stop' (works for one release)
   brief     Print a workstream brief and classify it as none, stub, or real
   threads   List collapsed AMQ thread summaries for one workstream
   thread    Read one AMQ thread transcript by project and session
@@ -281,7 +264,7 @@ Commands:
   agent     Launch or resume a single agent (agent up / agent resume)
   version   Print the amq-squad version
 
-Removed legacy verbs (each prints a one-line migration hint): launch (use 'agent up'),
+Removed in 2.0 (see MIGRATION.md): down (use 'stop'), launch (use 'agent up'),
 restore (use 'history' or 'agent resume'), list (use 'status' or 'history'),
 team show (use 'up --dry-run'), team launch (use 'up').
 
@@ -297,8 +280,7 @@ Exit codes:
   2  system / runtime error (IO, process, config, environment)
   3  partial success (some targets succeeded, some failed)
 
-Note: 'stop'/'down' without --force used to exit 2 ("graceful unavailable").
-They now perform the SIGTERM teardown and exit 0 (or 3 on a partial run).
+Note: 'stop' performs the SIGTERM teardown and exits 0 (or 3 on a partial run).
 
 Examples:
   amq-squad new team --roles cto,fullstack --binary cto=codex

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -63,7 +63,6 @@ var completionTopCommands = []string{
 	"task",
 	"up",
 	"stop",
-	"down",
 	"brief",
 	"threads",
 	"thread",

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -61,7 +61,7 @@ func TestRunCompletionBashContainsRepresentativeTokens(t *testing.T) {
 		"_amq_squad_complete",
 		"complete -F _amq_squad_complete amq-squad",
 		// commands
-		"new", "team", "up", "stop", "down", "status", "history", "resume", "fork",
+		"new", "team", "up", "stop", "status", "history", "resume", "fork",
 		"agent", "completion", "version",
 		// new subcommands
 		"new_subcommands", "profile", "session",
@@ -224,7 +224,6 @@ func TestCompletionTopCommandsMatchesDispatch(t *testing.T) {
 		"task":       true,
 		"up":         true,
 		"stop":       true,
-		"down":       true,
 		"brief":      true,
 		"threads":    true,
 		"thread":     true,

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/omriariav/amq-squad/internal/team"
 )
 
-// The five legacy verbs (top-level launch/restore/list and team show/launch)
-// are legacy commands. Each must return a UsageError (exit 1) whose message
-// names the modern replacement -- a helpful migration hint, NOT a silent
-// unknown-command. These tests pin both the exit classification and the hint.
+// The legacy verbs (top-level launch/restore/list, the old `down` alias, and
+// team show/launch) are fully removed in 2.0. Each must now return a
+// UsageError (exit 1); the modern replacements are documented in MIGRATION.md
+// and the top-level --help "Removed in 2.0" note. These tests pin the exit
+// classification so a removed verb can never silently succeed.
 
-// assertRemovedHint runs args through the public Run dispatcher and asserts it
-// returns a UsageError (exit 1) whose message contains each wanted substring.
-func assertRemovedHint(t *testing.T, args []string, wants ...string) {
+// assertRemovedUsageError runs args through the public Run dispatcher and
+// asserts it returns a UsageError (exit 1).
+func assertRemovedUsageError(t *testing.T, args []string) {
 	t.Helper()
 	_, _, err := captureOutput(t, func() error { return Run(args, "test") })
 	if err == nil {
@@ -31,56 +32,19 @@ func assertRemovedHint(t *testing.T, args []string, wants ...string) {
 	if code := ExitCode(err); code != ExitUser {
 		t.Errorf("Run %v: want exit %d, got %d", args, ExitUser, code)
 	}
-	for _, want := range wants {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("Run %v: error %q missing hint %q", args, err.Error(), want)
-		}
-	}
 }
 
-func TestLaunchVerbRemovedWithHint(t *testing.T) {
-	assertRemovedHint(t, []string{"launch", "codex"}, "legacy verb", "agent up")
-}
-
-func TestRestoreVerbRemovedWithHint(t *testing.T) {
-	// The restore hint must name both the print-mode replacement (history)
-	// and the exec-mode replacement (agent resume).
-	assertRemovedHint(t, []string{"restore", "--exec", "--role", "cto"},
-		"legacy verb", "history", "agent resume")
-}
-
-func TestListVerbRemovedWithHint(t *testing.T) {
-	assertRemovedHint(t, []string{"list"}, "legacy verb", "status", "history")
-}
-
-func TestTeamShowRemovedWithHint(t *testing.T) {
-	assertRemovedHint(t, []string{"team", "show"}, "legacy verb", "up --dry-run")
-}
-
-func TestTeamLaunchRemovedWithHint(t *testing.T) {
-	assertRemovedHint(t, []string{"team", "launch"}, "legacy verb", "up")
-}
-
-// The removed verbs must not be silently swallowed as unknown-command: the
-// hint text proves we routed to the dedicated removal message, not the
-// generic "unknown command" branch.
-func TestRemovedVerbsAreNotUnknownCommand(t *testing.T) {
+func TestRemovedVerbsReturnUsageError(t *testing.T) {
 	cases := [][]string{
-		{"launch"},
-		{"restore"},
+		{"launch", "codex"},
+		{"restore", "--exec", "--role", "cto"},
 		{"list"},
+		{"down", "--role", "cto"},
 		{"team", "show"},
 		{"team", "launch"},
 	}
 	for _, args := range cases {
-		_, _, err := captureOutput(t, func() error { return Run(args, "test") })
-		if err == nil {
-			t.Errorf("Run %v: want UsageError, got nil", args)
-			continue
-		}
-		if strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "unknown 'team' subcommand") {
-			t.Errorf("Run %v: removed verb should emit a migration hint, not unknown-command: %q", args, err.Error())
-		}
+		assertRemovedUsageError(t, args)
 	}
 }
 
@@ -288,13 +252,13 @@ func TestCompletionDropsRemovedVerbs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"agent", "team", "up", "down"} {
+	for _, want := range []string{"agent", "team", "up", "stop"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("bash completion missing modern verb %q", want)
 		}
 	}
 	// Top-level removed verbs must be gone from the top-command list.
-	for _, gone := range []string{"launch", "restore", "list"} {
+	for _, gone := range []string{"launch", "restore", "list", "down"} {
 		if containsString(completionTopCommands, gone) {
 			t.Errorf("completionTopCommands should not list removed verb %q", gone)
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -483,7 +483,7 @@ func doctorCheckTmux(d doctorExecution) doctorCheck {
 		return doctorCheck{
 			Name:   "tmux",
 			Status: doctorFail,
-			Detail: "tmux not found on PATH (required for team launch)",
+			Detail: "tmux not found on PATH (required for 'up' with --terminal tmux)",
 		}
 	}
 	return doctorCheck{Name: "tmux", Status: doctorOK, Detail: path}

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -110,18 +110,7 @@ func signalNameOf(term processTerminator) string {
 // recoverable via `amq-squad resume`. --force escalates to SIGKILL for agents
 // that ignore SIGTERM.
 func runStop(args []string) error {
-	return runStopOrDown("stop", false, args)
-}
-
-// runDown is a deprecated alias for `stop`, kept for one release so existing
-// muscle-memory and scripts keep working. It runs the identical stop logic and
-// prints a one-line stderr deprecation hint.
-func runDown(args []string) error {
-	return runStopOrDown("down", true, args)
-}
-
-func runStopOrDown(verb string, deprecated bool, args []string) error {
-	fs := flag.NewFlagSet(verb, flag.ContinueOnError)
+	fs := flag.NewFlagSet("stop", flag.ContinueOnError)
 	sessionName := fs.String("session", "", "AMQ workstream session name (default: team workstream)")
 	role := fs.String("role", "", "narrow to a single configured role")
 	all := fs.Bool("all", false, "target every configured member of the team")
@@ -129,7 +118,7 @@ func runStopOrDown(verb string, deprecated bool, args []string) error {
 	projectFlag := fs.String("project", "", "project/team-home directory to target (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to target (default: default profile)")
 	fs.Usage = func() {
-		fmt.Fprint(os.Stderr, stopUsage(verb, deprecated))
+		fmt.Fprint(os.Stderr, stopUsage())
 	}
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -139,12 +128,7 @@ func runStopOrDown(verb string, deprecated bool, args []string) error {
 		return usageErrorf("--role and --all are mutually exclusive")
 	}
 	if *role == "" && !*all {
-		return usageErrorf("%s requires a target selector: pass --role <role> or --all", verb)
-	}
-
-	if deprecated {
-		// One-line stderr deprecation hint; the command still does the work.
-		fmt.Fprintln(os.Stderr, "down is now 'stop'; 'amq-squad down' still works for one release.")
+		return usageErrorf("stop requires a target selector: pass --role <role> or --all")
 	}
 
 	profile, err := resolveProfileFlag(*profileFlag)
@@ -163,7 +147,7 @@ func runStopOrDown(verb string, deprecated bool, args []string) error {
 		return fmt.Errorf("no team configured for profile %q. Run '%s' first.", profile, profileInitCommand(profile))
 	}
 	return executeDown(downExecution{
-		Verb:             verb,
+		Verb:             "stop",
 		ProjectDir:       projectDir,
 		RequestedSession: *sessionName,
 		ExplicitSession:  flagWasSet(fs, "session"),
@@ -179,17 +163,10 @@ func runStopOrDown(verb string, deprecated bool, args []string) error {
 	})
 }
 
-func stopUsage(verb string, deprecated bool) string {
-	header := "amq-squad stop - stop configured team members (the session stays resumable)"
-	if deprecated {
-		header = "amq-squad down - deprecated alias for 'amq-squad stop'"
-	}
+func stopUsage() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n\n", header)
-	fmt.Fprintf(&b, "Usage:\n  amq-squad %s (--role R | --all) [--project DIR] [--force] [--profile NAME] [--session NAME]\n\n", verb)
-	if deprecated {
-		b.WriteString("'down' is now 'stop'. This alias keeps working for one release and runs\nthe identical logic; prefer 'amq-squad stop'.\n\n")
-	}
+	b.WriteString("amq-squad stop - stop configured team members (the session stays resumable)\n\n")
+	b.WriteString("Usage:\n  amq-squad stop (--role R | --all) [--project DIR] [--force] [--profile NAME] [--session NAME]\n\n")
 	b.WriteString(`Exactly one selector is required: --role R or --all. --all targets the
 configured members from this project's team.json in the resolved session
 (default: the team's workstream). --project targets another team-home without
@@ -205,16 +182,14 @@ The on-disk state (launch record, mailbox, brief) is PRESERVED, so the session
 is recoverable: bring it back with 'amq-squad resume'.
 
 Exit codes: a successful stop exits 0; a mixed run (some stopped, some failed
-or unconfirmed) exits 3. NOTE: prior releases made 'down' without --force exit
-2 ("graceful unavailable"); stop now performs the SIGTERM teardown and exits 0
-(or 3 partial) instead.
+or unconfirmed) exits 3.
 
 Examples:
+  amq-squad stop --role cto
+  amq-squad stop --project ~/Code/app --all --session issue-96
+  amq-squad stop --all --session issue-96
+  amq-squad stop --role cto --force   # SIGKILL an agent that ignores SIGTERM
 `)
-	fmt.Fprintf(&b, "  amq-squad %s --role cto\n", verb)
-	fmt.Fprintf(&b, "  amq-squad %s --project ~/Code/app --all --session issue-96\n", verb)
-	fmt.Fprintf(&b, "  amq-squad %s --all --session issue-96\n", verb)
-	fmt.Fprintf(&b, "  amq-squad %s --role cto --force   # SIGKILL an agent that ignores SIGTERM\n", verb)
 	return b.String()
 }
 

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -92,30 +92,15 @@ func runDownExec(t *testing.T, d downExecution) (string, error) {
 	return buf.String(), err
 }
 
-func TestRunDownRejectsRoleAndAll(t *testing.T) {
+func TestRunStopRejectsRoleAndAll(t *testing.T) {
 	seedTeam(t, team.Team{
 		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"}},
 	})
 	_, _, err := captureOutput(t, func() error {
-		return runDown([]string{"--role", "cto", "--all"})
+		return runStop([]string{"--role", "cto", "--all"})
 	})
 	if err == nil {
 		t.Fatal("--role and --all together should be a usage error")
-	}
-	if _, ok := err.(UsageError); !ok {
-		t.Fatalf("want UsageError, got %T: %v", err, err)
-	}
-}
-
-func TestRunDownRequiresSelector(t *testing.T) {
-	seedTeam(t, team.Team{
-		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"}},
-	})
-	_, _, err := captureOutput(t, func() error {
-		return runDown([]string{})
-	})
-	if err == nil {
-		t.Fatal("missing selector should be a usage error")
 	}
 	if _, ok := err.(UsageError); !ok {
 		t.Fatalf("want UsageError, got %T: %v", err, err)

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -45,7 +45,9 @@ func TestParseFlagsWrapsUnknownFlag(t *testing.T) {
 }
 
 // Representative coverage: unknown flag on a top-level, a doctor, a
-// completion, and a nested `team show` command must all return UsageError.
+// completion, and a nested `team profiles` command must all return UsageError.
+// (Uses a LIVE nested subcommand so the case exercises the subcommand's
+// flag-parse path, not the unknown-subcommand default branch.)
 func TestParseFlagsUsageErrorAcrossCommands(t *testing.T) {
 	cases := []struct {
 		name string
@@ -54,7 +56,7 @@ func TestParseFlagsUsageErrorAcrossCommands(t *testing.T) {
 		{"up", func() error { return runUp([]string{"--banana"}) }},
 		{"doctor", func() error { return runDoctor([]string{"--banana"}) }},
 		{"completion", func() error { return runCompletion([]string{"--banana"}) }},
-		{"team show", func() error { return runTeam([]string{"show", "--banana"}) }},
+		{"team profiles", func() error { return runTeam([]string{"profiles", "--banana"}) }},
 		{"team rules init", func() error { return runTeam([]string{"rules", "init", "--banana"}) }},
 		{"version", func() error { return Run([]string{"version", "--banana"}, "test") }},
 	}
@@ -154,7 +156,7 @@ func TestRootHelpIncludesExitCodeTable(t *testing.T) {
 		}
 	}
 	// Command list must remain intact.
-	for _, want := range []string{"team", "up", "down", "status", "history", "doctor", "completion", "version"} {
+	for _, want := range []string{"team", "up", "stop", "status", "history", "doctor", "completion", "version"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("root --help missing command %q in:\n%s", want, stdout)
 		}

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -24,7 +24,6 @@ func TestHelpSurfacesIncludeExamples(t *testing.T) {
 		{"thread", "--help"},
 		{"status", "--help"},
 		{"console", "--help"},
-		{"down", "--help"},
 		{"up", "--help"},
 		{"resume", "--help"},
 		{"fork", "--help"},
@@ -75,7 +74,7 @@ func TestHelpExitsZeroAcrossCommands(t *testing.T) {
 	}{
 		{name: "team init --help", args: []string{"team", "init", "--help"}, want: "amq-squad team init"},
 		{name: "up --help", args: []string{"up", "--help"}, want: "amq-squad up"},
-		{name: "down --help", args: []string{"down", "--help"}, want: "amq-squad down"},
+		{name: "stop --help", args: []string{"stop", "--help"}, want: "amq-squad stop"},
 		{name: "status --help", args: []string{"status", "--help"}, want: "amq-squad status"},
 		{name: "console --help", args: []string{"console", "--help"}, want: "amq-squad console"},
 		{name: "history --help", args: []string{"history", "--help"}, want: "amq-squad history"},

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -101,50 +101,10 @@ func TestExecuteStopDoesNotSignalReusedPID(t *testing.T) {
 	}
 }
 
-// TestRunDownAliasBehavesLikeStopAndPrintsHint drives the deprecated alias
-// end-to-end: it prints the one-line stderr hint, renders the same report as
-// stop (resumable hint included), and preserves on-disk state. The recorded
-// PID is dead so the real signalTerminator is never invoked — the test never
-// signals a real process.
-func TestRunDownAliasBehavesLikeStopAndPrintsHint(t *testing.T) {
-	base := setupFakeAMQSessionRoots(t)
-	seedTeam(t, team.Team{
-		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
-	})
-	// Dead PID + stale presence: terminateMember resolves to not-live without
-	// ever calling Terminate, so the real terminator in runDown is safe here.
-	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
-		Binary: "codex", Handle: "cto", AgentPID: 0,
-	})
-	writePresence(t, agentDir, presenceFile{
-		Schema: 1, Handle: "cto", Status: "active",
-		LastSeen: time.Now().Add(-2 * time.Hour),
-	})
-
-	stdout, stderr, err := captureOutput(t, func() error {
-		return runDown([]string{"--role", "cto", "--session", "issue-96"})
-	})
-	if err != nil {
-		t.Fatalf("down alias: %v\nstdout:\n%s", err, stdout)
-	}
-	if !strings.Contains(stderr, "down is now 'stop'") {
-		t.Errorf("deprecation hint missing from stderr:\n%s", stderr)
-	}
-	if !strings.Contains(stdout, "# amq-squad down") {
-		t.Errorf("alias should still render under its own verb header:\n%s", stdout)
-	}
-	if !strings.Contains(stdout, "not-live") {
-		t.Errorf("dead-pid member should read not-live:\n%s", stdout)
-	}
-	// On-disk state preserved (recoverable via resume).
-	if _, readErr := launch.Read(agentDir); readErr != nil {
-		t.Errorf("launch record must be preserved: %v", readErr)
-	}
-}
-
-// TestRunStopPrimaryHasNoDeprecationHint proves the primary verb does not emit
-// the alias hint. Uses a dead-pid member so the real terminator never fires.
-func TestRunStopPrimaryHasNoDeprecationHint(t *testing.T) {
+// TestRunStopRendersUnderStopHeader proves the primary verb renders its report
+// under the stop header and never emits a deprecation hint. Uses a dead-pid
+// member so the real terminator never fires.
+func TestRunStopRendersUnderStopHeader(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	seedTeam(t, team.Team{
 		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
@@ -164,10 +124,17 @@ func TestRunStopPrimaryHasNoDeprecationHint(t *testing.T) {
 		t.Fatalf("stop: %v\nstdout:\n%s", err, stdout)
 	}
 	if strings.Contains(stderr, "down is now 'stop'") {
-		t.Errorf("primary stop must not print the deprecation hint:\n%s", stderr)
+		t.Errorf("primary stop must not print any deprecation hint:\n%s", stderr)
 	}
 	if !strings.Contains(stdout, "# amq-squad stop") {
 		t.Errorf("stop should render under the stop verb header:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "not-live") {
+		t.Errorf("dead-pid member should read not-live:\n%s", stdout)
+	}
+	// On-disk state preserved (recoverable via resume).
+	if _, readErr := launch.Read(agentDir); readErr != nil {
+		t.Errorf("launch record must be preserved: %v", readErr)
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -27,13 +27,6 @@ func runTeam(args []string) error {
 		return nil
 	case "init":
 		return runTeamInit(args[1:])
-	case "show":
-		// Legacy verb. Kept as an explicit hint (not unknown-command) for one
-		// release so muscle-memory invocations get a pointer.
-		return usageErrorf("'team show' is a legacy verb; use 'up --dry-run' to preview the launch plan.")
-	case "launch":
-		// Legacy verb. Kept as an explicit hint for one release.
-		return usageErrorf("'team launch' is a legacy verb; use 'up' to bring the team up.")
 	case "resume":
 		return runTeamResume(args[1:])
 	case "rules":
@@ -1712,8 +1705,7 @@ Usage:
   amq-squad team rm [--profile NAME]  Delete one team profile config (confirm-gated)
 
 To launch the team, use the top-level 'up' verb: 'amq-squad up' brings it up,
-'amq-squad up --dry-run' prints one launch command per member. ('team show'
-and 'team launch' are legacy verbs.)
+'amq-squad up --dry-run' prints one launch command per member.
 
 Most subcommands accept --profile NAME to operate on a named profile under
 .amq-squad/teams/<name>.json; omit the flag (or pass --profile default) to


### PR DESCRIPTION
**DO NOT MERGE — held for go/no-go.** This is the first of three stacked PRs preparing the amq-squad **2.0.0** breaking cut. Nothing merges to main, nothing is tagged/published until you give the word. Opened as a draft so it can't be merged accidentally.

## What this PR does
Deletes the six deprecated CLI verbs outright (major-version cleanup):

| Removed | Use instead |
|---|---|
| `down` | `stop` |
| `launch` | `agent up` |
| `restore` | `history` / `agent resume` |
| `list` | `status` / `history` |
| `team show` | `up --dry-run` |
| `team launch` | `up` |

Invoking any removed verb now returns a plain `UsageError` (exit 1). The replacement mapping lives in the top-level `--help` "Removed in 2.0" note and (PR c) `MIGRATION.md`.

## Scope
- Dispatch removal in `cli.go` / `team.go`; `runStopOrDown` collapsed into `runStop`; `stopUsage()` simplified.
- `completion.go` + drift-guard test updated (`down` gone from top-command list/map).
- `deprecation_test.go` rewritten: a single `TestRemovedVerbsReturnUsageError` pins all six verbs to exit-1.
- Test fallout in `down_test.go` / `stop_test.go` / `exit_test.go` / `help_test.go` repointed to `stop`.

## Review
Reviewed by an independent Codex pass and a Claude pr-reviewer. Two real findings folded in:
- `doctor.go` tmux check named the removed `team launch` verb → reworded to `up --terminal tmux`.
- `exit_test.go` flag-parse case used the now-dead `team show` subcommand (hit the unknown-subcommand branch before flag parsing) → repointed to the live `team profiles`.

One reviewer finding (live `up` printing a `# amq-squad team launch` header) was investigated and **disproven**: that header is only emitted by `executeTeamLaunch`'s `opts.DryRun` branch, which live `up` never sets (`up --dry-run` returns via `emitTeamCommands`; the live path calls `backend.Launch`). It's reachable only from the orphaned, test-only `runTeamLaunch`.

## Deferred (intentionally out of scope)
The orphaned front-ends `runTeamLaunch` / `runTeamShow` / `runList` and the restore print-mode branch are now dead production code (test-only callers). Their stale labels never print under any modern verb. Cleaning them up — which would require rewriting ~600 lines of launcher tests against `up`/`status`/`history` semantics — belongs to a focused dead-code pass, not this verb-removal PR. Docs/README/skills updates are PR c.

## Verification
`make ci` green: build, vet, full test suite, README/docs HTML sync. Diff is net **-136** (−186/+50), all in `internal/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)