### PR TITLE
Prepare v2.14.0 release candidate

### DIFF
--- a/README.html
+++ b/README.html
@@ -462,7 +462,7 @@ workstream)</li>
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.13.0</span>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.14.0</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
@@ -1512,7 +1512,7 @@ attached.</p>
 <p><code>amq-squad amq ...</code> is a project-aware wrapper around AMQ
 diagnostics. It resolves the same AMQ root, base root, session, and
 handle that the squad launcher uses, then delegates to AMQ.</p>
-<p>amq-squad v2.13.0 requires AMQ 0.38.0 or newer. That floor includes
+<p>amq-squad v2.14.0 requires AMQ 0.38.0 or newer. That floor includes
 eval-safe <code>amq env --export</code> and the reserved human
 <code>user</code> mailbox behavior used by operator gates and
 notification surfaces.</p>
@@ -1766,7 +1766,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb35-1"><a href="#
 <span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--trust</span> approve-for-me</span>
 <span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5,fullstack=sonnet</span>
 <span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5</span></code></pre></div>
-<p>amq-squad v2.13.0 requires amq <strong>0.38.0+</strong>. Launches
+<p>amq-squad v2.14.0 requires amq <strong>0.38.0+</strong>. Launches
 pass <code>--require-wake</code> to <code>amq coop exec</code>, so a
 launch <strong>fails at the door</strong> when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 2.0 line (note the `/v2` module path):
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.13.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.14.0
 amq-squad version
 ```
 
@@ -919,7 +919,7 @@ It renders to `/dev/tty`, so `stdout` stays clean for the other verbs. With `--o
 
 `amq-squad amq ...` is a project-aware wrapper around AMQ diagnostics. It resolves the same AMQ root, base root, session, and handle that the squad launcher uses, then delegates to AMQ.
 
-amq-squad v2.13.0 requires AMQ 0.38.0 or newer. That floor includes eval-safe `amq env --export` and the reserved human `user` mailbox behavior used by operator gates and notification surfaces.
+amq-squad v2.14.0 requires AMQ 0.38.0 or newer. That floor includes eval-safe `amq env --export` and the reserved human `user` mailbox behavior used by operator gates and notification surfaces.
 
 Read-only diagnostics run directly:
 
@@ -1147,7 +1147,7 @@ amq-squad team init --personas cto,fullstack --model cto=gpt-5,fullstack=sonnet
 amq-squad agent up codex --model gpt-5
 ```
 
-amq-squad v2.13.0 requires amq **0.38.0+**. Launches pass `--require-wake` to
+amq-squad v2.14.0 requires amq **0.38.0+**. Launches pass `--require-wake` to
 `amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale or
 orphaned wake. `--no-require-wake` opts out for environments where wake cannot

--- a/docs/v2.14.0-plan.md
+++ b/docs/v2.14.0-plan.md
@@ -1,0 +1,108 @@
+# amq-squad v2.14.0 Plan
+
+## Theme
+
+v2.14.0 is the **wake-driven global orchestration** release (EPIC #286).
+
+v2.13.0 shipped the wake building blocks (`--register-orchestrator` #279,
+`lead register --wake` #280) but the end-to-end loop was not seamless: the
+v2.13.0 release itself ran on manual `amq drain` polling and manual `tmux
+send-keys` pane nudges. v2.14.0 closes that gap so a global orchestrator can
+drive an orchestrated run wake-first, with the no-wake fallbacks made
+first-class, and be set up from a plain-English goal rather than a
+hand-assembled flag list.
+
+The release goal is:
+
+> An orchestrated milestone run completes with far fewer manual polling loops and
+> pane-keystroke injections; the orchestrator is woken on inbox events, drains,
+> and routes directives durably; the operator sets it up from a plain goal with a
+> guided preview; and the final release commit is co-signed before it is made
+> immutable.
+
+## Current State After v2.13.0
+
+- Wakeable-orchestrator building blocks exist (`--register-orchestrator`,
+  `lead register --wake`) but no single reliable path produces a wakeable
+  identity, and a lead stops draining once its `/goal` reaches "achieved".
+- Dispatch nudges a worker via a raw pane send-keys, which is fragile.
+- Launched workers prompt on in-scope actions (`gh pr create`, feature push).
+- From a neutral control root, `target_project_root` is silently guessed as cwd.
+- The `/amq-squad-orchestrator` Step 1/2/3 flow is powerful but not guided, and
+  `goal draft --skill-invocation` omits recommended flags.
+- Nothing enforces a developer co-sign of the final release commit before publish.
+- No-wake orchestration has no first-class poller or mid-turn-halt watchdog.
+
+## v2.14.0 Issues
+
+Workstream A — wake / no-polling core: #282, #287, #283, #288, #289.
+Workstream B — operator UX (plain goal, no hand-assembled flags): #290, #291.
+Workstream C — release process gate: #285.
+Mid-milestone operator additions: #295 (no-wake monitor), #296 (worker in-scope
+pre-auth), #299 (idle-with-active-task watchdog).
+Dogfood / EPIC acceptance: #286 (handoff + honest residual capture).
+
+## Recommended Execution Order
+
+1. #282 (gate ordering) — unblocks #287.
+2. #287 → #283 → #288 → #289 (wake core).
+3. #296 (worker pre-auth) with/after #289.
+4. #290 → #291 (operator UX, parallelizable with A).
+5. #285 (release co-sign gate).
+6. #295 (no-wake monitor), then #299 (idle watchdog, extends monitor).
+7. #286 (handoff/dogfood) last, after all implementation lands.
+
+## Must
+
+### Milestone plan + handoff documents
+`docs/v2.14.0-plan.md` (this file), `docs/v2.14.0-release-notes.md`, and
+`docs/v2.14.0-handoff.md` (dogfood evidence + release-gate checklist).
+
+### Gate-ordered orchestrator registration (#282)
+`goal start --register-orchestrator` must not write the roster before `--yes`.
+
+### Wakeable orchestrator identity (#287)
+One command yields a durable member + pane-bound launch record + lead + wake
+sidecar; `status --json` proves it (`goal_binding` + `external`); idempotent.
+
+### Post-"achieved" drain + wake-first dispatch (#283 / #288 / #289)
+The wake sidecar injects a drain instruction on arrival; `status --json`
+surfaces `wake_auto_drain`; dispatch is wake-first with pane injection as a
+clearly-marked last-resort.
+
+### Worker in-scope pre-authorization (#296)
+Orchestrated Claude workers get `gh pr create` pre-authorized; main push, tags,
+releases, and destructive git stay gated; the allowlist is auditable.
+
+### target_project_root verification (#290)
+`global_orchestrator` fails closed without an explicit `--target-project-root`;
+`goal draft` classifies the source and never emits an unconfirmed path into an
+actionable start command.
+
+### Guided operator flow + skill-invocation completeness (#291)
+DEFAULT/PROVIDED labels, guided Step 1/2/3 sections, and a complete, safe
+`goal draft --skill-invocation`.
+
+### Release co-sign gate (#285)
+`amq-squad verify release`: exact-SHA developer co-sign + separate operator
+release approval, non-substitutable, before any publish.
+
+### No-wake monitor + idle watchdog (#295 / #299)
+`amq-squad monitor` polls read-only and exits on the first operator-needed
+event; `idle_with_active_task` flags a halted owner of an `in_progress` task.
+
+## Validation Gates
+
+- Per-PR: exact-head `make ci`, senior-dev review, QA, `amq-squad verify merge`.
+- Release: `make release-check VERSION=v2.14.0`, integrated `make ci` on `main`,
+  and `amq-squad verify release` on the final release commit before publish.
+- Merge / push-to-main / tag / release remain operator-gated.
+
+## Out of Scope
+
+- New AMQ protocol / dispatch primitives beyond what wake requires.
+- Autonomous composition (seeded mode only this run).
+- Making the virtual `user` operator handle wakeable/runnable (#288 out of scope).
+- Breaking flag/API changes without a migration note.
+- A constrained feature-branch-push wrapper (deferred #296 follow-up).
+- coop-exec-restore replay of `--inject-cmd` (needs an upstream AMQ surface).

--- a/docs/v2.14.0-release-notes.md
+++ b/docs/v2.14.0-release-notes.md
@@ -1,0 +1,82 @@
+# amq-squad v2.14.0
+
+Wake-driven global orchestration release: an orchestrated milestone run should
+be driven wake-first with far fewer manual polling loops and pane-keystroke
+interventions, and set up from a plain-English goal rather than a hand-assembled
+flag list.
+
+## Highlights
+
+- Deferred the `goal start --register-orchestrator` roster write until after the
+  `--yes` confirmation gate, so a preview/`--dry-run` never mutates `team.json`
+  (#282).
+- Made the orchestrator's AMQ identity wakeable end-to-end from a single command
+  (durable member + pane-bound launch record + lead + wake sidecar), and surfaced
+  `external` on each `status --json` member so the registered orchestrator is
+  positively identifiable (#287).
+- Kept a lead draining after its native `/goal` reaches a terminal "achieved"
+  state: the wake sidecar injects a drain instruction on each durable-message
+  arrival via AMQ's sanctioned injector (`launch.Record.wake_inject_cmd`),
+  re-engaging it without a raw `tmux send-keys` (#283).
+- Surfaced orchestrator auto-drain-on-wake in `status --json` as
+  `wake_auto_drain`, distinct from liveness so a dead sidecar reads as degraded
+  rather than silently healthy (#288).
+- Made `amq-squad dispatch` wake-first: a wake-live recipient is delivered via
+  durable AMQ + its own wake sidecar with no pane injection; a raw pane nudge is
+  an explicit, clearly-marked last-resort (`last_resort_pane_injection` /
+  `forced_pane_injection`), and the legacy fallback method/stage are preserved
+  additively (#289).
+- Pre-authorized `gh pr create` for an orchestrated Claude worker so creating its
+  PR no longer blocks on a permission prompt; main-branch push, tags, releases,
+  and destructive git stay gated, and the allowlist is audited via
+  `status --json.preauthorized_actions` (#296).
+- Verified `target_project_root` for a `global_orchestrator` run: `team init`
+  fails closed without an explicit `--target-project-root`, `goal draft`
+  classifies the value (`provided` / `resolved_unconfirmed` / `unresolved` /
+  `default`) by matching a local checkout's git remote under the control root,
+  and a resolved-but-unconfirmed path is never emitted into an actionable start
+  command or the execution contract (#290).
+- Made the `/amq-squad-orchestrator` Step 1/2/3 flow self-describing: DEFAULT vs
+  PROVIDED field labels in the preview, guided step sections, and a complete
+  `goal draft --skill-invocation` (adds `--register-orchestrator`, carries an
+  explicitly-provided `--target-project-root`, and renders reasoning-effort as a
+  recommendation comment rather than a silent flag) (#291).
+- Added `amq-squad verify release`: an enforced final-release-commit co-sign gate
+  requiring an exact-SHA developer co-sign (a second actor) plus a separate,
+  non-substitutable operator release approval before any push/tag/release (#285).
+- Added `amq-squad monitor`: a read-only, no-wake polling loop over the task
+  store, evidence dir, operator gates, and operator inbox that exits on the first
+  operator-needed event, replacing the hand-rolled polling shell loop (#295).
+- Added an `idle_with_active_task` monitor event: a read-only watchdog that flags
+  an owner holding an `in_progress` task who has halted (not-live, or
+  live-but-confirmed-not-busy past `--stale-after`), with conservative
+  false-positive suppression; recovery stays the orchestrator's controlled
+  wake-first re-nudge (#299).
+- Added release planning and dogfood-handoff documentation:
+  - `docs/v2.14.0-plan.md`
+  - `docs/v2.14.0-handoff.md`
+
+## Verification
+
+- `go test ./...`
+- `make test`
+- `make ci`
+- `make release-check VERSION=v2.14.0`
+- Per-PR: exact-head `make ci`, senior-dev review, QA, and
+  `amq-squad verify merge` evidence under `.amq-squad/evidence/`.
+- The final release commit itself must pass `amq-squad verify release` (exact-SHA
+  developer co-sign + operator release approval) before publish — see
+  `docs/v2.14.0-handoff.md` section 5.
+
+## Upgrade Notes
+
+amq-squad v2.14.0 continues to require AMQ 0.38.0 or newer.
+
+After installing the v2.14.0 binary, refresh the Codex or Claude plugin cache so
+new agent sessions load the matching `amq-squad skill v2.14.0` bundle.
+
+Behavioral note: `amq-squad monitor` and the `idle_with_active_task` watchdog are
+the no-wake companions to the wake path; they surface operator-needed work but do
+not replace wake delivery or operator gates. The end-to-end "zero manual
+intervention" behavior is validated by dogfood, not by unit tests alone — see the
+residuals in `docs/v2.14.0-handoff.md`.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.13.0** — on your FIRST response of a session, print the line `amq-squad skill v2.13.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.14.0** — on your FIRST response of a session, print the line `amq-squad skill v2.14.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.13.0** — on your FIRST response of a session, print the line `amq-squad skill v2.13.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.14.0** — on your FIRST response of a session, print the line `amq-squad skill v2.14.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.13.0** — on your FIRST response of a session, print the line `amq-squad skill v2.13.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.14.0** — on your FIRST response of a session, print the line `amq-squad skill v2.14.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 


### PR DESCRIPTION
## Summary
Phase 1 release-candidate prep for v2.14.0 (EPIC #286), following the `feebe9b` "Prepare v2.13.0 release candidate" shape. **No tag/release/publish** — this goes through normal PR merge discipline; the #285 exact-SHA co-sign + operator release approval are a separate Phase 2 after this merges.

## Changes
- **Version bump to 2.14.0:** both plugin manifests (`plugins/{claude,codex}/.{claude,codex}-plugin/plugin.json`), the `amq-squad` skill version marker + startup echo (`plugins/skills-src/amq-squad/SKILL.md`, with regenerated Claude/Codex mirrors), and the README `go install …@v2.14.0` + `amq-squad v2.14.0 requires AMQ/amq` lines; `README.html` regenerated.
- **Release docs:** `docs/v2.14.0-release-notes.md` (highlights across all 11 merged issues) and `docs/v2.14.0-plan.md`. (`docs/v2.14.0-handoff.md` already merged via #306.)

## Verification
- `make release-check VERSION=v2.14.0` → `release metadata matches v2.14.0`.
- `make ci` green (fmt/vet/test + README.html & docs/skills.html sync + skills-check).

## Boundaries
No tag, release, publish, or push to `main`. After this RC PR merges, **STOP** — Phase 2 is the final release commit's `amq-squad verify release` co-sign gate + operator release approval before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)