### PR TITLE
Implement #335 external evidence lane

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -81,24 +81,25 @@ type statusSignals struct {
 // statusEnvelopeData is the kind="status" payload: resolved team-home,
 // workstream, profile, and the per-member records.
 type statusEnvelopeData struct {
-	TeamHome          string                 `json:"team_home"`
-	Workstream        string                 `json:"workstream"`
-	Profile           string                 `json:"profile,omitempty"`
-	Namespace         squadnamespace.Ref     `json:"namespace"`
-	Operator          statusOperatorView     `json:"operator"`
-	OperatorDelivery  operatorDeliveryData   `json:"operator_delivery"`
-	Capabilities      team.Capabilities      `json:"capabilities"`
-	Orchestrated      bool                   `json:"orchestrated,omitempty"`
-	Lead              string                 `json:"lead,omitempty"`
-	LeadHandle        string                 `json:"lead_handle,omitempty"`
-	GoalBinding       goalBindingData        `json:"goal_binding"`
-	Autonomous        team.AutonomousStatus  `json:"autonomous"`
-	Execution         executionModeData      `json:"execution"`
-	Versions          versionAlignmentData   `json:"versions"`
-	NamespaceConflict *namespaceConflictData `json:"namespace_conflict,omitempty"`
-	Warnings          []statusWarning        `json:"warnings,omitempty"`
-	Topology          *statusTopology        `json:"topology,omitempty"`
-	Records           []statusRecord         `json:"records"`
+	TeamHome          string                      `json:"team_home"`
+	Workstream        string                      `json:"workstream"`
+	Profile           string                      `json:"profile,omitempty"`
+	Namespace         squadnamespace.Ref          `json:"namespace"`
+	Operator          statusOperatorView          `json:"operator"`
+	OperatorDelivery  operatorDeliveryData        `json:"operator_delivery"`
+	Capabilities      team.Capabilities           `json:"capabilities"`
+	Orchestrated      bool                        `json:"orchestrated,omitempty"`
+	Lead              string                      `json:"lead,omitempty"`
+	LeadHandle        string                      `json:"lead_handle,omitempty"`
+	GoalBinding       goalBindingData             `json:"goal_binding"`
+	Autonomous        team.AutonomousStatus       `json:"autonomous"`
+	Execution         executionModeData           `json:"execution"`
+	Versions          versionAlignmentData        `json:"versions"`
+	NamespaceConflict *namespaceConflictData      `json:"namespace_conflict,omitempty"`
+	Warnings          []statusWarning             `json:"warnings,omitempty"`
+	Topology          *statusTopology             `json:"topology,omitempty"`
+	ExternalEvidence  []state.ExternalEvidenceRow `json:"external_evidence,omitempty"`
+	Records           []statusRecord              `json:"records"`
 	// Actions are the SESSION-scope operator actions (status / resume preview /
 	// resume in current window / resume in new tmux session / stop), the catalog
 	// counterpart to each record's agent-scope actions. A client renders these
@@ -361,6 +362,7 @@ func executeStatus(s statusExecution) error {
 		operatorView := statusOperatorForTeam(t, ns)
 		applyGoalBindingOpenBlockers(&operatorView, binding)
 		topology := statusTopologyForRows(rows, ctx.Orchestrated)
+		externalEvidence := statusExternalEvidence(t, s.Profile, workstream, rows, now)
 		version := strings.TrimSpace(s.RuntimeVersion)
 		if version == "" {
 			version = "dev"
@@ -393,6 +395,7 @@ func executeStatus(s statusExecution) error {
 			NamespaceConflict: conflict,
 			Warnings:          warnings,
 			Topology:          topology,
+			ExternalEvidence:  externalEvidence,
 			Records:           rows,
 			Actions:           ctx.Actions,
 		})
@@ -1296,6 +1299,33 @@ func attachStatusLocalInputs(t team.Team, rows []statusRecord) {
 			Source:      "tmux-pane-tail",
 		}
 	}
+}
+
+func statusExternalEvidence(t team.Team, profile, workstream string, rows []statusRecord, now time.Time) []state.ExternalEvidenceRow {
+	root := firstStatusRoot(rows)
+	if strings.TrimSpace(root) == "" {
+		return nil
+	}
+	operatorHandle := team.DefaultOperatorHandle
+	if op := team.EffectiveOperator(t); op.Enabled && strings.TrimSpace(op.Handle) != "" {
+		operatorHandle = strings.TrimSpace(op.Handle)
+	}
+	probe := state.Probe{
+		PIDAlive:     func(int) bool { return false },
+		ProcessMatch: func(int, func(string) bool) bool { return false },
+		Now:          func() time.Time { return now },
+	}
+	snap, err := state.BuildWithThresholds(t.Project, filepath.Dir(root), probe, state.Thresholds{OperatorHandle: operatorHandle})
+	if err != nil {
+		return nil
+	}
+	namespaceID := squadnamespace.ID(profile, workstream)
+	for _, sess := range snap.Sessions {
+		if sess.NamespaceID == namespaceID {
+			return sess.Coordination.ExternalEvidence
+		}
+	}
+	return nil
 }
 
 func statusLocalInputCandidate(t team.Team, row statusRecord) bool {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -33,6 +33,33 @@ func runStatusExec(t *testing.T, s statusExecution) (string, error) {
 	return buf.String(), err
 }
 
+func seedStatusExternalEvidenceMessage(t *testing.T, agentDir string) {
+	t.Helper()
+	dir := filepath.Join(agentDir, "inbox", "cur")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `---json
+{
+  "schema": 1,
+  "id": "ext1",
+  "from": "kanban",
+  "to": ["cto"],
+  "thread": "task/KAN-42",
+  "subject": "external kanban evidence",
+  "created": "2026-06-22T11:55:00Z",
+  "kind": "status",
+  "labels": ["orchestrator", "orchestrator:kanban", "task-state:blocked", "blocking"],
+  "context": {"orchestrator":{"task":{"id":"KAN-42"}}}
+}
+---
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "ext1.md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func actionsByKind(actions []runtimeActionJSON) map[string]runtimeActionJSON {
 	out := map[string]runtimeActionJSON{}
 	for _, action := range actions {
@@ -125,6 +152,40 @@ func TestRunStatusProjectTargetsSessionOtherDir(t *testing.T) {
 	}
 	if env.Data.Workstream != "issue-99" {
 		t.Fatalf("status --project workstream = %q, want issue-99", env.Data.Workstream)
+	}
+}
+
+func TestExecuteStatusJSONIncludesExternalEvidence(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	project := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}},
+	})
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary: "codex", Role: "cto", Handle: "cto", Session: "issue-96", CWD: project, AgentPID: 11,
+	})
+	seedStatusExternalEvidenceMessage(t, agentDir)
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       project,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		Profile:          team.DefaultProfile,
+		Probe:            statusProbe(map[int]bool{}, map[int]bool{}, notifyNow),
+		JSON:             true,
+	})
+	if err != nil {
+		t.Fatalf("executeStatus: %v", err)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	if len(env.Data.ExternalEvidence) != 1 {
+		t.Fatalf("external_evidence = %+v, want one row", env.Data.ExternalEvidence)
+	}
+	row := env.Data.ExternalEvidence[0]
+	if row.Source != "amq-kanban" || row.SourceLabel != "orchestrator:kanban" || row.ExternalTaskID != "KAN-42" || row.State != "blocked" || row.Mutable {
+		t.Fatalf("external evidence row = %+v", row)
+	}
+	if len(env.Data.Records) != 1 || env.Data.Records[0].Handle != "cto" {
+		t.Fatalf("native status records changed: %+v", env.Data.Records)
 	}
 }
 

--- a/internal/console/filter.go
+++ b/internal/console/filter.go
@@ -230,7 +230,16 @@ func threadMatchesOrchestrator(t state.ThreadSummary, want string) bool {
 	if want == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(t.Orchestrator), want)
+	if strings.Contains(strings.ToLower(t.Orchestrator), want) {
+		return true
+	}
+	for _, label := range t.Labels {
+		label = strings.ToLower(strings.TrimSpace(label))
+		if strings.HasPrefix(label, "orchestrator:") && strings.Contains(strings.TrimPrefix(label, "orchestrator:"), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func threadHasLabel(t state.ThreadSummary, want string) bool {

--- a/internal/console/rows.go
+++ b/internal/console/rows.go
@@ -197,6 +197,20 @@ func sortThreadsNewest(s state.Session, f Filter) []state.ThreadSummary {
 	return out
 }
 
+func sortExternalEvidence(s state.Session, f Filter) []state.ExternalEvidenceRow {
+	threads := make(map[string]state.ThreadSummary, len(s.Coordination.Threads))
+	for _, t := range s.Coordination.Threads {
+		threads[t.ID] = t
+	}
+	out := make([]state.ExternalEvidenceRow, 0, len(s.Coordination.ExternalEvidence))
+	for _, row := range s.Coordination.ExternalEvidence {
+		if thread, ok := threads[row.Thread]; ok && f.matchThread(thread) {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
 // statusRank orders thread statuses by attention within a triage tier.
 func statusRank(s state.ThreadStatus) int {
 	switch s {

--- a/internal/console/run_test.go
+++ b/internal/console/run_test.go
@@ -274,6 +274,31 @@ func TestStaticBoardOmitsUnresolvedSectionWhenClear(t *testing.T) {
 	}
 }
 
+func TestStaticBoardRendersExternalEvidenceBeforeUnresolved(t *testing.T) {
+	thread := mkUnresolved("task/SW-7", "swarm task", []string{"swarm", "cto"}, state.TriageBlocked, 10*time.Minute, 2)
+	thread.LatestID = "ext1"
+	thread.Labels = []string{"orchestrator", "orchestrator:swarm", "task-state:blocked"}
+	thread.ExternalTaskID = "SW-7"
+	s := state.Session{
+		Name:   "wedged",
+		Agents: []state.Agent{{Handle: "cto", Engine: "codex", Liveness: state.LivenessAlive, LastSeen: runNow}},
+		Coordination: state.Coordination{
+			Threads:          []state.ThreadSummary{thread},
+			ExternalEvidence: state.BuildExternalEvidence([]state.ThreadSummary{thread}),
+		},
+		Rollup: state.TriageRollup{Blocked: 1},
+	}
+	board := StaticBoard(state.Snapshot{BaseRoot: "/base", Sessions: []state.Session{s}, Rollup: s.Rollup}, onceClock)
+	for _, want := range []string{"external evidence", "amq-swarm", "task=SW-7", "state=blocked", "mutable=false"} {
+		if !contains(board, want) {
+			t.Fatalf("--once external evidence missing %q:\n%s", want, board)
+		}
+	}
+	if strings.Index(board, "external evidence") > strings.Index(board, "swarm, cto  blocked") {
+		t.Fatalf("external evidence should render before unresolved rows:\n%s", board)
+	}
+}
+
 // TestStaticBoardStoppedSessionLabelsAgentsStopped proves a session that rolled
 // up to STOPPED (clear triage, no live/degraded agents) renders each agent as
 // "stopped" — NOT the alarming "process-dead"/"stale".

--- a/internal/console/view.go
+++ b/internal/console/view.go
@@ -390,6 +390,11 @@ func (m Model) renderDetail() string {
 	}
 	b.WriteString("\n")
 
+	if sec := externalEvidenceSection(s, m.filter, m.now()); sec != "" {
+		b.WriteString(sec)
+		b.WriteString("\n")
+	}
+
 	if m.timeline {
 		// TIMELINE pane (state transitions, not raw messages).
 		b.WriteString(styleHeader.Render("timeline") + "\n")
@@ -467,6 +472,36 @@ func renderTimeline(s state.Session) string {
 	for _, ev := range s.Coordination.Timeline {
 		b.WriteString(fmt.Sprintf("  %-6s  %s  %s\n",
 			ageLabel(timeSinceObserved(s, ev)), ev.Summary, styleFaint.Render(shortID(ev.Source))))
+	}
+	return b.String()
+}
+
+func externalEvidenceSection(s state.Session, f Filter, now func() time.Time) string {
+	rows := sortExternalEvidence(s, f)
+	if len(rows) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(styleHeader.Render("external evidence") + "\n")
+	for _, row := range rows {
+		task := strings.TrimSpace(row.ExternalTaskID)
+		if task == "" {
+			task = "(no-task-id)"
+		}
+		subject := strings.TrimSpace(row.Subject)
+		if subject == "" {
+			subject = shortID(row.Thread)
+		}
+		age := ""
+		if now != nil && !row.LastEventAt.IsZero() {
+			d := now().Sub(row.LastEventAt)
+			if d < 0 {
+				d = 0
+			}
+			age = " · " + ageLabel(d)
+		}
+		b.WriteString(fmt.Sprintf("  %-14s task=%-12s state=%-10s mutable=false  %s  %s%s\n",
+			row.Source, task, row.State, subject, styleFaint.Render(shortID(row.Thread)), age))
 	}
 	return b.String()
 }
@@ -906,6 +941,9 @@ func sessionBlock(s state.Session, now func() time.Time) string {
 			activity = " · " + activity
 		}
 		fmt.Fprintf(&b, "  - %s (%s): %s%s\n", a.Handle, a.Engine, agentStateLabel(a, stopped, now), activity)
+	}
+	if sec := externalEvidenceSection(s, Filter{}, now); sec != "" {
+		b.WriteString(sec)
 	}
 	// Unresolved coordination threads (at-risk / blocked), urgency-sorted. Omitted
 	// entirely when there is nothing unresolved to surface.

--- a/internal/console/views_test.go
+++ b/internal/console/views_test.go
@@ -700,6 +700,47 @@ func TestDetailRendersEdgesAndAgents(t *testing.T) {
 	}
 }
 
+func TestDetailRendersExternalEvidenceReadOnly(t *testing.T) {
+	thread := state.ThreadSummary{
+		ID:             "task/KAN-42",
+		LatestID:       "ext1",
+		Participants:   []string{"kanban", "cto"},
+		Subject:        "external kanban evidence",
+		Labels:         []string{"orchestrator", "orchestrator:kanban", "task-state:blocked"},
+		ExternalTaskID: "KAN-42",
+		LastEventAt:    viewNow.Add(-5 * time.Minute),
+		MessageCount:   1,
+		Freshness:      state.Freshness{Source: state.SourceEmbedded, Age: 5 * time.Minute},
+	}
+	s := state.Session{
+		Name:   "issue-96",
+		Agents: []state.Agent{{Handle: "cto", Engine: "codex", Liveness: state.LivenessAlive, LastSeen: viewNow}},
+		Coordination: state.Coordination{
+			Threads:          []state.ThreadSummary{thread},
+			ExternalEvidence: state.BuildExternalEvidence([]state.ThreadSummary{thread}),
+		},
+	}
+	m := newModel(rebuildConfig{BaseRoot: "/base", Probe: state.Probe{Now: func() time.Time { return viewNow }}}, state.Snapshot{Sessions: []state.Session{s}}, "")
+	m.route = routeSession
+	m.session = "issue-96"
+
+	out := m.renderDetail()
+	for _, want := range []string{"external evidence", "amq-kanban", "task=KAN-42", "state=blocked", "mutable=false"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("detail external evidence missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDetailOmitsExternalEvidenceWhenAbsent(t *testing.T) {
+	m := boardModel()
+	m = press(t, m, "enter")
+	out := m.renderDetail()
+	if strings.Contains(out, "external evidence") {
+		t.Fatalf("detail should omit external evidence section when empty:\n%s", out)
+	}
+}
+
 // TestHelpOverlay proves `?` opens the help overlay listing the keymap.
 func TestHelpOverlay(t *testing.T) {
 	m := boardModel()

--- a/internal/state/collapse.go
+++ b/internal/state/collapse.go
@@ -10,11 +10,12 @@ import (
 // threads, edges, timeline, triage rollup, and any scan warnings. It is built
 // purely from scanned mailbox messages plus the injected clock + thresholds.
 type Coordination struct {
-	Threads  []ThreadSummary
-	Edges    []Edge
-	Timeline []TimelineEvent
-	Rollup   TriageRollup
-	Warnings []Warning
+	Threads          []ThreadSummary
+	Edges            []Edge
+	Timeline         []TimelineEvent
+	ExternalEvidence []ExternalEvidenceRow
+	Rollup           TriageRollup
+	Warnings         []Warning
 }
 
 // collapseInput is the raw material for building a session's coordination view:
@@ -36,6 +37,7 @@ func buildCoordination(in collapseInput, now time.Time, th Thresholds) Coordinat
 	threads := collapseThreads(in.messages, now, th, in.agents)
 	edges := buildEdges(in.messages)
 	timeline := buildTimeline(threads, in.messages)
+	externalEvidence := BuildExternalEvidence(threads)
 
 	var rollup TriageRollup
 	for _, t := range threads {
@@ -43,27 +45,29 @@ func buildCoordination(in collapseInput, now time.Time, th Thresholds) Coordinat
 	}
 
 	return Coordination{
-		Threads:  threads,
-		Edges:    edges,
-		Timeline: timeline,
-		Rollup:   rollup,
-		Warnings: in.warnings,
+		Threads:          threads,
+		Edges:            edges,
+		Timeline:         timeline,
+		ExternalEvidence: externalEvidence,
+		Rollup:           rollup,
+		Warnings:         in.warnings,
 	}
 }
 
 // threadAccumulator gathers everything about one canonical thread as messages
 // stream in, so the final summary is a single pass.
 type threadAccumulator struct {
-	id           string
-	participants map[string]bool
-	subject      string
-	lastKind     Kind
-	labels       map[string]bool
-	orchestrator string
-	fromProject  string
-	replyProject string
-	lastEventAt  time.Time
-	count        int
+	id             string
+	participants   map[string]bool
+	subject        string
+	lastKind       Kind
+	labels         map[string]bool
+	orchestrator   string
+	fromProject    string
+	replyProject   string
+	externalTaskID string
+	lastEventAt    time.Time
+	count          int
 	// unreadBy: recipient handle -> still has an unread copy (inbox/new).
 	unreadBy map[string]bool
 	// readBy: recipient handle -> has a read copy (inbox/cur). Used so a later
@@ -149,6 +153,7 @@ func (a *threadAccumulator) observe(m Message) {
 		a.orchestrator = m.Orchestrator
 		a.fromProject = m.FromProject
 		a.replyProject = m.ReplyProject
+		a.externalTaskID = m.ExternalTaskID
 	} else if a.subject == "" && m.Subject != "" {
 		a.subject = m.Subject
 	}
@@ -180,25 +185,26 @@ func (a *threadAccumulator) summarize(now time.Time, th Thresholds, agents []Age
 	historical := isHistoricalNeedsYou(triage, fresh, agents, th.OperatorHandle)
 
 	return ThreadSummary{
-		ID:           a.id,
-		LatestID:     a.latest.ID,
-		Participants: parts,
-		Subject:      a.subject,
-		Kind:         a.lastKind,
-		Labels:       labels,
-		Orchestrator: a.orchestrator,
-		FromProject:  a.fromProject,
-		ReplyProject: a.replyProject,
-		Status:       status,
-		LastEventAt:  a.lastEventAt,
-		MessageCount: a.count,
-		UnreadBy:     unread,
-		Triage:       triage,
-		Freshness:    fresh,
-		Stale:        stale,
-		Historical:   historical,
-		AttnReason:   reason,
-		OperatorGate: operatorGate,
+		ID:             a.id,
+		LatestID:       a.latest.ID,
+		Participants:   parts,
+		Subject:        a.subject,
+		Kind:           a.lastKind,
+		Labels:         labels,
+		Orchestrator:   a.orchestrator,
+		FromProject:    a.fromProject,
+		ReplyProject:   a.replyProject,
+		ExternalTaskID: a.externalTaskID,
+		Status:         status,
+		LastEventAt:    a.lastEventAt,
+		MessageCount:   a.count,
+		UnreadBy:       unread,
+		Triage:         triage,
+		Freshness:      fresh,
+		Stale:          stale,
+		Historical:     historical,
+		AttnReason:     reason,
+		OperatorGate:   operatorGate,
 	}
 }
 

--- a/internal/state/coordination.go
+++ b/internal/state/coordination.go
@@ -229,21 +229,22 @@ func withThresholdDefaults(t Thresholds) Thresholds {
 // ThreadSummary collapses every message sharing a canonical thread id into one
 // derived row. Participants are the union of from+to across the thread.
 type ThreadSummary struct {
-	ID           string
-	LatestID     string
-	Participants []string // union of from + to, sorted
-	Subject      string   // latest non-empty subject
-	Kind         Kind     // latest recognized kind
-	Labels       []string // union of AMQ labels observed on messages in the thread
-	Orchestrator string   // latest orchestrator metadata, when present
-	FromProject  string   // latest cross-project sender metadata, when present
-	ReplyProject string   // latest cross-project reply metadata, when present
-	Status       ThreadStatus
-	LastEventAt  time.Time
-	MessageCount int
-	UnreadBy     []string // recipients still holding a copy in inbox/new
-	Triage       Triage
-	Freshness    Freshness
+	ID             string
+	LatestID       string
+	Participants   []string // union of from + to, sorted
+	Subject        string   // latest non-empty subject
+	Kind           Kind     // latest recognized kind
+	Labels         []string // union of AMQ labels observed on messages in the thread
+	Orchestrator   string   // latest orchestrator metadata, when present
+	FromProject    string   // latest cross-project sender metadata, when present
+	ReplyProject   string   // latest cross-project reply metadata, when present
+	ExternalTaskID string   // latest verified external task id from orchestrator context
+	Status         ThreadStatus
+	LastEventAt    time.Time
+	MessageCount   int
+	UnreadBy       []string // recipients still holding a copy in inbox/new
+	Triage         Triage
+	Freshness      Freshness
 	// Stale is true when now - LastEventAt exceeds Thresholds.StaleAfter. A stale
 	// thread's triage is age-decayed: it is NOT counted as LIVE attention and is
 	// rendered dim/parenthesized. Needs-you uses Historical instead of Stale when

--- a/internal/state/coordination_test.go
+++ b/internal/state/coordination_test.go
@@ -665,6 +665,28 @@ func TestExternalEvidenceReadsLegacySwarmTaskIDContext(t *testing.T) {
 	}
 }
 
+func TestExternalEvidenceFormatsNumericTaskIDContext(t *testing.T) {
+	base := t.TempDir()
+	proj := t.TempDir()
+	ctoDir := seedAgent(t, base, "s", "cto", launch.Record{Binary: "codex", Handle: "cto", Session: "s", AgentPID: 1})
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "kanban2", from: "kanban", to: []string{"cto"},
+		thread: "task/42", subject: "numeric kanban task", kind: "status",
+		createdAt: coordNow.Add(-1 * time.Minute),
+		labels:    []string{"orchestrator", "orchestrator:kanban", "task-state:ready"},
+		context:   `{"orchestrator":{"task":{"id":42}}}`,
+	})
+
+	snap, err := Build(proj, base, coordProbe())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := snap.Sessions[0].Coordination.ExternalEvidence
+	if len(rows) != 1 || rows[0].ExternalTaskID != "42" {
+		t.Fatalf("numeric task id evidence = %+v, want external_task_id 42", rows)
+	}
+}
+
 // --- triage: at-risk via threshold (deterministic clock) -----------------
 
 func TestTriageAtRiskAgingReview(t *testing.T) {

--- a/internal/state/coordination_test.go
+++ b/internal/state/coordination_test.go
@@ -29,6 +29,8 @@ type msgSpec struct {
 	body      string
 	createdAt time.Time
 	schema    int // 0 => default to 1
+	labels    []string
+	context   string // raw JSON object; empty => omitted
 
 	torn        bool // write an invalid/partial file (must be skipped)
 	badThreadID bool // write the thread id verbatim (caller supplies malformed)
@@ -81,6 +83,19 @@ func seedMessage(t *testing.T, agentDir, state string, s msgSpec) {
 	}
 	if s.kind != "" {
 		b.WriteString(",\n  \"kind\": \"" + s.kind + "\"")
+	}
+	if len(s.labels) > 0 {
+		b.WriteString(",\n  \"labels\": [")
+		for i, label := range s.labels {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString("\"" + label + "\"")
+		}
+		b.WriteString("]")
+	}
+	if strings.TrimSpace(s.context) != "" {
+		b.WriteString(",\n  \"context\": " + s.context)
 	}
 	b.WriteString("\n}\n---\n")
 	b.WriteString(s.body)
@@ -566,6 +581,87 @@ func TestThreadSummaryCarriesAMQIntegrationMetadata(t *testing.T) {
 	th := findThread(t, snap.Sessions[0].Coordination, "handoff/test")
 	if strings.Join(th.Labels, ",") != "blocking,handoff" || th.Orchestrator != "kanban" || th.FromProject != "api" || th.ReplyProject != "web" {
 		t.Fatalf("thread metadata mismatch: %+v", th)
+	}
+}
+
+func TestCoordinationBuildsExternalEvidenceRows(t *testing.T) {
+	base := t.TempDir()
+	proj := t.TempDir()
+	ctoDir := seedAgent(t, base, "s", "cto", launch.Record{Binary: "codex", Handle: "cto", Session: "s", AgentPID: 1})
+
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "swarm1", from: "swarm", to: []string{"cto"},
+		thread: "task/SW-7", subject: "swarm task", kind: "status",
+		createdAt: coordNow.Add(-1 * time.Minute),
+		labels:    []string{"orchestrator", "orchestrator:swarm", "task-state:blocked", "blocking"},
+		context:   `{"orchestrator":{"task":{"id":"SW-7"}}}`,
+	})
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "symphony1", from: "symphony", to: []string{"cto"},
+		thread: "task/SYM-4", subject: "symphony task", kind: "status",
+		createdAt: coordNow.Add(-2 * time.Minute),
+		labels:    []string{"orchestrator", "orchestrator:symphony", "task-state:running", "handoff"},
+		context:   `{"orchestrator":{"task":{"id":"SYM-4"}}}`,
+	})
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "kanban1", from: "kanban", to: []string{"cto"},
+		thread: "task/KAN-2", subject: "kanban task", kind: "status",
+		createdAt: coordNow.Add(-3 * time.Minute),
+		labels:    []string{"orchestrator", "orchestrator:kanban"},
+		context:   `{"orchestrator":{"task":{"id":"KAN-2"}}}`,
+	})
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "native1", from: "cto", to: []string{"qa"},
+		thread: "p2p/cto__qa", subject: "native", kind: "status",
+		createdAt: coordNow.Add(-4 * time.Minute),
+		labels:    []string{"task-state:done"},
+	})
+
+	snap, err := Build(proj, base, coordProbe())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := snap.Sessions[0].Coordination.ExternalEvidence
+	if len(rows) != 3 {
+		t.Fatalf("external evidence rows = %d, want 3: %+v", len(rows), rows)
+	}
+	got := map[string]ExternalEvidenceRow{}
+	for _, row := range rows {
+		got[row.Source] = row
+		if row.Mutable {
+			t.Fatalf("external evidence row must be immutable: %+v", row)
+		}
+	}
+	if got["amq-swarm"].ExternalTaskID != "SW-7" || got["amq-swarm"].State != "blocked" || got["amq-swarm"].SourceLabel != "orchestrator:swarm" {
+		t.Fatalf("swarm row = %+v", got["amq-swarm"])
+	}
+	if got["amq-symphony"].ExternalTaskID != "SYM-4" || got["amq-symphony"].State != "running" {
+		t.Fatalf("symphony row = %+v", got["amq-symphony"])
+	}
+	if got["amq-kanban"].ExternalTaskID != "KAN-2" || got["amq-kanban"].State != "unknown" {
+		t.Fatalf("kanban row = %+v", got["amq-kanban"])
+	}
+}
+
+func TestExternalEvidenceReadsLegacySwarmTaskIDContext(t *testing.T) {
+	base := t.TempDir()
+	proj := t.TempDir()
+	ctoDir := seedAgent(t, base, "s", "cto", launch.Record{Binary: "codex", Handle: "cto", Session: "s", AgentPID: 1})
+	seedMessage(t, ctoDir, "cur", msgSpec{
+		id: "swarm2", from: "swarm", to: []string{"cto"},
+		thread: "task/SW-8", subject: "legacy swarm task", kind: "status",
+		createdAt: coordNow.Add(-1 * time.Minute),
+		labels:    []string{"orchestrator", "orchestrator:amq-swarm", "task-state:done"},
+		context:   `{"task_id":"SW-8","source":"swarm-bridge"}`,
+	})
+
+	snap, err := Build(proj, base, coordProbe())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := snap.Sessions[0].Coordination.ExternalEvidence
+	if len(rows) != 1 || rows[0].ExternalTaskID != "SW-8" || rows[0].Source != "amq-swarm" {
+		t.Fatalf("legacy swarm evidence = %+v", rows)
 	}
 }
 

--- a/internal/state/external_evidence.go
+++ b/internal/state/external_evidence.go
@@ -1,0 +1,110 @@
+package state
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// ExternalEvidenceRow is a read-only projection of externally orchestrated task
+// traffic observed in AMQ mailboxes. It is evidence only: callers must not turn
+// these rows into native task-store mutations or copy-ready mutation actions.
+type ExternalEvidenceRow struct {
+	Source         string    `json:"source"`
+	SourceLabel    string    `json:"source_label"`
+	ExternalTaskID string    `json:"external_task_id,omitempty"`
+	State          string    `json:"state"`
+	Labels         []string  `json:"labels,omitempty"`
+	Thread         string    `json:"thread"`
+	MessageID      string    `json:"message_id"`
+	Subject        string    `json:"subject,omitempty"`
+	Participants   []string  `json:"participants,omitempty"`
+	LastEventAt    time.Time `json:"last_event_at"`
+	Mutable        bool      `json:"mutable"`
+}
+
+// BuildExternalEvidence derives source-labeled external evidence from the same
+// collapsed thread summaries used by the console and status surfaces.
+func BuildExternalEvidence(threads []ThreadSummary) []ExternalEvidenceRow {
+	rows := make([]ExternalEvidenceRow, 0)
+	for _, t := range threads {
+		sourceLabel, source, ok := externalSource(t.Labels)
+		if !ok {
+			continue
+		}
+		rows = append(rows, ExternalEvidenceRow{
+			Source:         source,
+			SourceLabel:    sourceLabel,
+			ExternalTaskID: t.ExternalTaskID,
+			State:          externalState(t.Labels),
+			Labels:         append([]string(nil), t.Labels...),
+			Thread:         t.ID,
+			MessageID:      t.LatestID,
+			Subject:        t.Subject,
+			Participants:   append([]string(nil), t.Participants...),
+			LastEventAt:    t.LastEventAt,
+			Mutable:        false,
+		})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if !rows[i].LastEventAt.Equal(rows[j].LastEventAt) {
+			return rows[i].LastEventAt.After(rows[j].LastEventAt)
+		}
+		if rows[i].Source != rows[j].Source {
+			return rows[i].Source < rows[j].Source
+		}
+		return rows[i].Thread < rows[j].Thread
+	})
+	return rows
+}
+
+func externalSource(labels []string) (sourceLabel, source string, ok bool) {
+	hasBare := false
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "orchestrator" {
+			hasBare = true
+			continue
+		}
+		raw, found := strings.CutPrefix(label, "orchestrator:")
+		if !found {
+			continue
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		return label, normalizeExternalSource(raw), true
+	}
+	if hasBare {
+		return "orchestrator", "external-orchestrator", true
+	}
+	return "", "", false
+}
+
+func normalizeExternalSource(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "swarm", "amq-swarm":
+		return "amq-swarm"
+	case "symphony", "amq-symphony":
+		return "amq-symphony"
+	case "kanban", "amq-kanban":
+		return "amq-kanban"
+	default:
+		return raw
+	}
+}
+
+func externalState(labels []string) string {
+	for _, label := range labels {
+		raw, ok := strings.CutPrefix(strings.TrimSpace(label), "task-state:")
+		if !ok {
+			continue
+		}
+		raw = strings.TrimSpace(raw)
+		if raw != "" {
+			return raw
+		}
+	}
+	return "unknown"
+}

--- a/internal/state/message.go
+++ b/internal/state/message.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -340,6 +341,8 @@ func stringFromJSONValue(v any) string {
 		return x
 	case json.Number:
 		return x.String()
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
 	default:
 		return ""
 	}

--- a/internal/state/message.go
+++ b/internal/state/message.go
@@ -55,20 +55,21 @@ const (
 // fields are decoded leniently: `to` is always an array on disk but we tolerate
 // a bare string too; priority/kind may be absent.
 type messageHeader struct {
-	Schema       int      `json:"schema"`
-	ID           string   `json:"id"`
-	From         string   `json:"from"`
-	To           []string `json:"to"`
-	Thread       string   `json:"thread"`
-	Subject      string   `json:"subject"`
-	Created      string   `json:"created"`
-	Priority     string   `json:"priority"`
-	Kind         string   `json:"kind"`
-	ReplyTo      string   `json:"reply_to"`
-	Labels       []string `json:"labels"`
-	Orchestrator string   `json:"orchestrator"`
-	FromProject  string   `json:"from_project"`
-	ReplyProject string   `json:"reply_project"`
+	Schema       int            `json:"schema"`
+	ID           string         `json:"id"`
+	From         string         `json:"from"`
+	To           []string       `json:"to"`
+	Thread       string         `json:"thread"`
+	Subject      string         `json:"subject"`
+	Created      string         `json:"created"`
+	Priority     string         `json:"priority"`
+	Kind         string         `json:"kind"`
+	ReplyTo      string         `json:"reply_to"`
+	Labels       []string       `json:"labels"`
+	Orchestrator string         `json:"orchestrator"`
+	FromProject  string         `json:"from_project"`
+	ReplyProject string         `json:"reply_project"`
+	Context      map[string]any `json:"context"`
 }
 
 // Message is one parsed maildir message: its decoded header fields plus the
@@ -88,10 +89,11 @@ type Message struct {
 	Labels    []string
 	// Integration/routing metadata is optional AMQ context for federated or
 	// orchestrator-originated traffic.
-	Orchestrator string
-	FromProject  string
-	ReplyProject string
-	Body         string
+	Orchestrator   string
+	FromProject    string
+	ReplyProject   string
+	ExternalTaskID string
+	Body           string
 
 	// Owner is the handle whose inbox this copy was found in.
 	Owner string
@@ -182,24 +184,25 @@ func parseMessageFile(path, owner string, state MailboxState, now func() time.Ti
 	}
 
 	m := Message{
-		ID:           strings.TrimSpace(h.ID),
-		From:         strings.TrimSpace(h.From),
-		To:           cleanRecipients(h.To),
-		RawThread:    h.Thread,
-		Thread:       canonicalThreadID(h.Thread),
-		Subject:      strings.TrimSpace(h.Subject),
-		Priority:     normalizePriority(h.Priority),
-		Kind:         normalizeKind(h.Kind),
-		ReplyTo:      strings.TrimSpace(h.ReplyTo),
-		Labels:       cleanLabels(h.Labels),
-		Orchestrator: strings.TrimSpace(h.Orchestrator),
-		FromProject:  strings.TrimSpace(h.FromProject),
-		ReplyProject: strings.TrimSpace(h.ReplyProject),
-		Body:         body,
-		Owner:        owner,
-		State:        state,
-		Path:         path,
-		SchemaOK:     h.Schema == MessageSchema,
+		ID:             strings.TrimSpace(h.ID),
+		From:           strings.TrimSpace(h.From),
+		To:             cleanRecipients(h.To),
+		RawThread:      h.Thread,
+		Thread:         canonicalThreadID(h.Thread),
+		Subject:        strings.TrimSpace(h.Subject),
+		Priority:       normalizePriority(h.Priority),
+		Kind:           normalizeKind(h.Kind),
+		ReplyTo:        strings.TrimSpace(h.ReplyTo),
+		Labels:         cleanLabels(h.Labels),
+		Orchestrator:   strings.TrimSpace(h.Orchestrator),
+		FromProject:    strings.TrimSpace(h.FromProject),
+		ReplyProject:   strings.TrimSpace(h.ReplyProject),
+		ExternalTaskID: externalTaskIDFromContext(h.Context),
+		Body:           body,
+		Owner:          owner,
+		State:          state,
+		Path:           path,
+		SchemaOK:       h.Schema == MessageSchema,
 	}
 	m.Created = parseCreated(h.Created, path, now)
 
@@ -283,6 +286,7 @@ func tryLenientHeader(header string) (messageHeader, bool) {
 		Orchestrator string          `json:"orchestrator"`
 		FromProject  string          `json:"from_project"`
 		ReplyProject string          `json:"reply_project"`
+		Context      map[string]any  `json:"context"`
 	}
 	if err := json.Unmarshal([]byte(header), &raw); err != nil {
 		return messageHeader{}, false
@@ -292,6 +296,7 @@ func tryLenientHeader(header string) (messageHeader, bool) {
 		Subject: raw.Subject, Created: raw.Created, Priority: raw.Priority,
 		Kind: raw.Kind, ReplyTo: raw.ReplyTo, Labels: raw.Labels,
 		Orchestrator: raw.Orchestrator, FromProject: raw.FromProject, ReplyProject: raw.ReplyProject,
+		Context: raw.Context,
 	}
 	if len(raw.To) > 0 {
 		var arr []string
@@ -305,6 +310,39 @@ func tryLenientHeader(header string) (messageHeader, bool) {
 		}
 	}
 	return h, true
+}
+
+func externalTaskIDFromContext(ctx map[string]any) string {
+	if id := stringAtPath(ctx, "orchestrator", "task", "id"); id != "" {
+		return id
+	}
+	return stringAtPath(ctx, "task_id")
+}
+
+func stringAtPath(root map[string]any, path ...string) string {
+	var cur any = root
+	for _, key := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur, ok = m[key]
+		if !ok {
+			return ""
+		}
+	}
+	return strings.TrimSpace(stringFromJSONValue(cur))
+}
+
+func stringFromJSONValue(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case json.Number:
+		return x.String()
+	default:
+		return ""
+	}
 }
 
 // cleanRecipients trims and drops empty recipients, preserving order.


### PR DESCRIPTION
Implements #335.

Summary:
- Adds a read-only external_evidence lane derived from existing AMQ orchestrator labels and context.
- Surfaces source-labeled immutable evidence rows in status --json and Mission Control console.
- Pins task IDs to upstream-verified context.orchestrator.task.id, with legacy swarm context.task_id support.
- Keeps native status/task rows structurally separate from external evidence.

Spec notes:
- Known source labels normalize to amq-swarm, amq-symphony, and amq-kanban.
- Unknown orchestrator:<raw> sub-sources intentionally pass raw through as source, while source_label preserves the exact label provenance. This is more informative than collapsing them to external-orchestrator.
- ExternalTaskID follows latest-message-wins thread semantics, matching the rest of ThreadSummary metadata.
- status --json performs an extra read-only state scan for this slice; acceptable for now, with perf follow-up only if status latency becomes an issue.

Validation:
- go test ./internal/state
- go test ./internal/console
- go test ./internal/cli
- go test ./...
- make ci