### PR TITLE
[2.0] Item 3: doctor warns on amq-squad PATH version skew + orchestrator PATH note

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,7 +63,7 @@ func Run(args []string, version string) error {
 		return err
 	}
 
-	err = dispatch(args)
+	err = dispatch(args, version)
 	if errors.Is(err, flag.ErrHelp) {
 		return nil
 	}
@@ -183,7 +183,7 @@ func projectHasDiscoverableSessions(projectDir string, resolveBaseRoot func(stri
 	return false
 }
 
-func dispatch(args []string) error {
+func dispatch(args []string, version string) error {
 	switch args[0] {
 	case "team":
 		return runTeam(args[1:])
@@ -226,7 +226,7 @@ func dispatch(args []string) error {
 	case "completion":
 		return runCompletion(args[1:])
 	case "doctor":
-		return runDoctor(args[1:])
+		return runDoctor(args[1:], version)
 	case "agent":
 		return runAgent(args[1:])
 	default:

--- a/internal/cli/console_test.go
+++ b/internal/cli/console_test.go
@@ -300,7 +300,7 @@ func TestRunConsoleRootFlagUnsupported(t *testing.T) {
 // the verb rather than reporting "unknown command").
 func TestConsoleVerbWiredIntoDispatch(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
-		return dispatch([]string{"console", "--definitely-not-a-flag"})
+		return dispatch([]string{"console", "--definitely-not-a-flag"}, "")
 	})
 	if err == nil {
 		t.Fatal("an unknown console flag should error")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -80,6 +80,13 @@ type doctorExecution struct {
 	// false when the option is unset or tmux is unavailable. Injectable so the
 	// extended-keys check never shells real tmux in tests.
 	TmuxShowOptions func(name string) (value string, ok bool)
+	// RunningVersion is the version of the binary executing `doctor` (threaded
+	// from Run). Empty or "dev" for an unstamped local build.
+	RunningVersion string
+	// PathBinaryVersion resolves the `amq-squad` found on PATH and its reported
+	// version. found=false when none is on PATH. Injectable so the version-skew
+	// check never shells a real binary in tests.
+	PathBinaryVersion func() (path, version string, found bool)
 }
 
 func defaultDoctorExecution(projectDir string) doctorExecution {
@@ -89,12 +96,78 @@ func defaultDoctorExecution(projectDir string) doctorExecution {
 		ResolveAMQEnv: func(projectDir string) (amqEnv, error) {
 			return resolveAMQEnvInDir(projectDir, "", "", "amq-squad")
 		},
-		RunAMQOps:       defaultDoctorAMQOps,
-		LookPath:        exec.LookPath,
-		Probe:           defaultDuplicateLaunchProbe,
-		Getenv:          os.Getenv,
-		TmuxShowOptions: defaultTmuxShowServerOption,
+		RunAMQOps:         defaultDoctorAMQOps,
+		LookPath:          exec.LookPath,
+		Probe:             defaultDuplicateLaunchProbe,
+		Getenv:            os.Getenv,
+		TmuxShowOptions:   defaultTmuxShowServerOption,
+		PathBinaryVersion: defaultPathBinaryVersion,
 	}
+}
+
+// defaultPathBinaryVersion resolves the `amq-squad` on PATH and runs
+// `<path> version` to read its reported version (e.g. "amq-squad v2.0.0" ->
+// "v2.0.0"). found=false when no amq-squad is on PATH. READ-ONLY.
+func defaultPathBinaryVersion() (string, string, bool) {
+	path, err := exec.LookPath("amq-squad")
+	if err != nil {
+		return "", "", false
+	}
+	out, err := exec.Command(path, "version").Output()
+	if err != nil {
+		return path, "", true
+	}
+	return path, parseAmqSquadVersion(string(out)), true
+}
+
+// parseAmqSquadVersion extracts the version token from `amq-squad version`
+// output ("amq-squad v2.0.0" -> "v2.0.0"). Returns the trimmed last field, or
+// the trimmed line when it has no spaces.
+func parseAmqSquadVersion(out string) string {
+	line := strings.TrimSpace(out)
+	if i := strings.LastIndex(line, " "); i >= 0 {
+		return strings.TrimSpace(line[i+1:])
+	}
+	return line
+}
+
+// doctorCheckVersionSkew warns when the `amq-squad` on PATH differs in version
+// from the binary running `doctor`. amq-squad launches every agent into a shell
+// that calls bare `amq-squad` (resolved via PATH), so if the operator runs a
+// different build than what is on PATH, each spawned agent — and a lead's whole
+// orchestration — silently uses the PATH version, not this one. (Exactly the
+// 2.0.0-rc dogfood trap: agents inherited a 1.9.1 on PATH and lost the new
+// team member/task primitives.)
+func doctorCheckVersionSkew(d doctorExecution) doctorCheck {
+	const name = "amq-squad on PATH"
+	const install = "go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest"
+
+	// Skip (and do NOT shell out) for an unstamped dev/test build: the version
+	// is only meaningful for an installed/released binary.
+	running := strings.TrimSpace(d.RunningVersion)
+	if running == "" || running == "dev" || running == "(devel)" {
+		return doctorCheck{Name: name, Status: doctorOK,
+			Detail: "running a dev/unstamped build; version-skew check skipped"}
+	}
+	resolve := d.PathBinaryVersion
+	if resolve == nil {
+		resolve = defaultPathBinaryVersion
+	}
+	path, pathVer, found := resolve()
+	if !found {
+		return doctorCheck{Name: name, Status: doctorWarn,
+			Detail: "amq-squad is not on PATH; agents launched by amq-squad call bare `amq-squad`, which must be on PATH. Install: " + install}
+	}
+	if pathVer == "" {
+		return doctorCheck{Name: name, Status: doctorWarn,
+			Detail: fmt.Sprintf("could not read the version of amq-squad on PATH (%s); cannot confirm spawned agents use this build (%s)", path, running)}
+	}
+	if pathVer == running {
+		return doctorCheck{Name: name, Status: doctorOK,
+			Detail: fmt.Sprintf("matches this build (%s) at %s", running, path)}
+	}
+	return doctorCheck{Name: name, Status: doctorWarn,
+		Detail: fmt.Sprintf("version skew: PATH amq-squad is %s (%s) but this process is %s; agents launched by amq-squad inherit the PATH binary, so orchestration uses %s. Reinstall to align: %s", pathVer, path, running, pathVer, install)}
 }
 
 // defaultTmuxShowServerOption reads a server-scoped tmux option via
@@ -114,7 +187,7 @@ func defaultTmuxShowServerOption(name string) (string, bool) {
 	return fields[len(fields)-1], true
 }
 
-func runDoctor(args []string) error {
+func runDoctor(args []string, version string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned doctor envelope instead of the human table")
 	projectFlag := fs.String("project", "", "project/team-home directory to check (default: cwd)")
@@ -126,8 +199,9 @@ func runDoctor(args []string) error {
 Usage:
   amq-squad doctor [--project DIR] [--profile NAME|--all-profiles] [--json]
 
-Checks: AMQ version and ops diagnostics, selected team profile, tmux
-availability, configured members' wake health, and CLAUDE.md / AGENTS.md
+Checks: AMQ version and ops diagnostics, the amq-squad on PATH vs this build
+(version skew — spawned agents inherit the PATH binary), selected team profile,
+tmux availability, configured members' wake health, and CLAUDE.md / AGENTS.md
 marker integrity plus pointer-sync drift for the selected profile's sync
 targets. Use --all-profiles for project health across every configured profile.
 Read-only. Exits non-zero if any check is "fail".
@@ -165,6 +239,7 @@ Examples:
 	d.JSON = *jsonOut
 	d.Profile = profile
 	d.AllProfiles = *allProfiles
+	d.RunningVersion = version
 	return executeDoctor(d)
 }
 
@@ -342,6 +417,7 @@ func runDoctorChecks(d doctorExecution) ([]doctorCheck, string) {
 	checks := []doctorCheck{}
 	checks = append(checks, doctorCheckAMQVersion(d))
 	checks = append(checks, doctorCheckAMQOps(d))
+	checks = append(checks, doctorCheckVersionSkew(d))
 	checks = append(checks, doctorCheckTeamConfig(d))
 	checks = append(checks, doctorCheckTmux(d))
 	checks = append(checks, doctorCheckTmuxExtendedKeys(d))

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -92,7 +92,7 @@ func syncDoctorPointers(t *testing.T, dir, rulesBody string) {
 }
 
 func TestRunDoctorRejectsPositionalArgs(t *testing.T) {
-	_, _, err := captureOutput(t, func() error { return runDoctor([]string{"foo"}) })
+	_, _, err := captureOutput(t, func() error { return runDoctor([]string{"foo"}, "") })
 	if err == nil {
 		t.Fatal("positional arg should be UsageError")
 	}
@@ -102,7 +102,7 @@ func TestRunDoctorRejectsPositionalArgs(t *testing.T) {
 }
 
 func TestRunDoctorRejectsUnknownFlag(t *testing.T) {
-	_, _, err := captureOutput(t, func() error { return runDoctor([]string{"--banana"}) })
+	_, _, err := captureOutput(t, func() error { return runDoctor([]string{"--banana"}, "") })
 	if err == nil {
 		t.Fatal("unknown flag should fail")
 	}
@@ -113,7 +113,7 @@ func TestRunDoctorRejectsUnknownFlag(t *testing.T) {
 
 func TestRunDoctorRejectsAllProfilesWithProfile(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
-		return runDoctor([]string{"--all-profiles", "--profile", "review"})
+		return runDoctor([]string{"--all-profiles", "--profile", "review"}, "")
 	})
 	if err == nil || !strings.Contains(err.Error(), "--all-profiles cannot be combined with --profile") {
 		t.Fatalf("all-profiles/profile error = %v", err)
@@ -127,7 +127,7 @@ func TestRunDoctorProjectTargetsOtherDir(t *testing.T) {
 	t.Setenv("PATH", "")
 
 	stdout, _, err := captureOutput(t, func() error {
-		return runDoctor([]string{"--project", project, "--json"})
+		return runDoctor([]string{"--project", project, "--json"}, "")
 	})
 	if err == nil {
 		t.Fatal("doctor with PATH stripped should fail health checks, preserving JSON output")
@@ -141,14 +141,14 @@ func TestRunDoctorProjectTargetsOtherDir(t *testing.T) {
 func TestRunDoctorProjectValidation(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
 	_, _, err := captureOutput(t, func() error {
-		return runDoctor([]string{"--project", missing, "--json"})
+		return runDoctor([]string{"--project", missing, "--json"}, "")
 	})
 	if err == nil || !strings.Contains(err.Error(), "--project") {
 		t.Fatalf("doctor --project missing error = %v, want --project error", err)
 	}
 
 	_, _, err = captureOutput(t, func() error {
-		return runDoctor([]string{"--project", "", "--json"})
+		return runDoctor([]string{"--project", "", "--json"}, "")
 	})
 	if err == nil || !strings.Contains(err.Error(), "--project requires a directory") {
 		t.Fatalf("doctor empty --project error = %v, want directory guidance", err)

--- a/internal/cli/doctor_version_skew_test.go
+++ b/internal/cli/doctor_version_skew_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDoctorCheckVersionSkew(t *testing.T) {
+	check := func(running, path, ver string, found bool) doctorCheck {
+		return doctorCheckVersionSkew(doctorExecution{
+			RunningVersion:    running,
+			PathBinaryVersion: func() (string, string, bool) { return path, ver, found },
+		})
+	}
+	cases := []struct {
+		name         string
+		got          doctorCheck
+		wantStatus   doctorStatus
+		wantInDetail string
+	}{
+		{"dev build is skipped without resolving PATH", check("dev", "/x", "v1.9.1", true), doctorOK, "dev"},
+		{"empty running version is skipped", check("", "/x", "v1.9.1", true), doctorOK, "dev"},
+		{"not on PATH warns", check("v2.0.0", "", "", false), doctorWarn, "not on PATH"},
+		{"matching version is ok", check("v2.0.0", "/usr/local/bin/amq-squad", "v2.0.0", true), doctorOK, "matches this build"},
+		{"version skew warns with both versions", check("v2.0.0", "/Users/x/go/bin/amq-squad", "v1.9.1", true), doctorWarn, "version skew"},
+		{"unreadable PATH version warns", check("v2.0.0", "/x", "", true), doctorWarn, "could not read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got.Status != tc.wantStatus {
+				t.Errorf("status = %q, want %q\ndetail: %s", tc.got.Status, tc.wantStatus, tc.got.Detail)
+			}
+			if !strings.Contains(tc.got.Detail, tc.wantInDetail) {
+				t.Errorf("detail %q missing %q", tc.got.Detail, tc.wantInDetail)
+			}
+		})
+	}
+
+	// The skew case must name BOTH versions so the operator can see the mismatch.
+	skew := check("v2.0.0", "/old/amq-squad", "v1.9.1", true)
+	if !strings.Contains(skew.Detail, "v1.9.1") || !strings.Contains(skew.Detail, "v2.0.0") {
+		t.Errorf("skew detail must name both versions, got %q", skew.Detail)
+	}
+
+	// A dev build must NOT shell out (PathBinaryVersion not consulted).
+	called := false
+	doctorCheckVersionSkew(doctorExecution{
+		RunningVersion:    "",
+		PathBinaryVersion: func() (string, string, bool) { called = true; return "", "", false },
+	})
+	if called {
+		t.Error("dev build must not resolve the PATH binary (no shell-out)")
+	}
+}
+
+func TestParseAmqSquadVersion(t *testing.T) {
+	for in, want := range map[string]string{
+		"amq-squad v2.0.0\n": "v2.0.0",
+		"amq-squad v1.9.1":   "v1.9.1",
+		"v2.0.0":             "v2.0.0",
+		"  amq-squad  dev  ": "dev",
+	} {
+		if got := parseAmqSquadVersion(in); got != want {
+			t.Errorf("parseAmqSquadVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/cli/exit_test.go
+++ b/internal/cli/exit_test.go
@@ -54,7 +54,7 @@ func TestParseFlagsUsageErrorAcrossCommands(t *testing.T) {
 		fn   func() error
 	}{
 		{"up", func() error { return runUp([]string{"--banana"}) }},
-		{"doctor", func() error { return runDoctor([]string{"--banana"}) }},
+		{"doctor", func() error { return runDoctor([]string{"--banana"}, "") }},
 		{"completion", func() error { return runCompletion([]string{"--banana"}) }},
 		{"team profiles", func() error { return runTeam([]string{"profiles", "--banana"}) }},
 		{"team rules init", func() error { return runTeam([]string{"rules", "init", "--banana"}) }},

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -104,6 +104,8 @@ yours.
 
 Launching a child **through amq-squad** is what captures its pane id into the launch record (the control contract). That is why you spawn via amq-squad, not via raw tmux.
 
+> **Version note:** a spawned child inherits the `amq-squad` on its `PATH` and calls it as bare `amq-squad`. If the binary you are driving differs from the one on `PATH`, children silently run that other version (and may lack newer primitives like `team member` / `task`). Run `amq-squad doctor` — it warns on this version skew — and align them (`go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest`) before composing a team.
+
 **Window-per-agent (preferred for a squad of children):**
 
 ```sh

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -100,6 +100,8 @@ yours.
 
 Launching a child **through amq-squad** is what captures its pane id into the launch record (the control contract). That is why you spawn via amq-squad, not via raw tmux.
 
+> **Version note:** a spawned child inherits the `amq-squad` on its `PATH` and calls it as bare `amq-squad`. If the binary you are driving differs from the one on `PATH`, children silently run that other version (and may lack newer primitives like `team member` / `task`). Run `amq-squad doctor` — it warns on this version skew — and align them (`go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest`) before composing a team.
+
 **Window-per-agent (preferred for a squad of children):**
 
 ```sh


### PR DESCRIPTION
Stacked on Slice F (#143); milestone 2.0.0. Draft/held with the 2.0 cut.

## Why
amq-squad launches every agent into a shell that calls bare `amq-squad` (resolved via `PATH`). If you drive a different build than what's on `PATH`, spawned agents — and a lead's whole orchestration — silently run the `PATH` version. **This is the exact 2.0.0-rc dogfood trap:** the Codex lead's agents inherited a 1.9.1 on PATH and never got the new `team member`/`task` primitives.

## What
- **`doctor`** gains an **"amq-squad on PATH"** check (`doctorCheckVersionSkew`): threads the running version (`Run → dispatch → runDoctor → doctorExecution.RunningVersion`) and compares it to `amq-squad version` resolved from PATH.
  - `warn` on skew (names both versions + the path + reinstall hint) or not-on-PATH; `ok` on match; **skips with no shell-out** for a dev/unstamped build (hermetic tests). Injectable `PathBinaryVersion` seam.
- **Orchestrator skill** (both mirrors): a "Version note" in *1. Spawn* — children inherit the PATH binary; run `doctor` and align before composing a team.
- `doctor --help` checks summary updated.

## Tests
`doctorCheckVersionSkew` (dev-skip-without-shell-out, not-on-PATH, match, skew-naming-both-versions, unreadable); `parseAmqSquadVersion`. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)