### PR TITLE
feat(#26): add team rules templates

### DIFF
--- a/README.html
+++ b/README.html
@@ -919,8 +919,18 @@ amq-squad team init [--project DIR] [--profile NAME] [--roles a,b|numbers|all] [
                                   --orchestrated [--lead ROLE] opts the squad
                                   into lead-agent orchestration (see Orchestration).
                                   --project targets a team-home without cd.
-amq-squad team rules init [--project DIR] [--force]
+amq-squad team rules templates
+                                  List available team-rules templates.
+amq-squad team rules init [--project DIR] [--profile NAME]
+                     [--template auto|dev-only|product-squad|scrum|custom] [--force]
                                   Seed or refresh .amq-squad/team-rules.md.
+                                  auto selects from the configured roster:
+                                  dev-only for engineering teams,
+                                  product-squad when product/design roles are
+                                  present, scrum for Scrum accountabilities,
+                                  and custom otherwise. --profile renders a
+                                  named profile while keeping team-rules.md
+                                  shared per team-home.
 amq-squad team rules show [--project DIR]
                                   Print .amq-squad/team-rules.md.
 amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]

--- a/README.md
+++ b/README.md
@@ -445,8 +445,18 @@ amq-squad team init [--project DIR] [--profile NAME] [--roles a,b|numbers|all] [
                                   --orchestrated [--lead ROLE] opts the squad
                                   into lead-agent orchestration (see Orchestration).
                                   --project targets a team-home without cd.
-amq-squad team rules init [--project DIR] [--force]
+amq-squad team rules templates
+                                  List available team-rules templates.
+amq-squad team rules init [--project DIR] [--profile NAME]
+                     [--template auto|dev-only|product-squad|scrum|custom] [--force]
                                   Seed or refresh .amq-squad/team-rules.md.
+                                  auto selects from the configured roster:
+                                  dev-only for engineering teams,
+                                  product-squad when product/design roles are
+                                  present, scrum for Scrum accountabilities,
+                                  and custom otherwise. --profile renders a
+                                  named profile while keeping team-rules.md
+                                  shared per team-home.
 amq-squad team rules show [--project DIR]
                                   Print .amq-squad/team-rules.md.
 amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -118,6 +118,7 @@ var completionTeamSubcommands = []string{
 var completionTeamRulesSubcommands = []string{
 	"init",
 	"show",
+	"templates",
 }
 
 // completionTeamMemberSubcommands lists `amq-squad team member` subcommands.
@@ -251,6 +252,7 @@ var completionCommonFlags = []string{
 	"--target-id",
 	"--target-project",
 	"--target-session",
+	"--template",
 	"--team-home",
 	"--team-profile",
 	"--team-workstream",

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1350,13 +1350,18 @@ func runTeamRules(args []string) error {
 Usage:
   amq-squad team rules show [--project DIR]
                                        Print team-rules.md
-  amq-squad team rules init [--project DIR] [--force]
+  amq-squad team rules init [--project DIR] [--profile NAME] [--template auto|dev-only|product-squad|scrum|custom] [--force]
                                        Seed or refresh team-rules.md
+  amq-squad team rules templates
+                                       List available templates
 
 Examples:
+  amq-squad team rules templates
   amq-squad team rules show
   amq-squad team rules show --project ~/Code/app
   amq-squad team rules init
+  amq-squad team rules init --template product-squad
+  amq-squad team rules init --profile codex-v2-5-0 --template auto --force
   amq-squad team rules init --project ~/Code/app
   amq-squad team rules init --force
 `)
@@ -1366,6 +1371,24 @@ Examples:
 		return nil
 	}
 	switch args[0] {
+	case "templates":
+		fs := flag.NewFlagSet("team rules templates", flag.ContinueOnError)
+		fs.Usage = func() {
+			fmt.Fprint(os.Stderr, `amq-squad team rules templates - list available team-rules templates
+
+Usage:
+  amq-squad team rules templates
+
+Templates can be used with 'amq-squad team rules init --template NAME'.
+`)
+		}
+		if err := parseFlags(fs, args[1:]); err != nil {
+			return err
+		}
+		for _, tmpl := range teamRulesTemplates {
+			fmt.Fprintf(os.Stdout, "%-14s %s\n", tmpl.Name, tmpl.Description)
+		}
+		return nil
 	case "show":
 		fs := flag.NewFlagSet("team rules show", flag.ContinueOnError)
 		projectFlag := fs.String("project", "", "project/team-home directory to inspect (default: cwd)")
@@ -1412,16 +1435,22 @@ Examples:
 		fs := flag.NewFlagSet("team rules init", flag.ContinueOnError)
 		force := fs.Bool("force", false, "overwrite an existing team-rules.md with the generated template")
 		projectFlag := fs.String("project", "", "project/team-home directory to update (default: cwd)")
+		profileFlag := fs.String("profile", "", "team profile to render when reading team.json (default: default)")
+		templateFlag := fs.String("template", "auto", "team-rules template: auto, dev-only, product-squad, scrum, or custom")
 		fs.Usage = func() {
 			fmt.Fprint(os.Stderr, `amq-squad team rules init - seed or refresh .amq-squad/team-rules.md
 
 Usage:
-  amq-squad team rules init [--project DIR] [--force]
+  amq-squad team rules init [--project DIR] [--profile NAME] [--template auto|dev-only|product-squad|scrum|custom] [--force]
 
 --project targets another team-home without changing directories.
+--profile renders a named team profile. team-rules.md is still shared per team-home.
+--template auto selects dev-only, product-squad, scrum, or custom from the roster.
 
 Examples:
   amq-squad team rules init
+  amq-squad team rules init --template dev-only
+  amq-squad team rules init --profile codex-v2-5-0 --template auto --force
   amq-squad team rules init --project ~/Code/app
   amq-squad team rules init --force
 `)
@@ -1437,13 +1466,30 @@ Examples:
 		if err != nil {
 			return err
 		}
+		profile, err := resolveProfileFlag(*profileFlag)
+		if err != nil {
+			return err
+		}
 		content := rules.StubContent
-		if t, err := team.Read(projectDir); err == nil {
-			rendered, err := renderTeamRules(t)
+		if team.ExistsProfile(projectDir, profile) {
+			t, err := team.ReadProfile(projectDir, profile)
+			if err != nil {
+				return fmt.Errorf("read profile %q: %w", profile, err)
+			}
+			selectedTemplate, err := selectTeamRulesTemplate(*templateFlag, t)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(*templateFlag) == "" || strings.TrimSpace(*templateFlag) == "auto" {
+				quietNotice("Selected team-rules template: %s\n", selectedTemplate)
+			}
+			rendered, err := renderTeamRulesWithTemplate(t, selectedTemplate)
 			if err != nil {
 				return fmt.Errorf("render team-rules.md: %w", err)
 			}
 			content = rendered
+		} else if flagWasSet(fs, "profile") {
+			return fmt.Errorf("team profile %q not found at %s", profile, team.ProfilePath(projectDir, profile))
 		}
 		if *force {
 			if err := rules.Write(projectDir, content); err != nil {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1470,6 +1470,9 @@ Examples:
 		if err != nil {
 			return err
 		}
+		if _, err := selectTeamRulesTemplate(*templateFlag, team.Team{}); err != nil {
+			return err
+		}
 		content := rules.StubContent
 		if team.ExistsProfile(projectDir, profile) {
 			t, err := team.ReadProfile(projectDir, profile)

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -31,7 +31,7 @@ func renderTeamRules(t team.Team) (string, error) {
 func renderTeamRulesWithTemplate(t team.Team, template string) (string, error) {
 	var b strings.Builder
 	projectDir := t.Project
-	workstream, err := resolveTeamWorkstreamName(t, "", false)
+	fallbackWorkstream, err := resolveTeamWorkstreamName(t, "", false)
 	if err != nil {
 		return "", err
 	}
@@ -50,7 +50,7 @@ func renderTeamRulesWithTemplate(t team.Team, template string) (string, error) {
 
 	for _, m := range t.Members {
 		fmt.Fprintf(&b, "%s, default workstream `%s`, cwd `%s`. %s\n",
-			memberRosterPrefix(m), workstream, m.EffectiveCWD(projectDir), roleScope(m.Role))
+			memberRosterPrefix(m), memberRulesWorkstream(m, fallbackWorkstream), m.EffectiveCWD(projectDir), roleScope(m.Role))
 	}
 	if team.SupportsOperatorGates(t) {
 		op := team.EffectiveOperator(t)
@@ -125,6 +125,13 @@ func renderTeamRulesWithTemplate(t team.Team, template string) (string, error) {
 	b.WriteString("- Do not use em dashes.\n")
 	b.WriteString("- Do not rewrite unrelated files.\n")
 	return b.String(), nil
+}
+
+func memberRulesWorkstream(m team.Member, fallback string) string {
+	if session := strings.TrimSpace(m.Session); session != "" {
+		return session
+	}
+	return fallback
 }
 
 func selectTeamRulesTemplate(requested string, t team.Team) (string, error) {

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -8,16 +8,41 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
+type teamRulesTemplate struct {
+	Name        string
+	Description string
+}
+
+var teamRulesTemplates = []teamRulesTemplate{
+	{Name: "dev-only", Description: "Engineering-only squads with strong ownership, review gates, and technical decision norms."},
+	{Name: "product-squad", Description: "Product, design, engineering, and QA squads with discovery-to-delivery handoff contracts."},
+	{Name: "scrum", Description: "Scrum-accountability squads using Product Owner, Scrum Master, and Developers framing."},
+	{Name: "custom", Description: "Lightweight operating rules for custom role mixes that do not fit a standard template."},
+}
+
 func renderTeamRules(t team.Team) (string, error) {
+	template, err := selectTeamRulesTemplate("auto", t)
+	if err != nil {
+		return "", err
+	}
+	return renderTeamRulesWithTemplate(t, template)
+}
+
+func renderTeamRulesWithTemplate(t team.Team, template string) (string, error) {
 	var b strings.Builder
 	projectDir := t.Project
 	workstream, err := resolveTeamWorkstreamName(t, "", false)
 	if err != nil {
 		return "", err
 	}
+	template, err = selectTeamRulesTemplate(template, t)
+	if err != nil {
+		return "", err
+	}
 	b.WriteString("# Team Rules\n\n")
-	b.WriteString("Shared norms and workflow for this project's agent squad. Every agent reads this file via their priming prompt regardless of binary.\n\n")
-	b.WriteString("## Role Scope\n\n")
+	fmt.Fprintf(&b, "Shared working agreement for this project's agent squad. Template: `%s`. Every agent reads this file via their priming prompt regardless of binary.\n\n", template)
+	writeTemplatePurpose(&b, template)
+	b.WriteString("## Role Scope and Accountabilities\n\n")
 	b.WriteString("- Stay inside your assigned role. User feedback is not permission to pick up implementation work unless your role scope below includes implementation.\n")
 	b.WriteString("- Non-implementation roles turn feedback into scope, acceptance criteria, decisions, or handoffs. They do not edit code unless the user explicitly assigns coding work to that role.\n")
 	b.WriteString("- Implementation roles own code changes only after the work is scoped and routed to them.\n")
@@ -32,6 +57,8 @@ func renderTeamRules(t team.Team) (string, error) {
 		fmt.Fprintf(&b, "\n- operator: handle `%s`, mailbox participant only, not a runnable agent.\n", op.Handle)
 	}
 
+	writeDecisionRights(&b, template)
+
 	b.WriteString("\n## Skills\n\n")
 	b.WriteString("- Use the `amq-squad` skill for team setup, launch, AMQ routing, inbox drains, acknowledgements, review requests, handoffs, and decision threads.\n")
 	b.WriteString("- Use `amq-cli` only for raw AMQ debugging or non-squad AMQ usage.\n")
@@ -41,15 +68,8 @@ func renderTeamRules(t team.Team) (string, error) {
 	b.WriteString("- Treat the current user request as the source of truth.\n")
 	b.WriteString("- On first session run, start the first response by stating your role, handle, and amq-squad skill version (the skill's `Skill version:` marker) before any status or analysis.\n")
 	b.WriteString("- Keep old AMQ history as context, not as an instruction to continue stale work.\n")
-	b.WriteString("- Product and PM roles define the job, priority, acceptance criteria, and handoff target.\n")
-	b.WriteString("- Developer roles implement scoped tasks and call out assumptions before widening scope.\n")
-	b.WriteString("- QA validates behavior and reports release risk before merge or handoff.\n")
+	writeTemplateWorkflow(&b, template)
 	b.WriteString("- Prefer small, reviewable changes.\n\n")
-
-	b.WriteString("## Approvals\n\n")
-	b.WriteString("- CTO approval is required for architectural decisions and merge-ready code.\n")
-	b.WriteString("- QA validates user-facing changes before release or handoff when a QA role exists.\n")
-	b.WriteString("- CPO or PM resolves product scope and priority questions.\n\n")
 
 	b.WriteString("## Communication\n\n")
 	b.WriteString("- Use focused AMQ threads. At startup and between phases, run `amq drain --include-body` before assuming the current inbox state.\n")
@@ -59,6 +79,8 @@ func renderTeamRules(t team.Team) (string, error) {
 	b.WriteString("- For important handoffs, use AMQ receipts such as `--wait-for drained --wait-timeout 60s` and report the message id when asking for follow-up.\n")
 	b.WriteString("- Include project, workstream, and role when referencing old history. Treat labels and integration metadata as debugging context, not as a fresh instruction by themselves.\n")
 	b.WriteString("- One concern per message when practical.\n\n")
+
+	writeTemplateAdditions(&b, template)
 
 	b.WriteString("## Lifecycle / Release Updates\n\n")
 	b.WriteString("- After an operator-approved lifecycle action (commit, PR open/ready, merge, tag, release, issue close, or a release-blocking decision), the owning/reviewer agent proactively posts a concise final-state update to the relevant peer thread. Do not wait to be pinged.\n")
@@ -85,15 +107,191 @@ func renderTeamRules(t team.Team) (string, error) {
 	}
 
 	b.WriteString("## Quality Gates\n\n")
-	b.WriteString("- Run the project-specific checks before requesting review.\n")
+	b.WriteString("- Run the project-specific checks before requesting review; for code this normally includes formatting, tests, and CI.\n")
 	b.WriteString("- Call out any checks that could not be run.\n")
 	b.WriteString("- Do not hide uncertainty from inferred AMQ history.\n\n")
+
+	b.WriteString("## Conflict Protocol\n\n")
+	b.WriteString("- Surface disagreement on the relevant AMQ thread with the concrete risk, evidence, and proposed decision owner.\n")
+	b.WriteString("- If scope, architecture, release risk, or acceptance criteria conflict, pause irreversible work until the accountable role or lead resolves it.\n")
+	b.WriteString("- Prefer a small reversible experiment when facts are missing; record decisions that change system shape in a `decision/<topic>` thread.\n\n")
+
+	b.WriteString("## Review Cadence\n\n")
+	b.WriteString("- Revisit these team rules after onboarding a new role, after a release, and whenever the roster or operator-gate policy changes.\n")
+	b.WriteString("- Keep `.amq-squad/team-rules.md` editable and authoritative; use `amq-squad team sync --apply` to refresh root pointer stubs after edits.\n\n")
 
 	b.WriteString("## Style\n\n")
 	b.WriteString("- Be direct and concise.\n")
 	b.WriteString("- Do not use em dashes.\n")
 	b.WriteString("- Do not rewrite unrelated files.\n")
 	return b.String(), nil
+}
+
+func selectTeamRulesTemplate(requested string, t team.Team) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		requested = "auto"
+	}
+	if requested != "auto" {
+		if isKnownTeamRulesTemplate(requested) {
+			return requested, nil
+		}
+		return "", fmt.Errorf("unknown team-rules template %q (use auto, dev-only, product-squad, scrum, or custom)", requested)
+	}
+	if hasScrumAccountabilities(t) {
+		return "scrum", nil
+	}
+	if hasProductSquadRole(t) {
+		return "product-squad", nil
+	}
+	if isDevOnlyTeam(t) {
+		return "dev-only", nil
+	}
+	return "custom", nil
+}
+
+func isKnownTeamRulesTemplate(name string) bool {
+	for _, tmpl := range teamRulesTemplates {
+		if tmpl.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasProductSquadRole(t team.Team) bool {
+	for _, m := range t.Members {
+		switch strings.ToLower(strings.TrimSpace(m.Role)) {
+		case "cpo", "pm", "designer":
+			return true
+		}
+	}
+	return false
+}
+
+func hasScrumAccountabilities(t team.Team) bool {
+	hasPO := false
+	hasSM := false
+	hasDev := false
+	for _, m := range t.Members {
+		role := strings.ToLower(strings.TrimSpace(m.Role))
+		switch role {
+		case "product-owner", "product_owner", "po":
+			hasPO = true
+		case "scrum-master", "scrum_master", "sm":
+			hasSM = true
+		case "developers", "developer":
+			hasDev = true
+		}
+		if strings.Contains(role, "product-owner") || strings.Contains(role, "product_owner") {
+			hasPO = true
+		}
+		if strings.Contains(role, "scrum-master") || strings.Contains(role, "scrum_master") {
+			hasSM = true
+		}
+		if strings.Contains(role, "developer") || strings.HasSuffix(role, "-dev") || strings.HasSuffix(role, "_dev") {
+			hasDev = true
+		}
+	}
+	return hasPO && hasSM && hasDev
+}
+
+func isDevOnlyTeam(t team.Team) bool {
+	if len(t.Members) == 0 {
+		return false
+	}
+	for _, m := range t.Members {
+		switch strings.ToLower(strings.TrimSpace(m.Role)) {
+		case "cto", "senior-dev", "fullstack", "frontend-dev", "backend-dev", "mobile-dev", "junior-dev", "qa":
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func writeTemplatePurpose(b *strings.Builder, template string) {
+	b.WriteString("## Purpose and Scope\n\n")
+	switch template {
+	case "dev-only":
+		b.WriteString("- Purpose: deliver scoped engineering changes with clear ownership, explicit architecture decisions, and reviewable implementation increments.\n")
+		b.WriteString("- Scope: technical scoping, implementation, validation, documentation, and release-readiness evidence for the configured project.\n")
+	case "product-squad":
+		b.WriteString("- Purpose: connect product intent to shippable implementation through explicit discovery, acceptance criteria, UX, engineering, and validation handoffs.\n")
+		b.WriteString("- Scope: user value, prioritization, design shape, technical feasibility, implementation, QA, and release-readiness evidence for the configured project.\n")
+	case "scrum":
+		b.WriteString("- Purpose: help a Scrum-style agent team turn a product goal into a useful increment while keeping accountabilities explicit.\n")
+		b.WriteString("- Scope: product goal clarity, backlog refinement, sprint or workstream planning, implementation, inspection, adaptation, and increment validation.\n")
+	default:
+		b.WriteString("- Purpose: give this custom agent team enough shared operating rules to start safely while preserving the user's ability to edit the charter.\n")
+		b.WriteString("- Scope: role boundaries, routing, decisions, workflow, validation, escalation, and review habits for the configured project.\n")
+	}
+	b.WriteString("\n")
+}
+
+func writeDecisionRights(b *strings.Builder, template string) {
+	b.WriteString("\n## Decision Rights\n\n")
+	b.WriteString("- Product scope and priority: CPO or PM decides when present; otherwise the user or team lead decides before implementation widens.\n")
+	b.WriteString("- Architecture and technical tradeoffs: CTO decides, with senior developer input when present.\n")
+	b.WriteString("- Implementation approach: the assigned developer owns the local plan inside approved scope and flags material tradeoffs early.\n")
+	b.WriteString("- QA and release risk: QA decides validation sufficiency when present; otherwise the implementing developer reports evidence and residual risk.\n")
+	b.WriteString("- Merge approval: the configured reviewer or lead gives final engineering sign-off; the human/operator owns explicit merge permission when required.\n")
+	switch template {
+	case "scrum":
+		b.WriteString("- Scrum accountabilities: Product Owner owns product goal and backlog clarity; Developers own the increment and technical plan; Scrum Master owns process health and impediment removal.\n")
+	case "product-squad":
+		b.WriteString("- UX acceptance: designer owns flow and interaction quality when present; engineering owns feasibility and implementation constraints.\n")
+	}
+}
+
+func writeTemplateWorkflow(b *strings.Builder, template string) {
+	switch template {
+	case "dev-only":
+		b.WriteString("- Intake starts with the user request or lead task; clarify scope and acceptance criteria before broad code changes.\n")
+		b.WriteString("- Developer roles implement scoped tasks, keep diffs reviewable, and call out assumptions before widening scope.\n")
+		b.WriteString("- Architecture-sensitive changes go through a CTO decision thread before implementation locks in.\n")
+		b.WriteString("- QA/testing responsibility stays explicit even when no dedicated QA role exists; the implementer reports validation and residual risk.\n")
+	case "product-squad":
+		b.WriteString("- Product roles define the problem, user value, priority, acceptance criteria, and handoff target.\n")
+		b.WriteString("- Design roles define flows, interaction quality, and visual constraints before engineering treats UX as settled.\n")
+		b.WriteString("- Developer roles own feasibility feedback and scoped implementation after product/design handoff is clear.\n")
+		b.WriteString("- QA validates behavior against acceptance criteria and reports release risk before merge or handoff.\n")
+	case "scrum":
+		b.WriteString("- Product Owner keeps the product goal, backlog ordering, and acceptance criteria clear enough for Developers to act.\n")
+		b.WriteString("- Developers plan and deliver the increment, including technical decomposition, implementation, tests, and done evidence.\n")
+		b.WriteString("- Scrum Master protects process health, removes impediments, and helps the team inspect and adapt.\n")
+		b.WriteString("- Sprint events may be used as lightweight rituals; do not treat them as mandatory ceremonies when the workstream does not need them.\n")
+	default:
+		b.WriteString("- Clarify intent, route the work to the accountable role, execute in small steps, and report evidence before handoff.\n")
+		b.WriteString("- Custom roles follow their `role.md`; when ownership is unclear, ask on AMQ instead of assuming authority.\n")
+		b.WriteString("- Validation belongs to the role that can prove the outcome; if no such role exists, the implementer reports checks and residual risk.\n")
+	}
+}
+
+func writeTemplateAdditions(b *strings.Builder, template string) {
+	switch template {
+	case "dev-only":
+		b.WriteString("## Engineering Ownership\n\n")
+		b.WriteString("- Every code change has one implementation owner and one reviewer before it is considered merge-ready.\n")
+		b.WriteString("- Code review posture is risk-first: correctness, maintainability, tests, and regression surface before style preferences.\n")
+		b.WriteString("- Handoffs include branch or diff location, exact checks run, unchecked risk, and any decision still needed.\n\n")
+	case "product-squad":
+		b.WriteString("## Discovery and Delivery Handoffs\n\n")
+		b.WriteString("- Product discovery artifacts name the user problem, priority, acceptance criteria, non-goals, and expected evidence.\n")
+		b.WriteString("- Design handoff names the intended flow, important states, edge cases, and constraints engineering must preserve.\n")
+		b.WriteString("- Engineering handoff names implementation approach, feasibility concerns, tests, and release-risk evidence.\n\n")
+	case "scrum":
+		b.WriteString("## Scrum Accountabilities\n\n")
+		b.WriteString("- Product Owner is accountable for product goal, backlog clarity, ordering, and acceptance criteria.\n")
+		b.WriteString("- Developers are accountable for creating the increment and for the technical plan, quality, and done evidence.\n")
+		b.WriteString("- Scrum Master is accountable for process health, impediment visibility, and team effectiveness.\n")
+		b.WriteString("- Optional rituals: planning, daily coordination, review, and retrospective. Use them when they improve delivery, not as ceremony.\n\n")
+	default:
+		b.WriteString("## Custom Role Contracts\n\n")
+		b.WriteString("- Keep custom role boundaries concrete in each `role.md`; do not rely on title alone for authority.\n")
+		b.WriteString("- When a custom role produces a handoff, include the decision needed, owner, evidence, and next action.\n\n")
+	}
 }
 
 // memberRosterPrefix is the stable leading segment of a member's line in the

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1511,6 +1511,134 @@ func TestRunTeamRulesInitForceRefreshesScopedRules(t *testing.T) {
 	}
 }
 
+func TestRunTeamRulesTemplatesListsAvailableTemplates(t *testing.T) {
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamRules([]string{"templates"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamRules templates: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("templates should be silent on stderr, got:\n%s", stderr)
+	}
+	for _, want := range []string{
+		"dev-only",
+		"product-squad",
+		"scrum",
+		"custom",
+		"Engineering-only squads",
+		"Product, design, engineering, and QA squads",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("templates output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestTeamRulesTemplateSelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		roles []string
+		want  string
+	}{
+		{name: "dev only", roles: []string{"cto", "fullstack", "qa"}, want: "dev-only"},
+		{name: "product squad", roles: []string{"pm", "designer", "fullstack"}, want: "product-squad"},
+		{name: "scrum accountabilities", roles: []string{"product-owner", "scrum-master", "developers"}, want: "scrum"},
+		{name: "custom", roles: []string{"rules-dev", "principal"}, want: "custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tm := team.Team{Project: t.TempDir()}
+			for _, role := range tt.roles {
+				tm.Members = append(tm.Members, team.Member{Role: role, Binary: "codex", Handle: role, Session: role})
+			}
+			got, err := selectTeamRulesTemplate("auto", tm)
+			if err != nil {
+				t.Fatalf("selectTeamRulesTemplate: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("template = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderTeamRulesTemplatesIncludeRequiredSections(t *testing.T) {
+	tm := team.Team{
+		Project: t.TempDir(),
+		Members: []team.Member{
+			{Role: "pm", Binary: "codex", Handle: "pm", Session: "shared"},
+			{Role: "designer", Binary: "codex", Handle: "designer", Session: "shared"},
+			{Role: "fullstack", Binary: "codex", Handle: "fullstack", Session: "shared"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "shared"},
+		},
+	}
+	for _, template := range []string{"dev-only", "product-squad", "scrum"} {
+		t.Run(template, func(t *testing.T) {
+			body, err := renderTeamRulesWithTemplate(tm, template)
+			if err != nil {
+				t.Fatalf("renderTeamRulesWithTemplate: %v", err)
+			}
+			for _, want := range []string{
+				"## Purpose and Scope",
+				"## Role Scope and Accountabilities",
+				"## Decision Rights",
+				"## Workflow",
+				"## Communication",
+				"## Quality Gates",
+				"## Conflict Protocol",
+				"## Review Cadence",
+				"pm (Project Manager / Product Owner): handle `pm`",
+				"fullstack (Fullstack Developer): handle `fullstack`",
+				"cwd `" + tm.Project + "`",
+			} {
+				if !strings.Contains(body, want) {
+					t.Errorf("%s template missing %q:\n%s", template, want, body)
+				}
+			}
+		})
+	}
+}
+
+func TestRunTeamRulesInitTemplateAutoUsesNamedProfile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := team.WriteProfile(dir, "codex-v2-5-0", team.Team{
+		Project: dir,
+		Members: []team.Member{
+			{Role: "pm", Binary: "codex", Handle: "pm", Session: "v2-5-0"},
+			{Role: "fullstack", Binary: "codex", Handle: "fullstack", Session: "v2-5-0"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runTeamRules([]string{"init", "--profile", "codex-v2-5-0", "--template", "auto", "--force"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamRules init named profile: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stderr, "Selected team-rules template: product-squad") {
+		t.Fatalf("auto selection notice missing from stderr:\n%s", stderr)
+	}
+	got, err := os.ReadFile(rules.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	for _, want := range []string{
+		"Template: `product-squad`",
+		"pm (Project Manager / Product Owner): handle `pm`",
+		"fullstack (Fullstack Developer): handle `fullstack`",
+		"Product discovery artifacts name the user problem",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("named-profile team-rules missing %q:\n%s", want, body)
+		}
+	}
+}
+
 func TestRunTeamRulesShowPrintsScopedRules(t *testing.T) {
 	dir := t.TempDir()
 	body := "# Team Rules\n\ncustom rules\n"

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1490,7 +1489,8 @@ func TestRunTeamRulesInitForceRefreshesScopedRules(t *testing.T) {
 		"pm (Project Manager / Product Owner)",
 		"Turns feedback into scoped tasks for the right owner. Does not implement code unless explicitly assigned by the user.",
 		"fullstack (Fullstack Developer)",
-		fmt.Sprintf("default workstream `%s`", defaultWorkstreamName(dir)),
+		"default workstream `pm`",
+		"default workstream `fullstack`",
 		"On first session run, start the first response by stating your role, handle, and amq-squad skill version",
 		"Use the `amq-squad` skill for team setup",
 		"Use `amq-cli` only for raw AMQ debugging",
@@ -1499,14 +1499,6 @@ func TestRunTeamRulesInitForceRefreshesScopedRules(t *testing.T) {
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("team-rules.md missing %q in:\n%s", want, body)
-		}
-	}
-	for _, legacy := range []string{
-		"default workstream `pm`",
-		"default workstream `fullstack`",
-	} {
-		if strings.Contains(body, legacy) {
-			t.Errorf("team-rules.md contains legacy role session %q in:\n%s", legacy, body)
 		}
 	}
 }
@@ -1636,6 +1628,61 @@ func TestRunTeamRulesInitTemplateAutoUsesNamedProfile(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("named-profile team-rules missing %q:\n%s", want, body)
 		}
+	}
+}
+
+func TestRunTeamRulesInitNamedProfilePreservesMixedMemberSessions(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := team.WriteProfile(dir, "codex-v2-5-0", team.Team{
+		Project: dir,
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "external-lead"},
+			{Role: "runtime-dev", Binary: "codex", Handle: "runtime-dev", Session: "v2-5-0"},
+			{Role: "rules-dev", Binary: "codex", Handle: "rules-dev", Session: "v2-5-0"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runTeamRules([]string{"init", "--profile", "codex-v2-5-0", "--template", "auto", "--force"})
+	})
+	if err != nil {
+		t.Fatalf("runTeamRules init named mixed profile: %v\nstderr:\n%s", err, stderr)
+	}
+	got, err := os.ReadFile(rules.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(got)
+	for _, want := range []string{
+		"cto (CTO): handle `cto`, default workstream `external-lead`",
+		"runtime-dev (runtime-dev): handle `runtime-dev`, default workstream `v2-5-0`",
+		"rules-dev (rules-dev): handle `rules-dev`, default workstream `v2-5-0`",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("mixed-session team-rules missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "default workstream `"+defaultWorkstreamName(dir)+"`") {
+		t.Errorf("mixed-session named profile should not collapse members to project fallback:\n%s", body)
+	}
+}
+
+func TestRunTeamRulesInitRejectsUnknownTemplateWithoutTeam(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := captureOutput(t, func() error {
+		return runTeamRules([]string{"init", "--project", dir, "--template", "nope", "--force"})
+	})
+	if err == nil {
+		t.Fatal("expected unknown template to fail even without a configured team")
+	}
+	if !strings.Contains(err.Error(), "unknown team-rules template") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(rules.Path(dir)); !os.IsNotExist(statErr) {
+		t.Fatalf("unknown template should not write team-rules.md, stat err = %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Closes #26.
- Adds `amq-squad team rules templates` to list available templates.
- Adds `amq-squad team rules init --template auto|dev-only|product-squad|scrum|custom` and `--profile` rendering for named profiles.
- Expands generated team rules into a working-agreement shape with purpose/scope, role accountabilities, decision rights, workflow, communication norms, quality gates, conflict protocol, review cadence, and template-specific sections.
- Updates README.md and regenerated README.html.

## Branch / Head
- Branch: `rules/templates-26-main`
- Head SHA: `5d14948dfefaf603176695c2f6e4964cd0ddf0d5`
- Base: `main` from `3c5eba5c28f32ad35580af7ec6be424370d148b3`

## Validation
- `go test ./internal/cli` passed.
- `git diff --check` clean.
- `make ci` passed, including README/docs HTML freshness and skill frontmatter checks.
- Independent Codex principal review passed at exact head `5d14948dfefaf603176695c2f6e4964cd0ddf0d5`.

## Dogfood / Preview
- Built local binary from the corrected worktree with `go build -o amq-squad ./cmd/amq-squad`.
- Copied the real `codex-v2-5-0` profile to a temp team-home and ran `./amq-squad team rules templates` plus `./amq-squad team rules init --project <tmp> --profile codex-v2-5-0 --template auto --force`.
- Auto selected `custom` for `codex-v2-5-0`, expected because that roster uses custom roles: `runtime-dev`, `amq-dev`, `rules-dev`, and `principal`.
- Verified mixed-session rendering preserves `cto` as `external-lead` while worker roles remain on `v2-5-0`.
- Verified `--template nope --force` fails in an empty project and does not write `team-rules.md`.
- Ran against the real team-home without `--force`: `./amq-squad team rules init --project /Users/omri.a/Code/amq-squad --profile codex-v2-5-0 --template auto`; it selected `custom` and left the existing live `.amq-squad/team-rules.md` unchanged.

## Merge
Do not merge without explicit operator approval.
