### PR TITLE
Add Terminal.app Tier C backend

### DIFF
--- a/README.html
+++ b/README.html
@@ -1822,6 +1822,16 @@ delivery, and pane-nudge dispatch stay disabled for iTerm2 until #374
 proves safe behavior; durable AMQ dispatch still queues normally. Manual
 smoke steps live in <a
 href="docs/iterm2-tier-b-smoke.md"><code>docs/iterm2-tier-b-smoke.md</code></a>.</p>
+<p>The experimental macOS Terminal.app backend is available with
+<code>--terminal terminal --target new-window</code>. It is Tier C
+launch-only: it records backend-neutral Terminal.app metadata when
+AppleScript exposes it and reports PID liveness, but focus, prompt
+injection, capture, busy detection, goal delivery, and safe close remain
+unavailable until follow-up spikes prove stable addressing and safe
+input semantics. Durable AMQ dispatch still queues normally; pane nudges
+are skipped with the Terminal.app safety reason. Manual smoke steps live
+in <a
+href="docs/terminal-app-tier-c-smoke.md"><code>docs/terminal-app-tier-c-smoke.md</code></a>.</p>
 <p>amq-squad owns the tmux execution/control contract for a team so
 external clients (such as amq-noc) can make agents actionable without
 scraping tmux or reconstructing pane layouts themselves.</p>

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,15 @@ injection, capture, busy detection, goal delivery, and pane-nudge dispatch stay
 disabled for iTerm2 until #374 proves safe behavior; durable AMQ dispatch still
 queues normally. Manual smoke steps live in [`docs/iterm2-tier-b-smoke.md`](docs/iterm2-tier-b-smoke.md).
 
+The experimental macOS Terminal.app backend is available with
+`--terminal terminal --target new-window`. It is Tier C launch-only: it records
+backend-neutral Terminal.app metadata when AppleScript exposes it and reports
+PID liveness, but focus, prompt injection, capture, busy detection, goal
+delivery, and safe close remain unavailable until follow-up spikes prove stable
+addressing and safe input semantics. Durable AMQ dispatch still queues normally;
+pane nudges are skipped with the Terminal.app safety reason. Manual smoke steps
+live in [`docs/terminal-app-tier-c-smoke.md`](docs/terminal-app-tier-c-smoke.md).
+
 amq-squad owns the tmux execution/control contract for a team so external
 clients (such as amq-noc) can make agents actionable without scraping tmux or
 reconstructing pane layouts themselves.

--- a/docs/iterm2-tier-b-smoke.md
+++ b/docs/iterm2-tier-b-smoke.md
@@ -27,8 +27,9 @@ desktop with iTerm2 installed.
    - `records[].terminal.backend` is `iterm2`.
    - `records[].terminal.pid_alive` is true for live agent processes.
    - `records[].terminal.tab_id` and `records[].terminal.session_id` are present
-     when iTerm2 exposes those AppleScript ids; an empty value is a recorded
-     iTerm2 metadata gap, not tmux identity.
+     when iTerm2 exposes those AppleScript ids. If iTerm2 returns an empty id,
+     the field is absent because the launch record uses `omitempty`; absence is
+     an iTerm2 metadata gap, not tmux identity.
    - `focus` is available when `window_id` is present and the agent PID/binary
      verifies live. A closed iTerm2 window can still fail at focus time; the
      command should report that the recorded window could not be raised.

--- a/docs/terminal-app-tier-c-smoke.md
+++ b/docs/terminal-app-tier-c-smoke.md
@@ -1,0 +1,49 @@
+# Terminal.app Tier C Manual Smoke Checklist
+
+This checklist covers the Tier C macOS Terminal.app backend added for
+`--terminal terminal`. CI verifies only the emitted AppleScript argv shape; this
+flow needs a macOS desktop with Terminal.app available.
+
+1. From a project with a configured team, start a fresh workstream:
+
+   ```sh
+   amq-squad up --session terminal-smoke --terminal terminal --target new-window --no-bootstrap
+   ```
+
+2. Confirm Terminal.app opens a visible window or tab for each launched agent.
+   Terminal.app controls whether `do script` opens a window or tab; either is
+   acceptable for this Tier C backend as long as each agent is visible.
+
+3. Confirm each agent's `launch.json` has a `terminal` block with
+   `backend: "terminal_app"`, `target: "new-window"`, `window_name:
+   "amq:<workstream>:<role>"`, and whatever Terminal.app exposed for
+   `window_id`, `tab_id`, and `tty`. Empty values are omitted.
+
+4. Run status and inspect the runtime actions:
+
+   ```sh
+   amq-squad status --session terminal-smoke --json
+   ```
+
+   Expected:
+
+   - `records[].terminal.backend` is `terminal_app`.
+   - `records[].terminal.pid_alive` is true for live agent processes.
+   - `records[].terminal.tty` is present when Terminal.app exposes the tab TTY.
+   - `focus` is unavailable with the stable-addressing/manual-focus reason.
+   - `send` and `goal_deliver` are unavailable with the #375 Accessibility
+     safety reason.
+   - `dispatch` is available because durable AMQ dispatch does not require pane
+     injection. If the wake sidecar is not live, the optional pane nudge is
+     skipped with the same #375 safety reason.
+
+5. Manually focus the Terminal.app window or tab if you need to inspect it.
+
+6. Stop the smoke session:
+
+   ```sh
+   amq-squad stop --session terminal-smoke --all
+   ```
+
+   Expected: agent PIDs stop; Terminal.app windows/tabs may remain open because
+   native safe close is outside this Tier C scope.

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
-	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	taskstore "github.com/omriariav/amq-squad/v2/internal/task"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -687,8 +686,8 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 	if err != nil {
 		return dispatchOutcome{}, err
 	}
-	if mr.isITerm2Runtime() {
-		return dispatchOutcome{Skipped: runtimecontrol.ITerm2InjectionDisabledReason + "; durable AMQ dispatch was queued"}, nil
+	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
+		return dispatchOutcome{Skipped: reason + "; durable AMQ dispatch was queued"}, nil
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
-	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -882,8 +881,8 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 	if err != nil {
 		return mutationResult{}, err
 	}
-	if mr.isITerm2Runtime() {
-		return mutationResult{}, fmt.Errorf("%s", runtimecontrol.ITerm2InjectionDisabledReason)
+	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
+		return mutationResult{}, fmt.Errorf("%s", reason)
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -37,6 +37,7 @@ const (
 	envTerminalWindowName = "AMQ_SQUAD_TERMINAL_WINDOW_NAME"
 	envTerminalTabID      = "AMQ_SQUAD_TERMINAL_TAB_ID"
 	envTerminalSessionID  = "AMQ_SQUAD_TERMINAL_SESSION_ID"
+	envTerminalTTY        = "AMQ_SQUAD_TERMINAL_TTY"
 	envTerminalTarget     = "AMQ_SQUAD_TERMINAL_TARGET"
 )
 
@@ -517,9 +518,10 @@ func terminalInfoFromEnv() *launch.TerminalInfo {
 		WindowName: strings.TrimSpace(os.Getenv(envTerminalWindowName)),
 		TabID:      strings.TrimSpace(os.Getenv(envTerminalTabID)),
 		SessionID:  strings.TrimSpace(os.Getenv(envTerminalSessionID)),
+		TTY:        strings.TrimSpace(os.Getenv(envTerminalTTY)),
 		Target:     strings.TrimSpace(os.Getenv(envTerminalTarget)),
 	}
-	if info.Backend == "" && info.Session == "" && info.WindowID == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.Target == "" {
+	if info.Backend == "" && info.Session == "" && info.WindowID == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.TTY == "" && info.Target == "" {
 		return nil
 	}
 	return info

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -212,18 +213,32 @@ func classifyAgentLiveness(agentDir, root, expectedProfile, handle, role, binary
 	// was relaunched OUTSIDE amq-squad, leaving a live replacement process the
 	// launch record never learned about. Look for a live tmux pane that
 	// resolves to this member.
-	if target, ok := classifierReplacementPane(role, handle, binary, cwd, workstream); ok {
-		out.Verdict = livenessReplacementLive
-		out.Status = statusStateLive
-		out.ReplacementTarget = target
-		out.Detail = fmt.Sprintf("recorded pid dead; live %s at %s — relaunch via amq-squad to re-register", binary, target)
-		return out
+	if replacementPaneAllowedForRecord(launchErr, launchRec) {
+		if target, ok := classifierReplacementPane(role, handle, binary, cwd, workstream); ok {
+			out.Verdict = livenessReplacementLive
+			out.Status = statusStateLive
+			out.ReplacementTarget = target
+			out.Detail = fmt.Sprintf("recorded pid dead; live %s at %s — relaunch via amq-squad to re-register", binary, target)
+			return out
+		}
 	}
 
 	out.Verdict = livenessStale
 	out.Status = statusStateStale
 	out.Detail = staleDetail(out.Signals, presenceMismatched) + "; relaunch via amq-squad to re-register"
 	return out
+}
+
+func replacementPaneAllowedForRecord(launchErr error, rec launch.Record) bool {
+	if launchErr != nil || rec.Terminal == nil {
+		return true
+	}
+	switch strings.TrimSpace(rec.Terminal.Backend) {
+	case "", runtimecontrol.BackendTmux:
+		return true
+	default:
+		return false
+	}
 }
 
 // classifierReplacementPane is the verdict-level live-replacement detector. It

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
@@ -321,6 +322,77 @@ func TestClassifierReplacementLive(t *testing.T) {
 	}
 	if !strings.Contains(live.Detail, "recorded pid dead") {
 		t.Fatalf("replacement detail should mention recorded pid dead, got %q", live.Detail)
+	}
+}
+
+func TestNativeTerminalRecordsDoNotUseReplacementPaneFallback(t *testing.T) {
+	for _, backend := range []string{runtimecontrol.BackendTerminalApp, runtimecontrol.BackendITerm2} {
+		t.Run(backend, func(t *testing.T) {
+			base := setupFakeAMQSessionRoots(t)
+			dir := seedTeam(t, team.Team{
+				Workstream: "issue-96",
+				Members: []team.Member{
+					{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+				},
+			})
+			writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+				CWD: dir, Binary: "codex", Role: "cto", AgentPID: 4242, StartedAt: time.Now(),
+				Terminal: &launch.TerminalInfo{
+					Backend:    backend,
+					Session:    "issue-96",
+					WindowName: "amq:issue-96:cto",
+					Target:     "new-window",
+				},
+			})
+			agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+			withStubPaneLister(t, []tmuxpane.TmuxPane{
+				{Session: "main", Window: "0", Pane: "3", Command: "codex", CWD: canonicalPath(dir)},
+			}, nil)
+
+			now := time.Now()
+			probe := livenessProbe(map[int]bool{}, map[int]bool{}, now)
+
+			live := classifyAgentLiveness(agentDir, filepath.Join(base, "issue-96"), "default", "cto", "cto", "codex", "issue-96", dir, probe)
+			if live.Verdict != livenessStale {
+				t.Fatalf("classifier verdict = %q, want stale", live.Verdict)
+			}
+			if live.Status != statusStateStale {
+				t.Fatalf("classifier status = %q, want stale", live.Status)
+			}
+			if live.Live() {
+				t.Fatalf("%s stale native-terminal record must not report Live()", backend)
+			}
+
+			tm, err := team.ReadProfile(dir, team.DefaultProfile)
+			if err != nil {
+				t.Fatalf("read team: %v", err)
+			}
+			rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+			if rec.Status != statusStateStale {
+				t.Fatalf("status = %q, want stale (detail %q)", rec.Status, rec.Detail)
+			}
+			if rec.Terminal == nil || rec.Terminal.Backend != backend || rec.Terminal.PIDAlive {
+				t.Fatalf("terminal runtime = %+v, want backend %q with pid_alive false", rec.Terminal, backend)
+			}
+
+			plan, err := planMemberResume(memberPlanInput{
+				Member:     tm.Members[0],
+				Team:       tm,
+				Workstream: "issue-96",
+				Mode:       resumeModeDefault,
+				SquadBin:   teamSquadBin(),
+				Probe:      probe,
+			})
+			if err != nil {
+				t.Fatalf("planMemberResume: %v", err)
+			}
+			if plan.Action != resumeRestore {
+				t.Fatalf("resume action = %q, want restore (note %q)", plan.Action, plan.Note)
+			}
+			if strings.TrimSpace(plan.Command) == "" {
+				t.Fatalf("restore action must emit a non-empty command")
+			}
+		})
 	}
 }
 

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -116,6 +116,21 @@ func (mr memberRuntime) isITerm2Runtime() bool {
 	return mr.recordedTerminalBackend() == runtimecontrol.BackendITerm2
 }
 
+func (mr memberRuntime) isTerminalAppRuntime() bool {
+	return mr.recordedTerminalBackend() == runtimecontrol.BackendTerminalApp
+}
+
+func (mr memberRuntime) nativePromptInjectionDisabledReason() (string, bool) {
+	switch mr.recordedTerminalBackend() {
+	case runtimecontrol.BackendITerm2:
+		return runtimecontrol.ITerm2InjectionDisabledReason, true
+	case runtimecontrol.BackendTerminalApp:
+		return runtimecontrol.TerminalAppInjectionDisabledReason, true
+	default:
+		return "", false
+	}
+}
+
 // resolveControlTarget picks the tmux pane to act on for a member: the exact
 // recorded pane id when it is still live AND its working directory still
 // matches the member (guarding against pane-id reuse after a tmux server
@@ -381,6 +396,9 @@ func focusTarget(projectDir, profile, session string, explicitSession bool, expl
 			}
 			return nil
 		}
+		if mr.isTerminalAppRuntime() {
+			return fmt.Errorf("%s", runtimecontrol.TerminalAppFocusDisabledReason)
+		}
 		if err := loadPanes(); err != nil {
 			return err
 		}
@@ -468,8 +486,8 @@ Examples:
 	}); err != nil {
 		return err
 	}
-	if mr.isITerm2Runtime() {
-		return fmt.Errorf("%s", runtimecontrol.ITerm2InjectionDisabledReason)
+	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
+		return fmt.Errorf("%s", reason)
 	}
 	panes, err := statusPaneLister()
 	if err != nil {

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -41,6 +41,7 @@ type terminalRuntimeJSON struct {
 	TabID      string `json:"tab_id,omitempty"`
 	SessionID  string `json:"session_id,omitempty"`
 	PaneID     string `json:"pane_id,omitempty"`
+	TTY        string `json:"tty,omitempty"`
 	Target     string `json:"target,omitempty"`
 	PaneAlive  bool   `json:"pane_alive"`
 	PIDAlive   bool   `json:"pid_alive,omitempty"`
@@ -72,7 +73,7 @@ func terminalRuntimeFromInfo(info *launch.TerminalInfo) *terminalRuntimeJSON {
 	if info == nil {
 		return nil
 	}
-	if info.Backend == "" && info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.Target == "" {
+	if info.Backend == "" && info.PaneID == "" && info.WindowID == "" && info.Session == "" && info.WindowName == "" && info.TabID == "" && info.SessionID == "" && info.TTY == "" && info.Target == "" {
 		return nil
 	}
 	return &terminalRuntimeJSON{
@@ -83,6 +84,7 @@ func terminalRuntimeFromInfo(info *launch.TerminalInfo) *terminalRuntimeJSON {
 		TabID:      info.TabID,
 		SessionID:  info.SessionID,
 		PaneID:     info.PaneID,
+		TTY:        info.TTY,
 		Target:     info.Target,
 	}
 }
@@ -234,6 +236,7 @@ func runtimeCapabilitiesForStatusRow(row statusRecord) *runtimecontrol.Capabilit
 		TabID:      row.Terminal.TabID,
 		SessionID:  row.Terminal.SessionID,
 		PaneID:     row.Terminal.PaneID,
+		TTY:        row.Terminal.TTY,
 		Target:     row.Terminal.Target,
 	}, runtimecontrol.Liveness{
 		PaneAlive:   row.Terminal.PaneAlive,

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
@@ -66,13 +67,48 @@ func TestTerminalRuntimeFromITerm2Info(t *testing.T) {
 		WindowName: "amq:issue-331:cto",
 		TabID:      "tab-1",
 		SessionID:  "session-1",
+		TTY:        "/dev/ttys001",
 		Target:     "new-window",
 	})
 	if term == nil {
 		t.Fatalf("terminal runtime should be present")
 	}
-	if term.Backend != "iterm2" || term.WindowID != "101" || term.TabID != "tab-1" || term.SessionID != "session-1" || term.PaneAlive {
+	if term.Backend != "iterm2" || term.WindowID != "101" || term.TabID != "tab-1" || term.SessionID != "session-1" || term.TTY != "/dev/ttys001" || term.PaneAlive {
 		t.Fatalf("terminal runtime = %+v", term)
+	}
+}
+
+func TestPolicyAwareMemberActionsForTerminalAppRow(t *testing.T) {
+	tm := team.Team{Project: "/repo", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex"}}}
+	row := statusRecord{
+		Role:    "cto",
+		Signals: statusSignals{AgentPID: 1234, AgentAlive: true, BinaryMatch: true},
+		Terminal: &terminalRuntimeJSON{
+			Backend:  "terminal_app",
+			Session:  "issue-332",
+			WindowID: "401",
+			TabID:    "1",
+			TTY:      "/dev/ttys001",
+			Target:   "new-window",
+			PIDAlive: true,
+		},
+	}
+	actions := policyAwareMemberActionsForRow(tm, "default", "issue-332", row)
+	byKind := map[string]runtimeActionJSON{}
+	for _, action := range actions {
+		byKind[action.Kind] = action
+	}
+	if action := byKind["focus"]; action.Available || action.Reason != runtimecontrol.TerminalAppFocusDisabledReason {
+		t.Fatalf("Terminal.app focus action = %+v", action)
+	}
+	for _, kind := range []string{"send", "goal_deliver"} {
+		action := byKind[kind]
+		if action.Available || action.Reason != runtimecontrol.TerminalAppInjectionDisabledReason {
+			t.Fatalf("%s action = %+v", kind, action)
+		}
+	}
+	if !byKind["dispatch"].Available {
+		t.Fatalf("Terminal.app dispatch should be available: %+v", byKind["dispatch"])
 	}
 }
 

--- a/internal/cli/team_launch_terminal.go
+++ b/internal/cli/team_launch_terminal.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func init() {
+	registerTeamLaunchBackend(terminalAppTeamLaunchBackend{})
+}
+
+type terminalAppTeamLaunchBackend struct{}
+
+type terminalAppLaunchPlan struct {
+	Workstream string
+	Target     string
+	Panes      []teamLaunchPane
+	StartDelay time.Duration
+}
+
+func (terminalAppTeamLaunchBackend) Name() string {
+	return "terminal"
+}
+
+func (terminalAppTeamLaunchBackend) Validate(opts teamLaunchOptions) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("--terminal terminal requires macOS")
+	}
+	if opts.Target != "new-window" {
+		return fmt.Errorf("--terminal terminal supports --target new-window; got %q", opts.Target)
+	}
+	if opts.Stagger < 0 {
+		return fmt.Errorf("--stagger cannot be negative")
+	}
+	return nil
+}
+
+func (b terminalAppTeamLaunchBackend) DryRun(t team.Team, opts teamLaunchOptions) error {
+	printTerminalAppLaunchPlan(b.buildPlan(t, opts))
+	return nil
+}
+
+func (b terminalAppTeamLaunchBackend) Launch(t team.Team, opts teamLaunchOptions) error {
+	return runTerminalAppLaunchPlan(b.buildPlan(t, opts))
+}
+
+func (terminalAppTeamLaunchBackend) buildPlan(t team.Team, opts teamLaunchOptions) terminalAppLaunchPlan {
+	return terminalAppLaunchPlan{
+		Workstream: opts.Workstream,
+		Target:     "new-window",
+		Panes:      buildTeamLaunchPanes(t, opts),
+		StartDelay: opts.Stagger,
+	}
+}
+
+func printTerminalAppLaunchPlan(plan terminalAppLaunchPlan) {
+	fmt.Println("# amq-squad team launch - Terminal.app")
+	fmt.Printf("# target:  %s\n", plan.Target)
+	if plan.Workstream != "" {
+		fmt.Printf("# workstream: %s\n", plan.Workstream)
+	}
+	fmt.Printf("# windows: %d\n\n", len(plan.Panes))
+	for _, line := range terminalAppDryRunLines(plan) {
+		fmt.Println(line)
+	}
+}
+
+func terminalAppDryRunLines(plan terminalAppLaunchPlan) []string {
+	lines := make([]string, 0, len(plan.Panes)*2)
+	for i, pane := range plan.Panes {
+		lines = append(lines, shellCommand("osascript", terminalAppLaunchArgv(plan.Workstream, pane)...))
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			lines = append(lines, sleepDryRunLine(plan.StartDelay))
+		}
+	}
+	return lines
+}
+
+func runTerminalAppLaunchPlan(plan terminalAppLaunchPlan) error {
+	if len(plan.Panes) == 0 {
+		return fmt.Errorf("Terminal.app plan has no panes")
+	}
+	for i, pane := range plan.Panes {
+		if err := runCommand("osascript", terminalAppLaunchArgv(plan.Workstream, pane)...); err != nil {
+			return err
+		}
+		if i < len(plan.Panes)-1 && plan.StartDelay > 0 {
+			time.Sleep(plan.StartDelay)
+		}
+	}
+	quietNotice("Opened %d Terminal.app window(s) for %s. %s\n", len(plan.Panes), shellQuote(plan.Workstream), runtimecontrol.TerminalAppInjectionDisabledReason)
+	verbosePolicyEcho()
+	return nil
+}
+
+func terminalAppLaunchArgv(workstream string, pane teamLaunchPane) []string {
+	script := `on run argv
+set workstreamName to item 1 of argv
+set roleName to item 2 of argv
+set agentCommand to item 3 of argv
+set windowName to "amq:" & workstreamName & ":" & roleName
+tell application "Terminal"
+	activate
+	set targetTab to do script ""
+	set custom title of targetTab to windowName
+	set targetWindow to front window
+	set winID to ""
+	try
+		set winID to (id of targetWindow as string)
+	end try
+	set tabIndex to ""
+	try
+		set tabIndex to (index of targetTab as string)
+	end try
+	set ttyName to ""
+	try
+		set ttyName to (tty of targetTab as string)
+	end try
+	set fullCommand to "(export AMQ_SQUAD_TERMINAL_BACKEND=terminal_app AMQ_SQUAD_TERMINAL_SESSION=" & quoted form of workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & quoted form of winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & quoted form of windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & quoted form of tabIndex & " AMQ_SQUAD_TERMINAL_TTY=" & quoted form of ttyName & "; " & agentCommand & ")"
+	do script fullCommand in targetTab
+end tell
+return winID
+end run`
+	return []string{"-e", script, workstream, pane.Role, pane.Command}
+}

--- a/internal/cli/team_launch_terminal_test.go
+++ b/internal/cli/team_launch_terminal_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTerminalAppLaunchArgvShape(t *testing.T) {
+	pane := teamLaunchPane{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
+	argv := terminalAppLaunchArgv("issue-332", pane)
+	if len(argv) != 5 || argv[0] != "-e" || argv[2] != "issue-332" || argv[3] != "cto" || argv[4] != pane.Command {
+		t.Fatalf("argv = %#v", argv)
+	}
+	script := argv[1]
+	for _, want := range []string{
+		`tell application "Terminal"`,
+		`set targetTab to do script ""`,
+		`set custom title of targetTab to windowName`,
+		`set winID to (id of targetWindow as string)`,
+		`set tabIndex to (index of targetTab as string)`,
+		`set ttyName to (tty of targetTab as string)`,
+		`AMQ_SQUAD_TERMINAL_BACKEND=terminal_app`,
+		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=`,
+		`AMQ_SQUAD_TERMINAL_TAB_ID=`,
+		`AMQ_SQUAD_TERMINAL_TTY=`,
+		`do script fullCommand in targetTab`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+}
+
+func TestTerminalAppDryRunLines(t *testing.T) {
+	plan := terminalAppLaunchPlan{
+		Workstream: "issue-332",
+		Target:     "new-window",
+		Panes: []teamLaunchPane{
+			{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"},
+			{Role: "qa", CWD: "/repo", Command: "cd /repo && amq-squad agent up claude --role qa"},
+		},
+		StartDelay: time.Second,
+	}
+	lines := terminalAppDryRunLines(plan)
+	joined := strings.Join(lines, "\n")
+	if got := strings.Count(joined, "osascript -e"); got != 2 {
+		t.Fatalf("dry run should emit one osascript per agent, got %d:\n%s", got, joined)
+	}
+	if !strings.Contains(joined, "sleep 1") {
+		t.Fatalf("dry run missing stagger sleep:\n%s", joined)
+	}
+	if strings.Contains(joined, "tmux send-keys") {
+		t.Fatalf("Terminal.app dry run must not use tmux send-keys:\n%s", joined)
+	}
+}
+
+func TestTerminalAppBackendRegistered(t *testing.T) {
+	if _, ok := teamLaunchBackends["terminal"]; !ok {
+		t.Fatal("terminal backend not registered")
+	}
+	got := strings.Join(registeredTeamLaunchTerminals(), ",")
+	if !strings.Contains(got, "terminal") {
+		t.Fatalf("registeredTeamLaunchTerminals = %q, want terminal included", got)
+	}
+}

--- a/internal/cli/terminal_env_test.go
+++ b/internal/cli/terminal_env_test.go
@@ -9,13 +9,14 @@ func TestTerminalInfoFromEnvITerm2(t *testing.T) {
 	t.Setenv(envTerminalWindowName, "amq:issue-331:cto")
 	t.Setenv(envTerminalTabID, "tab-1")
 	t.Setenv(envTerminalSessionID, "session-1")
+	t.Setenv(envTerminalTTY, "/dev/ttys001")
 	t.Setenv(envTerminalTarget, "new-window")
 
 	info := terminalInfoFromEnv()
 	if info == nil {
 		t.Fatal("expected terminal info from env")
 	}
-	if info.Backend != "iterm2" || info.Session != "issue-331" || info.WindowID != "101" || info.WindowName != "amq:issue-331:cto" || info.TabID != "tab-1" || info.SessionID != "session-1" || info.Target != "new-window" {
+	if info.Backend != "iterm2" || info.Session != "issue-331" || info.WindowID != "101" || info.WindowName != "amq:issue-331:cto" || info.TabID != "tab-1" || info.SessionID != "session-1" || info.TTY != "/dev/ttys001" || info.Target != "new-window" {
 		t.Fatalf("terminal info = %+v", info)
 	}
 }

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -162,6 +162,7 @@ type TerminalInfo struct {
 	TabID      string `json:"tab_id,omitempty"`
 	SessionID  string `json:"session_id,omitempty"`
 	PaneID     string `json:"pane_id,omitempty"`
+	TTY        string `json:"tty,omitempty"`
 	Target     string `json:"target,omitempty"`
 }
 

--- a/internal/runtimecontrol/capabilities.go
+++ b/internal/runtimecontrol/capabilities.go
@@ -3,11 +3,14 @@ package runtimecontrol
 import "strings"
 
 const (
-	BackendTmux   = "tmux"
-	BackendITerm2 = "iterm2"
+	BackendTmux        = "tmux"
+	BackendITerm2      = "iterm2"
+	BackendTerminalApp = "terminal_app"
 )
 
 const ITerm2InjectionDisabledReason = "iTerm2 prompt/native-goal injection is disabled until #374 proves safe send/capture/busy support"
+const TerminalAppInjectionDisabledReason = "Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input"
+const TerminalAppFocusDisabledReason = "Terminal.app focus requires stable window/tab addressing; manual focus is required in v2.18.0"
 
 type Capability string
 
@@ -79,6 +82,15 @@ func ITerm2Capabilities(identity Identity, live Liveness) Capabilities {
 		CapabilityFocus:       {Available: focusAvailable, Reason: focusReason},
 		CapabilitySendPrompt:  {Available: false, Reason: ITerm2InjectionDisabledReason},
 		CapabilityGoalDeliver: {Available: false, Reason: ITerm2InjectionDisabledReason},
+		CapabilityDispatch:    {Available: true},
+	})
+}
+
+func TerminalAppCapabilities() Capabilities {
+	return NewCapabilities(map[Capability]CapabilityState{
+		CapabilityFocus:       {Available: false, Reason: TerminalAppFocusDisabledReason},
+		CapabilitySendPrompt:  {Available: false, Reason: TerminalAppInjectionDisabledReason},
+		CapabilityGoalDeliver: {Available: false, Reason: TerminalAppInjectionDisabledReason},
 		CapabilityDispatch:    {Available: true},
 	})
 }

--- a/internal/runtimecontrol/capabilities_test.go
+++ b/internal/runtimecontrol/capabilities_test.go
@@ -78,6 +78,37 @@ func TestDefaultRegistryIncludesITerm2Controller(t *testing.T) {
 	}
 }
 
+func TestTerminalAppControllerCapabilities(t *testing.T) {
+	ctrl := TerminalAppController{}
+	if ctrl.Backend() != BackendTerminalApp {
+		t.Fatalf("backend = %q, want %q", ctrl.Backend(), BackendTerminalApp)
+	}
+
+	caps := ctrl.Capabilities(Identity{Backend: BackendTerminalApp, WindowID: "401", TabID: "1"}, Liveness{AgentAlive: true, BinaryMatch: true})
+	if state := caps.State(CapabilityFocus); state.Available || state.Reason != TerminalAppFocusDisabledReason {
+		t.Fatalf("Terminal.app focus state = %+v", state)
+	}
+	for _, cap := range []Capability{CapabilitySendPrompt, CapabilityGoalDeliver} {
+		state := caps.State(cap)
+		if state.Available || state.Reason != TerminalAppInjectionDisabledReason {
+			t.Fatalf("%s state = %+v", cap, state)
+		}
+	}
+	if !caps.State(CapabilityDispatch).Available {
+		t.Fatalf("Terminal.app dispatch should remain available because durable AMQ dispatch does not require pane injection")
+	}
+}
+
+func TestDefaultRegistryIncludesTerminalAppController(t *testing.T) {
+	ctrl, ok := DefaultRegistry().Lookup(BackendTerminalApp)
+	if !ok {
+		t.Fatalf("default registry missing Terminal.app controller")
+	}
+	if ctrl.Backend() != BackendTerminalApp {
+		t.Fatalf("lookup backend = %q", ctrl.Backend())
+	}
+}
+
 func TestZeroValueRegistryCanRegister(t *testing.T) {
 	var r Registry
 	r.Register(TmuxController{})

--- a/internal/runtimecontrol/controller.go
+++ b/internal/runtimecontrol/controller.go
@@ -10,6 +10,7 @@ type Identity struct {
 	TabID      string
 	SessionID  string
 	PaneID     string
+	TTY        string
 	Target     string
 }
 
@@ -26,6 +27,7 @@ type Controller interface {
 
 type TmuxController struct{}
 type ITerm2Controller struct{}
+type TerminalAppController struct{}
 
 func (TmuxController) Backend() string {
 	return BackendTmux
@@ -41,6 +43,14 @@ func (ITerm2Controller) Backend() string {
 
 func (ITerm2Controller) Capabilities(identity Identity, live Liveness) Capabilities {
 	return ITerm2Capabilities(identity, live)
+}
+
+func (TerminalAppController) Backend() string {
+	return BackendTerminalApp
+}
+
+func (TerminalAppController) Capabilities(_ Identity, _ Liveness) Capabilities {
+	return TerminalAppCapabilities()
 }
 
 type Registry struct {
@@ -78,5 +88,5 @@ func (r *Registry) Lookup(backend string) (Controller, bool) {
 }
 
 func DefaultRegistry() *Registry {
-	return NewRegistry(TmuxController{}, ITerm2Controller{})
+	return NewRegistry(TmuxController{}, ITerm2Controller{}, TerminalAppController{})
 }


### PR DESCRIPTION
## Summary
- Add macOS Terminal.app launch backend via `--terminal terminal --target new-window`, using AppleScript `do script` to open visible per-agent sessions.
- Record backend-neutral Terminal.app metadata in launch/status (`backend: "terminal_app"`, window/tab/TTY fields when discoverable) plus existing agent PID liveness.
- Add Terminal.app runtime capabilities as Tier C: durable dispatch remains available, while focus/send/goal delivery stay unavailable with explicit safety reasons.
- Skip pane-nudge injection for Terminal.app dispatch, matching the native-terminal degraded behavior.
- Add CI-only AppleScript argv-shape tests, a manual smoke checklist, README/README.html docs, and the requested iTerm2 smoke doc wording fix for omitted empty IDs.

## Validation
- `go test ./internal/runtimecontrol ./internal/launch ./internal/cli`
- `go test ./...`
- `make ci`

Head SHA: 87d30a5efb48e1ed80ccfaf9f1f30ebeeb5b95c8
