### PR TITLE
ci: guard SKILL.md frontmatter YAML (regression guard for the 1.9.2 fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check docs-html docs-html-check html dogfood-claude clean
+.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check docs-html docs-html-check html skills-check dogfood-claude clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -32,7 +32,14 @@ fmt-check:
 vet:
 	go vet ./...
 
-ci: fmt-check vet test readme-html-check docs-html-check
+ci: fmt-check vet test readme-html-check docs-html-check skills-check
+
+# Validate the YAML frontmatter of every plugin SKILL.md. A stray unquoted
+# colon-space in a description makes the loader silently skip the skill (it
+# shipped once in 1.9.1 and broke Codex orchestration), so this is a ci gate.
+skills-check:
+	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for skills-check" >&2; exit 1; }
+	@python3 scripts/check-skill-frontmatter.py
 
 # Regenerate the browsable README.html from README.md. Run this whenever
 # README.md changes (the release process bumps README.md, so it runs here).

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -27,12 +27,16 @@ except ImportError:
     )
     sys.exit(2)
 
-FRONTMATTER = re.compile(r"^---\n(.*?)\n---", re.S)
+# Closing fence must be `---` alone on its own line (optional trailing spaces),
+# so a `---`-prefixed line inside the body cannot be mistaken for the delimiter.
+# CRLF tolerant.
+FRONTMATTER = re.compile(r"^---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\Z)", re.S)
 
 
 def check(path):
     """Return an error string for `path`, or None when it is valid."""
-    text = open(path, encoding="utf-8").read()
+    # utf-8-sig strips a leading BOM so a BOM'd-but-valid file is not false-failed.
+    text = open(path, encoding="utf-8-sig").read()
     m = FRONTMATTER.match(text)
     if not m:
         return "missing `---` frontmatter block"
@@ -44,7 +48,11 @@ def check(path):
     if not isinstance(data, dict):
         return "frontmatter is not a YAML mapping"
     for key in ("name", "description"):
-        if not str(data.get(key, "")).strip():
+        # `key:` with no value parses to None, and `.get(key, "")` would miss it
+        # because the key IS present -> check the value explicitly so an empty
+        # name/description cannot false-pass (str(None) == "None" is truthy).
+        value = data.get(key)
+        if value is None or not str(value).strip():
             return f"missing or empty `{key}`"
     return None
 

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate the YAML frontmatter of every plugin SKILL.md.
+
+A single unquoted ``: `` (colon-space) in a `description:` value is enough to
+make the whole frontmatter invalid YAML, which makes the Claude and Codex skill
+loaders silently SKIP the skill. That shipped once (the amq-squad-orchestrator
+skill in 1.9.1) and broke goal-first orchestration on Codex without any build
+error. This guard runs in `make ci` so it can never ship again.
+
+Checks, per plugins/*/skills/*/SKILL.md:
+  - a `---\\n...\\n---` frontmatter block exists,
+  - it parses as a YAML mapping,
+  - `name` and `description` are present and non-empty.
+
+Exits non-zero (with a per-file report) if any file fails.
+"""
+import glob
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "PyYAML is required for the SKILL.md frontmatter check: pip3 install pyyaml\n"
+    )
+    sys.exit(2)
+
+FRONTMATTER = re.compile(r"^---\n(.*?)\n---", re.S)
+
+
+def check(path):
+    """Return an error string for `path`, or None when it is valid."""
+    text = open(path, encoding="utf-8").read()
+    m = FRONTMATTER.match(text)
+    if not m:
+        return "missing `---` frontmatter block"
+    try:
+        data = yaml.safe_load(m.group(1))
+    except yaml.YAMLError as exc:
+        detail = str(exc).replace("\n", " ")
+        return f"invalid YAML: {detail}"
+    if not isinstance(data, dict):
+        return "frontmatter is not a YAML mapping"
+    for key in ("name", "description"):
+        if not str(data.get(key, "")).strip():
+            return f"missing or empty `{key}`"
+    return None
+
+
+def main():
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    files = sorted(glob.glob(os.path.join(root, "plugins/*/skills/*/SKILL.md")))
+    if not files:
+        sys.stderr.write("no SKILL.md files found under plugins/*/skills/\n")
+        return 1
+    failures = 0
+    for f in files:
+        err = check(f)
+        rel = os.path.relpath(f, root)
+        if err:
+            failures += 1
+            sys.stderr.write(f"FAIL  {rel}\n      {err}\n")
+        else:
+            print(f"ok    {rel}")
+    if failures:
+        sys.stderr.write(f"\n{failures} SKILL.md file(s) have invalid frontmatter.\n")
+        return 1
+    print(f"\nall {len(files)} SKILL.md frontmatters valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #138 (stacked on it; **base is the hotfix branch**, retarget to main after #138 merges).

Adds the regression guard that would have caught the orchestrator bug before it shipped: a `skills-check` step in `make ci` that YAML-parses the frontmatter of **every** `plugins/*/skills/*/SKILL.md` and asserts `name`/`description` exist.

- `scripts/check-skill-frontmatter.py` — per-file report; exits non-zero on any invalid frontmatter or missing required key.
- `Makefile` — `skills-check` wired into the `ci` chain (and `.PHONY`).

**Verified:**
- passes on all 8 current SKILL.md files,
- a deliberately broken frontmatter fails with exit 1 and reproduces the same `mapping values are not allowed` error the real bug threw.

Pure tooling — no Go deps added (uses PyYAML, same external-tool pattern as the existing pandoc html checks). `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)