### PR TITLE
[2.0 Phase 1c — HOLD] MIGRATION.md + docs/skills resync + plugin bumps

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,92 @@
+# Migrating to amq-squad 2.0.0
+
+2.0.0 is a breaking release. The breaking surface is intentionally small and
+mechanical: a set of long-deprecated verbs is removed, and the Go module path
+gains the `/v2` suffix that Go requires for a v2+ module. Your on-disk team and
+session state does **not** need to be migrated.
+
+This guide covers everything you have to change.
+
+## 1. Module path: add `/v2`
+
+Go requires a `/vN` suffix on the module path for v2 and later, so v1 and v2
+resolve to distinct modules.
+
+**Install:**
+
+```sh
+# before (1.x)
+go install github.com/omriariav/amq-squad/cmd/amq-squad@latest
+
+# 2.0+
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest
+```
+
+**If you import amq-squad as a library**, update every import prefix:
+
+```go
+// before
+import "github.com/omriariav/amq-squad/internal/team"
+
+// 2.0+
+import "github.com/omriariav/amq-squad/v2/internal/team"
+```
+
+(amq-squad's packages are `internal/`, so this only affects a fork or vendored
+copy; the public consumer is the `amq-squad` binary.)
+
+Nothing else about the binary's name, flags, or behavior changes from the
+rename — `amq-squad version` still reports the same way.
+
+## 2. Removed verbs
+
+Six verbs that were deprecated through the 1.x line are removed. Invoking one
+now returns a **usage error (exit 1)** — a clear "unknown command", not a
+silent success and no migration hint. Switch to the replacement:
+
+| Removed verb | Use instead |
+| --- | --- |
+| `amq-squad down` | `amq-squad stop` |
+| `amq-squad launch <binary>` | `amq-squad agent up <binary>` |
+| `amq-squad restore` (print mode) | `amq-squad history` |
+| `amq-squad restore --exec --role R` | `amq-squad agent resume R` |
+| `amq-squad list` | `amq-squad status` (live) or `amq-squad history` (records) |
+| `amq-squad team show` | `amq-squad up --dry-run` |
+| `amq-squad team launch` | `amq-squad up` |
+| `amq-squad team launch --fresh --session X` | `amq-squad fork --from <current> --as X` |
+
+The replacement command shapes are unchanged from 1.x — only the deprecated
+aliases are gone. The top-level `amq-squad --help` also lists this mapping
+under "Removed in 2.0".
+
+### `stop` exit-code reminder
+
+`stop` (the replacement for `down`) performs the SIGTERM teardown and exits
+`0`, or `3` on a partial run (some agents stopped, some failed). It preserves
+all on-disk state, so the session stays resumable with `amq-squad resume`.
+
+## 3. No team.json migration
+
+The `team.json` schema is unchanged (still schema v3). Team configs written by
+the 1.x line load as-is under 2.0 — there is no rewrite or conversion step.
+The mutable-roster commands (`team member add/rm/list`) and the native task
+store (`task ...`, stored under `.amq-squad/tasks/`) are additive and do not
+alter the `team.json` shape.
+
+## 4. Shell completion
+
+Regenerate your shell completion so the removed verbs stop being suggested:
+
+```sh
+amq-squad completion bash   # or zsh / fish
+```
+
+## Quick checklist
+
+- [ ] Reinstall from the `/v2` path (`go install …/v2/cmd/amq-squad@latest`).
+- [ ] Replace any `down` calls with `stop`.
+- [ ] Replace any `launch` / `restore` / `list` / `team show` / `team launch`
+      calls per the table above.
+- [ ] Update import prefixes to `/v2` if you vendor or fork the source.
+- [ ] Regenerate shell completion.
+- [ ] No action needed for existing `team.json` / session state.

--- a/README.html
+++ b/README.html
@@ -304,8 +304,6 @@ id="toc-messaging-inside-a-squad">Messaging inside a squad</a></li>
 id="toc-files-amq-squad-writes">Files amq-squad writes</a></li>
 <li><a href="#removed-legacy-verbs"
 id="toc-removed-legacy-verbs">Removed legacy verbs</a></li>
-<li><a href="#migrating-to-130" id="toc-migrating-to-130">Migrating to
-1.3.0</a></li>
 <li><a href="#known-gaps" id="toc-known-gaps">Known gaps</a></li>
 <li><a href="#requires" id="toc-requires">Requires</a></li>
 </ul></li>
@@ -337,11 +335,11 @@ workstream)</li>
 (<code>launch.json</code> + <code>role.md</code> inside the AMQ
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
-<p>Install the 1.9 line:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@v1.9.3</span>
+<p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.0.0</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
-<p>For the latest 1.x build:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/cmd/amq-squad@latest</span></code></pre></div>
+<p>For the latest 2.x build:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
 <p>Requires Go 1.25+, the <code>amq</code> binary on <code>PATH</code>
 (v0.34+), and <code>tmux</code> on <code>PATH</code> for
 <code>amq-squad up</code>.</p>
@@ -519,8 +517,8 @@ for <code>team init</code>.</li>
 alias for <code>team init --profile NAME</code>.</li>
 <li><strong><code>stop</code></strong> is the primary teardown: SIGTERM
 the live agents (<code>--force</code> = SIGKILL), but PRESERVE all
-on-disk state so the session stays resumable. (<code>down</code> is a
-deprecated alias for one release.)</li>
+on-disk state so the session stays resumable. (The <code>down</code>
+alias was removed in 2.0.)</li>
 <li><strong><code>resume</code></strong> re-orients a stopped session.
 If an agent has a saved conversation, amq-squad reattaches it; otherwise
 it re-runs bootstrap so the agent re-reads its brief and AMQ history. It
@@ -566,12 +564,12 @@ alongside.</p>
 <p>Single-agent primitives:</p>
 <div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--role</span> cto <span class="at">--session</span> issue-96</span>
 <span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack</span></code></pre></div>
-<p>The old legacy verbs (<code>launch</code>, <code>restore</code>,
-<code>list</code>, <code>team show</code>, <code>team launch</code>) are
-removed from the primary command model; each prints a one-line migration
-hint pointing at its replacement. See <a
+<p>The legacy verbs (<code>down</code>, <code>launch</code>,
+<code>restore</code>, <code>list</code>, <code>team show</code>,
+<code>team launch</code>) are <strong>removed in 2.0</strong>. Invoking
+one returns a usage error (exit 1); the replacements are listed in <a
 href="#removed-legacy-verbs">Removed legacy verbs</a> and <a
-href="#migrating-to-130">Migrating to 1.3.0</a>.</p>
+href="MIGRATION.md"><code>MIGRATION.md</code></a>.</p>
 <h3 id="custom-launchers">Custom launchers</h3>
 <p>A managed member can be launched through a project-specific wrapper
 script while still receiving AMQ identity, bootstrap, a launch record,
@@ -843,7 +841,7 @@ amq-squad stop [--all | --role R] [--project DIR] [--force]
                                   sidecar, flip presence offline. On-disk state is
                                   preserved, so the session stays resumable.
                                   --project targets a team-home without cd.
-                                  (&#39;down&#39; is a deprecated alias for one release.)
+                                  (The &#39;down&#39; alias was removed in 2.0.)
 amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
                  [--exec] [--dry-run] [--force-duplicate]
                  [--no-bootstrap] [--trust sandboxed|trusted]
@@ -1296,10 +1294,10 @@ message id. If routing is unclear, run <code>amq route explain</code> or
 <p><code>&lt;AM_ROOT&gt;</code> is resolved via AMQ's JSON env contract
 (<code>amq env --json</code>).</p>
 <h2 id="removed-legacy-verbs">Removed legacy verbs</h2>
-<p>The legacy top-level verbs below are still recognized as explicit
-pointers: running one prints a one-line <code>stderr</code> migration
-hint (not an "unknown command") and exits with a usage error. Use the
-replacement.</p>
+<p>These verbs are <strong>removed in 2.0</strong>. Invoking one returns
+a usage error (exit 1, not a silent "unknown command"). Use the
+replacement. The full upgrade notes live in <a
+href="MIGRATION.md"><code>MIGRATION.md</code></a>.</p>
 <table>
 <thead>
 <tr>
@@ -1308,6 +1306,10 @@ replacement.</p>
 </tr>
 </thead>
 <tbody>
+<tr>
+<td><code>amq-squad down</code></td>
+<td><code>amq-squad stop</code></td>
+</tr>
 <tr>
 <td><code>amq-squad launch &lt;binary&gt;</code></td>
 <td><code>amq-squad agent up &lt;binary&gt;</code></td>
@@ -1339,58 +1341,8 @@ replacement.</p>
 </tr>
 </tbody>
 </table>
-<p><code>down</code> is <strong>deprecated</strong> (not removed): it is
-an alias for <code>stop</code> that keeps working for one release and
-runs the identical logic. Prefer <code>stop</code>.</p>
 <p>Replay paths that emit copy-paste commands use the modern
 <code>agent up &lt;binary&gt;</code> command shape.</p>
-<h2 id="migrating-to-130">Migrating to 1.3.0</h2>
-<p>1.3.0 keeps amq-squad focused on team setup, lifecycle, status, AMQ
-diagnostics, and the project-scoped console.</p>
-<table>
-<thead>
-<tr>
-<th>Before</th>
-<th>1.3.0</th>
-<th>Migration</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>down</code></td>
-<td><code>stop</code> (primary)</td>
-<td>Use <code>amq-squad stop</code>. <code>down</code> still works for
-one release as a deprecated alias.</td>
-</tr>
-<tr>
-<td><code>launch &lt;binary&gt;</code></td>
-<td>removed</td>
-<td><code>amq-squad agent up &lt;binary&gt;</code></td>
-</tr>
-<tr>
-<td><code>restore</code> (print) /
-<code>restore --exec --role R</code></td>
-<td>removed</td>
-<td><code>amq-squad history</code> /
-<code>amq-squad agent resume R</code></td>
-</tr>
-<tr>
-<td><code>list</code></td>
-<td>removed</td>
-<td><code>amq-squad status</code> (live) or
-<code>amq-squad history</code> (records)</td>
-</tr>
-<tr>
-<td><code>team show</code> / <code>team launch</code></td>
-<td>removed</td>
-<td><code>amq-squad up --dry-run</code> / <code>amq-squad up</code></td>
-</tr>
-</tbody>
-</table>
-<p>Each removed verb prints a migration hint when invoked, so
-muscle-memory commands get a pointer rather than a crash. JSON callers
-on the deprecated <code>down</code> alias still get pure JSON on stdout;
-the warning goes to stderr.</p>
 <h2 id="known-gaps">Known gaps</h2>
 <ul>
 <li>True cross-workstream sends from a setup terminal still depend on

--- a/README.html
+++ b/README.html
@@ -271,6 +271,9 @@
 <ul>
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
+<li><a href="#20--goal-first-dynamic-teams"
+id="toc-20--goal-first-dynamic-teams">2.0 — goal-first, dynamic
+teams</a></li>
 <li><a href="#why" id="toc-why">Why</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#using-amq-squad" id="toc-using-amq-squad">Using
@@ -315,8 +318,88 @@ href="https://github.com/avivsinai/agent-message-queue">AMQ</a> by <a
 href="https://github.com/avivsinai">Aviv Sinai</a>.</p>
 <p>AMQ owns messaging between agents. <code>amq-squad</code> owns the
 layer above: who is on the team, what role each agent plays, what shared
-norms they follow, and how to bring the whole squad up, down, back, or
-into a new workstream.</p>
+norms they follow, and how to bring the whole squad up, stop it, resume
+it, or fork it into a new workstream.</p>
+<h2 id="20--goal-first-dynamic-teams">2.0 — goal-first, dynamic
+teams</h2>
+<p><strong>The shift.</strong> Until now you <em>designed a team, then
+ran it</em>: <code>team init</code> authored a static roster,
+<code>up</code> spawned exactly that roster, and composition was frozen
+for the session. 2.0 inverts it — <strong>you hand a lead a goal and the
+lead composes the team</strong>, proposing, spawning, and pruning agents
+at runtime as the work reveals what it needs. Goal-first changes the
+default <em>mental model</em>; manual still works exactly as before.</p>
+<p>The load-bearing constraint, and why this is amq-squad-native rather
+than "just use Claude Code Agent Teams": <strong>orchestration is
+binary-neutral — a Codex agent can <em>lead</em>, not just be
+led.</strong> No core primitive depends on <code>~/.claude/</code>.</p>
+<p>Composition is a spectrum, and <strong>manual stays the
+floor</strong>:</p>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th>Who composes the team</th>
+<th>2.0</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Manual</strong></td>
+<td>You design the roster up front (<code>team init</code> / the setup
+wizard).</td>
+<td>first-class, unchanged</td>
+</tr>
+<tr>
+<td><strong>Seeded</strong></td>
+<td>The lead <strong>proposes</strong> each spawn from the goal; the
+<strong>operator approves</strong> it over a
+<code>gate/&lt;topic&gt;</code> thread.</td>
+<td>shipped</td>
+</tr>
+<tr>
+<td><strong>Autonomous</strong></td>
+<td>The lead spawns/prunes within guardrails, no per-spawn
+approval.</td>
+<td>deferred to 2.1</td>
+</tr>
+</tbody>
+</table>
+<p>Three binary-neutral primitives make it work, and all of them
+round-trip through stop/resume so a resumed session rebuilds the team
+the lead <strong>built</strong>, not the seed:</p>
+<ul>
+<li><strong>Mutable roster</strong> —
+<code>amq-squad team member add/rm/list</code> grows or shrinks the team
+mid-session (atomic, file-locked, re-validated, persisted).</li>
+<li><strong>Native task store</strong> —
+<code>amq-squad task add/list/claim/done/fail/block</code>: a
+pull-based, dependency-gated queue under
+<code>.amq-squad/tasks/&lt;session&gt;/</code>, so a lead of either
+binary decomposes the goal into claimable work.</li>
+<li><strong>Compose-from-goal playbook</strong> — the
+<code>amq-squad-orchestrator</code> skill (in both the Claude and Codex
+marketplaces) drives propose → approve → <code>team member add</code> →
+<code>task add</code> → prune.</li>
+</ul>
+<h3 id="breaking-changes">Breaking changes</h3>
+<p>2.0 is a major version; the breaking surface is small and mechanical
+(full upgrade notes in <a
+href="MIGRATION.md"><code>MIGRATION.md</code></a>):</p>
+<ul>
+<li><strong>Removed verbs</strong> — <code>down</code>,
+<code>launch</code>, <code>restore</code>, <code>list</code>,
+<code>team show</code>, <code>team launch</code> now return a usage
+error. Use <code>stop</code>, <code>agent up</code>,
+<code>history</code> / <code>agent resume</code>, <code>status</code> /
+<code>history</code>, <code>up --dry-run</code>, and <code>up</code>
+respectively.</li>
+<li><strong><code>/v2</code> module path</strong> — install from
+<code>github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</code>
+(note the <code>/v2</code>).</li>
+<li><strong>No data migration</strong> — existing <code>team.json</code>
+(schema v3) loads unchanged.</li>
+</ul>
 <h2 id="why">Why</h2>
 <p>AMQ's <code>coop exec</code> is a generic launcher. It sets up a
 mailbox and execs into <code>claude</code> or <code>codex</code>, but it

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 
 ## Install
 
-Install the 1.9 line:
+Install the 2.0 line (note the `/v2` module path):
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@v1.9.3
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.0.0
 amq-squad version
 ```
 
-For the latest 1.x build:
+For the latest 2.x build:
 
 ```sh
-go install github.com/omriariav/amq-squad/cmd/amq-squad@latest
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest
 ```
 
 Requires Go 1.25+, the `amq` binary on `PATH` (v0.34+), and `tmux` on `PATH` for `amq-squad up`.
@@ -170,7 +170,7 @@ A session moves through one small state machine:
 - **`new session [<name>]`** is the create-focused alias for `up [<name>]`. It follows the same NEW-work refusal rules.
 - **`new team`** is the create-focused alias for `team init`.
 - **`new profile NAME`** is the named-profile alias for `team init --profile NAME`.
-- **`stop`** is the primary teardown: SIGTERM the live agents (`--force` = SIGKILL), but PRESERVE all on-disk state so the session stays resumable. (`down` is a deprecated alias for one release.)
+- **`stop`** is the primary teardown: SIGTERM the live agents (`--force` = SIGKILL), but PRESERVE all on-disk state so the session stays resumable. (The `down` alias was removed in 2.0.)
 - **`resume`** re-orients a stopped session. If an agent has a saved conversation, amq-squad reattaches it; otherwise it re-runs bootstrap so the agent re-reads its brief and AMQ history. It does NOT replay prior hidden reasoning.
 - **`rm` / `archive`** are the session-destructive ops. Both are confirm-gated (`--yes` to skip the prompt) and refuse a session with live agents unless `--force`. `rm` deletes the session root + brief; `archive` moves them aside, recoverable. `team rm` is separate: it removes one team profile config only.
 - A **restart** is just `stop` then `up` (after `rm`/`archive`) or `resume` for the same session.
@@ -211,7 +211,7 @@ amq-squad agent up codex --role cto --session issue-96
 amq-squad agent resume fullstack
 ```
 
-The old legacy verbs (`launch`, `restore`, `list`, `team show`, `team launch`) are removed from the primary command model; each prints a one-line migration hint pointing at its replacement. See [Removed legacy verbs](#removed-legacy-verbs) and [Migrating to 1.3.0](#migrating-to-130).
+The legacy verbs (`down`, `launch`, `restore`, `list`, `team show`, `team launch`) are **removed in 2.0**. Invoking one returns a usage error (exit 1); the replacements are listed in [Removed legacy verbs](#removed-legacy-verbs) and [`MIGRATION.md`](MIGRATION.md).
 
 ### Custom launchers
 
@@ -435,7 +435,7 @@ amq-squad stop [--all | --role R] [--project DIR] [--force]
                                   sidecar, flip presence offline. On-disk state is
                                   preserved, so the session stays resumable.
                                   --project targets a team-home without cd.
-                                  ('down' is a deprecated alias for one release.)
+                                  (The 'down' alias was removed in 2.0.)
 amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
                  [--exec] [--dry-run] [--force-duplicate]
                  [--no-bootstrap] [--trust sandboxed|trusted]
@@ -843,10 +843,11 @@ Inside an amq-squad-launched shell, use bare `amq` commands. The launcher alread
 
 ## Removed legacy verbs
 
-The legacy top-level verbs below are still recognized as explicit pointers: running one prints a one-line `stderr` migration hint (not an "unknown command") and exits with a usage error. Use the replacement.
+These verbs are **removed in 2.0**. Invoking one returns a usage error (exit 1, not a silent "unknown command"). Use the replacement. The full upgrade notes live in [`MIGRATION.md`](MIGRATION.md).
 
 | Removed verb | Replacement |
 | --- | --- |
+| `amq-squad down` | `amq-squad stop` |
 | `amq-squad launch <binary>` | `amq-squad agent up <binary>` |
 | `amq-squad restore` (print) | `amq-squad history` |
 | `amq-squad restore --exec --role R` | `amq-squad agent resume R` |
@@ -855,23 +856,7 @@ The legacy top-level verbs below are still recognized as explicit pointers: runn
 | `amq-squad team launch` | `amq-squad up` |
 | `amq-squad team launch --fresh --session X` | `amq-squad fork --from <current> --as X` |
 
-`down` is **deprecated** (not removed): it is an alias for `stop` that keeps working for one release and runs the identical logic. Prefer `stop`.
-
 Replay paths that emit copy-paste commands use the modern `agent up <binary>` command shape.
-
-## Migrating to 1.3.0
-
-1.3.0 keeps amq-squad focused on team setup, lifecycle, status, AMQ diagnostics, and the project-scoped console.
-
-| Before | 1.3.0 | Migration |
-| --- | --- | --- |
-| `down` | `stop` (primary) | Use `amq-squad stop`. `down` still works for one release as a deprecated alias. |
-| `launch <binary>` | removed | `amq-squad agent up <binary>` |
-| `restore` (print) / `restore --exec --role R` | removed | `amq-squad history` / `amq-squad agent resume R` |
-| `list` | removed | `amq-squad status` (live) or `amq-squad history` (records) |
-| `team show` / `team launch` | removed | `amq-squad up --dry-run` / `amq-squad up` |
-
-Each removed verb prints a migration hint when invoked, so muscle-memory commands get a pointer rather than a crash. JSON callers on the deprecated `down` alias still get pure JSON on stdout; the warning goes to stderr.
 
 ## Known gaps
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,35 @@
 
 Role-aware agent team launcher built on top of [AMQ](https://github.com/avivsinai/agent-message-queue) by [Aviv Sinai](https://github.com/avivsinai).
 
-AMQ owns messaging between agents. `amq-squad` owns the layer above: who is on the team, what role each agent plays, what shared norms they follow, and how to bring the whole squad up, down, back, or into a new workstream.
+AMQ owns messaging between agents. `amq-squad` owns the layer above: who is on the team, what role each agent plays, what shared norms they follow, and how to bring the whole squad up, stop it, resume it, or fork it into a new workstream.
+
+## 2.0 — goal-first, dynamic teams
+
+**The shift.** Until now you *designed a team, then ran it*: `team init` authored a static roster, `up` spawned exactly that roster, and composition was frozen for the session. 2.0 inverts it — **you hand a lead a goal and the lead composes the team**, proposing, spawning, and pruning agents at runtime as the work reveals what it needs. Goal-first changes the default *mental model*; manual still works exactly as before.
+
+The load-bearing constraint, and why this is amq-squad-native rather than "just use Claude Code Agent Teams": **orchestration is binary-neutral — a Codex agent can *lead*, not just be led.** No core primitive depends on `~/.claude/`.
+
+Composition is a spectrum, and **manual stays the floor**:
+
+| Mode | Who composes the team | 2.0 |
+| --- | --- | --- |
+| **Manual** | You design the roster up front (`team init` / the setup wizard). | first-class, unchanged |
+| **Seeded** | The lead **proposes** each spawn from the goal; the **operator approves** it over a `gate/<topic>` thread. | shipped |
+| **Autonomous** | The lead spawns/prunes within guardrails, no per-spawn approval. | deferred to 2.1 |
+
+Three binary-neutral primitives make it work, and all of them round-trip through stop/resume so a resumed session rebuilds the team the lead **built**, not the seed:
+
+- **Mutable roster** — `amq-squad team member add/rm/list` grows or shrinks the team mid-session (atomic, file-locked, re-validated, persisted).
+- **Native task store** — `amq-squad task add/list/claim/done/fail/block`: a pull-based, dependency-gated queue under `.amq-squad/tasks/<session>/`, so a lead of either binary decomposes the goal into claimable work.
+- **Compose-from-goal playbook** — the `amq-squad-orchestrator` skill (in both the Claude and Codex marketplaces) drives propose → approve → `team member add` → `task add` → prune.
+
+### Breaking changes
+
+2.0 is a major version; the breaking surface is small and mechanical (full upgrade notes in [`MIGRATION.md`](MIGRATION.md)):
+
+- **Removed verbs** — `down`, `launch`, `restore`, `list`, `team show`, `team launch` now return a usage error. Use `stop`, `agent up`, `history` / `agent resume`, `status` / `history`, `up --dry-run`, and `up` respectively.
+- **`/v2` module path** — install from `github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest` (note the `/v2`).
+- **No data migration** — existing `team.json` (schema v3) loads unchanged.
 
 ## Why
 

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -447,7 +447,7 @@ skill as <code>$&lt;skill&gt;</code> — e.g.
 </ul>
 <p>All four skills are user-invocable and require the
 <code>amq-squad</code> binary on <code>PATH</code>
-(<code>go install github.com/omriariav/amq-squad/cmd/amq-squad@latest</code>).
+(<code>go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</code>).
 Their workflows are equivalent across the two marketplaces; the platform
 metadata differs (a Claude skill carries <code>trigger</code> /
 <code>allowed-tools</code> / <code>argument-hint</code>; the Codex skill

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -69,7 +69,7 @@ Install the marketplace once; the skills are then discovered automatically.
   e.g. `$amq-team-setup`.
 
 All four skills are user-invocable and require the `amq-squad` binary on `PATH`
-(`go install github.com/omriariav/amq-squad/cmd/amq-squad@latest`). Their
+(`go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest`). Their
 workflows are equivalent across the two marketplaces; the platform metadata
 differs (a Claude skill carries `trigger` / `allowed-tools` / `argument-hint`;
 the Codex skill omits them) and so does tool wording (a Claude skill says "use

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "1.9.3",
+  "version": "2.0.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-squad
-description: Project-aware skill for live amq-squad team coordination after `.amq-squad/team.json` exists. Covers inbox drains, routing, review/handoff, status board/console/history, up/stop/resume/fork/rm/archive (down is a deprecated alias), agent up/resume, doctor, workstream briefs, ACTIVE-EPIC startup, and tmux runtime control — focus/open/send to exact panes, deterministic prompt delivery, --target new-window window-per-agent, and tmux runtime metadata (pane ids, pane_alive, action commands) in status/history/resume --json for clients like amq-noc. For first-time team design (personas, profile choice, team rules, pointer stubs, brief authoring, sync), prefer the companion `amq-team-setup` skill. Use raw `amq-cli` only for AMQ debugging outside the squad.
+description: Project-aware skill for live amq-squad team coordination after `.amq-squad/team.json` exists. Covers inbox drains, routing, review/handoff, status board/console/history, up/stop/resume/fork/rm/archive, agent up/resume, doctor, workstream briefs, ACTIVE-EPIC startup, and tmux runtime control — focus/open/send to exact panes, deterministic prompt delivery, --target new-window window-per-agent, and tmux runtime metadata (pane ids, pane_alive, action commands) in status/history/resume --json for clients like amq-noc. For first-time team design (personas, profile choice, team rules, pointer stubs, brief authoring, sync), prefer the companion `amq-team-setup` skill. Use raw `amq-cli` only for AMQ debugging outside the squad.
 allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep
 argument-hint: "[drain | review | handoff | status | console | up | focus | send | resume | fork | rm | doctor]"
 user-invocable: true
@@ -52,10 +52,14 @@ The lifecycle is one small state machine: `(none) --up--> running --stop--> stop
 | Diagnose AMQ/tmux/markers/wake health | `amq-squad doctor` |
 | List configured profiles | `amq-squad team profiles` |
 | Sync the pointer stub into `CLAUDE.md` / `AGENTS.md` | `amq-squad team sync --apply` |
+| Mutate the live roster at runtime | `amq-squad team member add <role> --binary B` / `team member rm <role>` / `team member list` |
+| Native pull-based task queue for a workstream | `amq-squad task add --title T --session S` / `task list --session S` / `task claim <id> --me H --session S` / `task done <id> --session S` |
 
-`up` means NEW work and **refuses** a session that already exists — use `resume` to continue it, or `up --reset` to start over. `stop` is the primary teardown (`down` is a deprecated alias for one release). With no `--seed-from`, `up` AUTO-STUBS the brief and prints a one-line notice — so before `up`, decide whether to author the brief first (`up --dry-run --seed-from ...`) or let `up` stub it and edit afterward. `rm`/`archive` are the only destructive ops; both confirm-gate (default No, `--yes` to skip) and refuse a live session unless `--force`.
+`up` means NEW work and **refuses** a session that already exists — use `resume` to continue it, or `up --reset` to start over. `stop` is the primary teardown (the `down` alias was removed in 2.0). With no `--seed-from`, `up` AUTO-STUBS the brief and prints a one-line notice — so before `up`, decide whether to author the brief first (`up --dry-run --seed-from ...`) or let `up` stub it and edit afterward. `rm`/`archive` are the only destructive ops; both confirm-gate (default No, `--yes` to skip) and refuse a live session unless `--force`.
 
 Pass `--profile NAME` to operate on a named profile under `.amq-squad/teams/<name>.json`. Omit (or pass `--profile default`) for `.amq-squad/team.json`.
+
+`team member` and `task` are the dynamic-team primitives. `team member add/rm` mutates `team.json` atomically under an exclusive lock and re-validates it (the new member is NOT launched — run the printed `agent up` command to start it). `task` is a native pull-based store under `.amq-squad/tasks/<session>/`: a task is claimable only once all its `--depends-on` tasks are completed, and every mutation is atomic and lock-serialized. Both take `--session` (tasks require it).
 
 Every command accepts `--json` where machine-readable output makes sense (`status`, `history`, `resume`, `doctor`, `team profiles`, `version`, and `up --dry-run`). JSON outputs are schema-versioned envelopes `{ schema_version, kind, data }`. Diagnostics stay on stderr; stdout under `--json` is pure JSON. For machine clients, the per-member records in `status --session <name> --json` (kind `status`), `history --json`, and `resume --json` (kind `resume_plan`) carry a `tmux` runtime block (`session`, `window_id`, `window_name`, `pane_id`, `target`) plus a computed `pane_alive` — **present only for agents launched in tmux**, so detect by presence. `status --session <name> --json` records additionally carry an `actions` array (`focus`/`send`/`resume`/`status`) with the exact runnable command and an `available` flag, so a client (e.g. amq-noc) renders/copies stable commands instead of inferring tmux state. (The bare `amq-squad status --json` is the multi-session board envelope `kind: sessions` — it has no per-member records or actions; use `--session <name>` for member detail.)
 
@@ -110,7 +114,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
    - NEW work: `amq-squad up [<session>]` opens the team in tmux. It REFUSES an existing session — use `resume` to continue, or `up --reset` to start over. With no `--seed-from`, the brief auto-stubs (one-line notice); decide brief-first vs stub-then-edit before launching.
    - Preview-only: `amq-squad up --dry-run` prints one launch command per member; share or paste into separate panes.
    - Restart someone: `amq-squad agent resume <role>` (delegates to the saved launch record). Use `agent up <binary> [flags]` for ad-hoc single-agent launches.
-   - Stop: `amq-squad stop --role R` (or `--all`); `--force` escalates to SIGKILL. State is preserved, so the session stays resumable. (`down` is a deprecated alias.)
+   - Stop: `amq-squad stop --role R` (or `--all`); `--force` escalates to SIGKILL. State is preserved, so the session stays resumable. (The `down` alias was removed in 2.0.)
    - Re-orient: `amq-squad resume` reattaches a saved conversation if present, else re-runs bootstrap so the agent re-reads its brief + AMQ history (no replay of prior reasoning). Plan-only; `--exec` opens the commands.
    - Tear down for good: `amq-squad rm <session>` (destructive, confirm-gated) or `amq-squad archive <session>` (recoverable). Both refuse a live session unless `--force` — stop first.
 
@@ -229,12 +233,13 @@ so `agent resume` reproduces it.
 - `2` system / runtime error (IO, process, config, environment)
 - `3` partial success (some targets succeeded, some failed; e.g. `stop` with mixed stopped + failed)
 
-## Removed / deprecated verbs
+## Removed verbs
 
-These 1.x verbs were **removed in 2.0**. Each still prints a one-line stderr migration hint (then exits with a usage error). Recommend the replacement, never the removed verb.
+These 1.x verbs were **removed in 2.0**. Each now returns a plain usage error (exit 1); there is no migration hint any more. Recommend the replacement, never the removed verb. Full notes live in `MIGRATION.md`.
 
 | Removed verb | Recommend |
 | --- | --- |
+| `amq-squad down` | `amq-squad stop` |
 | `amq-squad launch <binary>` | `amq-squad agent up <binary>` |
 | `amq-squad restore` (print) | `amq-squad history` |
 | `amq-squad restore --exec --role R` | `amq-squad agent resume R` |
@@ -242,8 +247,6 @@ These 1.x verbs were **removed in 2.0**. Each still prints a one-line stderr mig
 | `amq-squad team show` | `amq-squad up --dry-run` |
 | `amq-squad team launch` | `amq-squad up` |
 | `amq-squad team launch --fresh --session X` | `amq-squad fork --from <current> --as X` |
-
-`amq-squad down` is **deprecated** (not removed): it is an alias for `stop` that works for one more release and runs identical logic. Prefer `stop`.
 
 ## Team-rules content (generated by `team init`)
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "1.9.3",
+  "version": "2.0.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amq-squad
-description: Project-aware skill for live amq-squad team coordination after `.amq-squad/team.json` exists. Covers inbox drains, routing, review/handoff, status board/console/history, up/stop/resume/fork/rm/archive (down is a deprecated alias), agent up/resume, doctor, workstream briefs, ACTIVE-EPIC startup, and tmux runtime control — focus/open/send to exact panes, deterministic prompt delivery, --target new-window window-per-agent, and tmux runtime metadata (pane ids, pane_alive, action commands) in status/history/resume --json for clients like amq-noc. For first-time team design (personas, profile choice, team rules, pointer stubs, brief authoring, sync), prefer the companion `amq-team-setup` skill. Use raw `amq-cli` only for AMQ debugging outside the squad.
+description: Project-aware skill for live amq-squad team coordination after `.amq-squad/team.json` exists. Covers inbox drains, routing, review/handoff, status board/console/history, up/stop/resume/fork/rm/archive, agent up/resume, doctor, workstream briefs, ACTIVE-EPIC startup, and tmux runtime control — focus/open/send to exact panes, deterministic prompt delivery, --target new-window window-per-agent, and tmux runtime metadata (pane ids, pane_alive, action commands) in status/history/resume --json for clients like amq-noc. For first-time team design (personas, profile choice, team rules, pointer stubs, brief authoring, sync), prefer the companion `amq-team-setup` skill. Use raw `amq-cli` only for AMQ debugging outside the squad.
 ---
 
 # amq-squad
@@ -48,10 +48,14 @@ The lifecycle is one small state machine: `(none) --up--> running --stop--> stop
 | Diagnose AMQ/tmux/markers/wake health | `amq-squad doctor` |
 | List configured profiles | `amq-squad team profiles` |
 | Sync the pointer stub into `CLAUDE.md` / `AGENTS.md` | `amq-squad team sync --apply` |
+| Mutate the live roster at runtime | `amq-squad team member add <role> --binary B` / `team member rm <role>` / `team member list` |
+| Native pull-based task queue for a workstream | `amq-squad task add --title T --session S` / `task list --session S` / `task claim <id> --me H --session S` / `task done <id> --session S` |
 
-`up` means NEW work and **refuses** a session that already exists — use `resume` to continue it, or `up --reset` to start over. `stop` is the primary teardown (`down` is a deprecated alias for one release). With no `--seed-from`, `up` AUTO-STUBS the brief and prints a one-line notice — so before `up`, decide whether to author the brief first (`up --dry-run --seed-from ...`) or let `up` stub it and edit afterward. `rm`/`archive` are the only destructive ops; both confirm-gate (default No, `--yes` to skip) and refuse a live session unless `--force`.
+`up` means NEW work and **refuses** a session that already exists — use `resume` to continue it, or `up --reset` to start over. `stop` is the primary teardown (the `down` alias was removed in 2.0). With no `--seed-from`, `up` AUTO-STUBS the brief and prints a one-line notice — so before `up`, decide whether to author the brief first (`up --dry-run --seed-from ...`) or let `up` stub it and edit afterward. `rm`/`archive` are the only destructive ops; both confirm-gate (default No, `--yes` to skip) and refuse a live session unless `--force`.
 
 Pass `--profile NAME` to operate on a named profile under `.amq-squad/teams/<name>.json`. Omit (or pass `--profile default`) for `.amq-squad/team.json`.
+
+`team member` and `task` are the dynamic-team primitives. `team member add/rm` mutates `team.json` atomically under an exclusive lock and re-validates it (the new member is NOT launched — run the printed `agent up` command to start it). `task` is a native pull-based store under `.amq-squad/tasks/<session>/`: a task is claimable only once all its `--depends-on` tasks are completed, and every mutation is atomic and lock-serialized. Both take `--session` (tasks require it).
 
 Every command accepts `--json` where machine-readable output makes sense (`status`, `history`, `resume`, `doctor`, `team profiles`, `version`, and `up --dry-run`). JSON outputs are schema-versioned envelopes `{ schema_version, kind, data }`. Diagnostics stay on stderr; stdout under `--json` is pure JSON. For machine clients, the per-member records in `status --session <name> --json` (kind `status`), `history --json`, and `resume --json` (kind `resume_plan`) carry a `tmux` runtime block (`session`, `window_id`, `window_name`, `pane_id`, `target`) plus a computed `pane_alive` — **present only for agents launched in tmux**, so detect by presence. `status --session <name> --json` records additionally carry an `actions` array (`focus`/`send`/`resume`/`status`) with the exact runnable command and an `available` flag, so a client (e.g. amq-noc) renders/copies stable commands instead of inferring tmux state. (The bare `amq-squad status --json` is the multi-session board envelope `kind: sessions` — it has no per-member records or actions; use `--session <name>` for member detail.)
 
@@ -106,7 +110,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
    - NEW work: `amq-squad up [<session>]` opens the team in tmux. It REFUSES an existing session — use `resume` to continue, or `up --reset` to start over. With no `--seed-from`, the brief auto-stubs (one-line notice); decide brief-first vs stub-then-edit before launching.
    - Preview-only: `amq-squad up --dry-run` prints one launch command per member; share or paste into separate panes.
    - Restart someone: `amq-squad agent resume <role>` (delegates to the saved launch record). Use `agent up <binary> [flags]` for ad-hoc single-agent launches.
-   - Stop: `amq-squad stop --role R` (or `--all`); `--force` escalates to SIGKILL. State is preserved, so the session stays resumable. (`down` is a deprecated alias.)
+   - Stop: `amq-squad stop --role R` (or `--all`); `--force` escalates to SIGKILL. State is preserved, so the session stays resumable. (The `down` alias was removed in 2.0.)
    - Re-orient: `amq-squad resume` reattaches a saved conversation if present, else re-runs bootstrap so the agent re-reads its brief + AMQ history (no replay of prior reasoning). Plan-only; `--exec` opens the commands.
    - Tear down for good: `amq-squad rm <session>` (destructive, confirm-gated) or `amq-squad archive <session>` (recoverable). Both refuse a live session unless `--force` — stop first.
 
@@ -225,12 +229,13 @@ so `agent resume` reproduces it.
 - `2` system / runtime error (IO, process, config, environment)
 - `3` partial success (some targets succeeded, some failed; e.g. `stop` with mixed stopped + failed)
 
-## Removed / deprecated verbs
+## Removed verbs
 
-These 1.x verbs were **removed in 2.0**. Each still prints a one-line stderr migration hint (then exits with a usage error). Recommend the replacement, never the removed verb.
+These 1.x verbs were **removed in 2.0**. Each now returns a plain usage error (exit 1); there is no migration hint any more. Recommend the replacement, never the removed verb. Full notes live in `MIGRATION.md`.
 
 | Removed verb | Recommend |
 | --- | --- |
+| `amq-squad down` | `amq-squad stop` |
 | `amq-squad launch <binary>` | `amq-squad agent up <binary>` |
 | `amq-squad restore` (print) | `amq-squad history` |
 | `amq-squad restore --exec --role R` | `amq-squad agent resume R` |
@@ -238,8 +243,6 @@ These 1.x verbs were **removed in 2.0**. Each still prints a one-line stderr mig
 | `amq-squad team show` | `amq-squad up --dry-run` |
 | `amq-squad team launch` | `amq-squad up` |
 | `amq-squad team launch --fresh --session X` | `amq-squad fork --from <current> --as X` |
-
-`amq-squad down` is **deprecated** (not removed): it is an alias for `stop` that works for one more release and runs identical logic. Prefer `stop`.
 
 ## Team-rules content (generated by `team init`)
 


### PR DESCRIPTION
**DO NOT MERGE — held for go/no-go.** Third of three stacked PRs for the amq-squad **2.0.0** cut. **Base is `phase1-b-v2-module-rename` (PR #136), not main** — review/merge order is a (#135) → b (#136) → c. Draft so it can't merge accidentally.

## What this PR does
The documentation + packaging half of the 2.0 cut. No code behavior change.

- **`MIGRATION.md` (new):** the `/v2` module path (install + import), the removed-verb mapping table, the `stop` exit-code reminder, an explicit **"no `team.json` migration"** (schema stays v3-loadable), and a quick checklist.
- **README.md:** install snippets use the `/v2` path; the "Removed legacy verbs" section is reframed from "prints a migration hint" → "removed in 2.0, returns a usage error" and gains the `down → stop` row; stale "down is a deprecated alias for one release" notes flipped to "removed in 2.0"; the historical "Migrating to 1.3.0" subsection folded into the consolidated table + `MIGRATION.md` link.
- **docs/skills.md:** install path → `/v2`.
- **Skills (both Claude + Codex mirrors):** "Removed verbs" section drops the migration-hint framing and adds `down`; every "down is a deprecated alias" mention corrected; the verbs table now documents the shipped dynamic-team primitives **`team member`** (add/rm/list) and **`task`** (add/list/claim/done) — these were missing entirely.
- **README.html / docs/skills.html:** regenerated via `make readme-html docs-html`.
- **Plugin manifests:** `plugins/{claude,codex}` 1.9.1 → **2.0.0**.

## What this PR deliberately does NOT do
- No binary version bump in source: the version is stamped from the git tag via `-X main.version` ldflags, so it moves when the release is tagged — which is held.
- No `team.json` schema change: 1.x configs load as-is under 2.0.

## Verification
`make ci` green: build, vet, full test suite, README/docs HTML freshness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)