### PR TITLE
README: composition spectrum — autonomous is 'future', not pinned to 2.1

### DIFF
--- a/README.html
+++ b/README.html
@@ -361,7 +361,7 @@ wizard).</td>
 <td><strong>Autonomous</strong></td>
 <td>The lead spawns/prunes within guardrails, no per-spawn
 approval.</td>
-<td>deferred to 2.1</td>
+<td>future</td>
 </tr>
 </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Composition is a spectrum, and **manual stays the floor**:
 | --- | --- | --- |
 | **Manual** | You design the roster up front (`team init` / the setup wizard). | first-class, unchanged |
 | **Seeded** | The lead **proposes** each spawn from the goal; the **operator approves** it over a `gate/<topic>` thread. | shipped |
-| **Autonomous** | The lead spawns/prunes within guardrails, no per-spawn approval. | deferred to 2.1 |
+| **Autonomous** | The lead spawns/prunes within guardrails, no per-spawn approval. | future |
 
 Three binary-neutral primitives make it work, and all of them round-trip through stop/resume so a resumed session rebuilds the team the lead **built**, not the seed:
 


### PR DESCRIPTION
Soften the autonomous-composition row from "deferred to 2.1" to "future" — the 2.1 target was a soft intention with no committed plan. Docs-only; regenerated README.html. 🤖 Generated with [Claude Code](https://claude.com/claude-code)