### PR TITLE
Wake-injected drain-on-arrival re-engages a lead after Goal achieved (#283)

### DIFF
--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -693,11 +693,13 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle string) error {
 	}
 	root := absoluteAMQRoot(cwd, env.Root)
 	agentDir := filepath.Join(root, "agents", handle)
+	wakeInjectCmdValue := wakeDrainInject()
 	wakeResult, err := leadWakeStarter(leadWakeOptions{
-		ProjectDir: cwd,
-		Root:       root,
-		Handle:     handle,
-		Require:    true,
+		ProjectDir:    cwd,
+		Root:          root,
+		Handle:        handle,
+		Require:       true,
+		WakeInjectCmd: wakeInjectCmdValue,
 	})
 	if err != nil {
 		return fmt.Errorf("start external orchestrator wake: %w", err)
@@ -720,6 +722,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle string) error {
 		Model:            strings.TrimSpace(member.Model),
 		Trust:            strings.TrimSpace(t.Trust),
 		External:         true,
+		WakeInjectCmd:    wakeInjectCmdValue,
 		WakePID:          wakePID,
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -347,6 +347,85 @@ func TestGoalDeliverRegistersExternalOrchestrator(t *testing.T) {
 	}
 }
 
+func seedCtoDeliverTeamForOrchestrator(t *testing.T) (string, string) {
+	t.Helper()
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members:      []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+	seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Handle: "cto", Role: "cto", Session: "issue-96",
+		AgentPID: 4242, Tmux: &launch.TmuxInfo{PaneID: "%7"},
+	})
+	prevPane := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{Session: "global", WindowID: "@1", WindowName: "orch", PaneID: "%99"}, nil
+	}
+	oldLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%7", CWD: dir, Command: "codex", Title: "amq:issue-96:cto"}}, nil
+	}
+	oldSend := sendPromptToPane
+	sendPromptToPane = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		currentPaneIdentity = prevPane
+		statusPaneLister = oldLister
+		sendPromptToPane = oldSend
+	})
+	return base, dir
+}
+
+// TestGoalDeliverRegisterOrchestratorStartsDrainInjectingWakeSidecar proves the
+// #283/#288 plumbing for the orchestrator caller: the wake sidecar is started
+// with the standard drain inject-cmd and the launch record persists it.
+func TestGoalDeliverRegisterOrchestratorStartsDrainInjectingWakeSidecar(t *testing.T) {
+	base, dir := seedCtoDeliverTeamForOrchestrator(t)
+	var wakeOpts []leadWakeOptions
+	prevWake := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		wakeOpts = append(wakeOpts, opts)
+		return leadWakeResult{PID: 9876, Started: true, Detail: "ready"}, nil
+	}
+	t.Cleanup(func() { leadWakeStarter = prevWake })
+
+	if _, stderr, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely", "--register-orchestrator=global-orch", "--json"})
+	}); err != nil {
+		t.Fatalf("goal deliver --register-orchestrator: %v\n%s", err, stderr)
+	}
+	if len(wakeOpts) != 1 || wakeOpts[0].WakeInjectCmd != wakeDrainInject() {
+		t.Fatalf("orchestrator wake sidecar must be started with the drain inject-cmd: %+v", wakeOpts)
+	}
+	rec, err := launch.Read(filepath.Join(base, "issue-96", "agents", "global-orch"))
+	if err != nil {
+		t.Fatalf("read orchestrator launch record: %v", err)
+	}
+	if rec.WakeInjectCmd != wakeDrainInject() {
+		t.Fatalf("orchestrator launch record must persist WakeInjectCmd, got %q", rec.WakeInjectCmd)
+	}
+}
+
+// TestGoalDeliverRegisterOrchestratorWakeFailureIsHonest proves the wake sidecar
+// is required: when it cannot start, registration surfaces the failure instead
+// of reporting a drain-injecting identity it did not create.
+func TestGoalDeliverRegisterOrchestratorWakeFailureIsHonest(t *testing.T) {
+	_, dir := seedCtoDeliverTeamForOrchestrator(t)
+	prevWake := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		return leadWakeResult{}, fmt.Errorf("wake sidecar lock busy")
+	}
+	t.Cleanup(func() { leadWakeStarter = prevWake })
+
+	_, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely", "--register-orchestrator=global-orch", "--json"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "wake") {
+		t.Fatalf("wake sidecar failure must surface honestly, got: %v", err)
+	}
+}
+
 func TestGoalApplyRefusesWithoutApprovedGate(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -93,6 +93,34 @@ func TestLaunchArgsFromRecordReplaysWakeInject(t *testing.T) {
 	}
 }
 
+// TestLaunchArgsFromRecordDoesNotReplayWakeInjectCmd guards #283 option B: the
+// drain inject-cmd lives only on the external wake path (amq wake --inject-cmd).
+// amq coop exec has no --inject-cmd, so restore/replay (which rebuilds a
+// coop-exec launch) must NOT emit a --wake-inject-cmd/--inject-cmd flag the
+// launch path cannot consume. Resume repair of the drain injection is via
+// re-running lead register / register-orchestrator, not coop-exec restore. The
+// record still carries WakeInjectCmd as durable evidence, and older records
+// (no field) stay compatible.
+func TestLaunchArgsFromRecordDoesNotReplayWakeInjectCmd(t *testing.T) {
+	rec := launch.Record{
+		Binary:        "codex",
+		Handle:        "cto",
+		Role:          "cto",
+		Session:       "issue-96",
+		WakeInjectCmd: "amq-squad: drain now",
+	}
+	args := launchArgsFromRecord(rec)
+	for _, arg := range args {
+		if strings.Contains(arg, "inject-cmd") {
+			t.Fatalf("restore must not emit an unsupported inject-cmd flag, got args: %v", args)
+		}
+	}
+	cmd := emitCommandWithOptions(rec, emitCommandOptions{})
+	if strings.Contains(cmd, "inject-cmd") {
+		t.Fatalf("restore command-string must not emit an unsupported inject-cmd flag: %s", cmd)
+	}
+}
+
 func TestRunRestoreProjectFlagExpandsHome(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	home := t.TempDir()

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -25,6 +25,17 @@ type leadWakeOptions struct {
 	Require        bool
 	WakeInjectVia  string
 	WakeInjectArgs []string
+	WakeInjectCmd  string
+}
+
+// wakeDrainInject is the standard instruction amq-squad asks the wake sidecar to
+// inject on each durable-message arrival (amq wake --inject-cmd). It re-engages a
+// lead or orchestrator even after its native /goal reaches a terminal "achieved"
+// state: the inbound directive drives an inbox drain through AMQ's sanctioned
+// injector instead of a raw tmux send-keys. Shared by lead register --wake (#283)
+// and the goal orchestrator registration (#288) so both use one mechanism.
+func wakeDrainInject() string {
+	return "amq-squad: a durable AMQ message arrived. Run `amq drain --include-body` now and act on the newest item, even if your current goal looks complete. Do not wait to be polled."
 }
 
 type leadWakeResult struct {
@@ -261,6 +272,7 @@ func runLeadRegister(args []string) error {
 	root := absoluteAMQRoot(cwd, env.Root)
 	agentDir := filepath.Join(root, "agents", handle)
 	existingRec, existingRecErr := launch.Read(agentDir)
+	wakeInjectCmdValue := wakeDrainInject()
 	var wakeResult leadWakeResult
 	if !*noWake {
 		wakeResult, err = leadWakeStarter(leadWakeOptions{
@@ -270,6 +282,7 @@ func runLeadRegister(args []string) error {
 			Require:        !*noRequireWake,
 			WakeInjectVia:  wakeInjectViaValue,
 			WakeInjectArgs: wakeInjectArgValues,
+			WakeInjectCmd:  wakeInjectCmdValue,
 		})
 		if err != nil {
 			return fmt.Errorf("start external lead wake: %w", err)
@@ -296,6 +309,7 @@ func runLeadRegister(args []string) error {
 		NoRequireWake:    *noRequireWake,
 		WakeInjectVia:    wakeInjectViaValue,
 		WakeInjectArgs:   wakeInjectArgValues,
+		WakeInjectCmd:    wakeInjectCmdValue,
 		WakePID:          wakePID,
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
@@ -367,6 +381,9 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 		for _, arg := range opts.WakeInjectArgs {
 			args = append(args, "--inject-arg", arg)
 		}
+	}
+	if cmd := strings.TrimSpace(opts.WakeInjectCmd); cmd != "" {
+		args = append(args, "--inject-cmd", cmd)
 	}
 	cmd := externalLeadWakeCommand("amq", args...)
 	cmd.Dir = opts.ProjectDir

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -114,8 +114,8 @@ func TestLeadRegisterWritesExternalRecordAndSetsLead(t *testing.T) {
 
 // TestLeadRegisterStartsDrainInjectingWakeSidecar proves the #283 plumbing for
 // the lead-register caller: the wake sidecar is started with the standard drain
-// inject-cmd and that instruction is persisted on the launch record so resume
-// repairs the same drain-injecting sidecar.
+// inject-cmd and that instruction is persisted on the launch record as durable
+// evidence (resume repair is via re-register; see the re-register test).
 func TestLeadRegisterStartsDrainInjectingWakeSidecar(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	seedTeam(t, team.Team{
@@ -147,7 +147,59 @@ func TestLeadRegisterStartsDrainInjectingWakeSidecar(t *testing.T) {
 		t.Fatalf("read external launch record: %v", err)
 	}
 	if rec.WakeInjectCmd != wakeDrainInject() {
-		t.Fatalf("launch record must persist WakeInjectCmd for resume repair, got %q", rec.WakeInjectCmd)
+		t.Fatalf("launch record must persist WakeInjectCmd as resume-repair evidence, got %q", rec.WakeInjectCmd)
+	}
+}
+
+// TestLeadRegisterReapplyDrainInjectOnReRegister proves the #283 resume-repair
+// path: re-running lead register (the way an external lead is brought back)
+// reapplies the drain inject-cmd on the new wake start and keeps it persisted.
+// This is the resume mechanism for the external wake path; coop-exec restore
+// deliberately does not carry inject-cmd (see restore_test.go).
+func TestLeadRegisterReapplyDrainInjectOnReRegister(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	prev := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{Session: "tmux-main", WindowID: "@7", WindowName: "lead", PaneID: "%5"}, nil
+	}
+	t.Cleanup(func() { currentPaneIdentity = prev })
+	var wakeOpts []leadWakeOptions
+	prevWake := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		wakeOpts = append(wakeOpts, opts)
+		return leadWakeResult{PID: 2222, Started: true, Detail: "ready"}, nil
+	}
+	t.Cleanup(func() { leadWakeStarter = prevWake })
+
+	register := func() error {
+		_, _, err := captureOutput(t, func() error {
+			return runLead([]string{"register", "--role", "cto", "--session", "issue-96"})
+		})
+		return err
+	}
+	if err := register(); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := register(); err != nil {
+		t.Fatalf("re-register (resume repair): %v", err)
+	}
+	if len(wakeOpts) != 2 {
+		t.Fatalf("expected two wake starts, got %d", len(wakeOpts))
+	}
+	for i, o := range wakeOpts {
+		if o.WakeInjectCmd != wakeDrainInject() {
+			t.Fatalf("wake start %d must reapply drain inject-cmd, got %q", i, o.WakeInjectCmd)
+		}
+	}
+	rec, err := launch.Read(filepath.Join(base, "issue-96", "agents", "cto"))
+	if err != nil {
+		t.Fatalf("read external launch record: %v", err)
+	}
+	if rec.WakeInjectCmd != wakeDrainInject() {
+		t.Fatalf("re-register must keep WakeInjectCmd persisted, got %q", rec.WakeInjectCmd)
 	}
 }
 

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -112,6 +112,45 @@ func TestLeadRegisterWritesExternalRecordAndSetsLead(t *testing.T) {
 	}
 }
 
+// TestLeadRegisterStartsDrainInjectingWakeSidecar proves the #283 plumbing for
+// the lead-register caller: the wake sidecar is started with the standard drain
+// inject-cmd and that instruction is persisted on the launch record so resume
+// repairs the same drain-injecting sidecar.
+func TestLeadRegisterStartsDrainInjectingWakeSidecar(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	prev := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{Session: "tmux-main", WindowID: "@7", WindowName: "lead", PaneID: "%5"}, nil
+	}
+	t.Cleanup(func() { currentPaneIdentity = prev })
+	var wakeOpts []leadWakeOptions
+	prevWake := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		wakeOpts = append(wakeOpts, opts)
+		return leadWakeResult{PID: 2222, Started: true, Detail: "ready"}, nil
+	}
+	t.Cleanup(func() { leadWakeStarter = prevWake })
+
+	if _, _, err := captureOutput(t, func() error {
+		return runLead([]string{"register", "--role", "cto", "--session", "issue-96"})
+	}); err != nil {
+		t.Fatalf("lead register: %v", err)
+	}
+	if len(wakeOpts) != 1 || wakeOpts[0].WakeInjectCmd != wakeDrainInject() {
+		t.Fatalf("wake sidecar must be started with the drain inject-cmd: %+v", wakeOpts)
+	}
+	rec, err := launch.Read(filepath.Join(base, "issue-96", "agents", "cto"))
+	if err != nil {
+		t.Fatalf("read external launch record: %v", err)
+	}
+	if rec.WakeInjectCmd != wakeDrainInject() {
+		t.Fatalf("launch record must persist WakeInjectCmd for resume repair, got %q", rec.WakeInjectCmd)
+	}
+}
+
 func TestLeadRegisterPreservesExistingNativeGoalBinding(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -77,8 +77,12 @@ type Record struct {
 	// each durable-message arrival (amq wake --inject-cmd). amq-squad sets it to
 	// the standard drain instruction so an inbound directive re-engages a lead
 	// even after its native /goal reaches a terminal state, via AMQ's sanctioned
-	// injector rather than a raw tmux send-keys. Additive: older records omit it
-	// and resume falls back to the wake default.
+	// injector rather than a raw tmux send-keys. It is set only on the external
+	// wake path (lead register / register-orchestrator); amq coop exec has no
+	// --inject-cmd, so coop-exec restore cannot replay it. Resume repair is via
+	// re-running those register commands, which reapply the instruction; this
+	// persisted value is durable evidence of the configured injection. Additive:
+	// older records omit it.
 	WakeInjectCmd string    `json:"wake_inject_cmd,omitempty"`
 	WakePID       int       `json:"wake_pid,omitempty"`
 	AgentPID      int       `json:"agent_pid,omitempty"`

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -71,12 +71,19 @@ type Record struct {
 	// WakeInjectVia and WakeInjectArgs record AMQ 0.37.0 external wake
 	// injector settings so resume/replay can repair and restart the same
 	// digest-bound wake target later.
-	WakeInjectVia  string    `json:"wake_inject_via,omitempty"`
-	WakeInjectArgs []string  `json:"wake_inject_args,omitempty"`
-	WakePID        int       `json:"wake_pid,omitempty"`
-	AgentPID       int       `json:"agent_pid,omitempty"`
-	AgentTTY       string    `json:"agent_tty,omitempty"`
-	StartedAt      time.Time `json:"started_at"`
+	WakeInjectVia  string   `json:"wake_inject_via,omitempty"`
+	WakeInjectArgs []string `json:"wake_inject_args,omitempty"`
+	// WakeInjectCmd records the literal instruction the wake sidecar injects on
+	// each durable-message arrival (amq wake --inject-cmd). amq-squad sets it to
+	// the standard drain instruction so an inbound directive re-engages a lead
+	// even after its native /goal reaches a terminal state, via AMQ's sanctioned
+	// injector rather than a raw tmux send-keys. Additive: older records omit it
+	// and resume falls back to the wake default.
+	WakeInjectCmd string    `json:"wake_inject_cmd,omitempty"`
+	WakePID       int       `json:"wake_pid,omitempty"`
+	AgentPID      int       `json:"agent_pid,omitempty"`
+	AgentTTY      string    `json:"agent_tty,omitempty"`
+	StartedAt     time.Time `json:"started_at"`
 	// TeamProfile names the profile the launch was emitted from. Empty
 	// means the implicit default profile. Captured so status / bootstrap
 	// routing can reuse the same profile without rereading flags.

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 )
@@ -73,6 +74,43 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 	if !out.StartedAt.Equal(in.StartedAt) {
 		t.Errorf("StartedAt = %v, want %v", out.StartedAt, in.StartedAt)
+	}
+}
+
+// TestWakeInjectCmdAdditiveBackCompat proves the #283 WakeInjectCmd field is
+// additive: an older record JSON without wake_inject_cmd loads with an empty
+// value, an empty value is omitted on write, and a set value round-trips.
+func TestWakeInjectCmdAdditiveBackCompat(t *testing.T) {
+	// Older record (no wake_inject_cmd key) must load with empty WakeInjectCmd.
+	legacyJSON := `{"schema":1,"cwd":"/p","binary":"codex","session":"s","handle":"cto","root":"/r","started_at":"2026-06-30T00:00:00Z"}`
+	var legacy Record
+	if err := json.Unmarshal([]byte(legacyJSON), &legacy); err != nil {
+		t.Fatalf("older record must still load: %v", err)
+	}
+	if legacy.WakeInjectCmd != "" {
+		t.Fatalf("missing wake_inject_cmd must decode empty, got %q", legacy.WakeInjectCmd)
+	}
+
+	// Empty value is omitted (omitempty), so no key appears for older writers.
+	emptyRaw, err := json.Marshal(Record{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(emptyRaw), "wake_inject_cmd") {
+		t.Fatalf("empty WakeInjectCmd must be omitted from JSON: %s", emptyRaw)
+	}
+
+	// A set value round-trips.
+	setRaw, err := json.Marshal(Record{WakeInjectCmd: "drain now"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Record
+	if err := json.Unmarshal(setRaw, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.WakeInjectCmd != "drain now" {
+		t.Fatalf("WakeInjectCmd round-trip = %q, want %q", back.WakeInjectCmd, "drain now")
 	}
 }
 


### PR DESCRIPTION
## Summary
Resolves #283 (part of EPIC #286). A lead whose native `/goal` reached the terminal **"Goal achieved"** state stopped draining its AMQ inbox; a durable directive sent afterward sat unprocessed and the only fallback was a raw `tmux send-keys`.

The sanctioned mechanism is AMQ's own wake injector: `amq wake` injects on **every** durable-message arrival, independent of the Codex goal lifecycle. This wires amq-squad to use it.

## Changes (approach A, shared with #288 per cto decision)
- Shared `wakeDrainInject()` helper returning the standard drain instruction.
- Plumb `leadWakeOptions.WakeInjectCmd` → `startExternalLeadWake` → `amq wake --inject-cmd`, so the wake sidecar injects an **actionable drain instruction** on arrival via AMQ's sanctioned path (never a raw send-keys).
- Applied to **both** wake-start callers — `lead register --wake` (#283) and `registerGoalOrchestrator` (#288) — so they share one mechanism.
- Additive `launch.Record.WakeInjectCmd` (`json:"wake_inject_cmd,omitempty"`) persisted so resume/replay repairs the same drain-injecting sidecar; older records load with the field omitted.

Scope held to the two callers per the approved decision: **no** new `--wake-inject-cmd` user flag, **no** dispatch-contract change, **no** new `goal resume/rearm` subcommand. Resume-repair works because re-running the register commands reapplies the constant.

## Evidence split (per QA guidance)
- **Plumbing — green (this PR, unit-proven):** both callers pass the inject-cmd; record persists it; field is additive/back-compatible; honest failure under the wake `Require`.
- **Behavior — deferred to #286 dogfood:** whether a real OS injection actually re-engages an *achieved* Codex lead is runtime behavior, **not** claimed from unit tests.

## Tests
- `TestLeadRegisterStartsDrainInjectingWakeSidecar`, `TestGoalDeliverRegisterOrchestratorStartsDrainInjectingWakeSidecar` — both callers pass inject-cmd + persist it.
- `TestGoalDeliverRegisterOrchestratorWakeFailureIsHonest` — honest failure under wake requirement.
- `TestWakeInjectCmdAdditiveBackCompat` — additive/omitempty/round-trip.
- `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)