### PR TITLE
fix(#177): apply session filter in up --dry-run; resume positional session

### DIFF
--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -453,8 +453,8 @@ func TestRunNewTeamRoleSelectionShortcuts(t *testing.T) {
 func TestRunNewSessionDelegatesToUpDryRun(t *testing.T) {
 	seedTeam(t, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack"},
 		},
 	})
 
@@ -518,7 +518,7 @@ func TestRunNewSessionProjectDelegatesFromOtherCWD(t *testing.T) {
 	other := t.TempDir()
 	if err := team.Write(project, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto"},
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
@@ -89,6 +90,24 @@ Examples:
 		return usageErrorf("--json is a read-only plan preview; it cannot be combined with --exec")
 	}
 
+	// Positional session, consistent with up/rm/archive.
+	requestedSession := *sessionFlag
+	explicitSession := flagWasSet(fs, "session")
+	if fs.NArg() > 1 {
+		return usageErrorf("resume takes at most one session positional; got %d", fs.NArg())
+	}
+	if fs.NArg() == 1 {
+		positional := strings.TrimSpace(fs.Arg(0))
+		if flagWasSet(fs, "session") {
+			return usageErrorf("pass the session name either positionally or via --session, not both")
+		}
+		if err := validateWorkstreamName(positional); err != nil {
+			return err
+		}
+		requestedSession = positional
+		explicitSession = true
+	}
+
 	profile, err := resolveProfileFlag(*profileFlag)
 	if err != nil {
 		return err
@@ -121,8 +140,8 @@ Examples:
 	}
 	return executeResume(resumeExecution{
 		ProjectDir:       projectDir,
-		RequestedSession: *sessionFlag,
-		ExplicitSession:  flagWasSet(fs, "session"),
+		RequestedSession: requestedSession,
+		ExplicitSession:  explicitSession,
 		RolesRaw:         *roleFlag,
 		Mode:             mode,
 		Force:            *forceDuplicate,

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -416,6 +416,68 @@ func TestExecResumePlanRejectsUnknownTerminal(t *testing.T) {
 	}
 }
 
+// TestRunResumePositionalSessionHonored verifies that `resume <session>`
+// treats the positional as the session name, fixing #177's secondary finding.
+func TestRunResumePositionalSessionHonored(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "beta"},
+			{Role: "architect", Binary: "codex", Handle: "architect", Session: "alpha"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, err := captureOutput(t, func() error { return runResume([]string{"beta"}) })
+	if err != nil {
+		t.Fatalf("resume beta: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "beta") {
+		t.Errorf("positional session not honored; got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "skipping architect") {
+		t.Errorf("stderr missing skip notice for cross-session member:\n%s", stderr)
+	}
+}
+
+// TestRunResumePositionalAndFlagIsError verifies that passing session both
+// positionally and via --session is rejected.
+func TestRunResumePositionalAndFlagIsError(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "beta"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := captureOutput(t, func() error {
+		return runResume([]string{"--session", "beta", "beta"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "positionally or via --session, not both") {
+		t.Fatalf("expected both-session error; got %v", err)
+	}
+}
+
+// TestRunResumeTooManyPositionalsIsError verifies that more than one positional
+// is rejected cleanly.
+func TestRunResumeTooManyPositionalsIsError(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "beta"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := captureOutput(t, func() error {
+		return runResume([]string{"beta", "extra"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "at most one session positional") {
+		t.Fatalf("expected too-many-positionals error; got %v", err)
+	}
+}
+
 // walkDir is a tiny wrapper around filepath.Walk used by the disk-mutation
 // fingerprint test. Kept local so the existing helpers stay focused on the
 // planner inputs.

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -690,6 +690,14 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 		}
 	}
 
+	active, skipped := filterMembersBySession(t.Members, workstream)
+	for _, m := range skipped {
+		quietNotice("notice: skipping %s: pinned to session %q, not %q\n", m.Role, m.Session, workstream)
+	}
+	if len(active) == 0 {
+		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
+	}
+	t.Members = active
 	members := orderedTeamMembers(t.Members)
 	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.ExtraBinaryArgs)
 	trustMode, err := resolveTeamTrustMode(t, opts.RequestedTrust, opts.ExplicitTrust)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -344,8 +344,8 @@ func TestRunTeamShowUsesDefaultSharedWorkstream(t *testing.T) {
 	})
 	if err := team.Write(dir, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "fullstack"},
+			{Role: "cto", Binary: "codex", Handle: "cto"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack"},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -527,7 +527,7 @@ func TestRunTeamShowFreshAllowsNewWorkstream(t *testing.T) {
 		}
 	})
 	if err := team.Write(dir, team.Team{
-		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}},
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto"}},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -117,7 +117,7 @@ func TestRunUpProjectDryRunTargetsOtherDir(t *testing.T) {
 	project := t.TempDir()
 	other := t.TempDir()
 	if err := team.Write(project, team.Team{
-		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto"}},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -172,8 +172,8 @@ func TestUpDryRunMatchesTeamShowWithFlags(t *testing.T) {
 		Trust:      trustModeTrusted,
 		BinaryArgs: map[string][]string{"codex": {"--enable", "goals"}},
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "cto"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack"},
 		},
 	}
 	setupFakeAMQSessionRoots(t)
@@ -428,5 +428,53 @@ func TestRunUpLiveRequiresTeam(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "no team configured") {
 		t.Fatalf("bare up without team config: got %v, want 'no team configured' error", err)
+	}
+}
+
+// TestRunUpDryRunMixedSessionFiltersOutCrossSessionMembers verifies that
+// up --dry-run applies the session filter (matching team launch --dry-run),
+// closing the gap filed in #177.
+func TestRunUpDryRunMixedSessionFiltersOutCrossSessionMembers(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "v2-4-0"},
+			{Role: "architect", Binary: "codex", Handle: "architect", Session: "v2-4-0"},
+			{Role: "pm-copilot", Binary: "claude", Handle: "pm-copilot", Session: "pm-copilot"},
+		},
+	})
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runUp([]string{"--dry-run", "--no-bootstrap", "v2-4-0"})
+	})
+	if err != nil {
+		t.Fatalf("up --dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Contains(stdout, "pm-copilot") {
+		t.Errorf("up --dry-run should not include cross-session member pm-copilot:\n%s", stdout)
+	}
+	for _, want := range []string{"--me go-dev", "--me architect"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("up --dry-run missing session member %q:\n%s", want, stdout)
+		}
+	}
+	if !strings.Contains(stderr, "skipping pm-copilot") {
+		t.Errorf("stderr missing skip notice for pm-copilot:\n%s", stderr)
+	}
+}
+
+// TestRunUpDryRunAllCrossSessionErrors verifies that up --dry-run returns an
+// error when no members match the target session (mirrors the live-launch
+// behavior added in #170).
+func TestRunUpDryRunAllCrossSessionErrors(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "go-dev", Binary: "claude", Handle: "go-dev", Session: "alpha"},
+			{Role: "architect", Binary: "codex", Handle: "architect", Session: "alpha"},
+		},
+	})
+	_, _, err := captureOutput(t, func() error {
+		return runUp([]string{"--dry-run", "--no-bootstrap", "beta"})
+	})
+	if err == nil || !strings.Contains(err.Error(), `no team members are pinned to session "beta"`) {
+		t.Fatalf("up --dry-run all-cross-session: got %v, want 'no team members' error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `up --dry-run` now applies `filterMembersBySession` before emitting the launch plan, matching `executeTeamLaunch` exactly. Previously the dry-run showed all roster members regardless of their `--session` pin; the live launch filtered them. Operators and JSON plan consumers saw a roster that disagreed with what actually launched.
- `resume` now accepts a positional session argument (`resume <S>`) consistent with `up`/`rm`/`archive`. Previously `amq-squad resume beta` resolved to the team-home directory name instead of `beta`, because the positional was silently ignored.

## Changes

- `internal/cli/team.go`: Add `filterMembersBySession` call in `emitTeamCommands` after workstream resolution, with skip notices and all-cross-session error, mirroring `executeTeamLaunch`.
- `internal/cli/resume.go`: Add positional session argument handling; mutual-exclusion error when both positional and `--session` are given.
- Tests: 5 new tests covering `up --dry-run` mixed-session filtering, all-cross-session error, and `resume` positional variants. 6 existing tests updated to remove session pins that were incidental to what those tests were asserting.

## Test plan

- [ ] `make ci` green on `feat/177-up-dry-run-session-filter`
- [ ] `TestRunUpDryRunMixedSessionFiltersOutCrossSessionMembers` passes
- [ ] `TestRunUpDryRunAllCrossSessionErrors` passes
- [ ] `TestRunResumePositionalSessionHonored` passes
- [ ] `TestRunResumePositionalAndFlagIsError` passes
- [ ] `TestRunResumeTooManyPositionalsIsError` passes

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)