### PR TITLE
Surface orchestrator auto-drain-on-wake in status --json (#288)

### DIFF
--- a/README.html
+++ b/README.html
@@ -911,6 +911,22 @@ together with a live wake signal (<code>status: "wake-live"</code>,
 <code>signals.wake_pid</code>). The <code>external</code> field lets a
 client positively identify the registered orchestrator instead of
 inferring it from the lead role alone.</p>
+<p>The registered orchestrator's wake sidecar is started so that each
+inbound durable AMQ message injects a drain instruction (via AMQ's
+<code>amq wake</code> injector, not a raw <code>tmux send-keys</code>).
+The orchestrator therefore drains and acts reactively on wake, with no
+periodic <code>amq drain</code> polling loop, even after its own
+<code>/goal</code> reaches a terminal "achieved" state.
+<code>status --json</code> reports <code>wake_auto_drain: true</code> on
+that member when the drain injection is configured; this is a
+configuration signal, so a dead sidecar still surfaces as degraded
+(<code>status</code> not <code>wake-live</code>,
+<code>signals.wake_alive: false</code>) rather than silently appearing
+healthy. The virtual operator (<code>user</code>) handle is non-runnable
+and stays poll-only
+(<code>operator_delivery.poll_required: true</code>); auto-drain on wake
+applies to the orchestrator and lead handles, not the operator
+mailbox.</p>
 <p>For an Autonomous preview, opt in explicitly and include a bounded
 policy:</p>
 <div class="sourceCode" id="cb17"><pre

--- a/README.md
+++ b/README.md
@@ -458,6 +458,18 @@ live wake signal (`status: "wake-live"`, `signals.wake_alive: true`, and
 `signals.wake_pid`). The `external` field lets a client positively identify the
 registered orchestrator instead of inferring it from the lead role alone.
 
+The registered orchestrator's wake sidecar is started so that each inbound
+durable AMQ message injects a drain instruction (via AMQ's `amq wake`
+injector, not a raw `tmux send-keys`). The orchestrator therefore drains and
+acts reactively on wake, with no periodic `amq drain` polling loop, even after
+its own `/goal` reaches a terminal "achieved" state. `status --json` reports
+`wake_auto_drain: true` on that member when the drain injection is configured;
+this is a configuration signal, so a dead sidecar still surfaces as degraded
+(`status` not `wake-live`, `signals.wake_alive: false`) rather than silently
+appearing healthy. The virtual operator (`user`) handle is non-runnable and
+stays poll-only (`operator_delivery.poll_required: true`); auto-drain on wake
+applies to the orchestrator and lead handles, not the operator mailbox.
+
 For an Autonomous preview, opt in explicitly and include a bounded policy:
 
 ```sh

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -148,6 +148,14 @@ type statusRecord struct {
 	// client can positively identify the wakeable orchestrator identity rather
 	// than inferring it from lead role alone. Set from launch.Record.External.
 	External bool `json:"external,omitempty"`
+	// WakeAutoDrain reports that this member's wake sidecar is configured to
+	// inject a drain instruction on each durable-message arrival (the launch
+	// record carries WakeInjectCmd). It means inbound messages are processed
+	// reactively on wake, with no periodic `amq drain` polling loop. It is a
+	// CONFIGURATION signal, not liveness: a client must still read signals
+	// (wake_alive) and status to know whether the sidecar is actually running,
+	// so a dead sidecar surfaces as degraded rather than silently lost.
+	WakeAutoDrain bool `json:"wake_auto_drain,omitempty"`
 	// Actions are the stable, project-scoped commands a client can render/copy
 	// for this member (focus/send/resume/status). Populated for --json only.
 	Actions []runtimeActionJSON `json:"actions,omitempty"`
@@ -901,6 +909,7 @@ func classifyMemberStatus(t team.Team, profile string, m team.Member, workstream
 	if live.LaunchFound {
 		rec.goalBinding = live.LaunchRecord.GoalBinding
 		rec.External = live.LaunchRecord.External
+		rec.WakeAutoDrain = strings.TrimSpace(live.LaunchRecord.WakeInjectCmd) != ""
 		rec.AdoptionMode = strings.TrimSpace(live.LaunchRecord.AdoptionMode)
 		rec.LauncherPaneID = strings.TrimSpace(live.LaunchRecord.LauncherPaneID)
 		if origin := strings.TrimSpace(live.LaunchRecord.SpawnOrigin); origin != "" {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1570,6 +1570,118 @@ func TestStatusJSONProvesExternalOrchestratorBinding(t *testing.T) {
 	}
 }
 
+func orchestratorStatusRecord(rows []statusRecord) *statusRecord {
+	for i := range rows {
+		if rows[i].Role == goalOrchestratorRole {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// TestStatusJSONOrchestratorWakeDrivenUserPollOnly proves #288: a registered
+// orchestrator whose wake sidecar carries a drain inject-cmd is reported as
+// wake-driven/auto-drain (no periodic amq drain loop), while the virtual
+// operator handle stays poll-only. wake_auto_drain composes with #283's
+// WakeInjectCmd.
+func TestStatusJSONOrchestratorWakeDrivenUserPollOnly(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members:       []team.Member{{Role: goalOrchestratorRole, Binary: "codex", Handle: "global-orch", Session: "issue-96"}},
+		Orchestrated:  true,
+		Lead:          goalOrchestratorRole,
+		ExecutionMode: executionModeProjectLead,
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "global-orch", launch.Record{
+		CWD:           dir,
+		Binary:        "codex",
+		Handle:        "global-orch",
+		Role:          goalOrchestratorRole,
+		Session:       "issue-96",
+		External:      true,
+		WakePID:       4321,
+		WakeInjectCmd: wakeDrainInject(),
+		Tmux:          &launch.TmuxInfo{Session: "global", WindowID: "@1", PaneID: "%99", Target: "external"},
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4321, Root: filepath.Join(base, "issue-96"), Started: time.Now()})
+
+	jsonOut, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(map[int]bool{4321: true}, map[int]bool{4321: true}, time.Now()),
+	})
+	if err != nil {
+		t.Fatalf("status json: %v\n%s", err, jsonOut)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, jsonOut)
+	row := orchestratorStatusRecord(env.Data.Records)
+	if row == nil {
+		t.Fatalf("no orchestrator record in %+v", env.Data.Records)
+	}
+	// Orchestrator handle: wake-driven auto-drain, reactively live (no polling).
+	if !row.WakeAutoDrain {
+		t.Fatalf("orchestrator must report wake_auto_drain=true: %+v", row)
+	}
+	if row.Status != statusStateWakeLive || !row.Signals.WakeAlive {
+		t.Fatalf("orchestrator must be reactively wake-live: %+v", row)
+	}
+	// Virtual operator handle: stays poll-only, not wakeable (out of scope).
+	if !env.Data.OperatorDelivery.PollRequired || env.Data.OperatorDelivery.WakeSupported {
+		t.Fatalf("operator handle must remain poll-only: %+v", env.Data.OperatorDelivery)
+	}
+}
+
+// TestStatusJSONWakeAutoDrainDegradedWhenSidecarDead proves QA's honest-failure
+// requirement: wake_auto_drain is a CONFIGURATION signal, so when the sidecar
+// process is dead the orchestrator surfaces as degraded (not wake-live) rather
+// than silently appearing healthy.
+func TestStatusJSONWakeAutoDrainDegradedWhenSidecarDead(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members:       []team.Member{{Role: goalOrchestratorRole, Binary: "codex", Handle: "global-orch", Session: "issue-96"}},
+		Orchestrated:  true,
+		Lead:          goalOrchestratorRole,
+		ExecutionMode: executionModeProjectLead,
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "global-orch", launch.Record{
+		CWD:           dir,
+		Binary:        "codex",
+		Handle:        "global-orch",
+		Role:          goalOrchestratorRole,
+		Session:       "issue-96",
+		External:      true,
+		WakePID:       4321,
+		WakeInjectCmd: wakeDrainInject(),
+		Tmux:          &launch.TmuxInfo{Session: "global", WindowID: "@1", PaneID: "%99", Target: "external"},
+	})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4321, Root: filepath.Join(base, "issue-96"), Started: time.Now()})
+
+	// Probe reports the wake PID as DEAD.
+	jsonOut, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(map[int]bool{4321: false}, map[int]bool{4321: false}, time.Now()),
+	})
+	if err != nil {
+		t.Fatalf("status json: %v\n%s", err, jsonOut)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, jsonOut)
+	row := orchestratorStatusRecord(env.Data.Records)
+	if row == nil {
+		t.Fatalf("no orchestrator record in %+v", env.Data.Records)
+	}
+	if !row.WakeAutoDrain {
+		t.Fatalf("wake_auto_drain (configuration) should stay true even with a dead sidecar: %+v", row)
+	}
+	if row.Status == statusStateWakeLive || row.Signals.WakeAlive {
+		t.Fatalf("dead sidecar must surface as degraded, not wake-live: %+v", row)
+	}
+}
+
 func TestExecuteStatusWakeLockOnlyWakeLive(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{


### PR DESCRIPTION
## Summary
Resolves #288 (part of EPIC #286). Builds directly on #283's external-wake drain-inject mechanism: `registerGoalOrchestrator` already starts the orchestrator's wake sidecar with the standard drain inject-cmd, so inbound messages are processed reactively **on wake** with no periodic `amq drain` polling loop. This PR adds the observability that makes that contract provable, and validates the orchestrator-vs-`user` scoping.

## Changes
- **Additive `wake_auto_drain` per-record field in `status --json`**, set when the launch record carries `WakeInjectCmd` (the wake sidecar injects a drain on every durable-message arrival). It is a **configuration** signal — liveness stays in `signals.wake_alive`/`status`, so a dead sidecar surfaces as **degraded**, not silently healthy.
- README: documents auto-drain-on-wake, the degraded-sidecar semantics, and that the virtual `user` handle stays poll-only (`operator_delivery.poll_required: true`).

## QA checklist coverage
- Orchestrator handle gets drain-inject wake → `wake_auto_drain: true` (composes with #283 `wakeDrainInject`).
- Virtual `user` handle stays poll-only / not wakeable → asserted via `operator_delivery.poll_required`.
- Sidecar death is honest → `TestStatusJSONWakeAutoDrainDegradedWhenSidecarDead` (degraded, no silent loss).
- No dispatch contract change; additive JSON; back-compat unaffected.

## Tests
- `TestStatusJSONOrchestratorWakeDrivenUserPollOnly`, `TestStatusJSONWakeAutoDrainDegradedWhenSidecarDead`. `make ci` green.

## Evidence split
- **Plumbing-green (this PR):** the wake sidecar is configured to auto-drain and `status --json` proves it; user handle stays poll-only.
- **Behavioral (deferred to #286 dogfood):** an actual orchestrated run completing with zero periodic `amq drain` is dogfood evidence, not claimed from unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)