### PR TITLE
feat(#165): brief decision — append-only dated decision log

### DIFF
--- a/internal/cli/brief.go
+++ b/internal/cli/brief.go
@@ -37,6 +37,9 @@ func runBrief(args []string) error {
 	if len(args) > 0 && args[0] == "seed" {
 		return runBriefSeed(args[1:])
 	}
+	if len(args) > 0 && args[0] == "decision" {
+		return runBriefDecision(args[1:])
+	}
 	fs := flag.NewFlagSet("brief", flag.ContinueOnError)
 	projectFlag := fs.String("project", "", "project/team-home directory to inspect (default: cwd)")
 	sessionFlag := fs.String("session", "", "AMQ workstream session name")
@@ -47,6 +50,7 @@ func runBrief(args []string) error {
 Usage:
   amq-squad brief --session NAME [--project DIR] [--json]
   amq-squad brief seed --session NAME --seed-from REF [--project DIR] [--force] [--dry-run] [--json]
+  amq-squad brief decision --session NAME --title TEXT --body TEXT [--project DIR]
 
 Reads .amq-squad/briefs/<session>.md from the selected team-home and reports
 whether the brief is missing, still the generated stub, or filled in.
@@ -56,6 +60,7 @@ Examples:
   amq-squad brief --project ~/Code/app --session issue-96
   amq-squad brief --session issue-96 --json | jq .
   amq-squad brief seed --session issue-96 --seed-from issue:31
+  amq-squad brief decision --session issue-96 --title "adopted stdlib-only rule" --body "No external deps beyond the Go stdlib."
 `)
 	}
 	if err := parseFlags(fs, args); err != nil {
@@ -253,6 +258,58 @@ func writeBriefSeedReport(out io.Writer, data briefSeedEnvelopeData) {
 	fmt.Fprintf(out, "# force: %t\n", data.Force)
 	fmt.Fprintln(out)
 	fmt.Fprint(out, data.Content)
+}
+
+func runBriefDecision(args []string) error {
+	fs := flag.NewFlagSet("brief decision", flag.ContinueOnError)
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	sessionFlag := fs.String("session", "", "AMQ workstream session name")
+	titleFlag := fs.String("title", "", "short label for the decision entry heading (optional)")
+	bodyFlag := fs.String("body", "", "decision prose to append")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad brief decision - append a dated decision entry to the workstream brief
+
+Usage:
+  amq-squad brief decision --session NAME --body TEXT [--title TEXT] [--project DIR]
+
+Atomically appends a dated "## Decisions" entry to .amq-squad/briefs/<session>.md.
+The section is created if it does not already exist. Entries are never rewritten.
+
+Format appended:
+  ### YYYY-MM-DD [— title]
+  body
+
+Examples:
+  amq-squad brief decision --session issue-96 --title "stdlib only" --body "No external deps beyond the Go stdlib."
+  amq-squad brief decision --session issue-96 --body "Decided to use flock for atomic appends."
+`)
+	}
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return usageErrorf("brief decision takes no positional arguments; use --session NAME --body TEXT")
+	}
+	if !flagWasSet(fs, "session") || strings.TrimSpace(*sessionFlag) == "" {
+		return usageErrorf("brief decision requires --session NAME")
+	}
+	if !flagWasSet(fs, "body") || strings.TrimSpace(*bodyFlag) == "" {
+		return usageErrorf("brief decision requires --body TEXT")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getwd: %w", err)
+	}
+	projectDir, err := resolveProjectDirFlag(cwd, *projectFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return err
+	}
+	path, err := appendBriefDecision(projectDir, *sessionFlag, *titleFlag, *bodyFlag, decisionNow())
+	if err != nil {
+		return err
+	}
+	quietNotice("appended decision to %s\n", path)
+	return nil
 }
 
 func briefKindString(kind briefKind) string {

--- a/internal/cli/brief_test.go
+++ b/internal/cli/brief_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunBriefReadsExisting(t *testing.T) {
@@ -215,6 +216,190 @@ func TestRunBriefSeedForceOverwrites(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "NEW") || strings.Contains(string(got), "OLD") {
 		t.Fatalf("force did not replace brief:\n%s", got)
+	}
+}
+
+// decision tests
+
+var fixedDecisionTime = time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+
+func withFixedDecisionTime(t *testing.T) {
+	t.Helper()
+	prev := decisionNow
+	decisionNow = func() time.Time { return fixedDecisionTime }
+	t.Cleanup(func() { decisionNow = prev })
+}
+
+func TestFormatDecisionEntryWithTitle(t *testing.T) {
+	got := formatDecisionEntry(fixedDecisionTime, "stdlib only", "No external deps.")
+	want := "### 2026-06-21 — stdlib only\nNo external deps.\n"
+	if got != want {
+		t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestFormatDecisionEntryWithoutTitle(t *testing.T) {
+	got := formatDecisionEntry(fixedDecisionTime, "", "No external deps.")
+	want := "### 2026-06-21\nNo external deps.\n"
+	if got != want {
+		t.Fatalf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestAppendBriefDecisionCreatesDecisionsSection(t *testing.T) {
+	project := t.TempDir()
+	writeTestBrief(t, project, "s1", "# s1\n\nGoal: ship.\n")
+
+	path, err := appendBriefDecision(project, "s1", "stdlib only", "No external deps.", fixedDecisionTime)
+	if err != nil {
+		t.Fatalf("appendBriefDecision: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	for _, want := range []string{
+		"## Decisions",
+		"### 2026-06-21 — stdlib only",
+		"No external deps.",
+		"Goal: ship.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in:\n%s", want, body)
+		}
+	}
+	if strings.Index(body, "## Decisions") < strings.Index(body, "Goal: ship.") {
+		t.Errorf("## Decisions should come after existing content, not before")
+	}
+}
+
+func TestAppendBriefDecisionAppendsToExistingSection(t *testing.T) {
+	project := t.TempDir()
+	writeTestBrief(t, project, "s2", "# s2\n\n## Decisions\n\n### 2026-06-20 — first\nFirst decision.\n")
+
+	_, err := appendBriefDecision(project, "s2", "second", "Second decision.", fixedDecisionTime)
+	if err != nil {
+		t.Fatalf("appendBriefDecision: %v", err)
+	}
+
+	got, err := os.ReadFile(briefPath(project, "s2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "### 2026-06-20 — first") {
+		t.Errorf("first entry should be preserved:\n%s", body)
+	}
+	if !strings.Contains(body, "### 2026-06-21 — second") {
+		t.Errorf("second entry missing:\n%s", body)
+	}
+	if strings.Index(body, "first") > strings.Index(body, "second") {
+		t.Errorf("first entry should appear before second in file")
+	}
+	if strings.Count(body, "## Decisions") != 1 {
+		t.Errorf("## Decisions header should appear exactly once:\n%s", body)
+	}
+}
+
+func TestAppendBriefDecisionCreatesFileWhenMissing(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".amq-squad", "briefs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := appendBriefDecision(project, "new-session", "first", "Body text.", fixedDecisionTime)
+	if err != nil {
+		t.Fatalf("appendBriefDecision on missing brief: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "## Decisions") || !strings.Contains(body, "### 2026-06-21 — first") {
+		t.Fatalf("unexpected content for new file:\n%s", body)
+	}
+}
+
+func TestAppendBriefDecisionWithoutTitleOmitsDash(t *testing.T) {
+	project := t.TempDir()
+	writeTestBrief(t, project, "s3", "# s3\n")
+
+	_, err := appendBriefDecision(project, "s3", "", "No title here.", fixedDecisionTime)
+	if err != nil {
+		t.Fatalf("appendBriefDecision: %v", err)
+	}
+
+	got, _ := os.ReadFile(briefPath(project, "s3"))
+	if strings.Contains(string(got), " — ") {
+		t.Errorf("no-title entry should not contain ' — ':\n%s", got)
+	}
+	if !strings.Contains(string(got), "### 2026-06-21\n") {
+		t.Errorf("no-title entry should use bare date heading:\n%s", got)
+	}
+}
+
+func TestAppendBriefDecisionDoesNotDuplicateHeader(t *testing.T) {
+	project := t.TempDir()
+	writeTestBrief(t, project, "s4", "# s4\n\n## Decisions\n\n")
+
+	for i := 0; i < 3; i++ {
+		if _, err := appendBriefDecision(project, "s4", "d", "body", fixedDecisionTime); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	got, _ := os.ReadFile(briefPath(project, "s4"))
+	if count := strings.Count(string(got), "## Decisions"); count != 1 {
+		t.Errorf("## Decisions appears %d times, want 1:\n%s", count, got)
+	}
+}
+
+func TestRunBriefDecisionAppendsEntry(t *testing.T) {
+	withFixedDecisionTime(t)
+	project := t.TempDir()
+	writeTestBrief(t, project, "issue-96", "# issue-96\n\nGoal: ship.\n")
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runBrief([]string{"decision",
+			"--project", project,
+			"--session", "issue-96",
+			"--title", "stdlib only",
+			"--body", "No external deps.",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runBrief decision: %v\nstderr:\n%s", err, stderr)
+	}
+
+	got, _ := os.ReadFile(briefPath(project, "issue-96"))
+	body := string(got)
+	if !strings.Contains(body, "## Decisions") || !strings.Contains(body, "### 2026-06-21 — stdlib only") {
+		t.Errorf("decision not appended:\n%s", body)
+	}
+	if !strings.Contains(stderr, "appended decision to") {
+		t.Errorf("success notice missing from stderr:\n%s", stderr)
+	}
+}
+
+func TestRunBriefDecisionRequiresSession(t *testing.T) {
+	_, _, err := captureOutput(t, func() error {
+		return runBrief([]string{"decision", "--body", "x"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "--session") {
+		t.Fatalf("missing --session should error, got %v", err)
+	}
+}
+
+func TestRunBriefDecisionRequiresBody(t *testing.T) {
+	_, _, err := captureOutput(t, func() error {
+		return runBrief([]string{"decision", "--session", "s"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "--body") {
+		t.Fatalf("missing --body should error, got %v", err)
 	}
 }
 

--- a/internal/cli/briefs.go
+++ b/internal/cli/briefs.go
@@ -6,9 +6,75 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 )
+
+// decisionNow is the clock for decision entry timestamps. Overridable in tests.
+var decisionNow = func() time.Time { return time.Now() }
+
+// decisionsHeader is the markdown section that hosts append-only decision
+// entries. appendBriefDecision ensures this header is present before appending.
+const decisionsHeader = "## Decisions"
+
+// appendBriefDecision atomically appends a dated decision entry to the brief
+// at (teamHome, session). If the brief does not yet contain a "## Decisions"
+// section, one is added. The operation is serialized by an flock on a sidecar
+// lock file so concurrent callers never produce interleaved writes.
+//
+// Entry format (mirrors the hand-written entries already in the brief):
+//
+//	### YYYY-MM-DD — <title>
+//	<body>
+func appendBriefDecision(teamHome, session, title, body string, now time.Time) (string, error) {
+	path := briefPath(teamHome, session)
+	if path == "" {
+		return "", fmt.Errorf("cannot resolve brief path: team-home or session is empty")
+	}
+	lockPath := path + ".lock"
+	var writtenPath string
+	err := flock.WithLock(lockPath, func() error {
+		existing, err := os.ReadFile(path)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("read brief: %w", err)
+		}
+		content := string(existing)
+		entry := formatDecisionEntry(now, title, body)
+		var newContent string
+		if !strings.Contains(content, decisionsHeader) {
+			newContent = strings.TrimRight(content, "\n") + "\n\n" + decisionsHeader + "\n\n" + entry
+		} else {
+			newContent = strings.TrimRight(content, "\n") + "\n\n" + entry
+		}
+		newContent = strings.TrimRight(newContent, "\n") + "\n"
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create briefs dir: %w", err)
+		}
+		tmp := path + ".tmp"
+		if err := os.WriteFile(tmp, []byte(newContent), 0o644); err != nil {
+			return fmt.Errorf("write tmp: %w", err)
+		}
+		if err := os.Rename(tmp, path); err != nil {
+			return fmt.Errorf("rename: %w", err)
+		}
+		writtenPath = path
+		return nil
+	})
+	return writtenPath, err
+}
+
+// formatDecisionEntry renders a single append-only decision block.
+func formatDecisionEntry(now time.Time, title, body string) string {
+	date := now.Format("2006-01-02")
+	title = strings.TrimSpace(title)
+	body = strings.TrimRight(strings.TrimSpace(body), "\n")
+	if title == "" {
+		return "### " + date + "\n" + body + "\n"
+	}
+	return "### " + date + " — " + title + "\n" + body + "\n"
+}
 
 // briefsDirName is the per-team-home directory holding workstream briefs.
 const briefsDirName = "briefs"

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -53,6 +53,12 @@ staged custom roles under `.amq-squad/roles/` (author new ones with the
 `amq-squad-role-creator` skill). Bias to **fewer** agents; add more only when
 the work is actually serializing.
 
+**Brief `## Decisions` convention (append-only).** A brief may contain a `## Decisions` section — an ordered log of dated, append-only entries recording choices the team has resolved. Never edit or delete prior entries. To record a new decision use the helper:
+```
+amq-squad brief decision --session <S> --body "…" [--title "short label"]
+```
+This atomically appends a `### YYYY-MM-DD [— title]\nbody` block, creating the section if it does not exist. Recording design choices here keeps them durable across context resets without coupling to the task store.
+
 **Picking each member — role, then horsepower.** Two independent choices:
 
 - **Role: catalog first, mint on a miss.** Use a **catalog** role (a built-in or

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -49,6 +49,12 @@ staged custom roles under `.amq-squad/roles/` (author new ones with the
 `amq-squad-role-creator` skill). Bias to **fewer** agents; add more only when
 the work is actually serializing.
 
+**Brief `## Decisions` convention (append-only).** A brief may contain a `## Decisions` section — an ordered log of dated, append-only entries recording choices the team has resolved. Never edit or delete prior entries. To record a new decision use the helper:
+```
+amq-squad brief decision --session <S> --body "…" [--title "short label"]
+```
+This atomically appends a `### YYYY-MM-DD [— title]\nbody` block, creating the section if it does not exist. Recording design choices here keeps them durable across context resets without coupling to the task store.
+
 **Picking each member — role, then horsepower.** Two independent choices:
 
 - **Role: catalog first, mint on a miss.** Use a **catalog** role (a built-in or


### PR DESCRIPTION
Closes #165.

Adds `amq-squad brief decision --session S --body TEXT [--title TEXT]` — atomically block-appends a dated entry to the `## Decisions` section of the workstream brief (creating the section if absent), mirroring the task store's atomic append. Never rewrites prior entries.

- `appendBriefDecision` (flock + tmp + rename) + `formatDecisionEntry` in briefs.go
- `--title` optional: `### YYYY-MM-DD — title` with it, `### YYYY-MM-DD` without
- Both orchestrator skill mirrors updated with the convention + helper
- 10 tests (unit + integration)

**Supersedes #172** (closed): that PR's branch was stacked on the #170 branch and got closed when #170 merged. This branch is the same #165 work cleanly rebased onto current main (post #170 + #164), verified `make ci` green. Re-review requested in this form.

Reviewed via amq-squad squad protocol; formal GitHub approval reserved for the human (agents share one GitHub identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)