### PR TITLE
Defer --register-orchestrator roster write behind --yes gate (#282)

### DIFF
--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -350,7 +350,27 @@ confirm-gated and requires --yes in this first implementation slice.
 	if goal == "" {
 		return usageErrorf("goal start requires --goal TEXT")
 	}
-	if flagWasSet(fs, "register-orchestrator") && !*dryRun {
+	// Dry-run previews the plan without any mutation. --register-orchestrator is
+	// intentionally not applied here; the preview resolves against the configured
+	// lead, matching delivery without registration.
+	if *dryRun {
+		opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "session"), "goal start")
+		if err != nil {
+			return err
+		}
+		plan := goalStartPlan(opts)
+		if *jsonOut {
+			return printJSONEnvelope("goal_start", plan)
+		}
+		writeGoalStartPlan(os.Stdout, plan)
+		return nil
+	}
+	// Non-dry-run delivery is confirm-gated. Defer every mutation (including the
+	// --register-orchestrator roster write) until after --yes is confirmed.
+	if !*yes {
+		return usageErrorf("goal start delivery requires --yes (or run --dry-run to preview first)")
+	}
+	if flagWasSet(fs, "register-orchestrator") {
 		role, err := prepareGoalOrchestratorRegistration(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, *registerOrchestrator, flagWasSet(fs, "project"), flagWasSet(fs, "session"), "goal start")
 		if err != nil {
 			return err
@@ -360,17 +380,6 @@ confirm-gated and requires --yes in this first implementation slice.
 	opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "session"), "goal start")
 	if err != nil {
 		return err
-	}
-	plan := goalStartPlan(opts)
-	if *dryRun {
-		if *jsonOut {
-			return printJSONEnvelope("goal_start", plan)
-		}
-		writeGoalStartPlan(os.Stdout, plan)
-		return nil
-	}
-	if !*yes {
-		return usageErrorf("goal start delivery requires --yes (or run --dry-run to preview first)")
 	}
 	if flagWasSet(fs, "register-orchestrator") {
 		if err := registerGoalOrchestrator(opts, *registerOrchestrator); err != nil {

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -186,6 +186,31 @@ func TestGoalStartRequiresYesForDelivery(t *testing.T) {
 	}
 }
 
+func TestGoalStartRegisterOrchestratorDefersRosterWriteUntilYes(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members:      []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+	_, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"start", "--project", dir, "--session", "issue-96", "--goal", "ship safely", "--register-orchestrator=global-orch"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("goal start --register-orchestrator without --yes should be confirm-gated, got %v", err)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	if _, ok := teamMemberByRole(cfg, goalOrchestratorRole); ok {
+		t.Fatal("orchestrator roster write must not happen before --yes is confirmed")
+	}
+	if cfg.Lead != "cto" {
+		t.Fatalf("team lead should be unchanged before --yes, got %q", cfg.Lead)
+	}
+}
+
 func TestGoalStartYesJSONDeliversThroughGoalDeliverPath(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{


### PR DESCRIPTION
## Summary
Resolves #282. `goal start --register-orchestrator` wrote the orchestrator member to `team.json` *before* the `--yes` confirmation gate. This moves the register → resolve → deliver block behind the gate so no roster mutation happens until the operator confirms.

- Dry-run preview is handled in its own branch and stays read-only (registration was already skipped for dry-run, so preview behavior is unchanged — it resolves against the configured lead).
- Non-dry-run: `--yes` is now checked *first*; only then do we register the orchestrator member, resolve delivery options, register the wake/launch record, and deliver.
- Re-run with `--yes` remains idempotent (`registerGoalOrchestrator` already calls `ensureGoalOrchestratorMember`).

## Why the whole block moved (not just the write)
`resolveGoalTargetOptions` requires the orchestrator member to already exist in `team.json` (it errors `no team member with role X` otherwise). So the write can't be dropped in place — the dependent resolve/deliver steps move with it behind the gate.

## Tests
- New: `TestGoalStartRegisterOrchestratorDefersRosterWriteUntilYes` — asserts `goal start --register-orchestrator` without `--yes` errors on `--yes` AND leaves `team.json` unmutated (no orchestrator member, lead unchanged).
- Existing `goal start/deliver/apply` tests still pass; full `internal/cli` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)