### PR TITLE
docs: correct the Why section for amq 0.40.0

### DIFF
--- a/README.html
+++ b/README.html
@@ -348,22 +348,36 @@ href="#files-amq-squad-writes">Files amq-squad writes</a></p>
 swarm interop</a> · <a href="#known-gaps">Known gaps</a> · <a
 href="#requires">Requires</a></p>
 <h2 id="why">Why</h2>
-<p>AMQ's <code>coop exec</code> is a generic launcher. It sets up a
-mailbox and execs into <code>claude</code> or <code>codex</code>, but it
-does not know:</p>
+<p>AMQ is the messaging and process substrate: it sets up mailboxes,
+routes and threads messages, tracks presence, wakes agents, federates
+across projects, and execs into <code>claude</code> or
+<code>codex</code> via <code>coop exec</code>. What it deliberately
+stays out of is who is on the team and what each agent is for. AMQ does
+not own:</p>
 <ul>
-<li>Which agent is the "CTO" vs "Fullstack" vs "QA" vs "PM" vs
-"Designer"</li>
-<li>What command originally launched each one (cwd, binary, flags,
-workstream)</li>
-<li>What durable team norms each agent should read at session start</li>
-<li>Which peers a given agent actively talks to</li>
+<li><strong>Roles</strong> — which agent is the "CTO" vs "Fullstack" vs
+"QA" vs "PM" vs "Designer"</li>
+<li><strong>The launch contract</strong> — what command originally
+launched each agent (cwd, binary, flags, workstream), so it can be
+stopped, resumed, or forked</li>
+<li><strong>Durable team norms</strong> — the shared rules each agent
+reads at session start</li>
+<li><strong>The declared roster</strong> — the role-mapped set of peers
+each agent is handed up front at bootstrap (AMQ can observe who talks to
+whom after the fact, via presence and threads; it does not declare the
+intended team a priori)</li>
 </ul>
-<p><code>amq-squad</code> captures this at team-setup time
-(<code>.amq-squad/team.json</code>,
-<code>.amq-squad/team-rules.md</code>) and per-agent at launch time
-(<code>launch.json</code> + <code>role.md</code> inside the AMQ
-mailbox). AMQ itself stays unchanged.</p>
+<p><code>amq-squad</code> owns that layer. It captures roles, roster,
+and norms at team-setup time (<code>.amq-squad/team.json</code>,
+<code>.amq-squad/team-rules.md</code>) and per-agent launch state
+(<code>launch.json</code> + <code>role.md</code>) in AMQ's per-agent
+extension-metadata namespace. AMQ stays domain-agnostic: it adds generic
+affordances that layers build on (the
+<code>extensions/&lt;layer&gt;/</code> namespace, external wake
+injection, a reserved <code>user</code>/operator handle,
+<code>env --json</code>), which is why amq-squad v2.17.0 requires amq
+0.40.0+ — but it still knows nothing about CTOs, rosters, or team
+rules.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.17.0</span>

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Built on [AMQ](https://github.com/avivsinai/agent-message-queue) by [Aviv Sinai]
 
 ## Why
 
-AMQ's `coop exec` is a generic launcher. It sets up a mailbox and execs into `claude` or `codex`, but it does not know:
+AMQ is the messaging and process substrate: it sets up mailboxes, routes and threads messages, tracks presence, wakes agents, federates across projects, and execs into `claude` or `codex` via `coop exec`. What it deliberately stays out of is who is on the team and what each agent is for. AMQ does not own:
 
-- Which agent is the "CTO" vs "Fullstack" vs "QA" vs "PM" vs "Designer"
-- What command originally launched each one (cwd, binary, flags, workstream)
-- What durable team norms each agent should read at session start
-- Which peers a given agent actively talks to
+- **Roles** — which agent is the "CTO" vs "Fullstack" vs "QA" vs "PM" vs "Designer"
+- **The launch contract** — what command originally launched each agent (cwd, binary, flags, workstream), so it can be stopped, resumed, or forked
+- **Durable team norms** — the shared rules each agent reads at session start
+- **The declared roster** — the role-mapped set of peers each agent is handed up front at bootstrap (AMQ can observe who talks to whom after the fact, via presence and threads; it does not declare the intended team a priori)
 
-`amq-squad` captures this at team-setup time (`.amq-squad/team.json`, `.amq-squad/team-rules.md`) and per-agent at launch time (`launch.json` + `role.md` inside the AMQ mailbox). AMQ itself stays unchanged.
+`amq-squad` owns that layer. It captures roles, roster, and norms at team-setup time (`.amq-squad/team.json`, `.amq-squad/team-rules.md`) and per-agent launch state (`launch.json` + `role.md`) in AMQ's per-agent extension-metadata namespace. AMQ stays domain-agnostic: it adds generic affordances that layers build on (the `extensions/<layer>/` namespace, external wake injection, a reserved `user`/operator handle, `env --json`), which is why amq-squad v2.17.0 requires amq 0.40.0+ — but it still knows nothing about CTOs, rosters, or team rules.
 
 ## Install
 


### PR DESCRIPTION
The Why section said 'AMQ itself stays unchanged' and implied AMQ is blind to peers. Both are stale as of the 0.40.0 floor:

- amq-squad v2.17.0 requires amq 0.40.0+ because it consumes AMQ affordances: the `extensions/<layer>/` metadata namespace (where `launch.json`/`role.md` live), external wake injection, the reserved `user`/operator handle, `env --json`. So 'unchanged' -> 'domain-agnostic'.
- AMQ observes the talk graph itself (presence/threads/routing); amq-squad's real distinction is the role-mapped roster handed to each agent a priori at bootstrap.

Roles, launch contract, and team norms still correctly belong to amq-squad. README.html regenerated; make ci + release-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)