### PR TITLE
Default run start to sibling tabs

### DIFF
--- a/README.html
+++ b/README.html
@@ -1434,14 +1434,14 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                     [--roles r,...] [--binary role=bin,...] [--model role=model,...]
                     [--lead-mode builder|planner]
                     [--codex-args A] [--claude-args A]
-                    [--visibility detached|sibling-tabs|current]
+                    [--visibility sibling-tabs|detached|current]
                     [--goal TEXT] [--seed-from REF] [--go]
                                   Create one orchestrated run: wraps new team
                                   (if --roles) then up, so the namespace is typed
                                   once. Preview by default (runs --dry-run
                                   validation); --go creates. Visibility defaults
-                                  to detached (hidden); supervise via status/
-                                  console/monitor + wake, attach to intervene.
+                                  to sibling-tabs in the current tmux session;
+                                  use --visibility detached for hidden workers.
 amq-squad up [&lt;session&gt;] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
              [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
              [--terminal tmux] [--target current-window|new-window|new-session]

--- a/README.md
+++ b/README.md
@@ -825,14 +825,14 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                     [--roles r,...] [--binary role=bin,...] [--model role=model,...]
                     [--lead-mode builder|planner]
                     [--codex-args A] [--claude-args A]
-                    [--visibility detached|sibling-tabs|current]
+                    [--visibility sibling-tabs|detached|current]
                     [--goal TEXT] [--seed-from REF] [--go]
                                   Create one orchestrated run: wraps new team
                                   (if --roles) then up, so the namespace is typed
                                   once. Preview by default (runs --dry-run
                                   validation); --go creates. Visibility defaults
-                                  to detached (hidden); supervise via status/
-                                  console/monitor + wake, attach to intervene.
+                                  to sibling-tabs in the current tmux session;
+                                  use --visibility detached for hidden workers.
 amq-squad up [<session>] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
              [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
              [--terminal tmux] [--target current-window|new-window|new-session]

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -14,9 +14,10 @@ verbs are the source of truth.
 
 ## Preconditions
 
-- Inside **tmux** for visible spawns (`global start --go`, and `run start` with
-  `--visibility sibling-tabs`/`current`). Hidden spawns (`run start` default
-  `--visibility detached`) do not require a visible pane.
+- Inside **tmux** for visible spawns (`global start --go`, and `run start --go`
+  with the default `--visibility sibling-tabs` or `--visibility current`).
+  Hidden spawns (`run start --visibility detached --go`) do not require a
+  visible pane.
 - `amq-squad` + `amq` on `PATH`; AMQ floor is **0.40.0**. `amq-squad doctor`
   warns on version skew (children inherit the `amq-squad` on `PATH`).
 - In the orchestrator conversation, invoke the **`amq-squad-orchestrator`** skill.
@@ -66,12 +67,14 @@ amq-squad run start -p ~/Code/app -s issue-96 -P release \
 
 ### Visibility (do I see the agents?)
 
-`--visibility` controls the spawn topology; default is **detached (hidden)**:
+`--visibility` controls the spawn topology; default is **sibling-tabs
+(visible)**:
 
-- `detached` (default) — agents run in a separate tmux session you don't see.
+- `sibling-tabs` (default) — one visible tmux tab per agent in the current tmux
+  session. Preview works outside tmux; `--go` requires a visible tmux pane.
+- `detached` — agents run in a separate tmux session you don't see.
   Supervise via `status`/`console`/`monitor` + wake; attach only to intervene
   (`amq-squad focus`, or the `attach_control` action in `status --json`).
-- `sibling-tabs` — one visible tmux tab per agent (requires a visible pane).
 - `current` — split panes in the current window.
 
 Note: this sets the **initial** spawn. Later dynamic spawns by the lead

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -169,7 +169,7 @@ Usage:
       [--roles "a,b,c"] [--binary "role=bin,..."] [--model "role=model,..."]
       [--lead-mode builder|planner]
       [--codex-args "..."] [--claude-args "..."]
-      [--visibility detached|sibling-tabs|current] [--goal TEXT] [--seed-from REF] [--go]
+      [--visibility sibling-tabs|detached|current] [--goal TEXT] [--seed-from REF] [--go]
 
 Managed model: amq-squad spawns the whole team (incl. the lead); panes are
 registered and wake-live automatically. This wraps the create sequence so the
@@ -177,11 +177,11 @@ registered and wake-live automatically. This wraps the create sequence so the
 
     new team (if --roles) -> up --visibility <mode>
 
-Visibility defaults to detached (hidden): agents run in a separate tmux session
-you don't see, and you supervise via status/console/monitor + wake, attaching
-only to intervene. Pass --visibility sibling-tabs for visible tabs (requires a
-visible tmux pane). Choose binary via --binary, model via --model, and effort
-via --codex-args/--claude-args (amq-squad has no first-class --effort flag).
+Visibility defaults to sibling-tabs: agents open as sibling tmux windows in the
+current visible tmux session (requires a visible tmux pane when --go is used).
+Pass --visibility detached for hidden workers in a separate tmux session. Choose
+binary via --binary, model via --model, and effort via
+--codex-args/--claude-args (amq-squad has no first-class --effort flag).
 
 Preview by default (prints the plan and runs read-only --dry-run validation, so
 its failures surface honestly); pass --go to create for real.
@@ -217,7 +217,7 @@ func runRunStart(args []string, version string) error {
 	modelFlag := fs.String("model", "", "per-role model overrides, e.g. \"cto=gpt-5,fullstack=sonnet\"")
 	codexArgsFlag := fs.String("codex-args", "", "extra args for every Codex member (e.g. reasoning effort)")
 	claudeArgsFlag := fs.String("claude-args", "", "extra args for every Claude member")
-	visibilityFlag := fs.String("visibility", visibilityDetached, "spawn topology: detached (hidden, default), sibling-tabs (visible tabs), or current")
+	visibilityFlag := fs.String("visibility", visibilitySiblingTabs, "spawn topology: sibling-tabs (visible default), detached (hidden), or current")
 	goalFlag := fs.String("goal", "", "after spawn, deliver this goal to the lead")
 	seedFlag := fs.String("seed-from", "", "seed the workstream brief from a reference (e.g. issue:96)")
 	externalLead := fs.Bool("external-lead", false, "(unsupported yet, see #339) your current pane is the lead")
@@ -350,6 +350,9 @@ func runRunStart(args []string, version string) error {
 	if visibility == visibilityDetached {
 		fmt.Printf("  (hidden: agents run in a detached tmux session; attach via the `attach_control` action from `status --json`, or `amq-squad focus`, when you want eyes on them)\n")
 	}
+	if !*goFlag && (visibility == visibilitySiblingTabs || visibility == visibilityCurrent) && !insideTmux() {
+		fmt.Printf("  note:    --go with --visibility %s requires a visible tmux pane; run inside tmux or pass --visibility detached.\n", visibility)
+	}
 	if strings.TrimSpace(*goalFlag) != "" {
 		fmt.Printf("  step %d:  amq-squad goal start --session %s --goal %q --yes\n", upStep+1, session, *goalFlag)
 	}
@@ -359,7 +362,7 @@ func runRunStart(args []string, version string) error {
 	}
 
 	if (visibility == visibilitySiblingTabs || visibility == visibilityCurrent) && !insideTmux() {
-		return usageErrorf("not inside tmux; --visibility %s requires a visible tmux pane. Use --visibility detached to spawn hidden, or attach a tmux session first.", visibility)
+		return usageErrorf("not inside tmux; --visibility %s requires a visible tmux pane. Run inside tmux, or pass --visibility detached to spawn hidden.", visibility)
 	}
 
 	// 1) roster

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -138,20 +138,71 @@ func TestRunStartRejectsBadSession(t *testing.T) {
 	}
 }
 
-func TestRunStartDefaultsToDetachedInPreview(t *testing.T) {
-	// A fresh project with --roles: preview should describe a detached (hidden)
-	// spawn by default and note the deferred spawn validation.
+func TestRunStartDefaultsToSiblingTabsInPreview(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	// A fresh project with --roles: preview should describe a visible sibling-tab
+	// spawn by default, stay usable outside tmux, and note the deferred spawn
+	// validation.
 	out, _, err := captureOutput(t, func() error {
 		return runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "--roles", "cto"}, "test")
 	})
 	if err != nil {
 		t.Fatalf("preview returned error: %v", err)
 	}
-	if !strings.Contains(out, "--visibility detached") {
-		t.Fatalf("default visibility should be detached:\n%s", out)
+	if !strings.Contains(out, "--visibility sibling-tabs") {
+		t.Fatalf("default visibility should be sibling-tabs:\n%s", out)
 	}
-	if !strings.Contains(out, "hidden") {
-		t.Fatalf("preview should explain hidden spawn:\n%s", out)
+	if !strings.Contains(out, "--go with --visibility sibling-tabs requires a visible tmux pane") {
+		t.Fatalf("outside-tmux preview should warn about --go requirements:\n%s", out)
+	}
+	if strings.Contains(out, "hidden") {
+		t.Fatalf("default preview should not describe detached hidden spawn:\n%s", out)
+	}
+}
+
+func TestRunStartGoOutsideTmuxRefusesSiblingTabsDefault(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "--roles", "cto", "--go"}, "test")
+	})
+	if err == nil {
+		t.Fatal("expected outside-tmux --go to fail under sibling-tabs default")
+	}
+	for _, want := range []string{"--visibility sibling-tabs", "Run inside tmux", "--visibility detached"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRunStartGoInsideTmuxDefaultsToSiblingTabsBackend(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	backend := &fakeBackend{}
+	prev, hadPrev := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = backend
+	t.Cleanup(func() {
+		if hadPrev {
+			teamLaunchBackends["tmux"] = prev
+			return
+		}
+		delete(teamLaunchBackends, "tmux")
+	})
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "--roles", "cto", "--go"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("run start --go inside tmux: %v", err)
+	}
+	if len(backend.launches) != 1 {
+		t.Fatalf("expected one launch, got %+v", backend.launches)
+	}
+	got := backend.launches[0]
+	if got.Terminal != "tmux" || got.Target != "new-window" || got.Workstream != "sess" {
+		t.Fatalf("launch opts = %+v, want tmux new-window for sess", got)
 	}
 }
 

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -569,10 +569,8 @@ func (e *FocusMissError) Error() string {
 	return "could not raise the agent's iTerm2 tab (its tmux session may not be attached here); run: " + e.Command
 }
 
-// AttachCommand renders the manual command to reach a target session that is not
-// currently a tab in this iTerm2: attach the session in a fresh client. It is
-// the actionable companion to a FocusMiss (whereas SuggestJump's switch-client
-// assumes the session is already attached somewhere).
+// AttachCommand renders the manual command to reach a target session from
+// outside tmux: attach the session in a fresh client.
 func AttachCommand(t TmuxTarget) string {
 	if t.Session == "" {
 		return SuggestJump(t)
@@ -666,7 +664,7 @@ func switchToWithSession(t TmuxTarget, curSession func() string) error {
 		// Not in a tmux client at all: best-effort select-window so an iTerm2 -CC
 		// attached window raises, then report the suggested command.
 		_ = switchExec("tmux", "select-window", "-t", spec)
-		return &NotInTmuxError{Target: t, Command: SuggestJump(t)}
+		return &NotInTmuxError{Target: t, Command: AttachCommand(t)}
 	}
 
 	cur := ""
@@ -697,7 +695,7 @@ func switchToWithSession(t TmuxTarget, curSession func() string) error {
 		// osascript ran cleanly but found no matching tab (out == "MISS" or, defensively,
 		// any non-OK output). The target session is not attached to this iTerm2: no
 		// select-window here can raise a tab that doesn't exist, so do NOT pretend.
-		return &FocusMissError{Target: t, Command: AttachCommand(t)}
+		return &FocusMissError{Target: t, Command: SuggestJump(t)}
 	}
 	// osascript itself failed (not macOS / not iTerm2): degrade to a best-effort
 	// tmux select-window and surface the manual command.

--- a/internal/tmuxpane/tmux_focus_test.go
+++ b/internal/tmuxpane/tmux_focus_test.go
@@ -154,9 +154,9 @@ func TestSwitchTo_DifferentSessionOsascriptFailsFallsBack(t *testing.T) {
 // every tab and matches NO session name. The agent's tmux session is not
 // attached to this iTerm2. The OLD code read only the exit code, saw 0, and
 // reported a false "jumped". The fix reads the MISS stdout sentinel and returns
-// a typed FocusMissError carrying the manual attach command and must NOT fall
-// back to a tmux select-window (there is no tab to raise; that would be another
-// silent no-op pretending to work).
+// a typed FocusMissError carrying the manual in-tmux switch-client command and
+// must NOT fall back to a tmux select-window (there is no tab to raise; that
+// would be another silent no-op pretending to work).
 func TestSwitchTo_DifferentSessionOsascriptMissReturnsFocusMiss(t *testing.T) {
 	var tmuxCalls [][]string
 	var osaCalls [][]string
@@ -174,8 +174,8 @@ func TestSwitchTo_DifferentSessionOsascriptMissReturnsFocusMiss(t *testing.T) {
 	if !errors.As(err, &fm) {
 		t.Fatalf("a MISS must return *FocusMissError (the QA-8 honest-failure fix), got %T (%v)", err, err)
 	}
-	if fm.Command != AttachCommand(target) {
-		t.Errorf("FocusMissError.Command = %q, want the attach hint %q", fm.Command, AttachCommand(target))
+	if fm.Command != SuggestJump(target) {
+		t.Errorf("FocusMissError.Command = %q, want the in-tmux switch hint %q", fm.Command, SuggestJump(target))
 	}
 	if len(osaCalls) != 1 {
 		t.Fatalf("osascript should be attempted exactly once, got %v", osaCalls)
@@ -266,6 +266,12 @@ func TestSwitchTo_OutsideTmuxStillReturnsTypedError(t *testing.T) {
 	}
 	if len(tmuxCalls) != 1 || tmuxCalls[0][1] != "select-window" {
 		t.Fatalf("outside tmux should emit one select-window, got %v", tmuxCalls)
+	}
+	if nit.Command != AttachCommand(target) {
+		t.Fatalf("outside-tmux hint = %q, want attach command %q", nit.Command, AttachCommand(target))
+	}
+	if strings.Contains(nit.Command, "switch-client") {
+		t.Fatalf("outside-tmux hint must not use switch-client: %q", nit.Command)
 	}
 }
 

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -289,8 +289,8 @@ func TestSwitchTo_OutsideTmuxReturnsTypedError(t *testing.T) {
 	if !errors.As(err, &nit) {
 		t.Fatalf("error = %T (%v), want *NotInTmuxError", err, err)
 	}
-	if nit.Command != SuggestJump(target) {
-		t.Fatalf("NotInTmuxError.Command = %q, want %q", nit.Command, SuggestJump(target))
+	if nit.Command != AttachCommand(target) {
+		t.Fatalf("NotInTmuxError.Command = %q, want %q", nit.Command, AttachCommand(target))
 	}
 	// Outside tmux we still attempt a best-effort select-window so an iTerm2 -CC
 	// window raises.


### PR DESCRIPTION
Closes #346.

## Summary
- Change `amq-squad run start` default `--visibility` from detached to `sibling-tabs`, while keeping explicit `--visibility detached` unchanged.
- Keep preview usable outside tmux and add an explicit preview note that `--go` with sibling-tabs/current requires a visible tmux pane or explicit `--visibility detached`.
- Fix the inverted focus recovery hint: outside tmux now suggests `tmux attach -t <session>`, while in-tmux focus miss recovery suggests `tmux switch-client -t <target>`.
- Update run start help, README, generated README.html, and the global orchestrator runbook.

## Design decisions
- Default switch is limited to `run start`; low-level `up` behavior remains the existing visibility shortcut surface.
- Outside tmux fallback: `run start` preview still renders, but `--go` refuses for sibling-tabs/current with both concrete fixes named. No silent detached fallback.
- Focus stealing: the sibling-tabs backend already uses `tmux new-window -d`, so worker windows are created in the current tmux session without stealing the operator pane focus. This PR preserves that behavior and adds run-start path coverage for `Target: new-window`.
- `status --json` topology expectations did not need fixture flips; existing sibling-tabs/detached topology tests remain scoped to actual launch records/status rows, not the `run start` default.

## Validation
- `go test ./internal/cli -run 'TestRunStart|TestApplyLaunchVisibility|TestLaunchVisibility'`\n- `go test ./internal/tmuxpane -run 'TestSwitchTo|TestITerm'`\n- `go test ./internal/cli`\n- `go test ./...`\n- `make ci`\n\nFinal local validation was run after rebasing onto `origin/main` at `3ad6c247b320767700f34af4ff7e3a7128d5d76e`.