### PR TITLE
Implement non-destructive namespace collision recovery

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -248,6 +248,7 @@ var completionCommonFlags = []string{
 	"--name",
 	"--model",
 	"--msg-id",
+	"--namespace-reason",
 	"--milestone",
 	"--mode",
 	"--max-agents",

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -268,6 +268,7 @@ var completionCommonFlags = []string{
 	"--operator",
 	"--orchestrated",
 	"--override-boundary",
+	"--override-namespace-conflict",
 	"--owner",
 	"--owner-id",
 	"--personas",

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -88,6 +88,8 @@ func runDispatch(args []string) error {
 	profileFlag := fs.String("profile", "", "team profile (default: default profile)")
 	forceFlag := fs.Bool("force", false, "nudge the pane even if the agent looks busy (mid-turn)")
 	noWakeFlag := fs.Bool("no-wake", false, "queue the durable task without nudging the pane")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	createTaskFlag := fs.Bool("create-task", false, "create and link a native task-store task before dispatch")
 	taskIDFlag := fs.String("task", "", "link dispatch metadata to an existing native task id")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned mutation result envelope")
@@ -98,7 +100,8 @@ Usage:
   amq-squad dispatch [--project DIR] [--profile NAME] --session S --role ROLE
                      [--from HANDLE] [--thread THREAD] [--kind todo] --subject SUBJ
                      (--body TEXT | --body-file FILE) [--priority P]
-                     [--force] [--no-wake] [--create-task | --task ID] [--json]
+                     [--force] [--no-wake] [--override-namespace-conflict --reason WHY]
+                     [--create-task | --task ID] [--json]
 
 The deterministic lead-to-child dispatch. It does two things, in order:
   1. Sends a DURABLE AMQ message to the workstream's resolved root (the single
@@ -165,7 +168,10 @@ Examples:
 	if err != nil {
 		return err
 	}
-	if err := ensureNoNamespaceConflict("dispatch", projectDir, profile, workstream, flagWasSet(fs, "profile")); err != nil {
+	if err := ensureNoNamespaceConflictWithOverride("dispatch", projectDir, profile, workstream, flagWasSet(fs, "profile"), namespaceConflictOverrideOptions{
+		Allowed: *overrideNamespaceConflict,
+		Reason:  *overrideNamespaceReason,
+	}); err != nil {
 		return err
 	}
 	ns := squadnamespace.Resolve(projectDir, profile, workstream)

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -282,12 +282,14 @@ func runGoalApply(args []string) error {
 	goalIDFlag := fs.String("goal-id", "", "approved goal identifier (recorded in JSON output)")
 	gateFlag := fs.String("gate", "", "gate topic carrying the operator APPROVED answer")
 	yes := fs.Bool("yes", false, "confirm apply without an interactive prompt")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned goal_apply envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad goal apply - apply an operator-approved visible lead goal
 
 Usage:
-  amq-squad goal apply [--project DIR] [--profile NAME] [--session S] [--role ROLE] [--goal-id ID] --gate TOPIC --yes [--json]
+  amq-squad goal apply [--project DIR] [--profile NAME] [--session S] [--role ROLE] [--goal-id ID] --gate TOPIC --yes [--override-namespace-conflict --reason WHY] [--json]
 
 Verifies that gate/<topic> contains a real operator APPROVED answer to the
 resolved visible lead, reads the native goal already recorded on that lead's
@@ -305,7 +307,10 @@ command is confirm-gated; pass --yes after reviewing the gate and lead state.
 	if gate == "" {
 		return usageErrorf("goal apply requires --gate <topic>")
 	}
-	target, err := resolveGoalTargetOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal apply")
+	target, err := resolveGoalTargetOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal apply", namespaceConflictOverrideOptions{
+		Allowed: *overrideNamespaceConflict,
+		Reason:  *overrideNamespaceReason,
+	})
 	if err != nil {
 		return err
 	}
@@ -358,12 +363,14 @@ func runGoalStart(args []string) error {
 	registerOrchestrator := fs.String("register-orchestrator", "", "before delivery, register the current pane as external orchestrator handle (default: orchestrator)")
 	dryRun := fs.Bool("dry-run", false, "preview the inferred start plan without delivering")
 	yes := fs.Bool("yes", false, "confirm delivery without an interactive prompt")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned goal_start envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad goal start - preview or deliver a goal to the visible lead
 
 Usage:
-  amq-squad goal start [--project DIR] [--profile NAME] --session S [--role ROLE] --goal TEXT [--register-orchestrator[=HANDLE]] [--dry-run] [--yes] [--json]
+  amq-squad goal start [--project DIR] [--profile NAME] --session S [--role ROLE] --goal TEXT [--register-orchestrator[=HANDLE]] [--dry-run] [--yes] [--override-namespace-conflict --reason WHY] [--json]
 
 Infers the current team profile, session, execution mode, and visible lead target
 from the project. Use --dry-run to inspect the plan. Non-dry-run delivery is
@@ -384,7 +391,7 @@ confirm-gated and requires --yes in this first implementation slice.
 	// intentionally not applied here; the preview resolves against the configured
 	// lead, matching delivery without registration.
 	if *dryRun {
-		opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start")
+		opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start", namespaceConflictOverrideOptions{})
 		if err != nil {
 			return err
 		}
@@ -400,14 +407,15 @@ confirm-gated and requires --yes in this first implementation slice.
 	if !*yes {
 		return usageErrorf("goal start delivery requires --yes (or run --dry-run to preview first)")
 	}
+	override := namespaceConflictOverrideOptions{Allowed: *overrideNamespaceConflict, Reason: *overrideNamespaceReason}
 	if flagWasSet(fs, "register-orchestrator") {
-		role, err := prepareGoalOrchestratorRegistration(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, *registerOrchestrator, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start")
+		role, err := prepareGoalOrchestratorRegistration(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, *registerOrchestrator, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start", override)
 		if err != nil {
 			return err
 		}
 		*roleFlag = role
 	}
-	opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start")
+	opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal start", override)
 	if err != nil {
 		return err
 	}
@@ -449,12 +457,14 @@ func runGoalDeliver(args []string) error {
 	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile (default: default profile)")
 	registerOrchestrator := fs.String("register-orchestrator", "", "before delivery, register the current pane as external orchestrator handle (default: orchestrator)")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned mutation result envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad goal deliver - deliver native /goal as a control action
 
 Usage:
-  amq-squad goal deliver [--project DIR] [--profile NAME] --session S [--role ROLE] --goal TEXT [--register-orchestrator[=HANDLE]] [--json]
+  amq-squad goal deliver [--project DIR] [--profile NAME] --session S [--role ROLE] --goal TEXT [--register-orchestrator[=HANDLE]] [--override-namespace-conflict --reason WHY] [--json]
 
 Delivers a native Codex /goal command to the visible lead as a first-class
 control action. This is not an ordinary prompt send: it preserves the busy guard
@@ -469,14 +479,15 @@ runtime accepts goal control messages safely.
 	if goal == "" {
 		return usageErrorf("goal deliver requires --goal TEXT")
 	}
+	override := namespaceConflictOverrideOptions{Allowed: *overrideNamespaceConflict, Reason: *overrideNamespaceReason}
 	if flagWasSet(fs, "register-orchestrator") {
-		role, err := prepareGoalOrchestratorRegistration(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, *registerOrchestrator, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal deliver")
+		role, err := prepareGoalOrchestratorRegistration(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, *registerOrchestrator, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal deliver", override)
 		if err != nil {
 			return err
 		}
 		*roleFlag = role
 	}
-	opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal deliver")
+	opts, err := resolveGoalDeliveryOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, goal, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), flagWasSet(fs, "session"), "goal deliver", override)
 	if err != nil {
 		return err
 	}
@@ -496,8 +507,8 @@ runtime accepts goal control messages safely.
 	return nil
 }
 
-func resolveGoalDeliveryOptions(projectFlag, profileFlag, sessionFlag, roleFlag, goal string, projectSet, profileSet, sessionSet bool, command string) (goalDeliveryOptions, error) {
-	opts, err := resolveGoalTargetOptions(projectFlag, profileFlag, sessionFlag, roleFlag, projectSet, profileSet, sessionSet, command)
+func resolveGoalDeliveryOptions(projectFlag, profileFlag, sessionFlag, roleFlag, goal string, projectSet, profileSet, sessionSet bool, command string, override namespaceConflictOverrideOptions) (goalDeliveryOptions, error) {
+	opts, err := resolveGoalTargetOptions(projectFlag, profileFlag, sessionFlag, roleFlag, projectSet, profileSet, sessionSet, command, override)
 	if err != nil {
 		return goalDeliveryOptions{}, err
 	}
@@ -505,7 +516,7 @@ func resolveGoalDeliveryOptions(projectFlag, profileFlag, sessionFlag, roleFlag,
 	return opts, nil
 }
 
-func resolveGoalTargetOptions(projectFlag, profileFlag, sessionFlag, roleFlag string, projectSet, profileSet, sessionSet bool, command string) (goalDeliveryOptions, error) {
+func resolveGoalTargetOptions(projectFlag, profileFlag, sessionFlag, roleFlag string, projectSet, profileSet, sessionSet bool, command string, override namespaceConflictOverrideOptions) (goalDeliveryOptions, error) {
 	projectDir, profile, err := resolveProjectProfile(projectFlag, profileFlag, projectSet)
 	if err != nil {
 		return goalDeliveryOptions{}, err
@@ -521,7 +532,7 @@ func resolveGoalTargetOptions(projectFlag, profileFlag, sessionFlag, roleFlag st
 	if err != nil {
 		return goalDeliveryOptions{}, err
 	}
-	if err := ensureNoNamespaceConflict(command, projectDir, profile, workstream, profileSet); err != nil {
+	if err := ensureNoNamespaceConflictWithOverride(command, projectDir, profile, workstream, profileSet, override); err != nil {
 		return goalDeliveryOptions{}, err
 	}
 	role := strings.TrimSpace(roleFlag)
@@ -774,7 +785,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle string) error {
 	return nil
 }
 
-func prepareGoalOrchestratorRegistration(projectFlag, profileFlag, sessionFlag, roleFlag, handle string, projectSet, profileSet, sessionSet bool, command string) (string, error) {
+func prepareGoalOrchestratorRegistration(projectFlag, profileFlag, sessionFlag, roleFlag, handle string, projectSet, profileSet, sessionSet bool, command string, override namespaceConflictOverrideOptions) (string, error) {
 	projectDir, profile, err := resolveProjectProfile(projectFlag, profileFlag, projectSet)
 	if err != nil {
 		return "", err
@@ -790,7 +801,7 @@ func prepareGoalOrchestratorRegistration(projectFlag, profileFlag, sessionFlag, 
 	if err != nil {
 		return "", err
 	}
-	if err := ensureNoNamespaceConflict(command, projectDir, profile, workstream, profileSet); err != nil {
+	if err := ensureNoNamespaceConflictWithOverride(command, projectDir, profile, workstream, profileSet, override); err != nil {
 		return "", err
 	}
 	if err := ensureGoalOrchestratorMember(projectDir, profile, workstream, strings.TrimSpace(handle)); err != nil {

--- a/internal/cli/namespace_conflict.go
+++ b/internal/cli/namespace_conflict.go
@@ -1,14 +1,18 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
+
+const coldNamespaceMigrationIssueURL = "https://github.com/omriariav/amq-squad/issues/359"
 
 type namespaceConflictData struct {
 	Kind               string                       `json:"kind"`
@@ -26,6 +30,28 @@ type namespaceConflictCandidate struct {
 	Profile string   `json:"profile"`
 	AMQRoot string   `json:"amq_root"`
 	Reasons []string `json:"reasons,omitempty"`
+}
+
+type namespaceConflictOverrideOptions struct {
+	Allowed bool
+	Reason  string
+}
+
+type namespaceConflictAuditRecord struct {
+	At                   time.Time `json:"at"`
+	Operation            string    `json:"operation"`
+	ProjectDir           string    `json:"project_dir"`
+	Profile              string    `json:"profile"`
+	Session              string    `json:"session"`
+	NamespaceID          string    `json:"namespace_id"`
+	Kind                 string    `json:"kind"`
+	RequestedAMQRoot     string    `json:"requested_amq_root"`
+	ConflictingAMQRoot   string    `json:"conflicting_amq_root"`
+	Actor                string    `json:"actor"`
+	ActorEnvSet          bool      `json:"actor_env_set"`
+	ActorSource          string    `json:"actor_source"`
+	Reason               string    `json:"reason"`
+	ColdMigrationBacklog string    `json:"cold_migration_backlog"`
 }
 
 func namespaceConflictForProfileSession(projectDir, profile, session string) *namespaceConflictData {
@@ -51,6 +77,10 @@ func namespaceConflictForProfileSession(projectDir, profile, session string) *na
 		RecoveryCommands: []string{
 			"amq-squad status --project " + shellQuote(projectDir) + " --profile " + shellQuote(profile) + " --session " + shellQuote(session) + " --json",
 			"amq-squad status --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --json",
+			"amq-squad goal deliver --project " + shellQuote(projectDir) + " --profile " + shellQuote(profile) + " --session " + shellQuote(session) + " --role <role> --goal <goal> --override-namespace-conflict --reason <why>",
+			"amq-squad dispatch --project " + shellQuote(projectDir) + " --profile " + shellQuote(profile) + " --session " + shellQuote(session) + " --role <role> --subject <subject> --body <body> --override-namespace-conflict --reason <why>",
+			"amq-squad send --project " + shellQuote(projectDir) + " --profile " + shellQuote(profile) + " --session " + shellQuote(session) + " --role <role> --body <prompt> --override-namespace-conflict --reason <why>",
+			"stopped-run namespace migration backlog: " + coldNamespaceMigrationIssueURL,
 			"amq-squad archive " + shellQuote(session) + " --project " + shellQuote(projectDir) + " --profile default",
 			"amq-squad rm " + shellQuote(session) + " --project " + shellQuote(projectDir) + " --profile default",
 			"amq send --root " + shellQuote(legacy) + " --me <sender> --to <recipient> --thread <thread> --kind todo --subject <subject> --body <body>",
@@ -96,6 +126,8 @@ func defaultProfileShadowConflict(projectDir, profile, session string, explicitP
 		Detail:             detail,
 		RecoveryCommands: []string{
 			"amq-squad status --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --json",
+			"amq-squad dispatch --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --role <role> --subject <subject> --body <body> --override-namespace-conflict --reason <why>",
+			"stopped-run namespace migration backlog: " + coldNamespaceMigrationIssueURL,
 		},
 		Conflicts: conflicts,
 	}, nil
@@ -161,14 +193,73 @@ func namespaceConflictError(operation string, conflict *namespaceConflictData) e
 }
 
 func ensureNoNamespaceConflict(operation, projectDir, profile, session string, explicitProfile bool) error {
+	return ensureNoNamespaceConflictWithOverride(operation, projectDir, profile, session, explicitProfile, namespaceConflictOverrideOptions{})
+}
+
+func ensureNoNamespaceConflictWithOverride(operation, projectDir, profile, session string, explicitProfile bool, override namespaceConflictOverrideOptions) error {
 	if conflict := namespaceConflictForProfileSession(projectDir, profile, session); conflict != nil {
+		if override.Allowed {
+			return writeNamespaceConflictAudit(operation, projectDir, profile, session, conflict, override)
+		}
 		return namespaceConflictError(operation, conflict)
 	}
 	conflict, err := defaultProfileShadowConflict(projectDir, profile, session, explicitProfile)
 	if err != nil {
 		return fmt.Errorf("%s refused: scan named profiles for session %q: %w", operation, session, err)
 	}
+	if conflict != nil && override.Allowed {
+		return writeNamespaceConflictAudit(operation, projectDir, profile, session, conflict, override)
+	}
 	return namespaceConflictError(operation, conflict)
+}
+
+func writeNamespaceConflictAudit(operation, projectDir, profile, session string, conflict *namespaceConflictData, override namespaceConflictOverrideOptions) error {
+	if conflict == nil {
+		return nil
+	}
+	reason := strings.TrimSpace(override.Reason)
+	if reason == "" {
+		return usageErrorf("%s --override-namespace-conflict requires --reason <why>", operation)
+	}
+	actor, actorSet := os.LookupEnv("AM_ME")
+	actorSource := "AM_ME"
+	if !actorSet {
+		actorSource = "unset"
+	}
+	dir := filepath.Join(projectDir, team.DirName, "namespace-audit")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensure namespace audit dir: %w", err)
+	}
+	rec := namespaceConflictAuditRecord{
+		At:                   time.Now().UTC(),
+		Operation:            operation,
+		ProjectDir:           projectDir,
+		Profile:              squadnamespace.NormalizeProfile(profile),
+		Session:              strings.TrimSpace(session),
+		NamespaceID:          conflict.NamespaceID,
+		Kind:                 conflict.Kind,
+		RequestedAMQRoot:     conflict.RequestedAMQRoot,
+		ConflictingAMQRoot:   conflict.ConflictingAMQRoot,
+		Actor:                strings.TrimSpace(actor),
+		ActorEnvSet:          actorSet,
+		ActorSource:          actorSource,
+		Reason:               reason,
+		ColdMigrationBacklog: coldNamespaceMigrationIssueURL,
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal namespace audit: %w", err)
+	}
+	path := filepath.Join(dir, sanitizeWorkstreamName(session)+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open namespace audit: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write namespace audit: %w", err)
+	}
+	return nil
 }
 
 func rootHasDurableState(root string) bool {
@@ -228,8 +319,7 @@ func legacyRootEntryIsDurable(root, path string, d os.DirEntry) bool {
 		return false
 	}
 	if d.IsDir() {
-		parts := strings.Split(rel, "/")
-		if len(parts) <= 2 && parts[0] == "agents" {
+		if legacyMailboxSkeletonDir(rel) {
 			return false
 		}
 		return true
@@ -238,6 +328,36 @@ func legacyRootEntryIsDurable(root, path string, d os.DirEntry) bool {
 		return false
 	}
 	return true
+}
+
+func legacyMailboxSkeletonDir(rel string) bool {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) == 0 || parts[0] != "agents" {
+		return false
+	}
+	switch len(parts) {
+	case 1, 2:
+		return true
+	case 3:
+		switch parts[2] {
+		case "inbox", "cur", "new", "tmp":
+			return true
+		default:
+			return false
+		}
+	case 4:
+		if parts[2] != "inbox" {
+			return false
+		}
+		switch parts[3] {
+		case "cur", "new", "tmp":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
 }
 
 func disableNamespaceConflictActions(actions []runtimeActionJSON, conflict *namespaceConflictData) []runtimeActionJSON {

--- a/internal/cli/namespace_conflict.go
+++ b/internal/cli/namespace_conflict.go
@@ -126,7 +126,7 @@ func defaultProfileShadowConflict(projectDir, profile, session string, explicitP
 		Detail:             detail,
 		RecoveryCommands: []string{
 			"amq-squad status --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --json",
-			"amq-squad dispatch --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --role <role> --subject <subject> --body <body> --override-namespace-conflict --reason <why>",
+			"explicit default-profile escape (acknowledged, not audited): amq-squad dispatch --project " + shellQuote(projectDir) + " --profile default --session " + shellQuote(session) + " --role <role> --subject <subject> --body <body>",
 			"stopped-run namespace migration backlog: " + coldNamespaceMigrationIssueURL,
 		},
 		Conflicts: conflicts,
@@ -222,8 +222,10 @@ func writeNamespaceConflictAudit(operation, projectDir, profile, session string,
 		return usageErrorf("%s --override-namespace-conflict requires --reason <why>", operation)
 	}
 	actor, actorSet := os.LookupEnv("AM_ME")
+	actor = strings.TrimSpace(actor)
 	actorSource := "AM_ME"
-	if !actorSet {
+	if !actorSet || actor == "" {
+		actorSet = false
 		actorSource = "unset"
 	}
 	dir := filepath.Join(projectDir, team.DirName, "namespace-audit")
@@ -240,7 +242,7 @@ func writeNamespaceConflictAudit(operation, projectDir, profile, session string,
 		Kind:                 conflict.Kind,
 		RequestedAMQRoot:     conflict.RequestedAMQRoot,
 		ConflictingAMQRoot:   conflict.ConflictingAMQRoot,
-		Actor:                strings.TrimSpace(actor),
+		Actor:                actor,
 		ActorEnvSet:          actorSet,
 		ActorSource:          actorSource,
 		Reason:               reason,

--- a/internal/cli/operator.go
+++ b/internal/cli/operator.go
@@ -196,17 +196,19 @@ func runOperatorAnswer(args []string) error {
 	approved := fs.Bool("approved", false, "send APPROVED answer")
 	denied := fs.Bool("denied", false, "send DENIED answer")
 	reasonFlag := fs.String("reason", "", "optional reason to include in the answer body")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned mutation result envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad operator answer - answer an operator gate
 
 Usage:
-  amq-squad operator answer [--project DIR] [--profile NAME] [--session S] --gate TOPIC --to HANDLE (--approved|--denied) [--reason TEXT] [--json]
+  amq-squad operator answer [--project DIR] [--profile NAME] [--session S] --gate TOPIC --to HANDLE (--approved|--denied) [--reason TEXT] [--override-namespace-conflict] [--json]
 
 Sends an AMQ answer from the configured operator handle on gate/<topic>. This
 first-class command avoids hand-writing the operator protocol. The --to handle
 is required for this release slice so the answer cannot accidentally target the
-non-runnable operator mailbox.
+non-runnable operator mailbox. When --override-namespace-conflict is set,
+--reason is also the required namespace audit reason.
 `)
 	}
 	if err := parseFlags(fs, args); err != nil {
@@ -225,6 +227,12 @@ non-runnable operator mailbox.
 	}
 	projectDir, profile, t, workstream, operatorHandle, err := resolveOperatorCommandContext(*projectFlag, *profileFlag, *sessionFlag, flagWasSet(fs, "project"), flagWasSet(fs, "session"))
 	if err != nil {
+		return err
+	}
+	if err := ensureNoNamespaceConflictWithOverride("operator answer", projectDir, profile, workstream, flagWasSet(fs, "profile"), namespaceConflictOverrideOptions{
+		Allowed: *overrideNamespaceConflict,
+		Reason:  *reasonFlag,
+	}); err != nil {
 		return err
 	}
 	if err := ensureOperatorCommandTarget(t, to, "operator answer"); err != nil {
@@ -263,12 +271,14 @@ func runOperatorDirective(args []string) error {
 	subjectFlag := fs.String("subject", "", "directive subject text, without the DIRECTIVE: prefix")
 	bodyFlag := fs.String("body", "", "directive body")
 	bodyFileFlag := fs.String("body-file", "", "read directive body from file ('-' for stdin)")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned mutation result envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad operator directive - send a directive to a visible lead
 
 Usage:
-  amq-squad operator directive [--project DIR] [--profile NAME] [--session S] --to HANDLE --subject TEXT (--body TEXT | --body-file FILE) [--json]
+  amq-squad operator directive [--project DIR] [--profile NAME] [--session S] --to HANDLE --subject TEXT (--body TEXT | --body-file FILE) [--override-namespace-conflict --reason WHY] [--json]
 
 Sends a DIRECTIVE todo from the configured operator handle on the canonical
 p2p/<lead>__<operator> thread. Directives are steering data; they do not answer
@@ -292,6 +302,12 @@ or clear gate/<topic> threads.
 	}
 	projectDir, profile, t, workstream, operatorHandle, err := resolveOperatorCommandContext(*projectFlag, *profileFlag, *sessionFlag, flagWasSet(fs, "project"), flagWasSet(fs, "session"))
 	if err != nil {
+		return err
+	}
+	if err := ensureNoNamespaceConflictWithOverride("operator directive", projectDir, profile, workstream, flagWasSet(fs, "profile"), namespaceConflictOverrideOptions{
+		Allowed: *overrideNamespaceConflict,
+		Reason:  *overrideNamespaceReason,
+	}); err != nil {
 		return err
 	}
 	if err := ensureOperatorCommandTarget(t, to, "operator directive"); err != nil {

--- a/internal/cli/operator.go
+++ b/internal/cli/operator.go
@@ -197,18 +197,18 @@ func runOperatorAnswer(args []string) error {
 	denied := fs.Bool("denied", false, "send DENIED answer")
 	reasonFlag := fs.String("reason", "", "optional reason to include in the answer body")
 	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("namespace-reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned mutation result envelope")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad operator answer - answer an operator gate
 
 Usage:
-  amq-squad operator answer [--project DIR] [--profile NAME] [--session S] --gate TOPIC --to HANDLE (--approved|--denied) [--reason TEXT] [--override-namespace-conflict] [--json]
+  amq-squad operator answer [--project DIR] [--profile NAME] [--session S] --gate TOPIC --to HANDLE (--approved|--denied) [--reason TEXT] [--override-namespace-conflict --namespace-reason WHY] [--json]
 
 Sends an AMQ answer from the configured operator handle on gate/<topic>. This
 first-class command avoids hand-writing the operator protocol. The --to handle
 is required for this release slice so the answer cannot accidentally target the
-non-runnable operator mailbox. When --override-namespace-conflict is set,
---reason is also the required namespace audit reason.
+non-runnable operator mailbox.
 `)
 	}
 	if err := parseFlags(fs, args); err != nil {
@@ -231,7 +231,7 @@ non-runnable operator mailbox. When --override-namespace-conflict is set,
 	}
 	if err := ensureNoNamespaceConflictWithOverride("operator answer", projectDir, profile, workstream, flagWasSet(fs, "profile"), namespaceConflictOverrideOptions{
 		Allowed: *overrideNamespaceConflict,
-		Reason:  *reasonFlag,
+		Reason:  *overrideNamespaceReason,
 	}); err != nil {
 		return err
 	}

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -793,6 +793,42 @@ func TestNamedProfileDispatchNamespaceOverrideQueuesAndAudits(t *testing.T) {
 	}
 }
 
+func TestNamespaceOverrideRequiresReasonBeforeDispatch(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	seedProfile(t, dir, "release", team.Team{
+		Project:      dir,
+		Workstream:   "main",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "main"},
+		},
+	})
+	legacyRoot := filepath.Join(dir, ".agent-mail", "main")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, "agents", "qa"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "agents", "qa", "inbox.md"), []byte("legacy durable state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-override to qa\n")
+
+	_, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--profile", "release", "--session", "main", "--role", "qa", "--subject", "X", "--body", "y", "--override-namespace-conflict"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "dispatch --override-namespace-conflict requires --reason") {
+		t.Fatalf("override without reason should fail closed, got %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("dispatch should not send AMQ before override reason is supplied, calls = %d", len(*calls))
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".amq-squad", "namespace-audit", "main.jsonl")); !os.IsNotExist(statErr) {
+		t.Fatalf("missing-reason override should not write audit, stat err = %v", statErr)
+	}
+}
+
 func TestGoalDeliverNamespaceOverrideDeliversAndAudits(t *testing.T) {
 	setupFakeAMQSessionRoots(t)
 	dir := t.TempDir()
@@ -861,7 +897,7 @@ func TestGoalDeliverNamespaceOverrideDeliversAndAudits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read namespace audit: %v", err)
 	}
-	for _, want := range []string{`"operation":"goal deliver"`, `"actor":""`, `"actor_env_set":true`, `"reason":"recover visible lead"`} {
+	for _, want := range []string{`"operation":"goal deliver"`, `"actor":""`, `"actor_env_set":false`, `"actor_source":"unset"`, `"reason":"recover visible lead"`} {
 		if !strings.Contains(string(audit), want) {
 			t.Fatalf("audit missing %q:\n%s", want, string(audit))
 		}
@@ -909,6 +945,51 @@ func TestUnprofiledDispatchRefusesMultipleNamedProfileOwners(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, ".agent-mail", "main")); !os.IsNotExist(statErr) {
 		t.Fatalf("refused dispatch must not create default root; stat err = %v", statErr)
+	}
+}
+
+func TestDefaultProfileShadowRecoveryDoesNotAdvertiseInertOverride(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	seedProfile(t, dir, team.DefaultProfile, team.Team{
+		Workstream:   "main",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "main"},
+		},
+	})
+	seedProfile(t, dir, "release", team.Team{
+		Workstream: "main",
+		Members: []team.Member{
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "main"},
+		},
+	})
+	namedRoot := filepath.Join(dir, ".agent-mail", "release", "main")
+	if err := os.MkdirAll(filepath.Join(namedRoot, "agents", "qa"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(namedRoot, "agents", "qa", "inbox.md"), []byte("named durable state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--session", "main", "--role", "qa", "--subject", "X", "--body", "y"})
+	})
+	if err == nil {
+		t.Fatal("unprofiled dispatch should refuse when named profile owns session")
+	}
+	for _, want := range []string{
+		"explicit default-profile escape (acknowledged, not audited)",
+		"amq-squad dispatch --project " + shellQuote(resolveDir(dir)) + " --profile default --session main",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("dispatch error missing %q:\n%v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "--profile default --session main --role <role> --subject <subject> --body <body> --override-namespace-conflict") {
+		t.Fatalf("shadow recovery must not print inert override flags:\n%v", err)
 	}
 }
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // seedProfile writes a profile config into projectDir without changing the
@@ -710,12 +711,159 @@ func TestNamedProfileDispatchConflictIncludesConcreteRecoveryCommands(t *testing
 	}
 	for _, want := range []string{
 		"legacy/default session root",
+		"--override-namespace-conflict --reason <why>",
+		coldNamespaceMigrationIssueURL,
 		"amq-squad archive main --project " + shellQuote(resolveDir(dir)) + " --profile default",
 		"amq-squad rm main --project " + shellQuote(resolveDir(dir)) + " --profile default",
 		"amq send --root " + shellQuote(filepath.Join(resolveDir(dir), ".agent-mail", "main")),
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("dispatch error missing recovery %q:\n%v", want, err)
+		}
+	}
+}
+
+func TestRootHasDurableStateIgnoresEmptyMailboxSkeletonDebris(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".agent-mail", "review")
+	for _, dir := range []string{
+		filepath.Join(root, "agents", "cto", "inbox"),
+		filepath.Join(root, "agents", "cto", "inbox", "new"),
+		filepath.Join(root, "agents", "cto", "inbox", "cur"),
+		filepath.Join(root, "agents", "cto", "inbox", "tmp"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rootHasDurableState(root) {
+		t.Fatalf("empty mailbox skeleton should not count as durable state")
+	}
+	if err := os.WriteFile(filepath.Join(root, "agents", "cto", "inbox", "new", "msg.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !rootHasDurableState(root) {
+		t.Fatalf("message file in mailbox skeleton should count as durable state")
+	}
+}
+
+func TestNamedProfileDispatchNamespaceOverrideQueuesAndAudits(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	t.Setenv("AM_ME", "operator-shell")
+	seedProfile(t, dir, "release", team.Team{
+		Project:      dir,
+		Workstream:   "main",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "main"},
+		},
+	})
+	legacyRoot := filepath.Join(dir, ".agent-mail", "main")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, "agents", "qa"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "agents", "qa", "inbox.md"), []byte("legacy durable state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-override to qa\n")
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--profile", "release", "--session", "main", "--role", "qa", "--subject", "X", "--body", "y", "--no-wake", "--json", "--override-namespace-conflict", "--reason", "recover live collided run"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch override: %v\n%s", err, stdout)
+	}
+	env := decodeJSONEnvelope[mutationResult](t, stdout)
+	if env.Data.MessageID != "msg-override" || env.Data.Root != filepath.Join(resolveDir(dir), ".agent-mail", "release", "main") {
+		t.Fatalf("dispatch result = %+v", env.Data)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("amq calls = %d, want 1", len(*calls))
+	}
+	audit, err := os.ReadFile(filepath.Join(dir, ".amq-squad", "namespace-audit", "main.jsonl"))
+	if err != nil {
+		t.Fatalf("read namespace audit: %v", err)
+	}
+	for _, want := range []string{`"operation":"dispatch"`, `"kind":"legacy_session_root"`, `"actor":"operator-shell"`, `"actor_env_set":true`, `"reason":"recover live collided run"`, coldNamespaceMigrationIssueURL} {
+		if !strings.Contains(string(audit), want) {
+			t.Fatalf("audit missing %q:\n%s", want, string(audit))
+		}
+	}
+}
+
+func TestGoalDeliverNamespaceOverrideDeliversAndAudits(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	t.Setenv("AM_ME", "")
+	seedProfile(t, dir, "release", team.Team{
+		Project:       dir,
+		Workstream:    "main",
+		Orchestrated:  true,
+		Lead:          "cto",
+		ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"},
+		},
+	})
+	legacyRoot := filepath.Join(dir, ".agent-mail", "main")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, "agents", "cto"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "agents", "cto", "inbox.md"), []byte("legacy durable state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	namedRoot := filepath.Join(dir, ".agent-mail", "release", "main")
+	agentDir := filepath.Join(namedRoot, "agents", "cto")
+	if err := launch.Write(agentDir, launch.Record{
+		CWD:         dir,
+		Binary:      "codex",
+		Handle:      "cto",
+		Role:        "cto",
+		Session:     "main",
+		Root:        namedRoot,
+		TeamProfile: "release",
+		Tmux:        &launch.TmuxInfo{PaneID: "%9"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%9", CWD: dir, Command: "codex", Title: "amq:main:cto"}}, nil
+	}
+	oldSend := sendPromptToPane
+	var sent []string
+	sendPromptToPane = func(paneID, prompt string) error {
+		sent = append(sent, paneID+"\x00"+prompt)
+		return nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister = oldLister
+		sendPromptToPane = oldSend
+	})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--profile", "release", "--session", "main", "--role", "cto", "--goal", "ship", "--json", "--override-namespace-conflict", "--reason", "recover visible lead"})
+	})
+	if err != nil {
+		t.Fatalf("goal deliver override: %v\n%s", err, stdout)
+	}
+	if len(sent) != 1 || !strings.Contains(sent[0], "/goal --goal") || !strings.Contains(sent[0], "--profile release") {
+		t.Fatalf("goal deliver sent = %+v", sent)
+	}
+	env := decodeJSONEnvelope[mutationResult](t, stdout)
+	if env.Kind != "goal_deliver" || env.Data.Status != "native_goal_delivered" {
+		t.Fatalf("goal deliver envelope = %+v", env)
+	}
+	audit, err := os.ReadFile(filepath.Join(dir, ".amq-squad", "namespace-audit", "main.jsonl"))
+	if err != nil {
+		t.Fatalf("read namespace audit: %v", err)
+	}
+	for _, want := range []string{`"operation":"goal deliver"`, `"actor":""`, `"actor_env_set":true`, `"reason":"recover visible lead"`} {
+		if !strings.Contains(string(audit), want) {
+			t.Fatalf("audit missing %q:\n%s", want, string(audit))
 		}
 	}
 }

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -374,12 +374,15 @@ func runSend(args []string) error {
 	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile (default: default profile)")
 	forceFlag := fs.Bool("force", false, "deliver even if the agent appears busy (mid-turn)")
+	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
+	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad send - deliver a prompt to an agent's tmux pane and submit it
 
 Usage:
   amq-squad send [--project DIR] [--profile NAME] --session S --role ROLE
                  (--body TEXT | --body-file FILE | --body-file -) [--force]
+                 [--override-namespace-conflict --reason WHY]
 
 Stages the prompt in a tmux paste buffer (via stdin, never a shell string) and
 pastes it into the agent's exact pane, then submits a single Enter. Multi-line
@@ -424,7 +427,10 @@ Examples:
 	if err != nil {
 		return err
 	}
-	if err := ensureNoNamespaceConflict("send", projectDir, profile, workstream, flagWasSet(fs, "profile")); err != nil {
+	if err := ensureNoNamespaceConflictWithOverride("send", projectDir, profile, workstream, flagWasSet(fs, "profile"), namespaceConflictOverrideOptions{
+		Allowed: *overrideNamespaceConflict,
+		Reason:  *overrideNamespaceReason,
+	}); err != nil {
 		return err
 	}
 	panes, err := statusPaneLister()


### PR DESCRIPTION
## Summary

Implements #353 recovery for collided namespaces without destroying a live run.

- Treats directory-only AMQ mailbox skeletons as non-durable debris, so empty legacy roots no longer block named-profile delivery.
- Adds explicit audited `--override-namespace-conflict --reason <why>` recovery to delivery verbs only: `goal start`, `goal deliver`, `goal apply`, `dispatch`, `send`, `operator answer`, and `operator directive`.
- Writes JSONL audit records under `.amq-squad/namespace-audit/<session>.jsonl`, including AM_ME actor data and whether AM_ME was set.
- Updates guard recovery guidance to point at the real override path and the stopped-run cold migration backlog issue #359.
- For default-profile shadow conflicts, the recovery copy now names explicit `--profile default` as the acknowledged, non-audited escape instead of printing inert override flags. I chose this over auditing explicit-default use because `--profile default` intentionally targets the default root and no longer has a namespace conflict to override.

## Migration rationale

Live namespace migration is deliberately deferred. A true live migration would have to relocate AMQ durable state and rewrite or rebind launch records for running agents, wake locks, root metadata, delivery receipts, status action roots, and possibly running process assumptions. That is higher-risk and likely incomplete without restarting or rehoming live agents. This PR implements the accepted live-run recovery path via audited override, and #359 tracks safer stopped-run `namespace migrate`.

## Review Notes

- `goal start --dry-run` still refuses conflicted namespaces. That is safe, accepted as-is, and can be relaxed later if preview ergonomics become important.
- Deep classifier block-case tests and audit-write-failure tests were accepted as unnecessary for this slice.
- `operator answer` now uses a dedicated `--namespace-reason` for namespace override audit so its gate `--reason` remains answer-body text only.

## Validation

- `go test ./internal/cli -run 'TestNamedProfile|TestRootHasDurableState|TestGoalDeliverNamespaceOverride|TestRunDispatch|TestOperatorAnswer|TestOperatorDirective'`
- `go test ./internal/cli -run 'TestNamedProfile|TestNamespaceOverrideRequiresReason|TestGoalDeliverNamespaceOverride|TestDefaultProfileShadowRecovery|TestOperatorAnswer|TestOperatorDirective'`
- `go test ./internal/cli`
- `go test ./...`
- `make ci`

Head SHA: `525ebd1930fd0716f5861d8743478efe711939e9`

Closes #353.
Refs #359.
