### PR TITLE
fix(#170): honor per-member --session pin in up and resume

### DIFF
--- a/internal/cli/fork_test.go
+++ b/internal/cli/fork_test.go
@@ -16,8 +16,8 @@ func seedForkTeam(t *testing.T, dir string) {
 	if err := team.Write(dir, team.Team{
 		Workstream: "issue-96",
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -508,7 +508,7 @@ func TestForkFooterCarriesProfile(t *testing.T) {
 	seedProfile(t, dir, "review", team.Team{
 		Workstream: "review",
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "review"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
 		},
 	})
 	// Seed a SOURCE root on disk so fork's source-state check passes.

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -250,7 +250,7 @@ func TestRunResumeHonorsExplicitSession(t *testing.T) {
 	resumeChdir(t, dir)
 	if err := team.Write(dir, team.Team{
 		Workstream: "issue-96",
-		Members:    []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+		Members:    []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-99"}},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -160,6 +160,14 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 		return err
 	}
 	opts.Workstream = workstream
+	active, skipped := filterMembersBySession(t.Members, workstream)
+	for _, m := range skipped {
+		quietNotice("notice: skipping %s: pinned to session %q, not %q\n", m.Role, m.Session, workstream)
+	}
+	if len(active) == 0 {
+		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
+	}
+	t.Members = active
 	trustMode, err := resolveTeamTrustMode(t, opts.Trust, explicitTrust)
 	if err != nil {
 		return err

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -14,8 +14,8 @@ func TestBuildTmuxLaunchPlanUsesCatalogOrderAndLaunchCommands(t *testing.T) {
 	tm := team.Team{
 		Project: "/repo",
 		Members: []team.Member{
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
 		},
 	}
 	plan := buildTmuxLaunchPlan(tm, teamLaunchOptions{
@@ -172,8 +172,8 @@ func TestRunTeamLaunchDryRunDefaultsToCurrentWindow(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -226,8 +226,8 @@ func TestRunTeamLaunchDryRunUsesExplicitSharedWorkstream(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -272,8 +272,8 @@ func TestRunTeamLaunchDryRunUsesBinaryArgs(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -319,8 +319,8 @@ func TestRunTeamLaunchFreshRejectsExistingWorkstream(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -351,8 +351,8 @@ func TestRunTeamLaunchDryRunUsesSharedWorkstreamAcrossMemberCWDs(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack", CWD: sibling},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "", CWD: sibling},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -391,7 +391,7 @@ func TestRunTeamLaunchDryRunNewSessionDoesNotAutoAttach(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -452,6 +452,168 @@ func TestParseTmuxClientsReturnsControlModeClients(t *testing.T) {
 	}
 	if got[0].TTY != "/dev/ttys001" || !strings.Contains(got[0].Flags, "pause-after=120") {
 		t.Fatalf("client = %+v", got[0])
+	}
+}
+
+// filterMembersBySession tests
+
+func TestFilterMembersBySessionReturnsAllWhenUnpinned(t *testing.T) {
+	members := []team.Member{
+		{Role: "cto", Session: ""},
+		{Role: "fullstack", Session: ""},
+	}
+	active, skipped := filterMembersBySession(members, "v2-3-0")
+	if len(active) != 2 {
+		t.Fatalf("active = %d, want 2", len(active))
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipped = %d, want 0", len(skipped))
+	}
+}
+
+func TestFilterMembersBySessionReturnsMatchingAndUnpinned(t *testing.T) {
+	members := []team.Member{
+		{Role: "go-dev", Session: "v2-3-0"},
+		{Role: "architect", Session: ""},
+		{Role: "pm-copilot", Session: "pm-copilot"},
+	}
+	active, skipped := filterMembersBySession(members, "v2-3-0")
+	if len(active) != 2 {
+		t.Fatalf("active = %d, want 2 (go-dev + architect)", len(active))
+	}
+	if active[0].Role != "go-dev" || active[1].Role != "architect" {
+		t.Fatalf("active roles = %v, want [go-dev architect]", []string{active[0].Role, active[1].Role})
+	}
+	if len(skipped) != 1 || skipped[0].Role != "pm-copilot" {
+		t.Fatalf("skipped = %v, want [pm-copilot]", skipped)
+	}
+}
+
+func TestFilterMembersBySessionSkipsAllCrossSession(t *testing.T) {
+	members := []team.Member{
+		{Role: "pm-a", Session: "pm-copilot"},
+		{Role: "pm-b", Session: "pm-copilot"},
+	}
+	active, skipped := filterMembersBySession(members, "v2-3-0")
+	if len(active) != 0 {
+		t.Fatalf("active = %d, want 0", len(active))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %d, want 2", len(skipped))
+	}
+}
+
+func TestRunTeamLaunchDryRunMixedSessionFiltersOutCrossSessionMembers(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "v2-3-0"},
+			{Role: "architect", Binary: "codex", Handle: "architect", Session: "v2-3-0"},
+			{Role: "pm-copilot", Binary: "claude", Handle: "pm-copilot", Session: "pm-copilot"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "pm-copilot") {
+		t.Errorf("dry-run should not include cross-session member pm-copilot:\n%s", stdout)
+	}
+	for _, want := range []string{"--me go-dev", "--me architect"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("dry-run missing session member %q:\n%s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, `skipping pm-copilot`) {
+		t.Errorf("stderr missing skip notice for pm-copilot:\n%s", stderr)
+	}
+}
+
+func TestRunTeamLaunchDryRunMixedSessionIncludesUnpinnedMembers(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "v2-3-0"},
+			{Role: "shared-bot", Binary: "claude", Handle: "shared-bot", Session: ""},
+			{Role: "pm-copilot", Binary: "claude", Handle: "pm-copilot", Session: "pm-copilot"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{"--me go-dev", "--me shared-bot"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("dry-run missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "pm-copilot") {
+		t.Errorf("dry-run should not include cross-session member pm-copilot:\n%s", stdout)
+	}
+}
+
+func TestRunTeamLaunchAllCrossSessionErrors(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "pm-a", Binary: "claude", Handle: "pm-a", Session: "pm-copilot"},
+			{Role: "pm-b", Binary: "claude", Handle: "pm-b", Session: "pm-copilot"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = captureOutput(t, func() error {
+		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--no-bootstrap"})
+	})
+	if err == nil || !strings.Contains(err.Error(), `no team members are pinned to session "v2-3-0"`) {
+		t.Fatalf("runTeamLaunch error = %v, want all-cross-session rejection", err)
 	}
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -306,6 +306,14 @@ func executeResume(r resumeExecution) error {
 	if err != nil {
 		return err
 	}
+	active, skipped := filterMembersBySession(t.Members, workstream)
+	for _, m := range skipped {
+		quietNotice("notice: skipping %s: pinned to session %q, not %q\n", m.Role, m.Session, workstream)
+	}
+	if len(active) == 0 {
+		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
+	}
+	t.Members = active
 	mergedBinaryArgs := mergeBinaryArgs(t.BinaryArgs, binaryArgs)
 	resolvedTrust, err := resolveTeamTrustMode(t, trustMode, r.ExplicitTrust)
 	if err != nil {

--- a/internal/cli/team_resume_test.go
+++ b/internal/cli/team_resume_test.go
@@ -375,7 +375,7 @@ func TestRunTeamResumeFreshIgnoresRestoreRecords(t *testing.T) {
 	if err := team.Write(dir, team.Team{
 		Workstream: "issue-96",
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: ""},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -934,6 +934,71 @@ func TestRunTeamResumeReattachWhenSavedConversation(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "reattach: saved conversation cto-thread") {
 		t.Errorf("plan Note should name the reattached conversation:\n%s", stdout)
+	}
+}
+
+func TestRunTeamResumeMixedSessionFiltersOutCrossSessionMembers(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "v2-3-0"},
+			{Role: "architect", Binary: "codex", Handle: "architect", Session: "v2-3-0"},
+			{Role: "pm-copilot", Binary: "claude", Handle: "pm-copilot", Session: "pm-copilot"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--session", "v2-3-0"})
+	})
+	if err != nil {
+		t.Fatalf("team resume: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "pm-copilot") {
+		t.Errorf("resume plan should not include cross-session member pm-copilot:\n%s", stdout)
+	}
+	for _, want := range []string{"go-dev", "architect"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("resume plan missing session member %q:\n%s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "skipping pm-copilot") {
+		t.Errorf("stderr missing skip notice for pm-copilot:\n%s", stderr)
+	}
+}
+
+func TestRunTeamResumeMixedSessionIncludesUnpinnedMembers(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "v2-3-0"},
+			{Role: "shared-bot", Binary: "claude", Handle: "shared-bot", Session: ""},
+			{Role: "pm-copilot", Binary: "claude", Handle: "pm-copilot", Session: "pm-copilot"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamResume([]string{"--session", "v2-3-0"})
+	})
+	if err != nil {
+		t.Fatalf("team resume: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{"go-dev", "shared-bot"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("resume plan missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "pm-copilot") {
+		t.Errorf("resume plan should not include cross-session member pm-copilot:\n%s", stdout)
 	}
 }
 

--- a/internal/cli/up_pr6_test.go
+++ b/internal/cli/up_pr6_test.go
@@ -41,7 +41,7 @@ func teamWith(role, session string) team.Team {
 func TestRunUpNewSessionAutoStubsAndWarns(t *testing.T) {
 	backend := useFakeBackend(t)
 	setupFakeAMQSessionRoots(t)
-	dir := seedTeam(t, teamWith("cto", "issue-96"))
+	dir := seedTeam(t, teamWith("cto", ""))
 
 	_, stderr, err := captureOutput(t, func() error {
 		return runUp([]string{"--terminal", "fake", "--session", "issue-200", "--no-bootstrap"})
@@ -70,7 +70,7 @@ func TestRunUpNewSessionAutoStubsAndWarns(t *testing.T) {
 func TestRunUpSeedFromAuthorsRealBriefNoWarning(t *testing.T) {
 	backend := useFakeBackend(t)
 	setupFakeAMQSessionRoots(t)
-	dir := seedTeam(t, teamWith("cto", "issue-96"))
+	dir := seedTeam(t, teamWith("cto", ""))
 
 	src := filepath.Join(t.TempDir(), "goal.md")
 	if err := os.WriteFile(src, []byte("Ship the new workstream gate.\n"), 0o644); err != nil {
@@ -106,7 +106,7 @@ func TestRunUpSeedFromAuthorsRealBriefNoWarning(t *testing.T) {
 func TestRunUpPositionalSessionName(t *testing.T) {
 	backend := useFakeBackend(t)
 	setupFakeAMQSessionRoots(t)
-	seedTeam(t, teamWith("cto", "issue-96"))
+	seedTeam(t, teamWith("cto", ""))
 
 	if _, _, err := captureOutput(t, func() error {
 		return runUp([]string{"--terminal", "fake", "--no-bootstrap", "issue-202"})
@@ -126,7 +126,7 @@ func TestRunUpPositionalSessionName(t *testing.T) {
 func TestRunUpPositionalAndSessionConflict(t *testing.T) {
 	useFakeBackend(t)
 	setupFakeAMQSessionRoots(t)
-	seedTeam(t, teamWith("cto", "issue-96"))
+	seedTeam(t, teamWith("cto", ""))
 
 	_, _, err := captureOutput(t, func() error {
 		return runUp([]string{"--terminal", "fake", "--no-bootstrap", "--session", "issue-203", "issue-204"})
@@ -147,7 +147,7 @@ func TestRunUpResetDeclinedMakesZeroChanges(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	// Decline ("n") with a dead probe so liveness never blocks before confirm.
 	withResetSeams(t, "n\n", deadStateProbe())
-	dir := seedTeam(t, teamWith("cto", "issue-96"))
+	dir := seedTeam(t, teamWith("cto", ""))
 
 	root := filepath.Join(base, "issue-205")
 	if err := os.MkdirAll(filepath.Join(root, "agents", "cto"), 0o755); err != nil {
@@ -187,7 +187,7 @@ func TestRunUpResetYesWipesAndRelaunches(t *testing.T) {
 	backend := useFakeBackend(t)
 	base := setupFakeAMQSessionRoots(t)
 	withResetSeams(t, "", deadStateProbe())
-	dir := seedTeam(t, teamWith("cto", "issue-96"))
+	dir := seedTeam(t, teamWith("cto", ""))
 
 	root := filepath.Join(base, "issue-206")
 	if err := os.MkdirAll(filepath.Join(root, "agents", "cto"), 0o755); err != nil {
@@ -235,7 +235,7 @@ func TestRunUpResetRefusesLiveSessionWithoutForce(t *testing.T) {
 	// Live: PID alive AND binary matches.
 	liveProbe := rmStateProbe(map[int]bool{4242: true}, map[int]bool{4242: true})
 	withResetSeams(t, "y\n", liveProbe)
-	seedTeam(t, teamWith("cto", "issue-96"))
+	seedTeam(t, teamWith("cto", ""))
 
 	root := filepath.Join(base, "issue-207")
 	seedAgentRecord(t, base, "issue-207", "cto", launch.Record{
@@ -263,7 +263,7 @@ func TestRunUpResetForceWipesLiveSession(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	liveProbe := rmStateProbe(map[int]bool{4242: true}, map[int]bool{4242: true})
 	withResetSeams(t, "", liveProbe)
-	seedTeam(t, teamWith("cto", "issue-96"))
+	seedTeam(t, teamWith("cto", ""))
 
 	root := filepath.Join(base, "issue-208")
 	seedAgentRecord(t, base, "issue-208", "cto", launch.Record{
@@ -289,7 +289,7 @@ func TestRunUpResetForceWipesLiveSession(t *testing.T) {
 func TestRunUpRefusesOnRestorableRecord(t *testing.T) {
 	backend := useFakeBackend(t)
 	base := setupFakeAMQSessionRoots(t)
-	seedTeam(t, teamWith("cto", "issue-96"))
+	seedTeam(t, teamWith("cto", ""))
 
 	// A restorable launch record under the session, but no live process; the
 	// root dir created by seedAgentRecord also makes teamWorkstreamExists true,

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -273,7 +273,7 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 	setupFakeAMQSessionRoots(t)
 	seedTeam(t, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-97"},
 		},
 	})
 
@@ -402,7 +402,7 @@ func TestRunUpLiveFreshIsNoOp(t *testing.T) {
 	backend := useFakeBackend(t)
 	setupFakeAMQSessionRoots(t)
 	seedTeam(t, team.Team{
-		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: ""}},
 	})
 
 	_, stderr, err := captureOutput(t, func() error {

--- a/internal/cli/workstream.go
+++ b/internal/cli/workstream.go
@@ -18,6 +18,21 @@ type bootstrapWorkstream struct {
 	LastTouched string
 }
 
+// filterMembersBySession partitions members into active and skipped groups for
+// a given target workstream. A member is active when its Session is empty (no
+// pin) or matches workstream exactly. Members pinned to a different session are
+// skipped and callers should emit a per-member notice before discarding them.
+func filterMembersBySession(members []team.Member, workstream string) (active, skipped []team.Member) {
+	for _, m := range members {
+		if m.Session == "" || m.Session == workstream {
+			active = append(active, m)
+		} else {
+			skipped = append(skipped, m)
+		}
+	}
+	return active, skipped
+}
+
 func defaultWorkstreamName(projectDir string) string {
 	base := filepath.Base(projectDir)
 	if base == "." || base == string(filepath.Separator) || base == "" {


### PR DESCRIPTION
## Summary

- `up <S>` and `resume <S>` now filter roster by per-member `Session` field: only members with `Session == <S>` or unpinned (`Session == ""`) are launched; members pinned to a different session are skipped with a per-member stderr notice (`notice: skipping pm-copilot: pinned to session "pm-copilot", not "v2-3-0"`)
- If the filter leaves no active members, the command errors immediately rather than silently launching nothing
- Adds `filterMembersBySession` helper in `workstream.go`; applies it in both `executeTeamLaunch` and `executeResume` right after workstream resolution
- Single-session and all-unpinned rosters behave exactly as before (filter is a no-op)

Closes #170

## Test plan

- [x] `make ci` green
- [x] `TestFilterMembersBySession*` — 3 unit tests for the helper (all-unpinned pass-through, mixed roster, all-cross-session empty)
- [x] `TestRunTeamLaunchDryRunMixedSession*` — launch with mixed roster: only session-matching + unpinned members appear in dry-run output; skip notice on stderr
- [x] `TestRunTeamLaunchAllCrossSessionErrors` — all-cross-session roster errors with clear message
- [x] `TestRunTeamResumeMixedSession*` — resume plan with mixed roster: cross-session member excluded, notice emitted
- [x] 22 existing tests updated — these fixtures used `Session: "role-name"` or `Session: "issue-96"` as old non-filtering hints; now use `Session: ""` (unpinned) or the matching target session

## High-stakes note (per brief)

This is the launch-path slice requiring binary-neutral cross-review. Requesting architect + cto review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)