### PR TITLE
Add run start external lead mode

### DIFF
--- a/README.html
+++ b/README.html
@@ -1434,7 +1434,7 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                     [--roles r,...] [--binary role=bin,...] [--model role=model,...]
                     [--lead-mode builder|planner]
                     [--codex-args A] [--claude-args A]
-                    [--visibility sibling-tabs|detached|current]
+                    [--visibility sibling-tabs|detached|current] [--external-lead]
                     [--goal TEXT] [--seed-from REF] [--go]
                                   Create one orchestrated run: wraps new team
                                   (if --roles) then up, so the namespace is typed
@@ -1448,6 +1448,12 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                                   exits non-zero and prints an exact
                                   `goal start ... --role &lt;lead&gt; --yes` retry
                                   command.
+                                  With --external-lead, the current tmux pane is
+                                  bound as the configured lead and only the
+                                  remaining workers are spawned. This mode must
+                                  run from the lead member&#39;s project root and
+                                  does not register or re-point a separate
+                                  orchestrator handle.
 amq-squad up [&lt;session&gt;] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
              [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
              [--terminal tmux] [--target current-window|new-window|new-session]

--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                     [--roles r,...] [--binary role=bin,...] [--model role=model,...]
                     [--lead-mode builder|planner]
                     [--codex-args A] [--claude-args A]
-                    [--visibility sibling-tabs|detached|current]
+                    [--visibility sibling-tabs|detached|current] [--external-lead]
                     [--goal TEXT] [--seed-from REF] [--go]
                                   Create one orchestrated run: wraps new team
                                   (if --roles) then up, so the namespace is typed
@@ -839,6 +839,12 @@ amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
                                   exits non-zero and prints an exact
                                   `goal start ... --role <lead> --yes` retry
                                   command.
+                                  With --external-lead, the current tmux pane is
+                                  bound as the configured lead and only the
+                                  remaining workers are spawned. This mode must
+                                  run from the lead member's project root and
+                                  does not register or re-point a separate
+                                  orchestrator handle.
 amq-squad up [<session>] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
              [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
              [--terminal tmux] [--target current-window|new-window|new-session]

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -8,6 +8,7 @@ once, not per command.
 | --- | --- | --- | --- |
 | **Global / root** | a multi-run supervisor at a neutral root (e.g. `~/Code`) | none — you poll | `amq-squad global start` |
 | **Project run** | driving one orchestrated run in a repo | yes (managed spawn registers panes) | `amq-squad run start` |
+| **Project run, external lead** | your current project pane is the lead | yes (current pane is registered as lead) | `amq-squad run start --external-lead` |
 
 The `scripts/orchestrator/*.sh` files are thin forwarders to these verbs; the
 verbs are the source of truth.
@@ -53,10 +54,34 @@ creates for real.
 # preview (no mutation)
 amq-squad run start -p ~/Code/app -s issue-96 -P release --roles "cto,fullstack,qa"
 
-# create it (hidden spawn — the default)
+# create it
 amq-squad run start -p ~/Code/app -s issue-96 -P release \
   --roles "cto,fullstack,qa" --binary "fullstack=codex" --goal "fix issue 96" --go
 ```
+
+### External lead mode
+
+Use `--external-lead` when the agent conversation already open in the current
+tmux pane should become the project lead. The command binds the current pane as
+the configured lead, starts or repairs lead wake, then spawns only the remaining
+workers. It does not run `goal start --register-orchestrator`, add an
+`orchestrator` member, or change the profile's configured lead.
+
+```sh
+amq-squad run start -p ~/Code/app -s issue-96 -P release \
+  --roles "cto,fullstack,qa" --external-lead --goal "fix issue 96" --go
+```
+
+Requirements:
+
+- Run from the lead member's project root. Passing `--project` from some other
+  cwd is refused, because the current pane is what is being adopted.
+- Run inside the lead tmux pane (`TMUX` and `TMUX_PANE` set). Preview is
+  read-only and validates this instead of printing a false OK.
+- Existing profiles keep their configured lead. If you need a different lead,
+  run `amq-squad team lead set <role>` first.
+- A lead-only roster is valid: the command binds the current pane and reports
+  that there are no remaining workers to spawn.
 
 ### Choosing binary / model / effort
 

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -196,7 +196,8 @@ Usage:
       [--roles "a,b,c"] [--binary "role=bin,..."] [--model "role=model,..."]
       [--lead-mode builder|planner]
       [--codex-args "..."] [--claude-args "..."]
-      [--visibility sibling-tabs|detached|current] [--goal TEXT] [--seed-from REF] [--go]
+      [--visibility sibling-tabs|detached|current] [--external-lead]
+      [--goal TEXT] [--seed-from REF] [--go]
 
 Managed model: amq-squad spawns the whole team (incl. the lead); panes are
 registered and wake-live automatically. This wraps the create sequence so the
@@ -213,8 +214,9 @@ binary via --binary, model via --model, and effort via
 Preview by default (prints the plan and runs read-only --dry-run validation, so
 its failures surface honestly); pass --go to create for real.
 
-External-lead mode (your current pane IS the lead) is not yet supported here;
-see issue #339.
+External-lead mode (--external-lead) binds the current tmux pane as the
+configured lead, then spawns only the remaining workers. It never registers a
+separate orchestrator handle or re-points lead state.
 `)
 		if len(args) == 0 {
 			return usageErrorf("run requires a subcommand (start)")
@@ -245,7 +247,7 @@ func runRunStart(args []string, version string) error {
 	visibilityFlag := fs.String("visibility", visibilitySiblingTabs, "spawn topology: sibling-tabs (visible default), detached (hidden), or current")
 	goalFlag := fs.String("goal", "", "after spawn, deliver this goal to the lead")
 	seedFlag := fs.String("seed-from", "", "seed the workstream brief from a reference (e.g. issue:96)")
-	externalLead := fs.Bool("external-lead", false, "(unsupported yet, see #339) your current pane is the lead")
+	externalLead := fs.Bool("external-lead", false, "bind the current pane as the lead and spawn only remaining workers")
 	goFlag := fs.Bool("go", false, "create for real (default: preview only)")
 	fs.Usage = func() { _ = runRunCmd([]string{"-h"}, version) }
 	if err := parseFlags(fs, args); err != nil {
@@ -253,9 +255,6 @@ func runRunStart(args []string, version string) error {
 	}
 	if fs.NArg() > 0 {
 		return usageErrorf("unexpected argument %q", fs.Arg(0))
-	}
-	if *externalLead {
-		return usageErrorf("external-lead mode is not yet supported (see #339); pane binding must be verified against the CLI before it ships. Use the managed model for now.")
 	}
 	project := strings.TrimSpace(*projectFlag)
 	session := strings.TrimSpace(*sessionFlag)
@@ -304,6 +303,20 @@ func runRunStart(args []string, version string) error {
 	leadForNewTeam := explicitLead
 	if leadForNewTeam == "" {
 		leadForNewTeam = "cto"
+	}
+	externalLeadRole := ""
+	if *externalLead {
+		externalLeadRole, err = resolveRunStartExternalLead(project, profile, explicitLead, freshRoster, leadForNewTeam)
+		if err != nil {
+			return err
+		}
+		preflightTeam, err := runStartExternalLeadPreflightTeam(project, profile, session, rolesText, freshRoster, externalLeadRole)
+		if err != nil {
+			return err
+		}
+		if err := validateRunStartExternalLeadPreconditions(project, profile, session, externalLeadRole, preflightTeam); err != nil {
+			return err
+		}
 	}
 
 	// Build the create commands as argument slices we can run in-process. This
@@ -363,11 +376,18 @@ func runRunStart(args []string, version string) error {
 			leadDisplay = "(inferred from profile)"
 		}
 	}
+	if *externalLead {
+		leadDisplay = externalLeadRole
+	}
 	upStep := 1
 	if freshRoster {
 		upStep = 2
 	}
-	fmt.Printf("orchestrated run (managed model)\n")
+	modelLabel := "managed model"
+	if *externalLead {
+		modelLabel = "external lead"
+	}
+	fmt.Printf("orchestrated run (%s)\n", modelLabel)
 	fmt.Printf("  project: %s\n", project)
 	fmt.Printf("  profile: %s\n", profileOrDefault(*profileFlag))
 	fmt.Printf("  session: %s\n", session)
@@ -381,6 +401,10 @@ func runRunStart(args []string, version string) error {
 		fmt.Printf("  step 1:  amq-squad new team --roles %s --orchestrated --lead %s%s\n", *rolesFlag, leadForNewTeam, leadModeSuffix)
 	} else if len(newTeamArgs) > 0 {
 		fmt.Printf("  note:    profile %s already exists; --roles ignored, using the existing roster\n", profileOrDefault(*profileFlag))
+	}
+	if *externalLead {
+		fmt.Printf("  step %d:  bind current pane as external lead %s\n", upStep, externalLeadRole)
+		upStep++
 	}
 	fmt.Printf("  step %d:  amq-squad up %s --visibility %s\n", upStep, session, visibility)
 	if visibility == visibilityDetached {
@@ -409,11 +433,74 @@ func runRunStart(args []string, version string) error {
 	}
 
 	if !*goFlag {
+		if *externalLead {
+			return runStartExternalLeadPreview(runStartExternalLeadPreviewOptions{
+				NewTeamArgs: newTeamArgs,
+				Project:     project,
+				Profile:     profile,
+				Session:     session,
+				Lead:        externalLeadRole,
+				FreshRoster: freshRoster,
+				TeamPresent: teamPresent,
+				Visibility:  visibility,
+				Model:       *modelFlag,
+				CodexArgs:   *codexArgsFlag,
+				ClaudeArgs:  *claudeArgsFlag,
+				Version:     version,
+			})
+		}
 		return runStartPreview(newTeamArgs, upArgs, freshRoster, teamPresent, version)
 	}
 
 	if (visibility == visibilitySiblingTabs || visibility == visibilityCurrent) && !insideTmux() {
 		return usageErrorf("not inside tmux; --visibility %s requires a visible tmux pane. Run inside tmux, or pass --visibility detached to spawn hidden.", visibility)
+	}
+
+	if *externalLead {
+		var externalSeedContent string
+		if strings.TrimSpace(*seedFlag) != "" {
+			body, err := resolveSeed(*seedFlag)
+			if err != nil {
+				return err
+			}
+			externalSeedContent = buildSeedBrief(*seedFlag, body, seedNow())
+		}
+		if freshRoster {
+			quietNotice("creating roster...\n")
+			if err := runNew(newTeamArgs); err != nil {
+				return err
+			}
+		} else if len(newTeamArgs) > 0 {
+			quietNotice("profile %q already exists; skipping new team (using existing roster)\n", profileOrDefault(*profileFlag))
+		}
+		quietNotice("binding current pane as external lead %s...\n", externalLeadRole)
+		if err := runStartRegisterExternalLead(project, profile, session, externalLeadRole); err != nil {
+			return err
+		}
+		opts, err := runStartTeamLaunchOptions(visibility, session, profile, externalSeedContent, false, false, externalLeadRole, true, *modelFlag, *codexArgsFlag, *claudeArgsFlag)
+		if err != nil {
+			return err
+		}
+		quietNotice("spawning remaining workers (--visibility %s)...\n", visibility)
+		if err := runInProject(project, func() error { return executeTeamLaunch(opts, true, false) }); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*goalFlag) != "" {
+			opts := runStartGoalDeliveryOptions{
+				Project: project,
+				Profile: profile,
+				Session: session,
+				Role:    externalLeadRole,
+				Goal:    *goalFlag,
+				Version: version,
+			}
+			quietNotice("waiting for lead readiness before goal delivery...\n")
+			if err := deliverRunStartGoalWhenReady(opts); err != nil {
+				return err
+			}
+		}
+		quietNotice("done. Current pane is the lead; drive remaining workers with dispatch/monitor/collect.\n")
+		return nil
 	}
 
 	// 1) roster
@@ -485,6 +572,182 @@ func runStartPreview(newTeamArgs, upArgs []string, freshRoster, teamPresent bool
 		"not exist yet, so `up --dry-run` cannot check the roster in preview.\n" +
 		"Re-run with --go to create the team and spawn.\n")
 	return nil
+}
+
+type runStartExternalLeadPreviewOptions struct {
+	NewTeamArgs []string
+	Project     string
+	Profile     string
+	Session     string
+	Lead        string
+	FreshRoster bool
+	TeamPresent bool
+	Visibility  string
+	Model       string
+	CodexArgs   string
+	ClaudeArgs  string
+	Version     string
+}
+
+func runStartExternalLeadPreview(opts runStartExternalLeadPreviewOptions) error {
+	fmt.Print("\nPREVIEW -- validating external-lead binding and worker launch; nothing is created.\n")
+	if opts.FreshRoster {
+		if err := runNew(append(append([]string{}, opts.NewTeamArgs...), "--dry-run")); err != nil {
+			return fmt.Errorf("roster dry-run failed: %w", err)
+		}
+		fmt.Print("\nExternal-lead adoption preconditions validated. Spawn validation is deferred: the team does\n" +
+			"not exist yet, so the worker-only launch plan cannot be checked without writing the roster.\n" +
+			"Re-run with --external-lead --go to bind this pane as lead and spawn remaining workers.\n")
+		return nil
+	}
+	if opts.TeamPresent {
+		launchOpts, err := runStartTeamLaunchOptions(opts.Visibility, opts.Session, opts.Profile, "", false, true, opts.Lead, true, opts.Model, opts.CodexArgs, opts.ClaudeArgs)
+		if err != nil {
+			return err
+		}
+		if err := runInProject(opts.Project, func() error {
+			return executeTeamLaunch(launchOpts, true, false)
+		}); err != nil {
+			return fmt.Errorf("worker spawn dry-run failed: %w", err)
+		}
+		fmt.Print("\nPreview OK. Re-run with --external-lead --go to bind this pane as lead and spawn remaining workers.\n")
+		return nil
+	}
+	return usageErrorf("no team profile %q in %s and no --roles given; pass --roles to create one or create the team first", opts.Profile, opts.Project)
+}
+
+func runStartTeamLaunchOptions(visibility, session, profile, seedContent string, seedForce, dryRun bool, externalLeadRole string, allowLeadOnly bool, modelRaw, codexArgsRaw, claudeArgsRaw string) (teamLaunchOptions, error) {
+	modelOverrides, err := parseKV(modelRaw)
+	if err != nil {
+		return teamLaunchOptions{}, fmt.Errorf("parse --model: %w", err)
+	}
+	modelOverrides = lowercaseKeys(modelOverrides)
+	binaryArgs, err := parseBinaryArgFlags(codexArgsRaw, claudeArgsRaw)
+	if err != nil {
+		return teamLaunchOptions{}, err
+	}
+	opts := teamLaunchOptions{
+		Terminal:       "tmux",
+		Target:         "current-window",
+		Layout:         "vertical",
+		Workstream:     session,
+		Stagger:        750 * time.Millisecond,
+		SquadBin:       teamSquadBin(),
+		BinaryArgs:     binaryArgs,
+		ModelOverrides: modelOverrides,
+	}
+	if err := applyLaunchVisibility(&opts, visibility, false, false, false, true); err != nil {
+		return teamLaunchOptions{}, err
+	}
+	opts.DryRun = dryRun
+	opts.Fresh = false
+	opts.Workstream = session
+	opts.Profile = profile
+	opts.SeedBriefContent = seedContent
+	opts.SeedBriefForce = seedForce
+	opts.WarnStubBrief = seedContent == "" && !dryRun
+	opts.ExternalLeadRole = externalLeadRole
+	opts.AllowNoMembersAfterExternalLead = allowLeadOnly
+	return opts, nil
+}
+
+func resolveRunStartExternalLead(project, profile, explicitLead string, freshRoster bool, leadForNewTeam string) (string, error) {
+	if freshRoster {
+		lead := strings.TrimSpace(explicitLead)
+		if lead == "" {
+			lead = strings.TrimSpace(leadForNewTeam)
+		}
+		if lead == "" {
+			return "", usageErrorf("--external-lead requires a lead role")
+		}
+		return strings.ToLower(lead), nil
+	}
+	t, err := team.ReadProfile(project, profile)
+	if err != nil {
+		return "", fmt.Errorf("read team profile %q: %w", profile, err)
+	}
+	lead := strings.TrimSpace(t.Lead)
+	if lead == "" && len(t.Members) == 1 {
+		lead = strings.TrimSpace(t.Members[0].Role)
+	}
+	if lead == "" {
+		return "", usageErrorf("--external-lead cannot infer lead role from profile %q; run `amq-squad team lead set <role>` first or pass --lead matching the configured lead", profile)
+	}
+	if explicit := strings.TrimSpace(explicitLead); explicit != "" && explicit != lead {
+		return "", usageErrorf("--external-lead cannot change existing profile lead from %q to %q; run `amq-squad team lead set %s --project %s --profile %s` first", lead, explicit, shellQuote(explicit), shellQuote(project), shellQuote(profile))
+	}
+	return strings.ToLower(lead), nil
+}
+
+func runStartExternalLeadPreflightTeam(project, profile, session, rolesText string, freshRoster bool, lead string) (team.Team, error) {
+	if !freshRoster {
+		t, err := team.ReadProfile(project, profile)
+		if err != nil {
+			return team.Team{}, fmt.Errorf("read team profile %q: %w", profile, err)
+		}
+		return t, nil
+	}
+	if strings.TrimSpace(rolesText) == "" {
+		return team.Team{}, usageErrorf("no team profile %q in %s and no --roles given; pass --roles to create one or create the team first", profile, project)
+	}
+	seen := map[string]bool{}
+	var members []team.Member
+	for _, role := range splitCSV(rolesText) {
+		role = strings.ToLower(strings.TrimSpace(role))
+		if role == "" || role == "all" || seen[role] {
+			continue
+		}
+		seen[role] = true
+		members = append(members, team.Member{Role: role, Handle: role, Session: session})
+	}
+	if lead != "" && !seen[lead] && strings.TrimSpace(rolesText) != "all" {
+		return team.Team{}, usageErrorf("run start --external-lead lead %q is not included in --roles %q; include the lead role or change --lead", lead, rolesText)
+	}
+	if lead != "" && !seen[lead] && strings.TrimSpace(rolesText) == "all" {
+		members = append(members, team.Member{Role: lead, Handle: lead, Session: session})
+	}
+	return team.Team{
+		Project:      project,
+		Orchestrated: true,
+		Lead:         lead,
+		Members:      members,
+	}, nil
+}
+
+func validateRunStartExternalLeadPreconditions(project, profile, session, lead string, t team.Team) error {
+	id, err := currentPaneIdentity()
+	if err != nil {
+		return err
+	}
+	if id == nil || strings.TrimSpace(id.PaneID) == "" {
+		return usageErrorf("run start --external-lead requires the current lead pane to be a tmux pane (TMUX/TMUX_PANE unset)")
+	}
+	if !currentWorkingDirMatches(project) {
+		return usageErrorf("run start --external-lead must be executed from the lead member project root %s; current working directory does not match --project", project)
+	}
+	if _, ok := memberByRole(t, lead); !ok {
+		return usageErrorf("run start --external-lead lead %q is not a member of the target roster", lead)
+	}
+	exists, root, err := teamWorkstreamExistsOrRestorable(t, profile, session)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return existingSessionRefusal(session, root)
+	}
+	return nil
+}
+
+func runStartRegisterExternalLead(project, profile, session, lead string) error {
+	args := []string{
+		"register",
+		"--project", project,
+		"--profile", profile,
+		"--session", session,
+		"--role", lead,
+		"--adopt-project-lead",
+	}
+	return runLead(args)
 }
 
 func teamExistsForProfile(project, profile string) bool {

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/role"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -473,6 +475,9 @@ func runRunStart(args []string, version string) error {
 		} else if len(newTeamArgs) > 0 {
 			quietNotice("profile %q already exists; skipping new team (using existing roster)\n", profileOrDefault(*profileFlag))
 		}
+		if err := validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, externalLeadRole, *modelFlag, *codexArgsFlag, *claudeArgsFlag); err != nil {
+			return err
+		}
 		quietNotice("binding current pane as external lead %s...\n", externalLeadRole)
 		if err := runStartRegisterExternalLead(project, profile, session, externalLeadRole); err != nil {
 			return err
@@ -601,13 +606,7 @@ func runStartExternalLeadPreview(opts runStartExternalLeadPreviewOptions) error 
 		return nil
 	}
 	if opts.TeamPresent {
-		launchOpts, err := runStartTeamLaunchOptions(opts.Visibility, opts.Session, opts.Profile, "", false, true, opts.Lead, true, opts.Model, opts.CodexArgs, opts.ClaudeArgs)
-		if err != nil {
-			return err
-		}
-		if err := runInProject(opts.Project, func() error {
-			return executeTeamLaunch(launchOpts, true, false)
-		}); err != nil {
+		if err := validateRunStartExternalLeadWorkerLaunch(opts.Project, opts.Visibility, opts.Session, opts.Profile, opts.Lead, opts.Model, opts.CodexArgs, opts.ClaudeArgs); err != nil {
 			return fmt.Errorf("worker spawn dry-run failed: %w", err)
 		}
 		fmt.Print("\nPreview OK. Re-run with --external-lead --go to bind this pane as lead and spawn remaining workers.\n")
@@ -673,10 +672,11 @@ func resolveRunStartExternalLead(project, profile, explicitLead string, freshRos
 	if lead == "" {
 		return "", usageErrorf("--external-lead cannot infer lead role from profile %q; run `amq-squad team lead set <role>` first or pass --lead matching the configured lead", profile)
 	}
-	if explicit := strings.TrimSpace(explicitLead); explicit != "" && explicit != lead {
+	lead = strings.ToLower(lead)
+	if explicit := strings.ToLower(strings.TrimSpace(explicitLead)); explicit != "" && explicit != lead {
 		return "", usageErrorf("--external-lead cannot change existing profile lead from %q to %q; run `amq-squad team lead set %s --project %s --profile %s` first", lead, explicit, shellQuote(explicit), shellQuote(project), shellQuote(profile))
 	}
-	return strings.ToLower(lead), nil
+	return lead, nil
 }
 
 func runStartExternalLeadPreflightTeam(project, profile, session, rolesText string, freshRoster bool, lead string) (team.Team, error) {
@@ -690,21 +690,26 @@ func runStartExternalLeadPreflightTeam(project, profile, session, rolesText stri
 	if strings.TrimSpace(rolesText) == "" {
 		return team.Team{}, usageErrorf("no team profile %q in %s and no --roles given; pass --roles to create one or create the team first", profile, project)
 	}
+	customDefs := map[string]role.Definition{}
+	if err := discoverStagedCustomRoleDefs(project, customDefs); err != nil {
+		return team.Team{}, err
+	}
+	picked, err := resolveTeamSelection(rolesText, customDefs)
+	if err != nil {
+		return team.Team{}, err
+	}
 	seen := map[string]bool{}
 	var members []team.Member
-	for _, role := range splitCSV(rolesText) {
+	for _, role := range picked {
 		role = strings.ToLower(strings.TrimSpace(role))
-		if role == "" || role == "all" || seen[role] {
+		if role == "" || seen[role] {
 			continue
 		}
 		seen[role] = true
 		members = append(members, team.Member{Role: role, Handle: role, Session: session})
 	}
-	if lead != "" && !seen[lead] && strings.TrimSpace(rolesText) != "all" {
+	if lead != "" && !seen[lead] {
 		return team.Team{}, usageErrorf("run start --external-lead lead %q is not included in --roles %q; include the lead role or change --lead", lead, rolesText)
-	}
-	if lead != "" && !seen[lead] && strings.TrimSpace(rolesText) == "all" {
-		members = append(members, team.Member{Role: lead, Handle: lead, Session: session})
 	}
 	return team.Team{
 		Project:      project,
@@ -728,6 +733,9 @@ func validateRunStartExternalLeadPreconditions(project, profile, session, lead s
 	if _, ok := memberByRole(t, lead); !ok {
 		return usageErrorf("run start --external-lead lead %q is not a member of the target roster", lead)
 	}
+	if err := authorizeRunStartExternalLeadAdoption(project, profile, session, lead, t, id.PaneID); err != nil {
+		return err
+	}
 	exists, root, err := teamWorkstreamExistsOrRestorable(t, profile, session)
 	if err != nil {
 		return err
@@ -736,6 +744,54 @@ func validateRunStartExternalLeadPreconditions(project, profile, session, lead s
 		return existingSessionRefusal(session, root)
 	}
 	return nil
+}
+
+func authorizeRunStartExternalLeadAdoption(project, profile, session, lead string, t team.Team, paneID string) error {
+	member, ok := memberByRole(t, lead)
+	if !ok {
+		return usageErrorf("run start --external-lead lead %q is not a member of the target roster", lead)
+	}
+	cwd := member.EffectiveCWD(t.Project)
+	if strings.TrimSpace(cwd) == "" {
+		cwd = project
+	}
+	handle := memberHandle(member)
+	env, err := resolveAMQEnvForTeamProfile(cwd, profile, session, handle)
+	if err != nil {
+		return fmt.Errorf("resolve amq env: %w", err)
+	}
+	if env.Me != "" {
+		handle = env.Me
+	}
+	root := absoluteAMQRoot(cwd, env.Root)
+	agentDir := filepath.Join(root, "agents", handle)
+	existingRec, existingRecErr := launch.Read(agentDir)
+	_, err = authorizeLeadRegister(leadRegisterAuthInput{
+		Team:              t,
+		Member:            member,
+		Role:              lead,
+		Handle:            handle,
+		Profile:           profile,
+		Workstream:        env.SessionName,
+		Root:              root,
+		CWD:               cwd,
+		PaneID:            paneID,
+		TargetMode:        leadRegisterTargetMode(t, lead),
+		ExistingRecord:    existingRec,
+		ExistingRecordErr: existingRecErr,
+		AdoptProjectLead:  true,
+	})
+	return err
+}
+
+func validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, lead, modelRaw, codexArgsRaw, claudeArgsRaw string) error {
+	launchOpts, err := runStartTeamLaunchOptions(visibility, session, profile, "", false, true, lead, true, modelRaw, codexArgsRaw, claudeArgsRaw)
+	if err != nil {
+		return err
+	}
+	return runInProject(project, func() error {
+		return executeTeamLaunch(launchOpts, true, false)
+	})
 }
 
 func runStartRegisterExternalLead(project, profile, session, lead string) error {

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // withStubbedTmux swaps orchestrateTmuxRun for a recorder and restores it.
@@ -22,6 +24,41 @@ func withStubbedTmux(t *testing.T) *[][]string {
 	}
 	t.Cleanup(func() { orchestrateTmuxRun = prev })
 	return &calls
+}
+
+func useFakeTmuxBackend(t *testing.T) *fakeBackend {
+	t.Helper()
+	backend := &fakeBackend{}
+	prev, hadPrev := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = backend
+	t.Cleanup(func() {
+		if hadPrev {
+			teamLaunchBackends["tmux"] = prev
+			return
+		}
+		delete(teamLaunchBackends, "tmux")
+	})
+	return backend
+}
+
+func stubCurrentRunStartPane(t *testing.T, paneID string) {
+	t.Helper()
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", paneID)
+	prev := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{Session: "tmux-main", WindowID: "@7", WindowName: "lead", PaneID: paneID}, nil
+	}
+	t.Cleanup(func() { currentPaneIdentity = prev })
+}
+
+func stubRunStartLeadWake(t *testing.T) {
+	t.Helper()
+	prev := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		return leadWakeResult{PID: 1234, Started: true, Detail: "ready"}, nil
+	}
+	t.Cleanup(func() { leadWakeStarter = prev })
 }
 
 func TestGlobalStartPreviewDoesNotLaunch(t *testing.T) {
@@ -121,10 +158,138 @@ func TestRunStartRequiresProjectAndSession(t *testing.T) {
 	}
 }
 
-func TestRunStartExternalLeadUnsupported(t *testing.T) {
-	err := runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "--external-lead"}, "test")
-	if err == nil || !strings.Contains(err.Error(), "external-lead mode is not yet supported") {
-		t.Fatalf("expected external-lead unsupported error, got %v", err)
+func TestRunStartExternalLeadPreviewExistingProfileIsReadOnlyAndWorkerOnly(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	backend := useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+
+	out, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("external-lead preview: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "orchestrated run (external lead)") || !strings.Contains(out, "Preview OK") {
+		t.Fatalf("preview output missing external-lead/ok text:\n%s", out)
+	}
+	if len(backend.dryRuns) != 1 || len(backend.teams) != 1 {
+		t.Fatalf("expected one worker dry-run, got dryRuns=%d teams=%d", len(backend.dryRuns), len(backend.teams))
+	}
+	if got := backend.teams[0].Members; len(got) != 1 || got[0].Role != "qa" {
+		t.Fatalf("worker dry-run members = %+v, want only qa", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(err) {
+		t.Fatalf("preview must not create .agent-mail, stat err=%v", err)
+	}
+	if _, err := launch.Read(filepath.Join(dir, ".agent-mail", "sess", "agents", "cto")); err == nil {
+		t.Fatal("preview must not write external lead launch record")
+	}
+}
+
+func TestRunStartExternalLeadPreviewFreshProfileDoesNotWriteTeam(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	stubCurrentRunStartPane(t, "%42")
+
+	out, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--roles", "cto,qa", "--external-lead"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("fresh external-lead preview: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Spawn validation is deferred") {
+		t.Fatalf("fresh preview should explain deferred worker validation:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".amq-squad")); !os.IsNotExist(err) {
+		t.Fatalf("fresh preview must not write .amq-squad, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(err) {
+		t.Fatalf("fresh preview must not write .agent-mail, stat err=%v", err)
+	}
+}
+
+func TestRunStartExternalLeadGoBindsLeadAndSpawnsOnlyWorkers(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	backend := useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+	stubRunStartLeadWake(t)
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--go"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("external-lead --go: %v", err)
+	}
+	if len(backend.launches) != 1 || len(backend.teams) != 1 {
+		t.Fatalf("expected one worker launch, got launches=%d teams=%d", len(backend.launches), len(backend.teams))
+	}
+	if got := backend.teams[0].Members; len(got) != 1 || got[0].Role != "qa" {
+		t.Fatalf("worker launch members = %+v, want only qa", got)
+	}
+	rec, err := launch.Read(filepath.Join(dir, ".agent-mail", "sess", "agents", "cto"))
+	if err != nil {
+		t.Fatalf("read external lead record: %v", err)
+	}
+	if !rec.External || rec.AdoptionMode != adoptionModeExternalProjectLead || rec.Tmux == nil || rec.Tmux.PaneID != "%42" {
+		t.Fatalf("external lead record = %+v", rec)
+	}
+}
+
+func TestRunStartExternalLeadExistingProfileLeadMismatchFailsWithGuidance(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	stubCurrentRunStartPane(t, "%42")
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--lead", "qa"}, "test")
+	})
+	if err == nil || !strings.Contains(err.Error(), "team lead set") {
+		t.Fatalf("expected lead mismatch guidance, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(statErr) {
+		t.Fatalf("lead mismatch must not create .agent-mail, stat err=%v", statErr)
+	}
+}
+
+func TestRunStartExternalLeadFreshLeadValidationBeforeTeamWrite(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	stubCurrentRunStartPane(t, "%42")
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--roles", "qa", "--lead", "cto", "--external-lead", "--go"}, "test")
+	})
+	if err == nil || !strings.Contains(err.Error(), "not included in --roles") {
+		t.Fatalf("expected pre-write lead validation error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".amq-squad")); !os.IsNotExist(statErr) {
+		t.Fatalf("failed fresh external-lead preflight must not write .amq-squad, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(statErr) {
+		t.Fatalf("failed fresh external-lead preflight must not write .agent-mail, stat err=%v", statErr)
 	}
 }
 

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -236,11 +236,13 @@ func TestRunStartExternalLeadGoBindsLeadAndSpawnsOnlyWorkers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("external-lead --go: %v", err)
 	}
-	if len(backend.launches) != 1 || len(backend.teams) != 1 {
-		t.Fatalf("expected one worker launch, got launches=%d teams=%d", len(backend.launches), len(backend.teams))
+	if len(backend.dryRuns) != 1 || len(backend.launches) != 1 || len(backend.teams) != 2 {
+		t.Fatalf("expected one worker dry-run and one worker launch, got dryRuns=%d launches=%d teams=%d", len(backend.dryRuns), len(backend.launches), len(backend.teams))
 	}
-	if got := backend.teams[0].Members; len(got) != 1 || got[0].Role != "qa" {
-		t.Fatalf("worker launch members = %+v, want only qa", got)
+	for _, got := range []team.Team{backend.teams[0], backend.teams[1]} {
+		if len(got.Members) != 1 || got.Members[0].Role != "qa" {
+			t.Fatalf("worker launch members = %+v, want only qa", got.Members)
+		}
 	}
 	rec, err := launch.Read(filepath.Join(dir, ".agent-mail", "sess", "agents", "cto"))
 	if err != nil {
@@ -248,6 +250,26 @@ func TestRunStartExternalLeadGoBindsLeadAndSpawnsOnlyWorkers(t *testing.T) {
 	}
 	if !rec.External || rec.AdoptionMode != adoptionModeExternalProjectLead || rec.Tmux == nil || rec.Tmux.PaneID != "%42" {
 		t.Fatalf("external lead record = %+v", rec)
+	}
+}
+
+func TestRunStartExternalLeadAcceptsCaseInsensitiveExplicitLead(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--lead", "CTO"}, "test")
+	}); err != nil {
+		t.Fatalf("expected case-insensitive explicit lead to pass, got %v", err)
 	}
 }
 
@@ -274,6 +296,65 @@ func TestRunStartExternalLeadExistingProfileLeadMismatchFailsWithGuidance(t *tes
 	}
 }
 
+func TestRunStartExternalLeadRefusesExistingWorkstreamBeforeWrites(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	stubCurrentRunStartPane(t, "%42")
+	if err := os.MkdirAll(filepath.Join(base, "sess"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--go"}, "test")
+	})
+	if err == nil || !strings.Contains(err.Error(), "session \"sess\" already exists") {
+		t.Fatalf("expected existing workstream refusal, got %v", err)
+	}
+	if _, err := launch.Read(filepath.Join(base, "sess", "agents", "cto")); err == nil {
+		t.Fatal("existing workstream refusal must not write external lead launch record")
+	}
+}
+
+func TestRunStartExternalLeadMissingTmuxFailsPreviewAndGoBeforeWrites(t *testing.T) {
+	for _, goMode := range []bool{false, true} {
+		t.Run(map[bool]string{false: "preview", true: "go"}[goMode], func(t *testing.T) {
+			dir := seedTeam(t, team.Team{
+				Project:      "",
+				Orchestrated: true,
+				Lead:         "cto",
+				Members: []team.Member{
+					{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+					{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+				},
+			})
+			t.Setenv("TMUX", "")
+			t.Setenv("TMUX_PANE", "")
+
+			args := []string{"-p", dir, "-s", "sess", "--external-lead"}
+			if goMode {
+				args = append(args, "--go")
+			}
+			_, _, err := captureOutput(t, func() error {
+				return runRunStart(args, "test")
+			})
+			if err == nil || !strings.Contains(err.Error(), "requires the current lead pane") {
+				t.Fatalf("expected missing tmux pane refusal, got %v", err)
+			}
+			if _, statErr := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(statErr) {
+				t.Fatalf("missing tmux refusal must not create .agent-mail, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
 func TestRunStartExternalLeadFreshLeadValidationBeforeTeamWrite(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
@@ -290,6 +371,116 @@ func TestRunStartExternalLeadFreshLeadValidationBeforeTeamWrite(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, ".agent-mail")); !os.IsNotExist(statErr) {
 		t.Fatalf("failed fresh external-lead preflight must not write .agent-mail, stat err=%v", statErr)
+	}
+}
+
+func TestRunStartExternalLeadGoalDeliveredToBoundLead(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+	stubRunStartLeadWake(t)
+	var goalCalls [][]string
+	stubRunStartGoalDelivery(t,
+		func(args []string, version string) error { return nil },
+		func(args []string, version string) error {
+			goalCalls = append(goalCalls, append([]string{}, args...))
+			return nil
+		},
+		func(project, profile, session, role string) (runStartLeadReadiness, error) {
+			return runStartLeadReadiness{Ready: true, Detail: "live"}, nil
+		},
+		func(time.Duration) {},
+		time.Now,
+	)
+
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--goal", "ship it", "--go"}, "test")
+	}); err != nil {
+		t.Fatalf("external-lead --goal --go: %v", err)
+	}
+	if len(goalCalls) != 1 {
+		t.Fatalf("expected one goal call, got %v", goalCalls)
+	}
+	goal := strings.Join(goalCalls[0], " ")
+	for _, want := range []string{"start", "--project " + dir, "--profile default", "--session sess", "--role cto", "--goal ship it", "--yes"} {
+		if !strings.Contains(goal, want) {
+			t.Fatalf("goal args %q missing %q", goal, want)
+		}
+	}
+	if strings.Contains(goal, "--register-orchestrator") {
+		t.Fatalf("external-lead goal delivery must not re-register orchestrator: %q", goal)
+	}
+}
+
+func TestRunStartExternalLeadLeadOnlyRosterReportsSuccess(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+		},
+	})
+	backend := useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+	stubRunStartLeadWake(t)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--go"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("lead-only external-lead --go: %v", err)
+	}
+	if !strings.Contains(stderr, "lead bound; no remaining workers to spawn") {
+		t.Fatalf("lead-only run should report no remaining workers, stderr:\n%s", stderr)
+	}
+	if len(backend.dryRuns) != 0 || len(backend.launches) != 0 {
+		t.Fatalf("lead-only run should not call backend, dryRuns=%d launches=%d", len(backend.dryRuns), len(backend.launches))
+	}
+	if _, err := launch.Read(filepath.Join(dir, ".agent-mail", "sess", "agents", "cto")); err != nil {
+		t.Fatalf("lead-only run should bind current lead: %v", err)
+	}
+}
+
+func TestRunStartExternalLeadWorkerValidationBeforeBind(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "sess"},
+		},
+	})
+	useFakeTmuxBackend(t)
+	stubCurrentRunStartPane(t, "%42")
+	wakeCalls := 0
+	prev := leadWakeStarter
+	leadWakeStarter = func(opts leadWakeOptions) (leadWakeResult, error) {
+		wakeCalls++
+		return leadWakeResult{PID: 1234, Started: true, Detail: "ready"}, nil
+	}
+	t.Cleanup(func() { leadWakeStarter = prev })
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--external-lead", "--model", "missing=gpt-5", "--go"}, "test")
+	})
+	if err == nil || !strings.Contains(err.Error(), "--model has unknown role(s): missing") {
+		t.Fatalf("expected worker validation error, got %v", err)
+	}
+	if wakeCalls != 0 {
+		t.Fatalf("worker validation failure must happen before wake start, wakeCalls=%d", wakeCalls)
+	}
+	if _, err := launch.Read(filepath.Join(dir, ".agent-mail", "sess", "agents", "cto")); err == nil {
+		t.Fatal("worker validation failure must not write external lead launch record")
 	}
 }
 

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -51,6 +51,14 @@ type teamLaunchOptions struct {
 	// source (--seed-from) was supplied so CI / send-keys flows keep working
 	// without a hard error, while nudging the operator to fill in the goal.
 	WarnStubBrief bool
+	// ExternalLeadRole names a profile lead that is already bound to the
+	// caller's current pane. Launch backends skip it and spawn only the
+	// remaining workers. This explicit path lets run start --external-lead
+	// validate previews without writing launch records or starting wake.
+	ExternalLeadRole string
+	// AllowNoMembersAfterExternalLead treats a lead-only run as a successful
+	// bind instead of an error after ExternalLeadRole filters out the lead.
+	AllowNoMembersAfterExternalLead bool
 }
 
 type teamLaunchPane struct {
@@ -205,12 +213,37 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 	if err := validateModelOverrideKeys(opts.ModelOverrides, memberRoles); err != nil {
 		return err
 	}
-	if filtered, skipped, err := maybeFilterCurrentExternalLead(t, opts.Workstream, opts.Profile, trustMode, mergedBinaryArgs, opts.ModelOverrides, !opts.DryRun); err != nil {
+	externalLeadFiltered := false
+	if strings.TrimSpace(opts.ExternalLeadRole) != "" {
+		filtered, skipped, err := filterExplicitExternalLead(t, opts.ExternalLeadRole)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			t = filtered
+			externalLeadFiltered = true
+		}
+	} else if filtered, skipped, err := maybeFilterCurrentExternalLead(t, opts.Workstream, opts.Profile, trustMode, mergedBinaryArgs, opts.ModelOverrides, !opts.DryRun); err != nil {
 		return err
 	} else if skipped {
 		t = filtered
+		externalLeadFiltered = true
 	}
 	if len(t.Members) == 0 {
+		if opts.AllowNoMembersAfterExternalLead && externalLeadFiltered {
+			if !opts.DryRun {
+				if opts.SeedBriefContent != "" {
+					if _, err := writeSeedBriefForProfile(t.Project, opts.Profile, opts.Workstream, opts.SeedBriefContent, opts.SeedBriefForce); err != nil {
+						return err
+					}
+				}
+				if _, _, err := ensureBriefStubForProfile(t.Project, opts.Profile, opts.Workstream); err != nil {
+					return fmt.Errorf("ensure brief: %w", err)
+				}
+			}
+			quietNotice("lead bound; no remaining workers to spawn for session %s.\n", opts.Workstream)
+			return nil
+		}
 		return fmt.Errorf("no team members to launch after external lead filtering")
 	}
 	if opts.Symphony {
@@ -441,6 +474,31 @@ func maybeFilterCurrentExternalLead(t team.Team, workstream, profile, trustMode 
 	rec := externalLeadRecordForLaunch(lead, cwd, handle, root, env, id, profile, trustMode, binaryArgs, modelOverrides)
 	if err := launch.Write(agentDir, rec); err != nil {
 		return t, false, fmt.Errorf("write external lead record: %w", err)
+	}
+	return filterLaunchMember(t, lead.Role, id.PaneID), true, nil
+}
+
+func filterExplicitExternalLead(t team.Team, role string) (team.Team, bool, error) {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		return t, false, nil
+	}
+	if !t.Orchestrated {
+		return t, false, usageErrorf("--external-lead requires an orchestrated team profile")
+	}
+	if configured := strings.TrimSpace(t.Lead); configured != "" && configured != role {
+		return t, false, usageErrorf("--external-lead role %q is not the configured profile lead %q", role, configured)
+	}
+	lead, ok := memberByRole(t, role)
+	if !ok {
+		return t, false, fmt.Errorf("lead role %q is not a team member", role)
+	}
+	id, err := currentPaneIdentity()
+	if err != nil {
+		return t, false, err
+	}
+	if id == nil || strings.TrimSpace(id.PaneID) == "" {
+		return t, false, usageErrorf("--external-lead requires a current tmux pane (TMUX/TMUX_PANE unset)")
 	}
 	return filterLaunchMember(t, lead.Role, id.PaneID), true, nil
 }

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -49,20 +49,23 @@ type fakeBackend struct {
 	mu       sync.Mutex
 	launches []teamLaunchOptions
 	dryRuns  []teamLaunchOptions
+	teams    []team.Team
 }
 
 func (f *fakeBackend) Name() string                          { return "fake" }
 func (f *fakeBackend) Validate(opts teamLaunchOptions) error { return nil }
-func (f *fakeBackend) DryRun(_ team.Team, opts teamLaunchOptions) error {
+func (f *fakeBackend) DryRun(t team.Team, opts teamLaunchOptions) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.dryRuns = append(f.dryRuns, opts)
+	f.teams = append(f.teams, t)
 	return nil
 }
-func (f *fakeBackend) Launch(_ team.Team, opts teamLaunchOptions) error {
+func (f *fakeBackend) Launch(t team.Team, opts teamLaunchOptions) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.launches = append(f.launches, opts)
+	f.teams = append(f.teams, t)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- enable `amq-squad run start --external-lead` to bind the current tmux pane as the configured lead and spawn only remaining workers
- add explicit read-only worker-only preview filtering and lead-only success handling
- document external-lead run start behavior in README/runbook and regenerate README.html

## Tests
- go test ./internal/cli -run 'TestRunStartExternalLead|TestTeamLaunch.*ExternalLead|TestRunStartGoGoal|TestRunStartRejectsBadVisibility'
- go test ./...
- make ci

Closes #340