### PR TITLE
Publish status orchestration metadata

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -70,6 +70,9 @@ type statusEnvelopeData struct {
 	Profile      string            `json:"profile,omitempty"`
 	Operator     team.OperatorView `json:"operator"`
 	Capabilities team.Capabilities `json:"capabilities"`
+	Orchestrated bool              `json:"orchestrated,omitempty"`
+	Lead         string            `json:"lead,omitempty"`
+	LeadHandle   string            `json:"lead_handle,omitempty"`
 	Records      []statusRecord    `json:"records"`
 	// Actions are the SESSION-scope operator actions (status / resume preview /
 	// resume in current window / resume in new tmux session / stop), the catalog
@@ -96,6 +99,29 @@ type statusRecord struct {
 	// Actions are the stable, project-scoped commands a client can render/copy
 	// for this member (focus/send/resume/status). Populated for --json only.
 	Actions []runtimeActionJSON `json:"actions,omitempty"`
+}
+
+type sessionStatusContext struct {
+	Team         team.Team
+	Profile      string
+	Workstream   string
+	Orchestrated bool
+	Lead         string
+	LeadHandle   string
+	Actions      []runtimeActionJSON
+}
+
+func newSessionStatusContext(t team.Team, profile, workstream, tmuxSession string) sessionStatusContext {
+	orchestrated, lead, leadHandle := orchestrationStatusFields(t)
+	return sessionStatusContext{
+		Team:         t,
+		Profile:      profile,
+		Workstream:   workstream,
+		Orchestrated: orchestrated,
+		Lead:         lead,
+		LeadHandle:   leadHandle,
+		Actions:      sessionActions(t.Project, profile, workstream, tmuxSession),
+	}
 }
 
 func runStatus(args []string) error {
@@ -185,64 +211,25 @@ func executeStatus(s statusExecution) error {
 		return err
 	}
 
-	// Share one tmux pane snapshot across this whole command: live-replacement
-	// detection inside classifyMemberStatus and pane_alive resolution below
-	// both read statusPaneLister, so memoize it for the command's duration —
-	// `tmux list-panes` runs at most once and both readings see the same
-	// snapshot (avoiding N+1 calls and snapshot skew).
-	restoreLister := statusPaneLister
-	statusPaneLister = memoizePaneLister(restoreLister)
-	defer func() { statusPaneLister = restoreLister }()
-
-	members := orderedTeamMembers(t.Members)
-	rows := make([]statusRecord, 0, len(members))
-	for _, m := range members {
-		rows = append(rows, classifyMemberStatus(t, m, workstream, s.Probe))
-	}
-	// #95: adopt a live tmux pane for live agents with no recorded tmux identity
-	// (launched outside amq-squad's tmux backend, e.g. a raw `tmux new-window`),
-	// so focus/send/attach_control and pane_alive work for them too. Resolved by
-	// PID lineage + cwd/engine from the memoized pane snapshot.
-	pidTree := childrenPidTree()
-	for i := range rows {
-		// Only verified AGENT-live agents adopt by PID lineage: Signals.AgentPID
-		// is then a confirmed live process of the right binary. wake-live /
-		// presence-live have no verified agent pid, so do not trust lineage there
-		// (#95 review).
-		if rows[i].Tmux == nil && rows[i].Signals.AgentAlive && rows[i].Signals.BinaryMatch {
-			if panes, perr := statusPaneLister(); perr == nil {
-				if adopted := adoptLivePane(rows[i].Role, rows[i].Handle, rows[i].Binary, rows[i].CWD, workstream, rows[i].Signals.AgentPID, panes, pidTree); adopted != nil {
-					rows[i].Tmux = tmuxRuntimeFromInfo(adopted)
-				}
-			}
-		}
-	}
-	// Resolve pane liveness for every member that recorded a tmux pane, so
-	// clients can tell a still-valid pane from a stale launch record. Uses the
-	// same memoized snapshot as classification above.
-	var livePanes map[string]bool
-	for i := range rows {
-		if rows[i].Tmux != nil {
-			if livePanes == nil {
-				livePanes = livePaneIDSet(statusPaneLister)
-			}
-			fillPaneAlive(rows[i].Tmux, livePanes)
-		}
-	}
+	rows := buildStatusRows(t, workstream, s.Probe)
 	if s.JSON {
 		// Attach the stable action commands a client can render/copy per member.
 		for i := range rows {
 			alive := rows[i].Tmux != nil && rows[i].Tmux.PaneAlive
 			rows[i].Actions = memberActions(t.Project, s.Profile, workstream, rows[i].Role, alive)
 		}
+		ctx := newSessionStatusContext(t, s.Profile, workstream, firstLiveTmuxSession(rows))
 		return writeJSONEnvelope(s.Out, "status", statusEnvelopeData{
 			TeamHome:     t.Project,
 			Workstream:   workstream,
 			Profile:      s.Profile,
 			Operator:     team.EffectiveOperator(t),
 			Capabilities: team.EffectiveCapabilities(t),
+			Orchestrated: ctx.Orchestrated,
+			Lead:         ctx.Lead,
+			LeadHandle:   ctx.LeadHandle,
 			Records:      rows,
-			Actions:      sessionActions(t.Project, s.Profile, workstream, firstLiveTmuxSession(rows)),
+			Actions:      ctx.Actions,
 		})
 	}
 	policy := outputPolicyCurrent()
@@ -257,6 +244,59 @@ func executeStatus(s statusExecution) error {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.Role, r.Handle, r.Binary, r.Session, colorStatus(policy, string(r.Status)), r.Detail)
 	}
 	return w.Flush()
+}
+
+func buildStatusRows(t team.Team, workstream string, probe duplicateLaunchProbe) []statusRecord {
+	// Share one tmux pane snapshot across this whole command: live-replacement
+	// detection inside classifyMemberStatus and pane_alive resolution below
+	// both read statusPaneLister, so memoize it for the command's duration.
+	restoreLister := statusPaneLister
+	statusPaneLister = memoizePaneLister(restoreLister)
+	defer func() { statusPaneLister = restoreLister }()
+
+	members := orderedTeamMembers(t.Members)
+	rows := make([]statusRecord, 0, len(members))
+	for _, m := range members {
+		rows = append(rows, classifyMemberStatus(t, m, workstream, probe))
+	}
+	// #95: adopt a live tmux pane for live agents with no recorded tmux identity
+	// (launched outside amq-squad's tmux backend, e.g. a raw `tmux new-window`),
+	// so focus/send/attach_control and pane_alive work for them too.
+	pidTree := childrenPidTree()
+	for i := range rows {
+		if rows[i].Tmux == nil && rows[i].Signals.AgentAlive && rows[i].Signals.BinaryMatch {
+			if panes, perr := statusPaneLister(); perr == nil {
+				if adopted := adoptLivePane(rows[i].Role, rows[i].Handle, rows[i].Binary, rows[i].CWD, workstream, rows[i].Signals.AgentPID, panes, pidTree); adopted != nil {
+					rows[i].Tmux = tmuxRuntimeFromInfo(adopted)
+				}
+			}
+		}
+	}
+	var livePanes map[string]bool
+	for i := range rows {
+		if rows[i].Tmux != nil {
+			if livePanes == nil {
+				livePanes = livePaneIDSet(statusPaneLister)
+			}
+			fillPaneAlive(rows[i].Tmux, livePanes)
+		}
+	}
+	return rows
+}
+
+func orchestrationStatusFields(t team.Team) (bool, string, string) {
+	if !t.Orchestrated {
+		return false, "", ""
+	}
+	lead := strings.TrimSpace(t.Lead)
+	leadHandle := lead
+	for _, m := range t.Members {
+		if m.Role == lead {
+			leadHandle = memberHandle(m)
+			break
+		}
+	}
+	return true, lead, leadHandle
 }
 
 func firstStatusRoot(rows []statusRecord) string {

--- a/internal/cli/status_board.go
+++ b/internal/cli/status_board.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // boardState is the rolled-up run-state of a whole session, derived from its
@@ -68,6 +69,7 @@ const (
 type sessionBoardRow struct {
 	Name        string     `json:"name"`
 	Root        string     `json:"root"`
+	Profile     string     `json:"profile,omitempty"`
 	State       boardState `json:"state"`
 	AgentsTotal int        `json:"agents_total"`
 	AgentsAlive int        `json:"agents_alive"`
@@ -79,9 +81,13 @@ type sessionBoardRow struct {
 	// ghost records from a prior session does not pin a quiet session at
 	// "degraded"; they are still surfaced (count + "(+N stale)" note) so the
 	// operator can prune them.
-	AgentsStale  int       `json:"agents_stale,omitempty"`
-	Brief        string    `json:"brief,omitempty"`
-	LastActivity time.Time `json:"last_activity,omitempty"`
+	AgentsStale  int                 `json:"agents_stale,omitempty"`
+	Brief        string              `json:"brief,omitempty"`
+	LastActivity time.Time           `json:"last_activity,omitempty"`
+	Actions      []runtimeActionJSON `json:"actions,omitempty"`
+	Orchestrated bool                `json:"orchestrated,omitempty"`
+	Lead         string              `json:"lead,omitempty"`
+	LeadHandle   string              `json:"lead_handle,omitempty"`
 	briefKind    briefKind
 }
 
@@ -166,8 +172,17 @@ func executeStatusBoard(s statusBoardExecution) error {
 	}
 
 	rows := make([]sessionBoardRow, 0, len(snap.Sessions))
+	var profiles []boardProfile
+	if s.JSON {
+		profiles = boardProfilesForProject(s.ProjectDir)
+	}
+	statusProbe := duplicateProbeFromStateProbe(s.Probe, now)
 	for _, sess := range snap.Sessions {
-		rows = append(rows, boardRowFor(s.ProjectDir, sess, now()))
+		row := boardRowFor(s.ProjectDir, sess, now())
+		if s.JSON {
+			enrichBoardRow(profiles, sess, statusProbe, &row)
+		}
+		rows = append(rows, row)
 	}
 
 	if s.JSON {
@@ -177,6 +192,95 @@ func executeStatusBoard(s statusBoardExecution) error {
 		})
 	}
 	return renderBoardTable(s.Out, snap.BaseRoot, rows, now())
+}
+
+type boardProfile struct {
+	Name string
+	Team team.Team
+}
+
+func boardProfilesForProject(projectDir string) []boardProfile {
+	names, err := configuredTeamProfiles(projectDir)
+	if err != nil {
+		return nil
+	}
+	out := make([]boardProfile, 0, len(names))
+	for _, name := range names {
+		t, err := team.ReadProfile(projectDir, name)
+		if err != nil {
+			continue
+		}
+		out = append(out, boardProfile{Name: name, Team: t})
+	}
+	return out
+}
+
+func duplicateProbeFromStateProbe(p state.Probe, now func() time.Time) duplicateLaunchProbe {
+	if p.PIDAlive == nil {
+		p.PIDAlive = state.DefaultProbe.PIDAlive
+	}
+	if p.ProcessMatch == nil {
+		p.ProcessMatch = state.DefaultProbe.ProcessMatch
+	}
+	if p.Now == nil {
+		p.Now = now
+	}
+	return duplicateLaunchProbe{
+		PIDAlive:     p.PIDAlive,
+		ProcessMatch: p.ProcessMatch,
+		Now:          p.Now,
+	}
+}
+
+func enrichBoardRow(profiles []boardProfile, sess state.Session, probe duplicateLaunchProbe, row *sessionBoardRow) {
+	profile, t, ok := boardProfileForSession(profiles, sess)
+	if !ok {
+		return
+	}
+	statusRows := buildStatusRows(t, sess.Name, probe)
+	ctx := newSessionStatusContext(t, profile, sess.Name, firstLiveTmuxSession(statusRows))
+	row.Profile = ctx.Profile
+	row.Actions = ctx.Actions
+	row.Orchestrated = ctx.Orchestrated
+	row.Lead = ctx.Lead
+	row.LeadHandle = ctx.LeadHandle
+}
+
+func boardProfileForSession(profiles []boardProfile, sess state.Session) (string, team.Team, bool) {
+	if profile, ok := launchProfileForSession(sess); ok {
+		for _, p := range profiles {
+			if p.Name == profile {
+				return p.Name, p.Team, true
+			}
+		}
+	}
+	for _, p := range profiles {
+		workstream, err := resolveTeamWorkstreamName(p.Team, "", false)
+		if err == nil && workstream == sess.Name {
+			return p.Name, p.Team, true
+		}
+	}
+	return "", team.Team{}, false
+}
+
+func launchProfileForSession(sess state.Session) (string, bool) {
+	seen := map[string]bool{}
+	for _, a := range sess.Agents {
+		profile := strings.TrimSpace(a.TeamProfile)
+		if profile == "" {
+			profile = team.DefaultProfile
+		}
+		seen[profile] = true
+	}
+	if len(seen) == 0 {
+		return "", false
+	}
+	profiles := make([]string, 0, len(seen))
+	for profile := range seen {
+		profiles = append(profiles, profile)
+	}
+	sort.Strings(profiles)
+	return profiles[0], true
 }
 
 // boardStaleRecordAge is how cold a leftover (stale/dead/missing) agent record

--- a/internal/cli/status_board_test.go
+++ b/internal/cli/status_board_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // boardNow is the deterministic clock anchoring the board tests so relative
@@ -327,6 +330,90 @@ func TestStatusBoardSessionsJSONEnvelope(t *testing.T) {
 	}
 	if running := byName["running-ws"]; running.AgentsAlive != 1 || running.AgentsTotal != 1 {
 		t.Errorf("running-ws alive/total = %d/%d, want 1/1", running.AgentsAlive, running.AgentsTotal)
+	}
+}
+
+func TestStatusBoardJSONCarriesProfileActionsAndOrchestration(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	proj := t.TempDir()
+	if err := team.Write(proj, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "lead-handle", Session: "running-ws"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "running-ws"},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedAgentRecord(t, base, "running-ws", "lead-handle", launch.Record{
+		Binary: "codex", Handle: "lead-handle", Role: "cto", Session: "running-ws", AgentPID: 1111,
+		TeamProfile: team.DefaultProfile,
+		Tmux:        &launch.TmuxInfo{Session: "tmux-running-ws", PaneID: "%118"},
+	})
+	seedBoardPresence(t, base, "running-ws", "lead-handle", "active", boardNow.Add(-30*time.Second))
+	swapStatusPaneLister(t, []tmuxpane.TmuxPane{{PaneID: "%118"}}, nil)
+
+	probe := boardProbe(map[int]bool{1111: true}, map[int]bool{1111: true})
+	boardOut, err := runBoardExec(t, base, proj, probe, true)
+	if err != nil {
+		t.Fatalf("board --json: %v\n%s", err, boardOut)
+	}
+	boardEnv := decodeJSONEnvelope[sessionsEnvelopeData](t, boardOut)
+	if len(boardEnv.Data.Sessions) != 1 {
+		t.Fatalf("sessions = %+v, want one", boardEnv.Data.Sessions)
+	}
+	row := boardEnv.Data.Sessions[0]
+	if row.Profile != team.DefaultProfile {
+		t.Fatalf("board profile = %q, want default", row.Profile)
+	}
+	if !row.Orchestrated || row.Lead != "cto" || row.LeadHandle != "lead-handle" {
+		t.Fatalf("board orchestration = orchestrated:%v lead:%q lead_handle:%q, want true/cto/lead-handle", row.Orchestrated, row.Lead, row.LeadHandle)
+	}
+	if len(row.Actions) == 0 {
+		t.Fatalf("board actions empty: %+v", row)
+	}
+
+	statusOut, err := runStatusExec(t, statusExecution{
+		ProjectDir:       proj,
+		RequestedSession: "running-ws",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(map[int]bool{1111: true}, map[int]bool{1111: true}, boardNow),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, statusOut)
+	}
+	statusEnv := decodeJSONEnvelope[statusEnvelopeData](t, statusOut)
+	if !reflect.DeepEqual(row.Actions, statusEnv.Data.Actions) {
+		t.Fatalf("board actions differ from single-session actions\nboard:  %+v\nstatus: %+v", row.Actions, statusEnv.Data.Actions)
+	}
+	if row.Actions[len(row.Actions)-1].Kind != "attach_control" {
+		t.Fatalf("board actions should include attach_control for live tmux session: %+v", row.Actions)
+	}
+}
+
+func TestStatusBoardJSONOmitsOrchestrationForFlatTeams(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	proj := t.TempDir()
+	if err := team.Write(proj, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "flat-ws"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedAgentRecord(t, base, "flat-ws", "cto", launch.Record{
+		Binary: "codex", Handle: "cto", Role: "cto", Session: "flat-ws", AgentPID: 1111,
+	})
+	seedBoardPresence(t, base, "flat-ws", "cto", "active", boardNow.Add(-30*time.Second))
+
+	out, err := runBoardExec(t, base, proj, boardProbe(map[int]bool{1111: true}, map[int]bool{1111: true}), true)
+	if err != nil {
+		t.Fatalf("board --json: %v\n%s", err, out)
+	}
+	for _, absent := range []string{`"orchestrated"`, `"lead"`, `"lead_handle"`} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("flat board JSON should omit %s:\n%s", absent, out)
+		}
 	}
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -456,12 +456,14 @@ func TestExecuteStatusJSON(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "cto", Binary: "codex", Handle: "lead-handle", Session: "issue-96"},
 			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "issue-96"},
 		},
+		Orchestrated: true,
+		Lead:         "cto",
 	})
-	seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
-		Binary: "codex", Handle: "cto", AgentPID: 100,
+	seedAgentRecord(t, base, "issue-96", "lead-handle", launch.Record{
+		Binary: "codex", Handle: "lead-handle", AgentPID: 100,
 	})
 
 	out, err := runStatusExec(t, statusExecution{
@@ -477,6 +479,9 @@ func TestExecuteStatusJSON(t *testing.T) {
 	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
 	if env.Kind != "status" {
 		t.Errorf("envelope kind = %q, want status", env.Kind)
+	}
+	if !env.Data.Orchestrated || env.Data.Lead != "cto" || env.Data.LeadHandle != "lead-handle" {
+		t.Fatalf("orchestration fields = orchestrated:%v lead:%q lead_handle:%q, want true/cto/lead-handle", env.Data.Orchestrated, env.Data.Lead, env.Data.LeadHandle)
 	}
 	rows := env.Data.Records
 	if len(rows) != 2 {
@@ -499,6 +504,28 @@ func TestExecuteStatusJSON(t *testing.T) {
 	}
 	if fullstackRow.Status != statusStateMissing {
 		t.Errorf("fullstack status = %q, want missing", fullstackRow.Status)
+	}
+}
+
+func TestExecuteStatusJSONOmitsOrchestrationForFlatTeams(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, time.Now()),
+	})
+	if err != nil {
+		t.Fatalf("status: %v\n%s", err, out)
+	}
+	for _, absent := range []string{`"orchestrated"`, `"lead"`, `"lead_handle"`} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("flat status JSON should omit %s:\n%s", absent, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- publish orchestrated, lead, and lead_handle in single-session status JSON for orchestrated teams
- enrich board JSON rows with profile-aware actions and the same orchestration metadata
- compare board session actions against single-session status actions, including live tmux attach_control parity

## Verification
- make ci

Closes #118
Closes #119