### PR TITLE
[2.0] Slice G: doc/skill coherence (folds the holistic 2.0.0 review)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -73,7 +73,27 @@ The mutable-roster commands (`team member add/rm/list`) and the native task
 store (`task ...`, stored under `.amq-squad/tasks/`) are additive and do not
 alter the `team.json` shape.
 
-## 4. Shell completion
+## 4. Teardown now closes tmux panes
+
+`rm` and `archive` now **close the torn-down agents' tmux panes by default**
+(the session is being removed, so its panes are dead weight). Panes of agents
+still considered live are never touched. Pass `--keep-panes` to leave them.
+
+`stop` is unchanged by default (it keeps panes so final output stays readable
+and `resume` re-creates them); pass `--close-panes` to close them on stop too.
+
+Only panes amq-squad recorded are ever touched, and only for agents it believes
+are down — so this is safe, but if a workflow relied on dead panes lingering
+after `rm`/`archive`, add `--keep-panes`.
+
+## 5. Check for version skew
+
+amq-squad launches every agent into a shell that calls bare `amq-squad`
+(resolved via `PATH`). If you run a different build than the one on `PATH`,
+spawned agents silently use the `PATH` version. `amq-squad doctor` now warns on
+this skew — run it after upgrading and align the two.
+
+## 6. Shell completion
 
 Regenerate your shell completion so the removed verbs stop being suggested:
 

--- a/README.html
+++ b/README.html
@@ -918,12 +918,15 @@ amq-squad up [&lt;session&gt;] [--project DIR] [--profile NAME] [--session ws] [
                                   no --seed-from/--brief the brief is AUTO-STUBBED (with a
                                   one-line notice) so CI/send-keys flows keep working.
                                   --project targets a team-home without cd.
-amq-squad stop [--all | --role R] [--project DIR] [--force]
+amq-squad stop [--all | --role R] [--project DIR] [--force] [--close-panes]
                                   Stop members: SIGTERM the live, binary-matched
                                   agent PID (--force = SIGKILL), reap the wake
                                   sidecar, flip presence offline. On-disk state is
                                   preserved, so the session stays resumable.
                                   --project targets a team-home without cd.
+                                  --close-panes also closes each stopped agent&#39;s
+                                  tmux pane (default: keep, so final output stays
+                                  readable; resume re-creates panes).
                                   (The &#39;down&#39; alias was removed in 2.0.)
 amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
                  [--exec] [--dry-run] [--force-duplicate]
@@ -947,17 +950,20 @@ amq-squad fork --from &lt;current&gt; --as &lt;new&gt; [--project DIR] [--force-
                                   created or preserved by the subsequent
                                   `up --session &lt;new&gt;` (or `agent up`) live launch.
                                   --project targets a team-home without cd.
-amq-squad rm &lt;session&gt; [--project DIR] [--yes] [--force]
+amq-squad rm &lt;session&gt; [--project DIR] [--yes] [--force] [--keep-panes]
                                   Permanently remove a finished session (its AMQ root dir
                                   + brief). Previews + prompts
                                   (default No) unless --yes; refuses a live session unless
-                                  --force; never touches a sibling session. --project
+                                  --force; never touches a sibling session. Closes the
+                                  torn-down agents&#39; tmux panes by default (live agents
+                                  excluded); --keep-panes to leave them. --project
                                   targets a team-home without cd.
-amq-squad archive &lt;session&gt; [--project DIR] [--yes] [--force]
+amq-squad archive &lt;session&gt; [--project DIR] [--yes] [--force] [--keep-panes]
                                   Move a finished session aside instead of deleting it
                                   (to &lt;baseRoot&gt;/.archive/&lt;session&gt;/, recoverable).
                                   Confirm-gated; refuses a live session unless --force.
-                                  --project targets a team-home without cd.
+                                  Closes the agents&#39; tmux panes by default; --keep-panes
+                                  to leave them. --project targets a team-home without cd.
 amq-squad status [--project DIR] [--json]
                                   Multi-session BOARD over every discovered session
 amq-squad status --session NAME [--project DIR] [--json]
@@ -982,9 +988,11 @@ amq-squad console [--project DIR] [--session NAME] [--refresh 2s] [--at-risk-wai
 amq-squad history [--json] [--project a,b]
                                   Restorable launch records across known projects.
 amq-squad doctor [--project DIR] [--profile NAME|--all-profiles] [--json]
-                                  AMQ version, AMQ ops diagnostics, profile
-                                  config, tmux, wake, marker integrity, and
-                                  pointer-sync drift.
+                                  AMQ version, AMQ ops diagnostics, the amq-squad
+                                  on PATH vs this build (version skew — spawned
+                                  agents inherit the PATH binary), profile config,
+                                  tmux, wake, marker integrity, and pointer-sync
+                                  drift.
 amq-squad amq env [--project DIR] [--session NAME] [--me HANDLE] [--json]
                                   Show the AMQ context amq-squad resolved for
                                   this project/session.

--- a/README.md
+++ b/README.md
@@ -457,12 +457,15 @@ amq-squad up [<session>] [--project DIR] [--profile NAME] [--session ws] [--rese
                                   no --seed-from/--brief the brief is AUTO-STUBBED (with a
                                   one-line notice) so CI/send-keys flows keep working.
                                   --project targets a team-home without cd.
-amq-squad stop [--all | --role R] [--project DIR] [--force]
+amq-squad stop [--all | --role R] [--project DIR] [--force] [--close-panes]
                                   Stop members: SIGTERM the live, binary-matched
                                   agent PID (--force = SIGKILL), reap the wake
                                   sidecar, flip presence offline. On-disk state is
                                   preserved, so the session stays resumable.
                                   --project targets a team-home without cd.
+                                  --close-panes also closes each stopped agent's
+                                  tmux pane (default: keep, so final output stays
+                                  readable; resume re-creates panes).
                                   (The 'down' alias was removed in 2.0.)
 amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
                  [--exec] [--dry-run] [--force-duplicate]
@@ -486,17 +489,20 @@ amq-squad fork --from <current> --as <new> [--project DIR] [--force-duplicate]
                                   created or preserved by the subsequent
                                   `up --session <new>` (or `agent up`) live launch.
                                   --project targets a team-home without cd.
-amq-squad rm <session> [--project DIR] [--yes] [--force]
+amq-squad rm <session> [--project DIR] [--yes] [--force] [--keep-panes]
                                   Permanently remove a finished session (its AMQ root dir
                                   + brief). Previews + prompts
                                   (default No) unless --yes; refuses a live session unless
-                                  --force; never touches a sibling session. --project
+                                  --force; never touches a sibling session. Closes the
+                                  torn-down agents' tmux panes by default (live agents
+                                  excluded); --keep-panes to leave them. --project
                                   targets a team-home without cd.
-amq-squad archive <session> [--project DIR] [--yes] [--force]
+amq-squad archive <session> [--project DIR] [--yes] [--force] [--keep-panes]
                                   Move a finished session aside instead of deleting it
                                   (to <baseRoot>/.archive/<session>/, recoverable).
                                   Confirm-gated; refuses a live session unless --force.
-                                  --project targets a team-home without cd.
+                                  Closes the agents' tmux panes by default; --keep-panes
+                                  to leave them. --project targets a team-home without cd.
 amq-squad status [--project DIR] [--json]
                                   Multi-session BOARD over every discovered session
 amq-squad status --session NAME [--project DIR] [--json]
@@ -521,9 +527,11 @@ amq-squad console [--project DIR] [--session NAME] [--refresh 2s] [--at-risk-wai
 amq-squad history [--json] [--project a,b]
                                   Restorable launch records across known projects.
 amq-squad doctor [--project DIR] [--profile NAME|--all-profiles] [--json]
-                                  AMQ version, AMQ ops diagnostics, profile
-                                  config, tmux, wake, marker integrity, and
-                                  pointer-sync drift.
+                                  AMQ version, AMQ ops diagnostics, the amq-squad
+                                  on PATH vs this build (version skew — spawned
+                                  agents inherit the PATH binary), profile config,
+                                  tmux, wake, marker integrity, and pointer-sync
+                                  drift.
 amq-squad amq env [--project DIR] [--session NAME] [--me HANDLE] [--json]
                                   Show the AMQ context amq-squad resolved for
                                   this project/session.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,10 +25,11 @@ cannot merge without the matching regenerated `README.html` (see step 1).
    make release-smoke VERSION=v0.5.1
    ```
 
-The smoke test installs `github.com/omriariav/amq-squad/cmd/amq-squad@VERSION`
-into a temporary `GOBIN` and fails unless `amq-squad version` prints the same
-version. This catches releases where the source tag works but the documented
-`go install` path reports `dev` or an old version.
+The smoke test installs `github.com/omriariav/amq-squad/v2/cmd/amq-squad@VERSION`
+(note the `/v2` module path for v2+) into a temporary `GOBIN` and fails unless
+`amq-squad version` prints the same version. This catches releases where the
+source tag works but the documented `go install` path reports `dev` or an old
+version.
 
 ## Minor release checklist
 
@@ -64,11 +65,12 @@ top of the patch checklist.
   --stop--> stopped --rm/archive--> (none)`, with `resume` returning a stopped
   session to running. `up` now means NEW work and refuses an existing session
   (`resume` to continue, `up --reset` to start over); `stop` is the primary
-  teardown (state preserved, resumable) and `down` is a deprecated alias; `rm`
-  and `archive` are the only destructive ops, both confirm-gated. The pinned
-  `team.json` `workstream` default is dropped behind a deprecation shim
-  (removal in 2.1). Removed verbs: `launch`, `restore`, `list`, `team show`,
-  `team launch` (each prints a migration hint). The brief auto-stubs on `up`.
+  teardown (state preserved, resumable) and `down` was removed in 2.0 (it had
+  been a deprecated alias); `rm` and `archive` are the only destructive ops,
+  both confirm-gated. The pinned `team.json` `workstream` default is dropped
+  behind a deprecation shim (removal in 2.1). Removed verbs: `down`, `launch`,
+  `restore`, `list`, `team show`, `team launch` (each now returns a usage
+  error). The brief auto-stubs on `up`.
 - **Mission Control.** New read-only `amq-squad console` TUI (board / detail /
   collapsed-thread bus / peek / triage rollup; `--once` for CI), and the bare
   `amq-squad` now renders a multi-session status board.

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -314,9 +314,9 @@ Global output flags work before or after the subcommand: `--quiet`,
 ## Companion skills
 
 - `amq-squad` - live coordination after setup: drains, routing, status
-  board/console/history, up/stop/resume/fork/rm/archive (down is a deprecated
-  alias), agent up/resume, doctor. Switch to it as soon as `up --dry-run` is
-  clean and the user is ready to launch.
+  board/console/history, up/stop/resume/fork/rm/archive, agent up/resume,
+  doctor. Switch to it as soon as `up --dry-run` is clean and the user is ready
+  to launch.
 - `amq-squad-orchestrator` - the lead-agent playbook for an orchestrated squad
   (spawn / dispatch / monitor / the `[AGENT-EVENT]`-over-AMQ reporting protocol /
   recover). The lead loads it; this skill only wires the opt-in.

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -311,9 +311,9 @@ Global output flags work before or after the subcommand: `--quiet`,
 ## Companion skills
 
 - `amq-squad` - live coordination after setup: drains, routing, status
-  board/console/history, up/stop/resume/fork/rm/archive (down is a deprecated
-  alias), agent up/resume, doctor. Switch to it as soon as `up --dry-run` is
-  clean and the user is ready to launch.
+  board/console/history, up/stop/resume/fork/rm/archive, agent up/resume,
+  doctor. Switch to it as soon as `up --dry-run` is clean and the user is ready
+  to launch.
 - `amq-squad-orchestrator` - the lead-agent playbook for an orchestrated squad
   (spawn / dispatch / monitor / the `[AGENT-EVENT]`-over-AMQ reporting protocol /
   recover). The lead loads it; this skill only wires the opt-in.


### PR DESCRIPTION
Stacked on item 3 (#144); milestone 2.0.0. Folds the findings from the pre-release **holistic** review (which caught gaps the per-slice reviews missed — docs/skills written before the later slices' behavior existed).

- **BLOCKER fixed:** both `amq-team-setup` SKILL.md mirrors still called `down` a deprecated alias → corrected (it's removed).
- **README:** `stop` lists `--close-panes`; `rm`/`archive` list `--keep-panes` + the default-close behavior; the `doctor` entry names the PATH version-skew check.
- **MIGRATION.md:** new sections for teardown pane-closing and the doctor version-skew check.
- **RELEASING.md:** release-smoke install path uses `/v2`; the historical changelog draft no longer says `down` is a deprecated alias or that removed verbs "print a migration hint".
- README.html / docs/skills.html regenerated.

`make ci` green; full sweep for stale deprecated-verb / non-/v2 install text is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)