### PR TITLE
Bump release surfaces for v2.6.0

### DIFF
--- a/README.html
+++ b/README.html
@@ -453,7 +453,7 @@ workstream)</li>
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.5.0</span>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.6.0</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 2.0 line (note the `/v2` module path):
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.5.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.6.0
 amq-squad version
 ```
 

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -15,7 +15,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.5.0** — on your FIRST response of a session, print the line `amq-squad skill v2.5.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.6.0** — on your FIRST response of a session, print the line `amq-squad skill v2.6.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 
@@ -231,11 +231,12 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-Launch wake gate (v2.5.0+): amq-squad requires amq 0.37.1+ and launches pass
-`--require-wake` to `amq coop exec`, so a launch fails at the door when the AMQ
-wake sidecar cannot start and acquire its lock (instead of surfacing later as a
-stale wake). `--no-require-wake` opts out for wake-hostile environments and
-persists into the launch record, so `agent resume` reproduces it.
+AMQ floor (v2.6.0+): amq-squad requires amq 0.38.0+. The launch wake
+gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
+launch fails at the door when the AMQ wake sidecar cannot start and acquire its
+lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out
+for wake-hostile environments and persists into the launch record, so `agent
+resume` reproduces it.
 External-injector wake setups can pass `--wake-inject-via /absolute/injector`
 and repeat `--wake-inject-arg=value`; these flags are forwarded to
 `amq coop exec`, persisted in launch.json, and replayed by resume. Use the

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -11,7 +11,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.5.0** — on your FIRST response of a session, print the line `amq-squad skill v2.5.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.6.0** — on your FIRST response of a session, print the line `amq-squad skill v2.6.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 
@@ -227,11 +227,12 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-Launch wake gate (v2.5.0+): amq-squad requires amq 0.37.1+ and launches pass
-`--require-wake` to `amq coop exec`, so a launch fails at the door when the AMQ
-wake sidecar cannot start and acquire its lock (instead of surfacing later as a
-stale wake). `--no-require-wake` opts out for wake-hostile environments and
-persists into the launch record, so `agent resume` reproduces it.
+AMQ floor (v2.6.0+): amq-squad requires amq 0.38.0+. The launch wake
+gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
+launch fails at the door when the AMQ wake sidecar cannot start and acquire its
+lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out
+for wake-hostile environments and persists into the launch record, so `agent
+resume` reproduces it.
 External-injector wake setups can pass `--wake-inject-via /absolute/injector`
 and repeat `--wake-inject-arg=value`; these flags are forwarded to
 `amq coop exec`, persisted in launch.json, and replayed by resume. Use the


### PR DESCRIPTION
Closes #213.

Summary:
- Bump README install command to `@v2.6.0`.
- Bump Claude and Codex plugin manifests to `2.6.0`.
- Bump Claude and Codex `amq-squad` skill version markers to `2.6.0`.
- Regenerate `README.html`.

Tests:
- `git diff --check`
- `make ci`

Release plan after merge:
- Run final `make ci` on merged main.
- Create/push tag `v2.6.0` on the verified merge commit.
- Run `make release-smoke VERSION=v2.6.0`.
- Create GitHub release `v2.6.0`.
