### PR TITLE
Add 'verify release' final-commit co-sign gate before publish (#285)

### DIFF
--- a/README.html
+++ b/README.html
@@ -979,6 +979,22 @@ decision. Prune requests must include measured idle age, explicit
 evidence that active task linkage was checked, and no linked active
 tasks; <code>--idle-reap-minutes</code> sets the minimum idle age before
 pruning is allowed.</p>
+<p>Releases carry one more gate. Before any publish step
+(<code>git push</code> of the release commit, <code>git tag</code>,
+<code>gh release create</code>),
+<code>amq-squad verify release --evidence &lt;file&gt;</code> requires
+the <strong>final assembled release commit SHA</strong> to carry both a
+<strong>developer co-sign</strong> (a second actor,
+<code>cosign.distinct_from_release_lead: true</code>,
+<code>cosign.sha</code> equal to the release commit SHA — a co-sign on
+an earlier per-delta SHA is rejected as stale) and an <strong>approved
+operator release gate</strong>. The two are non-substitutable: an
+"APPROVED to release" operator decision alone never authorizes publish
+without the exact-SHA developer co-sign, and the co-sign never
+substitutes for the operator gate. <code>verify release</code> only
+validates normalized evidence; it never pushes, tags, or releases —
+those remain operator-performed. The release commit's own final SHA must
+pass this gate before it becomes immutable.</p>
 <h3 id="profiles-schema-3">Profiles (schema 3)</h3>
 <p>Profiles let one team-home hold parallel team shapes (for example a
 release team and a research team).</p>

--- a/README.md
+++ b/README.md
@@ -521,6 +521,19 @@ measured idle age, explicit evidence that active task linkage was checked, and
 no linked active tasks; `--idle-reap-minutes` sets the minimum idle age before
 pruning is allowed.
 
+Releases carry one more gate. Before any publish step (`git push` of the release
+commit, `git tag`, `gh release create`), `amq-squad verify release --evidence
+<file>` requires the **final assembled release commit SHA** to carry both a
+**developer co-sign** (a second actor, `cosign.distinct_from_release_lead: true`,
+`cosign.sha` equal to the release commit SHA — a co-sign on an earlier per-delta
+SHA is rejected as stale) and an **approved operator release gate**. The two are
+non-substitutable: an "APPROVED to release" operator decision alone never
+authorizes publish without the exact-SHA developer co-sign, and the co-sign never
+substitutes for the operator gate. `verify release` only validates normalized
+evidence; it never pushes, tags, or releases — those remain operator-performed.
+The release commit's own final SHA must pass this gate before it becomes
+immutable.
+
 ### Profiles (schema 3)
 
 Profiles let one team-home hold parallel team shapes (for example a release team and a research team).

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -145,6 +145,7 @@ var completionTaskSubcommands = []string{
 // completionVerifySubcommands lists the `amq-squad verify` subcommands.
 var completionVerifySubcommands = []string{
 	"merge",
+	"release",
 }
 
 // completionCommonFlags lists every flag registered by the current stdlib

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -77,21 +77,29 @@ func runVerify(args []string) error {
 
 Usage:
   amq-squad verify merge --evidence <file|-> [--json]
+  amq-squad verify release --evidence <file|-> [--json]
 
-The merge preflight validates normalized lead-supplied evidence. It does not
-query providers, infer PR state, merge, or mutate remote state. Failed evidence
-prints the failed conditions and exits non-zero.
+The merge preflight validates normalized per-PR evidence (CI + review at a head
+SHA). The release preflight validates a final-release-commit co-sign gate: an
+exact-SHA developer co-sign AND an operator release approval before publish.
+Neither queries providers, infers state, merges, or mutates remote state.
+'APPROVED to release' alone never authorizes publish: push/tag/release require
+the final release commit SHA to carry a developer co-sign and an approved
+operator release gate, and remain operator-performed. Failed evidence prints the
+failed conditions and exits non-zero.
 `)
 		if len(args) == 0 {
-			return usageErrorf("verify requires a subcommand (merge)")
+			return usageErrorf("verify requires a subcommand (merge or release)")
 		}
 		return nil
 	}
 	switch args[0] {
 	case "merge":
 		return runVerifyMerge(args[1:])
+	case "release":
+		return runVerifyRelease(args[1:])
 	default:
-		return usageErrorf("unknown 'verify' subcommand: %q. Try merge.", args[0])
+		return usageErrorf("unknown 'verify' subcommand: %q. Try merge or release.", args[0])
 	}
 }
 
@@ -274,4 +282,207 @@ func displaySubject(e verifyMergeEvidence) string {
 		return s
 	}
 	return "change"
+}
+
+const verifyReleaseStateApproved = "approved"
+
+// verifyReleaseEvidence is the normalized evidence for the #285 final-release
+// co-sign gate. It is a DIFFERENT artifact from merge evidence: it binds release
+// CI, a developer co-sign, and an operator release approval to the exact final
+// assembled release commit SHA before publish.
+type verifyReleaseEvidence struct {
+	Subject          string                        `json:"subject"`
+	Version          string                        `json:"version"`
+	ReleaseCommitSHA string                        `json:"release_commit_sha"`
+	CI               verifyMergeCheck              `json:"ci"`
+	Cosign           verifyReleaseCosign           `json:"cosign"`
+	OperatorApproval verifyReleaseOperatorApproval `json:"operator_release_approval"`
+}
+
+type verifyReleaseCosign struct {
+	State string `json:"state"`
+	SHA   string `json:"sha"`
+	// Reviewer is the developer co-signing the final release commit; must be a
+	// SECOND actor, not the release-lead.
+	Reviewer string `json:"reviewer"`
+	// DistinctFromReleaseLead asserts the co-signer is a different actor than the
+	// release-lead. amq-squad cannot infer this from git alone, so the evidence
+	// must assert it and the gate validates the assertion.
+	DistinctFromReleaseLead bool   `json:"distinct_from_release_lead"`
+	Source                  string `json:"source"`
+	CheckedAt               string `json:"checked_at"`
+	URL                     string `json:"url,omitempty"`
+}
+
+type verifyReleaseOperatorApproval struct {
+	Approved  bool   `json:"approved"`
+	Gate      string `json:"gate"`
+	Source    string `json:"source"`
+	CheckedAt string `json:"checked_at"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type verifyReleaseResult struct {
+	OK               bool                          `json:"ok"`
+	Subject          string                        `json:"subject,omitempty"`
+	Version          string                        `json:"version,omitempty"`
+	ReleaseCommitSHA string                        `json:"release_commit_sha,omitempty"`
+	EvidenceSummary  *verifyReleaseEvidenceSummary `json:"evidence_summary,omitempty"`
+	Failures         []verifyMergeFailure          `json:"failures,omitempty"`
+}
+
+type verifyReleaseEvidenceSummary struct {
+	CI               verifyMergeCheckSummary       `json:"ci"`
+	Cosign           verifyReleaseCosign           `json:"cosign"`
+	OperatorApproval verifyReleaseOperatorApproval `json:"operator_release_approval"`
+}
+
+func runVerifyRelease(args []string) error {
+	fs := flag.NewFlagSet("verify release", flag.ContinueOnError)
+	evidencePath := fs.String("evidence", "", "path to normalized release evidence JSON, or '-' for stdin (required)")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned JSON envelope")
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad verify release - validate the final-release-commit co-sign gate (#285)
+
+Usage:
+  amq-squad verify release --evidence <file|->
+  amq-squad verify release --evidence <file|-> --json
+
+Evidence schema:
+  {
+    "subject": "release vX.Y.Z",
+    "version": "vX.Y.Z",
+    "release_commit_sha": "<final assembled release commit SHA>",
+    "ci": {"state": "success", "sha": "<release_commit_sha>", "source": "...", "checked_at": "..."},
+    "cosign": {"state": "approved", "sha": "<release_commit_sha>", "reviewer": "<dev, not release-lead>", "distinct_from_release_lead": true, "source": "...", "checked_at": "..."},
+    "operator_release_approval": {"approved": true, "gate": "gate/<topic>", "source": "...", "checked_at": "..."}
+  }
+
+Publish-ready requires BOTH an exact-SHA developer co-sign and an approved
+operator release gate; neither substitutes for the other. The command never
+pushes, tags, or releases. Failed evidence prints the failed conditions and
+exits non-zero.
+`)
+	}
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return usageErrorf("unexpected argument %q", fs.Arg(0))
+	}
+	path := strings.TrimSpace(*evidencePath)
+	if path == "" {
+		return usageErrorf("--evidence is required")
+	}
+	evidence, err := readVerifyReleaseEvidence(path, os.Stdin)
+	if err != nil {
+		return err
+	}
+	result := validateVerifyReleaseEvidence(evidence)
+	if *jsonOut {
+		if err := printJSONEnvelope("verify_release", result); err != nil {
+			return err
+		}
+		if !result.OK {
+			return UsageError("release preflight failed")
+		}
+		return nil
+	}
+	subject := strings.TrimSpace(evidence.Subject)
+	if subject == "" {
+		subject = "release"
+	}
+	if result.OK {
+		fmt.Printf("release preflight passed for %s at %s\n", subject, strings.TrimSpace(evidence.ReleaseCommitSHA))
+		return nil
+	}
+	fmt.Printf("release preflight failed for %s at %s\n", subject, strings.TrimSpace(evidence.ReleaseCommitSHA))
+	for _, f := range result.Failures {
+		fmt.Printf("- %s: %s\n", f.Code, f.Detail)
+	}
+	return UsageError("release preflight failed")
+}
+
+func readVerifyReleaseEvidence(path string, stdin io.Reader) (verifyReleaseEvidence, error) {
+	var r io.Reader
+	if path == "-" {
+		r = stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return verifyReleaseEvidence{}, fmt.Errorf("read evidence: %w", err)
+		}
+		defer f.Close()
+		r = f
+	}
+	var evidence verifyReleaseEvidence
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&evidence); err != nil {
+		return verifyReleaseEvidence{}, fmt.Errorf("decode evidence: %w", err)
+	}
+	var extra struct{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		return verifyReleaseEvidence{}, fmt.Errorf("decode evidence: multiple JSON values")
+	}
+	return evidence, nil
+}
+
+func validateVerifyReleaseEvidence(e verifyReleaseEvidence) verifyReleaseResult {
+	result := verifyReleaseResult{
+		Subject:          strings.TrimSpace(e.Subject),
+		Version:          strings.TrimSpace(e.Version),
+		ReleaseCommitSHA: strings.TrimSpace(e.ReleaseCommitSHA),
+	}
+	sha := result.ReleaseCommitSHA
+	if sha == "" {
+		result.Failures = append(result.Failures, verifyMergeFailure{
+			Code:   "missing_release_commit_sha",
+			Detail: "release_commit_sha is required",
+		})
+	}
+	// Release CI must be green and bound to the exact final release commit.
+	result.Failures = append(result.Failures, validateVerifyMergeCheck("ci", e.CI, sha, verifyMergeStateSuccess)...)
+
+	// Developer co-sign on the exact final release commit (a SECOND actor).
+	cs := e.Cosign
+	state := strings.TrimSpace(cs.State)
+	switch {
+	case state == "":
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_missing_state", Detail: "cosign.state is required"})
+	case state != verifyReleaseStateApproved:
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_state_not_approved", Detail: fmt.Sprintf("cosign.state is %q, want %q", state, verifyReleaseStateApproved)})
+	}
+	csSHA := strings.TrimSpace(cs.SHA)
+	if csSHA == "" {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_missing_sha", Detail: "cosign.sha is required"})
+	} else if sha != "" && csSHA != sha {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_stale_sha", Detail: fmt.Sprintf("cosign.sha is %q, want release_commit_sha %q (the co-sign must be on the exact final release commit)", csSHA, sha)})
+	}
+	if strings.TrimSpace(cs.Reviewer) == "" {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_missing_reviewer", Detail: "cosign.reviewer is required (the developer co-signing the final release commit)"})
+	}
+	if !cs.DistinctFromReleaseLead {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "cosign_not_distinct_actor", Detail: "cosign.distinct_from_release_lead must be true: the co-signer must be a second actor, not the release-lead"})
+	}
+
+	// Operator release approval is a SEPARATE required gate; it never substitutes
+	// for the co-sign, and the co-sign never substitutes for it.
+	op := e.OperatorApproval
+	if !op.Approved {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "operator_approval_not_approved", Detail: "operator_release_approval.approved must be true"})
+	}
+	if strings.TrimSpace(op.Gate) == "" && strings.TrimSpace(op.Source) == "" {
+		result.Failures = append(result.Failures, verifyMergeFailure{Code: "operator_approval_missing_reference", Detail: "operator_release_approval requires a gate or source reference"})
+	}
+
+	result.OK = len(result.Failures) == 0
+	if result.OK {
+		result.EvidenceSummary = &verifyReleaseEvidenceSummary{
+			CI:               summarizeVerifyMergeCheck(e.CI),
+			Cosign:           cs,
+			OperatorApproval: op,
+		}
+	}
+	return result
 }

--- a/internal/cli/verify_release_test.go
+++ b/internal/cli/verify_release_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func validReleaseEvidence() verifyReleaseEvidence {
+	return verifyReleaseEvidence{
+		Subject:          "release v2.14.0",
+		Version:          "v2.14.0",
+		ReleaseCommitSHA: "deadbeef",
+		CI:               verifyMergeCheck{State: "success", SHA: "deadbeef", Source: "make ci", CheckedAt: "2026-06-30T20:00:00Z"},
+		Cosign:           verifyReleaseCosign{State: "approved", SHA: "deadbeef", Reviewer: "senior-dev", DistinctFromReleaseLead: true, Source: "AMQ cosign", CheckedAt: "2026-06-30T20:01:00Z"},
+		OperatorApproval: verifyReleaseOperatorApproval{Approved: true, Gate: "gate/release-2-14-0", Source: "operator", CheckedAt: "2026-06-30T20:02:00Z"},
+	}
+}
+
+func TestVerifyReleasePassesExactSHACosign(t *testing.T) {
+	dir := t.TempDir()
+	evidence := writeVerifyEvidence(t, dir, `{
+  "subject": "release v2.14.0",
+  "version": "v2.14.0",
+  "release_commit_sha": "deadbeef",
+  "ci": {"state": "success", "sha": "deadbeef", "source": "make ci", "checked_at": "2026-06-30T20:00:00Z"},
+  "cosign": {"state": "approved", "sha": "deadbeef", "reviewer": "senior-dev", "distinct_from_release_lead": true, "source": "AMQ", "checked_at": "2026-06-30T20:01:00Z"},
+  "operator_release_approval": {"approved": true, "gate": "gate/release-2-14-0", "source": "operator", "checked_at": "2026-06-30T20:02:00Z"}
+}`)
+	stdout, _, err := captureOutput(t, func() error {
+		return runVerify([]string{"release", "--evidence", evidence})
+	})
+	if err != nil {
+		t.Fatalf("verify release: %v", err)
+	}
+	if !strings.Contains(stdout, "release preflight passed for release v2.14.0 at deadbeef") {
+		t.Fatalf("unexpected pass output:\n%s", stdout)
+	}
+}
+
+func TestVerifyReleaseJSONEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	evidence := writeVerifyEvidence(t, dir, `{
+  "subject": "release v2.14.0",
+  "version": "v2.14.0",
+  "release_commit_sha": "deadbeef",
+  "ci": {"state": "success", "sha": "deadbeef", "source": "make ci", "checked_at": "t"},
+  "cosign": {"state": "approved", "sha": "deadbeef", "reviewer": "senior-dev", "distinct_from_release_lead": true, "source": "AMQ", "checked_at": "t"},
+  "operator_release_approval": {"approved": true, "gate": "gate/release-2-14-0", "source": "operator", "checked_at": "t"}
+}`)
+	stdout, _, err := captureOutput(t, func() error {
+		return runVerify([]string{"release", "--evidence", evidence, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("verify release --json: %v", err)
+	}
+	env := decodeJSONEnvelope[verifyReleaseResult](t, stdout)
+	if env.Kind != "verify_release" || !env.Data.OK || env.Data.ReleaseCommitSHA != "deadbeef" || env.Data.EvidenceSummary == nil {
+		t.Fatalf("unexpected release envelope: %+v", env)
+	}
+}
+
+func TestVerifyReleaseFailureCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(e *verifyReleaseEvidence)
+		wantCode string
+	}{
+		{"missing_release_commit_sha", func(e *verifyReleaseEvidence) { e.ReleaseCommitSHA = ""; e.CI.SHA = ""; e.Cosign.SHA = "" }, "missing_release_commit_sha"},
+		{"missing_cosign", func(e *verifyReleaseEvidence) { e.Cosign = verifyReleaseCosign{} }, "cosign_missing_state"},
+		{"cosign_not_approved", func(e *verifyReleaseEvidence) { e.Cosign.State = "pending" }, "cosign_state_not_approved"},
+		{"stale_cosign_sha", func(e *verifyReleaseEvidence) { e.Cosign.SHA = "oldsha" }, "cosign_stale_sha"},
+		{"missing_distinct_actor", func(e *verifyReleaseEvidence) { e.Cosign.DistinctFromReleaseLead = false }, "cosign_not_distinct_actor"},
+		{"missing_reviewer", func(e *verifyReleaseEvidence) { e.Cosign.Reviewer = "" }, "cosign_missing_reviewer"},
+		{"ci_sha_mismatch", func(e *verifyReleaseEvidence) { e.CI.SHA = "othersha" }, "ci_stale_sha"},
+		{"ci_not_success", func(e *verifyReleaseEvidence) { e.CI.State = "failure" }, "ci_state_not_success"},
+		{"missing_operator_approval", func(e *verifyReleaseEvidence) { e.OperatorApproval.Approved = false }, "operator_approval_not_approved"},
+		{"operator_approval_missing_reference", func(e *verifyReleaseEvidence) { e.OperatorApproval.Gate = ""; e.OperatorApproval.Source = "" }, "operator_approval_missing_reference"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validReleaseEvidence()
+			tc.mutate(&e)
+			result := validateVerifyReleaseEvidence(e)
+			if result.OK {
+				t.Fatalf("validateVerifyReleaseEvidence OK, want failure %q", tc.wantCode)
+			}
+			for _, f := range result.Failures {
+				if f.Code == tc.wantCode {
+					return
+				}
+			}
+			t.Fatalf("missing failure code %q in %#v", tc.wantCode, result.Failures)
+		})
+	}
+}
+
+// TestVerifyReleaseGatesAreNonSubstitutable proves the key invariant: an operator
+// approval cannot satisfy the co-sign, and a co-sign cannot satisfy the operator
+// approval — both are required for a publish-ready release.
+func TestVerifyReleaseGatesAreNonSubstitutable(t *testing.T) {
+	// Operator approved, but no co-sign → still fails.
+	e1 := validReleaseEvidence()
+	e1.Cosign = verifyReleaseCosign{}
+	if validateVerifyReleaseEvidence(e1).OK {
+		t.Fatal("operator approval must not substitute for the developer co-sign")
+	}
+	// Co-sign present, but operator not approved → still fails.
+	e2 := validReleaseEvidence()
+	e2.OperatorApproval.Approved = false
+	if validateVerifyReleaseEvidence(e2).OK {
+		t.Fatal("developer co-sign must not substitute for operator release approval")
+	}
+}


### PR DESCRIPTION
## Summary
Resolves #285 (part of #286). A release is irreversible once tagged/published, yet the **final assembled release commit** (version bumps + README.html regen + merge commit) was never reviewed by a second actor before becoming immutable — an operator "APPROVED to release" authorized the whole chain.

## Changes
Adds `amq-squad verify release --evidence <file> [--json]` — a separate subcommand (per-PR `verify merge` semantics untouched) and the enforced fail-closed gate between commit-prepared and publish:
- `release_commit_sha` required.
- Release CI bound to the exact final commit: `ci.state==success` AND `ci.sha==release_commit_sha`.
- **Developer co-sign**: `cosign.state==approved`, `cosign.sha==release_commit_sha` (a co-sign on any earlier/other SHA is a hard **stale** failure), `reviewer` non-empty, `distinct_from_release_lead==true` (a SECOND actor — asserted in evidence since git can't prove it).
- **Operator release approval**: `approved==true` with a gate/source reference.
- The two gates are **non-substitutable**: operator approval never satisfies the co-sign and vice versa; both required for publish-ready.

`verify release` validates normalized evidence only — it never pushes/tags/releases (operator-performed). Help + README tighten the wording.

## Tests
Positive exact-SHA pass + JSON envelope; negative matrix (missing/stale cosign sha, not-approved, missing reviewer, missing distinct actor, CI sha mismatch, CI not success, missing operator approval, missing reference); non-substitutable invariant. `verify merge` unchanged; `make ci` green.

## Dogfood (#285 self-application)
This release's own final commit must pass `verify release` before publish — noted for #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)