### PR TITLE
Add idle_with_active_task watchdog event to monitor (#299)

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -72,6 +72,24 @@ type monitorEvent struct {
 	Path    string `json:"path,omitempty"`
 	Issue   string `json:"issue,omitempty"`
 	Detail  string `json:"detail,omitempty"`
+	// Idle carries the liveness/busy evidence behind an idle_with_active_task
+	// flag (#299), so a consumer can tell a confirmed not-busy idle from any
+	// other state. Present only on idle_with_active_task events.
+	Idle *monitorIdleEvidence `json:"idle_evidence,omitempty"`
+}
+
+// monitorIdleEvidence records exactly why an idle_with_active_task event fired.
+// A live owner is only ever flagged when Busy is positively known false
+// (BusyKnown=true, Busy=false); unknown busy state is never classified as idle.
+type monitorIdleEvidence struct {
+	Owner            string `json:"owner"`
+	OwnerStatus      string `json:"owner_status"`
+	Live             bool   `json:"live"`
+	BusyKnown        bool   `json:"busy_known"`
+	Busy             bool   `json:"busy"`
+	PaneID           string `json:"pane_id,omitempty"`
+	AgeSeconds       int    `json:"age_seconds"`
+	ThresholdSeconds int    `json:"threshold_seconds"`
 }
 
 // monitorTick is the per-tick envelope emitted under --json (one NDJSON object
@@ -366,25 +384,32 @@ func idleWithActiveTaskEvents(o monitorLoopOptions, session string, tasks []task
 		}
 		live := row.Status == statusStateLive || row.Status == statusStateWakeLive
 		age := now.Sub(tk.UpdatedAt)
+		paneID := ""
+		busy, busyKnown := false, false
+		if row.Tmux != nil && row.Tmux.PaneAlive {
+			paneID = row.Tmux.PaneID
+			busy, busyKnown = monitorPaneBusy(paneID)
+		}
 		var reason string
-		switch {
-		case !live:
-			// Halted/dead owner still holding the task — flag regardless of age.
-			reason = fmt.Sprintf("owner %q is %s while owning in_progress task", owner, row.Status)
-		case row.Tmux != nil && row.Tmux.PaneAlive:
-			if busy, known := monitorPaneBusy(row.Tmux.PaneID); known && busy {
-				continue // busy/mid-turn: never flag
+		if live {
+			// A live owner is flagged ONLY with positive evidence it is not busy
+			// (busyKnown && !busy) AND a stale task. Busy/mid-turn is never idle,
+			// and UNKNOWN busy state is treated conservatively as not-idle so an
+			// owner we cannot inspect is never a false positive.
+			if !busyKnown {
+				continue // cannot confirm not-busy: do not classify as idle
+			}
+			if busy {
+				continue // busy/mid-turn
 			}
 			if age < o.StaleAfter {
-				continue // live, idle-or-unknown-busy, but task is fresh
+				continue // confirmed not-busy but task is fresh
 			}
-			reason = fmt.Sprintf("owner %q is live but idle and task untouched for %s", owner, age.Round(time.Second))
-		default:
-			// Live by record but no live pane to gauge busyness: rely on staleness.
-			if age < o.StaleAfter {
-				continue
-			}
-			reason = fmt.Sprintf("owner %q live (no pane busy signal) and task untouched for %s", owner, age.Round(time.Second))
+			reason = fmt.Sprintf("owner %q is live, confirmed not busy, and the task is untouched for %s", owner, age.Round(time.Second))
+		} else {
+			// Not-live owner still holding the task: flag regardless of age; busy
+			// is irrelevant (and was not probed).
+			reason = fmt.Sprintf("owner %q is %s while owning an in_progress task", owner, row.Status)
 		}
 		out = append(out, monitorEvent{
 			Type:    monitorEventIdleActiveTask,
@@ -392,6 +417,16 @@ func idleWithActiveTaskEvents(o monitorLoopOptions, session string, tasks []task
 			Source:  "task:" + tk.ID + " owner:" + owner + " status:" + string(row.Status),
 			Detail: fmt.Sprintf("%s — %s (age %s, threshold %s). Suggested: controlled wake-first re-nudge (amq-squad dispatch) to resume task %s; escalate to operator after repeated no-advance.",
 				tk.Title, reason, age.Round(time.Second), o.StaleAfter, tk.ID),
+			Idle: &monitorIdleEvidence{
+				Owner:            owner,
+				OwnerStatus:      string(row.Status),
+				Live:             live,
+				BusyKnown:        busyKnown,
+				Busy:             busy,
+				PaneID:           paneID,
+				AgeSeconds:       int(age / time.Second),
+				ThresholdSeconds: int(o.StaleAfter / time.Second),
+			},
 		})
 	}
 	return out, nil

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	taskstore "github.com/omriariav/amq-squad/v2/internal/task"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 const defaultMonitorInterval = 30 * time.Second
@@ -25,7 +27,40 @@ const (
 	monitorEventMergeReady  = "merge_gate_ready"
 	monitorEventOpenGate    = "open_operator_gate"
 	monitorEventInbox       = "operator_inbox_message"
+	// monitorEventIdleActiveTask (#299) flags an agent that owns an in_progress
+	// task but has halted: either its owner is not live, or it is live-but-idle
+	// past --stale-after with no legitimate wait condition. Read-only signal;
+	// recovery is the orchestrator's job via the existing controlled wake-first
+	// dispatch re-nudge, never monitor itself.
+	monitorEventIdleActiveTask = "idle_with_active_task"
 )
+
+const defaultMonitorStaleAfter = 15 * time.Minute
+
+// monitorStatusRows resolves per-member liveness for a session (read-only),
+// overridable in tests. Returns nil rows when no team/liveness is resolvable;
+// the caller treats absent owner liveness conservatively (no flag).
+var monitorStatusRows = func(projectDir, profile, session string) ([]statusRecord, error) {
+	t, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return nil, err
+	}
+	return buildStatusRows(t, profile, session, defaultDuplicateLaunchProbe), nil
+}
+
+// monitorPaneBusy reports whether a pane is busy (mid-turn). Best-effort: the
+// second return is false when busyness cannot be determined (e.g. tmux access
+// denied), in which case the caller must not assume idle. Overridable in tests.
+var monitorPaneBusy = func(paneID string) (busy bool, known bool) {
+	if strings.TrimSpace(paneID) == "" {
+		return false, false
+	}
+	b, err := tmuxpane.PaneBusy(paneID)
+	if err != nil {
+		return false, false
+	}
+	return b, true
+}
 
 // monitorEvent is one operator-needed signal. Fields are populated where
 // available; absent fields are omitted.
@@ -73,6 +108,7 @@ func runMonitor(args []string) error {
 	var sessions stringListFlag
 	fs.Var(&sessions, "session", "workstream session to watch (repeatable)")
 	interval := fs.Duration("interval", defaultMonitorInterval, "poll interval in loop mode")
+	staleAfter := fs.Duration("stale-after", defaultMonitorStaleAfter, "a live owner with an in_progress task untouched for longer than this (and no legitimate wait) is flagged idle_with_active_task")
 	once := fs.Bool("once", false, "run one tick and exit (no loop)")
 	timeout := fs.Duration("timeout", 0, "stop the loop after this long with no operator-needed event (0 = no timeout)")
 	maxTicks := fs.Int("max-ticks", 0, "stop the loop after this many idle ticks (0 = unlimited)")
@@ -120,6 +156,9 @@ Examples:
 	if *interval <= 0 {
 		return usageErrorf("--interval must be > 0")
 	}
+	if *staleAfter <= 0 {
+		return usageErrorf("--stale-after must be > 0")
+	}
 	if *timeout < 0 {
 		return usageErrorf("--timeout must be >= 0")
 	}
@@ -141,6 +180,7 @@ Examples:
 		Sessions:      append([]string(nil), sessions...),
 		Handled:       handled,
 		FeaturePrefix: strings.TrimSpace(*featurePrefix),
+		StaleAfter:    *staleAfter,
 		Interval:      *interval,
 		Once:          *once,
 		Timeout:       *timeout,
@@ -156,6 +196,7 @@ type monitorLoopOptions struct {
 	Sessions      []string
 	Handled       map[string]bool
 	FeaturePrefix string
+	StaleAfter    time.Duration
 	Interval      time.Duration
 	Once          bool
 	Timeout       time.Duration
@@ -222,6 +263,7 @@ func collectMonitorEvents(o monitorLoopOptions) ([]monitorEvent, error) {
 		if session == "" {
 			continue
 		}
+		sessionEventStart := len(events)
 		// 1. Task store: blocked/failed tasks. A missing task dir is empty (nil
 		// error); a real read/parse failure fails closed so a broken source is
 		// never reported as idle.
@@ -270,8 +312,89 @@ func collectMonitorEvents(o monitorLoopOptions) ([]monitorEvent, error) {
 				Detail:  fmt.Sprintf("%d unread operator inbox message(s)", unread),
 			})
 		}
+		// 5. #299 idle-with-active-task. Suppress when this session already has an
+		// operator-needed event (a gate, blocker, merge-ready, or queued inbox
+		// message already pulls the operator/orchestrator back — adding an idle
+		// flag would be noise and the recovery path is already implied).
+		if len(events) == sessionEventStart {
+			idle, err := idleWithActiveTaskEvents(o, session, tasks)
+			if err != nil {
+				return nil, fmt.Errorf("monitor: assess idle-with-active-task for session %q: %w", session, err)
+			}
+			events = append(events, idle...)
+		}
 	}
 	return events, nil
+}
+
+// idleWithActiveTaskEvents flags an agent that owns an in_progress task but has
+// halted (#299). It only reaches here when the session has no other
+// operator-needed event this tick. False-positive controls: a busy/mid-turn
+// owner is never flagged; a fresh in_progress task (within --stale-after) is not
+// flagged; an owner whose liveness cannot be resolved is treated conservatively
+// (not flagged). A not-live owner with an active task is flagged regardless of
+// age; a live-but-idle owner is flagged only when the task is stale past
+// --stale-after. Read-only: it suggests a controlled recovery but performs none.
+func idleWithActiveTaskEvents(o monitorLoopOptions, session string, tasks []taskstore.Task) ([]monitorEvent, error) {
+	var inProgress []taskstore.Task
+	for _, tk := range tasks {
+		if tk.Status == taskstore.StatusInProgress {
+			inProgress = append(inProgress, tk)
+		}
+	}
+	if len(inProgress) == 0 {
+		return nil, nil
+	}
+	rows, err := monitorStatusRows(o.ProjectDir, o.Profile, session)
+	if err != nil {
+		return nil, err
+	}
+	byHandle := make(map[string]statusRecord, len(rows))
+	for _, r := range rows {
+		byHandle[strings.TrimSpace(r.Handle)] = r
+	}
+	now := time.Now()
+	var out []monitorEvent
+	for _, tk := range inProgress {
+		owner := strings.TrimSpace(tk.AssignedTo)
+		if owner == "" {
+			continue // unowned in_progress: cannot attribute a stall conservatively
+		}
+		row, ok := byHandle[owner]
+		if !ok {
+			continue // owner liveness unknown: do not flag
+		}
+		live := row.Status == statusStateLive || row.Status == statusStateWakeLive
+		age := now.Sub(tk.UpdatedAt)
+		var reason string
+		switch {
+		case !live:
+			// Halted/dead owner still holding the task — flag regardless of age.
+			reason = fmt.Sprintf("owner %q is %s while owning in_progress task", owner, row.Status)
+		case row.Tmux != nil && row.Tmux.PaneAlive:
+			if busy, known := monitorPaneBusy(row.Tmux.PaneID); known && busy {
+				continue // busy/mid-turn: never flag
+			}
+			if age < o.StaleAfter {
+				continue // live, idle-or-unknown-busy, but task is fresh
+			}
+			reason = fmt.Sprintf("owner %q is live but idle and task untouched for %s", owner, age.Round(time.Second))
+		default:
+			// Live by record but no live pane to gauge busyness: rely on staleness.
+			if age < o.StaleAfter {
+				continue
+			}
+			reason = fmt.Sprintf("owner %q live (no pane busy signal) and task untouched for %s", owner, age.Round(time.Second))
+		}
+		out = append(out, monitorEvent{
+			Type:    monitorEventIdleActiveTask,
+			Session: session,
+			Source:  "task:" + tk.ID + " owner:" + owner + " status:" + string(row.Status),
+			Detail: fmt.Sprintf("%s — %s (age %s, threshold %s). Suggested: controlled wake-first re-nudge (amq-squad dispatch) to resume task %s; escalate to operator after repeated no-advance.",
+				tk.Title, reason, age.Round(time.Second), o.StaleAfter, tk.ID),
+		})
+	}
+	return out, nil
 }
 
 // monitorMergeReadyEvents scans the evidence dir for this session's

--- a/internal/cli/monitor_idle_test.go
+++ b/internal/cli/monitor_idle_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	taskstore "github.com/omriariav/amq-squad/v2/internal/task"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func withMonitorStatusRows(t *testing.T, rows []statusRecord) {
+	t.Helper()
+	prev := monitorStatusRows
+	monitorStatusRows = func(projectDir, profile, session string) ([]statusRecord, error) {
+		return rows, nil
+	}
+	t.Cleanup(func() { monitorStatusRows = prev })
+}
+
+func withMonitorPaneBusy(t *testing.T, busy, known bool) {
+	t.Helper()
+	prev := monitorPaneBusy
+	monitorPaneBusy = func(paneID string) (bool, bool) { return busy, known }
+	t.Cleanup(func() { monitorPaneBusy = prev })
+}
+
+func seedInProgressTask(t *testing.T, dir, session, owner string, updatedAt time.Time) string {
+	t.Helper()
+	tk, err := taskstore.AddForProfile(dir, team.DefaultProfile, session, taskstore.AddInput{Title: "ship it"}, updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := taskstore.ClaimForProfile(dir, team.DefaultProfile, session, tk.ID, owner, updatedAt); err != nil {
+		t.Fatal(err)
+	}
+	return tk.ID
+}
+
+func runMonitorOnce(t *testing.T) (string, error) {
+	t.Helper()
+	stdout, _, err := captureOutput(t, func() error {
+		return runMonitor([]string{"--session", "s", "--once", "--json"})
+	})
+	return stdout, err
+}
+
+func TestMonitorIdleFlagsNotLiveOwnerWithActiveTask(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateMissing}})
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now()) // age irrelevant for not-live
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if !strings.Contains(out, monitorEventIdleActiveTask) || !strings.Contains(out, "owner:fullstack") {
+		t.Fatalf("not-live owner with active task must be flagged:\n%s", out)
+	}
+}
+
+func TestMonitorIdleSuppressedForBusyOwner(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateLive, Tmux: &tmuxRuntimeJSON{PaneID: "%5", PaneAlive: true}}})
+	withMonitorPaneBusy(t, true, true) // busy/mid-turn
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now().Add(-2*time.Hour))
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("a busy/mid-turn owner must never be flagged idle:\n%s", out)
+	}
+	if !strings.Contains(out, `"events_found":false`) {
+		t.Fatalf("expected idle tick (busy owner suppressed):\n%s", out)
+	}
+}
+
+func TestMonitorIdleFlagsLiveStaleOwner(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateLive, Tmux: &tmuxRuntimeJSON{PaneID: "%5", PaneAlive: true}}})
+	withMonitorPaneBusy(t, false, true) // live, not busy
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now().Add(-1*time.Hour))
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if !strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("live-but-idle owner with a stale active task must be flagged:\n%s", out)
+	}
+}
+
+func TestMonitorIdleSuppressedForFreshTask(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateLive, Tmux: &tmuxRuntimeJSON{PaneID: "%5", PaneAlive: true}}})
+	withMonitorPaneBusy(t, false, true)
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now()) // fresh: within --stale-after
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("a fresh (within --stale-after) in_progress task must not be flagged:\n%s", out)
+	}
+}
+
+func TestMonitorIdleSuppressedWhenOtherOperatorEvent(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	// An open operator gate (and unread inbox) means the operator is already
+	// being pulled back; idle must not also fire even though the owner is not-live.
+	withMonitorOperatorState(t, 1, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateMissing}})
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now().Add(-2*time.Hour))
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("idle must be suppressed when another operator-needed event fired:\n%s", out)
+	}
+	if !strings.Contains(out, monitorEventOpenGate) {
+		t.Fatalf("the open gate event should still fire:\n%s", out)
+	}
+}
+
+func TestMonitorIdleFailsClosedOnStatusReadError(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	prev := monitorStatusRows
+	monitorStatusRows = func(projectDir, profile, session string) ([]statusRecord, error) {
+		return nil, errMonitorStatusTest
+	}
+	t.Cleanup(func() { monitorStatusRows = prev })
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now())
+
+	_, err := runMonitorOnce(t)
+	if err == nil {
+		t.Fatal("a status/liveness read failure during idle assessment must fail closed")
+	}
+}
+
+var errMonitorStatusTest = errMonitorStatus("status read failed")
+
+type errMonitorStatus string
+
+func (e errMonitorStatus) Error() string { return string(e) }

--- a/internal/cli/monitor_idle_test.go
+++ b/internal/cli/monitor_idle_test.go
@@ -93,6 +93,48 @@ func TestMonitorIdleFlagsLiveStaleOwner(t *testing.T) {
 	if !strings.Contains(out, monitorEventIdleActiveTask) {
 		t.Fatalf("live-but-idle owner with a stale active task must be flagged:\n%s", out)
 	}
+	// Finding #2: the event must carry busy/liveness evidence distinguishing
+	// confirmed-not-busy from unknown.
+	for _, want := range []string{`"idle_evidence"`, `"busy_known":true`, `"busy":false`, `"owner_status":"live"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("idle event missing busy evidence %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMonitorIdleSuppressedWhenBusyUnknown(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateLive, Tmux: &tmuxRuntimeJSON{PaneID: "%5", PaneAlive: true}}})
+	withMonitorPaneBusy(t, false, false) // busy state UNKNOWN (e.g. tmux access denied)
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now().Add(-2*time.Hour))
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("a live owner whose busy state is UNKNOWN must not be classified idle:\n%s", out)
+	}
+	if !strings.Contains(out, `"events_found":false`) {
+		t.Fatalf("expected idle tick when busy is unresolved:\n%s", out)
+	}
+}
+
+func TestMonitorIdleSuppressedWhenLiveOwnerHasNoPane(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"}}})
+	withMonitorOperatorState(t, 0, 0)
+	// Live by record but no live pane → busy cannot be probed → unresolved → no flag.
+	withMonitorStatusRows(t, []statusRecord{{Handle: "fullstack", Status: statusStateWakeLive}})
+	seedInProgressTask(t, dir, "s", "fullstack", time.Now().Add(-2*time.Hour))
+
+	out, err := runMonitorOnce(t)
+	if err != nil {
+		t.Fatalf("monitor: %v", err)
+	}
+	if strings.Contains(out, monitorEventIdleActiveTask) {
+		t.Fatalf("a live owner with no inspectable pane must not be classified idle:\n%s", out)
+	}
 }
 
 func TestMonitorIdleSuppressedForFreshTask(t *testing.T) {

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -142,11 +142,21 @@ and the orchestrator or NOC must drain/poll them instead of waiting for wake.
 first-class no-wake poller: it watches (read-only) the task store, the evidence
 dir, open operator gates, and the operator inbox, and **exits on the first
 operator-needed event** (blocked/failed task, `merge_gate_ready`,
-`open_operator_gate`, `operator_inbox_message`) so you are pulled back exactly
-when something needs you. It only surfaces work — it never answers gates, marks
-messages read, or mutates anything. Pass `--handled-issue N` to suppress a
-merge-ready event you have already actioned. This is the no-wake fallback to the
-wake path, not a replacement for wake delivery or operator gates.
+`open_operator_gate`, `operator_inbox_message`, `idle_with_active_task`) so you
+are pulled back exactly when something needs you. It only surfaces work — it
+never answers gates, marks messages read, or mutates anything. Pass
+`--handled-issue N` to suppress a merge-ready event you have already actioned.
+This is the no-wake fallback to the wake path, not a replacement for wake
+delivery or operator gates.
+`idle_with_active_task` is the **mid-turn-halt watchdog**: it flags an agent that
+owns an `in_progress` task but has halted — owner not-live, or live-but-idle with
+the task untouched past `--stale-after` and no legitimate wait (open gate,
+merge/CI evidence, queued AMQ, busy/mid-turn). It catches the silent stall where
+an agent stops mid-turn with nothing queued (no wake event to fire on). monitor
+only **surfaces** it; you recover with a controlled wake-first `amq-squad
+dispatch` re-nudge (durable AMQ + wake, busy-guarded — never raw `tmux
+send-keys`) to resume the agent's own in-progress task, and escalate to the
+operator if it does not advance after repeated nudges.
 Use `goal_binding` in `goal draft --json` and `status --json` to distinguish a
 generated native `/goal` plan (`native_goal_pending`), verified launch-record
 native binding (`native_goal`), blocked native goal state

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -138,11 +138,21 @@ and the orchestrator or NOC must drain/poll them instead of waiting for wake.
 first-class no-wake poller: it watches (read-only) the task store, the evidence
 dir, open operator gates, and the operator inbox, and **exits on the first
 operator-needed event** (blocked/failed task, `merge_gate_ready`,
-`open_operator_gate`, `operator_inbox_message`) so you are pulled back exactly
-when something needs you. It only surfaces work — it never answers gates, marks
-messages read, or mutates anything. Pass `--handled-issue N` to suppress a
-merge-ready event you have already actioned. This is the no-wake fallback to the
-wake path, not a replacement for wake delivery or operator gates.
+`open_operator_gate`, `operator_inbox_message`, `idle_with_active_task`) so you
+are pulled back exactly when something needs you. It only surfaces work — it
+never answers gates, marks messages read, or mutates anything. Pass
+`--handled-issue N` to suppress a merge-ready event you have already actioned.
+This is the no-wake fallback to the wake path, not a replacement for wake
+delivery or operator gates.
+`idle_with_active_task` is the **mid-turn-halt watchdog**: it flags an agent that
+owns an `in_progress` task but has halted — owner not-live, or live-but-idle with
+the task untouched past `--stale-after` and no legitimate wait (open gate,
+merge/CI evidence, queued AMQ, busy/mid-turn). It catches the silent stall where
+an agent stops mid-turn with nothing queued (no wake event to fire on). monitor
+only **surfaces** it; you recover with a controlled wake-first `amq-squad
+dispatch` re-nudge (durable AMQ + wake, busy-guarded — never raw `tmux
+send-keys`) to resume the agent's own in-progress task, and escalate to the
+operator if it does not advance after repeated nudges.
 Use `goal_binding` in `goal draft --json` and `status --json` to distinguish a
 generated native `/goal` plan (`native_goal_pending`), verified launch-record
 native binding (`native_goal`), blocked native goal state

--- a/plugins/skills-src/amq-squad-orchestrator/SKILL.md
+++ b/plugins/skills-src/amq-squad-orchestrator/SKILL.md
@@ -139,11 +139,21 @@ and the orchestrator or NOC must drain/poll them instead of waiting for wake.
 first-class no-wake poller: it watches (read-only) the task store, the evidence
 dir, open operator gates, and the operator inbox, and **exits on the first
 operator-needed event** (blocked/failed task, `merge_gate_ready`,
-`open_operator_gate`, `operator_inbox_message`) so you are pulled back exactly
-when something needs you. It only surfaces work — it never answers gates, marks
-messages read, or mutates anything. Pass `--handled-issue N` to suppress a
-merge-ready event you have already actioned. This is the no-wake fallback to the
-wake path, not a replacement for wake delivery or operator gates.
+`open_operator_gate`, `operator_inbox_message`, `idle_with_active_task`) so you
+are pulled back exactly when something needs you. It only surfaces work — it
+never answers gates, marks messages read, or mutates anything. Pass
+`--handled-issue N` to suppress a merge-ready event you have already actioned.
+This is the no-wake fallback to the wake path, not a replacement for wake
+delivery or operator gates.
+`idle_with_active_task` is the **mid-turn-halt watchdog**: it flags an agent that
+owns an `in_progress` task but has halted — owner not-live, or live-but-idle with
+the task untouched past `--stale-after` and no legitimate wait (open gate,
+merge/CI evidence, queued AMQ, busy/mid-turn). It catches the silent stall where
+an agent stops mid-turn with nothing queued (no wake event to fire on). monitor
+only **surfaces** it; you recover with a controlled wake-first `amq-squad
+dispatch` re-nudge (durable AMQ + wake, busy-guarded — never raw `tmux
+send-keys`) to resume the agent's own in-progress task, and escalate to the
+operator if it does not advance after repeated nudges.
 Use `goal_binding` in `goal draft --json` and `status --json` to distinguish a
 generated native `/goal` plan (`native_goal_pending`), verified launch-record
 native binding (`native_goal`), blocked native goal state


### PR DESCRIPTION
## Summary
Resolves #299 (part of #286). Wake re-engages on **message arrival**, but an agent can halt mid-its-own-turn with nothing queued — the 2.14.0 dogfood stall where `fullstack` pushed a branch then idled before `gh pr create`/`review_request`, and the team sat silent until the **operator** noticed. No AMQ event fires, so wake alone never re-advances it.

**Stacked PR:** base is `codex/v2-14-0-295-monitor-no-wake-poll` (PR #304, unmerged — `monitor` lives there). **Retarget to `main` after #304 merges.** Exact-head review: base = the #295 branch, head = `f59ce23`.

## Changes
Adds an additive, read-only `monitor` event **`idle_with_active_task`** (composes with #295; monitor stays read-only — no nudge/dispatch/wake/mutation). Per in_progress task owned by H:
- **Flag:** H not-live (no agent-alive AND no wake-live) regardless of age; OR H live-but-idle with the task untouched past `--stale-after` (default 15m, validated >0) and no busy signal.
- **Suppress (false-positive controls):** busy/mid-turn owner (best-effort `PaneBusy`); fresh task within `--stale-after`; unresolved owner liveness; and the event is skipped entirely for a session that already produced any other operator-needed event (open gate, blocker, merge-ready, queued inbox — the operator is already being pulled back / the wait is legitimate).
- Event carries task id/title/owner/liveness + age/threshold + a suggested controlled recovery; **no durable state / hidden files**; recovery stays the orchestrator's job (wake-first dispatch re-nudge, escalate after repeated no-advance). Source-read failures fail closed (inherited from #295).

Documented in the orchestrator skill as the mid-turn-halt watchdog with the detect → controlled re-nudge → escalate loop.

## Tests
not-live detection, busy suppression, live-idle-stale detection, fresh suppression, other-operator-event suppression, status-read fail-closed. `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)