### PR TITLE
Prepare v2.17.0 release

### DIFF
--- a/README.html
+++ b/README.html
@@ -468,7 +468,7 @@ workstream)</li>
 mailbox). AMQ itself stays unchanged.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.16.0</span>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.17.0</span>
 <span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
@@ -906,7 +906,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#
 <span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> /path/to/repo <span class="dt">\</span></span>
 <span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> v2-15-0 <span class="dt">\</span></span>
 <span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--register-orchestrator</span><span class="op">=</span>orchestrator <span class="dt">\</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;deliver GitHub milestone v2.16.0&quot;</span> <span class="dt">\</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;deliver GitHub milestone v2.17.0&quot;</span> <span class="dt">\</span></span>
 <span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--yes</span></span></code></pre></div>
 <p>In one verified step this produces (1) a durable
 <code>orchestrator</code> team member, (2) a launch record bound to the
@@ -1058,7 +1058,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--no-operator</span>   <span class="co"># explicit opt-out</span></span></code></pre></div>
 <p>The operator is not a runnable team member. AMQ 0.38.0+ reserves the
 conventional <code>user</code> mailbox for this human/operator role, and
-amq-squad v2.16.0 requires AMQ 0.40.0+ overall; custom operator handles
+amq-squad v2.17.0 requires AMQ 0.40.0+ overall; custom operator handles
 use the same amq-squad protocol. JSON discovery derives
 <code>operator</code> and <code>capabilities.operator_gates</code>;
 <code>capabilities</code> is not persisted in
@@ -1657,7 +1657,7 @@ attached.</p>
 <p><code>amq-squad amq ...</code> is a project-aware wrapper around AMQ
 diagnostics. It resolves the same AMQ root, base root, session, and
 handle that the squad launcher uses, then delegates to AMQ.</p>
-<p>amq-squad v2.16.0 requires AMQ 0.40.0 or newer. That floor includes
+<p>amq-squad v2.17.0 requires AMQ 0.40.0 or newer. That floor includes
 the wake-inject stale-process fix (AMQ-owned <code>--inject-via</code>
 wake processes exit when their recorded owner is gone or no longer
 matches), eval-safe <code>amq env --export</code>, the reserved human
@@ -2006,7 +2006,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb37-1"><a href="#
 <span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5.5,fullstack=fable-5 <span class="dt">\</span></span>
 <span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span>
 <span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5.5 <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span></code></pre></div>
-<p>amq-squad v2.16.0 requires amq <strong>0.40.0+</strong>. Launches
+<p>amq-squad v2.17.0 requires amq <strong>0.40.0+</strong>. Launches
 pass <code>--require-wake</code> to <code>amq coop exec</code>, so a
 launch <strong>fails at the door</strong> when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `cl
 Install the 2.0 line (note the `/v2` module path):
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.16.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.17.0
 amq-squad version
 ```
 
@@ -447,7 +447,7 @@ amq-squad goal start \
   --project /path/to/repo \
   --session v2-15-0 \
   --register-orchestrator=orchestrator \
-  --goal "deliver GitHub milestone v2.16.0" \
+  --goal "deliver GitHub milestone v2.17.0" \
   --yes
 ```
 
@@ -584,7 +584,7 @@ amq-squad new team --roles cto,qa --operator ops  # custom operator handle
 amq-squad new team --roles cto,qa --no-operator   # explicit opt-out
 ```
 
-The operator is not a runnable team member. AMQ 0.38.0+ reserves the conventional `user` mailbox for this human/operator role, and amq-squad v2.16.0 requires AMQ 0.40.0+ overall; custom operator handles use the same amq-squad protocol. JSON discovery derives `operator` and `capabilities.operator_gates`; `capabilities` is not persisted in `team.json`.
+The operator is not a runnable team member. AMQ 0.38.0+ reserves the conventional `user` mailbox for this human/operator role, and amq-squad v2.17.0 requires AMQ 0.40.0+ overall; custom operator handles use the same amq-squad protocol. JSON discovery derives `operator` and `capabilities.operator_gates`; `capabilities` is not persisted in `team.json`.
 
 Operator gates are structural AMQ handoffs, not authentication. Send human-only decisions or manual actions to the configured operator handle on stable `gate/<topic>` threads, with `--kind question --subject "APPROVAL: <decision>"` for approvals and `--kind decision --subject "DONE: <goal>"` for manual closeout. The operator replies on the same thread with `--kind answer` and subjects such as `APPROVED:`, `DENIED:`, or `ANSWER:`. If the operator answers a pending gate in a live pane/chat instead of AMQ, the lead treats it as operator input, immediately ACKs or mirrors it on the matching `gate/<topic>` thread without spoofing the operator handle, and checks both the live channel and AMQ gate/inbox state before declaring the gate blocked. P2P prose like "pending operator" is evidence only; it is not a gate. `amq-squad notify` surfaces new or stale needs-you gates with inspect/respond commands and de-duplicates unchanged items, but notification output never authorizes or clears a gate.
 
@@ -1015,7 +1015,7 @@ It renders to `/dev/tty`, so `stdout` stays clean for the other verbs. With `--o
 
 `amq-squad amq ...` is a project-aware wrapper around AMQ diagnostics. It resolves the same AMQ root, base root, session, and handle that the squad launcher uses, then delegates to AMQ.
 
-amq-squad v2.16.0 requires AMQ 0.40.0 or newer. That floor includes the wake-inject stale-process fix (AMQ-owned `--inject-via` wake processes exit when their recorded owner is gone or no longer matches), eval-safe `amq env --export`, the reserved human `user` mailbox behavior used by operator gates and notification surfaces, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file hardening.
+amq-squad v2.17.0 requires AMQ 0.40.0 or newer. That floor includes the wake-inject stale-process fix (AMQ-owned `--inject-via` wake processes exit when their recorded owner is gone or no longer matches), eval-safe `amq env --export`, the reserved human `user` mailbox behavior used by operator gates and notification surfaces, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file hardening.
 
 Read-only diagnostics run directly:
 
@@ -1323,7 +1323,7 @@ amq-squad team init --personas cto,fullstack --model cto=gpt-5.5,fullstack=fable
 amq-squad agent up codex --model gpt-5.5 --codex-args "-c model_reasoning_effort=medium"
 ```
 
-amq-squad v2.16.0 requires amq **0.40.0+**. Launches pass `--require-wake` to
+amq-squad v2.17.0 requires amq **0.40.0+**. Launches pass `--require-wake` to
 `amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale or
 orphaned wake. `--no-require-wake` opts out for environments where wake cannot

--- a/docs/v2.17.0-release-notes.md
+++ b/docs/v2.17.0-release-notes.md
@@ -1,0 +1,40 @@
+# amq-squad v2.17.0
+
+## Highlights
+
+- Added one-command orchestrator bootstrap as native, tested CLI verbs (#339,
+  PR #338). `amq-squad global start` launches a global/NOC orchestrator — a
+  poller (no wake) at a neutral root such as `~/Code` that supervises many runs
+  by explicit `--project/--profile/--session`. `amq-squad run start` creates one
+  orchestrated run in a project: it wraps `new team` (when `--roles` is given)
+  then `up`, pinning the roster to the run's session so the spawn is not refused.
+  Both preview by default and act only with `--go`; the preview runs read-only
+  `--dry-run` validation whose failures surface honestly (it strips `--seed-from`
+  so `up --dry-run` performs the real roster/session check rather than the
+  brief-only early return).
+- `run start` spawn visibility defaults to `detached` (hidden): agents run in a
+  separate tmux session and you supervise via `status`/`console`/`monitor` plus
+  wake, attaching only to intervene. `--visibility sibling-tabs` (or `current`)
+  opts into visible panes and requires a visible tmux pane.
+- Agent selection is first-class: binary via `--agent` (global) / `--binary`
+  (run), model via `--model`, and effort via `--codex-args` / `--claude-args`
+  (amq-squad has no dedicated `--effort` flag; effort rides the agent-args
+  passthrough, consistent with the rest of the CLI).
+- The `scripts/orchestrator/*.sh` helpers are now thin forwarders to the CLI
+  verbs, which are the single tested source of truth; a new
+  `docs/global-orchestrator-runbook.md` documents both modes, and bash/zsh/fish
+  completion covers the new verbs and their `start` subcommand.
+
+## Deferred
+
+- `run start --external-lead` (bind the operator's current pane as the lead
+  rather than spawning a managed lead) is intentionally rejected with a clear
+  error and tracked in #340. The scripted binding sequence was proven invalid
+  against the current CLI (`lead register` fail-closes without
+  `--adopt-project-lead`, `up` refuses the already-taken workstream, and
+  `goal start --register-orchestrator` targets a separate operator pane), so it
+  ships only once the correct ordering is verified.
+
+## Compatibility
+
+- amq-squad v2.17.0 requires amq 0.40.0+ (unchanged from v2.16.0).

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.16.0** — on your FIRST response of a session, print the line `amq-squad skill v2.16.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.17.0** — on your FIRST response of a session, print the line `amq-squad skill v2.17.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 
@@ -218,7 +218,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
 
 Human escalations follow the current team rules. When operator gates are enabled, send approval questions or manual-action requests to the virtual operator handle and do not treat it as a runnable peer. When operator gates are disabled, route through the role named by team rules.
 
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
 
 ## Common command patterns
 
@@ -290,7 +290,7 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.16.0+): amq-squad requires amq 0.40.0+. The launch wake
+AMQ floor (v2.17.0+): amq-squad requires amq 0.40.0+. The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out
@@ -299,7 +299,7 @@ resume` reproduces it.
 Use `--no-gitignore` on `agent up`, `up`, or `up --dry-run` when AMQ coop
 auto-init should leave `.gitignore` unchanged; the opt-out is persisted in the
 launch record and replayed by `agent resume`.
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to
 the configured operator handle escalate from `initial` to `reminder` after 30m
 and `strong-warning` after 2h. `amq-squad notify` bypasses its normal throttle
 when the escalation band advances, while `status --json` warnings and

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.16.0** — on your FIRST response of a session, print the line `amq-squad skill v2.16.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.17.0** — on your FIRST response of a session, print the line `amq-squad skill v2.17.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 
@@ -214,7 +214,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
 
 Human escalations follow the current team rules. When operator gates are enabled, send approval questions or manual-action requests to the virtual operator handle and do not treat it as a runnable peer. When operator gates are disabled, route through the role named by team rules.
 
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
 
 ## Common command patterns
 
@@ -286,7 +286,7 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.16.0+): amq-squad requires amq 0.40.0+. The launch wake
+AMQ floor (v2.17.0+): amq-squad requires amq 0.40.0+. The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out
@@ -295,7 +295,7 @@ resume` reproduces it.
 Use `--no-gitignore` on `agent up`, `up`, or `up --dry-run` when AMQ coop
 auto-init should leave `.gitignore` unchanged; the opt-out is persisted in the
 launch record and replayed by `agent resume`.
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to
 the configured operator handle escalate from `initial` to `reminder` after 30m
 and `strong-warning` after 2h. `amq-squad notify` bypasses its normal throttle
 when the escalation band advances, while `status --json` warnings and

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.16.0** — on your FIRST response of a session, print the line `amq-squad skill v2.16.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.17.0** — on your FIRST response of a session, print the line `amq-squad skill v2.17.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 
@@ -216,7 +216,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
 
 Human escalations follow the current team rules. When operator gates are enabled, send approval questions or manual-action requests to the virtual operator handle and do not treat it as a runnable peer. When operator gates are disabled, route through the role named by team rules.
 
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to the configured operator handle escalate from `initial` to `reminder` after 30m and `strong-warning` after 2h, measured from the last unanswered operator-facing gate message. `amq-squad notify` bypasses its normal de-duplication when a gate crosses into a stronger band; `status --json` warnings and `console --once` labels make aged gates distinct.
 
 ## Common command patterns
 
@@ -288,7 +288,7 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.16.0+): amq-squad requires amq 0.40.0+. The launch wake
+AMQ floor (v2.17.0+): amq-squad requires amq 0.40.0+. The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out
@@ -297,7 +297,7 @@ resume` reproduces it.
 Use `--no-gitignore` on `agent up`, `up`, or `up --dry-run` when AMQ coop
 auto-init should leave `.gitignore` unchanged; the opt-out is persisted in the
 launch record and replayed by `agent resume`.
-Operator-gate escalation (v2.16.0+): unanswered `gate/<topic>` asks addressed to
+Operator-gate escalation (v2.17.0+): unanswered `gate/<topic>` asks addressed to
 the configured operator handle escalate from `initial` to `reminder` after 30m
 and `strong-warning` after 2h. `amq-squad notify` bypasses its normal throttle
 when the escalation band advances, while `status --json` warnings and


### PR DESCRIPTION
Version bump for v2.17.0 (orchestrator bootstrap verbs, #338/#339).

- README `go install @v2.17.0` + AMQ-floor strings, both plugin manifests, amq-squad skill marker/echo (source + regenerated mirrors), README.html.
- Adds `docs/v2.17.0-release-notes.md`.
- `make ci` green; `make release-check VERSION=v2.17.0` passes.

After merge: tag v2.17.0 on the merge commit, create the GitHub release, and `make release-smoke VERSION=v2.17.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)