### PR TITLE
Adopt AMQ 0.37.1 wake features

### DIFF
--- a/README.html
+++ b/README.html
@@ -458,7 +458,7 @@ mailbox). AMQ itself stays unchanged.</p>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
 <p>Requires Go 1.25+, the <code>amq</code> binary on <code>PATH</code>
-(v0.34+), and <code>tmux</code> on <code>PATH</code> for
+(v0.37.1+), and <code>tmux</code> on <code>PATH</code> for
 <code>amq-squad up</code>.</p>
 <h3 id="skills-plugin-marketplaces">Skills (plugin marketplaces)</h3>
 <p>This repo doubles as a plugin marketplace that ships the amq-squad
@@ -1556,7 +1556,7 @@ project's <code>.amqrc</code> for cross-project AMQ routing.
 <h2 id="requires">Requires</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> binary on <code>PATH</code> (v0.34+)</li>
+<li><code>amq</code> binary on <code>PATH</code> (v0.37.1+)</li>
 <li><code>tmux</code> on <code>PATH</code> for
 <code>amq-squad up</code></li>
 </ul>

--- a/README.html
+++ b/README.html
@@ -1404,11 +1404,11 @@ resume reproduces it.</p>
 <p>For external-injector wake setups, pass
 <code>--wake-inject-via /absolute/injector</code> and repeat
 <code>--wake-inject-arg=value</code> as needed on <code>agent up</code>,
-<code>up</code>, or <code>team show</code>. These flags are forwarded to
-<code>amq coop exec</code>, persisted in <code>launch.json</code>, and
-replayed by <code>agent resume</code>. Use the <code>--flag=value</code>
-form for dash-prefixed injector arguments such as
-<code>--wake-inject-arg=--pane</code>.</p>
+<code>up</code>, or <code>up --dry-run</code> launch-plan output. These
+flags are forwarded to <code>amq coop exec</code>, persisted in
+<code>launch.json</code>, and replayed by <code>agent resume</code>. Use
+the <code>--flag=value</code> form for dash-prefixed injector arguments
+such as <code>--wake-inject-arg=--pane</code>.</p>
 <h2 id="workstreams-and-threads">Workstreams and threads</h2>
 <ul>
 <li><strong>Workstream</strong> = AMQ <code>--session</code>. All

--- a/README.html
+++ b/README.html
@@ -1394,14 +1394,21 @@ persists per-member models.</p>
 class="sourceCode sh"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--trust</span> trusted</span>
 <span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5,fullstack=sonnet</span>
 <span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5</span></code></pre></div>
-<p>With amq <strong>0.34.1+</strong>, launches pass
+<p>amq-squad v2.5.0 requires amq <strong>0.37.1+</strong>. Launches pass
 <code>--require-wake</code> to <code>amq coop exec</code>, so a launch
 <strong>fails at the door</strong> when the AMQ wake sidecar cannot
-start and acquire its lock — instead of surfacing later as a stale or
-orphaned wake. Older amq versions are detected and skip the flag.
-<code>--no-require-wake</code> opts out for environments where wake
-cannot run; the opt-out is persisted in the launch record so resume
-reproduces it.</p>
+start and acquire its lock, instead of surfacing later as a stale or
+orphaned wake. <code>--no-require-wake</code> opts out for environments
+where wake cannot run; the opt-out is persisted in the launch record so
+resume reproduces it.</p>
+<p>For external-injector wake setups, pass
+<code>--wake-inject-via /absolute/injector</code> and repeat
+<code>--wake-inject-arg=value</code> as needed on <code>agent up</code>,
+<code>up</code>, or <code>team show</code>. These flags are forwarded to
+<code>amq coop exec</code>, persisted in <code>launch.json</code>, and
+replayed by <code>agent resume</code>. Use the <code>--flag=value</code>
+form for dash-prefixed injector arguments such as
+<code>--wake-inject-arg=--pane</code>.</p>
 <h2 id="workstreams-and-threads">Workstreams and threads</h2>
 <ul>
 <li><strong>Workstream</strong> = AMQ <code>--session</code>. All

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For the latest 2.x build:
 go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest
 ```
 
-Requires Go 1.25+, the `amq` binary on `PATH` (v0.34+), and `tmux` on `PATH` for `amq-squad up`.
+Requires Go 1.25+, the `amq` binary on `PATH` (v0.37.1+), and `tmux` on `PATH` for `amq-squad up`.
 
 ### Skills (plugin marketplaces)
 
@@ -981,5 +981,5 @@ Replay paths that emit copy-paste commands use the modern `agent up <binary>` co
 ## Requires
 
 - Go 1.25+
-- `amq` binary on `PATH` (v0.34+)
+- `amq` binary on `PATH` (v0.37.1+)
 - `tmux` on `PATH` for `amq-squad up`

--- a/README.md
+++ b/README.md
@@ -875,12 +875,17 @@ amq-squad team init --personas cto,fullstack --model cto=gpt-5,fullstack=sonnet
 amq-squad agent up codex --model gpt-5
 ```
 
-With amq **0.34.1+**, launches pass `--require-wake` to `amq coop exec`, so a
-launch **fails at the door** when the AMQ wake sidecar cannot start and acquire
-its lock — instead of surfacing later as a stale or orphaned wake. Older amq
-versions are detected and skip the flag. `--no-require-wake` opts out for
-environments where wake cannot run; the opt-out is persisted in the launch
-record so resume reproduces it.
+amq-squad v2.5.0 requires amq **0.37.1+**. Launches pass `--require-wake` to
+`amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
+cannot start and acquire its lock, instead of surfacing later as a stale or
+orphaned wake. `--no-require-wake` opts out for environments where wake cannot
+run; the opt-out is persisted in the launch record so resume reproduces it.
+
+For external-injector wake setups, pass `--wake-inject-via /absolute/injector`
+and repeat `--wake-inject-arg=value` as needed on `agent up`, `up`, or
+`team show`. These flags are forwarded to `amq coop exec`, persisted in
+`launch.json`, and replayed by `agent resume`. Use the `--flag=value` form for
+dash-prefixed injector arguments such as `--wake-inject-arg=--pane`.
 
 ## Workstreams and threads
 

--- a/README.md
+++ b/README.md
@@ -883,9 +883,10 @@ run; the opt-out is persisted in the launch record so resume reproduces it.
 
 For external-injector wake setups, pass `--wake-inject-via /absolute/injector`
 and repeat `--wake-inject-arg=value` as needed on `agent up`, `up`, or
-`team show`. These flags are forwarded to `amq coop exec`, persisted in
-`launch.json`, and replayed by `agent resume`. Use the `--flag=value` form for
-dash-prefixed injector arguments such as `--wake-inject-arg=--pane`.
+`up --dry-run` launch-plan output. These flags are forwarded to
+`amq coop exec`, persisted in `launch.json`, and replayed by `agent resume`.
+Use the `--flag=value` form for dash-prefixed injector arguments such as
+`--wake-inject-arg=--pane`.
 
 ## Workstreams and threads
 

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -643,10 +643,10 @@ drain your inbox.</li>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. With amq 0.34.1+, launches also
-pass <code>--require-wake</code> so a launch fails immediately when the
-wake sidecar cannot acquire its lock (<code>--no-require-wake</code>
-opts out and persists into resume).</p>
+<code>--settings</code> file is missing. In v2.5.0 with amq 0.37.1+,
+launches also pass <code>--require-wake</code> so a launch fails
+immediately when the wake sidecar cannot acquire its lock
+(<code>--no-require-wake</code> opts out and persists into resume).</p>
 <h3 id="runtime-control-tmux">Runtime control (tmux)</h3>
 <p>amq-squad owns the tmux control contract — drive agents by stable
 command, never raw <code>tmux send-keys</code>. Control targets the

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -200,7 +200,7 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. With amq 0.34.1+, launches also pass `--require-wake` so a launch
+missing. In v2.5.0 with amq 0.37.1+, launches also pass `--require-wake` so a launch
 fails immediately when the wake sidecar cannot acquire its lock
 (`--no-require-wake` opts out and persists into resume).
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -280,12 +280,14 @@ func translateAgentUpArgs(args []string) []string {
 func launchKnownFlag(name string) string {
 	switch name {
 	case "--codex-args", "--claude-args", "--launcher-args",
-		"-codex-args", "-claude-args", "-launcher-args":
+		"--wake-inject-arg",
+		"-codex-args", "-claude-args", "-launcher-args",
+		"-wake-inject-arg":
 		return "string-accepts-dash"
 	case "--role", "--session", "--me", "--root", "--project", "--team-home", "--team-profile",
-		"--conversation", "--conversation-id", "--trust", "--model", "--launcher",
+		"--conversation", "--conversation-id", "--trust", "--model", "--launcher", "--wake-inject-via",
 		"-role", "-session", "-me", "-root", "-project", "-team-home", "-team-profile",
-		"-conversation", "-conversation-id", "-trust", "-model", "-launcher":
+		"-conversation", "-conversation-id", "-trust", "-model", "-launcher", "-wake-inject-via":
 		return "string"
 	case "--team-workstream", "--no-bootstrap", "--no-default-args",
 		"--force-duplicate", "--dry-run", "--no-require-wake",

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -30,6 +30,7 @@ func resolveAMQEnv(rootFlag, session, handle string) (amqEnv, error) {
 // minRequireWakeAMQVersion is the first AMQ release whose `coop exec` accepts
 // --require-wake (refuse to launch unless the wake sidecar acquires its lock).
 const minRequireWakeAMQVersion = "0.34.1"
+const minWakeInjectAMQVersion = "0.37.0"
 
 // amqSupportsRequireWake reports whether the amq version string from `amq env`
 // is new enough for `coop exec --require-wake`. Empty or unparseable versions
@@ -42,6 +43,23 @@ func amqSupportsRequireWake(version string) bool {
 	}
 	min, _ := parseSemverParts(minRequireWakeAMQVersion)
 	return compareSemverParts(got, min) >= 0
+}
+
+func amqSupportsWakeInject(version string) bool {
+	got, ok := parseSemverParts(strings.TrimSpace(version))
+	if !ok {
+		return false
+	}
+	min, _ := parseSemverParts(minWakeInjectAMQVersion)
+	return compareSemverParts(got, min) >= 0
+}
+
+func versionOrUnknown(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "unknown"
+	}
+	return version
 }
 
 func resolveAMQEnvInDir(cwd, rootFlag, session, handle string) (amqEnv, error) {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -300,6 +300,9 @@ func routeCommandFor(sourceRoot, sourceSession string, currentProject, targetPro
 	if !sameCWD && currentProject.Name != targetProject.Name {
 		args = append(args, "--project", targetProject.Name)
 	}
+	if sourceSession != "" && session != "" && session != sourceSession {
+		args = append(args, "--from-session", sourceSession)
+	}
 	if session != "" {
 		args = append(args, "--session", session)
 	}

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -323,8 +323,35 @@ func TestBootstrapCurrentTeamKeepsLegacyRoleSessions(t *testing.T) {
 	if qa.Session != "qa" {
 		t.Fatalf("legacy qa session = %q, want qa", qa.Session)
 	}
-	if qa.Route != "amq send --to qa --session qa --thread p2p/cto__qa" {
+	if qa.Route != "amq send --to qa --from-session cto --session qa --thread p2p/cto__qa" {
 		t.Fatalf("legacy qa route = %q", qa.Route)
+	}
+}
+
+func TestBootstrapCurrentTeamCrossSessionRouteUsesFromSession(t *testing.T) {
+	teamHome := t.TempDir()
+	if err := team.Write(teamHome, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "qa"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := launch.Record{Role: "cto", Handle: "cto", Session: "cto", CWD: teamHome}
+	got, warnings := bootstrapCurrentTeam(rec, teamHome)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	var qa bootstrapTeamMember
+	for _, m := range got {
+		if m.Role == "qa" {
+			qa = m
+		}
+	}
+	if qa.Route != "amq send --to qa --from-session cto --session qa --thread p2p/cto__qa" {
+		t.Fatalf("cross-session qa route = %q", qa.Route)
 	}
 }
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -279,6 +279,8 @@ var completionCommonFlags = []string{
 	"--tree",
 	"--trust",
 	"--timeout",
+	"--wake-inject-arg",
+	"--wake-inject-via",
 	"--yes",
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -21,7 +21,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.34.0"
+const doctorMinAMQVersion = "0.37.1"
 
 type doctorStatus string
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -20,7 +20,7 @@ func newDoctorExec(t *testing.T, dir string) doctorExecution {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.34.1", Root: filepath.Join(dir, ".agent-mail")}, nil
+			return amqEnv{AMQVersion: "0.37.1", Root: filepath.Join(dir, ".agent-mail")}, nil
 		},
 		RunAMQOps: func(string, amqEnv) ([]byte, error) {
 			return []byte(`{"status":"ok"}`), nil
@@ -159,7 +159,7 @@ func TestExecuteDoctorAMQVersionTooOld(t *testing.T) {
 	dir := t.TempDir()
 	d := newDoctorExec(t, dir)
 	d.ResolveAMQEnv = func(string) (amqEnv, error) {
-		return amqEnv{AMQVersion: "0.33.9", Root: dir}, nil
+		return amqEnv{AMQVersion: "0.37.0", Root: dir}, nil
 	}
 	var buf bytes.Buffer
 	d.Out = &buf
@@ -173,7 +173,7 @@ func TestExecuteDoctorAMQVersionTooOld(t *testing.T) {
 	if got == nil || got.Status != doctorFail {
 		t.Fatalf("amq version check = %+v, want fail", got)
 	}
-	if !strings.Contains(got.Detail, "0.33.9") {
+	if !strings.Contains(got.Detail, "0.37.0") || !strings.Contains(got.Detail, "0.37.1") {
 		t.Errorf("detail should name the bad version: %q", got.Detail)
 	}
 }
@@ -227,9 +227,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts034x(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0371Plus(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.34.0", "0.34.1", "v0.35.0-rc1", "1.0.0+build42"} {
+	for _, v := range []string{"0.37.1", "v0.37.1", "0.38.0-rc1", "1.0.0+build42"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -712,7 +712,7 @@ func TestExecuteDoctorWakeReuseClassifyMemberStatus(t *testing.T) {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.34.1", Root: filepath.Join(base, "issue-96")}, nil
+			return amqEnv{AMQVersion: "0.37.1", Root: filepath.Join(base, "issue-96")}, nil
 		},
 		LookPath: func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe: duplicateLaunchProbe{
@@ -755,7 +755,7 @@ func TestExecuteDoctorWakeHandlesAMQEnvErrorPerMember(t *testing.T) {
 	d := doctorExecution{
 		ProjectDir:    dir,
 		Out:           &bytes.Buffer{},
-		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.34.1"}, nil },
+		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.37.1"}, nil },
 		LookPath:      func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe:         defaultDuplicateLaunchProbe,
 	}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -24,6 +24,17 @@ import (
 // unset and record an empty target.
 const envTmuxTarget = "AMQ_SQUAD_TMUX_TARGET"
 
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	return strings.Join(*f, " ")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 // runLaunch is the real single-agent launcher. The top-level `launch` verb is
 // legacy; this body now backs `agent up` (via runAgentUp -> translateAgentUpArgs)
 // and the replay path (execRestoreRecord). It is internal-only and carries no
@@ -51,6 +62,9 @@ func runLaunch(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args to treat as launch defaults, e.g. '--chrome'")
 	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent for the same handle/workstream is detected")
 	noRequireWake := fs.Bool("no-require-wake", false, "do not pass --require-wake to amq coop exec (allows launching when the wake sidecar cannot acquire its lock)")
+	wakeInjectVia := fs.String("wake-inject-via", "", "absolute executable passed to amq coop exec --wake-inject-via (amq 0.37.1+)")
+	var wakeInjectArgs stringListFlag
+	fs.Var(&wakeInjectArgs, "wake-inject-arg", "argument passed to amq coop exec --wake-inject-arg (repeatable; requires --wake-inject-via)")
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 	launcherRaw := fs.String("launcher", "", "custom launcher to exec instead of <binary> (still receives AMQ env/identity, bootstrap, and a launch record)")
 	launcherArgsRaw := fs.String("launcher-args", "", "args passed to --launcher before the agent's child args; the launcher must forward trailing args to <binary>")
@@ -83,10 +97,12 @@ Side effects before exec:
   9. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
  10. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
-     With amq 0.34.1+, --require-wake is passed so the launch fails at the
+     With amq 0.37.1+, --require-wake is passed so the launch fails at the
      door when the wake sidecar cannot start and acquire its lock (instead
      of surfacing as a stale/orphaned wake later). --no-require-wake opts
      out for environments where wake cannot run but the agent should.
+     --wake-inject-via and repeatable --wake-inject-arg are forwarded to
+     amq coop exec so AMQ can save a repairable external wake target.
 
 With --dry-run, the resolved coop exec command is printed and amq-squad exits.
 Disk state is untouched and no exec occurs.
@@ -129,6 +145,14 @@ Examples:
 	}
 	if err := validateTrustCombination(trustMode, trustExplicit, *noDefaultArgs, binaryArgs); err != nil {
 		return err
+	}
+	wakeInjectViaValue := strings.TrimSpace(*wakeInjectVia)
+	wakeInjectArgValues := append([]string(nil), wakeInjectArgs...)
+	if len(wakeInjectArgValues) > 0 && wakeInjectViaValue == "" {
+		return usageErrorf("--wake-inject-arg requires --wake-inject-via")
+	}
+	if wakeInjectViaValue != "" && !filepath.IsAbs(wakeInjectViaValue) {
+		return usageErrorf("--wake-inject-via must be an absolute path")
 	}
 	launcher := strings.TrimSpace(*launcherRaw)
 	var launcherArgs []string
@@ -209,6 +233,8 @@ Examples:
 		Trust:            trustMode,
 		NoDefaultArgs:    *noDefaultArgs,
 		NoRequireWake:    *noRequireWake,
+		WakeInjectVia:    wakeInjectViaValue,
+		WakeInjectArgs:   wakeInjectArgValues,
 		AgentPID:         os.Getpid(),
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
@@ -267,6 +293,15 @@ Examples:
 	if !*noRequireWake && amqSupportsRequireWake(env.AMQVersion) {
 		coopArgs = append(coopArgs, "--require-wake")
 	}
+	if wakeInjectViaValue != "" {
+		if !amqSupportsWakeInject(env.AMQVersion) {
+			return fmt.Errorf("--wake-inject-via requires amq %s or newer (found %s)", minWakeInjectAMQVersion, versionOrUnknown(env.AMQVersion))
+		}
+		coopArgs = append(coopArgs, "--wake-inject-via", wakeInjectViaValue)
+		for _, arg := range wakeInjectArgValues {
+			coopArgs = append(coopArgs, "--wake-inject-arg="+arg)
+		}
+	}
 	// A custom launcher is exec'd in place of the binary. Launcher args precede
 	// the agent's normal child args; the launcher is expected to forward the
 	// trailing args to the binary so bootstrap and default args still reach it.
@@ -292,6 +327,11 @@ Examples:
 	if launcher != "" {
 		if err := ensureLauncherExecutable(launcher); err != nil {
 			return err
+		}
+	}
+	if wakeInjectViaValue != "" {
+		if err := ensureLauncherExecutable(wakeInjectViaValue); err != nil {
+			return fmt.Errorf("wake inject executable: %w", err)
 		}
 	}
 

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -47,6 +47,22 @@ func TestAMQSupportsRequireWake(t *testing.T) {
 	}
 }
 
+func TestAMQSupportsWakeInject(t *testing.T) {
+	for version, want := range map[string]bool{
+		"":         false,
+		"garbage":  false,
+		"0.36.9":   false,
+		"0.37.0":   true,
+		"v0.37.0":  true,
+		"0.38.0":   true,
+		" 0.37.0 ": true,
+	} {
+		if got := amqSupportsWakeInject(version); got != want {
+			t.Errorf("amqSupportsWakeInject(%q) = %v, want %v", version, got, want)
+		}
+	}
+}
+
 func TestRunLaunchDryRunRequireWakeVersionGate(t *testing.T) {
 	// amq 0.34.1+ launches fail at the door when the wake sidecar cannot
 	// acquire its lock (#30): coop exec gains --require-wake by default.
@@ -74,6 +90,55 @@ func TestRunLaunchDryRunRequireWakeWithSessionShape(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "amq coop exec --session issue-96 --require-wake codex -- test-prompt") {
 		t.Fatalf("session + require-wake argv shape drifted:\n%s", stdout)
+	}
+}
+
+func TestRunLaunchDryRunWakeInjectVersionGate(t *testing.T) {
+	setupFakeAMQWithVersion(t, "0.37.0")
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{
+			"--dry-run", "--no-bootstrap",
+			"--wake-inject-via", "/opt/amq-inject",
+			"--wake-inject-arg=--pane", "--wake-inject-arg=%42",
+			"codex", "test-prompt",
+		})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"--require-wake",
+		"--wake-inject-via /opt/amq-inject",
+		"--wake-inject-arg=--pane",
+		"--wake-inject-arg=%42",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q in:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRunLaunchDryRunWakeInjectRejectsOldAMQ(t *testing.T) {
+	setupFakeAMQWithVersion(t, "0.36.0")
+	_, _, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-via", "/opt/amq-inject", "codex"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires amq 0.37.0 or newer") {
+		t.Fatalf("wake-inject old amq error = %v", err)
+	}
+}
+
+func TestRunLaunchWakeInjectValidatesShape(t *testing.T) {
+	setupFakeAMQWithVersion(t, "0.37.0")
+	if _, _, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-arg=x", "codex"})
+	}); err == nil || !strings.Contains(err.Error(), "requires --wake-inject-via") {
+		t.Fatalf("missing via error = %v", err)
+	}
+	if _, _, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-via", "relative-inject", "codex"})
+	}); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		t.Fatalf("relative via error = %v", err)
 	}
 }
 

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -18,10 +20,12 @@ type previewFlags struct {
 	codexArgsRaw   *string
 	claudeArgsRaw  *string
 	forceDuplicate *bool
+	wakeInjectVia  *string
+	wakeInjectArgs stringListFlag
 }
 
 func registerPreviewFlags(fs *flag.FlagSet) *previewFlags {
-	return &previewFlags{
+	p := &previewFlags{
 		noBootstrap:    fs.Bool("no-bootstrap", false, "emit launch commands that skip the generated bootstrap prompt"),
 		session:        fs.String("session", "", "AMQ workstream session name (default: sanitized team-home directory name; lowercase a-z, 0-9, -, _)"),
 		fresh:          fs.Bool("fresh", false, "fail if the selected workstream session already exists"),
@@ -30,7 +34,10 @@ func registerPreviewFlags(fs *flag.FlagSet) *previewFlags {
 		codexArgsRaw:   fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'"),
 		claudeArgsRaw:  fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'"),
 		forceDuplicate: fs.Bool("force-duplicate", false, "include --force-duplicate in emitted launch commands"),
+		wakeInjectVia:  fs.String("wake-inject-via", "", "absolute executable forwarded to every agent launch as amq coop exec --wake-inject-via"),
 	}
+	fs.Var(&p.wakeInjectArgs, "wake-inject-arg", "argument forwarded to every agent launch as amq coop exec --wake-inject-arg (repeatable; requires --wake-inject-via)")
+	return p
 }
 
 func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) {
@@ -47,6 +54,14 @@ func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) 
 	if err != nil {
 		return emitTeamOptions{}, err
 	}
+	wakeInjectVia := strings.TrimSpace(*p.wakeInjectVia)
+	wakeInjectArgs := append([]string(nil), p.wakeInjectArgs...)
+	if len(wakeInjectArgs) > 0 && wakeInjectVia == "" {
+		return emitTeamOptions{}, usageErrorf("--wake-inject-arg requires --wake-inject-via")
+	}
+	if wakeInjectVia != "" && !filepath.IsAbs(wakeInjectVia) {
+		return emitTeamOptions{}, usageErrorf("--wake-inject-via must be an absolute path")
+	}
 	return emitTeamOptions{
 		NoBootstrap:      *p.noBootstrap,
 		RequestedSession: *p.session,
@@ -57,6 +72,8 @@ func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) 
 		ExplicitTrust:    flagWasSet(fs, "trust"),
 		ModelOverrides:   modelOverrides,
 		ForceDuplicate:   *p.forceDuplicate,
+		WakeInjectVia:    wakeInjectVia,
+		WakeInjectArgs:   wakeInjectArgs,
 	}, nil
 }
 
@@ -107,5 +124,7 @@ func buildLiveLaunchOptions(fs *flag.FlagSet, pf *previewFlags, lf *liveLaunchFl
 		Trust:           emit.RequestedTrust,
 		ModelOverrides:  emit.ModelOverrides,
 		ForceDuplicate:  emit.ForceDuplicate,
+		WakeInjectVia:   emit.WakeInjectVia,
+		WakeInjectArgs:  emit.WakeInjectArgs,
 	}, nil
 }

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -246,6 +246,12 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoRequireWake {
 		args = append(args, "--no-require-wake")
 	}
+	if via := strings.TrimSpace(rec.WakeInjectVia); via != "" {
+		args = append(args, "--wake-inject-via", via)
+		for _, arg := range rec.WakeInjectArgs {
+			args = append(args, "--wake-inject-arg="+arg)
+		}
+	}
 	if trust := trustModeFromRecord(rec); trust != "" {
 		args = append(args, "--trust", trust)
 	}
@@ -423,6 +429,14 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	}
 	if rec.NoRequireWake {
 		b.WriteString(" --no-require-wake")
+	}
+	if via := strings.TrimSpace(rec.WakeInjectVia); via != "" {
+		b.WriteString(" --wake-inject-via ")
+		b.WriteString(shellQuote(via))
+		for _, arg := range rec.WakeInjectArgs {
+			b.WriteString(" --wake-inject-arg=")
+			b.WriteString(shellQuote(arg))
+		}
 	}
 	if trust := trustModeFromRecord(rec); trust != "" {
 		b.WriteString(" --trust ")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -63,6 +63,36 @@ func TestLaunchArgsFromRecordIncludesLauncher(t *testing.T) {
 	}
 }
 
+func TestLaunchArgsFromRecordReplaysWakeInject(t *testing.T) {
+	rec := launch.Record{
+		Binary:         "codex",
+		Handle:         "cto",
+		Role:           "cto",
+		Session:        "issue-96",
+		WakeInjectVia:  "/opt/amq-inject",
+		WakeInjectArgs: []string{"--pane", "%42"},
+	}
+	want := []string{
+		"--role", "cto", "--session", "issue-96",
+		"--wake-inject-via", "/opt/amq-inject",
+		"--wake-inject-arg=--pane", "--wake-inject-arg=%42",
+		"--trust", "sandboxed", "--me", "cto", "codex",
+	}
+	if got := launchArgsFromRecord(rec); !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord(rec)\n got: %v\nwant: %v", got, want)
+	}
+	cmd := emitCommandWithOptions(rec, emitCommandOptions{})
+	for _, want := range []string{
+		"--wake-inject-via /opt/amq-inject",
+		"--wake-inject-arg=--pane",
+		"--wake-inject-arg='%42'",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emit command missing %q in: %s", want, cmd)
+		}
+	}
+}
+
 func TestRunRestoreProjectFlagExpandsHome(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	home := t.TempDir()

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -633,6 +633,8 @@ type emitTeamOptions struct {
 	ExplicitTrust    bool
 	ModelOverrides   map[string]string
 	ForceDuplicate   bool
+	WakeInjectVia    string
+	WakeInjectArgs   []string
 	Profile          string
 	// JSON requests a structured "team_plan" envelope on stdout instead of
 	// the human launch-command preview. Diagnostics still go to stderr.
@@ -782,6 +784,8 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 					Model:          effectiveModel,
 					ForceDuplicate: opts.ForceDuplicate,
 					Profile:        opts.Profile,
+					WakeInjectVia:  opts.WakeInjectVia,
+					WakeInjectArgs: opts.WakeInjectArgs,
 				}),
 			})
 		}
@@ -834,6 +838,8 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 			Model:          effectiveModel,
 			Profile:        opts.Profile,
 			ForceDuplicate: opts.ForceDuplicate,
+			WakeInjectVia:  opts.WakeInjectVia,
+			WakeInjectArgs: opts.WakeInjectArgs,
 		}))
 		fmt.Println()
 	}
@@ -977,6 +983,8 @@ type emitTeamCommandInput struct {
 	TrustMode      string
 	Model          string
 	ForceDuplicate bool
+	WakeInjectVia  string
+	WakeInjectArgs []string
 	Profile        string
 }
 
@@ -1018,6 +1026,14 @@ func emitTeamCommand(in emitTeamCommandInput) string {
 	}
 	if in.ForceDuplicate {
 		b.WriteString(" --force-duplicate")
+	}
+	if via := strings.TrimSpace(in.WakeInjectVia); via != "" {
+		b.WriteString(" --wake-inject-via ")
+		b.WriteString(shellQuote(via))
+		for _, arg := range in.WakeInjectArgs {
+			b.WriteString(" --wake-inject-arg=")
+			b.WriteString(shellQuote(arg))
+		}
 	}
 	if m.Handle != "" {
 		// Always explicit: a role-named handle avoids collisions when the

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -27,6 +27,8 @@ type teamLaunchOptions struct {
 	Trust           string
 	ModelOverrides  map[string]string
 	ForceDuplicate  bool
+	WakeInjectVia   string
+	WakeInjectArgs  []string
 	// SeedBriefContent, when non-empty, is the rendered active brief that
 	// the live launch path should write to .amq-squad/briefs/<workstream>.md
 	// AFTER all team-launch validations and preflight pass. Empty means no
@@ -331,6 +333,8 @@ func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane 
 				Model:          memberEffectiveModel(m, opts.ModelOverrides),
 				ForceDuplicate: opts.ForceDuplicate,
 				Profile:        opts.Profile,
+				WakeInjectVia:  opts.WakeInjectVia,
+				WakeInjectArgs: opts.WakeInjectArgs,
 			}),
 		})
 	}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -274,6 +274,24 @@ func TestEmitTeamCommandPerMemberArgsOnly(t *testing.T) {
 	}
 }
 
+func TestEmitTeamCommandAddsWakeInject(t *testing.T) {
+	m := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: "cto"}
+	cmd := emitTeamCommand(emitTeamCommandInput{
+		CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p",
+		Member: m, Workstream: "p", TrustMode: trustModeSandboxed,
+		WakeInjectVia: "/opt/amq-inject", WakeInjectArgs: []string{"--pane", "%42"},
+	})
+	for _, want := range []string{
+		"--wake-inject-via /opt/amq-inject",
+		"--wake-inject-arg=--pane",
+		"--wake-inject-arg='%42'",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
+		}
+	}
+}
+
 func TestValidateMembersTrustRejectsSmuggledBypass(t *testing.T) {
 	// A sandboxed team must not smuggle the Codex bypass flag through one
 	// member's codex_args; the rejection names the member.

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -188,6 +188,8 @@ func TestUpDryRunMatchesTeamShowWithFlags(t *testing.T) {
 		"--codex-args=--profile fast",
 		"--claude-args=--chrome",
 		"--force-duplicate",
+		"--wake-inject-via", "/opt/amq-inject",
+		"--wake-inject-arg=--pane",
 	}
 
 	showOut, _, err := captureOutput(t, func() error {
@@ -216,6 +218,9 @@ func TestUpDryRunMatchesTeamShowWithFlags(t *testing.T) {
 	}
 	if !strings.Contains(upOut, "--claude-args=--chrome") {
 		t.Errorf("--claude-args not applied: %s", upOut)
+	}
+	if !strings.Contains(upOut, "--wake-inject-via /opt/amq-inject") || !strings.Contains(upOut, "--wake-inject-arg=--pane") {
+		t.Errorf("wake injector flags not applied: %s", upOut)
 	}
 }
 
@@ -292,6 +297,8 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 			"--codex-args=--profile fast",
 			"--claude-args=--chrome",
 			"--force-duplicate",
+			"--wake-inject-via", "/opt/amq-inject",
+			"--wake-inject-arg=--pane",
 			"--no-attach",
 		})
 	})
@@ -340,6 +347,12 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 	}
 	if !opts.ForceDuplicate {
 		t.Error("--force-duplicate not propagated")
+	}
+	if opts.WakeInjectVia != "/opt/amq-inject" {
+		t.Errorf("WakeInjectVia = %q, want /opt/amq-inject", opts.WakeInjectVia)
+	}
+	if got := opts.WakeInjectArgs; len(got) != 1 || got[0] != "--pane" {
+		t.Errorf("WakeInjectArgs = %v, want [--pane]", got)
 	}
 }
 

--- a/internal/cli/workstream.go
+++ b/internal/cli/workstream.go
@@ -295,7 +295,7 @@ func latestWorkstreamModTime(root string) time.Time {
 		}
 		agentRoot := filepath.Join(agentsRoot, e.Name())
 		observe(agentRoot)
-		for _, name := range []string{"inbox", "outbox", "acks", "receipts", "dlq"} {
+		for _, name := range []string{"inbox", "outbox", "receipts", "dlq"} {
 			observe(filepath.Join(agentRoot, name))
 		}
 	}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -51,11 +51,16 @@ type Record struct {
 	// reproduces it: the constraint it answers (wake cannot acquire its lock
 	// in this environment) is a property of the execution environment, not a
 	// one-shot launch decision.
-	NoRequireWake bool      `json:"no_require_wake,omitempty"`
-	External      bool      `json:"external,omitempty"`
-	AgentPID      int       `json:"agent_pid,omitempty"`
-	AgentTTY      string    `json:"agent_tty,omitempty"`
-	StartedAt     time.Time `json:"started_at"`
+	NoRequireWake bool `json:"no_require_wake,omitempty"`
+	External      bool `json:"external,omitempty"`
+	// WakeInjectVia and WakeInjectArgs record AMQ 0.37.0 external wake
+	// injector settings so resume/replay can repair and restart the same
+	// digest-bound wake target later.
+	WakeInjectVia  string    `json:"wake_inject_via,omitempty"`
+	WakeInjectArgs []string  `json:"wake_inject_args,omitempty"`
+	AgentPID       int       `json:"agent_pid,omitempty"`
+	AgentTTY       string    `json:"agent_tty,omitempty"`
+	StartedAt      time.Time `json:"started_at"`
 	// TeamProfile names the profile the launch was emitted from. Empty
 	// means the implicit default profile. Captured so status / bootstrap
 	// routing can reuse the same profile without rereading flags.
@@ -334,7 +339,7 @@ func hasLegacyActivity(agentDir string) bool {
 	if _, err := os.Stat(filepath.Join(agentDir, "presence.json")); err == nil {
 		return true
 	}
-	for _, name := range []string{"inbox", "outbox", "acks", "receipts", "dlq"} {
+	for _, name := range []string{"inbox", "outbox", "receipts", "dlq"} {
 		if hasFiles(filepath.Join(agentDir, name)) {
 			return true
 		}

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -25,6 +26,8 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		BaseRoot:         filepath.Dir(dir),
 		RootSource:       "project_amqrc",
 		AMQVersion:       "0.34.0",
+		WakeInjectVia:    "/opt/amq-inject",
+		WakeInjectArgs:   []string{"--pane", "%42"},
 		StartedAt:        time.Now().UTC().Truncate(time.Second),
 	}
 	if err := Write(dir, in); err != nil {
@@ -52,8 +55,11 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		out.Conversation != in.Conversation ||
 		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root ||
 		out.BaseRoot != in.BaseRoot || out.RootSource != in.RootSource ||
-		out.AMQVersion != in.AMQVersion {
+		out.AMQVersion != in.AMQVersion || out.WakeInjectVia != in.WakeInjectVia {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
+	}
+	if !reflect.DeepEqual(out.WakeInjectArgs, in.WakeInjectArgs) {
+		t.Errorf("WakeInjectArgs = %v, want %v", out.WakeInjectArgs, in.WakeInjectArgs)
 	}
 	if len(out.Argv) != len(in.Argv) {
 		t.Fatalf("Argv len mismatch: %v vs %v", out.Argv, in.Argv)

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -231,12 +231,16 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-Launch wake gate (v1.8.0+): with amq 0.34.1+, launches pass `--require-wake`
-to `amq coop exec`, so a launch fails at the door when the AMQ wake sidecar
-cannot start and acquire its lock (instead of surfacing later as a stale
-wake). Older amq versions are detected and skip the flag. `--no-require-wake`
-opts out for wake-hostile environments and persists into the launch record,
-so `agent resume` reproduces it.
+Launch wake gate (v2.5.0+): amq-squad requires amq 0.37.1+ and launches pass
+`--require-wake` to `amq coop exec`, so a launch fails at the door when the AMQ
+wake sidecar cannot start and acquire its lock (instead of surfacing later as a
+stale wake). `--no-require-wake` opts out for wake-hostile environments and
+persists into the launch record, so `agent resume` reproduces it.
+External-injector wake setups can pass `--wake-inject-via /absolute/injector`
+and repeat `--wake-inject-arg=value`; these flags are forwarded to
+`amq coop exec`, persisted in launch.json, and replayed by resume. Use the
+`--flag=value` form for dash-prefixed injector args such as
+`--wake-inject-arg=--pane`.
 
 ## Exit codes
 

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -227,12 +227,16 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-Launch wake gate (v1.8.0+): with amq 0.34.1+, launches pass `--require-wake`
-to `amq coop exec`, so a launch fails at the door when the AMQ wake sidecar
-cannot start and acquire its lock (instead of surfacing later as a stale
-wake). Older amq versions are detected and skip the flag. `--no-require-wake`
-opts out for wake-hostile environments and persists into the launch record,
-so `agent resume` reproduces it.
+Launch wake gate (v2.5.0+): amq-squad requires amq 0.37.1+ and launches pass
+`--require-wake` to `amq coop exec`, so a launch fails at the door when the AMQ
+wake sidecar cannot start and acquire its lock (instead of surfacing later as a
+stale wake). `--no-require-wake` opts out for wake-hostile environments and
+persists into the launch record, so `agent resume` reproduces it.
+External-injector wake setups can pass `--wake-inject-via /absolute/injector`
+and repeat `--wake-inject-arg=value`; these flags are forwarded to
+`amq coop exec`, persisted in launch.json, and replayed by resume. Use the
+`--flag=value` form for dash-prefixed injector args such as
+`--wake-inject-arg=--pane`.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

Adopts the AMQ 0.37.x wake reliability surface for v2.5.0 and sets the supported AMQ floor to 0.37.1.

- Move the doctor AMQ minimum version check to 0.37.1.
- Add `--wake-inject-via` and repeatable `--wake-inject-arg` to `agent up`, `up`, and `team show` launch flows.
- Persist `WakeInjectVia` and `WakeInjectArgs` in `launch.json` and replay them through `agent resume`.
- Forward injector args to AMQ as `--wake-inject-arg=value` so dash-prefixed values parse correctly.
- Add `--from-session` to bootstrap route fallback commands when source and target sessions differ.
- Stop treating stale `acks/` directories as AMQ activity.
- Update README, generated README.html, and both amq-squad skill mirrors.

Closes #193.
Closes #30.
Closes #194.

## Version Floor

The v2.5.0 AMQ floor is 0.37.1, not 0.37.0. AMQ 0.37.0 has the new wake and ops features, but 0.37.1 hardens stale `.wake.lock` cleanup so live wake processes with mismatched or tampered identity metadata are not removed. That is the safer floor for the Ohad-reported stale wake-lock failure class.

## Evidence

- Live `amq --version`: 0.37.1.
- Local build doctor with live AMQ reported `amq 0.37.1 (min 0.37.1)` and `amq doctor --ops ok`.
- Status and resume preview with live AMQ 0.37.1 and profile `codex-v2-5-0` succeeded for `v2-5-0`.
- `up --dry-run` with wake injector showed each v2-5-0 worker command includes `--wake-inject-via` and `--wake-inject-arg=--pane`.
- Direct AMQ parser proof confirmed `--wake-inject-arg=--pane` is accepted by AMQ 0.37.1, not only by amq-squad parsing.
- Ohad wake-lock safety proof: a real `amq wake` via external injector had `.wake.lock` `process_start` tampered while the PID remained live. `amq doctor --ops --fix-wake-locks --json` returned a wake-lock error saying the process-start mismatch was not removable while the PID may still be `amq wake`; the lock remained present.
- `amq send --root /.../.amq-live-root-label-check` reported `session: .amq-live-root-label-check`, verifying the 0.37.1 root basename session-label fix.

## Caveats

- `doctor --profile codex-v2-5-0` still reports workstream `amq-squad`; this is a known scoping evidence gap and is not fixed in this AMQ adoption slice.
- Current-window worker panes still show `pane_alive: false`, consistent with the existing #179 dogfood issue.

## Validation

- `git diff --check`
- `go test ./internal/cli ./internal/launch ./internal/team`
- `make ci`
