### PR TITLE
Add Symphony lifecycle launch opt-in

### DIFF
--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -21,6 +21,7 @@ const (
 	StateUnknown = "unknown"
 
 	SourceHeartbeat = "heartbeat-file"
+	SourceSymphony  = "symphony-hook"
 	SourceTaskStore = "task-store"
 	SourceUnknown   = "unknown"
 )
@@ -113,6 +114,36 @@ func TaskStoreSnapshot(handle, taskID, detail string, updatedAt, now time.Time, 
 		Phase:     "task_in_progress",
 		Detail:    strings.TrimSpace(detail),
 		WrittenAt: updatedAt,
+		Stale:     stale,
+	}
+}
+
+func SymphonySnapshot(handle, event, taskID, detail string, observedAt, now time.Time, staleAfter time.Duration) Snapshot {
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleAfter
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	event = strings.TrimSpace(event)
+	stale := true
+	quality := StateUnknown
+	if !observedAt.IsZero() && event != "before_remove" {
+		stale = now.Sub(observedAt) > staleAfter
+		if stale {
+			quality = StateStale
+		} else {
+			quality = StateFresh
+		}
+	}
+	return Snapshot{
+		Source:    SourceSymphony,
+		Quality:   quality,
+		Handle:    strings.TrimSpace(handle),
+		TaskID:    strings.TrimSpace(taskID),
+		Phase:     "symphony_" + event,
+		Detail:    strings.TrimSpace(detail),
+		WrittenAt: observedAt,
 		Stale:     stale,
 	}
 }

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -128,7 +128,7 @@ func SymphonySnapshot(handle, event, taskID, detail string, observedAt, now time
 	event = strings.TrimSpace(event)
 	stale := true
 	quality := StateUnknown
-	if !observedAt.IsZero() && event != "before_remove" {
+	if !observedAt.IsZero() && symphonyEventClaimsActivity(event) {
 		stale = now.Sub(observedAt) > staleAfter
 		if stale {
 			quality = StateStale
@@ -145,6 +145,15 @@ func SymphonySnapshot(handle, event, taskID, detail string, observedAt, now time
 		Detail:    strings.TrimSpace(detail),
 		WrittenAt: observedAt,
 		Stale:     stale,
+	}
+}
+
+func symphonyEventClaimsActivity(event string) bool {
+	switch event {
+	case "after_create", "before_remove":
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -311,6 +311,7 @@ var completionCommonFlags = []string{
 	"--stop-agents",
 	"--subject",
 	"--sync",
+	"--symphony",
 	"--target",
 	"--target-contract",
 	"--target-project-root",

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -32,6 +32,31 @@ const envTmuxLauncherPane = "AMQ_SQUAD_TMUX_LAUNCHER_PANE"
 
 var launchStdinIsTerminal = stdinIsTerminal
 
+type symphonyInitConfig struct {
+	Workflow string
+	Root     string
+	Me       string
+}
+
+var runSymphonyInit = defaultRunSymphonyInit
+
+func defaultRunSymphonyInit(cfg symphonyInitConfig) error {
+	cmd := exec.Command("amq", "integration", "symphony", "init",
+		"--workflow", cfg.Workflow,
+		"--root", cfg.Root,
+		"--me", cfg.Me,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(string(out))
+	if detail != "" {
+		return fmt.Errorf("amq integration symphony init: %s", detail)
+	}
+	return fmt.Errorf("amq integration symphony init: %w", err)
+}
+
 type stringListFlag []string
 
 func (f *stringListFlag) String() string {
@@ -76,6 +101,7 @@ func runLaunch(args []string) error {
 	forceDuplicate := fs.Bool("force-duplicate", false, "launch even when a live agent for the same handle/workstream is detected")
 	noRequireWake := fs.Bool("no-require-wake", false, "do not pass --require-wake to amq coop exec (allows launching when the wake sidecar cannot acquire its lock)")
 	noGitignore := fs.Bool("no-gitignore", false, "pass --no-gitignore to amq coop exec (leave .gitignore unchanged during AMQ auto-init)")
+	symphony := fs.Bool("symphony", false, "Codex only: patch the existing WORKFLOW.md with AMQ Symphony lifecycle hooks for this resolved root and handle")
 	wakeInjectVia := fs.String("wake-inject-via", "", "absolute executable passed to amq coop exec --wake-inject-via")
 	var wakeInjectArgs stringListFlag
 	fs.Var(&wakeInjectArgs, "wake-inject-arg", "argument passed to amq coop exec --wake-inject-arg (repeatable; requires --wake-inject-via)")
@@ -112,7 +138,11 @@ Side effects before exec:
   8. Translates --conversation for Codex or Claude resume when provided.
   9. Adds a generated bootstrap prompt unless --no-bootstrap is set or
      non-default binary args were provided.
- 10. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
+ 10. With --symphony (Codex only), patches the existing <cwd>/WORKFLOW.md with
+     AMQ Symphony lifecycle hooks pinned to the resolved AMQ root and handle.
+     If WORKFLOW.md is absent, the AMQ adapter error is returned and launch
+     stops; amq-squad does not create the file itself.
+ 11. Execs 'amq coop exec --session <session> <binary> -- <binary-flags>'.
      With supported amq versions, --require-wake is passed so the launch fails at the
      door when the wake sidecar cannot start and acquire its lock (instead
      of surfacing as a stale/orphaned wake later). --no-require-wake opts
@@ -189,6 +219,9 @@ Examples:
 		return usageErrorf("agent up requires a binary (e.g. 'amq-squad agent up codex --role cpo')")
 	}
 	binary := remaining[0]
+	if *symphony && normalizedAgentBinary(binary) != "codex" {
+		return usageErrorf("--symphony is only supported for Codex agents; got %s", binary)
+	}
 	// Positional args before "--" get folded into childArgs.
 	if len(remaining) > 1 {
 		childArgs = append(remaining[1:], childArgs...)
@@ -272,6 +305,7 @@ Examples:
 		SpawnDepth:           *spawnDepth,
 		NoRequireWake:        *noRequireWake,
 		NoGitignore:          *noGitignore,
+		Symphony:             *symphony,
 		GoalBinding:          nativeGoalBindingFromArgs(childArgs),
 		PreauthorizedActions: preauthorizedActions,
 		WakeInjectVia:        wakeInjectViaValue,
@@ -375,6 +409,10 @@ Examples:
 
 	if *dryRun {
 		fmt.Println(shellCommand("amq", coopArgs...))
+		if *symphony {
+			fmt.Fprintf(os.Stderr, "(dry run - would patch existing %s with AMQ Symphony hooks pinned to root %s and handle %s; no files written)\n",
+				filepath.Join(cwd, "WORKFLOW.md"), root, handle)
+		}
 		quietNotice("(dry run - no files written, not execing)\n")
 		verbosePolicyEcho()
 		return nil
@@ -417,6 +455,14 @@ Examples:
 		if _, _, err := ensureBriefStubForProfile(briefHome, rec.TeamProfile, rec.Session); err != nil {
 			return fmt.Errorf("ensure brief: %w", err)
 		}
+	}
+
+	if rec.Symphony {
+		workflow := filepath.Join(cwd, "WORKFLOW.md")
+		if err := runSymphonyInit(symphonyInitConfig{Workflow: workflow, Root: root, Me: handle}); err != nil {
+			return err
+		}
+		quietNotice("symphony: patched %s with AMQ lifecycle hooks for %s (root %s)\n", workflow, handle, root)
 	}
 
 	if err := launch.Write(agentDir, rec); err != nil {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -580,6 +580,34 @@ func TestRunLaunchDryRunAddsBinaryArgs(t *testing.T) {
 	}
 }
 
+func TestRunLaunchDryRunSymphonyForCodex(t *testing.T) {
+	setupFakeAMQ(t)
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "sandboxed", "--symphony", "--me", "cto", "codex"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "amq coop exec") || !strings.Contains(stdout, "codex") {
+		t.Fatalf("dry-run stdout missing coop exec command:\n%s", stdout)
+	}
+	for _, want := range []string{"would patch existing", "WORKFLOW.md", "AMQ Symphony hooks", "handle cto"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("dry-run stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+func TestRunLaunchSymphonyRejectsNonCodex(t *testing.T) {
+	setupFakeAMQ(t)
+	_, _, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--symphony", "claude"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "--symphony is only supported for Codex agents; got claude") {
+		t.Fatalf("expected non-Codex symphony error, got %v", err)
+	}
+}
+
 func TestRunLaunchDryRunNoDefaultArgsKeepsExplicitBinaryArgs(t *testing.T) {
 	setupFakeAMQ(t)
 

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -21,6 +21,7 @@ type previewFlags struct {
 	claudeArgsRaw  *string
 	forceDuplicate *bool
 	noGitignore    *bool
+	symphony       *bool
 	wakeInjectVia  *string
 	wakeInjectArgs stringListFlag
 }
@@ -36,6 +37,7 @@ func registerPreviewFlags(fs *flag.FlagSet) *previewFlags {
 		claudeArgsRaw:  fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'"),
 		forceDuplicate: fs.Bool("force-duplicate", false, "include --force-duplicate in emitted launch commands"),
 		noGitignore:    fs.Bool("no-gitignore", false, "forward --no-gitignore to every amq coop exec launch"),
+		symphony:       fs.Bool("symphony", false, "Codex only: emit launch commands that patch the existing WORKFLOW.md with AMQ Symphony lifecycle hooks"),
 		wakeInjectVia:  fs.String("wake-inject-via", "", "absolute executable forwarded to every agent launch as amq coop exec --wake-inject-via"),
 	}
 	fs.Var(&p.wakeInjectArgs, "wake-inject-arg", "argument forwarded to every agent launch as amq coop exec --wake-inject-arg (repeatable; requires --wake-inject-via)")
@@ -75,6 +77,7 @@ func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) 
 		ModelOverrides:   modelOverrides,
 		ForceDuplicate:   *p.forceDuplicate,
 		NoGitignore:      *p.noGitignore,
+		Symphony:         *p.symphony,
 		WakeInjectVia:    wakeInjectVia,
 		WakeInjectArgs:   wakeInjectArgs,
 	}, nil
@@ -128,6 +131,7 @@ func buildLiveLaunchOptions(fs *flag.FlagSet, pf *previewFlags, lf *liveLaunchFl
 		ModelOverrides:  emit.ModelOverrides,
 		ForceDuplicate:  emit.ForceDuplicate,
 		NoGitignore:     emit.NoGitignore,
+		Symphony:        emit.Symphony,
 		WakeInjectVia:   emit.WakeInjectVia,
 		WakeInjectArgs:  emit.WakeInjectArgs,
 	}, nil

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -268,6 +268,9 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoGitignore {
 		args = append(args, "--no-gitignore")
 	}
+	if rec.Symphony {
+		args = append(args, "--symphony")
+	}
 	if via := strings.TrimSpace(rec.WakeInjectVia); via != "" {
 		args = append(args, "--wake-inject-via", via)
 		for _, arg := range rec.WakeInjectArgs {
@@ -484,6 +487,9 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	}
 	if rec.NoGitignore {
 		b.WriteString(" --no-gitignore")
+	}
+	if rec.Symphony {
+		b.WriteString(" --symphony")
 	}
 	if via := strings.TrimSpace(rec.WakeInjectVia); via != "" {
 		b.WriteString(" --wake-inject-via ")

--- a/internal/cli/restore_test.go
+++ b/internal/cli/restore_test.go
@@ -114,6 +114,27 @@ func TestLaunchArgsFromRecordReplaysNoGitignore(t *testing.T) {
 	}
 }
 
+func TestLaunchArgsFromRecordReplaysSymphony(t *testing.T) {
+	rec := launch.Record{
+		Binary:   "codex",
+		Handle:   "cto",
+		Role:     "cto",
+		Session:  "issue-96",
+		Symphony: true,
+	}
+	want := []string{
+		"--role", "cto", "--session", "issue-96",
+		"--symphony",
+		"--trust", "sandboxed", "--me", "cto", "codex",
+	}
+	if got := launchArgsFromRecord(rec); !reflect.DeepEqual(got, want) {
+		t.Errorf("launchArgsFromRecord(rec)\n got: %v\nwant: %v", got, want)
+	}
+	if cmd := emitCommandWithOptions(rec, emitCommandOptions{}); !strings.Contains(cmd, "--symphony") {
+		t.Errorf("emit command missing --symphony: %s", cmd)
+	}
+}
+
 func TestLaunchArgsFromRecordPreservesClaudeIdentityForRenameOnResume(t *testing.T) {
 	rec := launch.Record{
 		Binary:  "claude",

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1236,6 +1236,7 @@ func buildStatusRows(t team.Team, profile, workstream string, probe duplicateLau
 
 func attachStatusActivities(projectDir, profile, workstream string, rows []statusRecord, now time.Time) {
 	activeTasks := activeTasksByAssignee(projectDir, profile, workstream)
+	symphony := symphonyActivitiesByHandle(rows, now)
 	for i := range rows {
 		if strings.TrimSpace(rows[i].AgentDir) != "" {
 			if act, ok, err := activity.Read(rows[i].AgentDir, now, activity.DefaultStaleAfter); err == nil && ok {
@@ -1247,10 +1248,62 @@ func attachStatusActivities(projectDir, profile, workstream string, rows []statu
 				continue
 			}
 		}
+		if act, ok := symphony[rows[i].Handle]; ok {
+			rows[i].Activity = &act
+			continue
+		}
 		if task, ok := activeTasks[rows[i].Handle]; ok {
 			rows[i].Activity = taskStoreActivity(task, now)
 		}
 	}
+}
+
+func symphonyActivitiesByHandle(rows []statusRecord, now time.Time) map[string]activity.Snapshot {
+	roots := map[string]bool{}
+	for _, row := range rows {
+		if root := strings.TrimSpace(row.Root); root != "" {
+			roots[root] = true
+		}
+	}
+	out := map[string]activity.Snapshot{}
+	latestID := map[string]string{}
+	for root := range roots {
+		msgs, _ := state.ScanSessionMessages(root, func() time.Time { return now })
+		for _, msg := range msgs {
+			if !isSymphonyLifecycleMessage(msg) {
+				continue
+			}
+			handle := strings.TrimSpace(msg.Owner)
+			if handle == "" {
+				handle = strings.TrimSpace(msg.From)
+			}
+			if handle == "" {
+				continue
+			}
+			act := activity.SymphonySnapshot(handle, msg.OrchestratorEvent, msg.ExternalTaskID, msg.Subject, msg.Created, now, activity.DefaultStaleAfter)
+			prev, ok := out[handle]
+			if !ok || act.WrittenAt.After(prev.WrittenAt) || (act.WrittenAt.Equal(prev.WrittenAt) && msg.ID > latestID[handle]) {
+				out[handle] = act
+				latestID[handle] = msg.ID
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isSymphonyLifecycleMessage(msg state.Message) bool {
+	if msg.Kind != state.KindStatus || strings.TrimSpace(msg.OrchestratorEvent) == "" {
+		return false
+	}
+	for _, label := range msg.Labels {
+		if strings.EqualFold(strings.TrimSpace(label), "orchestrator:symphony") {
+			return true
+		}
+	}
+	return false
 }
 
 func activeTasksByAssignee(projectDir, profile, workstream string) map[string]taskstore.Task {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -60,6 +60,33 @@ body
 	}
 }
 
+func seedStatusSymphonyMessage(t *testing.T, agentDir, id, event string, created time.Time) {
+	t.Helper()
+	dir := filepath.Join(agentDir, "inbox", "cur")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `---json
+{
+  "schema": 1,
+  "id": "` + id + `",
+  "from": "cto",
+  "to": ["cto"],
+  "thread": "task/amq-squad",
+  "subject": "[symphony] ` + event + `: amq-squad",
+  "created": "` + created.UTC().Format(time.RFC3339Nano) + `",
+  "kind": "status",
+  "labels": ["orchestrator", "orchestrator:symphony"],
+  "context": {"orchestrator":{"event":"` + event + `","name":"symphony","task":{"id":"amq-squad"},"transport":"hook","version":1}}
+}
+---
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, id+".md"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func actionsByKind(actions []runtimeActionJSON) map[string]runtimeActionJSON {
 	out := map[string]runtimeActionJSON{}
 	for _, action := range actions {
@@ -773,6 +800,130 @@ func TestStatusJSONIncludesHeartbeatActivity(t *testing.T) {
 	if rec.Activity.Source != activity.SourceHeartbeat || rec.Activity.Quality != activity.StateFresh ||
 		rec.Activity.TaskID != "t11" || rec.Activity.Phase != "testing" || rec.Activity.Detail != "make ci" {
 		t.Fatalf("status activity = %+v", rec.Activity)
+	}
+}
+
+func TestStatusJSONUsesSymphonyActivityFallback(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary:  "codex",
+		Handle:  "cto",
+		Role:    "cto",
+		Session: "issue-96",
+		CWD:     dir,
+	})
+	seedStatusSymphonyMessage(t, agentDir, "symphony-after-run", "after_run", now.Add(-30*time.Second))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	rec := findStatusRecord(env.Data.Records, "cto")
+	if rec == nil || rec.Activity == nil {
+		t.Fatalf("cto symphony activity missing: %+v", env.Data.Records)
+	}
+	if rec.Activity.Source != activity.SourceSymphony || rec.Activity.Quality != activity.StateFresh ||
+		rec.Activity.TaskID != "amq-squad" || rec.Activity.Phase != "symphony_after_run" ||
+		rec.Activity.Detail != "[symphony] after_run: amq-squad" {
+		t.Fatalf("symphony activity = %+v", rec.Activity)
+	}
+}
+
+func TestStatusJSONHeartbeatWinsOverSymphony(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary:  "codex",
+		Handle:  "cto",
+		Role:    "cto",
+		Session: "issue-96",
+		CWD:     dir,
+	})
+	seedStatusSymphonyMessage(t, agentDir, "symphony-after-run", "after_run", now.Add(-10*time.Second))
+	if err := activity.Write(agentDir, activity.File{
+		Handle:    "cto",
+		TaskID:    "t11",
+		Phase:     "testing",
+		Detail:    "make ci",
+		WrittenAt: now.Add(-30 * time.Second),
+	}); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	rec := findStatusRecord(env.Data.Records, "cto")
+	if rec == nil || rec.Activity == nil {
+		t.Fatalf("cto activity missing: %+v", env.Data.Records)
+	}
+	if rec.Activity.Source != activity.SourceHeartbeat || rec.Activity.TaskID != "t11" ||
+		rec.Activity.Phase != "testing" {
+		t.Fatalf("heartbeat should win over symphony activity, got %+v", rec.Activity)
+	}
+}
+
+func TestStatusJSONSymphonyBeforeRemoveNeverFresh(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary:  "codex",
+		Handle:  "cto",
+		Role:    "cto",
+		Session: "issue-96",
+		CWD:     dir,
+	})
+	seedStatusSymphonyMessage(t, agentDir, "symphony-before-remove", "before_remove", now.Add(-10*time.Second))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	rec := findStatusRecord(env.Data.Records, "cto")
+	if rec == nil || rec.Activity == nil {
+		t.Fatalf("cto symphony activity missing: %+v", env.Data.Records)
+	}
+	if rec.Activity.Source != activity.SourceSymphony || rec.Activity.Quality != activity.StateUnknown ||
+		!rec.Activity.Stale || rec.Activity.Phase != "symphony_before_remove" {
+		t.Fatalf("before_remove symphony activity = %+v", rec.Activity)
 	}
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -842,6 +842,44 @@ func TestStatusJSONUsesSymphonyActivityFallback(t *testing.T) {
 	}
 }
 
+func TestStatusJSONSymphonyBeforeRunCanBeFresh(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary:  "codex",
+		Handle:  "cto",
+		Role:    "cto",
+		Session: "issue-96",
+		CWD:     dir,
+	})
+	seedStatusSymphonyMessage(t, agentDir, "symphony-before-run", "before_run", now.Add(-10*time.Second))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	rec := findStatusRecord(env.Data.Records, "cto")
+	if rec == nil || rec.Activity == nil {
+		t.Fatalf("cto symphony activity missing: %+v", env.Data.Records)
+	}
+	if rec.Activity.Source != activity.SourceSymphony || rec.Activity.Quality != activity.StateFresh ||
+		rec.Activity.Stale || rec.Activity.Phase != "symphony_before_run" {
+		t.Fatalf("before_run symphony activity = %+v", rec.Activity)
+	}
+}
+
 func TestStatusJSONHeartbeatWinsOverSymphony(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{
@@ -886,6 +924,44 @@ func TestStatusJSONHeartbeatWinsOverSymphony(t *testing.T) {
 	if rec.Activity.Source != activity.SourceHeartbeat || rec.Activity.TaskID != "t11" ||
 		rec.Activity.Phase != "testing" {
 		t.Fatalf("heartbeat should win over symphony activity, got %+v", rec.Activity)
+	}
+}
+
+func TestStatusJSONSymphonyAfterCreateNeverFresh(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	now := time.Date(2026, 7, 6, 10, 0, 0, 0, time.UTC)
+	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
+		Binary:  "codex",
+		Handle:  "cto",
+		Role:    "cto",
+		Session: "issue-96",
+		CWD:     dir,
+	})
+	seedStatusSymphonyMessage(t, agentDir, "symphony-after-create", "after_create", now.Add(-10*time.Second))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       dir,
+		RequestedSession: "issue-96",
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            statusProbe(nil, nil, now),
+	})
+	if err != nil {
+		t.Fatalf("status --json: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	rec := findStatusRecord(env.Data.Records, "cto")
+	if rec == nil || rec.Activity == nil {
+		t.Fatalf("cto symphony activity missing: %+v", env.Data.Records)
+	}
+	if rec.Activity.Source != activity.SourceSymphony || rec.Activity.Quality != activity.StateUnknown ||
+		!rec.Activity.Stale || rec.Activity.Phase != "symphony_after_create" {
+		t.Fatalf("after_create symphony activity = %+v", rec.Activity)
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -692,7 +692,7 @@ func runTeamShow(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
 
 Usage:
-  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted] [--model role=model,...] [--codex-args args] [--claude-args args] [--force-duplicate] [--no-gitignore] [--json]
+  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted] [--model role=model,...] [--codex-args args] [--claude-args args] [--force-duplicate] [--no-gitignore] [--symphony] [--json]
 
 Examples:
   amq-squad team show
@@ -729,6 +729,7 @@ type emitTeamOptions struct {
 	ModelOverrides   map[string]string
 	ForceDuplicate   bool
 	NoGitignore      bool
+	Symphony         bool
 	WakeInjectVia    string
 	WakeInjectArgs   []string
 	Profile          string
@@ -770,6 +771,7 @@ type teamPlan struct {
 	Capabilities  team.Capabilities     `json:"capabilities"`
 	Autonomous    team.AutonomousStatus `json:"autonomous"`
 	Visibility    string                `json:"visibility,omitempty"`
+	Symphony      bool                  `json:"symphony,omitempty"`
 	LaunchCommand string                `json:"launch_command,omitempty"`
 	Plan          []teamPlanMember      `json:"plan"`
 }
@@ -839,6 +841,11 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 		t = filtered
 		members = orderedTeamMembers(t.Members)
 	}
+	if opts.Symphony {
+		if err := validateTeamSymphonyMembers(t, members); err != nil {
+			return err
+		}
+	}
 
 	// Use the running amq-squad's absolute path so emitted commands work
 	// even when amq-squad isn't on PATH.
@@ -869,6 +876,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 			Capabilities:  team.EffectiveCapabilities(t),
 			Autonomous:    team.EffectiveAutonomousStatus(t),
 			Visibility:    opts.Visibility,
+			Symphony:      opts.Symphony,
 			LaunchCommand: visibilityPreviewLaunchCommand(workstream, profileName, opts.Visibility),
 			Plan:          make([]teamPlanMember, 0, len(members)),
 		}
@@ -887,6 +895,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 				Model:          effectiveModel,
 				ForceDuplicate: opts.ForceDuplicate,
 				NoGitignore:    opts.NoGitignore,
+				Symphony:       opts.Symphony,
 				Profile:        opts.Profile,
 				WakeInjectVia:  opts.WakeInjectVia,
 				WakeInjectArgs: opts.WakeInjectArgs,
@@ -962,6 +971,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 			Profile:        opts.Profile,
 			ForceDuplicate: opts.ForceDuplicate,
 			NoGitignore:    opts.NoGitignore,
+			Symphony:       opts.Symphony,
 			WakeInjectVia:  opts.WakeInjectVia,
 			WakeInjectArgs: opts.WakeInjectArgs,
 		}
@@ -1143,6 +1153,7 @@ type emitTeamCommandInput struct {
 	Model          string
 	ForceDuplicate bool
 	NoGitignore    bool
+	Symphony       bool
 	WakeInjectVia  string
 	WakeInjectArgs []string
 	Profile        string
@@ -1204,6 +1215,9 @@ func emitTeamCommandWithPreview(in emitTeamCommandInput, preview teamCommandPrev
 	}
 	if in.NoGitignore {
 		b.WriteString(" --no-gitignore")
+	}
+	if in.Symphony && normalizedAgentBinary(m.Binary) == "codex" {
+		b.WriteString(" --symphony")
 	}
 	if origin := strings.TrimSpace(m.SpawnOrigin); origin != "" {
 		b.WriteString(" --spawn-origin ")

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -30,6 +30,7 @@ type teamLaunchOptions struct {
 	ModelOverrides  map[string]string
 	ForceDuplicate  bool
 	NoGitignore     bool
+	Symphony        bool
 	WakeInjectVia   string
 	WakeInjectArgs  []string
 	// SeedBriefContent, when non-empty, is the rendered active brief that
@@ -101,7 +102,7 @@ Usage:
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|approve-for-me|trusted] [--model role=model,...]
     [--codex-args args] [--claude-args args]
-    [--force-duplicate] [--no-gitignore] [--dry-run]
+    [--force-duplicate] [--no-gitignore] [--symphony] [--dry-run]
 
 Supported terminal backends: %s
 
@@ -110,6 +111,11 @@ tmux defaults to splitting the current tmux window into one pane per agent. Use
 full-size terminal each, better for many agents. Use --target new-session to
 create a detached squad session. The whole roster is preflighted for live
 duplicates before any tmux command runs; --force-duplicate overrides.
+
+--symphony is an opt-in Codex-only lifecycle hook: each launched Codex member
+patches its existing WORKFLOW.md with AMQ Symphony hooks pinned to the resolved
+AMQ root and handle. If WORKFLOW.md is absent, the AMQ adapter error is
+propagated and launch stops. amq-squad never creates WORKFLOW.md itself.
 
 Examples:
   amq-squad team launch
@@ -207,6 +213,11 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 	if len(t.Members) == 0 {
 		return fmt.Errorf("no team members to launch after external lead filtering")
 	}
+	if opts.Symphony {
+		if err := validateTeamSymphonyMembers(t, t.Members); err != nil {
+			return err
+		}
+	}
 	if opts.Fresh {
 		exists, root, err := teamWorkstreamExists(t, opts.Workstream)
 		if err != nil {
@@ -291,6 +302,34 @@ func commandProfileArg(profile string) string {
 	return " --profile " + shellQuote(profile)
 }
 
+func validateTeamSymphonyMembers(t team.Team, members []team.Member) error {
+	byCWD := map[string][]string{}
+	codexCount := 0
+	for _, m := range members {
+		if normalizedAgentBinary(m.Binary) != "codex" {
+			continue
+		}
+		codexCount++
+		cwd := filepath.Clean(m.EffectiveCWD(t.Project))
+		label := m.Role
+		if handle := memberHandle(m); handle != "" && handle != m.Role {
+			label += " (" + handle + ")"
+		}
+		byCWD[cwd] = append(byCWD[cwd], label)
+	}
+	if codexCount == 0 {
+		return usageErrorf("--symphony requires at least one Codex member")
+	}
+	for cwd, labels := range byCWD {
+		if len(labels) <= 1 {
+			continue
+		}
+		sort.Strings(labels)
+		return usageErrorf("--symphony cannot launch multiple Codex members sharing cwd %s (%s): AMQ Symphony manages one --me per WORKFLOW.md; launch one Codex member per cwd or run agent up --symphony explicitly", cwd, strings.Join(labels, ", "))
+	}
+	return nil
+}
+
 // buildTeamPreflights computes the agent-identity tuples team launch would
 // produce so preflightTeam can refuse before any pane is created. dryRun
 // passes through to each preflight so a --dry-run team launch never mutates
@@ -353,6 +392,7 @@ func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane 
 				Model:          memberResolvedModel(m, opts.ModelOverrides, binaryArgs),
 				ForceDuplicate: opts.ForceDuplicate,
 				NoGitignore:    opts.NoGitignore,
+				Symphony:       opts.Symphony,
 				Profile:        opts.Profile,
 				WakeInjectVia:  opts.WakeInjectVia,
 				WakeInjectArgs: opts.WakeInjectArgs,

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -291,6 +291,45 @@ func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
 	}
 }
 
+func TestEmitTeamCommandAddsSymphonyForCodexOnly(t *testing.T) {
+	codex := emitTeamCommand(emitTeamCommandInput{
+		CWD:        "/repo",
+		SquadBin:   "amq-squad",
+		TeamHome:   "/repo",
+		Member:     team.Member{Role: "cto", Binary: "codex", Handle: "cto"},
+		Workstream: "issue-96",
+		Symphony:   true,
+	})
+	if !strings.Contains(codex, "--symphony") {
+		t.Fatalf("codex command missing --symphony:\n%s", codex)
+	}
+	claude := emitTeamCommand(emitTeamCommandInput{
+		CWD:        "/repo",
+		SquadBin:   "amq-squad",
+		TeamHome:   "/repo",
+		Member:     team.Member{Role: "qa", Binary: "claude", Handle: "qa"},
+		Workstream: "issue-96",
+		Symphony:   true,
+	})
+	if strings.Contains(claude, "--symphony") {
+		t.Fatalf("claude command must not include --symphony:\n%s", claude)
+	}
+}
+
+func TestValidateTeamSymphonyRejectsSharedCodexCWD(t *testing.T) {
+	tm := team.Team{
+		Project: "/repo",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto"},
+			{Role: "reviewer", Binary: "codex", Handle: "reviewer"},
+		},
+	}
+	err := validateTeamSymphonyMembers(tm, tm.Members)
+	if err == nil || !strings.Contains(err.Error(), "multiple Codex members sharing cwd") || !strings.Contains(err.Error(), "/repo") {
+		t.Fatalf("expected shared-cwd symphony error, got %v", err)
+	}
+}
+
 func TestEmitTeamCommandAppendsPerMemberArgsAfterTeamArgs(t *testing.T) {
 	// #111: member claude_args ride after the team-level binary_args so the
 	// member-specific value wins by position, and they appear BOTH in the

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -49,7 +49,7 @@ Usage:
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|approve-for-me|trusted] [--model role=model,...]
     [--codex-args args] [--claude-args args]
-    [--force-duplicate] [--no-gitignore]
+    [--force-duplicate] [--no-gitignore] [--symphony]
     [--seed-from REF [--force]] [--dry-run]
 
 up means NEW work. It REFUSES by default when the target session already
@@ -70,6 +70,11 @@ refused unless --force; --reset never silently stops agents.
 Brief: with --seed-from the active brief is authored from the source. With no
 source, up AUTO-STUBS the brief and prints a one-line notice so CI and
 send-keys flows keep working; edit the stub or pass --seed-from to set the goal.
+
+--symphony is an opt-in Codex-only lifecycle hook: each launched Codex member
+patches its existing WORKFLOW.md with AMQ Symphony hooks pinned to the resolved
+AMQ root and handle. If WORKFLOW.md is absent, the AMQ adapter error is
+propagated and launch stops. amq-squad never creates WORKFLOW.md itself.
 
 --seed-from sources (deterministic only in 8A):
   file:<path>            literal file body

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -66,6 +66,10 @@ type Record struct {
 	// reproduces launches that intentionally leave .gitignore untouched during
 	// AMQ coop auto-init.
 	NoGitignore bool `json:"no_gitignore,omitempty"`
+	// Symphony records that this Codex launch opted into AMQ's Symphony
+	// WORKFLOW.md lifecycle hook integration. The hook patches the user's
+	// project working tree and is replayed only when this explicit bit is set.
+	Symphony bool `json:"symphony,omitempty"`
 	// NoWakeReason records the explicit compatibility reason for adopting a
 	// project lead without wake. It is intentionally separate from
 	// NoRequireWake: --no-require-wake weakens wake startup strictness, while

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -115,6 +115,40 @@ func TestWakeInjectCmdAdditiveBackCompat(t *testing.T) {
 	}
 }
 
+// TestSymphonyAdditiveBackCompat proves the #336 Symphony flag is additive:
+// older launch records without the key decode false, false omits the key, and
+// true round-trips for explicit restore/replay.
+func TestSymphonyAdditiveBackCompat(t *testing.T) {
+	legacyJSON := `{"schema":1,"cwd":"/p","binary":"codex","session":"s","handle":"cto","root":"/r","started_at":"2026-06-30T00:00:00Z"}`
+	var legacy Record
+	if err := json.Unmarshal([]byte(legacyJSON), &legacy); err != nil {
+		t.Fatalf("older record must still load: %v", err)
+	}
+	if legacy.Symphony {
+		t.Fatalf("missing symphony must decode false")
+	}
+
+	emptyRaw, err := json.Marshal(Record{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(emptyRaw), "symphony") {
+		t.Fatalf("false Symphony must be omitted from JSON: %s", emptyRaw)
+	}
+
+	setRaw, err := json.Marshal(Record{Symphony: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Record
+	if err := json.Unmarshal(setRaw, &back); err != nil {
+		t.Fatal(err)
+	}
+	if !back.Symphony {
+		t.Fatalf("Symphony true did not round-trip")
+	}
+}
+
 func TestWriteReadTmuxMetadata(t *testing.T) {
 	dir := t.TempDir()
 	in := Record{

--- a/internal/state/message.go
+++ b/internal/state/message.go
@@ -90,11 +90,12 @@ type Message struct {
 	Labels    []string
 	// Integration/routing metadata is optional AMQ context for federated or
 	// orchestrator-originated traffic.
-	Orchestrator   string
-	FromProject    string
-	ReplyProject   string
-	ExternalTaskID string
-	Body           string
+	Orchestrator      string
+	FromProject       string
+	ReplyProject      string
+	OrchestratorEvent string
+	ExternalTaskID    string
+	Body              string
 
 	// Owner is the handle whose inbox this copy was found in.
 	Owner string
@@ -185,25 +186,26 @@ func parseMessageFile(path, owner string, state MailboxState, now func() time.Ti
 	}
 
 	m := Message{
-		ID:             strings.TrimSpace(h.ID),
-		From:           strings.TrimSpace(h.From),
-		To:             cleanRecipients(h.To),
-		RawThread:      h.Thread,
-		Thread:         canonicalThreadID(h.Thread),
-		Subject:        strings.TrimSpace(h.Subject),
-		Priority:       normalizePriority(h.Priority),
-		Kind:           normalizeKind(h.Kind),
-		ReplyTo:        strings.TrimSpace(h.ReplyTo),
-		Labels:         cleanLabels(h.Labels),
-		Orchestrator:   strings.TrimSpace(h.Orchestrator),
-		FromProject:    strings.TrimSpace(h.FromProject),
-		ReplyProject:   strings.TrimSpace(h.ReplyProject),
-		ExternalTaskID: externalTaskIDFromContext(h.Context),
-		Body:           body,
-		Owner:          owner,
-		State:          state,
-		Path:           path,
-		SchemaOK:       h.Schema == MessageSchema,
+		ID:                strings.TrimSpace(h.ID),
+		From:              strings.TrimSpace(h.From),
+		To:                cleanRecipients(h.To),
+		RawThread:         h.Thread,
+		Thread:            canonicalThreadID(h.Thread),
+		Subject:           strings.TrimSpace(h.Subject),
+		Priority:          normalizePriority(h.Priority),
+		Kind:              normalizeKind(h.Kind),
+		ReplyTo:           strings.TrimSpace(h.ReplyTo),
+		Labels:            cleanLabels(h.Labels),
+		Orchestrator:      strings.TrimSpace(h.Orchestrator),
+		FromProject:       strings.TrimSpace(h.FromProject),
+		ReplyProject:      strings.TrimSpace(h.ReplyProject),
+		OrchestratorEvent: orchestratorEventFromContext(h.Context),
+		ExternalTaskID:    externalTaskIDFromContext(h.Context),
+		Body:              body,
+		Owner:             owner,
+		State:             state,
+		Path:              path,
+		SchemaOK:          h.Schema == MessageSchema,
 	}
 	m.Created = parseCreated(h.Created, path, now)
 
@@ -318,6 +320,10 @@ func externalTaskIDFromContext(ctx map[string]any) string {
 		return id
 	}
 	return stringAtPath(ctx, "task_id")
+}
+
+func orchestratorEventFromContext(ctx map[string]any) string {
+	return stringAtPath(ctx, "orchestrator", "event")
 }
 
 func stringAtPath(root map[string]any, path ...string) string {


### PR DESCRIPTION
## Summary
- add Codex-only `--symphony` launch/up/team opt-in that runs `amq integration symphony init` against the existing `WORKFLOW.md`
- persist the opt-in in launch records and restore/replay output
- surface AMQ Symphony lifecycle status as a status activity fallback below heartbeat files and above task-store ownership
- refuse team-level `--symphony` when multiple Codex members share a cwd/WORKFLOW.md

Fixes #336.

## Dogfood / adapter evidence
- `amq --version` reports `0.41.0`
- `amq integration symphony init --help` documents WORKFLOW hook patching and root/me pinning
- missing `WORKFLOW.md` returns adapter error (`WORKFLOW.md not found: ...`); amq-squad does not create it
- same WORKFLOW initialized with a second `--me` rewrites the managed hooks to the second handle, so amq-squad rejects shared-CWD multi-Codex team usage instead of silently shipping last-writer-wins

## Validation
- `go test ./internal/activity ./internal/state ./internal/cli`
- `go test ./...`
- `make ci`