### PR TITLE
[2.0] Slice E: send/focus survive tmux -CC via direct pane addressing (closes #140)

### DIFF
--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -88,7 +88,15 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 	// wrong agent (a same-cwd/engine peer whose pane is still alive). Report
 	// not-found so the verb errors clearly instead of guessing.
 	if id := mr.recordedPaneID(); id != "" {
-		if p, found := tmuxpane.FindPaneByID(id, panes); found &&
+		p, found := tmuxpane.FindPaneByID(id, panes)
+		if !found {
+			// The global `list-panes -a` scan missed this pane — it was empty,
+			// or it failed wholesale under iTerm2 tmux -CC even though the
+			// recorded id is still individually addressable. The recorded id IS
+			// the authoritative address, so inspect that one pane directly.
+			p, found = statusPaneInspector(id)
+		}
+		if found &&
 			sameResolvedDir(p.CWD, mr.CWD) &&
 			!paneTitledForDifferentAgent(p.Title, workstream, mr.Member.Role) {
 			return id, tmuxpane.TargetFromPane(p), true
@@ -212,7 +220,11 @@ Examples:
 func focusTarget(projectDir, profile, session string, explicitSession bool, role string) error {
 	panes, err := statusPaneLister()
 	if err != nil {
-		return fmt.Errorf("list tmux panes: %w", err)
+		// The global `tmux list-panes -a` scan can fail wholesale under iTerm2
+		// tmux -CC control mode even when a recorded pane is still directly
+		// addressable. Degrade to no scan results and let resolveControlTarget
+		// address the recorded pane id directly rather than aborting the op.
+		panes = nil
 	}
 	roles := []string{role}
 	if strings.TrimSpace(role) == "" {
@@ -303,7 +315,11 @@ Examples:
 	}
 	panes, err := statusPaneLister()
 	if err != nil {
-		return fmt.Errorf("list tmux panes: %w", err)
+		// The global `tmux list-panes -a` scan can fail wholesale under iTerm2
+		// tmux -CC control mode even when a recorded pane is still directly
+		// addressable. Degrade to no scan results and let resolveControlTarget
+		// address the recorded pane id directly rather than aborting the op.
+		panes = nil
 	}
 	paneID, _, ok := resolveControlTarget(mr, workstream, panes)
 	if !ok || strings.TrimSpace(paneID) == "" {

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -114,6 +114,17 @@ func TestResolveControlTargetDirectInspectUnderCCScanMiss(t *testing.T) {
 		t.Fatal("a gone pane must not resolve")
 	}
 
+	// Safety preserved: a directly-inspected pane in the right cwd but TITLED for
+	// a different agent (reused id after a tmux restart) must NOT be trusted —
+	// `send` must never deliver to a sibling. This guards the direct path the same
+	// way the scan path is guarded.
+	statusPaneInspector = func(string) (tmuxpane.TmuxPane, bool) {
+		return tmuxpane.TmuxPane{PaneID: "%265", CWD: "/repo", Command: "codex", Title: "amq:issue-96:qa"}, true
+	}
+	if _, _, ok := resolveControlTarget(mr, "issue-96", nil); ok {
+		t.Fatal("a directly-inspected pane titled for a different agent must be rejected")
+	}
+
 	// Happy path: when the scan ALREADY has the pane, the direct inspector must
 	// NOT be consulted (no extra tmux call).
 	called := false
@@ -124,6 +135,20 @@ func TestResolveControlTargetDirectInspectUnderCCScanMiss(t *testing.T) {
 	}
 	if called {
 		t.Error("direct inspector must not be called when the scan already found the pane")
+	}
+}
+
+// TestResolveControlTargetNoRecordedIDNilScan proves the -CC degrade path is safe
+// for a member with NO recorded pane id: runSend/focusTarget pass nil panes after
+// a scan failure, and the cwd+engine fallback resolver must handle that cleanly
+// (unresolved, never a panic or a wrong-pane guess).
+func TestResolveControlTargetNoRecordedIDNilScan(t *testing.T) {
+	mr := memberRuntime{
+		Member: team.Member{Role: "cto", Binary: "codex"}, Handle: "cto", CWD: "/repo",
+		HasRecord: true, Record: launch.Record{AgentPID: 4242}, // no Tmux block -> no recorded pane id
+	}
+	if _, _, ok := resolveControlTarget(mr, "issue-96", nil); ok {
+		t.Fatal("no recorded pane id + nil scan must resolve to not-found, not panic or guess")
 	}
 }
 

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -74,6 +74,59 @@ func TestResolveControlTargetExactRecordedPane(t *testing.T) {
 	}
 }
 
+// TestResolveControlTargetDirectInspectUnderCCScanMiss proves the iTerm2 tmux -CC
+// fix (#140): when the global list-panes scan misses the recorded pane (returned
+// nothing, or failed wholesale so the caller degraded to nil), the recorded pane
+// id is inspected directly and still resolves — while the cwd/title safety guards
+// are preserved.
+func TestResolveControlTargetDirectInspectUnderCCScanMiss(t *testing.T) {
+	mr := memberRuntime{
+		Member: team.Member{Role: "cto", Binary: "codex"}, Handle: "cto", CWD: "/repo",
+		HasRecord: true, Record: launch.Record{Tmux: &launch.TmuxInfo{PaneID: "%265"}},
+	}
+	restore := statusPaneInspector
+	defer func() { statusPaneInspector = restore }()
+
+	// Scan list is empty (the caller degraded after a -CC scan failure); direct
+	// inspection of the recorded id returns the live pane -> resolves.
+	statusPaneInspector = func(id string) (tmuxpane.TmuxPane, bool) {
+		if id != "%265" {
+			return tmuxpane.TmuxPane{}, false
+		}
+		return tmuxpane.TmuxPane{PaneID: "%265", Session: "main", Window: "0", Pane: "1", CWD: "/repo", Command: "codex"}, true
+	}
+	if id, _, ok := resolveControlTarget(mr, "issue-96", nil); !ok || id != "%265" {
+		t.Fatalf("recorded pane must resolve via direct inspection when the scan misses, got id=%q ok=%v", id, ok)
+	}
+
+	// Safety preserved: a directly-inspected pane in a DIFFERENT cwd (reused id
+	// after a tmux restart) must NOT be trusted.
+	statusPaneInspector = func(string) (tmuxpane.TmuxPane, bool) {
+		return tmuxpane.TmuxPane{PaneID: "%265", CWD: "/somewhere/else", Command: "codex"}, true
+	}
+	if _, _, ok := resolveControlTarget(mr, "issue-96", nil); ok {
+		t.Fatal("a directly-inspected pane in a different cwd must not be trusted")
+	}
+
+	// Pane truly gone: direct inspection returns not-found -> unresolved.
+	statusPaneInspector = func(string) (tmuxpane.TmuxPane, bool) { return tmuxpane.TmuxPane{}, false }
+	if _, _, ok := resolveControlTarget(mr, "issue-96", nil); ok {
+		t.Fatal("a gone pane must not resolve")
+	}
+
+	// Happy path: when the scan ALREADY has the pane, the direct inspector must
+	// NOT be consulted (no extra tmux call).
+	called := false
+	statusPaneInspector = func(string) (tmuxpane.TmuxPane, bool) { called = true; return tmuxpane.TmuxPane{}, false }
+	panes := []tmuxpane.TmuxPane{{PaneID: "%265", Session: "main", Window: "0", Pane: "1", CWD: "/repo", Command: "codex"}}
+	if _, _, ok := resolveControlTarget(mr, "issue-96", panes); !ok {
+		t.Fatal("scan hit should resolve")
+	}
+	if called {
+		t.Error("direct inspector must not be called when the scan already found the pane")
+	}
+}
+
 func TestResolveControlTargetRejectsReusedPaneTitledForOther(t *testing.T) {
 	// The recorded pane id is alive and in the right cwd, but tmux restarted and
 	// %42 is now a SIBLING agent's pane (titled for qa, same repo). cto's send

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -23,6 +23,12 @@ import (
 // tmux pane resolver uses, keeping detection consistent across surfaces.
 var statusPaneLister = tmuxpane.DefaultPaneLister
 
+// statusPaneInspector resolves a single pane directly by its recorded tmux id,
+// bypassing the global `list-panes -a` scan. It is the authoritative-address
+// path used when the scan misses or fails wholesale (e.g. under iTerm2 tmux -CC
+// control mode). Injected as a package var so tests supply a fake.
+var statusPaneInspector = tmuxpane.InspectPaneByID
+
 // statusState is the precise state vocabulary emitted by `amq-squad status`.
 // Definitions:
 //   - live:      launch-record PID alive AND binary matches; the agent is running.

--- a/internal/tmuxpane/inspect_test.go
+++ b/internal/tmuxpane/inspect_test.go
@@ -1,0 +1,55 @@
+package tmuxpane
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestInspectPaneByIDResolvesSinglePane(t *testing.T) {
+	// One full paneListFormat row (session, window_index, pane_index, pane_pid,
+	// command, path, pane_id, window_id, pane_title, window_name).
+	row := "main\t0\t1\t1234\tcodex\t/repo\t%265\t@42\tamq:issue-96:cto\tdogfood\n"
+	got := swapCapture(t, row, nil)
+
+	p, ok := InspectPaneByID("%265")
+	if !ok {
+		t.Fatal("a valid display-message row should resolve")
+	}
+	if p.PaneID != "%265" || p.CWD != "/repo" || p.Command != "codex" ||
+		p.Session != "main" || p.Title != "amq:issue-96:cto" || p.WindowID != "@42" {
+		t.Fatalf("unexpected pane parsed: %+v", p)
+	}
+	// display-message takes the format as a trailing positional arg, NOT -F.
+	want := []string{"display-message", "-p", "-t", "%265", paneListFormat}
+	if !reflect.DeepEqual(*got, want) {
+		t.Fatalf("argv = %v, want %v", *got, want)
+	}
+}
+
+func TestInspectPaneByIDEmptyIDDoesNotShell(t *testing.T) {
+	got := swapCapture(t, "ignored", nil)
+	if _, ok := InspectPaneByID("   "); ok {
+		t.Fatal("empty pane id must not resolve")
+	}
+	if len(*got) != 0 {
+		t.Errorf("empty pane id must not shell tmux; got argv %v", *got)
+	}
+}
+
+func TestInspectPaneByIDErrorReturnsFalse(t *testing.T) {
+	// A gone pane: display-message exits non-zero. This is exactly the -CC case
+	// where the global scan fails but a present pane still resolves — here the
+	// pane is genuinely absent, so we must report not-found, not error.
+	swapCapture(t, "", errors.New("can't find pane %9"))
+	if _, ok := InspectPaneByID("%9"); ok {
+		t.Fatal("a display-message error must return false (pane gone)")
+	}
+}
+
+func TestInspectPaneByIDMalformedReturnsFalse(t *testing.T) {
+	swapCapture(t, "main\t0\n", nil) // too few fields -> parsePanes skips the row
+	if _, ok := InspectPaneByID("%9"); ok {
+		t.Fatal("a malformed row must return false")
+	}
+}

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -152,24 +152,50 @@ func PaneIdentityFor(paneID string) (*PaneIdentity, error) {
 	}, nil
 }
 
+// paneListFormat is the tab-separated tmux format shared by the global
+// `list-panes -a` scan and the single-pane `display-message` lookup, so both
+// produce rows parsePanes understands.
+//
+// pane_id + window_id (exact control addresses, tab-free) are placed before the
+// trailing human labels pane_title + window_name so a label containing a tab can
+// never shift the ids. window_name remains the last field so the parser can
+// absorb any embedded tabs into it; an empty pane_title (older/non-amq panes)
+// leaves a trailing tab the parser tolerates.
+const paneListFormat = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_id}\t#{window_id}\t#{pane_title}\t#{window_name}"
+
 // DefaultPaneLister shells `tmux list-panes -a` with a tab-separated format and
 // parses each row into a TmuxPane. It is strictly READ-ONLY. A missing tmux
 // binary or no server is reported as an error so callers can degrade.
 func DefaultPaneLister() ([]TmuxPane, error) {
-	// pane_title + window_name are appended last so an empty title (older/non-amq
-	// panes) leaves a trailing tab the parser tolerates; pane_title carries the
-	// name-first resolution token and window_name the cross-session focus
-	// fallback.
-	// pane_id + window_id (exact control addresses, tab-free) are placed before
-	// the trailing human labels pane_title + window_name so a label containing a
-	// tab can never shift the ids. window_name remains the last field so the
-	// parser can absorb any embedded tabs into it.
-	const format = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_id}\t#{window_id}\t#{pane_title}\t#{window_name}"
-	out, err := exec.Command("tmux", "list-panes", "-a", "-F", format).Output()
+	out, err := exec.Command("tmux", "list-panes", "-a", "-F", paneListFormat).Output()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w", err)
 	}
 	return parsePanes(string(out)), nil
+}
+
+// InspectPaneByID resolves a single pane directly by its tmux id via
+// `tmux display-message -t <id>`, bypassing the global `list-panes -a` scan.
+// This is the robust path under iTerm2 tmux -CC control mode, where the global
+// scan can fail wholesale (exit 1) even though the exact recorded pane is still
+// individually addressable. Strictly READ-ONLY. Returns false when paneID is
+// empty, the pane is gone (display-message errors), or the row is malformed.
+// It uses the same captureExec seam as PaneIdentityFor so tests never shell real
+// tmux. display-message takes the format as a trailing positional argument (not
+// -F), matching PaneIdentityFor.
+func InspectPaneByID(paneID string) (TmuxPane, bool) {
+	if strings.TrimSpace(paneID) == "" {
+		return TmuxPane{}, false
+	}
+	out, err := captureExec("display-message", "-p", "-t", paneID, paneListFormat)
+	if err != nil {
+		return TmuxPane{}, false
+	}
+	panes := parsePanes(out)
+	if len(panes) == 0 {
+		return TmuxPane{}, false
+	}
+	return panes[0], true
 }
 
 // parsePanes parses the tab-separated `tmux list-panes` output. Malformed rows


### PR DESCRIPTION
Closes #140. Stacked on the 2.0 stack (base `phase1-c-migration-docs`); milestone 2.0.0. Draft/held with the rest of the 2.0 cut.

## Problem (from the 2.0.0-rc dogfood)
`send`/`focus` resolved the target pane via the global `tmux list-panes -a` scan and **hard-failed** (`list tmux panes: exit status 1`) when it errored. Under iTerm2 tmux `-CC` control mode that scan fails wholesale even though the agent's recorded `pane_id` is still individually addressable — so a Codex lead couldn't dispatch into its children's panes and fell back to AMQ messages.

## Fix
- **`tmuxpane.InspectPaneByID`** — resolve one pane directly via `tmux display-message -t <id>` (reuses the `captureExec` seam + the now-shared `paneListFormat`), bypassing the global scan. Read-only.
- **`resolveControlTarget`** — when the recorded id isn't in the scan results (empty/failed), inspect that pane directly. The same cwd + title guards apply, so a reused/foreign pane is never trusted; the inspector is skipped when the scan already found the pane (no extra tmux call on the happy path).
- **`runSend`/`focusTarget`** — a failed global scan degrades to nil results (→ direct path) instead of aborting.

## Tests
`InspectPaneByID` (positional format not `-F`; error/empty/malformed); `resolveControlTarget` direct-inspect path incl. cwd-guard rejection, gone-pane, and no-call-on-scan-hit. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)