### PR TITLE
Harden native terminal launch metadata

### DIFF
--- a/docs/iterm2-tier-b-smoke.md
+++ b/docs/iterm2-tier-b-smoke.md
@@ -5,10 +5,11 @@ CI verifies only the emitted AppleScript argv shape; this flow needs a macOS
 desktop with iTerm2 installed.
 
 The backend asks iTerm2 to type a shell-agnostic launch line into the new
-session: `env AMQ_SQUAD_TERMINAL_* ... /bin/sh -c <agent command>`. This lets
-fish, nushell, and POSIX login shells hand off to `/bin/sh` for the generated
-agent command; the terminal metadata is captured by `amq-squad launch` and then
-stripped before the agent process is exec'd.
+session: `/bin/sh -c <quoted payload>`. The payload exports
+`AMQ_SQUAD_TERMINAL_*` metadata before running the generated agent command. This
+lets fish, nushell, and POSIX login shells hand off to `/bin/sh`; the terminal
+metadata is captured by `amq-squad launch` and then stripped before the agent
+process is exec'd.
 
 1. From a project with a configured team, start a fresh workstream:
 

--- a/docs/iterm2-tier-b-smoke.md
+++ b/docs/iterm2-tier-b-smoke.md
@@ -4,6 +4,12 @@ This checklist covers the Tier B iTerm2 backend added for `--terminal iterm2`.
 CI verifies only the emitted AppleScript argv shape; this flow needs a macOS
 desktop with iTerm2 installed.
 
+The backend asks iTerm2 to type a shell-agnostic launch line into the new
+session: `env AMQ_SQUAD_TERMINAL_* ... /bin/sh -c <agent command>`. This lets
+fish, nushell, and POSIX login shells hand off to `/bin/sh` for the generated
+agent command; the terminal metadata is captured by `amq-squad launch` and then
+stripped before the agent process is exec'd.
+
 1. From a project with a configured team, start a fresh workstream:
 
    ```sh

--- a/docs/terminal-app-tier-c-smoke.md
+++ b/docs/terminal-app-tier-c-smoke.md
@@ -4,6 +4,12 @@ This checklist covers the Tier C macOS Terminal.app backend added for
 `--terminal terminal`. CI verifies only the emitted AppleScript argv shape; this
 flow needs a macOS desktop with Terminal.app available.
 
+The backend asks Terminal.app to type a shell-agnostic launch line into the new
+tab: `env AMQ_SQUAD_TERMINAL_* ... /bin/sh -c <agent command>`. This lets fish,
+nushell, and POSIX login shells hand off to `/bin/sh` for the generated agent
+command; the terminal metadata is captured by `amq-squad launch` and then
+stripped before the agent process is exec'd.
+
 1. From a project with a configured team, start a fresh workstream:
 
    ```sh

--- a/docs/terminal-app-tier-c-smoke.md
+++ b/docs/terminal-app-tier-c-smoke.md
@@ -5,10 +5,11 @@ This checklist covers the Tier C macOS Terminal.app backend added for
 flow needs a macOS desktop with Terminal.app available.
 
 The backend asks Terminal.app to type a shell-agnostic launch line into the new
-tab: `env AMQ_SQUAD_TERMINAL_* ... /bin/sh -c <agent command>`. This lets fish,
-nushell, and POSIX login shells hand off to `/bin/sh` for the generated agent
-command; the terminal metadata is captured by `amq-squad launch` and then
-stripped before the agent process is exec'd.
+tab: `/bin/sh -c <quoted payload>`. The payload exports
+`AMQ_SQUAD_TERMINAL_*` metadata before running the generated agent command. This
+lets fish, nushell, and POSIX login shells hand off to `/bin/sh`; the terminal
+metadata is captured by `amq-squad launch` and then stripped before the agent
+process is exec'd.
 
 1. From a project with a configured team, start a fresh workstream:
 

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -170,7 +170,7 @@ func envWithoutAMQIdentity(env []string) []string {
 	out := make([]string, 0, len(env))
 	for _, entry := range env {
 		key, _, ok := strings.Cut(entry, "=")
-		if !ok || !remove[key] {
+		if !ok || (!remove[key] && !strings.HasPrefix(key, "AMQ_SQUAD_TERMINAL_")) {
 			out = append(out, entry)
 		}
 	}

--- a/internal/cli/team_launch_iterm2.go
+++ b/internal/cli/team_launch_iterm2.go
@@ -102,11 +102,19 @@ func runITerm2LaunchPlan(plan iterm2LaunchPlan) error {
 }
 
 func iterm2LaunchArgv(workstream string, pane teamLaunchPane) []string {
+	windowName := nativeTerminalWindowName(workstream, pane.Role)
+	payload := nativeTerminalLaunchPayload(pane.Command, []nativeTerminalEnv{
+		{Key: envTerminalBackend, Value: "iterm2"},
+		{Key: envTerminalSession, Value: workstream},
+		{Key: envTerminalTarget, Value: "new-window"},
+		{Key: envTerminalWindowID, Value: nativeTerminalWindowIDPlaceholder, Raw: true},
+		{Key: envTerminalWindowName, Value: windowName},
+		{Key: envTerminalTabID, Value: nativeTerminalTabIDPlaceholder, Raw: true},
+		{Key: envTerminalSessionID, Value: nativeTerminalSessionIDPlaceholder, Raw: true},
+	})
 	script := `on run argv
-set workstreamName to item 1 of argv
-set roleName to item 2 of argv
-set agentCommand to item 3 of argv
-set windowName to "amq:" & workstreamName & ":" & roleName
+set windowName to item 1 of argv
+set payloadTemplate to item 2 of argv
 tell application "iTerm2"
 	activate
 	set w to (create window with default profile)
@@ -122,13 +130,33 @@ tell application "iTerm2"
 	end try
 	tell sess
 		set name to windowName
-		set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=iterm2 AMQ_SQUAD_TERMINAL_SESSION=" & workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & tabID & " AMQ_SQUAD_TERMINAL_SESSION_ID=" & sessID & " /bin/sh -c " & quoted form of agentCommand
+		set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))
+		set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabID))
+		set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_SESSION_ID__", my shellSingleQuote(sessID))
+		set fullCommand to "/bin/sh -c " & quoted form of payload
 		write text fullCommand
 	end tell
 end tell
 return winID
-end run`
-	return []string{"-e", script, workstream, pane.Role, pane.Command}
+end run
+
+on replaceText(sourceText, searchText, replacementText)
+	set oldDelimiters to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to searchText
+	set textItems to text items of sourceText
+	set AppleScript's text item delimiters to replacementText
+	set replacedText to textItems as text
+	set AppleScript's text item delimiters to oldDelimiters
+	return replacedText
+end replaceText
+
+on shellSingleQuote(valueText)
+	set valueText to valueText as string
+	set singleQuote to ASCII character 39
+	set spliceQuote to singleQuote & (ASCII character 92) & singleQuote & singleQuote
+	return singleQuote & my replaceText(valueText, singleQuote, spliceQuote) & singleQuote
+end shellSingleQuote`
+	return []string{"-e", script, windowName, payload}
 }
 
 func focusITerm2Window(windowID string) error {

--- a/internal/cli/team_launch_iterm2.go
+++ b/internal/cli/team_launch_iterm2.go
@@ -122,7 +122,7 @@ tell application "iTerm2"
 	end try
 	tell sess
 		set name to windowName
-		set fullCommand to "(export AMQ_SQUAD_TERMINAL_BACKEND=iterm2 AMQ_SQUAD_TERMINAL_SESSION=" & quoted form of workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & quoted form of winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & quoted form of windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & quoted form of tabID & " AMQ_SQUAD_TERMINAL_SESSION_ID=" & quoted form of sessID & "; " & agentCommand & ")"
+		set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=iterm2 AMQ_SQUAD_TERMINAL_SESSION=" & workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & tabID & " AMQ_SQUAD_TERMINAL_SESSION_ID=" & sessID & " /bin/sh -c " & quoted form of agentCommand
 		write text fullCommand
 	end tell
 end tell

--- a/internal/cli/team_launch_iterm2_test.go
+++ b/internal/cli/team_launch_iterm2_test.go
@@ -9,7 +9,7 @@ import (
 func TestITerm2LaunchArgvShape(t *testing.T) {
 	pane := teamLaunchPane{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
 	argv := iterm2LaunchArgv("issue-331", pane)
-	if len(argv) != 5 || argv[0] != "-e" || argv[2] != "issue-331" || argv[3] != "cto" || argv[4] != pane.Command {
+	if len(argv) != 4 || argv[0] != "-e" || argv[2] != "amq:issue-331:cto" {
 		t.Fatalf("argv = %#v", argv)
 	}
 	script := argv[1]
@@ -17,23 +17,64 @@ func TestITerm2LaunchArgvShape(t *testing.T) {
 		`tell application "iTerm2"`,
 		`create window with default profile`,
 		`set winID to (id of w as string)`,
-		`set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=iterm2`,
-		` /bin/sh -c " & quoted form of agentCommand`,
-		`AMQ_SQUAD_TERMINAL_BACKEND=iterm2`,
-		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
-		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
-		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=`,
-		`AMQ_SQUAD_TERMINAL_TAB_ID=`,
-		`AMQ_SQUAD_TERMINAL_SESSION_ID=`,
+		`set payloadTemplate to item 2 of argv`,
+		`set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))`,
+		`set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabID))`,
+		`set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_SESSION_ID__", my shellSingleQuote(sessID))`,
+		`set fullCommand to "/bin/sh -c " & quoted form of payload`,
+		`on shellSingleQuote(valueText)`,
 		`write text fullCommand`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
 		}
 	}
-	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `; " & agentCommand`} {
+	if got := strings.Count(script, "quoted form of"); got != 1 {
+		t.Fatalf("script should apply AppleScript quoted form only at the receiving-shell boundary, got %d:\n%s", got, script)
+	}
+	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `agentCommand`, `workstreamName`, `roleName`, `AMQ_SQUAD_TERMINAL_SESSION=" &`} {
 		if strings.Contains(script, unwanted) {
 			t.Fatalf("script contains shell-specific launch fragment %q:\n%s", unwanted, script)
+		}
+	}
+	payload := argv[3]
+	for _, want := range []string{
+		`export AMQ_SQUAD_TERMINAL_BACKEND='iterm2'`,
+		`AMQ_SQUAD_TERMINAL_SESSION='issue-331'`,
+		`AMQ_SQUAD_TERMINAL_TARGET='new-window'`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_ID=__AMQ_SQUAD_TERMINAL_WINDOW_ID__`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME='amq:issue-331:cto'`,
+		`AMQ_SQUAD_TERMINAL_TAB_ID=__AMQ_SQUAD_TERMINAL_TAB_ID__`,
+		`AMQ_SQUAD_TERMINAL_SESSION_ID=__AMQ_SQUAD_TERMINAL_SESSION_ID__`,
+		`; ` + pane.Command,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("payload missing %q:\n%s", want, payload)
+		}
+	}
+}
+
+func TestITerm2LaunchPayloadQuotesHostileValues(t *testing.T) {
+	workstream := `issue 331 'x $(touch /tmp/amq-pwn)`
+	pane := teamLaunchPane{Role: `cto '$(nope)`, CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
+	argv := iterm2LaunchArgv(workstream, pane)
+	payload := argv[3]
+	for _, want := range []string{
+		`AMQ_SQUAD_TERMINAL_SESSION='issue 331 '\''x $(touch /tmp/amq-pwn)'`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME='amq:issue 331 '\''x $(touch /tmp/amq-pwn):cto '\''$(nope)'`,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("hostile value was not inert in payload; missing %q:\n%s", want, payload)
+		}
+	}
+	for _, unwanted := range []string{
+		`AMQ_SQUAD_TERMINAL_SESSION=issue 331`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=amq:issue 331`,
+		`" & workstreamName & "`,
+		`" & windowName & "`,
+	} {
+		if strings.Contains(payload, unwanted) || strings.Contains(argv[1], unwanted) {
+			t.Fatalf("hostile value has naked shell/script splice %q\nscript:\n%s\npayload:\n%s", unwanted, argv[1], payload)
 		}
 	}
 }

--- a/internal/cli/team_launch_iterm2_test.go
+++ b/internal/cli/team_launch_iterm2_test.go
@@ -17,6 +17,8 @@ func TestITerm2LaunchArgvShape(t *testing.T) {
 		`tell application "iTerm2"`,
 		`create window with default profile`,
 		`set winID to (id of w as string)`,
+		`set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=iterm2`,
+		` /bin/sh -c " & quoted form of agentCommand`,
 		`AMQ_SQUAD_TERMINAL_BACKEND=iterm2`,
 		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
 		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
@@ -27,6 +29,11 @@ func TestITerm2LaunchArgvShape(t *testing.T) {
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `; " & agentCommand`} {
+		if strings.Contains(script, unwanted) {
+			t.Fatalf("script contains shell-specific launch fragment %q:\n%s", unwanted, script)
 		}
 	}
 }

--- a/internal/cli/team_launch_native_terminal.go
+++ b/internal/cli/team_launch_native_terminal.go
@@ -1,0 +1,36 @@
+package cli
+
+import "strings"
+
+const (
+	nativeTerminalWindowIDPlaceholder  = "__AMQ_SQUAD_TERMINAL_WINDOW_ID__"
+	nativeTerminalTabIDPlaceholder     = "__AMQ_SQUAD_TERMINAL_TAB_ID__"
+	nativeTerminalSessionIDPlaceholder = "__AMQ_SQUAD_TERMINAL_SESSION_ID__"
+	nativeTerminalTTYPlaceholder       = "__AMQ_SQUAD_TERMINAL_TTY__"
+)
+
+type nativeTerminalEnv struct {
+	Key   string
+	Value string
+	Raw   bool
+}
+
+func nativeTerminalWindowName(workstream, role string) string {
+	return "amq:" + workstream + ":" + role
+}
+
+func nativeTerminalLaunchPayload(agentCommand string, env []nativeTerminalEnv) string {
+	assignments := make([]string, 0, len(env))
+	for _, item := range env {
+		value := item.Value
+		if !item.Raw {
+			value = posixSingleQuote(item.Value)
+		}
+		assignments = append(assignments, item.Key+"="+value)
+	}
+	return "export " + strings.Join(assignments, " ") + "; " + agentCommand
+}
+
+func posixSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/cli/team_launch_terminal.go
+++ b/internal/cli/team_launch_terminal.go
@@ -115,15 +115,6 @@ tell application "Terminal"
 	activate
 	set targetTab to do script ""
 	set custom title of targetTab to windowName
-	try
-		set targetWindow to window of targetTab
-	on error
-		set targetWindow to front window
-	end try
-	set winID to ""
-	try
-		set winID to (id of targetWindow as string)
-	end try
 	set tabIndex to ""
 	try
 		set tabIndex to (index of targetTab as string)
@@ -131,6 +122,29 @@ tell application "Terminal"
 	set ttyName to ""
 	try
 		set ttyName to (tty of targetTab as string)
+	end try
+	set targetWindow to missing value
+	if ttyName is not "" then
+		repeat with candidateWindow in windows
+			repeat with candidateTab in tabs of candidateWindow
+				try
+					if (tty of candidateTab as string) is ttyName then
+						set targetWindow to candidateWindow
+						exit repeat
+					end if
+				end try
+			end repeat
+			if targetWindow is not missing value then
+				exit repeat
+			end if
+		end repeat
+	end if
+	if targetWindow is missing value then
+		set targetWindow to front window
+	end if
+	set winID to ""
+	try
+		set winID to (id of targetWindow as string)
 	end try
 	set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))
 	set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabIndex))

--- a/internal/cli/team_launch_terminal.go
+++ b/internal/cli/team_launch_terminal.go
@@ -98,11 +98,19 @@ func runTerminalAppLaunchPlan(plan terminalAppLaunchPlan) error {
 }
 
 func terminalAppLaunchArgv(workstream string, pane teamLaunchPane) []string {
+	windowName := nativeTerminalWindowName(workstream, pane.Role)
+	payload := nativeTerminalLaunchPayload(pane.Command, []nativeTerminalEnv{
+		{Key: envTerminalBackend, Value: "terminal_app"},
+		{Key: envTerminalSession, Value: workstream},
+		{Key: envTerminalTarget, Value: "new-window"},
+		{Key: envTerminalWindowID, Value: nativeTerminalWindowIDPlaceholder, Raw: true},
+		{Key: envTerminalWindowName, Value: windowName},
+		{Key: envTerminalTabID, Value: nativeTerminalTabIDPlaceholder, Raw: true},
+		{Key: envTerminalTTY, Value: nativeTerminalTTYPlaceholder, Raw: true},
+	})
 	script := `on run argv
-set workstreamName to item 1 of argv
-set roleName to item 2 of argv
-set agentCommand to item 3 of argv
-set windowName to "amq:" & workstreamName & ":" & roleName
+set windowName to item 1 of argv
+set payloadTemplate to item 2 of argv
 tell application "Terminal"
 	activate
 	set targetTab to do script ""
@@ -124,10 +132,30 @@ tell application "Terminal"
 	try
 		set ttyName to (tty of targetTab as string)
 	end try
-	set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=terminal_app AMQ_SQUAD_TERMINAL_SESSION=" & workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & tabIndex & " AMQ_SQUAD_TERMINAL_TTY=" & ttyName & " /bin/sh -c " & quoted form of agentCommand
+	set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))
+	set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabIndex))
+	set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TTY__", my shellSingleQuote(ttyName))
+	set fullCommand to "/bin/sh -c " & quoted form of payload
 	do script fullCommand in targetTab
 end tell
 return winID
-end run`
-	return []string{"-e", script, workstream, pane.Role, pane.Command}
+end run
+
+on replaceText(sourceText, searchText, replacementText)
+	set oldDelimiters to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to searchText
+	set textItems to text items of sourceText
+	set AppleScript's text item delimiters to replacementText
+	set replacedText to textItems as text
+	set AppleScript's text item delimiters to oldDelimiters
+	return replacedText
+end replaceText
+
+on shellSingleQuote(valueText)
+	set valueText to valueText as string
+	set singleQuote to ASCII character 39
+	set spliceQuote to singleQuote & (ASCII character 92) & singleQuote & singleQuote
+	return singleQuote & my replaceText(valueText, singleQuote, spliceQuote) & singleQuote
+end shellSingleQuote`
+	return []string{"-e", script, windowName, payload}
 }

--- a/internal/cli/team_launch_terminal.go
+++ b/internal/cli/team_launch_terminal.go
@@ -107,7 +107,11 @@ tell application "Terminal"
 	activate
 	set targetTab to do script ""
 	set custom title of targetTab to windowName
-	set targetWindow to front window
+	try
+		set targetWindow to window of targetTab
+	on error
+		set targetWindow to front window
+	end try
 	set winID to ""
 	try
 		set winID to (id of targetWindow as string)
@@ -120,7 +124,7 @@ tell application "Terminal"
 	try
 		set ttyName to (tty of targetTab as string)
 	end try
-	set fullCommand to "(export AMQ_SQUAD_TERMINAL_BACKEND=terminal_app AMQ_SQUAD_TERMINAL_SESSION=" & quoted form of workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & quoted form of winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & quoted form of windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & quoted form of tabIndex & " AMQ_SQUAD_TERMINAL_TTY=" & quoted form of ttyName & "; " & agentCommand & ")"
+	set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=terminal_app AMQ_SQUAD_TERMINAL_SESSION=" & workstreamName & " AMQ_SQUAD_TERMINAL_TARGET=new-window AMQ_SQUAD_TERMINAL_WINDOW_ID=" & winID & " AMQ_SQUAD_TERMINAL_WINDOW_NAME=" & windowName & " AMQ_SQUAD_TERMINAL_TAB_ID=" & tabIndex & " AMQ_SQUAD_TERMINAL_TTY=" & ttyName & " /bin/sh -c " & quoted form of agentCommand
 	do script fullCommand in targetTab
 end tell
 return winID

--- a/internal/cli/team_launch_terminal_test.go
+++ b/internal/cli/team_launch_terminal_test.go
@@ -17,11 +17,16 @@ func TestTerminalAppLaunchArgvShape(t *testing.T) {
 		`tell application "Terminal"`,
 		`set targetTab to do script ""`,
 		`set custom title of targetTab to windowName`,
-		`set targetWindow to window of targetTab`,
-		`set targetWindow to front window`,
-		`set winID to (id of targetWindow as string)`,
 		`set tabIndex to (index of targetTab as string)`,
 		`set ttyName to (tty of targetTab as string)`,
+		`set targetWindow to missing value`,
+		`repeat with candidateWindow in windows`,
+		`repeat with candidateTab in tabs of candidateWindow`,
+		`if (tty of candidateTab as string) is ttyName then`,
+		`set targetWindow to candidateWindow`,
+		`if targetWindow is missing value then`,
+		`set targetWindow to front window`,
+		`set winID to (id of targetWindow as string)`,
 		`set payloadTemplate to item 2 of argv`,
 		`set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))`,
 		`set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabIndex))`,
@@ -41,6 +46,9 @@ func TestTerminalAppLaunchArgvShape(t *testing.T) {
 		if strings.Contains(script, unwanted) {
 			t.Fatalf("script contains shell-specific launch fragment %q:\n%s", unwanted, script)
 		}
+	}
+	if strings.Contains(script, `window of targetTab`) {
+		t.Fatalf("script must not use unsupported Terminal.app tab->window property:\n%s", script)
 	}
 	payload := argv[3]
 	for _, want := range []string{

--- a/internal/cli/team_launch_terminal_test.go
+++ b/internal/cli/team_launch_terminal_test.go
@@ -17,9 +17,13 @@ func TestTerminalAppLaunchArgvShape(t *testing.T) {
 		`tell application "Terminal"`,
 		`set targetTab to do script ""`,
 		`set custom title of targetTab to windowName`,
+		`set targetWindow to window of targetTab`,
+		`set targetWindow to front window`,
 		`set winID to (id of targetWindow as string)`,
 		`set tabIndex to (index of targetTab as string)`,
 		`set ttyName to (tty of targetTab as string)`,
+		`set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=terminal_app`,
+		` /bin/sh -c " & quoted form of agentCommand`,
 		`AMQ_SQUAD_TERMINAL_BACKEND=terminal_app`,
 		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
 		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
@@ -30,6 +34,11 @@ func TestTerminalAppLaunchArgvShape(t *testing.T) {
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
+		}
+	}
+	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `; " & agentCommand`} {
+		if strings.Contains(script, unwanted) {
+			t.Fatalf("script contains shell-specific launch fragment %q:\n%s", unwanted, script)
 		}
 	}
 }

--- a/internal/cli/team_launch_terminal_test.go
+++ b/internal/cli/team_launch_terminal_test.go
@@ -9,7 +9,7 @@ import (
 func TestTerminalAppLaunchArgvShape(t *testing.T) {
 	pane := teamLaunchPane{Role: "cto", CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
 	argv := terminalAppLaunchArgv("issue-332", pane)
-	if len(argv) != 5 || argv[0] != "-e" || argv[2] != "issue-332" || argv[3] != "cto" || argv[4] != pane.Command {
+	if len(argv) != 4 || argv[0] != "-e" || argv[2] != "amq:issue-332:cto" {
 		t.Fatalf("argv = %#v", argv)
 	}
 	script := argv[1]
@@ -22,23 +22,64 @@ func TestTerminalAppLaunchArgvShape(t *testing.T) {
 		`set winID to (id of targetWindow as string)`,
 		`set tabIndex to (index of targetTab as string)`,
 		`set ttyName to (tty of targetTab as string)`,
-		`set fullCommand to "env AMQ_SQUAD_TERMINAL_BACKEND=terminal_app`,
-		` /bin/sh -c " & quoted form of agentCommand`,
-		`AMQ_SQUAD_TERMINAL_BACKEND=terminal_app`,
-		`AMQ_SQUAD_TERMINAL_TARGET=new-window`,
-		`AMQ_SQUAD_TERMINAL_WINDOW_ID=`,
-		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=`,
-		`AMQ_SQUAD_TERMINAL_TAB_ID=`,
-		`AMQ_SQUAD_TERMINAL_TTY=`,
+		`set payloadTemplate to item 2 of argv`,
+		`set payload to my replaceText(payloadTemplate, "__AMQ_SQUAD_TERMINAL_WINDOW_ID__", my shellSingleQuote(winID))`,
+		`set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TAB_ID__", my shellSingleQuote(tabIndex))`,
+		`set payload to my replaceText(payload, "__AMQ_SQUAD_TERMINAL_TTY__", my shellSingleQuote(ttyName))`,
+		`set fullCommand to "/bin/sh -c " & quoted form of payload`,
+		`on shellSingleQuote(valueText)`,
 		`do script fullCommand in targetTab`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
 		}
 	}
-	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `; " & agentCommand`} {
+	if got := strings.Count(script, "quoted form of"); got != 1 {
+		t.Fatalf("script should apply AppleScript quoted form only at the receiving-shell boundary, got %d:\n%s", got, script)
+	}
+	for _, unwanted := range []string{`(export AMQ_SQUAD_TERMINAL_BACKEND`, `agentCommand`, `workstreamName`, `roleName`, `AMQ_SQUAD_TERMINAL_SESSION=" &`} {
 		if strings.Contains(script, unwanted) {
 			t.Fatalf("script contains shell-specific launch fragment %q:\n%s", unwanted, script)
+		}
+	}
+	payload := argv[3]
+	for _, want := range []string{
+		`export AMQ_SQUAD_TERMINAL_BACKEND='terminal_app'`,
+		`AMQ_SQUAD_TERMINAL_SESSION='issue-332'`,
+		`AMQ_SQUAD_TERMINAL_TARGET='new-window'`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_ID=__AMQ_SQUAD_TERMINAL_WINDOW_ID__`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME='amq:issue-332:cto'`,
+		`AMQ_SQUAD_TERMINAL_TAB_ID=__AMQ_SQUAD_TERMINAL_TAB_ID__`,
+		`AMQ_SQUAD_TERMINAL_TTY=__AMQ_SQUAD_TERMINAL_TTY__`,
+		`; ` + pane.Command,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("payload missing %q:\n%s", want, payload)
+		}
+	}
+}
+
+func TestTerminalAppLaunchPayloadQuotesHostileValues(t *testing.T) {
+	workstream := `issue 332 'x $(touch /tmp/amq-pwn)`
+	pane := teamLaunchPane{Role: `cto '$(nope)`, CWD: "/repo", Command: "cd /repo && amq-squad agent up codex --role cto"}
+	argv := terminalAppLaunchArgv(workstream, pane)
+	payload := argv[3]
+	for _, want := range []string{
+		`AMQ_SQUAD_TERMINAL_SESSION='issue 332 '\''x $(touch /tmp/amq-pwn)'`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME='amq:issue 332 '\''x $(touch /tmp/amq-pwn):cto '\''$(nope)'`,
+	} {
+		if !strings.Contains(payload, want) {
+			t.Fatalf("hostile value was not inert in payload; missing %q:\n%s", want, payload)
+		}
+	}
+	for _, unwanted := range []string{
+		`AMQ_SQUAD_TERMINAL_SESSION=issue 332`,
+		`AMQ_SQUAD_TERMINAL_WINDOW_NAME=amq:issue 332`,
+		`" & workstreamName & "`,
+		`" & windowName & "`,
+	} {
+		if strings.Contains(payload, unwanted) || strings.Contains(argv[1], unwanted) {
+			t.Fatalf("hostile value has naked shell/script splice %q\nscript:\n%s\npayload:\n%s", unwanted, argv[1], payload)
 		}
 	}
 }

--- a/internal/cli/terminal_env_test.go
+++ b/internal/cli/terminal_env_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestTerminalInfoFromEnvITerm2(t *testing.T) {
 	t.Setenv(envTerminalBackend, "iterm2")
@@ -24,5 +28,25 @@ func TestTerminalInfoFromEnvITerm2(t *testing.T) {
 func TestTerminalInfoFromEmptyEnvIsNil(t *testing.T) {
 	if info := terminalInfoFromEnv(); info != nil {
 		t.Fatalf("empty env should not create terminal info: %+v", info)
+	}
+}
+
+func TestTerminalInfoCapturedBeforeTerminalEnvStripped(t *testing.T) {
+	t.Setenv(envTerminalBackend, "terminal_app")
+	t.Setenv(envTerminalSession, "issue-386")
+	t.Setenv(envTerminalWindowID, "401")
+	t.Setenv("AM_ROOT", "/stale")
+
+	info := terminalInfoFromEnv()
+	if info == nil || info.Backend != "terminal_app" || info.Session != "issue-386" || info.WindowID != "401" {
+		t.Fatalf("terminal info = %+v", info)
+	}
+
+	clean := envWithoutAMQIdentity(os.Environ())
+	for _, entry := range clean {
+		key, _, _ := strings.Cut(entry, "=")
+		if key == "AM_ROOT" || strings.HasPrefix(key, "AMQ_SQUAD_TERMINAL_") {
+			t.Fatalf("exec env leaked %s in %v", key, clean)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Make iTerm2 and Terminal.app typed launch lines shell-agnostic by using `env AMQ_SQUAD_TERMINAL_* ... /bin/sh -c <agent command>` instead of a bare POSIX `export` prefix.
- Derive Terminal.app `window_id` from `window of targetTab`, with a `front window` fallback, to avoid recording an unrelated foreground window.
- Strip all `AMQ_SQUAD_TERMINAL_*` variables from the environment passed into `amq coop exec` after `amq-squad launch` captures terminal metadata.
- Update iTerm2 and Terminal.app smoke docs to document the native terminal delivery mechanism.

## Validation
- `go test ./internal/cli -run 'Test(ITerm2LaunchArgvShape|TerminalAppLaunchArgvShape|TerminalInfoCapturedBeforeTerminalEnvStripped|TerminalInfoFromEnvITerm2)'`
- `go test ./...`
- `make ci`

Head SHA: d8950204e85e5d2f0d4ae193b212207adacd5ba4
