### PR TITLE
[2.0] Slice H: amq-squad skill echoes its version on startup (+ drift guard)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,10 @@ cannot merge without the matching regenerated `README.html` (see step 1).
    Any time you change `README.md`, run `make readme-html` to regenerate
    `README.html` (requires `pandoc`) and commit both; `make ci` fails if
    `README.html` is out of sync.
+   When bumping a plugin manifest version, also bump the `Skill version: X.Y.Z`
+   marker in `plugins/{claude,codex}/skills/amq-squad/SKILL.md` (the agent echoes
+   it on startup). `make ci` (`skills-check`) fails if the marker and the manifest
+   version drift apart.
 2. Merge the release PR.
 3. Tag the merge commit:
 

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -15,6 +15,8 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
+**Skill version: 2.0.0** — on your FIRST response of a session, print the line `amq-squad skill v2.0.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+
 ## Context model
 
 The context model has three durable layers. The skill never asks you to duplicate any of them into another file.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -11,6 +11,8 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
+**Skill version: 2.0.0** — on your FIRST response of a session, print the line `amq-squad skill v2.0.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+
 ## Context model
 
 The context model has three durable layers. The skill never asks you to duplicate any of them into another file.

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -12,7 +12,11 @@ Checks, per plugins/*/skills/*/SKILL.md:
   - it parses as a YAML mapping,
   - `name` and `description` are present and non-empty.
 
-Exits non-zero (with a per-file report) if any file fails.
+Also checks that the `Skill version: X.Y.Z` marker in each mirror's amq-squad
+skill (which the agent echoes on startup) matches that mirror's plugin manifest
+version, so the echoed version can never silently drift from the release.
+
+Exits non-zero (with a per-file report) if any check fails.
 """
 import glob
 import os
@@ -69,6 +73,37 @@ def check(path):
     return None
 
 
+# Each mirror's amq-squad skill carries a "Skill version: X.Y.Z" marker that the
+# agent echoes on startup. It must match that mirror's plugin manifest version so
+# the echoed version is trustworthy, not drifted.
+VERSION_MARKER = re.compile(r"Skill version:\s*([0-9]+\.[0-9]+\.[0-9]+)")
+VERSIONED_SKILL = "amq-squad"  # skill id (dir) that must carry the marker
+MANIFEST = {
+    "claude": ".claude-plugin/plugin.json",
+    "codex": ".codex-plugin/plugin.json",
+}
+
+
+def check_version_marker(root, mirror):
+    """Return an error string if the amq-squad skill marker != plugin manifest."""
+    skill = os.path.join(root, "plugins", mirror, "skills", VERSIONED_SKILL, "SKILL.md")
+    manifest = os.path.join(root, "plugins", mirror, MANIFEST[mirror])
+    if not (os.path.isfile(skill) and os.path.isfile(manifest)):
+        return None  # mirror not present; nothing to compare
+    m = VERSION_MARKER.search(open(skill, encoding="utf-8-sig").read())
+    if not m:
+        return f"{os.path.relpath(skill, root)}: missing `Skill version: X.Y.Z` marker"
+    import json
+
+    want = str(json.load(open(manifest, encoding="utf-8")).get("version", "")).strip()
+    if m.group(1) != want:
+        return (
+            f"{os.path.relpath(skill, root)}: marker version {m.group(1)} != "
+            f"manifest version {want} ({os.path.relpath(manifest, root)})"
+        )
+    return None
+
+
 def main():
     root = sys.argv[1] if len(sys.argv) > 1 else "."
     files = sorted(glob.glob(os.path.join(root, "plugins/*/skills/*/SKILL.md")))
@@ -84,10 +119,15 @@ def main():
             sys.stderr.write(f"FAIL  {rel}\n      {err}\n")
         else:
             print(f"ok    {rel}")
+    for mirror in ("claude", "codex"):
+        err = check_version_marker(root, mirror)
+        if err:
+            failures += 1
+            sys.stderr.write(f"FAIL  skill-version marker\n      {err}\n")
     if failures:
-        sys.stderr.write(f"\n{failures} SKILL.md file(s) have invalid frontmatter.\n")
+        sys.stderr.write(f"\n{failures} skill check(s) failed.\n")
         return 1
-    print(f"\nall {len(files)} SKILL.md frontmatters valid")
+    print(f"\nall {len(files)} SKILL.md frontmatters valid; version markers match manifests")
     return 0
 
 


### PR DESCRIPTION
Stacked on Slice G (#145); milestone 2.0.0.

Makes **"did the agent load the 2.0 skills?"** visible at a glance — the gap from the dogfood (we could verify the *binary* via `doctor`, but not the *skills*).

## What
- The `amq-squad` skill (both mirrors) now carries a `**Skill version: 2.0.0**` marker and instructs the agent to print `amq-squad skill v2.0.0` as the **first line of its first response**. An older cached skill lacks the step and stays silent — so the *absence* of the line is itself the signal that the expected build didn't load. Pairs with `amq-squad version` (binary) + the doctor PATH-skew check.
- **Drift guard:** `skills-check` (in `make ci`) now asserts each mirror's marker matches that mirror's plugin manifest version, so the echoed version can never silently drift from the release. Verified: passes aligned (2.0.0 == 2.0.0); a drifted marker fails with a clear message.
- RELEASING checklist notes the paired bump.

`make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)