### PR TITLE
Add runtime control capability abstraction

### DIFF
--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -777,6 +777,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle string) error {
 			Target:     "external",
 		},
 	}
+	rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 	if err := launch.Write(agentDir, rec); err != nil {
 		return fmt.Errorf("write external orchestrator launch record: %w", err)
 	}

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -575,6 +575,9 @@ func TestGoalDeliverRegistersExternalOrchestrator(t *testing.T) {
 	if !rec.External || rec.Role != goalOrchestratorRole || rec.Handle != "global-orch" || rec.WakePID != 9876 || rec.Tmux == nil || rec.Tmux.PaneID != "%99" {
 		t.Fatalf("orchestrator launch record = %+v", rec)
 	}
+	if rec.Terminal == nil || rec.Terminal.Backend != "tmux" || rec.Terminal.PaneID != "%99" || rec.Terminal.Target != "external" {
+		t.Fatalf("orchestrator launch terminal identity = %+v", rec.Terminal)
+	}
 }
 
 type orchestratorRegStubs struct {
@@ -670,6 +673,9 @@ func TestGoalStartRegisterOrchestratorProducesWakeableIdentity(t *testing.T) {
 	}
 	if !rec.External || rec.Role != goalOrchestratorRole || rec.WakePID != 9876 || rec.Tmux == nil || rec.Tmux.PaneID != "%99" {
 		t.Fatalf("orchestrator launch record = %+v", rec)
+	}
+	if rec.Terminal == nil || rec.Terminal.Backend != "tmux" || rec.Terminal.PaneID != "%99" || rec.Terminal.Target != "external" {
+		t.Fatalf("orchestrator launch terminal identity = %+v", rec.Terminal)
 	}
 	if len(*stubs.wakeOpts) != 1 || (*stubs.wakeOpts)[0].Handle != "global-orch" || !(*stubs.wakeOpts)[0].Require {
 		t.Fatalf("wake opts = %+v", *stubs.wakeOpts)

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -336,6 +336,7 @@ Examples:
 			PaneID:     id.PaneID,
 			Target:     target,
 		}
+		rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 	}
 	// Keep generated bootstrap out of launch.json so restore stays compact
 	// and does not replay stale startup text.

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -29,6 +29,19 @@ type tmuxRuntimeJSON struct {
 	PaneAlive bool `json:"pane_alive"`
 }
 
+// terminalRuntimeJSON is the additive backend-neutral runtime identity block.
+// For tmux-backed launches it mirrors tmuxRuntimeJSON so consumers can start
+// selecting a controller by backend without losing the legacy tmux contract.
+type terminalRuntimeJSON struct {
+	Backend    string `json:"backend,omitempty"`
+	Session    string `json:"session,omitempty"`
+	WindowID   string `json:"window_id,omitempty"`
+	WindowName string `json:"window_name,omitempty"`
+	PaneID     string `json:"pane_id,omitempty"`
+	Target     string `json:"target,omitempty"`
+	PaneAlive  bool   `json:"pane_alive"`
+}
+
 // tmuxRuntimeFromInfo converts a persisted launch.TmuxInfo into the JSON block,
 // leaving PaneAlive false for the caller to fill from a live-pane set. Returns
 // nil when there is no tmux identity.
@@ -48,6 +61,45 @@ func tmuxRuntimeFromInfo(info *launch.TmuxInfo) *tmuxRuntimeJSON {
 		WindowName: info.WindowName,
 		PaneID:     info.PaneID,
 		Target:     info.Target,
+	}
+}
+
+func terminalRuntimeFromInfo(info *launch.TerminalInfo) *terminalRuntimeJSON {
+	if info == nil {
+		return nil
+	}
+	if info.Backend == "" && info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.Target == "" {
+		return nil
+	}
+	return &terminalRuntimeJSON{
+		Backend:    info.Backend,
+		Session:    info.Session,
+		WindowID:   info.WindowID,
+		WindowName: info.WindowName,
+		PaneID:     info.PaneID,
+		Target:     info.Target,
+	}
+}
+
+func terminalRuntimeFromTmuxInfo(info *launch.TmuxInfo) *terminalRuntimeJSON {
+	return terminalRuntimeFromInfo(launch.TerminalInfoFromTmux(info))
+}
+
+func syncTerminalRuntimeFromTmux(row *statusRecord) {
+	if row == nil || row.Tmux == nil {
+		return
+	}
+	if row.Terminal == nil {
+		row.Terminal = terminalRuntimeFromTmuxInfo(&launch.TmuxInfo{
+			Session:    row.Tmux.Session,
+			WindowID:   row.Tmux.WindowID,
+			WindowName: row.Tmux.WindowName,
+			PaneID:     row.Tmux.PaneID,
+			Target:     row.Tmux.Target,
+		})
+	}
+	if row.Terminal != nil && row.Terminal.Backend == "tmux" {
+		row.Terminal.PaneAlive = row.Tmux.PaneAlive
 	}
 }
 

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -41,6 +41,39 @@ func TestTmuxRuntimeFromEmptyInfoIsNil(t *testing.T) {
 	}
 }
 
+func TestTerminalRuntimeMirrorsTmuxIdentity(t *testing.T) {
+	term := terminalRuntimeFromTmuxInfo(&launch.TmuxInfo{
+		Session:    "main",
+		WindowID:   "@1",
+		WindowName: "lead",
+		PaneID:     "%5",
+		Target:     "external",
+	})
+	if term == nil {
+		t.Fatalf("terminal runtime should be present")
+	}
+	if term.Backend != "tmux" || term.Session != "main" || term.WindowID != "@1" || term.WindowName != "lead" || term.PaneID != "%5" || term.Target != "external" {
+		t.Fatalf("terminal runtime = %+v", term)
+	}
+}
+
+func TestSyncTerminalRuntimeFromTmuxUsesSamePaneAlive(t *testing.T) {
+	row := statusRecord{Tmux: &tmuxRuntimeJSON{Session: "main", PaneID: "%5", PaneAlive: true}}
+	syncTerminalRuntimeFromTmux(&row)
+	if row.Terminal == nil {
+		t.Fatalf("terminal should be derived from tmux")
+	}
+	if row.Terminal.Backend != "tmux" || row.Terminal.PaneID != "%5" || !row.Terminal.PaneAlive {
+		t.Fatalf("terminal runtime = %+v", row.Terminal)
+	}
+
+	row.Tmux.PaneAlive = false
+	syncTerminalRuntimeFromTmux(&row)
+	if row.Terminal.PaneAlive {
+		t.Fatalf("terminal pane_alive must follow tmux pane_alive: %+v", row.Terminal)
+	}
+}
+
 func TestMemoizePaneListerCallsUnderlyingOnce(t *testing.T) {
 	calls := 0
 	memo := memoizePaneLister(func() ([]tmuxpane.TmuxPane, error) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -156,6 +156,9 @@ type statusRecord struct {
 	// a computed pane_alive, so clients can target follow-up control. Omitted
 	// when the agent's launch record carried no tmux identity.
 	Tmux *tmuxRuntimeJSON `json:"tmux,omitempty"`
+	// Terminal is the additive backend-neutral runtime identity. For current
+	// tmux launches it mirrors Tmux and carries the same computed pane_alive.
+	Terminal *terminalRuntimeJSON `json:"terminal,omitempty"`
 	// Visibility fields distinguish "agent process is live" from "this member
 	// is the operator-visible project lead". operator_visible is fail-closed:
 	// it is true only when persisted launch-origin evidence proves visibility.
@@ -1214,6 +1217,7 @@ func buildStatusRows(t team.Team, profile, workstream string, probe duplicateLau
 			if panes, perr := statusPaneLister(); perr == nil {
 				if adopted := adoptLivePane(rows[i].Role, rows[i].Handle, rows[i].Binary, rows[i].CWD, workstream, rows[i].Signals.AgentPID, panes, pidTree); adopted != nil {
 					rows[i].Tmux = tmuxRuntimeFromInfo(adopted)
+					rows[i].Terminal = terminalRuntimeFromTmuxInfo(adopted)
 				}
 			}
 		}
@@ -1227,6 +1231,7 @@ func buildStatusRows(t team.Team, profile, workstream string, probe duplicateLau
 			fillPaneAliveFromLiveness(rows[i].Tmux, livePanes, &agentLiveness{Signals: rows[i].Signals})
 			rows[i].AgentPaneID = strings.TrimSpace(rows[i].Tmux.PaneID)
 			rows[i].ManagedTarget = strings.TrimSpace(rows[i].Tmux.Target)
+			syncTerminalRuntimeFromTmux(&rows[i])
 		}
 	}
 	attachStatusActivities(t.Project, profile, workstream, rows, probe.Now())
@@ -1481,6 +1486,7 @@ func classifyMemberStatus(t team.Team, profile string, m team.Member, workstream
 	live := classifyAgentLiveness(rec.AgentDir, root, profile, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe)
 	rec.Tmux = tmuxRuntimeFromInfo(live.Tmux)
 	if live.LaunchFound {
+		rec.Terminal = terminalRuntimeFromInfo(live.LaunchRecord.Terminal)
 		rec.goalBinding = live.LaunchRecord.GoalBinding
 		rec.External = live.LaunchRecord.External
 		rec.WakeAutoDrain = strings.TrimSpace(live.LaunchRecord.WakeInjectCmd) != ""

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -547,6 +547,7 @@ func externalLeadRecordForLaunch(m team.Member, cwd, handle, root string, env am
 			Target:     "external",
 		},
 	}
+	rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 	extra := append(binaryArgsFor(m.Binary, binaryArgs), m.ExtraArgs()...)
 	switch normalizedAgentBinary(m.Binary) {
 	case "codex":

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -365,6 +365,7 @@ func runLeadRegister(args []string) error {
 			Target:     "external",
 		},
 	}
+	rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 	if preserveExternalGoalBinding(existingRec, existingRecErr, role, env.SessionName) {
 		gb := *existingRec.GoalBinding
 		rec.GoalBinding = &gb

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -769,6 +769,7 @@ func adoptResumeExecLaunchRecords(results []resumeExecLaunchResult) bool {
 			PaneID:     pane.PaneID,
 			Target:     "adopted",
 		}
+		rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 		if err := launch.Write(r.Check.AgentDir, rec); err == nil {
 			adopted = true
 		}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -118,6 +118,11 @@ type Record struct {
 	// tmux metadata could not be resolved). Clients detect runtime-control
 	// availability by the presence of this object, not by Schema.
 	Tmux *TmuxInfo `json:"tmux,omitempty"`
+	// Terminal is the additive backend-neutral runtime identity captured at
+	// launch time. It mirrors Tmux for tmux-backed launches so newer control
+	// planes can select a controller by backend while legacy clients keep using
+	// the stable tmux block.
+	Terminal *TerminalInfo `json:"terminal,omitempty"`
 }
 
 // GoalBinding is launch-time evidence for a visible lead's goal binding.
@@ -143,6 +148,38 @@ type TmuxInfo struct {
 	// environment: "current-window", "new-window", or "new-session". Empty
 	// when not known to the launcher.
 	Target string `json:"target,omitempty"`
+}
+
+// TerminalInfo is the backend-neutral runtime identity for terminal control.
+// For tmux-backed launches it intentionally duplicates the existing tmux ids
+// instead of nesting TmuxInfo, keeping the JSON shape simple for clients that
+// select behavior by backend first.
+type TerminalInfo struct {
+	Backend    string `json:"backend,omitempty"`
+	Session    string `json:"session,omitempty"`
+	WindowID   string `json:"window_id,omitempty"`
+	WindowName string `json:"window_name,omitempty"`
+	PaneID     string `json:"pane_id,omitempty"`
+	Target     string `json:"target,omitempty"`
+}
+
+// TerminalInfoFromTmux maps the legacy tmux identity into the additive generic
+// terminal identity. Empty tmux records carry no useful control target.
+func TerminalInfoFromTmux(info *TmuxInfo) *TerminalInfo {
+	if info == nil {
+		return nil
+	}
+	if info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.Target == "" {
+		return nil
+	}
+	return &TerminalInfo{
+		Backend:    "tmux",
+		Session:    info.Session,
+		WindowID:   info.WindowID,
+		WindowName: info.WindowName,
+		PaneID:     info.PaneID,
+		Target:     info.Target,
+	}
 }
 
 // Entry is a launch record plus the mailbox directory it was discovered in.

--- a/internal/launch/record_terminal_test.go
+++ b/internal/launch/record_terminal_test.go
@@ -1,0 +1,28 @@
+package launch
+
+import "testing"
+
+func TestTerminalInfoFromTmux(t *testing.T) {
+	got := TerminalInfoFromTmux(&TmuxInfo{
+		Session:    "main",
+		WindowID:   "@1",
+		WindowName: "lead",
+		PaneID:     "%5",
+		Target:     "external",
+	})
+	if got == nil {
+		t.Fatalf("terminal info should be present")
+	}
+	if got.Backend != "tmux" || got.Session != "main" || got.WindowID != "@1" || got.WindowName != "lead" || got.PaneID != "%5" || got.Target != "external" {
+		t.Fatalf("terminal info = %+v", got)
+	}
+}
+
+func TestTerminalInfoFromEmptyTmuxIsNil(t *testing.T) {
+	if got := TerminalInfoFromTmux(&TmuxInfo{}); got != nil {
+		t.Fatalf("empty tmux identity should map to nil, got %+v", got)
+	}
+	if got := TerminalInfoFromTmux(nil); got != nil {
+		t.Fatalf("nil tmux identity should map to nil, got %+v", got)
+	}
+}

--- a/internal/runtimeaction/actions.go
+++ b/internal/runtimeaction/actions.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 )
 
 type Action struct {
@@ -66,18 +67,22 @@ func SyncUnavailableReason(a *Action) {
 }
 
 func Member(projectDir, profile, session, role string, paneAlive bool) []Action {
+	return MemberForCapabilities(projectDir, profile, session, role, runtimecontrol.TmuxCapabilities(paneAlive))
+}
+
+func MemberForCapabilities(projectDir, profile, session, role string, caps runtimecontrol.Capabilities) []Action {
 	scope := commandScope(projectDir, profile, session)
 	namespaceID := squadnamespace.ID(profile, session)
 	roleArg := " --role " + ShellQuote(role)
-	deadReason := ""
-	if !paneAlive {
-		deadReason = "agent pane is not live"
-	}
+	focus := caps.State(runtimecontrol.CapabilityFocus)
+	send := caps.State(runtimecontrol.CapabilitySendPrompt)
+	goal := caps.State(runtimecontrol.CapabilityGoalDeliver)
+	dispatch := caps.State(runtimecontrol.CapabilityDispatch)
 	return ApplyCanonical([]Action{
-		{Kind: "focus", Label: "focus pane", Scope: "agent", NamespaceID: namespaceID, Mutates: false, NeedsConfirmation: false, Available: paneAlive, Reason: deadReason, Command: "amq-squad focus" + scope + roleArg},
-		{Kind: "send", Label: "send a prompt", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: paneAlive, Reason: deadReason, Command: "amq-squad send" + scope + roleArg + " --body-file -"},
-		{Kind: "goal_deliver", Label: "deliver native /goal", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: paneAlive, Reason: deadReason, Command: "amq-squad goal deliver" + scope + roleArg + " --goal <goal>"},
-		{Kind: "dispatch", Label: "dispatch task", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: true, Command: "amq-squad dispatch" + scope + roleArg + " --subject <subject> --body-file <file>"},
+		{Kind: "focus", Label: "focus pane", Scope: "agent", NamespaceID: namespaceID, Mutates: false, NeedsConfirmation: false, Available: focus.Available, Reason: focus.Reason, Command: "amq-squad focus" + scope + roleArg},
+		{Kind: "send", Label: "send a prompt", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: send.Available, Reason: send.Reason, Command: "amq-squad send" + scope + roleArg + " --body-file -"},
+		{Kind: "goal_deliver", Label: "deliver native /goal", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: goal.Available, Reason: goal.Reason, Command: "amq-squad goal deliver" + scope + roleArg + " --goal <goal>"},
+		{Kind: "dispatch", Label: "dispatch task", Scope: "agent", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: dispatch.Available, Reason: dispatch.Reason, Command: "amq-squad dispatch" + scope + roleArg + " --subject <subject> --body-file <file>"},
 		{Kind: "resume", Label: "resume session", Scope: "session", NamespaceID: namespaceID, Mutates: true, NeedsConfirmation: true, Available: true, Command: "amq-squad resume" + scope + " --exec"},
 		{Kind: "status", Label: "show session status", Scope: "session", NamespaceID: namespaceID, Mutates: false, NeedsConfirmation: false, Available: true, Command: "amq-squad status" + scope + " --json"},
 		{Kind: "task_list", Label: "list tasks", Scope: "session", NamespaceID: namespaceID, Mutates: false, NeedsConfirmation: false, Available: true, Command: "amq-squad task list" + scope},

--- a/internal/runtimeaction/actions_test.go
+++ b/internal/runtimeaction/actions_test.go
@@ -1,0 +1,57 @@
+package runtimeaction
+
+import (
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
+)
+
+func TestMemberForCapabilitiesDegradesFakeControllerActions(t *testing.T) {
+	caps := runtimecontrol.TmuxCapabilities(true).
+		With(runtimecontrol.CapabilitySendPrompt, false, "fake controller cannot send prompts").
+		With(runtimecontrol.CapabilityGoalDeliver, false, "fake controller cannot deliver goals").
+		With(runtimecontrol.CapabilityDispatch, false, "fake controller cannot dispatch")
+
+	actions := MemberForCapabilities("/repo", "default", "issue-331", "dev", caps)
+	byKind := map[string]Action{}
+	for _, action := range actions {
+		byKind[action.Kind] = action
+	}
+
+	if !byKind["focus"].Available {
+		t.Fatalf("focus should remain available when the fake controller supports it")
+	}
+	for _, tc := range []struct {
+		kind   string
+		reason string
+	}{
+		{"send", "fake controller cannot send prompts"},
+		{"goal_deliver", "fake controller cannot deliver goals"},
+		{"dispatch", "fake controller cannot dispatch"},
+	} {
+		action := byKind[tc.kind]
+		if action.Available || action.Reason != tc.reason || action.UnavailableReason != tc.reason {
+			t.Fatalf("%s action = %+v, want unavailable reason %q", tc.kind, action, tc.reason)
+		}
+	}
+	if !byKind["status"].Available || !byKind["resume"].Available || !byKind["task_list"].Available {
+		t.Fatalf("session actions should stay available under degraded member capabilities: %+v", actions)
+	}
+}
+
+func TestMemberKeepsTmuxDeadPaneCompatibility(t *testing.T) {
+	actions := Member("/repo", "default", "issue-331", "dev", false)
+	byKind := map[string]Action{}
+	for _, action := range actions {
+		byKind[action.Kind] = action
+	}
+
+	for _, kind := range []string{"focus", "send", "goal_deliver"} {
+		if byKind[kind].Available || byKind[kind].Reason != "agent pane is not live" {
+			t.Fatalf("%s action = %+v, want existing dead-pane behavior", kind, byKind[kind])
+		}
+	}
+	if !byKind["dispatch"].Available {
+		t.Fatalf("dispatch must remain available for dead tmux panes")
+	}
+}

--- a/internal/runtimecontrol/capabilities.go
+++ b/internal/runtimecontrol/capabilities.go
@@ -1,0 +1,62 @@
+package runtimecontrol
+
+const (
+	BackendTmux = "tmux"
+)
+
+type Capability string
+
+const (
+	CapabilityFocus       Capability = "focus"
+	CapabilitySendPrompt  Capability = "send_prompt"
+	CapabilityGoalDeliver Capability = "goal_deliver"
+	CapabilityDispatch    Capability = "dispatch"
+)
+
+type CapabilityState struct {
+	Available bool
+	Reason    string
+}
+
+type Capabilities struct {
+	states map[Capability]CapabilityState
+}
+
+func NewCapabilities(states map[Capability]CapabilityState) Capabilities {
+	out := Capabilities{states: make(map[Capability]CapabilityState, len(states))}
+	for cap, state := range states {
+		out.states[cap] = state
+	}
+	return out
+}
+
+func (c Capabilities) State(cap Capability) CapabilityState {
+	if c.states != nil {
+		if state, ok := c.states[cap]; ok {
+			return state
+		}
+	}
+	return CapabilityState{Available: false, Reason: "runtime capability unavailable"}
+}
+
+func (c Capabilities) With(cap Capability, available bool, reason string) Capabilities {
+	states := make(map[Capability]CapabilityState, len(c.states)+1)
+	for k, v := range c.states {
+		states[k] = v
+	}
+	states[cap] = CapabilityState{Available: available, Reason: reason}
+	return Capabilities{states: states}
+}
+
+func TmuxCapabilities(paneAlive bool) Capabilities {
+	deadReason := ""
+	if !paneAlive {
+		deadReason = "agent pane is not live"
+	}
+	return NewCapabilities(map[Capability]CapabilityState{
+		CapabilityFocus:       {Available: paneAlive, Reason: deadReason},
+		CapabilitySendPrompt:  {Available: paneAlive, Reason: deadReason},
+		CapabilityGoalDeliver: {Available: paneAlive, Reason: deadReason},
+		CapabilityDispatch:    {Available: true},
+	})
+}

--- a/internal/runtimecontrol/capabilities_test.go
+++ b/internal/runtimecontrol/capabilities_test.go
@@ -1,0 +1,39 @@
+package runtimecontrol
+
+import "testing"
+
+func TestTmuxControllerCapabilities(t *testing.T) {
+	ctrl := TmuxController{}
+	if ctrl.Backend() != BackendTmux {
+		t.Fatalf("backend = %q, want %q", ctrl.Backend(), BackendTmux)
+	}
+
+	live := ctrl.Capabilities(Identity{Backend: BackendTmux, PaneID: "%1"}, Liveness{PaneAlive: true})
+	if !live.State(CapabilityFocus).Available || !live.State(CapabilitySendPrompt).Available || !live.State(CapabilityGoalDeliver).Available {
+		t.Fatalf("live tmux capabilities should allow pane-scoped controls")
+	}
+	if !live.State(CapabilityDispatch).Available {
+		t.Fatalf("tmux dispatch should remain available independent of pane liveness")
+	}
+
+	dead := ctrl.Capabilities(Identity{Backend: BackendTmux, PaneID: "%1"}, Liveness{PaneAlive: false})
+	for _, cap := range []Capability{CapabilityFocus, CapabilitySendPrompt, CapabilityGoalDeliver} {
+		state := dead.State(cap)
+		if state.Available || state.Reason != "agent pane is not live" {
+			t.Fatalf("%s dead-pane state = %+v", cap, state)
+		}
+	}
+	if !dead.State(CapabilityDispatch).Available {
+		t.Fatalf("tmux dispatch must stay available for dead panes to preserve existing behavior")
+	}
+}
+
+func TestDefaultRegistryIncludesTmuxController(t *testing.T) {
+	ctrl, ok := DefaultRegistry().Lookup(BackendTmux)
+	if !ok {
+		t.Fatalf("default registry missing tmux controller")
+	}
+	if ctrl.Backend() != BackendTmux {
+		t.Fatalf("lookup backend = %q", ctrl.Backend())
+	}
+}

--- a/internal/runtimecontrol/capabilities_test.go
+++ b/internal/runtimecontrol/capabilities_test.go
@@ -37,3 +37,15 @@ func TestDefaultRegistryIncludesTmuxController(t *testing.T) {
 		t.Fatalf("lookup backend = %q", ctrl.Backend())
 	}
 }
+
+func TestZeroValueRegistryCanRegister(t *testing.T) {
+	var r Registry
+	r.Register(TmuxController{})
+	ctrl, ok := r.Lookup(BackendTmux)
+	if !ok {
+		t.Fatalf("zero-value registry should accept registrations")
+	}
+	if ctrl.Backend() != BackendTmux {
+		t.Fatalf("lookup backend = %q", ctrl.Backend())
+	}
+}

--- a/internal/runtimecontrol/controller.go
+++ b/internal/runtimecontrol/controller.go
@@ -1,0 +1,66 @@
+package runtimecontrol
+
+import "strings"
+
+type Identity struct {
+	Backend    string
+	Session    string
+	WindowID   string
+	WindowName string
+	PaneID     string
+	Target     string
+}
+
+type Liveness struct {
+	PaneAlive bool
+}
+
+type Controller interface {
+	Backend() string
+	Capabilities(Identity, Liveness) Capabilities
+}
+
+type TmuxController struct{}
+
+func (TmuxController) Backend() string {
+	return BackendTmux
+}
+
+func (TmuxController) Capabilities(_ Identity, live Liveness) Capabilities {
+	return TmuxCapabilities(live.PaneAlive)
+}
+
+type Registry struct {
+	controllers map[string]Controller
+}
+
+func NewRegistry(controllers ...Controller) *Registry {
+	r := &Registry{controllers: map[string]Controller{}}
+	for _, c := range controllers {
+		r.Register(c)
+	}
+	return r
+}
+
+func (r *Registry) Register(c Controller) {
+	if r == nil || c == nil {
+		return
+	}
+	backend := strings.TrimSpace(c.Backend())
+	if backend == "" {
+		return
+	}
+	r.controllers[backend] = c
+}
+
+func (r *Registry) Lookup(backend string) (Controller, bool) {
+	if r == nil {
+		return nil, false
+	}
+	c, ok := r.controllers[strings.TrimSpace(backend)]
+	return c, ok
+}
+
+func DefaultRegistry() *Registry {
+	return NewRegistry(TmuxController{})
+}

--- a/internal/runtimecontrol/controller.go
+++ b/internal/runtimecontrol/controller.go
@@ -50,6 +50,9 @@ func (r *Registry) Register(c Controller) {
 	if backend == "" {
 		return
 	}
+	if r.controllers == nil {
+		r.controllers = map[string]Controller{}
+	}
 	r.controllers[backend] = c
 }
 


### PR DESCRIPTION
## Summary

- add `internal/runtimecontrol` with controller registry, tmux controller adapter, and capability states
- make member action availability consume runtime capabilities while preserving the existing tmux `paneAlive` wrapper behavior
- add additive launch/status `terminal` identity that mirrors existing tmux identity and pane liveness for tmux-backed launches

## Compatibility

- existing `tmux` status JSON remains in place and continues to drive pane liveness
- tmux dead-pane behavior is preserved: focus/send/goal_deliver unavailable, dispatch/status/resume/task_list available
- fake/degraded runtime capabilities can disable individual actions with stable unavailable reasons

## Validation

- `go test ./internal/runtimecontrol ./internal/runtimeaction ./internal/launch ./internal/cli`
- `go test ./...`
- `make ci`

Closes #331
