### PR TITLE
Add generic built-in roles

### DIFF
--- a/README.html
+++ b/README.html
@@ -1915,7 +1915,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb32-1"><a href="#
 step on most shells.</p>
 <h2 id="custom-roles">Custom roles</h2>
 <p><code>--roles</code>/<code>--personas</code> accept built-in personas
-(<code>cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm, designer, scribe</code>)
+(<code>cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm, designer, scribe, lead, agent</code>)
 and <strong>custom roles</strong> that are not in the catalog. A custom
 role is any valid slug (lowercase <code>a-z</code>, <code>0-9</code>,
 <code>-</code>, <code>_</code>) and must carry an explicit
@@ -1924,6 +1924,9 @@ to. Built-in roles keep their catalog defaults unless overridden. Custom
 roles are first-class team members in <code>team.json</code>,
 <code>team-rules.md</code>, the bootstrap prompt, status/history, and
 launch/resume.</p>
+<p>Use <code>lead</code> and <code>agent</code> for persona-light squads
+when you need a generic orchestrator or individual contributor without a
+domain-specific title.</p>
 <div class="sourceCode" id="cb33"><pre
 class="sourceCode sh"><code class="sourceCode bash"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="co"># inline: id + CLI, minimal role.md (generic custom-role fallback text)</span></span>
 <span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span>

--- a/README.md
+++ b/README.md
@@ -1240,12 +1240,15 @@ amq-squad completion fish > ~/.config/fish/completions/amq-squad.fish
 
 `--roles`/`--personas` accept built-in personas (`cpo, cto, senior-dev,
 fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
-designer, scribe`) and **custom roles** that are not in the catalog. A custom role is
+designer, scribe, lead, agent`) and **custom roles** that are not in the catalog. A custom role is
 any valid slug (lowercase `a-z`, `0-9`, `-`, `_`) and must carry an explicit
 `--binary` because there is no catalog default to fall back to. Built-in roles
 keep their catalog defaults unless overridden. Custom roles are first-class
 team members in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume.
+
+Use `lead` and `agent` for persona-light squads when you need a generic
+orchestrator or individual contributor without a domain-specific title.
 
 ```sh
 # inline: id + CLI, minimal role.md (generic custom-role fallback text)

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -127,6 +127,22 @@ var roles = []Role{
 		Description:     "Owns the written deliverable: API references, guides, READMEs, and the team's written record. The right author for a docs goal — does not implement product code.",
 		DefaultPeers:    []string{"cto", "backend-dev", "frontend-dev", "pm"},
 	},
+	{
+		ID:              "lead",
+		Label:           "Lead",
+		PreferredBinary: "codex",
+		Profile:         "Generic orchestrator for decomposition, delegation, review, gates, and final evidence.",
+		Description:     "Coordinates the workstream: breaks down goals, delegates tasks, tracks blockers, requests reviews, raises and tracks operator gates, and reports final evidence. Does not assume merge, release, or external-action authority unless the user or operator explicitly grants it.",
+		DefaultPeers:    []string{"agent"},
+	},
+	{
+		ID:              "agent",
+		Label:           "Agent",
+		PreferredBinary: "codex",
+		Profile:         "Generic individual contributor for scoped tasks and evidence-backed handoffs.",
+		Description:     "Executes assigned tasks within the current brief and team rules, asks when scope or authority is unclear, and reports concise evidence for review or handoff. Carries no domain-specific persona.",
+		DefaultPeers:    []string{"lead"},
+	},
 }
 
 // All returns a copy of the catalog in display order.

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -45,6 +45,8 @@ func TestMarketPersonas(t *testing.T) {
 		"backend-dev":  {label: "Backend Developer", binary: "codex"},
 		"mobile-dev":   {label: "Mobile Developer", binary: "claude"},
 		"junior-dev":   {label: "Junior Developer", binary: "codex"},
+		"lead":         {label: "Lead", binary: "codex"},
+		"agent":        {label: "Agent", binary: "codex"},
 	}
 	for id, want := range cases {
 		got := Lookup(id)
@@ -56,6 +58,39 @@ func TestMarketPersonas(t *testing.T) {
 		}
 		if got.Profile == "" || got.Description == "" {
 			t.Errorf("persona %s should have profile and description", id)
+		}
+	}
+}
+
+func TestGenericRolesAreNeutral(t *testing.T) {
+	lead := Lookup("lead")
+	if lead == nil {
+		t.Fatal("lead role missing")
+	}
+	for _, want := range []string{
+		"Generic orchestrator",
+		"raises and tracks operator gates",
+		"Does not assume merge, release, or external-action authority",
+	} {
+		if !strings.Contains(lead.Profile+" "+lead.Description, want) {
+			t.Fatalf("lead role missing %q: %+v", want, *lead)
+		}
+	}
+	if strings.Contains(lead.Description, "handles operator gates") {
+		t.Fatalf("lead role uses ambiguous gate wording: %q", lead.Description)
+	}
+
+	agent := Lookup("agent")
+	if agent == nil {
+		t.Fatal("agent role missing")
+	}
+	for _, want := range []string{
+		"Generic individual contributor",
+		"asks when scope or authority is unclear",
+		"Carries no domain-specific persona",
+	} {
+		if !strings.Contains(agent.Profile+" "+agent.Description, want) {
+			t.Fatalf("agent role missing %q: %+v", want, *agent)
 		}
 	}
 }
@@ -125,6 +160,15 @@ func TestResolveSelection(t *testing.T) {
 	}
 	if _, err := ResolveSelection("banana"); err == nil || !strings.Contains(err.Error(), "banana") {
 		t.Fatalf("ResolveSelection banana error = %v, want unknown persona", err)
+	}
+
+	got, err = ResolveSelection("lead,agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []string{"lead", "agent"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ResolveSelection lead,agent = %v, want %v", got, want)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -75,6 +75,10 @@ func TestRunRolesListsMarketNumbers(t *testing.T) {
 		"cto",
 		"9",
 		"qa",
+		"lead",
+		"agent",
+		"Generic orchestrator",
+		"Generic individual contributor",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("roles output missing %q:\n%s", want, stdout)

--- a/internal/cli/custom_role_test.go
+++ b/internal/cli/custom_role_test.go
@@ -52,6 +52,86 @@ func TestNewTeamCustomRoleDryRunJSON(t *testing.T) {
 	}
 }
 
+func TestNewTeamGenericBuiltInRolesDoNotRequireBinary(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{
+			"team",
+			"--roles", "lead,agent",
+			"--orchestrated", "--lead", "lead",
+			"--session", "issue-345",
+			"--dry-run", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("new team generic roles dry-run: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	if env.Data.Members != 2 || len(env.Data.Plan) != 2 {
+		t.Fatalf("members/plan = %d/%d, want 2/2", env.Data.Members, len(env.Data.Plan))
+	}
+	want := map[string]string{"lead": "codex", "agent": "codex"}
+	for _, m := range env.Data.Plan {
+		bin, ok := want[m.Role]
+		if !ok {
+			t.Fatalf("unexpected role in plan: %q", m.Role)
+		}
+		if m.Binary != bin {
+			t.Errorf("role %s binary = %q, want %q", m.Role, m.Binary, bin)
+		}
+		if m.Session != "issue-345" {
+			t.Errorf("role %s session = %q, want issue-345", m.Role, m.Session)
+		}
+	}
+}
+
+func TestSeedGenericRoleStubUsesNeutralCatalogText(t *testing.T) {
+	dir := t.TempDir()
+	if err := seedRoleStub(dir, "lead", ""); err != nil {
+		t.Fatalf("seed lead role: %v", err)
+	}
+	body, err := os.ReadFile(role.Path(dir))
+	if err != nil {
+		t.Fatalf("read lead role.md: %v", err)
+	}
+	got := string(body)
+	for _, want := range []string{
+		"# Role: Lead",
+		"raises and tracks operator gates",
+		"Does not assume merge, release, or external-action authority",
+		"- agent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("lead role.md missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "handles operator gates") {
+		t.Fatalf("lead role.md uses ambiguous gate wording:\n%s", got)
+	}
+
+	agentDir := t.TempDir()
+	if err := seedRoleStub(agentDir, "agent", ""); err != nil {
+		t.Fatalf("seed agent role: %v", err)
+	}
+	body, err = os.ReadFile(role.Path(agentDir))
+	if err != nil {
+		t.Fatalf("read agent role.md: %v", err)
+	}
+	got = string(body)
+	for _, want := range []string{
+		"# Role: Agent",
+		"asks when scope or authority is unclear",
+		"Carries no domain-specific persona",
+		"- lead",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("agent role.md missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestTeamInitCustomRoleLiveWrite confirms a custom role persists to team.json
 // as a first-class member through the `team init` path.
 func TestTeamInitCustomRoleLiveWrite(t *testing.T) {

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -227,6 +227,46 @@ func TestRunStartGoInsideTmuxDefaultsToSiblingTabsBackend(t *testing.T) {
 	}
 }
 
+func TestRunStartGoAcceptsGenericLeadRole(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%42")
+	backend := &fakeBackend{}
+	prev, hadPrev := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = backend
+	t.Cleanup(func() {
+		if hadPrev {
+			teamLaunchBackends["tmux"] = prev
+			return
+		}
+		delete(teamLaunchBackends, "tmux")
+	})
+	dir := t.TempDir()
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--roles", "lead", "--lead", "lead", "--go"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("run start --roles lead --lead lead --go: %v", err)
+	}
+	if len(backend.launches) != 1 {
+		t.Fatalf("expected one launch, got %+v", backend.launches)
+	}
+	got := backend.launches[0]
+	if got.Workstream != "sess" || got.Terminal != "tmux" || got.Target != "new-window" {
+		t.Fatalf("launch opts = %+v, want tmux new-window for sess", got)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	if !cfg.Orchestrated || cfg.Lead != "lead" {
+		t.Fatalf("team orchestration = %v/%q, want true/lead", cfg.Orchestrated, cfg.Lead)
+	}
+	if len(cfg.Members) != 1 || cfg.Members[0].Role != "lead" || cfg.Members[0].Binary != "codex" {
+		t.Fatalf("team members = %+v, want one built-in lead using codex", cfg.Members)
+	}
+}
+
 func TestRunStartProfileAliasAndExplicitLead(t *testing.T) {
 	out, _, err := captureOutput(t, func() error {
 		return runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "-P", "release", "--roles", "cto,qa", "--lead", "qa"}, "test")

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -703,7 +703,7 @@ Global output flags work before or after the subcommand: `--quiet`,
 
 Use this section to add a **custom role** — one that is not in the built-in
 persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
-mobile-dev, junior-dev, qa, pm, designer, scribe`). Custom roles are first-class team
+mobile-dev, junior-dev, qa, pm, designer, scribe, lead, agent`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -699,7 +699,7 @@ Global output flags work before or after the subcommand: `--quiet`,
 
 Use this section to add a **custom role** — one that is not in the built-in
 persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
-mobile-dev, junior-dev, qa, pm, designer, scribe`). Custom roles are first-class team
+mobile-dev, junior-dev, qa, pm, designer, scribe, lead, agent`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -701,7 +701,7 @@ Global output flags work before or after the subcommand: `--quiet`,
 
 Use this section to add a **custom role** — one that is not in the built-in
 persona catalog (`cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev,
-mobile-dev, junior-dev, qa, pm, designer, scribe`). Custom roles are first-class team
+mobile-dev, junior-dev, qa, pm, designer, scribe, lead, agent`). Custom roles are first-class team
 members: they appear in `team.json`, `team-rules.md`, the bootstrap prompt,
 status/history, and launch/resume exactly like built-ins.
 


### PR DESCRIPTION
Closes #345

## Summary
- add persona-light built-in `lead` and `agent` catalog roles
- keep generic role prose neutral, including explicit denial of merge/release/external-action authority for `lead`
- cover catalog selection, `amq-squad roles`, team creation without custom-role binaries, role.md seeding, and `run start -p <repo> -s <s> --roles lead --lead lead --go`
- update README/custom-role docs plus generated README HTML and plugin skill mirrors

## Scope Notes
- This PR does not change `run start`'s existing fresh-roster default lead behavior. Flipping the default lead from `cto` to `lead` can be considered separately.
- Broader role catalog additions such as `devops`/`sre`, `data`, `security`, `researcher`, and `tech-writer` are left as follow-up potential.

## Validation
- `go test ./internal/catalog ./internal/cli -run 'TestGenericRolesAreNeutral|TestMarketPersonas|TestResolveSelection|TestRunRolesListsMarketNumbers|TestNewTeamGenericBuiltInRolesDoNotRequireBinary|TestSeedGenericRoleStubUsesNeutralCatalogText|TestRunStartGoAcceptsGenericLeadRole'` PASS
- `git diff --check` PASS
- `go test ./...` PASS
- `make ci` PASS
