### PR TITLE
fix(#178): amq send passthrough parity — --from, --body-file, stdin

### DIFF
--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -402,28 +402,6 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 			me = val
 			i = next
 			continue
-		case "body-file":
-			// --body-file is a send/reply convenience only; for other verbs
-			// forward verbatim. Rewrites to --body @<path> (or --body - for stdin).
-			if sub != "send" && sub != "reply" {
-				break
-			}
-			val := inlineVal
-			next := i + 1
-			if !hasInline {
-				if next >= len(args) {
-					return "", "", "", false, nil, usageErrorf("flag --body-file needs a value")
-				}
-				val = args[next]
-				next++
-			}
-			bodyVal := "@" + val
-			if val == "-" {
-				bodyVal = "-"
-			}
-			passthrough = append(passthrough, "--body", bodyVal)
-			i = next
-			continue
 		case "root", "from-root":
 			return "", "", "", false, nil, usageErrorf(
 				"do not pass --%s to 'amq-squad amq %s'; amq-squad resolves the queue root from --project/--session. Use bare 'amq %s' for manual root control.",
@@ -433,7 +411,42 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 		break
 	}
 	passthrough = append(passthrough, args[i:]...)
+	// --body-file is a send/reply parity flag: rewrite it to --body @<path>
+	// (or --body - for stdin) anywhere in the passthrough, not just the leading
+	// position. Other verbs (drain, list, etc.) receive --body-file verbatim.
+	if sub == "send" || sub == "reply" {
+		passthrough = normalizeBodyFileFlag(passthrough)
+	}
 	return project, session, me, projectSet, passthrough, nil
+}
+
+// normalizeBodyFileFlag rewrites every --body-file <path> or --body-file=<path>
+// token in args to --body @<path> (or --body - for stdin). Safe to call on the
+// full passthrough slice because amq has no native --body-file flag.
+func normalizeBodyFileFlag(args []string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		name, inlineVal, hasInline := amqFlagName(args[i])
+		if name != "body-file" {
+			out = append(out, args[i])
+			continue
+		}
+		val := inlineVal
+		if !hasInline {
+			if i+1 >= len(args) {
+				out = append(out, args[i]) // malformed; forward as-is
+				continue
+			}
+			i++
+			val = args[i]
+		}
+		bodyVal := "@" + val
+		if val == "-" {
+			bodyVal = "-"
+		}
+		out = append(out, "--body", bodyVal)
+	}
+	return out
 }
 
 // amqFlagName normalizes a CLI token to its flag name (leading dashes stripped,

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -12,9 +12,10 @@ import (
 )
 
 type amqCommandRequest struct {
-	Dir string
-	Env []string
-	Arg []string
+	Dir   string
+	Env   []string
+	Arg   []string
+	Stdin io.Reader // optional; nil means no stdin
 }
 
 type amqCommandRunner func(amqCommandRequest) ([]byte, error)
@@ -27,6 +28,7 @@ func defaultRunAMQCommand(req amqCommandRequest) ([]byte, error) {
 	cmd := exec.Command("amq", req.Arg...)
 	cmd.Env = req.Env
 	cmd.Dir = req.Dir
+	cmd.Stdin = req.Stdin
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		detail := strings.TrimSpace(string(out))
@@ -127,10 +129,14 @@ func amqCommandEnv(ctx amqContext) []string {
 }
 
 func runAndWriteAMQ(out io.Writer, ctx amqContext, args []string) error {
+	return runAndWriteAMQWithStdin(out, ctx, args, nil)
+}
+
+func runAndWriteAMQWithStdin(out io.Writer, ctx amqContext, args []string, stdin io.Reader) error {
 	if out == nil {
 		out = os.Stdout
 	}
-	data, err := runAMQCommand(amqCommandRequest{Dir: ctx.ProjectDir, Env: amqCommandEnv(ctx), Arg: args})
+	data, err := runAMQCommand(amqCommandRequest{Dir: ctx.ProjectDir, Env: amqCommandEnv(ctx), Arg: args, Stdin: stdin})
 	if err != nil {
 		return err
 	}
@@ -314,7 +320,24 @@ func runAMQPassthrough(sub string, args []string) error {
 	if sub == "watch" {
 		return runAMQStreaming(ctx, cmd)
 	}
+	if passthroughNeedsStdin(passthrough) {
+		return runAndWriteAMQWithStdin(os.Stdout, ctx, cmd, os.Stdin)
+	}
 	return runAndWriteAMQ(os.Stdout, ctx, cmd)
+}
+
+// passthroughNeedsStdin reports whether the passthrough args include a --body
+// value of "-", which means the amq subprocess will read its body from stdin.
+func passthroughNeedsStdin(args []string) bool {
+	for i, a := range args {
+		if a == "--body=-" {
+			return true
+		}
+		if a == "--body" && i+1 < len(args) && args[i+1] == "-" {
+			return true
+		}
+	}
+	return false
 }
 
 // splitAMQPassthroughArgs separates the wrapper's resolution flags
@@ -340,7 +363,9 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 		}
 		name, inlineVal, hasInline := amqFlagName(a)
 		switch name {
-		case "project", "session", "me":
+		case "project", "session", "me",
+			"from",      // alias for --me, matches dispatch/send ergonomics
+			"body-file": // rewritten to --body @<path> (or --body - for stdin)
 			val := inlineVal
 			next := i + 1
 			if !hasInline {
@@ -355,8 +380,16 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 				project, projectSet = val, true
 			case "session":
 				session = val
-			case "me":
+			case "me", "from":
 				me = val
+			case "body-file":
+				// Rewrite --body-file <path> to --body @<path>.
+				// The special value "-" means stdin: rewrite to --body -.
+				bodyVal := "@" + val
+				if val == "-" {
+					bodyVal = "-"
+				}
+				passthrough = append(passthrough, "--body", bodyVal)
 			}
 			i = next
 			continue

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -363,9 +363,7 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 		}
 		name, inlineVal, hasInline := amqFlagName(a)
 		switch name {
-		case "project", "session", "me",
-			"from",      // alias for --me, matches dispatch/send ergonomics
-			"body-file": // rewritten to --body @<path> (or --body - for stdin)
+		case "project", "session", "me":
 			val := inlineVal
 			next := i + 1
 			if !hasInline {
@@ -380,17 +378,50 @@ func splitAMQPassthroughArgs(sub string, args []string) (project, session, me st
 				project, projectSet = val, true
 			case "session":
 				session = val
-			case "me", "from":
+			case "me":
 				me = val
-			case "body-file":
-				// Rewrite --body-file <path> to --body @<path>.
-				// The special value "-" means stdin: rewrite to --body -.
-				bodyVal := "@" + val
-				if val == "-" {
-					bodyVal = "-"
-				}
-				passthrough = append(passthrough, "--body", bodyVal)
 			}
+			i = next
+			continue
+		case "from":
+			// --from is a --me alias for send/reply only, matching dispatch
+			// ergonomics. For other verbs (drain, watch, list, etc.) it is not
+			// a wrapper flag; stop wrapper parsing and forward --from verbatim.
+			if sub != "send" && sub != "reply" {
+				break
+			}
+			val := inlineVal
+			next := i + 1
+			if !hasInline {
+				if next >= len(args) {
+					return "", "", "", false, nil, usageErrorf("flag --from needs a value")
+				}
+				val = args[next]
+				next++
+			}
+			me = val
+			i = next
+			continue
+		case "body-file":
+			// --body-file is a send/reply convenience only; for other verbs
+			// forward verbatim. Rewrites to --body @<path> (or --body - for stdin).
+			if sub != "send" && sub != "reply" {
+				break
+			}
+			val := inlineVal
+			next := i + 1
+			if !hasInline {
+				if next >= len(args) {
+					return "", "", "", false, nil, usageErrorf("flag --body-file needs a value")
+				}
+				val = args[next]
+				next++
+			}
+			bodyVal := "@" + val
+			if val == "-" {
+				bodyVal = "-"
+			}
+			passthrough = append(passthrough, "--body", bodyVal)
 			i = next
 			continue
 		case "root", "from-root":

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -409,3 +409,101 @@ func envHasPrefix(env []string, key, valSubstr string) bool {
 	}
 	return false
 }
+
+// TestSplitAMQPassthroughArgsParityFlags covers the flag-parity fixes from
+// #178: --from aliases --me, and --body-file is rewritten to --body @<path>
+// (or --body - for stdin).
+func TestSplitAMQPassthroughArgsParityFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantMe   string
+		wantPass []string
+	}{
+		{
+			name:   "--from aliases --me",
+			args:   []string{"--from", "lead", "--to", "worker"},
+			wantMe: "lead", wantPass: []string{"--to", "worker"},
+		},
+		{
+			name:   "--from= inline alias",
+			args:   []string{"--from=lead", "--to", "worker"},
+			wantMe: "lead", wantPass: []string{"--to", "worker"},
+		},
+		{
+			name:     "--body-file rewrites to --body @path",
+			args:     []string{"--body-file", "/tmp/msg.txt", "--to", "worker"},
+			wantPass: []string{"--body", "@/tmp/msg.txt", "--to", "worker"},
+		},
+		{
+			name:     "--body-file - rewrites to --body -",
+			args:     []string{"--body-file", "-", "--to", "worker"},
+			wantPass: []string{"--body", "-", "--to", "worker"},
+		},
+		{
+			name:     "--body-file= inline rewrite",
+			args:     []string{"--body-file=/tmp/msg.txt", "--to", "worker"},
+			wantPass: []string{"--body", "@/tmp/msg.txt", "--to", "worker"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, me, _, pass, err := splitAMQPassthroughArgs("send", tc.args)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if me != tc.wantMe {
+				t.Fatalf("me = %q, want %q", me, tc.wantMe)
+			}
+			if strings.Join(pass, " ") != strings.Join(tc.wantPass, " ") {
+				t.Fatalf("passthrough = %v, want %v", pass, tc.wantPass)
+			}
+		})
+	}
+}
+
+func TestPassthroughNeedsStdin(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"--to", "worker", "--body", "-"}, true},
+		{[]string{"--body=-"}, true},
+		{[]string{"--to", "worker", "--body", "@/tmp/file"}, false},
+		{[]string{"--to", "worker"}, false},
+		// value "--body" at end (no value) should not panic
+		{[]string{"--body"}, false},
+	}
+	for _, tc := range cases {
+		if got := passthroughNeedsStdin(tc.args); got != tc.want {
+			t.Errorf("passthroughNeedsStdin(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestAMQPassthroughSendForwardsStdin verifies that --body - causes the
+// runner to receive the stdin reader (the stdin-forwarding fix from #178).
+func TestAMQPassthroughSendForwardsStdin(t *testing.T) {
+	chdir(t, t.TempDir())
+	var capturedReq amqCommandRequest
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/work", BaseRoot: ".agent-mail"}, "msg-001\n")
+	// Wrap the seam to capture the full request including Stdin.
+	prevRun := runAMQCommand
+	runAMQCommand = func(req amqCommandRequest) ([]byte, error) {
+		capturedReq = req
+		return prevRun(req)
+	}
+	t.Cleanup(func() { runAMQCommand = prevRun })
+
+	_, _, err := captureOutput(t, func() error {
+		return runAMQ([]string{"send", "--session", "work", "--me", "lead",
+			"--to", "worker", "--kind", "status", "--body", "-"})
+	})
+	if err != nil {
+		t.Fatalf("amq send with --body -: %v", err)
+	}
+	if capturedReq.Stdin == nil {
+		t.Error("stdin should be forwarded when --body - is in the passthrough args")
+	}
+	_ = calls
+}

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -461,6 +461,14 @@ func TestSplitAMQPassthroughArgsParityFlags(t *testing.T) {
 			wantPass: []string{"--body", "@/tmp/msg.txt", "--to", "worker"},
 		},
 		{
+			// --body-file after --to (real-world shape): leading scan stops at --to,
+			// but normalizeBodyFileFlag post-processes the full passthrough.
+			name:     "--body-file after --to rewrites for send",
+			sub:      "send",
+			args:     []string{"--session", "work", "--to", "worker", "--body-file", "-"},
+			wantPass: []string{"--to", "worker", "--body", "-"},
+		},
+		{
 			// --body-file for list is NOT rewritten; forwarded verbatim.
 			name:     "--body-file forwarded verbatim for list (not rewritten)",
 			sub:      "list",
@@ -513,10 +521,11 @@ func TestAMQPassthroughSendForwardsStdin(t *testing.T) {
 		args []string
 	}{
 		{"--body -", []string{"send", "--session", "work", "--me", "lead", "--to", "worker", "--kind", "status", "--body", "-"}},
-		// --body-file must come in the leading (wrapper-flag) position, before
-		// passthrough flags like --to, since splitAMQPassthroughArgs only rewrites
-		// leading wrapper flags. Placing it after --to would leave it unrewritten.
-		{"--body-file -", []string{"send", "--session", "work", "--me", "lead", "--body-file", "-", "--to", "worker", "--kind", "status"}},
+		// --body-file before --to (leading position, same result).
+		{"--body-file - (leading)", []string{"send", "--session", "work", "--me", "lead", "--body-file", "-", "--to", "worker", "--kind", "status"}},
+		// --body-file after --to: real-world shape; normalizeBodyFileFlag rewrites
+		// it in the full passthrough even though leading scan stopped at --to.
+		{"--body-file - (after --to)", []string{"send", "--session", "work", "--me", "lead", "--to", "worker", "--kind", "status", "--body-file", "-"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var capturedReq amqCommandRequest

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -411,44 +411,66 @@ func envHasPrefix(env []string, key, valSubstr string) bool {
 }
 
 // TestSplitAMQPassthroughArgsParityFlags covers the flag-parity fixes from
-// #178: --from aliases --me, and --body-file is rewritten to --body @<path>
-// (or --body - for stdin).
+// #178: --from aliases --me and --body-file rewrites to --body @<path> for
+// send/reply ONLY. Both are forwarded verbatim for other verbs (drain, list…).
 func TestSplitAMQPassthroughArgsParityFlags(t *testing.T) {
 	cases := []struct {
 		name     string
+		sub      string
 		args     []string
 		wantMe   string
 		wantPass []string
 	}{
 		{
-			name:   "--from aliases --me",
+			name:   "--from aliases --me for send",
+			sub:    "send",
 			args:   []string{"--from", "lead", "--to", "worker"},
 			wantMe: "lead", wantPass: []string{"--to", "worker"},
 		},
 		{
-			name:   "--from= inline alias",
+			name:   "--from aliases --me for reply",
+			sub:    "reply",
 			args:   []string{"--from=lead", "--to", "worker"},
 			wantMe: "lead", wantPass: []string{"--to", "worker"},
 		},
 		{
-			name:     "--body-file rewrites to --body @path",
+			// --from for drain is NOT a wrapper flag; stops parsing and forwards
+			// --from verbatim (amq will reject it, but not our wrapper).
+			name:     "--from forwarded verbatim for drain (not aliased)",
+			sub:      "drain",
+			args:     []string{"--from", "lead", "--me", "other"},
+			wantMe:   "",
+			wantPass: []string{"--from", "lead", "--me", "other"},
+		},
+		{
+			name:     "--body-file rewrites to --body @path for send",
+			sub:      "send",
 			args:     []string{"--body-file", "/tmp/msg.txt", "--to", "worker"},
 			wantPass: []string{"--body", "@/tmp/msg.txt", "--to", "worker"},
 		},
 		{
-			name:     "--body-file - rewrites to --body -",
+			name:     "--body-file - rewrites to --body - (stdin) for send",
+			sub:      "send",
 			args:     []string{"--body-file", "-", "--to", "worker"},
 			wantPass: []string{"--body", "-", "--to", "worker"},
 		},
 		{
-			name:     "--body-file= inline rewrite",
+			name:     "--body-file= inline rewrite for reply",
+			sub:      "reply",
 			args:     []string{"--body-file=/tmp/msg.txt", "--to", "worker"},
 			wantPass: []string{"--body", "@/tmp/msg.txt", "--to", "worker"},
+		},
+		{
+			// --body-file for list is NOT rewritten; forwarded verbatim.
+			name:     "--body-file forwarded verbatim for list (not rewritten)",
+			sub:      "list",
+			args:     []string{"--body-file", "/tmp/f"},
+			wantPass: []string{"--body-file", "/tmp/f"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, me, _, pass, err := splitAMQPassthroughArgs("send", tc.args)
+			_, _, me, _, pass, err := splitAMQPassthroughArgs(tc.sub, tc.args)
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}
@@ -481,29 +503,38 @@ func TestPassthroughNeedsStdin(t *testing.T) {
 	}
 }
 
-// TestAMQPassthroughSendForwardsStdin verifies that --body - causes the
-// runner to receive the stdin reader (the stdin-forwarding fix from #178).
+// TestAMQPassthroughSendForwardsStdin covers both stdin paths (#178):
+// --body - (explicit stdin flag) and --body-file - (rewritten to --body -).
 func TestAMQPassthroughSendForwardsStdin(t *testing.T) {
 	chdir(t, t.TempDir())
-	var capturedReq amqCommandRequest
-	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/work", BaseRoot: ".agent-mail"}, "msg-001\n")
-	// Wrap the seam to capture the full request including Stdin.
-	prevRun := runAMQCommand
-	runAMQCommand = func(req amqCommandRequest) ([]byte, error) {
-		capturedReq = req
-		return prevRun(req)
-	}
-	t.Cleanup(func() { runAMQCommand = prevRun })
 
-	_, _, err := captureOutput(t, func() error {
-		return runAMQ([]string{"send", "--session", "work", "--me", "lead",
-			"--to", "worker", "--kind", "status", "--body", "-"})
-	})
-	if err != nil {
-		t.Fatalf("amq send with --body -: %v", err)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"--body -", []string{"send", "--session", "work", "--me", "lead", "--to", "worker", "--kind", "status", "--body", "-"}},
+		// --body-file must come in the leading (wrapper-flag) position, before
+		// passthrough flags like --to, since splitAMQPassthroughArgs only rewrites
+		// leading wrapper flags. Placing it after --to would leave it unrewritten.
+		{"--body-file -", []string{"send", "--session", "work", "--me", "lead", "--body-file", "-", "--to", "worker", "--kind", "status"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedReq amqCommandRequest
+			_ = withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/work", BaseRoot: ".agent-mail"}, "msg-001\n")
+			prevRun := runAMQCommand
+			runAMQCommand = func(req amqCommandRequest) ([]byte, error) {
+				capturedReq = req
+				return prevRun(req)
+			}
+			t.Cleanup(func() { runAMQCommand = prevRun })
+
+			_, _, err := captureOutput(t, func() error { return runAMQ(tc.args) })
+			if err != nil {
+				t.Fatalf("amq send: %v", err)
+			}
+			if capturedReq.Stdin == nil {
+				t.Errorf("stdin should be forwarded for %s", tc.name)
+			}
+		})
 	}
-	if capturedReq.Stdin == nil {
-		t.Error("stdin should be forwarded when --body - is in the passthrough args")
-	}
-	_ = calls
 }


### PR DESCRIPTION
## Summary

Three flag/IO gaps in `amq-squad amq send` vs `dispatch`/`send` that caused multi-try broadcast sends as documented in #178:

1. **`--from` aliased to `--me`** in the passthrough arg parser. Switching from `dispatch` (which uses `--from`) to `amq send` no longer requires renaming the sender flag.
2. **`--body-file <path>` rewritten to `--body @<path>`** (or `--body -` for the stdin case). Matches `dispatch --body-file` behavior.
3. **Stdin forwarded when `--body -` is passed.** The `amqCommandRequest` struct gains an optional `Stdin` field; `defaultRunAMQCommand` wires it through to the subprocess; `runAMQPassthrough` detects `--body -` in the forwarded args and passes `os.Stdin`.

## Changes

- `internal/cli/amq.go`: `amqCommandRequest.Stdin` field; `defaultRunAMQCommand` sets `cmd.Stdin`; `runAndWriteAMQWithStdin` variant; `passthroughNeedsStdin` detector; `splitAMQPassthroughArgs` now handles `--from` and `--body-file`.

## Test plan

- [ ] `make ci` green on `feat/178-amq-send-passthrough-parity`
- [ ] `TestSplitAMQPassthroughArgsParityFlags` (5 subtests) passes
- [ ] `TestPassthroughNeedsStdin` passes
- [ ] `TestAMQPassthroughSendForwardsStdin` passes

Closes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)