### PR TITLE
Adopt AMQ 0.41.0 and close wake nudge residue

### DIFF
--- a/README.html
+++ b/README.html
@@ -375,8 +375,8 @@ extension-metadata namespace. AMQ stays domain-agnostic: it adds generic
 affordances that layers build on (the
 <code>extensions/&lt;layer&gt;/</code> namespace, external wake
 injection, a reserved <code>user</code>/operator handle,
-<code>env --json</code>), which is why amq-squad v2.17.0 requires amq
-0.40.0+ — but it still knows nothing about CTOs, rosters, or team
+<code>env --json</code>), which is why amq-squad v2.18.0 requires amq
+0.41.0+ — but it still knows nothing about CTOs, rosters, or team
 rules.</p>
 <h2 id="install">Install</h2>
 <p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
@@ -385,7 +385,7 @@ rules.</p>
 <p>For the latest 2.x build:</p>
 <div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
 <p>Requires Go 1.25+, the <code>amq</code> binary on <code>PATH</code>
-(v0.40.0+), and <code>tmux</code> on <code>PATH</code> for
+(v0.41.0+), and <code>tmux</code> on <code>PATH</code> for
 <code>amq-squad up</code>.</p>
 <h3 id="skills-plugin-marketplaces">Skills (plugin marketplaces)</h3>
 <p>This repo doubles as a plugin marketplace that ships the amq-squad
@@ -1106,7 +1106,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb21-1"><a href="#
 <span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--no-operator</span>   <span class="co"># explicit opt-out</span></span></code></pre></div>
 <p>The operator is not a runnable team member. AMQ 0.38.0+ reserves the
 conventional <code>user</code> mailbox for this human/operator role, and
-amq-squad v2.17.0 requires AMQ 0.40.0+ overall; custom operator handles
+amq-squad v2.18.0 requires AMQ 0.41.0+ overall; custom operator handles
 use the same amq-squad protocol. JSON discovery derives
 <code>operator</code> and <code>capabilities.operator_gates</code>;
 <code>capabilities</code> is not persisted in
@@ -1727,13 +1727,13 @@ attached.</p>
 <p><code>amq-squad amq ...</code> is a project-aware wrapper around AMQ
 diagnostics. It resolves the same AMQ root, base root, session, and
 handle that the squad launcher uses, then delegates to AMQ.</p>
-<p>amq-squad v2.17.0 requires AMQ 0.40.0 or newer. That floor includes
-the wake-inject stale-process fix (AMQ-owned <code>--inject-via</code>
-wake processes exit when their recorded owner is gone or no longer
-matches), eval-safe <code>amq env --export</code>, the reserved human
-<code>user</code> mailbox behavior used by operator gates and
-notification surfaces, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake
-metadata file hardening.</p>
+<p>amq-squad v2.18.0 requires AMQ 0.41.0 or newer. That floor includes
+AMQ wake input-queue draining before CR injection, receipt-confirmed
+send/reply waits, absolute roots from <code>amq env --json</code>, plus
+the earlier wake-inject stale-process fix, eval-safe
+<code>amq env --export</code>, reserved human <code>user</code> mailbox
+behavior, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file
+hardening.</p>
 <p>Read-only diagnostics run directly:</p>
 <div class="sourceCode" id="cb26"><pre
 class="sourceCode sh"><code class="sourceCode bash"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
@@ -2088,7 +2088,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb38-1"><a href="#
 <span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5.5,fullstack=fable-5 <span class="dt">\</span></span>
 <span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span>
 <span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5.5 <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span></code></pre></div>
-<p>amq-squad v2.17.0 requires amq <strong>0.40.0+</strong>. Launches
+<p>amq-squad v2.18.0 requires amq <strong>0.41.0+</strong>. Launches
 pass <code>--require-wake</code> to <code>amq coop exec</code>, so a
 launch <strong>fails at the door</strong> when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale
@@ -2366,7 +2366,7 @@ project's <code>.amqrc</code> for cross-project AMQ routing.
 <h2 id="requires">Requires</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> binary on <code>PATH</code> (v0.40.0+)</li>
+<li><code>amq</code> binary on <code>PATH</code> (v0.41.0+)</li>
 <li><code>tmux</code> on <code>PATH</code> for
 <code>amq-squad up</code></li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ AMQ is the messaging and process substrate: it sets up mailboxes, routes and thr
 - **Durable team norms** — the shared rules each agent reads at session start
 - **The declared roster** — the role-mapped set of peers each agent is handed up front at bootstrap (AMQ can observe who talks to whom after the fact, via presence and threads; it does not declare the intended team a priori)
 
-`amq-squad` owns that layer. It captures roles, roster, and norms at team-setup time (`.amq-squad/team.json`, `.amq-squad/team-rules.md`) and per-agent launch state (`launch.json` + `role.md`) in AMQ's per-agent extension-metadata namespace. AMQ stays domain-agnostic: it adds generic affordances that layers build on (the `extensions/<layer>/` namespace, external wake injection, a reserved `user`/operator handle, `env --json`), which is why amq-squad v2.17.0 requires amq 0.40.0+ — but it still knows nothing about CTOs, rosters, or team rules.
+`amq-squad` owns that layer. It captures roles, roster, and norms at team-setup time (`.amq-squad/team.json`, `.amq-squad/team-rules.md`) and per-agent launch state (`launch.json` + `role.md`) in AMQ's per-agent extension-metadata namespace. AMQ stays domain-agnostic: it adds generic affordances that layers build on (the `extensions/<layer>/` namespace, external wake injection, a reserved `user`/operator handle, `env --json`), which is why amq-squad v2.18.0 requires amq 0.41.0+ — but it still knows nothing about CTOs, rosters, or team rules.
 
 ## Install
 
@@ -42,7 +42,7 @@ For the latest 2.x build:
 go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest
 ```
 
-Requires Go 1.25+, the `amq` binary on `PATH` (v0.40.0+), and `tmux` on `PATH` for `amq-squad up`.
+Requires Go 1.25+, the `amq` binary on `PATH` (v0.41.0+), and `tmux` on `PATH` for `amq-squad up`.
 
 ### Skills (plugin marketplaces)
 
@@ -618,7 +618,7 @@ amq-squad new team --roles cto,qa --operator ops  # custom operator handle
 amq-squad new team --roles cto,qa --no-operator   # explicit opt-out
 ```
 
-The operator is not a runnable team member. AMQ 0.38.0+ reserves the conventional `user` mailbox for this human/operator role, and amq-squad v2.17.0 requires AMQ 0.40.0+ overall; custom operator handles use the same amq-squad protocol. JSON discovery derives `operator` and `capabilities.operator_gates`; `capabilities` is not persisted in `team.json`.
+The operator is not a runnable team member. AMQ 0.38.0+ reserves the conventional `user` mailbox for this human/operator role, and amq-squad v2.18.0 requires AMQ 0.41.0+ overall; custom operator handles use the same amq-squad protocol. JSON discovery derives `operator` and `capabilities.operator_gates`; `capabilities` is not persisted in `team.json`.
 
 Operator gates are structural AMQ handoffs, not authentication. Send human-only decisions or manual actions to the configured operator handle on stable `gate/<topic>` threads, with `--kind question --subject "APPROVAL: <decision>"` for approvals and `--kind decision --subject "DONE: <goal>"` for manual closeout. The operator replies on the same thread with `--kind answer` and subjects such as `APPROVED:`, `DENIED:`, or `ANSWER:`. If the operator answers a pending gate in a live pane/chat instead of AMQ, the lead treats it as operator input, immediately ACKs or mirrors it on the matching `gate/<topic>` thread without spoofing the operator handle, and checks both the live channel and AMQ gate/inbox state before declaring the gate blocked. P2P prose like "pending operator" is evidence only; it is not a gate. `amq-squad notify` surfaces new or stale needs-you gates with inspect/respond commands and de-duplicates unchanged items, but notification output never authorizes or clears a gate.
 
@@ -1069,7 +1069,7 @@ It renders to `/dev/tty`, so `stdout` stays clean for the other verbs. With `--o
 
 `amq-squad amq ...` is a project-aware wrapper around AMQ diagnostics. It resolves the same AMQ root, base root, session, and handle that the squad launcher uses, then delegates to AMQ.
 
-amq-squad v2.17.0 requires AMQ 0.40.0 or newer. That floor includes the wake-inject stale-process fix (AMQ-owned `--inject-via` wake processes exit when their recorded owner is gone or no longer matches), eval-safe `amq env --export`, the reserved human `user` mailbox behavior used by operator gates and notification surfaces, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file hardening.
+amq-squad v2.18.0 requires AMQ 0.41.0 or newer. That floor includes AMQ wake input-queue draining before CR injection, receipt-confirmed send/reply waits, absolute roots from `amq env --json`, plus the earlier wake-inject stale-process fix, eval-safe `amq env --export`, reserved human `user` mailbox behavior, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file hardening.
 
 Read-only diagnostics run directly:
 
@@ -1389,7 +1389,7 @@ amq-squad team init --personas cto,fullstack --model cto=gpt-5.5,fullstack=fable
 amq-squad agent up codex --model gpt-5.5 --codex-args "-c model_reasoning_effort=medium"
 ```
 
-amq-squad v2.17.0 requires amq **0.40.0+**. Launches pass `--require-wake` to
+amq-squad v2.18.0 requires amq **0.41.0+**. Launches pass `--require-wake` to
 `amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
 cannot start and acquire its lock, instead of surfacing later as a stale or
 orphaned wake. `--no-require-wake` opts out for environments where wake cannot
@@ -1569,5 +1569,5 @@ Replay paths that emit copy-paste commands use the modern `agent up <binary>` co
 ## Requires
 
 - Go 1.25+
-- `amq` binary on `PATH` (v0.40.0+)
+- `amq` binary on `PATH` (v0.41.0+)
 - `tmux` on `PATH` for `amq-squad up`

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -18,7 +18,7 @@ verbs are the source of truth.
   with the default `--visibility sibling-tabs` or `--visibility current`).
   Hidden spawns (`run start --visibility detached --go`) do not require a
   visible pane.
-- `amq-squad` + `amq` on `PATH`; AMQ floor is **0.40.0**. `amq-squad doctor`
+- `amq-squad` + `amq` on `PATH`; AMQ floor is **0.41.0**. `amq-squad doctor`
   warns on version skew (children inherit the `amq-squad` on `PATH`).
 - In the orchestrator conversation, invoke the **`amq-squad-orchestrator`** skill.
 

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -638,8 +638,8 @@ drain your inbox.</li>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. AMQ floor (v2.16.0+): amq-squad
-requires amq 0.40.0+. Launches pass <code>--require-wake</code> so a
+<code>--settings</code> file is missing. AMQ floor (v2.18.0+): amq-squad
+requires amq 0.41.0+. Launches pass <code>--require-wake</code> so a
 launch fails immediately when the wake sidecar cannot acquire its lock
 (<code>--no-require-wake</code> opts out and persists into resume). Use
 <code>--no-gitignore</code> on <code>agent up</code>, <code>up</code>,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -201,7 +201,7 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ floor (v2.16.0+): amq-squad requires amq 0.40.0+. Launches pass
+missing. AMQ floor (v2.18.0+): amq-squad requires amq 0.41.0+. Launches pass
 `--require-wake` so a launch fails immediately when the wake sidecar cannot
 acquire its lock (`--no-require-wake` opts out and persists into resume).
 Use `--no-gitignore` on `agent up`, `up`, or `up --dry-run` when AMQ coop

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -57,9 +57,9 @@ func defaultRunAMQCommand(req amqCommandRequest) ([]byte, error) {
 	if err != nil {
 		detail := strings.TrimSpace(string(out))
 		if detail != "" {
-			return nil, fmt.Errorf("%w: %s", err, detail)
+			return out, fmt.Errorf("%w: %s", err, detail)
 		}
-		return nil, err
+		return out, err
 	}
 	return out, nil
 }

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -89,6 +89,28 @@ func TestResolveAMQContextForProjectIsPrimaryResolver(t *testing.T) {
 	}
 }
 
+func TestResolveAMQContextNormalizesRelativeRootsToAbsoluteEnv(t *testing.T) {
+	dir := t.TempDir()
+	_ = withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail", AMQVersion: "0.41.0"}, "ok\n")
+
+	ctx, err := resolveAMQContextForProject(dir, "issue-96", "cto")
+	if err != nil {
+		t.Fatalf("resolveAMQContextForProject: %v", err)
+	}
+	wantRoot := filepath.Join(dir, ".agent-mail", "issue-96")
+	wantBase := filepath.Join(dir, ".agent-mail")
+	if ctx.Root != wantRoot {
+		t.Fatalf("ctx.Root = %q, want absolute %q", ctx.Root, wantRoot)
+	}
+	env := amqCommandEnv(ctx)
+	if !envHas(env, "AM_ROOT", wantRoot) {
+		t.Fatalf("AM_ROOT not injected as absolute root: %v", env)
+	}
+	if !envHas(env, "AM_BASE_ROOT", wantBase) {
+		t.Fatalf("AM_BASE_ROOT not injected as absolute base root: %v", env)
+	}
+}
+
 func TestAMQRouteAddsJSONByDefault(t *testing.T) {
 	chdir(t, t.TempDir())
 	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, `{"routable":true}`+"\n")

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -334,6 +334,8 @@ var completionCommonFlags = []string{
 	"--ttl",
 	"--unsafe-send-as",
 	"--visibility",
+	"--wait-for",
+	"--wait-timeout",
 	"--wake",
 	"--wake-inject-arg",
 	"--wake-inject-via",

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -42,6 +42,12 @@ const (
 	dispatchSubmitUnconfirmed = "submit_unconfirmed"
 )
 
+const (
+	dispatchNoWait                 = "none"
+	dispatchAnswerDefaultWaitFor   = "drained"
+	dispatchAnswerDefaultWaitAfter = 60 * time.Second
+)
+
 type dispatchEnvelopeData struct {
 	Session   string          `json:"session"`
 	Role      string          `json:"role"`
@@ -89,6 +95,8 @@ func runDispatch(args []string) error {
 	registerScopedFlagAliases(fs, projectFlag, sessionFlag, profileFlag)
 	forceFlag := fs.Bool("force", false, "nudge the pane even if the agent looks busy (mid-turn)")
 	noWakeFlag := fs.Bool("no-wake", false, "queue the durable task without nudging the pane")
+	waitForFlag := fs.String("wait-for", "", "AMQ receipt stage to wait for after send (default: drained for --kind answer; use none to disable)")
+	waitTimeoutFlag := fs.Duration("wait-timeout", dispatchAnswerDefaultWaitAfter, "maximum time to wait for the AMQ receipt stage")
 	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
 	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	createTaskFlag := fs.Bool("create-task", false, "create and link a native task-store task before dispatch")
@@ -101,7 +109,8 @@ Usage:
   amq-squad dispatch [--project DIR] [--profile NAME] --session S --role ROLE
                      [--from HANDLE] [--thread THREAD] [--kind todo] --subject SUBJ
                      (--body TEXT | --body-file FILE) [--priority P]
-                     [--force] [--no-wake] [--override-namespace-conflict --reason WHY]
+                     [--force] [--no-wake] [--wait-for STAGE] [--wait-timeout DURATION]
+                     [--override-namespace-conflict --reason WHY]
                      [--create-task | --task ID] [--json]
 
 The deterministic lead-to-child dispatch. It does two things, in order:
@@ -229,7 +238,9 @@ Examples:
 		}
 	}
 
-	sendCmd := dispatchSendArgs(ctx.Root, from, member.Handle, *threadFlag, *kindFlag, *subjectFlag, taskBody, *priorityFlag)
+	waitFor := dispatchReceiptWaitFor(*kindFlag, *waitForFlag)
+	waitTimeout := *waitTimeoutFlag
+	sendCmd := dispatchSendArgs(ctx.Root, from, member.Handle, *threadFlag, *kindFlag, *subjectFlag, taskBody, *priorityFlag, waitFor, waitTimeout)
 	out, err := runAMQCommand(amqCommandRequest{Dir: cwd, Env: amqCommandEnv(ctx), Arg: sendCmd})
 	if err != nil {
 		return fmt.Errorf("dispatch send to %s: %w", *roleFlag, err)
@@ -240,6 +251,9 @@ Examples:
 	receipt.Thread = strings.TrimSpace(*threadFlag)
 	receipt.Status = "written_to_amq"
 	receipt.addStage("written_to_amq", "durable AMQ message written to recipient inbox")
+	if waitFor != "" {
+		receipt.addStage("amq_wait_"+waitFor, fmt.Sprintf("amq send waited for %s receipt with timeout %s", waitFor, waitTimeout))
+	}
 	if taskID != "" {
 		linked, lerr := dispatchLinkTask(projectDir, profile, workstream, taskID, taskstore.Dispatch{
 			Sender:    from,
@@ -274,8 +288,12 @@ Examples:
 			if taskID != "" {
 				taskText = fmt.Sprintf(" — task %s", taskID)
 			}
-			fmt.Printf("Dispatched %s to %s (handle %s) on session %s — msg %s%s (root %s)\n",
-				*kindFlag, *roleFlag, member.Handle, workstream, msgID, taskText, ctx.Root)
+			waitText := ""
+			if waitFor != "" {
+				waitText = fmt.Sprintf("; waited for %s receipt up to %s", waitFor, waitTimeout)
+			}
+			fmt.Printf("Dispatched %s to %s (handle %s) on session %s — msg %s%s (root %s%s)\n",
+				*kindFlag, *roleFlag, member.Handle, workstream, msgID, taskText, ctx.Root, waitText)
 		} else {
 			if msg := strings.TrimSpace(string(out)); msg != "" {
 				fmt.Println(msg)
@@ -553,7 +571,7 @@ func parseSentMessageID(out string) string {
 // dispatchSendArgs builds the `amq send` argv for a dispatch: a durable message
 // to the resolved root from the lead handle to the child handle. The body is
 // always passed (it is required and validated upstream). Pure + table-testable.
-func dispatchSendArgs(root, from, to, thread, kind, subject, body, priority string) []string {
+func dispatchSendArgs(root, from, to, thread, kind, subject, body, priority, waitFor string, waitTimeout time.Duration) []string {
 	args := []string{"send", "--root", root, "--me", from, "--to", to}
 	if th := strings.TrimSpace(thread); th != "" {
 		args = append(args, "--thread", th)
@@ -568,7 +586,27 @@ func dispatchSendArgs(root, from, to, thread, kind, subject, body, priority stri
 	if p := strings.TrimSpace(priority); p != "" {
 		args = append(args, "--priority", p)
 	}
+	if w := strings.TrimSpace(waitFor); w != "" {
+		args = append(args, "--wait-for", w)
+		if waitTimeout > 0 {
+			args = append(args, "--wait-timeout", waitTimeout.String())
+		}
+	}
 	return args
+}
+
+func dispatchReceiptWaitFor(kind, explicit string) string {
+	explicit = strings.TrimSpace(explicit)
+	if strings.EqualFold(explicit, dispatchNoWait) {
+		return ""
+	}
+	if explicit != "" {
+		return explicit
+	}
+	if strings.EqualFold(strings.TrimSpace(kind), "answer") {
+		return dispatchAnswerDefaultWaitFor
+	}
+	return ""
 }
 
 // resolveDispatchSender picks the AMQ handle the dispatched task is sent FROM.

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -243,7 +243,9 @@ Examples:
 	sendCmd := dispatchSendArgs(ctx.Root, from, member.Handle, *threadFlag, *kindFlag, *subjectFlag, taskBody, *priorityFlag, waitFor, waitTimeout)
 	out, err := runAMQCommand(amqCommandRequest{Dir: cwd, Env: amqCommandEnv(ctx), Arg: sendCmd})
 	if err != nil {
-		return fmt.Errorf("dispatch send to %s: %w", *roleFlag, err)
+		if !dispatchSendWaitTimedOut(out, err, waitFor) {
+			return fmt.Errorf("dispatch send to %s: %w", *roleFlag, err)
+		}
 	}
 	msgID := parseSentMessageID(string(out))
 	receipt.MessageID = msgID
@@ -251,7 +253,10 @@ Examples:
 	receipt.Thread = strings.TrimSpace(*threadFlag)
 	receipt.Status = "written_to_amq"
 	receipt.addStage("written_to_amq", "durable AMQ message written to recipient inbox")
-	if waitFor != "" {
+	waitTimedOut := dispatchSendWaitTimedOut(out, err, waitFor)
+	if waitTimedOut {
+		receipt.addStage("amq_wait_timeout", fmt.Sprintf("durable message queued, but %s receipt was not observed before timeout %s; do not re-send", waitFor, waitTimeout))
+	} else if waitFor != "" {
 		receipt.addStage("amq_wait_"+waitFor, fmt.Sprintf("amq send waited for %s receipt with timeout %s", waitFor, waitTimeout))
 	}
 	if taskID != "" {
@@ -290,7 +295,11 @@ Examples:
 			}
 			waitText := ""
 			if waitFor != "" {
-				waitText = fmt.Sprintf("; waited for %s receipt up to %s", waitFor, waitTimeout)
+				if waitTimedOut {
+					waitText = fmt.Sprintf("; queued, %s receipt unconfirmed after %s; do NOT re-send, nudge drain instead", waitFor, waitTimeout)
+				} else {
+					waitText = fmt.Sprintf("; waited for %s receipt up to %s", waitFor, waitTimeout)
+				}
 			}
 			fmt.Printf("Dispatched %s to %s (handle %s) on session %s — msg %s%s (root %s%s)\n",
 				*kindFlag, *roleFlag, member.Handle, workstream, msgID, taskText, ctx.Root, waitText)
@@ -607,6 +616,17 @@ func dispatchReceiptWaitFor(kind, explicit string) string {
 		return dispatchAnswerDefaultWaitFor
 	}
 	return ""
+}
+
+func dispatchSendWaitTimedOut(out []byte, err error, waitFor string) bool {
+	if err == nil || strings.TrimSpace(waitFor) == "" {
+		return false
+	}
+	if parseSentMessageID(string(out)) == "" {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timed out waiting")
 }
 
 // resolveDispatchSender picks the AMQ handle the dispatched task is sent FROM.

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -208,6 +208,66 @@ func TestRunDispatchAnswerWaitCanBeDisabled(t *testing.T) {
 	}
 }
 
+func TestRunDispatchAnswerWaitTimeoutIsQueuedUnconfirmed(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeDispatchTeam(t, dir)
+	calls := withDispatchAMQCommandErrorSeam(t,
+		amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"},
+		"Sent msg-timeout to qa (session: , root: /x/.agent-mail/issue-96)\ntimed out waiting for drained\n",
+		errors.New("exit status 4: timed out waiting for drained"),
+	)
+	withDispatchWakeLiveSeam(t, true)
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--session", "issue-96", "--role", "qa", "--kind", "answer", "--subject", "A", "--body", "resolved", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch answer wait timeout should not fail: %v", err)
+	}
+	got := strings.Join((*calls)[0].Arg, " ")
+	for _, want := range []string{"--kind answer", "--wait-for drained", "--wait-timeout 1m0s"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("answer timeout dispatch missing %q: %s", want, got)
+		}
+	}
+	env := decodeJSONEnvelope[mutationResult](t, stdout)
+	if env.Data.MessageID != "msg-timeout" {
+		t.Fatalf("message id = %q, want msg-timeout", env.Data.MessageID)
+	}
+	r := env.Data.DeliveryReceipt
+	if r == nil || r.MessageID != "msg-timeout" || !receiptHasStage(r, "amq_wait_timeout") {
+		t.Fatalf("timeout receipt = %+v, want queued receipt with amq_wait_timeout", r)
+	}
+	if receiptHasStage(r, "amq_wait_drained") || receiptHasStage(r, "failed") {
+		t.Fatalf("timeout receipt must not claim drained or failed: %+v", r.Stages)
+	}
+}
+
+func TestRunDispatchAnswerWaitTimeoutHumanOutputWarnsDoNotResend(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeDispatchTeam(t, dir)
+	_ = withDispatchAMQCommandErrorSeam(t,
+		amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"},
+		"Sent msg-timeout to qa (session: , root: /x/.agent-mail/issue-96)\ntimed out waiting for drained\n",
+		errors.New("exit status 4: timed out waiting for drained"),
+	)
+	withDispatchWakeLiveSeam(t, true)
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--session", "issue-96", "--role", "qa", "--kind", "answer", "--subject", "A", "--body", "resolved"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch answer wait timeout should not fail: %v", err)
+	}
+	for _, want := range []string{"msg msg-timeout", "queued, drained receipt unconfirmed", "do NOT re-send", "nudge drain instead"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("timeout human output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
 func TestRunDispatchJSONEnvelopeReportsSubmitUnconfirmed(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
@@ -247,6 +307,36 @@ func TestRunDispatchJSONEnvelopeReportsSubmitUnconfirmed(t *testing.T) {
 		!receiptHasStage(r, dispatchSubmitUnconfirmed) {
 		t.Fatalf("dispatch receipt stages = %+v, want explicit submit-unconfirmed state machine", r.Stages)
 	}
+}
+
+func withDispatchAMQCommandErrorSeam(t *testing.T, env amqEnv, output string, sendErr error) *[]amqCommandRequest {
+	t.Helper()
+	var calls []amqCommandRequest
+	prevEnv := resolveAMQEnvForAMQCommand
+	prevRun := runAMQCommand
+	resolveAMQEnvForAMQCommand = func(cwd, rootFlag, session, handle string) (amqEnv, error) {
+		got := env
+		if strings.TrimSpace(rootFlag) != "" {
+			got.Root = rootFlag
+		} else {
+			got.Root = strings.ReplaceAll(got.Root, "{session}", session)
+		}
+		got.SessionName = session
+		got.Me = handle
+		if got.BaseRoot == "" {
+			got.BaseRoot = ".agent-mail"
+		}
+		return got, nil
+	}
+	runAMQCommand = func(req amqCommandRequest) ([]byte, error) {
+		calls = append(calls, req)
+		return []byte(output), sendErr
+	}
+	t.Cleanup(func() {
+		resolveAMQEnvForAMQCommand = prevEnv
+		runAMQCommand = prevRun
+	})
+	return &calls
 }
 
 func receiptHasStage(r *deliveryReceiptData, state string) bool {

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -12,24 +12,40 @@ import (
 )
 
 func TestDispatchSendArgs(t *testing.T) {
-	got := dispatchSendArgs("/repo/.agent-mail/issue-96", "cto", "qa", "p2p/cto__qa", "todo", "Do X", "details here", "urgent")
+	got := dispatchSendArgs("/repo/.agent-mail/issue-96", "cto", "qa", "p2p/cto__qa", "todo", "Do X", "details here", "urgent", "drained", 60*time.Second)
 	want := []string{
 		"send", "--root", "/repo/.agent-mail/issue-96", "--me", "cto", "--to", "qa",
 		"--thread", "p2p/cto__qa", "--kind", "todo", "--subject", "Do X", "--body", "details here", "--priority", "urgent",
+		"--wait-for", "drained", "--wait-timeout", "1m0s",
 	}
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("dispatchSendArgs = %v\nwant %v", got, want)
 	}
 
 	// Optional fields omitted when empty; body always present.
-	got = dispatchSendArgs("/r", "a", "b", "", "", "", "body", "")
-	for _, bad := range []string{"--thread", "--kind", "--subject", "--priority"} {
+	got = dispatchSendArgs("/r", "a", "b", "", "", "", "body", "", "", 0)
+	for _, bad := range []string{"--thread", "--kind", "--subject", "--priority", "--wait-for", "--wait-timeout"} {
 		if containsString(got, bad) {
 			t.Fatalf("empty %s should be omitted: %v", bad, got)
 		}
 	}
 	if !containsString(got, "--body") {
 		t.Fatalf("body must always be sent: %v", got)
+	}
+}
+
+func TestDispatchReceiptWaitForPolicy(t *testing.T) {
+	if got := dispatchReceiptWaitFor("answer", ""); got != "drained" {
+		t.Fatalf("answer default wait = %q, want drained", got)
+	}
+	if got := dispatchReceiptWaitFor("todo", ""); got != "" {
+		t.Fatalf("todo default wait = %q, want none", got)
+	}
+	if got := dispatchReceiptWaitFor("todo", "dlq"); got != "dlq" {
+		t.Fatalf("explicit wait = %q, want dlq", got)
+	}
+	if got := dispatchReceiptWaitFor("answer", "none"); got != "" {
+		t.Fatalf("answer none opt-out = %q, want empty", got)
 	}
 }
 
@@ -141,6 +157,54 @@ func TestRunDispatchJSONEnvelope(t *testing.T) {
 	}
 	if !foundCollect {
 		t.Fatalf("dispatch JSON actions missing collect: %+v", env.Data.Actions)
+	}
+}
+
+func TestRunDispatchAnswerDefaultsToDrainedWait(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeDispatchTeam(t, dir)
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"},
+		"Sent msg-answer to qa (session: , root: /x/.agent-mail/issue-96); drained by qa\n")
+	withDispatchWakeLiveSeam(t, true)
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--session", "issue-96", "--role", "qa", "--kind", "answer", "--subject", "A", "--body", "resolved", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch answer --json: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("amq calls = %d, want 1", len(*calls))
+	}
+	got := strings.Join((*calls)[0].Arg, " ")
+	for _, want := range []string{"--kind answer", "--wait-for drained", "--wait-timeout 1m0s"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("answer dispatch missing %q: %s", want, got)
+		}
+	}
+	r := decodeJSONEnvelope[mutationResult](t, stdout).Data.DeliveryReceipt
+	if r == nil || !receiptHasStage(r, "amq_wait_drained") {
+		t.Fatalf("answer receipt missing amq_wait_drained stage: %+v", r)
+	}
+}
+
+func TestRunDispatchAnswerWaitCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeDispatchTeam(t, dir)
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-answer to qa\n")
+	withDispatchWakeLiveSeam(t, true)
+
+	_, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{"--session", "issue-96", "--role", "qa", "--kind", "answer", "--subject", "A", "--body", "resolved", "--wait-for", "none", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("dispatch answer --wait-for none: %v", err)
+	}
+	got := strings.Join((*calls)[0].Arg, " ")
+	if strings.Contains(got, "--wait-for") || strings.Contains(got, "--wait-timeout") {
+		t.Fatalf("answer wait opt-out still passed wait flags: %s", got)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -22,7 +22,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.40.0"
+const doctorMinAMQVersion = "0.41.0"
 
 type doctorStatus string
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -20,7 +20,7 @@ func newDoctorExec(t *testing.T, dir string) doctorExecution {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.40.0", Root: filepath.Join(dir, ".agent-mail")}, nil
+			return amqEnv{AMQVersion: "0.41.0", Root: filepath.Join(dir, ".agent-mail")}, nil
 		},
 		RunAMQOps: func(string, amqEnv) ([]byte, error) {
 			return []byte(`{"status":"ok"}`), nil
@@ -176,7 +176,7 @@ func TestExecuteDoctorAMQVersionTooOld(t *testing.T) {
 	if got == nil || got.Status != doctorFail {
 		t.Fatalf("amq version check = %+v, want fail", got)
 	}
-	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, "0.40.0") {
+	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, "0.41.0") {
 		t.Errorf("detail should name the bad version: %q", got.Detail)
 	}
 	if !strings.Contains(got.Detail, "amq upgrade") {
@@ -233,9 +233,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts040x(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts041x(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.40.0", "v0.40.1-rc1", "1.0.0+build42"} {
+	for _, v := range []string{"0.41.0", "v0.41.1-rc1", "1.0.0+build42"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -253,19 +253,19 @@ func TestExecuteDoctorAMQVersionAccepts040x(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionRejectsOlderThan040(t *testing.T) {
+func TestExecuteDoctorAMQVersionRejectsOlderThan041(t *testing.T) {
 	dir := t.TempDir()
 	d := newDoctorExec(t, dir)
 	d.ResolveAMQEnv = func(string) (amqEnv, error) {
-		return amqEnv{AMQVersion: "0.39.1", Root: dir}, nil
+		return amqEnv{AMQVersion: "0.40.9", Root: dir}, nil
 	}
 	var buf bytes.Buffer
 	d.Out = &buf
 	if err := executeDoctor(d); err == nil {
-		t.Fatal("doctor should fail when amq is below the 0.40.0 floor")
+		t.Fatal("doctor should fail when amq is below the 0.41.0 floor")
 	}
 	amqLine := firstLineWith(buf.String(), "amq version")
-	if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.40.0") {
+	if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.41.0") {
 		t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 	}
 	if !strings.Contains(amqLine, "amq upgrade") {
@@ -738,7 +738,7 @@ func TestExecuteDoctorWakeReuseClassifyMemberStatus(t *testing.T) {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.40.0", Root: filepath.Join(base, "issue-96")}, nil
+			return amqEnv{AMQVersion: "0.41.0", Root: filepath.Join(base, "issue-96")}, nil
 		},
 		LookPath: func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe: duplicateLaunchProbe{
@@ -781,7 +781,7 @@ func TestExecuteDoctorWakeHandlesAMQEnvErrorPerMember(t *testing.T) {
 	d := doctorExecution{
 		ProjectDir:    dir,
 		Out:           &bytes.Buffer{},
-		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.40.0"}, nil },
+		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.41.0"}, nil },
 		LookPath:      func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe:         defaultDuplicateLaunchProbe,
 	}

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -893,8 +893,6 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 	}
 	receipt.PaneID = paneID
 	receipt.addStage("control_delivery_started", "resolved exact target pane for native /goal control")
-	waitPaneSettledForSend(paneID)
-	receipt.addStage("pane_settled", "waited for target pane output to settle before native /goal control delivery")
 	if err := sendPromptToPane(paneID, prompt); err != nil {
 		receipt.Status = "failed"
 		receipt.Detail = err.Error()
@@ -902,6 +900,7 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 		_ = writeDeliveryReceipt(opts.Project, opts.Profile, opts.Session, &receipt)
 		return mutationResult{}, err
 	}
+	receipt.addStage("pane_settled", "SendPromptToPane waited for target pane output to settle before native /goal control delivery")
 	receipt.Status = "native_goal_delivered"
 	receipt.addStage("native_goal_delivered", "native /goal command delivered without ordinary prompt busy-guard semantics")
 	if mr.HasRecord {

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -465,7 +465,6 @@ func TestGoalStartYesJSONDeliversThroughGoalDeliverPath(t *testing.T) {
 	oldSend := sendPromptToPane
 	var events []string
 	sendPromptToPane = func(paneID, prompt string) error {
-		events = append(events, "settle:"+paneID)
 		events = append(events, "send:"+paneID+"\x00"+prompt)
 		return nil
 	}
@@ -480,7 +479,7 @@ func TestGoalStartYesJSONDeliversThroughGoalDeliverPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("goal start --yes: %v\nstderr:\n%s", err, stderr)
 	}
-	if len(events) != 2 || events[0] != "settle:%7" || !strings.HasPrefix(events[1], "send:%7\x00/goal --goal") || !strings.Contains(events[1], "ship safely") {
+	if len(events) != 1 || !strings.HasPrefix(events[0], "send:%7\x00/goal --goal") || !strings.Contains(events[0], "ship safely") {
 		t.Fatalf("goal start delivery events = %+v", events)
 	}
 	env := decodeJSONEnvelope[goalStartData](t, stdout)

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -463,19 +463,15 @@ func TestGoalStartYesJSONDeliversThroughGoalDeliverPath(t *testing.T) {
 		return []tmuxpane.TmuxPane{{PaneID: "%7", CWD: dir, Command: "codex", Title: "amq:issue-96:cto"}}, nil
 	}
 	oldSend := sendPromptToPane
-	oldWait := waitPaneSettledForSend
 	var events []string
 	sendPromptToPane = func(paneID, prompt string) error {
+		events = append(events, "settle:"+paneID)
 		events = append(events, "send:"+paneID+"\x00"+prompt)
 		return nil
-	}
-	waitPaneSettledForSend = func(paneID string) {
-		events = append(events, "settle:"+paneID)
 	}
 	t.Cleanup(func() {
 		statusPaneLister = oldLister
 		sendPromptToPane = oldSend
-		waitPaneSettledForSend = oldWait
 	})
 
 	stdout, stderr, err := captureOutput(t, func() error {

--- a/internal/cli/operator.go
+++ b/internal/cli/operator.go
@@ -393,7 +393,7 @@ func sendOperatorAMQ(o operatorSendOptions) error {
 		return fmt.Errorf("resolve amq root for %s: %w", o.Command, err)
 	}
 	ctx.Me = o.From
-	args := dispatchSendArgs(ctx.Root, o.From, o.To, o.Thread, o.Kind, o.Subject, o.Body, "")
+	args := dispatchSendArgs(ctx.Root, o.From, o.To, o.Thread, o.Kind, o.Subject, o.Body, "", "", 0)
 	raw, err := runAMQCommand(amqCommandRequest{Dir: o.Project, Env: amqCommandEnv(ctx), Arg: args})
 	if err != nil {
 		return fmt.Errorf("%s send to %s: %w", o.Command, o.To, err)

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -255,7 +255,6 @@ func paneIDForTarget(tgt tmuxpane.TmuxTarget, panes []tmuxpane.TmuxPane) string 
 
 var paneBusyForSend = tmuxpane.PaneBusy
 var sendPromptToPane = tmuxpane.SendPromptToPane
-var waitPaneSettledForSend = tmuxpane.WaitPaneSettled
 
 func runFocus(args []string) error {
 	fs := flag.NewFlagSet("focus", flag.ContinueOnError)

--- a/internal/tmuxpane/deliver.go
+++ b/internal/tmuxpane/deliver.go
@@ -176,13 +176,6 @@ func pasteBufferArgs(buf, paneID, prompt string) []string {
 	return []string{"paste-buffer", "-d", "-b", buf, "-t", paneID}
 }
 
-// WaitPaneSettled exposes the same bounded TUI-readiness wait used before
-// bracketed paste, for single-line control deliveries that still need the TUI to
-// be ready before the final Enter is sent.
-func WaitPaneSettled(paneID string) {
-	waitPaneSettled(paneID)
-}
-
 // waitPaneSettled blocks (bounded) until the pane's visible content stops
 // changing across a capture interval — the signal that a freshly-spawned TUI has
 // finished drawing and (with it) enabled bracketed-paste mode. Best-effort: it

--- a/internal/tmuxpane/deliver.go
+++ b/internal/tmuxpane/deliver.go
@@ -110,11 +110,13 @@ func SendKeysToPane(paneID string, keys ...string) error {
 // SendPromptToPane delivers prompt to the exact tmux pane and submits it with an
 // explicit Enter. The prompt is staged into a tmux paste buffer via stdin
 // (`load-buffer -`), never a shell string or argv, so multi-line text, quotes,
-// and shell metacharacters are preserved verbatim. For MULTI-LINE text it pastes
-// with `-p` (bracketed paste) so embedded newlines do not submit the prompt
-// prematurely; the trailing Enter is the single submit event. A SINGLE-LINE
-// prompt is pasted WITHOUT `-p` (see pasteBufferArgs). Returns *DeadPaneError
-// when the pane is gone.
+// and shell metacharacters are preserved verbatim. It first waits, bounded, for
+// the target pane to stop drawing so single-line prompts do not race a cold TUI's
+// input readiness and multi-line bracketed paste is not echoed as literal marker
+// text. For MULTI-LINE text it pastes with `-p` (bracketed paste) so embedded
+// newlines do not submit the prompt prematurely; the trailing Enter is the
+// single submit event. A SINGLE-LINE prompt is pasted WITHOUT `-p` (see
+// pasteBufferArgs). Returns *DeadPaneError when the pane is gone.
 func SendPromptToPane(paneID, prompt string) error {
 	if strings.TrimSpace(paneID) == "" {
 		return fmt.Errorf("send: empty pane id")
@@ -122,16 +124,12 @@ func SendPromptToPane(paneID, prompt string) error {
 	if !PaneExists(paneID) {
 		return &DeadPaneError{PaneID: paneID, Err: fmt.Errorf("display-message returned no pane")}
 	}
+	// Freshly-spawned agent TUIs can accept pane text before their input layer is
+	// ready to submit it. Keep this one bounded wait at the delivery boundary so
+	// all pane prompt paths (dispatch fallback, manual send, /rename, /goal) share
+	// the same cold-pane protection.
+	waitPaneSettled(paneID)
 	bracketed := promptNeedsBracketedPaste(prompt)
-	if bracketed {
-		// A bracketed paste's ESC[200~/ESC[201~ wrappers are only honored once the
-		// agent TUI has enabled bracketed-paste mode (DECSET 2004), which a
-		// freshly-spawned pane does late in its boot. Wait for the pane to finish
-		// drawing (its output stops changing) before pasting, so the markers are
-		// consumed instead of echoed as literal "[200~" text and the body's
-		// embedded newlines are not submitted line-by-line. Best-effort + bounded.
-		waitPaneSettled(paneID)
-	}
 	// Stage the prompt in a unique buffer via stdin — the text never appears on
 	// a command line, so no quoting/metacharacter handling is required, and a
 	// per-send name keeps concurrent sends from clobbering each other.

--- a/internal/tmuxpane/deliver_test.go
+++ b/internal/tmuxpane/deliver_test.go
@@ -127,6 +127,33 @@ func TestSendPromptBracketedPasteOnlyForMultiline(t *testing.T) {
 	}
 }
 
+func TestSendPromptSingleLineWaitsForPaneToSettleBeforePaste(t *testing.T) {
+	calls := swapDeliver(t, nil)
+	seq := []string{"", "booting", "ready", "ready", "│ staged │", "● Working\n>"}
+	var captures []string
+	paneCapturer = func(string) (string, error) {
+		if len(seq) == 0 {
+			return "● Working\n>", nil
+		}
+		got := seq[0]
+		seq = seq[1:]
+		captures = append(captures, got)
+		return got, nil
+	}
+	if err := SendPromptToPane("%7", "run `amq drain --include-body` and act on it"); err != nil {
+		t.Fatalf("SendPromptToPane: %v", err)
+	}
+	if len(captures) < 4 || captures[0] != "" || captures[1] != "booting" || captures[2] != "ready" || captures[3] != "ready" {
+		t.Fatalf("single-line send did not wait through blank/drawing/stable captures: %q", captures)
+	}
+	paste := (*calls)[2].args
+	for _, arg := range paste {
+		if arg == "-p" {
+			t.Fatalf("single-line prompt must still avoid bracketed paste after settle: %v", paste)
+		}
+	}
+}
+
 func TestSendPromptMultilineLeakReturnsError(t *testing.T) {
 	// A multi-line prompt pasted into a not-yet-ready TUI leaves the bracketed-
 	// paste START marker as literal text. We must detect that and FAIL clearly
@@ -283,21 +310,21 @@ func TestSendPromptRetriesEnterWhenInputUnchanged(t *testing.T) {
 	calls := swapDeliver(t, nil)
 	// before/after per attempt: attempt 1 sees the input region UNCHANGED (Enter
 	// dropped) -> retry; attempt 2 sees it CHANGE (submitted).
+	const ready = "> ready"
 	const staged = "│ please review the long set of changes │\n  ? for shortcuts"
 	const cleared = "> \n  ? for shortcuts"
 	n := 0
 	paneCapturer = func(string) (string, error) {
 		n++
 		switch n {
-		case 1, 2, 3: // attempt1 before, attempt1 after, attempt2 before
+		case 1, 2: // settle wait
+			return ready, nil
+		case 3, 4, 5: // attempt1 before, attempt1 after, attempt2 before
 			return staged, nil
 		default: // attempt2 after
 			return cleared, nil
 		}
 	}
-	// Single-line so the only captures are submit's before/after pair (a
-	// multi-line prompt would add the settle + leak-check captures and shift this
-	// counter); the Enter-retry behavior under test is identical either way.
 	if err := SendPromptToPane("%5", "please review the long set of changes"); err != nil {
 		t.Fatalf("SendPromptToPane: %v", err)
 	}
@@ -332,10 +359,14 @@ func TestSendPromptSubmitsOnInputChangeOrFailsOpen(t *testing.T) {
 	n := 0
 	paneCapturer = func(string) (string, error) {
 		n++
-		if n == 1 {
+		switch n {
+		case 1, 2:
+			return "> ready", nil // settle wait
+		case 3:
 			return "│ staged │\n? for shortcuts", nil // before
+		default:
+			return "● Working... esc to interrupt\n>", nil // after: changed
 		}
-		return "● Working… esc to interrupt\n>", nil // after: changed
 	}
 	if err := SendPromptToPane("%5", "go"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- Raise the active AMQ baseline to 0.41.0 in doctor/docs.
- Centralize bounded pane settle-wait inside `SendPromptToPane` so dispatch fallback, manual sends, `/rename`, and native `/goal` share the cold-pane protection; remove the duplicate goal-delivery caller wait while preserving the receipt stage.
- Add dispatch answer receipt waits: `--kind answer` defaults to `--wait-for drained --wait-timeout 60s`; other dispatches remain fire-and-report unless explicitly opted in, and `--wait-for none` disables the answer default.
- Add regression coverage for absolute AMQ root normalization and confirm no production Go parser consumes `amq who` text.

## #363 AMQ 0.41.0 retest evidence
Local AMQ version:
```
0.41.0
```

Cold/slow pane retest: wake was launched before the pane read loop was ready; message sent after a 2s startup delay. Pane log:
```
READ:AMQ: message from cto - Retest #363 cold wake. Drain with: amq drain --include-body — then act on it
```
Wake debug log:
```
amq wake [debug]: input deferral atime_source=stdin
amq wake [debug]: mode=raw text_len=102
amq wake [debug]: injecting 102 bytes of text
amq wake [debug]: input queue drained after 791ns; injecting CR
amq wake [debug]: CR injected OK
```

Scope decision: AMQ 0.41.0 fixes the upstream wake sidecar/TIOCSTI cold-pane path. amq-squad still had local pane-prompt residue for `SendPromptToPane` callers that bypass `amq wake`, so this PR adds the defense-in-depth settle there and retires #363 together with the upstream fix.

## Receipt wait policy
Defaulting `--wait-for drained` only for `--kind answer` makes unblock answers receipt-confirmed without slowing ordinary task dispatches. The timeout is 60s because team rules already use 60s for important handoffs and it is long enough for a live recipient to drain while still bounded for operator feedback.

## Absolute-root audit
`resolveAMQContextForProject` and `resolveAMQContextForNamespace` already normalize `amq env --json` roots through `absoluteAMQRoot`; `amqCommandEnv` injects absolute `AM_ROOT` and `AM_BASE_ROOT`. Added `TestResolveAMQContextNormalizesRelativeRootsToAbsoluteEnv` to lock this in even if a fake or old AMQ returns relative roots.

## Validation
- `go test ./internal/tmuxpane ./internal/cli`
- `go test ./...`
- `git diff --check`

Closes #365, closes #363