### PR TITLE
[2.0 Phase 1b — HOLD] Rename Go module to /v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ release-smoke:
 	@test "$(VERSION)" != "dev" || (echo "VERSION is required, for example VERSION=v0.5.1" >&2; exit 1)
 	@tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
-	GOBIN="$$tmp" GOPROXY=direct go install github.com/omriariav/amq-squad/cmd/amq-squad@$(VERSION); \
+	GOBIN="$$tmp" GOPROXY=direct go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@$(VERSION); \
 	got="$$("$$tmp/amq-squad" version)"; \
 	want="amq-squad $(VERSION)"; \
 	if [ "$$got" != "$$want" ]; then \

--- a/cmd/amq-squad/main.go
+++ b/cmd/amq-squad/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/omriariav/amq-squad/internal/cli"
+	"github.com/omriariav/amq-squad/v2/internal/cli"
 )
 
 var version = "dev"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/omriariav/amq-squad
+module github.com/omriariav/amq-squad/v2
 
 go 1.25.9
 

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -32,7 +32,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // OpMessage is a single operator-authored AMQ write. The zero value is not

--- a/internal/act/act_test.go
+++ b/internal/act/act_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // sampleThread is the thread context the builder tests reply/approve/deny into.

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 const (

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/role"
-	"github.com/omriariav/amq-squad/internal/rules"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 //go:embed bootstrap.md

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestBuildBootstrapPrompt(t *testing.T) {

--- a/internal/cli/briefs.go
+++ b/internal/cli/briefs.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
 )
 
 // briefsDirName is the per-team-home directory holding workstream briefs.

--- a/internal/cli/briefs_live_test.go
+++ b/internal/cli/briefs_live_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // TestRunUpLiveCreatesTeamHomeBriefOnce proves the live up path creates the

--- a/internal/cli/briefs_seed_test.go
+++ b/internal/cli/briefs_seed_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // frozenClock returns a fixed timestamp so provenance assertions are

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // UsageError signals a misuse of the CLI (unknown command/flag, bad

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestRunVersionCommand(t *testing.T) {

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/console"
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/console"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // runConsole is the `amq-squad console` verb: a read-only, full-screen Mission

--- a/internal/cli/console_test.go
+++ b/internal/cli/console_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/console"
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/console"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // captureConsole drives executeConsole with a captured RunConsole seam so the

--- a/internal/cli/custom_role_test.go
+++ b/internal/cli/custom_role_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/role"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // TestNewTeamCustomRoleDryRunJSON covers the NOC contract: a custom role that

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // The legacy verbs (top-level launch/restore/list, the old `down` alias, and

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/internal/rules"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // doctorMinAMQVersion is the lowest AMQ release this build of amq-squad

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/rules"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func newDoctorExec(t *testing.T, dir string) doctorExecution {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type downStatus string

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type recordingTerminator struct {

--- a/internal/cli/fork.go
+++ b/internal/cli/fork.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func runFork(args []string) error {

--- a/internal/cli/fork_test.go
+++ b/internal/cli/fork_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func seedForkTeam(t *testing.T, dir string) {

--- a/internal/cli/history.go
+++ b/internal/cli/history.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // historyEnvelopeData is the kind="history" payload: the projects scanned

--- a/internal/cli/history_test.go
+++ b/internal/cli/history_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func TestRunHistoryScansCurrentProject(t *testing.T) {

--- a/internal/cli/json_envelopes_test.go
+++ b/internal/cli/json_envelopes_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestRunVersionJSONEnvelope(t *testing.T) {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -10,11 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/catalog"
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/role"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/catalog"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // envTmuxTarget carries the tmux launch target (current-window / new-window /

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func TestRunLaunchDryRunSandboxedCodexOmitsBypassDefault(t *testing.T) {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -11,7 +11,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 type listRecord struct {

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func TestListRecordsFromEntriesIncludesSource(t *testing.T) {

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // agentLivenessVerdict is the single shared liveness vocabulary that BOTH

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // livenessProbe builds a deterministic probe for the unification tests: a PID

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // runNew is the operator-facing creation group. It is intentionally a thin

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/catalog"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/catalog"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestRunNewRequiresSubcommand(t *testing.T) {

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // withOutputPolicy sets currentOutputPolicy for one test and restores it

--- a/internal/cli/pane_adopt.go
+++ b/internal/cli/pane_adopt.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/procinfo"
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/procinfo"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // verifiedAgentPID returns pid only when it is a LIVE process running the

--- a/internal/cli/pane_adopt_test.go
+++ b/internal/cli/pane_adopt_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // #95: adoptLivePane must resolve an externally-launched agent's live pane, and

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/procinfo"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 )
 
 // presenceFreshness defines how recently a presence.json must have been

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func writeWakeLock(t *testing.T, agentDir string, lock wakeLockFile) {

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // profileRow is one entry inside the team profiles list. Reused by both

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // seedProfile writes a profile config into projectDir without changing the

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/role"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type restoreCandidate struct {

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func runResume(args []string) error {

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestRunResumeRequiresTeam(t *testing.T) {

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // archiveDirName is the base-root subdirectory that `archive` MOVES sessions

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // rmStateProbe builds an internal/state.Probe with deterministic per-PID

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/internal/catalog"
+	"github.com/omriariav/amq-squad/v2/internal/catalog"
 )
 
 type rolesEnvelopeData struct {

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // memberRuntime is a resolved team member plus its on-disk launch record, used

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // TestResolveControlTargetSymlinkedCWD reproduces the live-test failure: the

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -4,9 +4,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // tmuxRuntimeJSON is the stable tmux runtime-identity block that amq-noc (and

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // swapStatusPaneLister installs a fake pane lister for the duration of a test.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -11,9 +11,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // statusPaneLister lists live tmux panes so status can detect a live agent that

--- a/internal/cli/status_board.go
+++ b/internal/cli/status_board.go
@@ -11,7 +11,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // boardState is the rolled-up run-state of a whole session, derived from its

--- a/internal/cli/status_board_test.go
+++ b/internal/cli/status_board_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // boardNow is the deterministic clock anchoring the board tests so relative

--- a/internal/cli/status_replacement_test.go
+++ b/internal/cli/status_replacement_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // withStubPaneLister swaps statusPaneLister for the test and restores it.

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func statusProbe(alive map[int]bool, match map[int]bool, now time.Time) duplicateLaunchProbe {

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // TestNewSignalTerminatorMapsForceToSIGKILL pins the flag wiring: stop with no

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -8,8 +8,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/task"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/task"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // taskNow is overridable in tests for deterministic timestamps.

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/internal/catalog"
-	"github.com/omriariav/amq-squad/internal/role"
-	"github.com/omriariav/amq-squad/internal/rules"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/catalog"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func runTeam(args []string) error {

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type teamLaunchOptions struct {

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestBuildTmuxLaunchPlanUsesCatalogOrderAndLaunchCommands(t *testing.T) {

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func init() {

--- a/internal/cli/team_launch_tmux_session.go
+++ b/internal/cli/team_launch_tmux_session.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func init() {

--- a/internal/cli/team_launch_tmux_session_test.go
+++ b/internal/cli/team_launch_tmux_session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // withStubTmuxSessionBinary makes Validate believe (or disbelieve) the

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/internal/flock"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // runTeamMember dispatches `amq-squad team member <add|rm|list>`: runtime roster

--- a/internal/cli/team_member_test.go
+++ b/internal/cli/team_member_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func teamMembers(t *testing.T, dir string) []team.Member {

--- a/internal/cli/team_overlay.go
+++ b/internal/cli/team_overlay.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // overlaysDirName is the team-home subdirectory that holds generated

--- a/internal/cli/team_overlay_test.go
+++ b/internal/cli/team_overlay_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func readTeamMember(t *testing.T, dir, role string) team.Member {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -11,8 +11,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // resumeAction labels what `team resume` would do for one member.

--- a/internal/cli/team_resume_test.go
+++ b/internal/cli/team_resume_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/team"
-	"github.com/omriariav/amq-squad/internal/tmuxpane"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // writeMemberLaunchRecord drops a v0.6 launch.json under the fake AMQ base

--- a/internal/cli/team_rm.go
+++ b/internal/cli/team_rm.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type teamRemoveExecution struct {

--- a/internal/cli/team_rm_test.go
+++ b/internal/cli/team_rm_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func teamRemoveFixture(t *testing.T, dir, profile string) string {

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/catalog"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/catalog"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func renderTeamRules(t team.Team) (string, error) {

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/rules"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // Persisted team args that contradict the trust profile must be caught

--- a/internal/cli/thread.go
+++ b/internal/cli/thread.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 const defaultThreadTranscriptLimit = 20

--- a/internal/cli/thread_test.go
+++ b/internal/cli/thread_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 func runThreadExec(t *testing.T, base, projectDir, session, threadID string, jsonOut bool, run func(threadAMQRequest) ([]byte, error)) (string, error) {

--- a/internal/cli/threads.go
+++ b/internal/cli/threads.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 const defaultThreadsLimit = 20

--- a/internal/cli/threads_test.go
+++ b/internal/cli/threads_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 var threadsNow = time.Date(2026, 5, 29, 12, 0, 0, 0, time.UTC)

--- a/internal/cli/trust_model_test.go
+++ b/internal/cli/trust_model_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 func TestDefaultChildArgsForBinaryWithTrust(t *testing.T) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func runUp(args []string) error {

--- a/internal/cli/up_pr6_test.go
+++ b/internal/cli/up_pr6_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // withResetSeams installs deterministic reset seams (a scripted confirm reader

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // chdir switches into dir for the duration of the test, restoring the

--- a/internal/cli/workstream.go
+++ b/internal/cli/workstream.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 type bootstrapWorkstream struct {

--- a/internal/cli/workstream_test.go
+++ b/internal/cli/workstream_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 func TestDefaultWorkstreamNameSanitizesProjectDir(t *testing.T) {

--- a/internal/console/attach.go
+++ b/internal/console/attach.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // suggestAttach computes the INERT attach hint for the current selection. v0

--- a/internal/console/console_test.go
+++ b/internal/console/console_test.go
@@ -8,7 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // fixedClock is the deterministic render-layer clock for the static-board tests

--- a/internal/console/filter.go
+++ b/internal/console/filter.go
@@ -3,7 +3,7 @@ package console
 import (
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // Filtering is a PURE, read-only narrowing of the snapshot. A Filter never reads

--- a/internal/console/filter_rollup_test.go
+++ b/internal/console/filter_rollup_test.go
@@ -3,7 +3,7 @@ package console
 import (
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // TestFilterSnapshotRecomputesRollup pins the consistency fix: a filtered

--- a/internal/console/labels.go
+++ b/internal/console/labels.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // clockOrDefault returns the probe's injected clock, or the real wall-clock when

--- a/internal/console/model.go
+++ b/internal/console/model.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // route is the top-level pane the console is focused on. The scaffold only ever

--- a/internal/console/rows.go
+++ b/internal/console/rows.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // row is one navigable line in a view. Every view projects the (filtered)

--- a/internal/console/run.go
+++ b/internal/console/run.go
@@ -10,7 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fsnotify/fsnotify"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // Config is everything runConsole needs to render Mission Control. The caller

--- a/internal/console/run_test.go
+++ b/internal/console/run_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // runNow is the deterministic clock anchoring the runner tests.

--- a/internal/console/update.go
+++ b/internal/console/update.go
@@ -5,7 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // Init kicks off the console: an immediate rebuild (so the first frame reflects

--- a/internal/console/view.go
+++ b/internal/console/view.go
@@ -10,7 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // Layout reserves rows for a header and a footer; the rest is the scrollable

--- a/internal/console/views_test.go
+++ b/internal/console/views_test.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // viewNow anchors the freshness ages in the view fixtures.

--- a/internal/state/attn_test.go
+++ b/internal/state/attn_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // TestClassifyAttnReason_FromOperatorAddressedSubject proves PR13c part C

--- a/internal/state/coordination_test.go
+++ b/internal/state/coordination_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // coordNow is the deterministic clock for coordination tests. All seeded

--- a/internal/state/heartbeat_alive_test.go
+++ b/internal/state/heartbeat_alive_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // TestHeartbeatQuietSkipsLiveAgent is the QA-9 regression: an agent that is

--- a/internal/state/snapshot.go
+++ b/internal/state/snapshot.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
-	"github.com/omriariav/amq-squad/internal/procinfo"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 )
 
 // Build constructs a Snapshot by scanning the filesystem under baseRoot. It

--- a/internal/state/stale_test.go
+++ b/internal/state/stale_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // staleProbe is a deterministic probe pinned to `now` with no live PIDs.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -26,7 +26,7 @@ package state
 import (
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/procinfo"
+	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 )
 
 // PresenceFreshness defines how recently a presence.json must have been updated

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 )
 
 // fixedNow returns a deterministic clock anchored at a known instant so

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/flock"
 )
 
 // Status values for the five-state machine.

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 // TmuxPane is one row from `tmux list-panes -a`: a pane plus its running

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/omriariav/amq-squad/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 )
 
 func TestResolveTmuxTarget_MatchesByCWDAndEngine(t *testing.T) {


### PR DESCRIPTION
**DO NOT MERGE — held for go/no-go.** Second of three stacked PRs for the amq-squad **2.0.0** cut. **Base is `phase1-a-verb-cleanup` (PR #135), not main** — review/merge order is a → b → c. Draft so it can't merge accidentally.

## What this PR does
Mechanical, scripted Go module rename for the semver-major bump. Go requires a `/vN` suffix on the module path for v2+ so v1 and v2 consumers resolve to distinct modules.

- `go.mod`: `module github.com/omriariav/amq-squad` → `.../amq-squad/v2`
- Every internal import across **107 files** repointed to the `/v2` path via a single guarded pass (negative lookahead prevents any double-`/v2`).
- `Makefile`: the `go install` target path gains `/v2` so `make install` resolves the v2 module.

## No behavior change
Pure path rewrite: 171 insertions / 171 deletions, every changed `.go` line is an import. Audited that the only non-import change is the Makefile install path — no clone/issues URL was versioned by mistake, and no string literal changed.

## Verification
`make ci` green: build, vet, full test suite, README/docs HTML sync. A leftover-reference grep over `*.go` / `go.mod` / `Makefile` is clean (no bare non-`/v2` module path remains).

> Note: the consumer-facing `go install …@latest` instructions in README/docs are updated in PR c alongside MIGRATION.md, so the doc churn stays in one reviewable place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)