### PR TITLE
Fix resume exec partial launch reporting

### DIFF
--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -485,7 +485,7 @@ func TestResumePlanJSONCarriesLiveness(t *testing.T) {
 	plans := []resumePlan{{
 		Role: "cto", Handle: "cto", Action: resumeRestore,
 		Command:  "amq-squad agent up codex --role cto",
-		Liveness: &agentLiveness{Status: statusStateStale, Detail: "agent pid dead", Signals: statusSignals{AgentPID: 7777}},
+		Liveness: &agentLiveness{Status: statusStateStale, Detail: "agent pid dead", Signals: statusSignals{AgentPID: 7777}, LaunchFound: true},
 	}}
 	if err := writeResumeJSON(&buf, team.Team{Project: "/p"}, "issue-96", resumeModeDefault, "", plans); err != nil {
 		t.Fatal(err)
@@ -493,8 +493,9 @@ func TestResumePlanJSONCarriesLiveness(t *testing.T) {
 	var env struct {
 		Data struct {
 			Plan []struct {
-				Action   string `json:"action"`
-				Liveness *struct {
+				Action      string `json:"action"`
+				RecordState string `json:"record_state"`
+				Liveness    *struct {
 					Status string `json:"status"`
 					Detail string `json:"detail"`
 				} `json:"liveness"`
@@ -513,6 +514,9 @@ func TestResumePlanJSONCarriesLiveness(t *testing.T) {
 	}
 	if p.Action != "restore" {
 		t.Errorf("a stale verdict should restore, got action %q", p.Action)
+	}
+	if p.RecordState != "stale-record" {
+		t.Errorf("record_state = %q, want stale-record", p.RecordState)
 	}
 }
 

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -400,6 +400,74 @@ func TestExecResumePlanNothingToLaunch(t *testing.T) {
 	}
 }
 
+// TestExecResumePlanReportsPartialLaunchRecordFailure covers #208's
+// current-window failure mode: tmux accepted a multi-role plan, but one
+// requested role never published a fresh launch.json. The command must return
+// non-zero with role-level detail instead of leaving the operator with only the
+// optimistic "Added team panes" notice.
+func TestExecResumePlanReportsPartialLaunchRecordFailure(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+
+	oldRun := runTmuxLaunchPlanForResume
+	oldTimeout := resumeExecLaunchVerifyTimeout
+	oldInterval := resumeExecLaunchVerifyInterval
+	runTmuxLaunchPlanForResume = func(plan tmuxLaunchPlan) error {
+		if plan.Target != "current-window" {
+			t.Errorf("target = %q, want current-window", plan.Target)
+		}
+		if len(plan.Panes) != 2 {
+			t.Errorf("panes = %d, want 2", len(plan.Panes))
+		}
+		writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+			CWD:       dir,
+			Binary:    "codex",
+			Role:      "cto",
+			StartedAt: time.Now().UTC(),
+			Tmux:      &launch.TmuxInfo{PaneID: "%101", Session: "squad", Target: "current-window"},
+		})
+		_, _ = os.Stderr.WriteString("Added 2 team pane(s) to current tmux window.\n")
+		return nil
+	}
+	resumeExecLaunchVerifyTimeout = time.Millisecond
+	resumeExecLaunchVerifyInterval = time.Millisecond
+	t.Cleanup(func() {
+		runTmuxLaunchPlanForResume = oldRun
+		resumeExecLaunchVerifyTimeout = oldTimeout
+		resumeExecLaunchVerifyInterval = oldInterval
+	})
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return execResumePlan(
+			team.Team{
+				Project: dir,
+				Members: []team.Member{
+					{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+					{Role: "frontend-dev", Binary: "codex", Handle: "frontend-dev", Session: "issue-96"},
+				},
+			},
+			"issue-96",
+			[]resumePlan{
+				{Role: "cto", Action: resumeFresh, Command: "amq-squad agent up codex --role cto"},
+				{Role: "frontend-dev", Action: resumeFresh, Command: "amq-squad agent up codex --role frontend-dev"},
+			},
+			resumeExecOptions{Enabled: true, Terminal: "tmux", Target: "current-window", Layout: "tiled"},
+			false,
+		)
+	})
+	if err == nil {
+		t.Fatal("partial launch record failure should return an error")
+	}
+	if _, ok := err.(*PartialError); !ok {
+		t.Fatalf("want *PartialError, got %T: %v", err, err)
+	}
+	for _, want := range []string{"Added 2 team pane", "partial launch failure", "frontend-dev", "missing", "launch record"} {
+		if !strings.Contains(stderr, want) && !strings.Contains(err.Error(), want) {
+			t.Errorf("missing %q in stderr/error\nstdout:\n%s\nstderr:\n%s\nerr:\n%v", want, stdout, stderr, err)
+		}
+	}
+}
+
 // TestExecResumePlanRejectsUnknownTerminal makes sure the operator gets a
 // clear error rather than a downstream nil-map panic when the terminal
 // flag value is wrong.

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -244,6 +244,8 @@ type resumeMemberJSON struct {
 	Role             string           `json:"role"`
 	Handle           string           `json:"handle,omitempty"`
 	Action           string           `json:"action"`
+	LaunchState      string           `json:"launch_state"`
+	RecordState      string           `json:"record_state"`
 	HasRestoreRecord bool             `json:"has_restore_record"`
 	Wake             string           `json:"wake,omitempty"`
 	Note             string           `json:"note,omitempty"`
@@ -302,6 +304,8 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 			Role:             p.Role,
 			Handle:           p.Handle,
 			Action:           string(p.Action),
+			LaunchState:      resumeLaunchState(p),
+			RecordState:      resumeRecordState(p),
 			HasRestoreRecord: p.HasRestoreRecord,
 			Wake:             wakeForJSON(p.Wake),
 			Note:             p.Note,
@@ -322,6 +326,42 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 		Members:    len(rows),
 		Plan:       rows,
 	})
+}
+
+func resumeLaunchState(p resumePlan) string {
+	switch {
+	case p.Action == resumeBlocked:
+		return "blocked"
+	case strings.TrimSpace(p.Command) != "":
+		return "will-launch"
+	case p.Action == resumeLive:
+		return "skipped"
+	default:
+		return "failed"
+	}
+}
+
+func resumeRecordState(p resumePlan) string {
+	if p.Liveness != nil {
+		switch p.Liveness.Status {
+		case statusStateLive, statusStateWakeLive:
+			if !p.Liveness.LaunchFound {
+				return "missing"
+			}
+			return "launched"
+		case statusStateStale:
+			if p.Liveness.LaunchFound {
+				return "stale-record"
+			}
+			return "stale-signal"
+		case statusStateMissing:
+			return "missing"
+		}
+	}
+	if p.HasRestoreRecord {
+		return "restorable"
+	}
+	return "missing"
 }
 
 // wakeForJSON normalizes the human "-" placeholder to an empty (omitted) field.

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -153,6 +153,9 @@ func TestWriteResumeJSONShapeAndPaneAlive(t *testing.T) {
 	if cto.Action != "restore" || !cto.HasRestoreRecord {
 		t.Errorf("cto plan wrong: %+v", cto)
 	}
+	if cto.LaunchState != "will-launch" || cto.RecordState != "restorable" {
+		t.Errorf("cto state wrong: launch=%q record=%q", cto.LaunchState, cto.RecordState)
+	}
 	if cto.Wake != "" {
 		t.Errorf("wake '-' should normalize to empty, got %q", cto.Wake)
 	}
@@ -162,6 +165,9 @@ func TestWriteResumeJSONShapeAndPaneAlive(t *testing.T) {
 	qa := env.Data.Plan[1]
 	if qa.Action != "launch fresh" || qa.Tmux != nil {
 		t.Errorf("qa plan should be fresh with no tmux: %+v", qa)
+	}
+	if qa.LaunchState != "will-launch" || qa.RecordState != "missing" {
+		t.Errorf("qa state wrong: launch=%q record=%q", qa.LaunchState, qa.RecordState)
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -92,6 +92,7 @@ type statusRecord struct {
 	Root        string        `json:"root,omitempty"`
 	AgentDir    string        `json:"agent_dir,omitempty"`
 	Status      statusState   `json:"status"`
+	RecordState string        `json:"record_state"`
 	Detail      string        `json:"detail,omitempty"`
 	Signals     statusSignals `json:"signals"`
 	// Tmux is the persisted tmux runtime identity (exact pane/window ids) plus
@@ -323,6 +324,7 @@ func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe d
 	env, err := resolveAMQEnvInDir(rec.CWD, "", workstream, m.Handle)
 	if err != nil {
 		rec.Status = statusStateMissing
+		rec.RecordState = "missing"
 		rec.Detail = "amq env unresolved: " + err.Error()
 		return rec
 	}
@@ -350,8 +352,28 @@ func classifyMemberStatus(t team.Team, m team.Member, workstream string, probe d
 	}
 	rec.Signals = live.Signals
 	rec.Status = live.Status
+	rec.RecordState = statusRecordState(live)
 	rec.Detail = live.Detail
 	return rec
+}
+
+func statusRecordState(live agentLiveness) string {
+	switch live.Status {
+	case statusStateLive, statusStateWakeLive:
+		if !live.LaunchFound {
+			return "missing"
+		}
+		return "launched"
+	case statusStateStale:
+		if live.LaunchFound {
+			return "stale-record"
+		}
+		return "stale-signal"
+	case statusStateMissing:
+		return "missing"
+	default:
+		return "unknown"
+	}
 }
 
 // liveReplacementPane reports a live tmux pane that resolves to this member when

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -161,6 +161,9 @@ func TestExecuteStatusJSONIncludesSpawnMetadata(t *testing.T) {
 	if got.SpawnOrigin != "cto" || got.SpawnDepth != 1 {
 		t.Fatalf("spawn metadata = origin %q depth %d, want cto/1", got.SpawnOrigin, got.SpawnDepth)
 	}
+	if got.RecordState != "launched" {
+		t.Fatalf("record_state = %q, want launched", got.RecordState)
+	}
 	if !env.Data.Capabilities.AutonomousGuardrails {
 		t.Fatalf("status capabilities must advertise autonomous guardrails")
 	}

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -220,6 +220,43 @@ type resumeExecOptions struct {
 	Stagger         time.Duration
 }
 
+type resumeExecLaunchCheck struct {
+	Role       string
+	CWD        string
+	AgentDir   string
+	Handle     string
+	Workstream string
+	Root       string
+	Binary     string
+	Force      bool
+}
+
+type resumeExecLaunchSnapshot struct {
+	Exists    bool
+	ModTime   time.Time
+	StartedAt time.Time
+}
+
+type resumeExecLaunchResult struct {
+	Check  resumeExecLaunchCheck
+	State  string
+	Detail string
+}
+
+const (
+	resumeExecLaunchStateLaunched    = "launched"
+	resumeExecLaunchStateMissing     = "missing"
+	resumeExecLaunchStateStaleRecord = "stale-record"
+	resumeExecLaunchStateFailed      = "failed"
+)
+
+var (
+	runTmuxLaunchPlanForResume       = runTmuxLaunchPlan
+	verifyResumeExecLaunchRecordsNow = verifyResumeExecLaunchRecords
+	resumeExecLaunchVerifyTimeout    = 5 * time.Second
+	resumeExecLaunchVerifyInterval   = 100 * time.Millisecond
+)
+
 // resumePrinterStyle parameterizes the per-entry-point output surface. The
 // zero value is the legacy `team resume` shape (preserved for old tests and
 // existing scripts). Top-level resume and fork supply non-zero values.
@@ -551,29 +588,45 @@ func execResumePlan(t team.Team, workstream string, plans []resumePlan, exec res
 	// AFTER tmux has split panes. Run the same aggregate check now so a
 	// blocked member aborts cleanly before any backend side effects, and
 	// honor --force-duplicate by stamping it into each plan.
-	preflights, err := buildResumeExecPreflights(t, panes, workstream, force)
+	checks, err := buildResumeExecLaunchChecks(t, panes, workstream, force)
 	if err != nil {
 		return err
 	}
-	if err := preflightTeam(preflights, defaultDuplicateLaunchProbe); err != nil {
+	if err := preflightTeam(resumeExecLaunchPreflights(checks), defaultDuplicateLaunchProbe); err != nil {
 		return err
 	}
 
 	for _, p := range skipped {
 		fmt.Fprintf(os.Stderr, "skipping %s: %s\n", p.Role, p.Note)
 	}
-	return runTmuxLaunchPlan(plan)
+	snapshots := snapshotResumeExecLaunchRecords(checks)
+	if err := runTmuxLaunchPlanForResume(plan); err != nil {
+		return err
+	}
+	results := verifyResumeExecLaunchRecordsNow(checks, snapshots)
+	if err := resumeExecLaunchError(results); err != nil {
+		return err
+	}
+	return nil
 }
 
 // buildResumeExecPreflights resolves the AMQ identity for each runnable
 // pane and constructs an agentLaunchPreflight tuple that preflightTeam can
 // use to refuse a blocked roster before tmux opens any pane.
 func buildResumeExecPreflights(t team.Team, panes []teamLaunchPane, workstream string, force bool) ([]agentLaunchPreflight, error) {
+	checks, err := buildResumeExecLaunchChecks(t, panes, workstream, force)
+	if err != nil {
+		return nil, err
+	}
+	return resumeExecLaunchPreflights(checks), nil
+}
+
+func buildResumeExecLaunchChecks(t team.Team, panes []teamLaunchPane, workstream string, force bool) ([]resumeExecLaunchCheck, error) {
 	byRole := make(map[string]team.Member, len(t.Members))
 	for _, m := range t.Members {
 		byRole[strings.ToLower(m.Role)] = m
 	}
-	out := make([]agentLaunchPreflight, 0, len(panes))
+	out := make([]resumeExecLaunchCheck, 0, len(panes))
 	for _, pane := range panes {
 		m, ok := byRole[strings.ToLower(pane.Role)]
 		if !ok {
@@ -592,7 +645,9 @@ func buildResumeExecPreflights(t team.Team, panes []teamLaunchPane, workstream s
 		if env.Me != "" {
 			handle = env.Me
 		}
-		out = append(out, agentLaunchPreflight{
+		out = append(out, resumeExecLaunchCheck{
+			Role:       pane.Role,
+			CWD:        cwd,
 			AgentDir:   filepath.Join(root, "agents", handle),
 			Handle:     handle,
 			Workstream: env.SessionName,
@@ -602,6 +657,128 @@ func buildResumeExecPreflights(t team.Team, panes []teamLaunchPane, workstream s
 		})
 	}
 	return out, nil
+}
+
+func resumeExecLaunchPreflights(checks []resumeExecLaunchCheck) []agentLaunchPreflight {
+	out := make([]agentLaunchPreflight, 0, len(checks))
+	for _, c := range checks {
+		out = append(out, agentLaunchPreflight{
+			AgentDir:   c.AgentDir,
+			Handle:     c.Handle,
+			Workstream: c.Workstream,
+			Root:       c.Root,
+			Binary:     c.Binary,
+			Force:      c.Force,
+		})
+	}
+	return out
+}
+
+func snapshotResumeExecLaunchRecords(checks []resumeExecLaunchCheck) map[string]resumeExecLaunchSnapshot {
+	out := make(map[string]resumeExecLaunchSnapshot, len(checks))
+	for _, c := range checks {
+		snap := resumeExecLaunchSnapshot{}
+		path := launch.ExistingPath(c.AgentDir)
+		if info, err := os.Stat(path); err == nil {
+			snap.Exists = true
+			snap.ModTime = info.ModTime()
+		}
+		if rec, err := launch.Read(c.AgentDir); err == nil {
+			snap.Exists = true
+			snap.StartedAt = rec.StartedAt
+		}
+		out[c.Role] = snap
+	}
+	return out
+}
+
+func verifyResumeExecLaunchRecords(checks []resumeExecLaunchCheck, snapshots map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+	deadline := time.Now().Add(resumeExecLaunchVerifyTimeout)
+	for {
+		results := inspectResumeExecLaunchRecords(checks, snapshots)
+		if allResumeExecLaunchesDone(results) || !time.Now().Before(deadline) {
+			return results
+		}
+		time.Sleep(resumeExecLaunchVerifyInterval)
+	}
+}
+
+func inspectResumeExecLaunchRecords(checks []resumeExecLaunchCheck, snapshots map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+	results := make([]resumeExecLaunchResult, 0, len(checks))
+	for _, c := range checks {
+		res := resumeExecLaunchResult{Check: c, State: resumeExecLaunchStateLaunched}
+		rec, err := launch.Read(c.AgentDir)
+		if err != nil {
+			res.State = resumeExecLaunchStateMissing
+			res.Detail = "launch record missing at " + launch.ExistingPath(c.AgentDir)
+			results = append(results, res)
+			continue
+		}
+		snap := snapshots[c.Role]
+		if snap.Exists {
+			path := launch.ExistingPath(c.AgentDir)
+			if info, statErr := os.Stat(path); statErr == nil && !info.ModTime().After(snap.ModTime) && !rec.StartedAt.After(snap.StartedAt) {
+				res.State = resumeExecLaunchStateStaleRecord
+				res.Detail = "launch record was not refreshed at " + path
+				results = append(results, res)
+				continue
+			}
+		}
+		if !strings.EqualFold(strings.TrimSpace(rec.Role), strings.TrimSpace(c.Role)) {
+			res.State = resumeExecLaunchStateFailed
+			res.Detail = fmt.Sprintf("launch record role %q does not match requested role %q", rec.Role, c.Role)
+			results = append(results, res)
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(rec.Handle), strings.TrimSpace(c.Handle)) {
+			res.State = resumeExecLaunchStateFailed
+			res.Detail = fmt.Sprintf("launch record handle %q does not match requested handle %q", rec.Handle, c.Handle)
+			results = append(results, res)
+			continue
+		}
+		if strings.TrimSpace(rec.Session) != strings.TrimSpace(c.Workstream) {
+			res.State = resumeExecLaunchStateFailed
+			res.Detail = fmt.Sprintf("launch record workstream %q does not match requested workstream %q", rec.Session, c.Workstream)
+			results = append(results, res)
+			continue
+		}
+		if rec.Tmux == nil || strings.TrimSpace(rec.Tmux.PaneID) == "" {
+			res.State = resumeExecLaunchStateFailed
+			res.Detail = "launch record did not capture a tmux pane id"
+			results = append(results, res)
+			continue
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+func allResumeExecLaunchesDone(results []resumeExecLaunchResult) bool {
+	for _, r := range results {
+		if r.State != resumeExecLaunchStateLaunched {
+			return false
+		}
+	}
+	return true
+}
+
+func resumeExecLaunchError(results []resumeExecLaunchResult) error {
+	failed := make([]resumeExecLaunchResult, 0)
+	for _, r := range results {
+		if r.State != resumeExecLaunchStateLaunched {
+			failed = append(failed, r)
+		}
+	}
+	if len(failed) == 0 {
+		return nil
+	}
+	lines := []string{fmt.Sprintf("resume --exec partial launch failure: %d of %d requested member(s) did not publish a fresh launch record:", len(failed), len(results))}
+	for _, r := range failed {
+		lines = append(lines, fmt.Sprintf("  - %s: %s: %s", r.Check.Role, r.State, r.Detail))
+	}
+	msg := strings.Join(lines, "\n")
+	fmt.Fprintln(os.Stderr, msg)
+	return &PartialError{Message: msg}
 }
 
 // planMemberCWD resolves the effective cwd for a planned role by looking up


### PR DESCRIPTION
Closes #208.

Summary:
- Verify resume --exec launch records after tmux sends commands and fail with role-level PartialError when any requested role is missing, stale, or invalid.
- Add resume/status JSON state fields so clients can distinguish launch intent and record state without inferring tmux state.
- Cover the current-window partial launch regression plus stale-record JSON output.

Tests:
- go test ./internal/cli -run "TestExecResumePlanReportsPartialLaunchRecordFailure|TestWriteResumeJSONShapeAndPaneAlive|TestExecuteStatusJSONIncludesSpawnMetadata|TestResumePlanJSONCarriesLiveness"
- go test ./internal/cli ./internal/launch ./internal/state
- git diff --check
- make ci

Conflict summary: none; branch created from current origin/main f591e9b22fbced6cf0a363ba0d4835e72c8951a6.