### PR TITLE
Deliver v2.8.1 release hotfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet ci install release-smoke readme-html readme-html-check docs-html docs-html-check html skills-check dogfood-claude clean
+.PHONY: build test fmt fmt-check vet ci install release-check release-smoke readme-html readme-html-check docs-html docs-html-check html skills-check dogfood-claude clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -40,6 +40,11 @@ ci: fmt-check vet test readme-html-check docs-html-check skills-check
 skills-check:
 	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for skills-check" >&2; exit 1; }
 	@python3 scripts/check-skill-frontmatter.py
+
+release-check:
+	@test "$(VERSION)" != "dev" || (echo "VERSION is required, for example VERSION=v2.8.1" >&2; exit 1)
+	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for release-check" >&2; exit 1; }
+	@python3 scripts/check-release-version.py "$(VERSION)"
 
 # Regenerate the browsable README.html from README.md. Run this whenever
 # README.md changes (the release process bumps README.md, so it runs here).
@@ -102,6 +107,7 @@ dogfood-claude:
 
 release-smoke:
 	@test "$(VERSION)" != "dev" || (echo "VERSION is required, for example VERSION=v0.5.1" >&2; exit 1)
+	@$(MAKE) --no-print-directory release-check VERSION="$(VERSION)"
 	@tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
 	GOBIN="$$tmp" GOPROXY=direct go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@$(VERSION); \

--- a/README.html
+++ b/README.html
@@ -460,7 +460,7 @@ workstream)</li>
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.7.0</span>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.8.1</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
@@ -1291,7 +1291,7 @@ attached.</p>
 <p><code>amq-squad amq ...</code> is a project-aware wrapper around AMQ
 diagnostics. It resolves the same AMQ root, base root, session, and
 handle that the squad launcher uses, then delegates to AMQ.</p>
-<p>amq-squad v2.7.0 requires AMQ 0.38.0 or newer. That floor includes
+<p>amq-squad v2.8.1 requires AMQ 0.38.0 or newer. That floor includes
 eval-safe <code>amq env --export</code> and the reserved human
 <code>user</code> mailbox behavior used by operator gates and
 notification surfaces.</p>
@@ -1538,7 +1538,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb34-1"><a href="#
 <span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--trust</span> approve-for-me</span>
 <span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5,fullstack=sonnet</span>
 <span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5</span></code></pre></div>
-<p>amq-squad v2.7.0 requires amq <strong>0.38.0+</strong>. Launches pass
+<p>amq-squad v2.8.1 requires amq <strong>0.38.0+</strong>. Launches pass
 <code>--require-wake</code> to <code>amq coop exec</code>, so a launch
 <strong>fails at the door</strong> when the AMQ wake sidecar cannot
 start and acquire its lock, instead of surfacing later as a stale or

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 2.0 line (note the `/v2` module path):
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.7.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.8.1
 amq-squad version
 ```
 
@@ -760,7 +760,7 @@ It renders to `/dev/tty`, so `stdout` stays clean for the other verbs. With `--o
 
 `amq-squad amq ...` is a project-aware wrapper around AMQ diagnostics. It resolves the same AMQ root, base root, session, and handle that the squad launcher uses, then delegates to AMQ.
 
-amq-squad v2.7.0 requires AMQ 0.38.0 or newer. That floor includes eval-safe `amq env --export` and the reserved human `user` mailbox behavior used by operator gates and notification surfaces.
+amq-squad v2.8.1 requires AMQ 0.38.0 or newer. That floor includes eval-safe `amq env --export` and the reserved human `user` mailbox behavior used by operator gates and notification surfaces.
 
 Read-only diagnostics run directly:
 
@@ -981,7 +981,7 @@ amq-squad team init --personas cto,fullstack --model cto=gpt-5,fullstack=sonnet
 amq-squad agent up codex --model gpt-5
 ```
 
-amq-squad v2.7.0 requires amq **0.38.0+**. Launches pass `--require-wake` to
+amq-squad v2.8.1 requires amq **0.38.0+**. Launches pass `--require-wake` to
 `amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale or
 orphaned wake. `--no-require-wake` opts out for environments where wake cannot

--- a/internal/cli/briefs_seed_test.go
+++ b/internal/cli/briefs_seed_test.go
@@ -335,7 +335,7 @@ func TestRunUpDryRunWithoutSeedStillMatchesTeamShow(t *testing.T) {
 		t.Fatalf("team show: %v", err)
 	}
 	upOut, _, err := captureOutput(t, func() error {
-		return runUp([]string{"--dry-run", "--no-bootstrap"})
+		return runUp([]string{"--dry-run", "--no-bootstrap", "--target", "current-window"})
 	})
 	if err != nil {
 		t.Fatalf("up --dry-run: %v", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -114,7 +114,7 @@ peers:
 		"Custom roles (.amq-squad/roles)",
 		"probe-officer",
 		"codex",
-		"Investigates runtime probes.",
+		"staged custom role",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("roles output missing %q:\n%s", want, stdout)

--- a/internal/cli/json_envelopes_test.go
+++ b/internal/cli/json_envelopes_test.go
@@ -104,6 +104,12 @@ peers: [cto]
 	if got.ID != "probe-officer" || got.Label != "Probe Officer" || got.PreferredBinary != "codex" {
 		t.Fatalf("custom role = %+v, want probe-officer metadata", got)
 	}
+	if got.Description != "Investigates runtime probes." {
+		t.Fatalf("custom role description = %q", got.Description)
+	}
+	if got.Profile != "" {
+		t.Fatalf("custom role profile = %q, want empty profile metadata", got.Profile)
+	}
 	if len(got.Skills) != 1 || got.Skills[0] != "/probe" || len(got.DefaultPeers) != 1 || got.DefaultPeers[0] != "cto" {
 		t.Fatalf("custom role skills/peers = %+v / %+v", got.Skills, got.DefaultPeers)
 	}
@@ -339,7 +345,7 @@ func TestRunTeamShowJSONMatchesUpDryRunPlan(t *testing.T) {
 		t.Fatalf("team show --json: %v", err)
 	}
 	upOut, _, err := captureOutput(t, func() error {
-		return runUp([]string{"--dry-run", "--json", "--no-bootstrap"})
+		return runUp([]string{"--dry-run", "--json", "--no-bootstrap", "--target", "current-window"})
 	})
 	if err != nil {
 		t.Fatalf("up --dry-run --json: %v", err)

--- a/internal/cli/roles.go
+++ b/internal/cli/roles.go
@@ -96,7 +96,6 @@ func rolesData(projectDir string) (rolesEnvelopeData, error) {
 			ID:              id,
 			Label:           label,
 			PreferredBinary: def.Binary,
-			Profile:         def.Description,
 			Description:     def.Description,
 			Skills:          append([]string(nil), def.Skills...),
 			DefaultPeers:    append([]string(nil), def.Peers...),

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -29,7 +29,7 @@ func runUp(args []string) error {
 	yes := fs.Bool("yes", false, "skip the --reset confirmation prompt (for automation)")
 	fs.BoolVar(yes, "y", false, "shorthand for --yes")
 	profileFlag := fs.String("profile", "", "team profile to bring up (default: default profile)")
-	visibilityFlag := fs.String("visibility", "", "launch topology shortcut: sibling-tabs, detached, current, or plan")
+	visibilityFlag := fs.String("visibility", visibilitySiblingTabs, "launch topology shortcut: sibling-tabs, detached, current, or plan")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned JSON envelope (requires --dry-run; the live up path stays human-only in 11A)")
 	pf := registerPreviewFlags(fs)
 	lf := registerLiveLaunchFlags(fs)
@@ -189,11 +189,12 @@ Examples:
 			opts.RequestedSession = positionalSession
 			opts.ExplicitSession = true
 		}
-		if flagWasSet(fs, "visibility") && (flagWasSet(fs, "terminal") || flagWasSet(fs, "target")) {
+		visibility := launchVisibilityForFlags(*visibilityFlag, flagWasSet(fs, "visibility"), flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"))
+		if visibility != "" && flagWasSet(fs, "visibility") && (flagWasSet(fs, "terminal") || flagWasSet(fs, "target")) {
 			return usageErrorf("--visibility cannot be combined with --terminal or --target; choose one topology surface")
 		}
-		if flagWasSet(fs, "visibility") {
-			mode, err := normalizeLaunchVisibility(*visibilityFlag)
+		if visibility != "" {
+			mode, err := normalizeLaunchVisibility(visibility)
 			if err != nil {
 				return err
 			}
@@ -253,7 +254,8 @@ Examples:
 	if err != nil {
 		return err
 	}
-	if err := applyLaunchVisibility(&opts, *visibilityFlag, flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"), true); err != nil {
+	visibility := launchVisibilityForFlags(*visibilityFlag, flagWasSet(fs, "visibility"), flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"))
+	if err := applyLaunchVisibility(&opts, visibility, flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"), true); err != nil {
 		return err
 	}
 	// --fresh is reconciled to a no-op on `up`: refuse-existing is the default

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -85,8 +85,9 @@ func useFakeBackend(t *testing.T) *fakeBackend {
 	return backend
 }
 
-// TestUpDryRunMatchesTeamShowCore proves the core path: with no extra flags,
-// `up --dry-run` emits the same launch-command plan as `team show`.
+// TestUpDryRunMatchesTeamShowCoreWithExplicitTarget proves the low-level
+// escape hatch: when an operator explicitly chooses a target, `up --dry-run`
+// keeps the legacy launch-command plan shape used by `team show`.
 func TestUpDryRunMatchesTeamShowCore(t *testing.T) {
 	cfg := team.Team{
 		Members: []team.Member{
@@ -103,13 +104,34 @@ func TestUpDryRunMatchesTeamShowCore(t *testing.T) {
 		t.Fatalf("team show: %v", err)
 	}
 	upOut, _, err := captureOutput(t, func() error {
-		return runUp([]string{"--dry-run", "--no-bootstrap"})
+		return runUp([]string{"--dry-run", "--no-bootstrap", "--target", "current-window"})
 	})
 	if err != nil {
 		t.Fatalf("up --dry-run: %v", err)
 	}
 	if showOut != upOut {
 		t.Fatalf("up --dry-run output differs from team show.\nteam show:\n%s\nup --dry-run:\n%s", showOut, upOut)
+	}
+}
+
+func TestUpDryRunDefaultsToSiblingTabsVisibility(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-238"}},
+	})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"issue-238", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("up --dry-run default visibility: %v", err)
+	}
+	env := decodeJSONEnvelope[teamPlan](t, stdout)
+	if env.Data.Visibility != "sibling-tabs" {
+		t.Fatalf("visibility = %q, want sibling-tabs", env.Data.Visibility)
+	}
+	if env.Data.LaunchCommand != "amq-squad up issue-238 --visibility sibling-tabs" {
+		t.Fatalf("launch_command = %q", env.Data.LaunchCommand)
 	}
 }
 
@@ -191,6 +213,7 @@ func TestUpDryRunMatchesTeamShowWithFlags(t *testing.T) {
 		"--wake-inject-via", "/opt/amq-inject",
 		"--wake-inject-arg=--pane",
 	}
+	upFlagSet := append([]string{"--target", "current-window"}, flagSet...)
 
 	showOut, _, err := captureOutput(t, func() error {
 		return runTeamShow(flagSet)
@@ -199,7 +222,7 @@ func TestUpDryRunMatchesTeamShowWithFlags(t *testing.T) {
 		t.Fatalf("team show: %v", err)
 	}
 	upOut, _, err := captureOutput(t, func() error {
-		return runUp(append([]string{"--dry-run"}, flagSet...))
+		return runUp(append([]string{"--dry-run"}, upFlagSet...))
 	})
 	if err != nil {
 		t.Fatalf("up --dry-run: %v", err)

--- a/internal/cli/visibility.go
+++ b/internal/cli/visibility.go
@@ -28,6 +28,16 @@ func normalizeLaunchVisibility(raw string) (string, error) {
 	}
 }
 
+func launchVisibilityForFlags(raw string, explicitVisibility, explicitTerminal, explicitTarget, explicitTerminalSession bool) string {
+	if explicitVisibility {
+		return strings.TrimSpace(raw)
+	}
+	if explicitTerminal || explicitTarget || explicitTerminalSession {
+		return ""
+	}
+	return visibilitySiblingTabs
+}
+
 func applyLaunchVisibility(opts *teamLaunchOptions, visibility string, explicitTerminal, explicitTarget, explicitTerminalSession, live bool) error {
 	visibility = strings.TrimSpace(visibility)
 	if visibility == "" {

--- a/internal/cli/visibility_test.go
+++ b/internal/cli/visibility_test.go
@@ -5,6 +5,18 @@ import (
 	"testing"
 )
 
+func TestLaunchVisibilityDefaultsUnlessLowLevelTopologyExplicit(t *testing.T) {
+	if got := launchVisibilityForFlags("sibling-tabs", false, false, false, false); got != "sibling-tabs" {
+		t.Fatalf("default visibility = %q, want sibling-tabs", got)
+	}
+	if got := launchVisibilityForFlags("sibling-tabs", false, false, true, false); got != "" {
+		t.Fatalf("explicit --target should disable default visibility, got %q", got)
+	}
+	if got := launchVisibilityForFlags("detached", true, false, false, false); got != "detached" {
+		t.Fatalf("explicit visibility = %q, want detached", got)
+	}
+}
+
 func TestApplyLaunchVisibilitySiblingTabsRequiresLiveTmuxPane(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_PANE", "")

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.7.0",
+  "version": "2.8.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -15,7 +15,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.7.0** — on your FIRST response of a session, print the line `amq-squad skill v2.7.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.8.1** — on your FIRST response of a session, print the line `amq-squad skill v2.8.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.7.0",
+  "version": "2.8.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -11,7 +11,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.7.0** — on your FIRST response of a session, print the line `amq-squad skill v2.7.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.8.1** — on your FIRST response of a session, print the line `amq-squad skill v2.8.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate release-facing version metadata before publishing a tag."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+
+VERSION_RE = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
+SKILL_MARKER_RE = re.compile(r"Skill version:\s*([0-9]+\.[0-9]+\.[0-9]+)")
+
+
+def read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def fail_if_missing(path: str, needle: str, failures: list[str]) -> None:
+    if needle not in read(path):
+        failures.append(f"{path}: missing {needle!r}")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: check-release-version.py VERSION\n")
+        return 2
+    m = VERSION_RE.match(sys.argv[1].strip())
+    if not m:
+        sys.stderr.write("VERSION must look like v2.8.1 or 2.8.1\n")
+        return 2
+
+    version = m.group(1)
+    tag = "v" + version
+    root = os.getcwd()
+    failures: list[str] = []
+
+    mirrors = {
+        "claude": "plugins/claude/.claude-plugin/plugin.json",
+        "codex": "plugins/codex/.codex-plugin/plugin.json",
+    }
+    for mirror, manifest_rel in mirrors.items():
+        manifest_path = os.path.join(root, manifest_rel)
+        manifest_version = str(json.loads(read(manifest_path)).get("version", "")).strip()
+        if manifest_version != version:
+            failures.append(f"{manifest_rel}: version {manifest_version!r} != {version!r}")
+
+        skill_rel = f"plugins/{mirror}/skills/amq-squad/SKILL.md"
+        skill_body = read(os.path.join(root, skill_rel))
+        marker = SKILL_MARKER_RE.search(skill_body)
+        if not marker:
+            failures.append(f"{skill_rel}: missing Skill version marker")
+        elif marker.group(1) != version:
+            failures.append(f"{skill_rel}: Skill version {marker.group(1)!r} != {version!r}")
+        expected_echo = f"amq-squad skill {tag}"
+        if expected_echo not in skill_body:
+            failures.append(f"{skill_rel}: missing startup echo {expected_echo!r}")
+
+    readme = os.path.join(root, "README.md")
+    fail_if_missing(readme, f"go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@{tag}", failures)
+    fail_if_missing(readme, f"amq-squad {tag} requires AMQ", failures)
+    fail_if_missing(readme, f"amq-squad {tag} requires amq", failures)
+
+    readme_html = os.path.join(root, "README.html")
+    if os.path.exists(readme_html):
+        fail_if_missing(readme_html, f"github.com/omriariav/amq-squad/v2/cmd/amq-squad@{tag}", failures)
+        fail_if_missing(readme_html, f"amq-squad {tag} requires AMQ", failures)
+        fail_if_missing(readme_html, f"amq-squad {tag} requires amq", failures)
+
+    if failures:
+        for failure in failures:
+            sys.stderr.write("FAIL  " + failure + "\n")
+        return 1
+
+    print(f"release metadata matches {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- make raw `amq-squad up` default to `--visibility sibling-tabs` unless an operator explicitly supplies low-level topology flags
- bump Claude/Codex plugin manifests, skill markers, startup echoes, README, and generated README HTML to v2.8.1
- add `make release-check VERSION=...` and wire it into `make release-smoke` so stale release metadata blocks publishing
- keep custom-role `description` separate from `profile` metadata in roles JSON/table output

## Objective Review Findings

- v2.8.0 shipped with plugin/skill/docs metadata still pointing at v2.7.0
- v2.8.0 goal/topology UX expected sibling tabs, but raw `amq-squad up` still defaulted to current-window unless `--visibility` was explicitly passed
- CI did not validate release-facing metadata against the intended tag
- custom role descriptions leaked into the `profile` field, making JSON consumers ambiguous

## Validation

- `git diff --cached --check`
- `make release-check VERSION=v2.8.1`
- `make ci`
- exact-head `make release-check VERSION=v2.8.1`
- exact-head `make ci`
