### PR TITLE
Add iTerm2 Tier B launch backend

### DIFF
--- a/README.html
+++ b/README.html
@@ -1814,6 +1814,14 @@ orchestrators and NOC tooling. Initial stable mutator envelopes include
 <code>--json</code> is not passed. This is the user-facing closure for
 #222.</p>
 <h2 id="runtime-control-tmux">Runtime control (tmux)</h2>
+<p>The experimental iTerm2 launch backend is available on macOS with
+<code>--terminal iterm2 --target new-window</code>. It records
+backend-neutral terminal identity and supports window focus by recorded
+iTerm2 window id. Prompt injection, capture, busy detection, goal
+delivery, and pane-nudge dispatch stay disabled for iTerm2 until #374
+proves safe behavior; durable AMQ dispatch still queues normally. Manual
+smoke steps live in <a
+href="docs/iterm2-tier-b-smoke.md"><code>docs/iterm2-tier-b-smoke.md</code></a>.</p>
 <p>amq-squad owns the tmux execution/control contract for a team so
 external clients (such as amq-noc) can make agents actionable without
 scraping tmux or reconstructing pane layouts themselves.</p>

--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,13 @@ when `--json` is not passed. This is the user-facing closure for #222.
 
 ## Runtime control (tmux)
 
+The experimental iTerm2 launch backend is available on macOS with
+`--terminal iterm2 --target new-window`. It records backend-neutral terminal
+identity and supports window focus by recorded iTerm2 window id. Prompt
+injection, capture, busy detection, goal delivery, and pane-nudge dispatch stay
+disabled for iTerm2 until #374 proves safe behavior; durable AMQ dispatch still
+queues normally. Manual smoke steps live in [`docs/iterm2-tier-b-smoke.md`](docs/iterm2-tier-b-smoke.md).
+
 amq-squad owns the tmux execution/control contract for a team so external
 clients (such as amq-noc) can make agents actionable without scraping tmux or
 reconstructing pane layouts themselves.

--- a/docs/iterm2-tier-b-smoke.md
+++ b/docs/iterm2-tier-b-smoke.md
@@ -1,0 +1,53 @@
+# iTerm2 Tier B Manual Smoke Checklist
+
+This checklist covers the Tier B iTerm2 backend added for `--terminal iterm2`.
+CI verifies only the emitted AppleScript argv shape; this flow needs a macOS
+desktop with iTerm2 installed.
+
+1. From a project with a configured team, start a fresh workstream:
+
+   ```sh
+   amq-squad up --session iterm2-smoke --terminal iterm2 --target new-window --no-bootstrap
+   ```
+
+2. Confirm iTerm2 opens one visible window per launched agent.
+
+3. Confirm each agent's `launch.json` has a `terminal` block with
+   `backend: "iterm2"`, `target: "new-window"`, a non-empty `window_id`, and no
+   `tmux` block unless the agent was itself launched inside tmux.
+
+4. Run status and inspect the runtime actions:
+
+   ```sh
+   amq-squad status --session iterm2-smoke --json
+   ```
+
+   Expected:
+
+   - `records[].terminal.backend` is `iterm2`.
+   - `records[].terminal.pid_alive` is true for live agent processes.
+   - `records[].terminal.tab_id` and `records[].terminal.session_id` are present
+     when iTerm2 exposes those AppleScript ids; an empty value is a recorded
+     iTerm2 metadata gap, not tmux identity.
+   - `focus` is available when `window_id` is present and the agent PID/binary
+     verifies live. A closed iTerm2 window can still fail at focus time; the
+     command should report that the recorded window could not be raised.
+   - `send` and `goal_deliver` are unavailable with the #374 safety reason.
+   - `dispatch` is available because durable AMQ dispatch does not require pane
+     injection; the optional pane nudge is skipped for iTerm2 with the #374
+     safety reason.
+
+5. Focus a role:
+
+   ```sh
+   amq-squad focus --session iterm2-smoke --role <role>
+   ```
+
+   Expected: the matching iTerm2 window is raised. Closing that window first
+   should make the command fail clearly instead of targeting another terminal.
+
+6. Stop the smoke session:
+
+   ```sh
+   amq-squad stop --session iterm2-smoke --all
+   ```

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	taskstore "github.com/omriariav/amq-squad/v2/internal/task"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -685,6 +686,9 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 	mr, workstream, err := resolveMemberRuntime(projectDir, profile, session, explicitSession, role)
 	if err != nil {
 		return dispatchOutcome{}, err
+	}
+	if mr.isITerm2Runtime() {
+		return dispatchOutcome{Skipped: runtimecontrol.ITerm2InjectionDisabledReason + "; durable AMQ dispatch was queued"}, nil
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -880,6 +881,9 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 	mr, resolvedWorkstream, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
 	if err != nil {
 		return mutationResult{}, err
+	}
+	if mr.isITerm2Runtime() {
+		return mutationResult{}, fmt.Errorf("%s", runtimecontrol.ITerm2InjectionDisabledReason)
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -30,6 +30,16 @@ const envTmuxTarget = "AMQ_SQUAD_TMUX_TARGET"
 // from TMUX_PANE. Status uses it to detect same-pane lead collapse.
 const envTmuxLauncherPane = "AMQ_SQUAD_TMUX_LAUNCHER_PANE"
 
+const (
+	envTerminalBackend    = "AMQ_SQUAD_TERMINAL_BACKEND"
+	envTerminalSession    = "AMQ_SQUAD_TERMINAL_SESSION"
+	envTerminalWindowID   = "AMQ_SQUAD_TERMINAL_WINDOW_ID"
+	envTerminalWindowName = "AMQ_SQUAD_TERMINAL_WINDOW_NAME"
+	envTerminalTabID      = "AMQ_SQUAD_TERMINAL_TAB_ID"
+	envTerminalSessionID  = "AMQ_SQUAD_TERMINAL_SESSION_ID"
+	envTerminalTarget     = "AMQ_SQUAD_TERMINAL_TARGET"
+)
+
 var launchStdinIsTerminal = stdinIsTerminal
 
 type symphonyInitConfig struct {
@@ -338,6 +348,12 @@ Examples:
 		}
 		rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
 	}
+	if rec.Terminal == nil {
+		rec.Terminal = terminalInfoFromEnv()
+		if rec.Terminal != nil {
+			rec.AdoptionMode = launchAdoptionMode(rec.Terminal.Target, "", "")
+		}
+	}
 	// Keep generated bootstrap out of launch.json so restore stays compact
 	// and does not replay stale startup text.
 	effectiveChildArgs := append([]string(nil), childArgs...)
@@ -491,6 +507,22 @@ Examples:
 	// stale AM_ROOT/AM_ME from the launching shell along to the agent would
 	// re-create the identity-leak asymmetry #46 closed for env resolution.
 	return syscall.Exec(amqBin, append([]string{"amq"}, coopArgs...), envWithoutAMQIdentity(os.Environ()))
+}
+
+func terminalInfoFromEnv() *launch.TerminalInfo {
+	info := &launch.TerminalInfo{
+		Backend:    strings.TrimSpace(os.Getenv(envTerminalBackend)),
+		Session:    strings.TrimSpace(os.Getenv(envTerminalSession)),
+		WindowID:   strings.TrimSpace(os.Getenv(envTerminalWindowID)),
+		WindowName: strings.TrimSpace(os.Getenv(envTerminalWindowName)),
+		TabID:      strings.TrimSpace(os.Getenv(envTerminalTabID)),
+		SessionID:  strings.TrimSpace(os.Getenv(envTerminalSessionID)),
+		Target:     strings.TrimSpace(os.Getenv(envTerminalTarget)),
+	}
+	if info.Backend == "" && info.Session == "" && info.WindowID == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.Target == "" {
+		return nil
+	}
+	return info
 }
 
 func validateManagedTmuxLaunch(rec launch.Record) error {

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -102,6 +103,17 @@ func (mr memberRuntime) recordedPaneID() string {
 		return strings.TrimSpace(mr.Record.Tmux.PaneID)
 	}
 	return ""
+}
+
+func (mr memberRuntime) recordedTerminalBackend() string {
+	if mr.HasRecord && mr.Record.Terminal != nil {
+		return strings.TrimSpace(mr.Record.Terminal.Backend)
+	}
+	return ""
+}
+
+func (mr memberRuntime) isITerm2Runtime() bool {
+	return mr.recordedTerminalBackend() == runtimecontrol.BackendITerm2
 }
 
 // resolveControlTarget picks the tmux pane to act on for a member: the exact
@@ -314,19 +326,31 @@ func focusTarget(projectDir, profile, session string, explicitSession bool, expl
 			return err
 		}
 	}
-	panes, err := statusPaneLister()
-	if err != nil {
-		if tmuxpane.IsPermissionDenied(err) {
-			// The tmux socket itself is unreachable because access was denied
-			// (a sandboxed agent). That is NOT "pane gone" — surface the real
-			// cause and how to fix it, instead of the misleading "no live pane".
-			return errTmuxAccessDenied()
+	var (
+		panes       []tmuxpane.TmuxPane
+		panesLoaded bool
+	)
+	loadPanes := func() error {
+		if panesLoaded {
+			return nil
 		}
-		// The global `tmux list-panes -a` scan can fail wholesale under iTerm2
-		// tmux -CC control mode even when a recorded pane is still directly
-		// addressable. Degrade to no scan results and let resolveControlTarget
-		// address the recorded pane id directly rather than aborting the op.
-		panes = nil
+		panesLoaded = true
+		var err error
+		panes, err = statusPaneLister()
+		if err != nil {
+			if tmuxpane.IsPermissionDenied(err) {
+				// The tmux socket itself is unreachable because access was denied
+				// (a sandboxed agent). That is NOT "pane gone" — surface the real
+				// cause and how to fix it, instead of the misleading "no live pane".
+				return errTmuxAccessDenied()
+			}
+			// The global `tmux list-panes -a` scan can fail wholesale under iTerm2
+			// tmux -CC control mode even when a recorded pane is still directly
+			// addressable. Degrade to no scan results and let resolveControlTarget
+			// address the recorded pane id directly rather than aborting the op.
+			panes = nil
+		}
+		return nil
 	}
 	roles := []string{role}
 	if strings.TrimSpace(role) == "" {
@@ -349,6 +373,15 @@ func focusTarget(projectDir, profile, session string, explicitSession bool, expl
 			continue
 		}
 		if err := ensureNoNamespaceConflict("focus", projectDir, profile, workstream, explicitProfile); err != nil {
+			return err
+		}
+		if mr.isITerm2Runtime() {
+			if err := focusITerm2Window(mr.Record.Terminal.WindowID); err != nil {
+				return err
+			}
+			return nil
+		}
+		if err := loadPanes(); err != nil {
 			return err
 		}
 		if _, target, ok := resolveControlTarget(mr, workstream, panes); ok {
@@ -434,6 +467,9 @@ Examples:
 		Reason:  *overrideNamespaceReason,
 	}); err != nil {
 		return err
+	}
+	if mr.isITerm2Runtime() {
+		return fmt.Errorf("%s", runtimecontrol.ITerm2InjectionDisabledReason)
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
@@ -360,6 +361,137 @@ func TestResolveControlTargetRefusesForeignProfileRecord(t *testing.T) {
 	panes := []tmuxpane.TmuxPane{{PaneID: "%5", CWD: dir, Command: "codex", Title: "amq:main:cto"}}
 	if paneID, _, ok := resolveControlTarget(mr, workstream, panes); ok || paneID != "" {
 		t.Fatalf("foreign-profile record must not fall back to fuzzy pane resolution, got ok=%v pane=%q", ok, paneID)
+	}
+}
+
+func TestFocusITerm2DoesNotRequireTmuxPaneList(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := t.TempDir()
+	seedProfile(t, dir, team.DefaultProfile, team.Team{
+		Project: dir,
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"}},
+	})
+	seedAgentRecord(t, base, "main", "cto", launch.Record{
+		CWD:         dir,
+		Binary:      "codex",
+		Handle:      "cto",
+		Role:        "cto",
+		Session:     "main",
+		TeamProfile: team.DefaultProfile,
+		Terminal: &launch.TerminalInfo{
+			Backend:  "iterm2",
+			Session:  "main",
+			WindowID: "101",
+			Target:   "new-window",
+		},
+	})
+
+	prevLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		t.Fatal("iTerm2 focus should not list tmux panes")
+		return nil, nil
+	}
+	prevOutput := iterm2OutputCommand
+	called := false
+	iterm2OutputCommand = func(name string, args ...string) (string, error) {
+		called = true
+		if name != "osascript" || len(args) != 3 || args[2] != "101" {
+			t.Fatalf("focus command = %s %v", name, args)
+		}
+		return "OK\n", nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister = prevLister
+		iterm2OutputCommand = prevOutput
+	})
+
+	if err := focusTarget(dir, team.DefaultProfile, "main", true, true, "cto"); err != nil {
+		t.Fatalf("focusTarget iTerm2: %v", err)
+	}
+	if !called {
+		t.Fatal("iTerm2 focus runner was not called")
+	}
+}
+
+func TestITerm2PaneInjectionVerbsReturnUnsupportedReason(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := t.TempDir()
+	seedProfile(t, dir, team.DefaultProfile, team.Team{
+		Project: dir,
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"}},
+	})
+	seedAgentRecord(t, base, "main", "cto", launch.Record{
+		CWD:         dir,
+		Binary:      "codex",
+		Handle:      "cto",
+		Role:        "cto",
+		Session:     "main",
+		TeamProfile: team.DefaultProfile,
+		Terminal: &launch.TerminalInfo{
+			Backend:  "iterm2",
+			Session:  "main",
+			WindowID: "101",
+			Target:   "new-window",
+		},
+	})
+
+	prevLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		t.Fatal("iTerm2 unsupported pane-injection verbs should not list tmux panes")
+		return nil, nil
+	}
+	t.Cleanup(func() { statusPaneLister = prevLister })
+
+	_, _, err := captureOutput(t, func() error {
+		return runSend([]string{"--project", dir, "--session", "main", "--role", "cto", "--body", "hello"})
+	})
+	if err == nil || !strings.Contains(err.Error(), runtimecontrol.ITerm2InjectionDisabledReason) || strings.Contains(err.Error(), "no live tmux pane") {
+		t.Fatalf("iTerm2 send error = %v", err)
+	}
+
+	_, _, err = captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "main", "--role", "cto", "--goal", "ship"})
+	})
+	if err == nil || !strings.Contains(err.Error(), runtimecontrol.ITerm2InjectionDisabledReason) || strings.Contains(err.Error(), "no live tmux pane") {
+		t.Fatalf("iTerm2 goal deliver error = %v", err)
+	}
+}
+
+func TestDispatchWakePaneSkipsITerm2Nudge(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := t.TempDir()
+	seedProfile(t, dir, team.DefaultProfile, team.Team{
+		Project: dir,
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"}},
+	})
+	seedAgentRecord(t, base, "main", "cto", launch.Record{
+		CWD:         dir,
+		Binary:      "codex",
+		Handle:      "cto",
+		Role:        "cto",
+		Session:     "main",
+		TeamProfile: team.DefaultProfile,
+		Terminal: &launch.TerminalInfo{
+			Backend:  "iterm2",
+			Session:  "main",
+			WindowID: "101",
+			Target:   "new-window",
+		},
+	})
+
+	prevLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		t.Fatal("iTerm2 dispatch nudge skip should not list tmux panes")
+		return nil, nil
+	}
+	t.Cleanup(func() { statusPaneLister = prevLister })
+
+	outcome, err := defaultDispatchWakePane(dir, team.DefaultProfile, "main", true, "cto", false)
+	if err != nil {
+		t.Fatalf("dispatch wake pane: %v", err)
+	}
+	if !strings.Contains(outcome.Skipped, runtimecontrol.ITerm2InjectionDisabledReason) || !strings.Contains(outcome.Skipped, "durable AMQ dispatch was queued") {
+		t.Fatalf("dispatch nudge outcome = %+v", outcome)
 	}
 }
 

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/runtimeaction"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
@@ -37,9 +38,12 @@ type terminalRuntimeJSON struct {
 	Session    string `json:"session,omitempty"`
 	WindowID   string `json:"window_id,omitempty"`
 	WindowName string `json:"window_name,omitempty"`
+	TabID      string `json:"tab_id,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
 	PaneID     string `json:"pane_id,omitempty"`
 	Target     string `json:"target,omitempty"`
 	PaneAlive  bool   `json:"pane_alive"`
+	PIDAlive   bool   `json:"pid_alive,omitempty"`
 }
 
 // tmuxRuntimeFromInfo converts a persisted launch.TmuxInfo into the JSON block,
@@ -68,7 +72,7 @@ func terminalRuntimeFromInfo(info *launch.TerminalInfo) *terminalRuntimeJSON {
 	if info == nil {
 		return nil
 	}
-	if info.Backend == "" && info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.Target == "" {
+	if info.Backend == "" && info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.Target == "" {
 		return nil
 	}
 	return &terminalRuntimeJSON{
@@ -76,6 +80,8 @@ func terminalRuntimeFromInfo(info *launch.TerminalInfo) *terminalRuntimeJSON {
 		Session:    info.Session,
 		WindowID:   info.WindowID,
 		WindowName: info.WindowName,
+		TabID:      info.TabID,
+		SessionID:  info.SessionID,
 		PaneID:     info.PaneID,
 		Target:     info.Target,
 	}
@@ -194,6 +200,47 @@ func memberActions(projectDir, profile, session, role string, paneAlive bool) []
 
 func policyAwareMemberActions(t team.Team, profile, session, role string, paneAlive bool) []runtimeActionJSON {
 	return applyMemberActionPolicy(t, role, memberActions(t.Project, profile, session, role, paneAlive))
+}
+
+func policyAwareMemberActionsForRow(t team.Team, profile, session string, row statusRecord) []runtimeActionJSON {
+	caps := runtimeCapabilitiesForStatusRow(row)
+	if caps == nil {
+		return policyAwareMemberActions(t, profile, session, row.Role, row.Tmux != nil && row.Tmux.PaneAlive)
+	}
+	return applyMemberActionPolicy(t, row.Role, runtimeaction.MemberForCapabilities(t.Project, profile, session, row.Role, *caps))
+}
+
+func runtimeCapabilitiesForStatusRow(row statusRecord) *runtimecontrol.Capabilities {
+	if row.Terminal == nil || strings.TrimSpace(row.Terminal.Backend) == "" {
+		return nil
+	}
+	backend := strings.TrimSpace(row.Terminal.Backend)
+	ctrl, ok := runtimecontrol.DefaultRegistry().Lookup(backend)
+	if !ok {
+		reason := "runtime backend " + backend + " is unsupported"
+		caps := runtimecontrol.NewCapabilities(map[runtimecontrol.Capability]runtimecontrol.CapabilityState{
+			runtimecontrol.CapabilityFocus:       {Available: false, Reason: reason},
+			runtimecontrol.CapabilitySendPrompt:  {Available: false, Reason: reason},
+			runtimecontrol.CapabilityGoalDeliver: {Available: false, Reason: reason},
+			runtimecontrol.CapabilityDispatch:    {Available: false, Reason: reason},
+		})
+		return &caps
+	}
+	caps := ctrl.Capabilities(runtimecontrol.Identity{
+		Backend:    backend,
+		Session:    row.Terminal.Session,
+		WindowID:   row.Terminal.WindowID,
+		WindowName: row.Terminal.WindowName,
+		TabID:      row.Terminal.TabID,
+		SessionID:  row.Terminal.SessionID,
+		PaneID:     row.Terminal.PaneID,
+		Target:     row.Terminal.Target,
+	}, runtimecontrol.Liveness{
+		PaneAlive:   row.Terminal.PaneAlive,
+		AgentAlive:  row.Signals.AgentAlive,
+		BinaryMatch: row.Signals.BinaryMatch,
+	})
+	return &caps
 }
 
 func applyMemberActionPolicy(t team.Team, role string, actions []runtimeActionJSON) []runtimeActionJSON {

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
@@ -54,6 +55,56 @@ func TestTerminalRuntimeMirrorsTmuxIdentity(t *testing.T) {
 	}
 	if term.Backend != "tmux" || term.Session != "main" || term.WindowID != "@1" || term.WindowName != "lead" || term.PaneID != "%5" || term.Target != "external" {
 		t.Fatalf("terminal runtime = %+v", term)
+	}
+}
+
+func TestTerminalRuntimeFromITerm2Info(t *testing.T) {
+	term := terminalRuntimeFromInfo(&launch.TerminalInfo{
+		Backend:    "iterm2",
+		Session:    "issue-331",
+		WindowID:   "101",
+		WindowName: "amq:issue-331:cto",
+		TabID:      "tab-1",
+		SessionID:  "session-1",
+		Target:     "new-window",
+	})
+	if term == nil {
+		t.Fatalf("terminal runtime should be present")
+	}
+	if term.Backend != "iterm2" || term.WindowID != "101" || term.TabID != "tab-1" || term.SessionID != "session-1" || term.PaneAlive {
+		t.Fatalf("terminal runtime = %+v", term)
+	}
+}
+
+func TestPolicyAwareMemberActionsForITerm2Row(t *testing.T) {
+	tm := team.Team{Project: "/repo", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex"}}}
+	row := statusRecord{
+		Role:    "cto",
+		Signals: statusSignals{AgentPID: 1234, AgentAlive: true, BinaryMatch: true},
+		Terminal: &terminalRuntimeJSON{
+			Backend:  "iterm2",
+			Session:  "issue-331",
+			WindowID: "101",
+			Target:   "new-window",
+			PIDAlive: true,
+		},
+	}
+	actions := policyAwareMemberActionsForRow(tm, "default", "issue-331", row)
+	byKind := map[string]runtimeActionJSON{}
+	for _, action := range actions {
+		byKind[action.Kind] = action
+	}
+	if !byKind["focus"].Available {
+		t.Fatalf("iTerm2 focus should be available with window id: %+v", byKind["focus"])
+	}
+	for _, kind := range []string{"send", "goal_deliver"} {
+		action := byKind[kind]
+		if action.Available || !strings.Contains(action.Reason, "disabled until #374") {
+			t.Fatalf("%s action = %+v", kind, action)
+		}
+	}
+	if !byKind["dispatch"].Available {
+		t.Fatalf("iTerm2 dispatch should be available: %+v", byKind["dispatch"])
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -356,8 +356,7 @@ func executeStatus(s statusExecution) error {
 		// Attach the stable action commands a client can render/copy per member.
 		for i := range rows {
 			rows[i].Namespace = ns
-			alive := rows[i].Tmux != nil && rows[i].Tmux.PaneAlive
-			rows[i].Actions = disableNamespaceConflictActions(policyAwareMemberActions(t, s.Profile, workstream, rows[i].Role, alive), conflict)
+			rows[i].Actions = disableNamespaceConflictActions(policyAwareMemberActionsForRow(t, s.Profile, workstream, rows[i]), conflict)
 		}
 		ctx := newSessionStatusContext(t, s.Profile, workstream, firstLiveTmuxSession(rows))
 		ctx.Actions = disableNamespaceConflictActions(ctx.Actions, conflict)
@@ -1507,6 +1506,9 @@ func classifyMemberStatus(t team.Team, profile string, m team.Member, workstream
 	if rec.Tmux != nil {
 		rec.AgentPaneID = strings.TrimSpace(rec.Tmux.PaneID)
 		rec.ManagedTarget = strings.TrimSpace(rec.Tmux.Target)
+	}
+	if rec.Terminal != nil && rec.Terminal.Backend != "tmux" {
+		rec.Terminal.PIDAlive = rec.Signals.AgentAlive && rec.Signals.BinaryMatch
 	}
 	return rec
 }

--- a/internal/cli/team_launch_iterm2.go
+++ b/internal/cli/team_launch_iterm2.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func init() {
+	registerTeamLaunchBackend(iterm2TeamLaunchBackend{})
+}
+
+type iterm2TeamLaunchBackend struct{}
+
+type iterm2LaunchPlan struct {
+	Workstream string
+	Target     string
+	Panes      []teamLaunchPane
+	StartDelay time.Duration
+}
+
+var iterm2RunCommand = runCommand
+var iterm2OutputCommand = outputCommand
+
+func (iterm2TeamLaunchBackend) Name() string {
+	return "iterm2"
+}
+
+func (iterm2TeamLaunchBackend) Validate(opts teamLaunchOptions) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("--terminal iterm2 requires macOS")
+	}
+	if opts.Target != "new-window" {
+		return fmt.Errorf("--terminal iterm2 supports --target new-window; got %q", opts.Target)
+	}
+	if opts.Stagger < 0 {
+		return fmt.Errorf("--stagger cannot be negative")
+	}
+	return nil
+}
+
+func (b iterm2TeamLaunchBackend) DryRun(t team.Team, opts teamLaunchOptions) error {
+	printITerm2LaunchPlan(b.buildPlan(t, opts))
+	return nil
+}
+
+func (b iterm2TeamLaunchBackend) Launch(t team.Team, opts teamLaunchOptions) error {
+	return runITerm2LaunchPlan(b.buildPlan(t, opts))
+}
+
+func (iterm2TeamLaunchBackend) buildPlan(t team.Team, opts teamLaunchOptions) iterm2LaunchPlan {
+	return iterm2LaunchPlan{
+		Workstream: opts.Workstream,
+		Target:     "new-window",
+		Panes:      buildTeamLaunchPanes(t, opts),
+		StartDelay: opts.Stagger,
+	}
+}
+
+func printITerm2LaunchPlan(plan iterm2LaunchPlan) {
+	fmt.Println("# amq-squad team launch - iTerm2")
+	fmt.Printf("# target:  %s\n", plan.Target)
+	if plan.Workstream != "" {
+		fmt.Printf("# workstream: %s\n", plan.Workstream)
+	}
+	fmt.Printf("# windows: %d\n\n", len(plan.Panes))
+	for _, line := range iterm2DryRunLines(plan) {
+		fmt.Println(line)
+	}
+}
+
+func iterm2DryRunLines(plan iterm2LaunchPlan) []string {
+	lines := make([]string, 0, len(plan.Panes)*2)
+	for i, pane := range plan.Panes {
+		lines = append(lines, shellCommand("osascript", iterm2LaunchArgv(plan.Workstream, pane)...))
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			lines = append(lines, sleepDryRunLine(plan.StartDelay))
+		}
+	}
+	return lines
+}
+
+func runITerm2LaunchPlan(plan iterm2LaunchPlan) error {
+	if len(plan.Panes) == 0 {
+		return fmt.Errorf("iTerm2 plan has no panes")
+	}
+	for i, pane := range plan.Panes {
+		if err := iterm2RunCommand("osascript", iterm2LaunchArgv(plan.Workstream, pane)...); err != nil {
+			return err
+		}
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			time.Sleep(plan.StartDelay)
+		}
+	}
+	quietNotice("Opened %d iTerm2 window(s) for %s. %s\n", len(plan.Panes), shellQuote(plan.Workstream), runtimecontrol.ITerm2InjectionDisabledReason)
+	verbosePolicyEcho()
+	return nil
+}
+
+func iterm2LaunchArgv(workstream string, pane teamLaunchPane) []string {
+	script := `on run argv
+set workstreamName to item 1 of argv
+set roleName to item 2 of argv
+set agentCommand to item 3 of argv
+set windowName to "amq:" & workstreamName & ":" & roleName
+tell application "iTerm2"
+	activate
+	set w to (create window with default profile)
+	set winID to (id of w as string)
+	set tabID to ""
+	try
+		set tabID to (id of current tab of w as string)
+	end try
+	set sess to current session of w
+	set sessID to ""
+	try
+		set sessID to (id of sess as string)
+	end try
+	tell sess
+		set name to windowName
+		set fullCommand to "(export AMQ_SQUAD_TERMINAL_BACKEND=iterm2 AMQ_SQUAD_TERMINAL_SESSION=" & quoted form of workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & quoted form of winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & quoted form of windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & quoted form of tabID & " AMQ_SQUAD_TERMINAL_SESSION_ID=" & quoted form of sessID & "; " & agentCommand & ")"
+		write text fullCommand
+	end tell
+end tell
+return winID
+end run`
+	return []string{"-e", script, workstream, pane.Role, pane.Command}
+}
+
+func focusITerm2Window(windowID string) error {
+	windowID = strings.TrimSpace(windowID)
+	if windowID == "" {
+		return fmt.Errorf("iTerm2 window id is unavailable")
+	}
+	out, err := iterm2OutputCommand("osascript", iterm2FocusArgv(windowID)...)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(out) != "OK" {
+		return fmt.Errorf("could not raise iTerm2 window %s; it may have been closed", windowID)
+	}
+	return nil
+}
+
+func iterm2FocusArgv(windowID string) []string {
+	script := `on run argv
+set targetID to item 1 of argv
+tell application "iTerm2"
+	activate
+	repeat with w in windows
+		if (id of w as string) is targetID then
+			tell w to select
+			return "OK"
+		end if
+	end repeat
+end tell
+return "MISS"
+end run`
+	return []string{"-e", script, windowID}
+}

--- a/internal/cli/team_launch_iterm2_test.go
+++ b/internal/cli/team_launch_iterm2_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestITerm2LaunchArgvShape(t *testing.T) {
+	pane := teamLaunchPane{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
+	argv := iterm2LaunchArgv("issue-331", pane)
+	if len(argv) != 5 || argv[0] != "-e" || argv[2] != "issue-331" || argv[3] != "cto" || argv[4] != pane.Command {
+		t.Fatalf("argv = %#v", argv)
+	}
+	script := argv[1]
+	for _, want := range []string{
+		`tell application "iTerm2"`,
+		`create window with default profile`,
+		`set winID to (id of w as string)`,
+		`AMQ_SQUAD_TERMINAL_BACKEND=iterm2`,
+		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=`,
+		`AMQ_SQUAD_TERMINAL_TAB_ID=`,
+		`AMQ_SQUAD_TERMINAL_SESSION_ID=`,
+		`write text fullCommand`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestITerm2DryRunLines(t *testing.T) {
+	plan := iterm2LaunchPlan{
+		Workstream: "issue-331",
+		Target:     "new-window",
+		Panes: []teamLaunchPane{
+			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"},
+			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up claude --role qa"},
+		},
+		StartDelay: time.Second,
+	}
+	lines := iterm2DryRunLines(plan)
+	joined := strings.Join(lines, "\n")
+	if got := strings.Count(joined, "osascript -e"); got != 2 {
+		t.Fatalf("dry run should emit one osascript per agent, got %d:\n%s", got, joined)
+	}
+	if !strings.Contains(joined, "sleep 1") {
+		t.Fatalf("dry run missing stagger sleep:\n%s", joined)
+	}
+	if strings.Contains(joined, "tmux send-keys") {
+		t.Fatalf("iTerm2 dry run must not use tmux send-keys:\n%s", joined)
+	}
+}
+
+func TestITerm2FocusArgvShape(t *testing.T) {
+	argv := iterm2FocusArgv("101")
+	if len(argv) != 3 || argv[0] != "-e" || argv[2] != "101" {
+		t.Fatalf("focus argv = %#v", argv)
+	}
+	for _, want := range []string{`tell application "iTerm2"`, `targetID`, `tell w to select`, `return "OK"`, `return "MISS"`} {
+		if !strings.Contains(argv[1], want) {
+			t.Fatalf("focus script missing %q:\n%s", want, argv[1])
+		}
+	}
+}
+
+func TestITerm2BackendRegistered(t *testing.T) {
+	if _, ok := teamLaunchBackends["iterm2"]; !ok {
+		t.Fatal("iterm2 backend not registered")
+	}
+	got := strings.Join(registeredTeamLaunchTerminals(), ",")
+	if !strings.Contains(got, "iterm2") {
+		t.Fatalf("registeredTeamLaunchTerminals = %q, want iterm2 included", got)
+	}
+}

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -90,12 +90,12 @@ func TestCommandProfileArgOmitsDefaultAndQuotesNamedProfile(t *testing.T) {
 
 func TestRunTeamLaunchRejectsUnsupportedTerminalWithRegistry(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--terminal", "iterm2", "--dry-run"})
+		return runTeamLaunch([]string{"--terminal", "bogus", "--dry-run"})
 	})
 	if err == nil {
 		t.Fatal("runTeamLaunch succeeded, want unsupported terminal error")
 	}
-	for _, want := range []string{`unsupported terminal "iterm2"`, "supported terminals: tmux"} {
+	for _, want := range []string{`unsupported terminal "bogus"`, "supported terminals: "} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err.Error(), want)
 		}

--- a/internal/cli/team_launch_tmux_session_test.go
+++ b/internal/cli/team_launch_tmux_session_test.go
@@ -179,8 +179,10 @@ func TestTmuxSessionBackendRegistered(t *testing.T) {
 		t.Fatal("tmux-session backend not registered")
 	}
 	got := strings.Join(registeredTeamLaunchTerminals(), ",")
-	if got != "tmux,tmux-session" {
-		t.Fatalf("registeredTeamLaunchTerminals = %q, want tmux,tmux-session", got)
+	for _, want := range []string{"tmux", "tmux-session"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("registeredTeamLaunchTerminals = %q, missing %s", got, want)
+		}
 	}
 }
 

--- a/internal/cli/terminal_env_test.go
+++ b/internal/cli/terminal_env_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+func TestTerminalInfoFromEnvITerm2(t *testing.T) {
+	t.Setenv(envTerminalBackend, "iterm2")
+	t.Setenv(envTerminalSession, "issue-331")
+	t.Setenv(envTerminalWindowID, "101")
+	t.Setenv(envTerminalWindowName, "amq:issue-331:cto")
+	t.Setenv(envTerminalTabID, "tab-1")
+	t.Setenv(envTerminalSessionID, "session-1")
+	t.Setenv(envTerminalTarget, "new-window")
+
+	info := terminalInfoFromEnv()
+	if info == nil {
+		t.Fatal("expected terminal info from env")
+	}
+	if info.Backend != "iterm2" || info.Session != "issue-331" || info.WindowID != "101" || info.WindowName != "amq:issue-331:cto" || info.TabID != "tab-1" || info.SessionID != "session-1" || info.Target != "new-window" {
+		t.Fatalf("terminal info = %+v", info)
+	}
+}
+
+func TestTerminalInfoFromEmptyEnvIsNil(t *testing.T) {
+	if info := terminalInfoFromEnv(); info != nil {
+		t.Fatalf("empty env should not create terminal info: %+v", info)
+	}
+}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -159,6 +159,8 @@ type TerminalInfo struct {
 	Session    string `json:"session,omitempty"`
 	WindowID   string `json:"window_id,omitempty"`
 	WindowName string `json:"window_name,omitempty"`
+	TabID      string `json:"tab_id,omitempty"`
+	SessionID  string `json:"session_id,omitempty"`
 	PaneID     string `json:"pane_id,omitempty"`
 	Target     string `json:"target,omitempty"`
 }

--- a/internal/launch/record_terminal_test.go
+++ b/internal/launch/record_terminal_test.go
@@ -16,6 +16,9 @@ func TestTerminalInfoFromTmux(t *testing.T) {
 	if got.Backend != "tmux" || got.Session != "main" || got.WindowID != "@1" || got.WindowName != "lead" || got.PaneID != "%5" || got.Target != "external" {
 		t.Fatalf("terminal info = %+v", got)
 	}
+	if got.TabID != "" || got.SessionID != "" {
+		t.Fatalf("tmux terminal identity should not invent native ids: %+v", got)
+	}
 }
 
 func TestTerminalInfoFromEmptyTmuxIsNil(t *testing.T) {

--- a/internal/runtimecontrol/capabilities.go
+++ b/internal/runtimecontrol/capabilities.go
@@ -1,8 +1,13 @@
 package runtimecontrol
 
+import "strings"
+
 const (
-	BackendTmux = "tmux"
+	BackendTmux   = "tmux"
+	BackendITerm2 = "iterm2"
 )
+
+const ITerm2InjectionDisabledReason = "iTerm2 prompt/native-goal injection is disabled until #374 proves safe send/capture/busy support"
 
 type Capability string
 
@@ -57,6 +62,23 @@ func TmuxCapabilities(paneAlive bool) Capabilities {
 		CapabilityFocus:       {Available: paneAlive, Reason: deadReason},
 		CapabilitySendPrompt:  {Available: paneAlive, Reason: deadReason},
 		CapabilityGoalDeliver: {Available: paneAlive, Reason: deadReason},
+		CapabilityDispatch:    {Available: true},
+	})
+}
+
+func ITerm2Capabilities(identity Identity, live Liveness) Capabilities {
+	focusReason := ""
+	focusAvailable := strings.TrimSpace(identity.WindowID) != "" && live.AgentAlive && live.BinaryMatch
+	switch {
+	case strings.TrimSpace(identity.WindowID) == "":
+		focusReason = "iTerm2 window id is unavailable"
+	case !live.AgentAlive || !live.BinaryMatch:
+		focusReason = "iTerm2 focus requires verified agent PID liveness"
+	}
+	return NewCapabilities(map[Capability]CapabilityState{
+		CapabilityFocus:       {Available: focusAvailable, Reason: focusReason},
+		CapabilitySendPrompt:  {Available: false, Reason: ITerm2InjectionDisabledReason},
+		CapabilityGoalDeliver: {Available: false, Reason: ITerm2InjectionDisabledReason},
 		CapabilityDispatch:    {Available: true},
 	})
 }

--- a/internal/runtimecontrol/capabilities_test.go
+++ b/internal/runtimecontrol/capabilities_test.go
@@ -38,6 +38,46 @@ func TestDefaultRegistryIncludesTmuxController(t *testing.T) {
 	}
 }
 
+func TestITerm2ControllerCapabilities(t *testing.T) {
+	ctrl := ITerm2Controller{}
+	if ctrl.Backend() != BackendITerm2 {
+		t.Fatalf("backend = %q, want %q", ctrl.Backend(), BackendITerm2)
+	}
+
+	caps := ctrl.Capabilities(Identity{Backend: BackendITerm2, WindowID: "101"}, Liveness{AgentAlive: true, BinaryMatch: true})
+	if !caps.State(CapabilityFocus).Available {
+		t.Fatalf("iTerm2 focus should be available with a recorded window id")
+	}
+	for _, cap := range []Capability{CapabilitySendPrompt, CapabilityGoalDeliver} {
+		state := caps.State(cap)
+		if state.Available || state.Reason != ITerm2InjectionDisabledReason {
+			t.Fatalf("%s state = %+v", cap, state)
+		}
+	}
+	if !caps.State(CapabilityDispatch).Available {
+		t.Fatalf("iTerm2 dispatch should remain available because durable AMQ dispatch does not require pane injection")
+	}
+
+	missing := ctrl.Capabilities(Identity{Backend: BackendITerm2}, Liveness{AgentAlive: true, BinaryMatch: true})
+	if state := missing.State(CapabilityFocus); state.Available || state.Reason != "iTerm2 window id is unavailable" {
+		t.Fatalf("missing-window focus state = %+v", state)
+	}
+	dead := ctrl.Capabilities(Identity{Backend: BackendITerm2, WindowID: "101"}, Liveness{})
+	if state := dead.State(CapabilityFocus); state.Available || state.Reason != "iTerm2 focus requires verified agent PID liveness" {
+		t.Fatalf("dead-agent focus state = %+v", state)
+	}
+}
+
+func TestDefaultRegistryIncludesITerm2Controller(t *testing.T) {
+	ctrl, ok := DefaultRegistry().Lookup(BackendITerm2)
+	if !ok {
+		t.Fatalf("default registry missing iTerm2 controller")
+	}
+	if ctrl.Backend() != BackendITerm2 {
+		t.Fatalf("lookup backend = %q", ctrl.Backend())
+	}
+}
+
 func TestZeroValueRegistryCanRegister(t *testing.T) {
 	var r Registry
 	r.Register(TmuxController{})

--- a/internal/runtimecontrol/controller.go
+++ b/internal/runtimecontrol/controller.go
@@ -7,12 +7,16 @@ type Identity struct {
 	Session    string
 	WindowID   string
 	WindowName string
+	TabID      string
+	SessionID  string
 	PaneID     string
 	Target     string
 }
 
 type Liveness struct {
-	PaneAlive bool
+	PaneAlive   bool
+	AgentAlive  bool
+	BinaryMatch bool
 }
 
 type Controller interface {
@@ -21,6 +25,7 @@ type Controller interface {
 }
 
 type TmuxController struct{}
+type ITerm2Controller struct{}
 
 func (TmuxController) Backend() string {
 	return BackendTmux
@@ -28,6 +33,14 @@ func (TmuxController) Backend() string {
 
 func (TmuxController) Capabilities(_ Identity, live Liveness) Capabilities {
 	return TmuxCapabilities(live.PaneAlive)
+}
+
+func (ITerm2Controller) Backend() string {
+	return BackendITerm2
+}
+
+func (ITerm2Controller) Capabilities(identity Identity, live Liveness) Capabilities {
+	return ITerm2Capabilities(identity, live)
 }
 
 type Registry struct {
@@ -65,5 +78,5 @@ func (r *Registry) Lookup(backend string) (Controller, bool) {
 }
 
 func DefaultRegistry() *Registry {
-	return NewRegistry(TmuxController{})
+	return NewRegistry(TmuxController{}, ITerm2Controller{})
 }


### PR DESCRIPTION
## Summary
- Add macOS iTerm2 team launch backend for `--terminal iterm2 --target new-window` with AppleScript argv generation and visible per-agent windows.
- Persist backend-neutral iTerm2 terminal identity from launch env and expose PID liveness in status JSON.
- Add iTerm2 runtime capabilities: focus by recorded window id when available; send/goal/dispatch remain disabled until #374 proves safe prompt injection/capture/busy support.
- Document manual smoke steps in `docs/iterm2-tier-b-smoke.md` and regenerate `README.html`.

## Validation
- `go test ./internal/runtimecontrol ./internal/launch ./internal/cli`
- `go test ./...`
- `make ci`

Head SHA: af80376812728f11fcc57230d01b14d44904d8af