### PR TITLE
Overhaul README for v2.18.0

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,2137 +272,629 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#why" id="toc-why">Why</a></li>
+<li><a href="#whats-new-in-v2180" id="toc-whats-new-in-v2180">What's new
+in v2.18.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
-<li><a href="#using-amq-squad" id="toc-using-amq-squad">Using
-amq-squad</a></li>
-<li><a href="#quick-start" id="toc-quick-start">Quick start</a></li>
-<li><a href="#goal-first-dynamic-teams"
-id="toc-goal-first-dynamic-teams">Goal-first, dynamic teams</a></li>
-<li><a href="#context-model" id="toc-context-model">Context
-model</a></li>
-<li><a href="#verbs" id="toc-verbs">Verbs</a></li>
-<li><a href="#status-board-and-mission-control-console"
-id="toc-status-board-and-mission-control-console">Status board and
-Mission Control console</a></li>
-<li><a href="#amq-diagnostics" id="toc-amq-diagnostics">AMQ
-diagnostics</a></li>
-<li><a href="#json-envelopes" id="toc-json-envelopes">JSON
-envelopes</a></li>
-<li><a href="#runtime-control-tmux"
-id="toc-runtime-control-tmux">Runtime control (tmux)</a></li>
-<li><a href="#exit-codes" id="toc-exit-codes">Exit codes</a></li>
-<li><a href="#shell-completions" id="toc-shell-completions">Shell
-completions</a></li>
-<li><a href="#custom-roles" id="toc-custom-roles">Custom roles</a></li>
-<li><a href="#trust-and-binary-defaults"
-id="toc-trust-and-binary-defaults">Trust and binary defaults</a></li>
-<li><a href="#workstreams-and-threads"
-id="toc-workstreams-and-threads">Workstreams and threads</a></li>
-<li><a href="#cross-project-teams"
-id="toc-cross-project-teams">Cross-project teams</a></li>
-<li><a href="#messaging-inside-a-squad"
-id="toc-messaging-inside-a-squad">Messaging inside a squad</a></li>
-<li><a href="#files-amq-squad-writes"
-id="toc-files-amq-squad-writes">Files amq-squad writes</a></li>
-<li><a href="#removed-legacy-verbs"
-id="toc-removed-legacy-verbs">Removed legacy verbs</a></li>
-<li><a href="#known-gaps" id="toc-known-gaps">Known gaps</a></li>
-<li><a href="#requires" id="toc-requires">Requires</a></li>
+<li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
+<li><a href="#execution-modes" id="toc-execution-modes">Execution
+modes</a></li>
+<li><a href="#core-concepts" id="toc-core-concepts">Core
+concepts</a></li>
+<li><a href="#orchestration-protocol-and-safety"
+id="toc-orchestration-protocol-and-safety">Orchestration protocol and
+safety</a></li>
+<li><a href="#terminal-capability-matrix"
+id="toc-terminal-capability-matrix">Terminal capability matrix</a></li>
+<li><a href="#command-map" id="toc-command-map">Command map</a></li>
+<li><a href="#skills-and-model-guidance"
+id="toc-skills-and-model-guidance">Skills and model guidance</a></li>
+<li><a href="#customize" id="toc-customize">Customize</a></li>
+<li><a href="#reference-and-moved-details"
+id="toc-reference-and-moved-details">Reference and moved
+details</a></li>
+<li><a href="#requirements" id="toc-requirements">Requirements</a></li>
 </ul></li>
 </ul>
 </nav>
 <h1 id="amq-squad">amq-squad</h1>
-<p><strong>amq-squad composes, launches, and drives teams of Claude and
-Codex agents that coordinate over AMQ.</strong> Hand a lead agent a goal
-and it builds the team — or design the roster yourself. Orchestration is
-binary-neutral: a Codex agent can <em>lead</em>, not just be led.</p>
-<p>Built on <a
+<p><strong>amq-squad launches and coordinates teams of Claude and Codex
+agents over durable AMQ.</strong> It owns the team layer above <a
 href="https://github.com/avivsinai/agent-message-queue">AMQ</a> by <a
-href="https://github.com/avivsinai">Aviv Sinai</a>: AMQ owns messaging
-between agents; <code>amq-squad</code> owns the layer above — who is on
-the team, what role each agent plays, the shared norms they follow, and
-how to bring the whole squad up, stop, resume, or fork it into a new
-workstream.</p>
-<h2 id="contents">Contents</h2>
-<p><strong>Start here:</strong> <a href="#install">Install</a> · <a
-href="#using-amq-squad">Using amq-squad</a> · <a
-href="#quick-start">Quick start</a></p>
-<p><strong>Concepts:</strong> <a href="#why">Why</a> · <a
-href="#context-model">Context model</a> · <a
-href="#goal-first-dynamic-teams">Goal-first dynamic teams</a> · <a
-href="#workstreams-and-threads">Workstreams &amp; threads</a> · <a
-href="#cross-project-teams">Cross-project teams</a></p>
-<p><strong>Command reference:</strong> <a href="#verbs">Verbs</a> · <a
-href="#status-board-and-mission-control-console">Status board &amp;
-console</a> · <a href="#amq-diagnostics">AMQ diagnostics</a> · <a
-href="#runtime-control-tmux">Runtime control (tmux)</a> · <a
-href="#json-envelopes">JSON envelopes</a> · <a href="#exit-codes">Exit
-codes</a> · <a href="#shell-completions">Shell completions</a> · <a
-href="#removed-legacy-verbs">Removed legacy verbs</a></p>
-<p><strong>Customize:</strong> <a href="#custom-roles">Custom roles</a>
-· <a href="#trust-and-binary-defaults">Trust &amp; binary defaults</a> ·
-<a href="#messaging-inside-a-squad">Messaging in a squad</a> · <a
-href="#files-amq-squad-writes">Files amq-squad writes</a></p>
-<p><strong>Reference:</strong> <a href="docs/amq-swarm-interop.md">AMQ
-swarm interop</a> · <a href="#known-gaps">Known gaps</a> · <a
-href="#requires">Requires</a></p>
-<h2 id="why">Why</h2>
-<p>AMQ is the messaging and process substrate: it sets up mailboxes,
-routes and threads messages, tracks presence, wakes agents, federates
-across projects, and execs into <code>claude</code> or
-<code>codex</code> via <code>coop exec</code>. What it deliberately
-stays out of is who is on the team and what each agent is for. AMQ does
-not own:</p>
+href="https://github.com/avivsinai">Aviv Sinai</a>: roles, rosters,
+briefs, operator gates, launch records, and the terminal/runtime
+controls that keep a squad observable.</p>
+<p>The 30-second mental model:</p>
 <ul>
-<li><strong>Roles</strong> — which agent is the "CTO" vs "Fullstack" vs
-"QA" vs "PM" vs "Designer"</li>
-<li><strong>The launch contract</strong> — what command originally
-launched each agent (cwd, binary, flags, workstream), so it can be
-stopped, resumed, or forked</li>
-<li><strong>Durable team norms</strong> — the shared rules each agent
-reads at session start</li>
-<li><strong>The declared roster</strong> — the role-mapped set of peers
-each agent is handed up front at bootstrap (AMQ can observe who talks to
-whom after the fact, via presence and threads; it does not declare the
-intended team a priori)</li>
+<li><strong>AMQ is the durable coordination rail.</strong> Agents
+communicate through inboxes, threads, receipts, presence, and wake
+signals.</li>
+<li><strong>amq-squad is the project/team layer.</strong> It declares
+who is on the team, what each role does, which workstream they share,
+and how to start/stop/resume them.</li>
+<li><strong>Terminals are runtime surfaces, not the source of
+truth.</strong> tmux, iTerm2, and Terminal.app make agents visible and
+sometimes controllable; durable AMQ dispatch works even when pane
+injection is unavailable.</li>
+<li><strong>Operator gates bind high-risk actions.</strong> Leads may
+plan, dispatch, review, and collect evidence, but default-branch pushes,
+tags, releases, external sends, and merges need verified operator
+approval tied to an exact action and target.</li>
 </ul>
-<p><code>amq-squad</code> owns that layer. It captures roles, roster,
-and norms at team-setup time (<code>.amq-squad/team.json</code>,
-<code>.amq-squad/team-rules.md</code>) and per-agent launch state
-(<code>launch.json</code> + <code>role.md</code>) in AMQ's per-agent
-extension-metadata namespace. AMQ stays domain-agnostic: it adds generic
-affordances that layers build on (the
-<code>extensions/&lt;layer&gt;/</code> namespace, external wake
-injection, a reserved <code>user</code>/operator handle,
-<code>env --json</code>), which is why amq-squad v2.18.0 requires amq
-0.41.0+ — but it still knows nothing about CTOs, rosters, or team
-rules.</p>
+<h2 id="contents">Contents</h2>
+<ul>
+<li><a href="#whats-new-in-v2180">What's new in v2.18.0</a></li>
+<li><a href="#install">Install</a></li>
+<li><a href="#quickstart">Quickstart</a></li>
+<li><a href="#execution-modes">Execution modes</a></li>
+<li><a href="#core-concepts">Core concepts</a></li>
+<li><a href="#orchestration-protocol-and-safety">Orchestration protocol
+and safety</a></li>
+<li><a href="#terminal-capability-matrix">Terminal capability
+matrix</a></li>
+<li><a href="#command-map">Command map</a></li>
+<li><a href="#skills-and-model-guidance">Skills and model
+guidance</a></li>
+<li><a href="#customize">Customize</a></li>
+<li><a href="#reference-and-moved-details">Reference and moved
+details</a></li>
+<li><a href="#requirements">Requirements</a></li>
+</ul>
+<h2 id="whats-new-in-v2180">What's new in v2.18.0</h2>
+<p>v2.18.0 is a coherence release for goal-driven, externally supervised
+squads:</p>
+<ul>
+<li><strong>Hard authorization boundary</strong> for high-risk lead
+actions (#349) and a <strong>planner/reviewer-only lead mode</strong>
+(#350).</li>
+<li><strong>Run start UX</strong>: native <code>run start</code>, short
+flags, default visible sibling tabs, and
+<code>run start --external-lead</code> for binding the current pane as
+the project lead (#340, #345-#348).</li>
+<li><strong>External-orchestrator integration</strong>: read-only
+evidence lane, adopt-evidence workflow, and Symphony lifecycle hooks
+(#335-#337).</li>
+<li><strong>Terminal platform support</strong> with an explicit runtime
+capability model: tmux Tier A, iTerm2 Tier B, Terminal.app Tier C, and
+cmux still pending (#330, #331, #332, #384-#386).</li>
+<li><strong>gpt-5.6 model family guidance</strong> lives in the skills
+as the source of truth for lead/worker selection (#380).</li>
+<li><strong>AMQ 0.41.x baseline</strong> for the coordination primitives
+this release depends on.</li>
+</ul>
 <h2 id="install">Install</h2>
-<p>Install the 2.0 line (note the <code>/v2</code> module path):</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.17.0</span>
+<p>Install the v2 module path:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
-<p>For the latest 2.x build:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span></code></pre></div>
-<p>Requires Go 1.25+, the <code>amq</code> binary on <code>PATH</code>
-(v0.41.0+), and <code>tmux</code> on <code>PATH</code> for
-<code>amq-squad up</code>.</p>
-<h3 id="skills-plugin-marketplaces">Skills (plugin marketplaces)</h3>
-<p>This repo doubles as a plugin marketplace that ships the amq-squad
-skills for both Claude Code and Codex. The primary skills are
-<code>amq-squad</code> and <code>amq-squad-orchestrator</code>; the
-older <code>amq-team-setup</code> and
-<code>amq-squad-role-creator</code> entries remain as redirect stubs.
-The CLI and the skills are versioned together.</p>
+<p>For a pinned release, replace <code>@latest</code> with the tag you
+want, for example:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.18.0</span></code></pre></div>
+<p>Install the skills from the plugin marketplace when agents should use
+the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">/plugin</span> marketplace add omriariav/amq-squad</span>
 <span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="ex">/plugin</span> install amq-squad@amq-squad</span></code></pre></div>
 <p>Codex:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">codex</span> plugin marketplace add omriariav/amq-squad</span>
 <span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="ex">codex</span> plugin add amq-squad@amq-squad</span></code></pre></div>
-<p>The Claude marketplace manifest lives at
-<code>.claude-plugin/marketplace.json</code> and the Codex one at
-<code>.agents/plugins/marketplace.json</code>; each points at the
-binary-specific plugin under <code>plugins/claude</code> and
-<code>plugins/codex</code>. In Claude Code, skills are namespaced by
-plugin, e.g. <code>/amq-squad:amq-squad</code>. In Codex, invoke them by
-skill name, e.g. <code>$amq-squad</code>.</p>
-<p>To dogfood the skills from this working tree (instead of the
-marketplace snapshot), run <code>make dogfood-claude</code> here: it
-launches Claude Code with <code>--plugin-dir plugins/claude</code>,
-which loads the plugin live from disk and shadows the
-marketplace-installed copy for that session only. Codex has no
-per-session equivalent; it always serves the marketplace snapshot
-(refresh with <code>codex plugin marketplace upgrade</code> after
-merging skill changes).</p>
-<h2 id="using-amq-squad">Using amq-squad</h2>
-<p>amq-squad has two surfaces, and you use them at different times:</p>
-<ul>
-<li><strong>The <code>amq-squad</code> CLI is for you, the
-operator.</strong> Design a team, bring it up / stop / resume in tmux,
-inspect it (<code>status</code>, <code>console</code>,
-<code>doctor</code>), and control agent panes (<code>focus</code>,
-<code>send</code>). Most commands are <strong>project-scoped</strong>
-(<code>--project DIR</code>, default cwd); the session-oriented ones
-(<code>up</code>, <code>status</code>, <code>send</code>,
-<code>stop</code>, <code>resume</code>, ...) are also
-<strong>session-scoped</strong> (<code>--session NAME</code>, the AMQ
-workstream). A few (<code>roles</code>, <code>doctor</code>) are neither
-or project-only.</li>
-<li><strong>The skills are for the agents.</strong> They teach a Claude
-or Codex agent how to drive amq-squad + AMQ from <em>inside</em> a
-session: coordinate with peers, and (as a lead) orchestrate a whole
-squad. You install them once per marketplace; the agents invoke them by
-name.</li>
-</ul>
-<h3 id="the-cli-in-60-seconds">The CLI in 60 seconds</h3>
+<p>The primary skills are <code>amq-squad</code> and
+<code>amq-squad-orchestrator</code>. The older
+<code>amq-team-setup</code> and <code>amq-squad-role-creator</code>
+skill entries are redirect stubs. The CLI and skills are versioned
+together.</p>
+<h2 id="quickstart">Quickstart</h2>
+<p>The shortest working path for a visible project lead and workers:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--sync</span>   <span class="co"># 1. design the team</span></span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96                        <span class="co"># 2. bring it up live in tmux</span></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96                   <span class="co"># 3. see who is live</span></span>
-<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span>   <span class="co"># 4. drive a pane</span></span>
-<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> qa          <span class="co">#    watch that agent work</span></span>
-<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span>               <span class="co"># 5. tear down (stays resumable)</span></span>
-<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span>            <span class="co"># 6. bring it back (bare resume = plan only)</span></span></code></pre></div>
-<p>The golden rules: <strong><code>up</code>/<code>new session</code> is
-for NEW work</strong> (it refuses an existing session — use
-<code>resume</code> to continue), <strong><code>stop</code> preserves
-state</strong> (resumable), and <strong>control targets the recorded
-pane id</strong>, never window names. Full surface: <a
-href="#quick-start">Quick start</a>, <a href="#verbs">Verbs</a>, <a
-href="#runtime-control-tmux">Runtime control</a>.</p>
-<h3 id="the-skills-and-when-to-use-each">The skills, and when to use
-each</h3>
-<table>
-<thead>
-<tr>
-<th>Skill</th>
-<th>Audience</th>
-<th>Reach for it when</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong><code>amq-squad</code></strong></td>
-<td>operator-facing and member agents</td>
-<td>setup, role authoring, and day-to-day coordination: capture a goal,
-draft the brief, pick roles/profile, sync pointer stubs, drain inboxes,
-route review/handoff, inspect
-<code>status</code>/<code>console</code>/<code>history</code>, run
-<code>up</code>/<code>stop</code>/<code>resume</code>/<code>fork</code>,
-and use tmux runtime control
-(<code>focus</code>/<code>send</code>).</td>
-</tr>
-<tr>
-<td><strong><code>amq-squad-orchestrator</code></strong></td>
-<td>a <strong>lead</strong> agent</td>
-<td>running a squad as a <em>driver</em>: spawn child agents, dispatch
-tasks to them over durable AMQ (the busy-guarded pane <code>send</code>
-is the fallback), monitor liveness via <code>status --json</code>,
-collect children's <code>[AGENT-EVENT]</code>-over-AMQ reports, and
-recover. The amq-squad-native equivalent of a hand-rolled tmux spawn
-protocol.</td>
-</tr>
-<tr>
-<td><code>amq-team-setup</code></td>
-<td>redirect stub</td>
-<td>deprecated; use <code>amq-squad</code> and its Setup section.</td>
-</tr>
-<tr>
-<td><code>amq-squad-role-creator</code></td>
-<td>redirect stub</td>
-<td>deprecated; use <code>amq-squad</code> and its Role Authoring
-section.</td>
-</tr>
-</tbody>
-</table>
-<p>Invoke a skill in Claude Code as
-<code>/amq-squad:&lt;skill&gt;</code> (e.g.
-<code>/amq-squad:amq-squad-orchestrator</code>); in Codex as
-<code>$&lt;skill&gt;</code> (e.g. <code>$amq-squad-orchestrator</code>).
-For routine member work use <code>amq-squad</code>; only the lead agent
-driving spawnees reaches for <code>amq-squad-orchestrator</code>.</p>
-<p><strong>Deeper guide:</strong> <a
-href="docs/skills.md">docs/skills.md</a> (<a
-href="docs/skills.html">HTML</a>) walks each skill end to end — when to
-reach for it, how to invoke it, worked examples, a decision table, an
-issue-to-merge walkthrough, and troubleshooting.</p>
-<h2 id="quick-start">Quick start</h2>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Preview, then create, an orchestrated run. --go is the mutation switch.</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="dt">\</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> . <span class="dt">\</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--lead</span> cto <span class="dt">\</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="dt">\</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--go</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a><span class="co"># Watch the run.</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a><span class="co"># Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="dt">\</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a>  <span class="at">--role</span> qa <span class="dt">\</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Run smoke tests&quot;</span> <span class="dt">\</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body</span> <span class="st">&quot;Validate the current PR and report findings.&quot;</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
+<p>Use <code>--external-lead</code> when the current pane is already the
+project lead and only the remaining workers should be spawned:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
 <span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> roles                      <span class="co"># list role IDs and menu numbers</span></span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--dry-run</span> <span class="at">--roles</span> cto,qa</span>
-<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--dry-run</span> <span class="at">--json</span> <span class="at">--roles</span> cto,qa</span>
-<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--sync</span> <span class="at">--session</span> issue-96</span>
-<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile review <span class="at">--roles</span> cto,qa <span class="at">--sync</span> <span class="at">--session</span> review</span>
-<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--dry-run</span>               <span class="co"># preview the launch plan</span></span>
-<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--project</span> ~/Code/other-app <span class="at">--dry-run</span></span>
-<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96       <span class="co"># NEW work: bring the team up live in tmux</span></span>
-<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-98 <span class="at">--seed-from</span> issue:31</span>
-<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session <span class="at">--project</span> ~/Code/other-app issue-97</span>
-<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span>                            <span class="co"># bare command -&gt; multi-session status board</span></span>
-<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96  <span class="co"># single-session detail</span></span>
-<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--project</span> ~/Code/other-app <span class="at">--session</span> issue-97</span>
-<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console                    <span class="co"># live read-only Mission Control TUI</span></span>
-<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--project</span> ~/Code/other-app <span class="at">--once</span></span>
-<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor                     <span class="co"># AMQ / PATH / Codex skill cache / tmux / wake / pointer sync</span></span>
-<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
-<span id="cb6-22"><a href="#cb6-22" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--all-profiles</span></span>
-<span id="cb6-23"><a href="#cb6-23" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96 <span class="co"># resolved AMQ root/session/handle</span></span>
-<span id="cb6-24"><a href="#cb6-24" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96 <span class="co"># AMQ operational diagnostics</span></span>
-<span id="cb6-25"><a href="#cb6-25" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span>
-<span id="cb6-26"><a href="#cb6-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--all</span>                 <span class="co"># SIGTERM the team (--force = SIGKILL); stays resumable</span></span>
-<span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--project</span> ~/Code/other-app <span class="at">--all</span> <span class="at">--session</span> issue-97</span>
-<span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume                     <span class="co"># re-orient (plan only; add --exec to relaunch)</span></span>
-<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--project</span> ~/Code/other-app <span class="at">--session</span> issue-97</span>
-<span id="cb6-31"><a href="#cb6-31" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> fork <span class="at">--from</span> issue-96 <span class="at">--as</span> issue-96-review  <span class="co"># branch a fresh workstream</span></span>
-<span id="cb6-32"><a href="#cb6-32" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> fork <span class="at">--project</span> ~/Code/other-app <span class="at">--from</span> issue-96 <span class="at">--as</span> issue-96-review</span>
-<span id="cb6-33"><a href="#cb6-33" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> rm issue-96                <span class="co"># remove a finished session (confirm-gated; or `archive`)</span></span></code></pre></div>
-<h3 id="lifecycle">Lifecycle</h3>
-<p>A session moves through one small state machine:</p>
-<pre class="text"><code>(none) --up--&gt; running --stop--&gt; stopped --rm/archive--&gt; (none)
-                  ^                  |
-                  +------ resume ----+</code></pre>
-<ul>
-<li><strong><code>up [&lt;name&gt;]</code></strong> means NEW work. It
-refuses a session that already exists — use <code>resume</code> to
-continue it, <code>up --reset</code> to start it over, or pick a new
-name.</li>
-<li><strong><code>new session [&lt;name&gt;]</code></strong> is the
-create-focused alias for <code>up [&lt;name&gt;]</code>. It follows the
-same NEW-work refusal rules.</li>
-<li><strong><code>new team</code></strong> is the create-focused alias
-for <code>team init</code>.</li>
-<li><strong><code>new profile NAME</code></strong> is the named-profile
-alias for <code>team init --profile NAME</code>.</li>
-<li><strong><code>stop</code></strong> is the primary teardown: SIGTERM
-the live agents (<code>--force</code> = SIGKILL), but PRESERVE all
-on-disk state so the session stays resumable. (The <code>down</code>
-alias was removed in 2.0.)</li>
-<li><strong><code>resume</code></strong> re-orients a stopped session.
-If an agent has a saved conversation, amq-squad reattaches it; otherwise
-it re-runs bootstrap so the agent re-reads its brief and AMQ history. It
-does NOT replay prior hidden reasoning.</li>
-<li><strong><code>rm</code> / <code>archive</code></strong> are the
-session-destructive ops. Both are confirm-gated (<code>--yes</code> to
-skip the prompt) and refuse a session with live agents unless
-<code>--force</code>. <code>rm</code> deletes the session root + brief;
-<code>archive</code> moves them aside, recoverable. <code>team rm</code>
-is separate: it removes one team profile config only.</li>
-<li>A <strong>restart</strong> is just <code>stop</code> then
-<code>up</code> (after <code>rm</code>/<code>archive</code>) or
-<code>resume</code> for the same session.</li>
-</ul>
-<h3 id="tmux-targets">tmux targets</h3>
-<p><code>amq-squad up</code> defaults to
-<code>--target current-window</code>, which splits the tmux window where
-you run the command. To bring a team up inside an existing tmux session
-such as <code>main</code>, switch or attach to the desired window first,
-then run <code>up</code> from that pane:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">tmux</span> switch-client <span class="at">-t</span> main:6</span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--session</span> v1-0-0-qa <span class="at">--terminal</span> tmux <span class="at">--target</span> current-window <span class="at">--layout</span> tiled</span></code></pre></div>
-<p>Use <code>--target new-session --terminal-session NAME</code> only
-when you want amq-squad to create a separate tmux session.
-<code>--terminal-session</code> names the new session; it does not
-select an existing tmux session for <code>current-window</code>.</p>
-<p>Panes are anchored to the pane you launch from
-(<code>$TMUX_PANE</code>), not to whatever window happens to be focused,
-so a <code>current-window</code> launch is safe even under iTerm2's
-<code>tmux -CC</code> integration: changing tabs mid-launch will not
-rehome the panes onto an unrelated window. If you launch from outside
-tmux, <code>current-window</code> refuses with a hint rather than
-guessing a target.</p>
-<p><code>up</code> is for NEW work and refuses a session that already
-exists. To continue an existing session use
-<code>amq-squad resume</code>; to start it over use
-<code>amq-squad up --reset</code> (destructive: it tears down and
-removes the session first, with a confirmation prompt unless
-<code>--yes</code>). Add <code>--force-duplicate</code> only when stale
-live-agent signals remain and you deliberately want a second agent
-alongside.</p>
-<p>Single-agent primitives:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--role</span> cto <span class="at">--session</span> issue-96</span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack</span></code></pre></div>
-<p>For Claude-binary agents launched in a tmux pane,
-<code>agent up</code>, <code>up</code>, and managed resume/replay
-schedule a best-effort <code>/rename &lt;role&gt;-&lt;session&gt;</code>
-injection after launch so Claude Code's resume picker shows the squad
-role/workstream. The launch is not blocked if that pane delivery fails.
-Codex has no equivalent slash command, so Codex agents are intentionally
-unaffected.</p>
-<p>The legacy verbs (<code>down</code>, <code>launch</code>,
-<code>restore</code>, <code>list</code>, <code>team show</code>,
-<code>team launch</code>) are <strong>removed in 2.0</strong>. Invoking
-one returns a usage error (exit 1); the replacements are listed in <a
-href="#removed-legacy-verbs">Removed legacy verbs</a> and <a
-href="MIGRATION.md"><code>MIGRATION.md</code></a>.</p>
-<h3 id="custom-launchers">Custom launchers</h3>
-<p>A managed member can be launched through a project-specific wrapper
-script while still receiving AMQ identity, bootstrap, a launch record,
-and status/resume. Pass <code>--launcher</code> (and optional
-<code>--launcher-args</code>) on <code>agent up</code>, or set
-<code>launcher</code> / <code>launcher_args</code> on the member in
-<code>team.json</code>:</p>
-<div class="sourceCode" id="cb10"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="at">--team-workstream</span> <span class="dt">\</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-pm-os-dev.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span></code></pre></div>
-<p>The launcher is exec'd in place of the binary.
-<code>--launcher-args</code> come first, then amq-squad appends the
-agent's normal child args (bootstrap + defaults), so <strong>the
-launcher script must forward its trailing args to the agent</strong>
-(e.g. end with <code>exec claude "$@"</code>). amq-squad refuses with a
-clear error if the launcher path is missing or not executable.
-<code>up --dry-run</code> prints the resolved launcher command.</p>
-<h3 id="per-member-native-args-and-context-overlays">Per-member native
-args and context overlays</h3>
-<p>A <code>team.json</code> member may carry <code>claude_args</code> /
-<code>codex_args</code> — extra native CLI args applied to <strong>that
-member only</strong>, appended after the team-level
-<code>binary_args</code> so the member value wins by position. The field
-must match the member's binary (<code>team sync</code> rejects a
-mismatch), launch records persist it, and resume reproduces it.</p>
-<p>The flagship use is the <strong>context-budget overlay</strong> for
-same-cwd squads: only the lead needs the full plugin/hook surface, while
-workers on smaller-context models burn tokens on plugins and per-prompt
-hook output they never use. Generate and wire it in one command
-(v1.9.0+):</p>
-<div class="sourceCode" id="cb11"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span> <span class="dt">\</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--disable-plugins</span> gws@workspace,document-skills@anthropics</span></code></pre></div>
-<p>This writes a Claude settings overlay per worker
-(<code>.amq-squad/overlays/&lt;role&gt;.claude.json</code>,
-human-editable, never clobbered on re-runs) and wires
-<code>claude_args: ["--settings", &lt;path&gt;]</code> into the member.
-<code>--workers</code> targets every claude member (the orchestration
-lead is excluded); <code>--role R</code> targets one. Launch planning
-(<code>up</code>, <code>resume</code>, the tmux backend) fails fast,
-naming the member, when a referenced <code>--settings</code> file is
-missing. Codex members use the native equivalent: a
-<code>$CODEX_HOME/&lt;name&gt;.config.toml</code> profile wired via
-<code>codex_args: ["--profile", "&lt;name&gt;"]</code>.</p>
-<h2 id="goal-first-dynamic-teams">Goal-first, dynamic teams</h2>
-<p><strong>The shift (2.0).</strong> Until now you <em>designed a team,
-then ran it</em>: <code>team init</code> authored a static roster,
-<code>up</code> spawned exactly that roster, and composition was frozen
-for the session. 2.0 inverts it — <strong>you hand a lead a goal and the
-lead composes the team</strong>, proposing, spawning, and pruning agents
-at runtime as the work reveals what it needs. Goal-first changes the
-default <em>mental model</em>; manual still works exactly as before.</p>
-<p>The load-bearing constraint, and why this is amq-squad-native rather
-than "just use Claude Code Agent Teams": <strong>orchestration is
-binary-neutral — a Codex agent can <em>lead</em>, not just be
-led.</strong> No core primitive depends on <code>~/.claude/</code>.</p>
-<p>Composition is a spectrum, and <strong>manual stays the
-floor</strong>:</p>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="dt">\</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">-p</span> . <span class="dt">\</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">-s</span> issue-96 <span class="dt">\</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--lead</span> cto <span class="dt">\</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--external-lead</span> <span class="dt">\</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="dt">\</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--go</span></span></code></pre></div>
+<p><code>run start</code> previews by default; <code>--go</code>
+creates. With <code>--goal</code>, it waits until the lead is live
+before delivering the goal. If goal delivery fails, it exits non-zero
+and prints an exact retry command.</p>
+<p>Manual setup still works when the team shape is known:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
+<h2 id="execution-modes">Execution modes</h2>
+<p>amq-squad separates the control root, target project root, visible
+lead, and implementation authority. The mode should be explicit in
+goal-first runs.</p>
 <table>
 <thead>
 <tr>
 <th>Mode</th>
-<th>Who composes the team</th>
-<th>Status</th>
+<th>What it means</th>
+<th>Use it when</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><strong>Manual</strong></td>
-<td>You design the roster up front (<code>team init</code> / the setup
-wizard).</td>
-<td>first-class, unchanged</td>
+<td><code>global_orchestrator</code></td>
+<td>A neutral control-plane session supervises one or more project runs.
+It previews, creates/registers project leads, routes gates, and watches
+evidence; it does not edit target project code.</td>
+<td>NOC/global coordination across repos or milestones.</td>
 </tr>
 <tr>
-<td><strong>Seeded</strong></td>
-<td>The lead <strong>proposes</strong> each spawn from the goal; the
-<strong>operator approves</strong> it over a
-<code>gate/&lt;topic&gt;</code> thread.</td>
-<td>shipped</td>
+<td><code>project_lead</code></td>
+<td>One visible project-root lead owns the run, delegates implementation
+over durable AMQ tasks, and produces final evidence.</td>
+<td>Default for most issue or milestone delivery.</td>
 </tr>
 <tr>
-<td><strong>Autonomous</strong></td>
-<td>The lead spawns/prunes within an explicit policy, no per-spawn
-approval.</td>
-<td>opt-in MVP</td>
-</tr>
-</tbody>
-</table>
-<p>Three binary-neutral primitives make it work, and all of them
-round-trip through stop/resume so a resumed session rebuilds the team
-the lead <strong>built</strong>, not the seed:</p>
-<ul>
-<li><strong>Mutable roster</strong> —
-<code>amq-squad team member add/rm/list</code> grows or shrinks the team
-mid-session (atomic, file-locked, re-validated, persisted). Add
-<code>--launch --dry-run</code> or <code>rm --stop --dry-run</code> to
-preview exact runtime actions before running them.</li>
-<li><strong>Native task store</strong> —
-<code>amq-squad task add/list/show/claim/done/fail/block/reset</code>: a
-pull-based, dependency-gated queue under
-<code>.amq-squad/tasks/&lt;session&gt;/</code> for the default profile,
-or <code>.amq-squad/tasks/&lt;profile&gt;/&lt;session&gt;/</code> for
-named profiles, so a lead of either binary decomposes the goal into
-claimable work.</li>
-<li><strong>Agent activity heartbeats</strong> —
-<code>amq-squad activity set/clear</code>: workers can atomically
-publish current task/phase activity under their AMQ agent directory.
-<code>status --json</code> and <code>console</code> show
-fresh/stale/unknown activity, with task-store ownership as a weaker
-source-separated fallback.</li>
-<li><strong>Compose-from-goal playbook</strong> — the
-<code>amq-squad-orchestrator</code> skill (in both the Claude and Codex
-marketplaces) drives propose → approve → <code>team member add</code> →
-<code>task add</code> → prune.</li>
-</ul>
-<p>AMQ <code>swarm</code> interop is supported as an external
-notification/adoption boundary, not as a replacement task store. See <a
-href="docs/amq-swarm-interop.md">docs/amq-swarm-interop.md</a> for the
-v2.7.0 decision.</p>
-<p>In practice — you stand up an orchestrated squad, then the lead
-composes and drives it:</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># You (operator): create an orchestrated team and bring it up, seeded from a goal.</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--session</span> issue-96</span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96 <span class="at">--target</span> new-window</span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="co"># The cto lead loads the amq-squad-orchestrator skill and, as the work reveals needs:</span></span>
-<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add fullstack <span class="at">--binary</span> codex <span class="at">--session</span> issue-96  <span class="co"># grow the roster</span></span>
-<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack <span class="at">--create-task</span> <span class="at">--subject</span> <span class="st">&quot;implement the fix&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span></code></pre></div>
-<h3 id="breaking-changes">Breaking changes</h3>
-<p>2.0 is a major version; the breaking surface is small and mechanical
-(full upgrade notes in <a
-href="MIGRATION.md"><code>MIGRATION.md</code></a>):</p>
-<ul>
-<li><strong>Removed verbs</strong> — <code>down</code>,
-<code>launch</code>, <code>restore</code>, <code>list</code>,
-<code>team show</code>, <code>team launch</code> now return a usage
-error. Use <code>stop</code>, <code>agent up</code>,
-<code>history</code> / <code>agent resume</code>, <code>status</code> /
-<code>history</code>, <code>up --dry-run</code>, and <code>up</code>
-respectively.</li>
-<li><strong><code>/v2</code> module path</strong> — install from
-<code>github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</code>
-(note the <code>/v2</code>).</li>
-<li><strong>No data migration</strong> — existing <code>team.json</code>
-(schema v3) loads unchanged.</li>
-</ul>
-<h2 id="context-model">Context model</h2>
-<p>The context model is three durable layers. Each layer has exactly one
-source of truth.</p>
-<table>
-<thead>
-<tr>
-<th>Layer</th>
-<th>File</th>
-<th>Owner</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Team norms</td>
-<td><code>.amq-squad/team-rules.md</code></td>
-<td>shared, hand-edited</td>
+<td><code>project_team</code></td>
+<td>Multiple visible project-root agents are launched as first-class
+members.</td>
+<td>The operator wants to watch and address several roles directly.</td>
 </tr>
 <tr>
-<td>Per-agent persona</td>
-<td><code>&lt;agent-dir&gt;/role.md</code></td>
-<td>seeded by launch, then user-editable</td>
-</tr>
-<tr>
-<td>Workstream brief</td>
-<td><code>.amq-squad/briefs/&lt;session&gt;.md</code> or
-<code>.amq-squad/briefs/&lt;profile&gt;/&lt;session&gt;.md</code></td>
-<td>one per profile/session namespace</td>
+<td><code>direct_lead_session</code></td>
+<td>The visible project lead may code directly in the project root.</td>
+<td>Single-lead exceptions where delegation would add no value.</td>
 </tr>
 </tbody>
 </table>
-<p><code>CLAUDE.md</code> and <code>AGENTS.md</code> carry a small
-managed pointer block that links to the three layers above; they never
-duplicate team-rules content. <code>amq-squad team sync --apply</code>
-writes and refreshes that block. Anything outside the markers is yours
-and is preserved.</p>
-<pre><code>&lt;!-- amq-squad:managed:begin --&gt;
-This project uses amq-squad for agent team coordination.
-
-- **Team norms:** `.amq-squad/team-rules.md`
-- **Your role:** when launched via amq-squad, `&lt;your-agent-dir&gt;/role.md` carries your persona.
-- **Active brief:** read `.amq-squad/briefs/&lt;session&gt;.md` for the current workstream (bootstrap names the exact path).
-
-These files are the source of truth. Do not duplicate their content here.
-&lt;!-- amq-squad:managed:end --&gt;</code></pre>
-<h3 id="workstream-briefs">Workstream briefs</h3>
-<p>A brief lives at <code>.amq-squad/briefs/&lt;session&gt;.md</code>
-for the default profile, or
-<code>.amq-squad/briefs/&lt;profile&gt;/&lt;session&gt;.md</code> for a
-named profile, and carries the goal, scope, and source-of-truth pointers
-for one profile/session namespace. Every team member in that namespace
-reads the same file.</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--dry-run</span> <span class="at">--seed-from</span> file:./brief.md     <span class="co"># preview candidate (no write)</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--dry-run</span> <span class="at">--seed-from</span> issue:31            <span class="co"># preview from current-repo issue</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--dry-run</span> <span class="at">--seed-from</span> gh:owner/repo#31    <span class="co"># preview from explicit GH issue</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--seed-from</span> issue:31                      <span class="co"># write brief + bring team up</span></span>
-<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:31    <span class="co"># create-focused spelling</span></span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--seed-from</span> issue:31 <span class="at">--force</span>              <span class="co"># overwrite an existing brief</span></span>
-<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up                                           <span class="co"># preserve existing brief</span></span>
-<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> brief <span class="at">--session</span> issue-96                     <span class="co"># read the current brief</span></span>
-<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> brief seed <span class="at">--session</span> issue-96 <span class="at">--seed-from</span> issue:31</span></code></pre></div>
-<p><code>--seed-from</code> semantics:</p>
-<ul>
-<li>With <code>--dry-run</code>: prints the candidate brief envelope and
-writes nothing.</li>
-<li>Without <code>--dry-run</code>: writes the selected namespace's
-brief and brings the team up in the same call. <code>--seed-from</code>
-needs <code>--force</code> to overwrite an existing brief; a bare
-<code>up</code> (no <code>--seed-from</code>) keeps it.</li>
-</ul>
-<p>The <code>amq-squad</code> skill's Setup section wraps this in a
-wizard: it captures a goal from <strong>any</strong> source you have —
-an inline prompt, a local <code>.md</code>, a GitHub issue or PR, a Jira
-key, or a doc URL — fetches it agent-side (amq-squad core stays
-tracker-neutral), and drafts a <strong>canonical brief</strong> (Goal /
-Source / Scope / Out of scope / Acceptance) for you to confirm before it
-is saved. The brief is per-session.</p>
-<h3 id="goal-draft">Goal draft</h3>
-<p><code>amq-squad goal draft</code> is the fast, preview-first setup
-helper for repeated goal-first runs. It turns a short goal, and
-optionally a GitHub milestone, into a deterministic setup plan without
-writing files, mutating rosters, creating tasks, sending AMQ messages,
-or launching agents.</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> goal draft <span class="dt">\</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;deliver GitHub milestone v2.7.0&quot;</span> <span class="dt">\</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--repo</span> omriariav/amq-squad <span class="dt">\</span></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--milestone</span> v2.7.0 <span class="dt">\</span></span>
-<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> v2-7-0 <span class="dt">\</span></span>
-<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--profile</span> codex-v2-7-0</span>
-<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> goal draft <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="at">--session</span> issue-96 <span class="at">--json</span></span></code></pre></div>
-<p>The draft includes a brief skeleton, proposed roster, task-store
-plan, seeded spawn-gate prompts, initial dispatch prompts, and the
-equivalent orchestrator <code>/goal --goal</code> prompt. Use it before
-the <code>amq-squad</code> Setup section or the
-<code>amq-squad-orchestrator</code> skill when you want a fast starting
-point, then review and explicitly approve any real setup mutations.
-Manual setup remains the right path when the team shape is already known
-or the goal needs unusual constraints. Execution ownership is explicit
-in the draft. <code>--mode project_lead</code> is the default: a visible
-project-root lead owns implementation and evidence.
-<code>--mode project_team</code> makes multiple project-root agents
-visible to the operator. <code>--mode direct_lead_session</code> is the
-explicit single-session exception where the current project-root lead
-may code directly. <code>--mode global_orchestrator</code> is a
-control-plane session only; it previews, creates or registers a project
-lead/team, routes approvals, and monitors evidence, but it does not
-inspect or edit project code. <code>--control-root</code>,
-<code>--target-project-root</code>, and <code>--target-contract</code>
-are emitted in the JSON <code>execution</code> object and generated
-prompts so amq-noc can show the mutable actor and version-compatibility
-state. The JSON envelope and generated brief also include
-<code>goal_binding</code>. Drafts prefer native binding
-(<code>mode: "native_goal_pending"</code>) by emitting a visible-lead
-<code>agent up ... -- '/goal ...'</code> command;
-<code>status --json</code> reports <code>mode: "native_goal"</code> only
-after the configured lead's launch record proves that native command was
-used or after <code>amq-squad goal deliver</code> records a successful
-native goal-control delivery. A live project lead without native
-evidence reports <code>mode: "native_goal_missing"</code>;
-older/runtime-fallback flows report the explicit
-<code>mode: "amq_task_brief"</code>, where the binding is the durable
-AMQ task, active brief, and task store.</p>
-<p><code>amq-squad goal deliver --goal TEXT --session S --role LEAD</code>
-is the first-class control path for native Codex <code>/goal</code>
-delivery. It is not the same as ordinary <code>amq-squad send</code>:
-normal prompts keep the busy guard, while native <code>/goal</code>
-delivery may target a busy Codex lead because the runtime accepts goal
-control messages safely. Successful delivery writes a delivery receipt
-and updates the lead launch record's <code>goal_binding</code> source to
-<code>goal-control</code>, so <code>status --json</code> can report
-verified native binding. When delivery starts from a non-agent
-operator/global-orchestrator pane, pass
-<code>--register-orchestrator[=HANDLE]</code> to add an
-<code>orchestrator</code> team member (default handle
-<code>orchestrator</code>), register the current pane as an external
-lead, and start/repair its wake sidecar before delivering the goal. This
-registers the control-plane orchestrator identity only; it does not
-adopt that pane as the project <code>cto</code> or other project
-lead.</p>
-<h4 id="wakeable-orchestrator-identity-in-one-command">Wakeable
-orchestrator identity in one command</h4>
-<p>From a neutral control root (a pane that is not itself a launched
-team agent), a single confirm-gated command gives the orchestrator a
-fully wakeable AMQ identity. No manual <code>team member add</code> or
-separate <code>lead register</code> is needed:</p>
-<div class="sourceCode" id="cb16"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> goal start <span class="dt">\</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> /path/to/repo <span class="dt">\</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> v2-15-0 <span class="dt">\</span></span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--register-orchestrator</span><span class="op">=</span>orchestrator <span class="dt">\</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;deliver GitHub milestone v2.17.0&quot;</span> <span class="dt">\</span></span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--yes</span></span></code></pre></div>
-<p>In one verified step this produces (1) a durable
-<code>orchestrator</code> team member, (2) a launch record bound to the
-live control pane, (3) the orchestrator set as lead where appropriate,
-and (4) a running wake sidecar targeting that pane. The roster write is
-deferred until after <code>--yes</code> is confirmed (run without
-<code>--yes</code>, or with <code>--dry-run</code>, to preview without
-mutating anything). Re-running the same command is idempotent: it does
-not duplicate the member or launch record, and re-uses the existing wake
-sidecar. If the wake sidecar cannot start, the command fails loudly
-rather than reporting an identity it did not create.</p>
-<p>Verify the binding with <code>status --json</code>. The envelope
-proves it on two surfaces: top-level <code>goal_binding</code> reports
-<code>mode: "native_goal"</code> with <code>verified: true</code>, and
-the orchestrator's per-member record carries <code>external: true</code>
-together with a live wake signal (<code>status: "wake-live"</code>,
-<code>signals.wake_alive: true</code>, and
-<code>signals.wake_pid</code>). The <code>external</code> field lets a
-client positively identify the registered orchestrator instead of
-inferring it from the lead role alone.</p>
-<p>The registered orchestrator's wake sidecar is started so that each
-inbound durable AMQ message injects a drain instruction (via AMQ's
-<code>amq wake</code> injector, not a raw <code>tmux send-keys</code>).
-The orchestrator therefore drains and acts reactively on wake, with no
-periodic <code>amq drain</code> polling loop, even after its own
-<code>/goal</code> reaches a terminal "achieved" state.
-<code>status --json</code> reports <code>wake_auto_drain: true</code> on
-that member when the drain injection is configured; this is a
-configuration signal, so a dead sidecar still surfaces as degraded
-(<code>status</code> not <code>wake-live</code>,
-<code>signals.wake_alive: false</code>) rather than silently appearing
-healthy. The virtual operator (<code>user</code>) handle is non-runnable
-and stays poll-only
-(<code>operator_delivery.poll_required: true</code>); auto-drain on wake
-applies to the orchestrator and lead handles, not the operator
-mailbox.</p>
-<p>To keep that wake-driven loop from stalling on routine permission
-prompts, an amq-squad-launched <strong>orchestrated Claude
-worker</strong> (a configured non-lead role) is launched with
-<code>gh pr create</code> pre-authorized, so creating its PR never
-blocks on a prompt. In this slice <strong>PR creation only</strong> is
-pre-authorized; feature-branch <code>git push</code> may still prompt
-and is tracked as future work (it needs a constrained wrapper that can
-enforce current-branch / no-tags / no-extra-refs before it can be safely
-allowlisted). Pushes to default/protected branches, tags, GitHub
-releases (<code>gh release create</code>/draft/publish/edit/upload),
-external sends, and destructive git are high-risk actions. Leads must
-run <code>amq-squad verify action</code> with the exact action and
-target before executing them, regardless of trust profile. The active
-allowlist is recorded on the launch record and surfaced in
-<code>status --json</code> as <code>preauthorized_actions</code> for
-audit. Pass <code>--no-preauthorize-inscope</code> to opt out; Codex
-workers and lead/operator sessions are unaffected.</p>
-<p>For an Autonomous preview, opt in explicitly and include a bounded
-policy:</p>
-<div class="sourceCode" id="cb17"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> goal draft <span class="dt">\</span></span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;deliver GitHub milestone v2.7.0&quot;</span> <span class="dt">\</span></span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> v2-7-0 <span class="dt">\</span></span>
-<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--composition</span> autonomous <span class="dt">\</span></span>
-<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--max-agents</span> 4 <span class="dt">\</span></span>
-<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--max-total-spawns</span> 3 <span class="dt">\</span></span>
-<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--allowed-roles</span> goal-dev,runtime-dev,cli-dev <span class="dt">\</span></span>
-<span id="cb17-8"><a href="#cb17-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--budget-turns</span> 20</span></code></pre></div>
-<p>Autonomous mode is never inferred from the goal text. A profile must
-be orchestrated and must declare <code>--composition autonomous</code>
-with positive <code>--max-agents</code>,
-<code>--max-total-spawns</code>, and <code>--budget-turns</code>, plus
-either <code>--allowed-roles</code> or
-<code>--allowed-role-classes</code>.
-<code>amq-squad status --json</code> and the status board expose the
-effective policy, counters, and remaining budget.</p>
-<p>Pause or permanently shut off an autonomous profile without editing
-JSON:</p>
-<div class="sourceCode" id="cb18"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
-<p>Autonomous only covers composition decisions inside that policy. It
-does not authorize merges, pushes, releases, destructive filesystem
-actions, external communications, provider side effects, or child-agent
-self-spawn authority. Those still require the normal operator/lead path.
-The runtime authorization path records JSONL audit evidence under
-<code>.amq-squad/autonomous/&lt;session&gt;/audit.jsonl</code> and
-persists policy counters before returning an allowed spawn/prune
-decision. Prune requests must include measured idle age, explicit
-evidence that active task linkage was checked, and no linked active
-tasks; <code>--idle-reap-minutes</code> sets the minimum idle age before
-pruning is allowed.</p>
-<p>High-risk actions carry a bound operator gate. Before a
-default/protected branch push, tag creation/push, GitHub release
-draft/publish action, or external send, run:</p>
-<div class="sourceCode" id="cb19"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="dt">\</span></span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> <span class="op">&lt;</span>repo<span class="op">&gt;</span> --profile <span class="op">&lt;</span>profile<span class="op">&gt;</span> --session <span class="op">&lt;</span>session<span class="op">&gt;</span> <span class="dt">\</span></span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> <span class="op">&lt;</span>topic<span class="op">&gt;</span> --action github_release <span class="dt">\</span></span>
-<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--target</span> <span class="st">&quot;draft v1.41.0 release for owner/repo&quot;</span> <span class="at">--json</span></span></code></pre></div>
-<p>The matching gate question and operator answer must both reference
-the same <code>Action:</code> and <code>Target:</code>.
-<code>verify action</code> exits <code>0</code> only for an approved
-bound answer from the configured operator handle on that exact
-<code>gate/&lt;topic&gt;</code> thread; it exits <code>10</code> for
-pending, <code>11</code> for denied, <code>12</code> for no matching
-gate, and <code>13</code> for an unbound or mismatched answer. Its JSON
-result includes <code>action</code>, <code>target</code>,
-<code>gate</code>, <code>decision</code>, <code>answered_by</code>, and
-<code>message_id</code>. If the operator approved in a live pane,
-resolve the board with
-<code>amq-squad operator answer --gate &lt;topic&gt; --to &lt;lead&gt; --approved --reason "Action: &lt;kind&gt;\nTarget: &lt;exact-target&gt;"</code>;
-p2p prose and mirrored ACKs do not satisfy the guard.</p>
-<p>This is a callable boundary, not command interception. A lead or
-wrapper that never calls <code>verify action</code> is not blocked by
-the operating system, shell, Git, or GitHub CLI. The guard's threat
-model is confused or overreaching agents that use the normal amq-squad
-CLI path; it is not a tamper-proof security boundary against an actor
-with direct filesystem write access to AMQ mailboxes, who can forge
-message bodies, <code>Created</code> timestamps, or message IDs. The
-harder enforcement path is a PATH shim or launch-hook interceptor that
-wraps <code>git</code>, <code>gh</code>, and external-send commands and
-forces this check before execution. That follow-up is tracked separately
-in #354 and should be referenced from release-hardening work.</p>
-<p>Releases carry one additional evidence gate. Before any publish step
-(<code>git push</code> of the release commit, <code>git tag</code>,
-<code>gh release create</code>),
-<code>amq-squad verify release --evidence &lt;file&gt;</code> requires
-the <strong>final assembled release commit SHA</strong> to carry both a
-<strong>developer co-sign</strong> (a second actor,
-<code>cosign.distinct_from_release_lead: true</code>,
-<code>cosign.sha</code> equal to the release commit SHA — a co-sign on
-an earlier per-delta SHA is rejected as stale) and an <strong>approved
-operator release gate</strong>. The two are non-substitutable: an
-"APPROVED to release" operator decision alone never authorizes publish
-without the exact-SHA developer co-sign, and the co-sign never
-substitutes for the operator gate. <code>verify release</code> only
-validates normalized evidence; it never pushes, tags, or releases —
-those remain operator-performed. The release commit's own final SHA must
-pass this gate before it becomes immutable.</p>
-<h3 id="profiles-schema-3">Profiles (schema 3)</h3>
-<p>Profiles let one team-home hold parallel team shapes (for example a
-release team and a research team).</p>
-<div class="sourceCode" id="cb20"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--session</span> issue-96        <span class="co"># default profile -&gt; .amq-squad/team.json</span></span>
-<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile release <span class="at">--session</span> qa   <span class="co"># named profile -&gt; .amq-squad/teams/release.json</span></span>
-<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team profiles                      <span class="co"># list configured profiles</span></span>
-<span id="cb20-4"><a href="#cb20-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team profiles <span class="at">--project</span> ~/Code/app <span class="co"># list another team-home</span></span>
-<span id="cb20-5"><a href="#cb20-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team profiles <span class="at">--json</span></span>
-<span id="cb20-6"><a href="#cb20-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team rm <span class="at">--profile</span> release          <span class="co"># delete one profile config only</span></span>
-<span id="cb20-7"><a href="#cb20-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--profile</span> release               <span class="co"># operate on a named profile</span></span>
-<span id="cb20-8"><a href="#cb20-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--profile</span> release           <span class="co"># check that profile&#39;s config, wake, and pointer sync</span></span></code></pre></div>
-<p>New <code>team.json</code> writes use <code>schema: 3</code> (the
-JSON key in persisted team profiles is <code>schema</code>;
-<code>schema_version</code> is reserved for the read-only JSON command
-envelopes documented below). Schema 1/2 profiles without an
-<code>operator</code> field are still supported and treated as implicit
-non-runnable <code>user</code> operator-gate teams until they are
-rewritten. Omit <code>--profile</code> (or pass
-<code>--profile default</code>) for the default profile.</p>
-<p>Default-profile storage remains backward compatible:
-<code>.agent-mail/&lt;session&gt;</code>,
-<code>.amq-squad/briefs/&lt;session&gt;.md</code>, and
-<code>.amq-squad/tasks/&lt;session&gt;</code>. Named profiles are
-storage-isolated under
-<code>.agent-mail/&lt;profile&gt;/&lt;session&gt;</code>,
-<code>.amq-squad/briefs/&lt;profile&gt;/&lt;session&gt;.md</code>, and
-<code>.amq-squad/tasks/&lt;profile&gt;/&lt;session&gt;</code>. Status,
-thread/threads, notify, dispatch, task, brief, launch, resume, and
-lifecycle commands resolve against the selected profile/session
-namespace rather than scanning a sibling legacy session root.</p>
-<p>Namespace-safety rule: mutating commands with <code>--session</code>
-in a multi-profile project should pass <code>--profile</code>. If an
-unprofiled mutation would write the default profile while a named
-profile already owns that session, amq-squad fails closed before writing
-and tells you to rerun with <code>--profile &lt;name&gt;</code> or the
-explicit escape hatch <code>--profile default</code>.
-<code>status --session &lt;name&gt;</code> stays read-only and warns
-when the default view is shadowed by a named profile.</p>
-<p>Schema 3 adds an optional virtual operator participant for human
-gates:</p>
-<div class="sourceCode" id="cb21"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa                 <span class="co"># default operator handle: user</span></span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--operator</span> ops  <span class="co"># custom operator handle</span></span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--no-operator</span>   <span class="co"># explicit opt-out</span></span></code></pre></div>
-<p>The operator is not a runnable team member. AMQ 0.38.0+ reserves the
-conventional <code>user</code> mailbox for this human/operator role, and
-amq-squad v2.18.0 requires AMQ 0.41.0+ overall; custom operator handles
-use the same amq-squad protocol. JSON discovery derives
-<code>operator</code> and <code>capabilities.operator_gates</code>;
-<code>capabilities</code> is not persisted in
-<code>team.json</code>.</p>
-<p>Operator gates are structural AMQ handoffs, not authentication. Send
-human-only decisions or manual actions to the configured operator handle
-on stable <code>gate/&lt;topic&gt;</code> threads, with
-<code>--kind question --subject "APPROVAL: &lt;decision&gt;"</code> for
-approvals and
-<code>--kind decision --subject "DONE: &lt;goal&gt;"</code> for manual
-closeout. The operator replies on the same thread with
-<code>--kind answer</code> and subjects such as <code>APPROVED:</code>,
-<code>DENIED:</code>, or <code>ANSWER:</code>. If the operator answers a
-pending gate in a live pane/chat instead of AMQ, the lead treats it as
-operator input, immediately ACKs or mirrors it on the matching
-<code>gate/&lt;topic&gt;</code> thread without spoofing the operator
-handle, and checks both the live channel and AMQ gate/inbox state before
-declaring the gate blocked. P2P prose like "pending operator" is
-evidence only; it is not a gate. <code>amq-squad notify</code> surfaces
-new or stale needs-you gates with inspect/respond commands and
-de-duplicates unchanged items, but notification output never authorizes
-or clears a gate.</p>
-<p>Unanswered operator gates age through visible escalation bands:
-<code>initial</code> immediately, <code>reminder</code> after 30
-minutes, and <code>strong-warning</code> after 2 hours. The age is
-measured from the last unanswered operator-facing gate message on the
-<code>gate/&lt;topic&gt;</code> thread, so re-raising a decision starts
-a fresh clock while later status chatter does not hide the pending gate.
-<code>notify</code> records the last emitted escalation band and
-bypasses normal de-duplication when a gate crosses into
-<code>reminder</code> or <code>strong-warning</code>;
-<code>status --json</code> emits <code>data.warnings[]</code> for aged
-gates, and <code>console</code> labels them as
-<code>needs-you/reminder</code> or
-<code>needs-you/strong-warning</code>.</p>
-<h3 id="orchestration-opt-in">Orchestration (opt-in)</h3>
-<p>By default a squad is flat: members coordinate peer-to-peer over AMQ.
-You can instead run an <strong>orchestrated</strong> squad, where one
-lead agent spawns, dispatches, and monitors the others and owns the
-deliverable. It is wired by a structured flag, not by hand-edited prose,
-so it cannot drift:</p>
-<div class="sourceCode" id="cb22"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto</span></code></pre></div>
-<p>This records <code>orchestrated</code>/<code>lead</code> in
-<code>team.json</code> and injects a generated
-<code>## Orchestration</code> reporting norm into
-<code>.amq-squad/team-rules.md</code>: the lead loads the
-<code>amq-squad-orchestrator</code> skill, dispatches durable AMQ tasks,
-and children push ACK/start, progress, blockers, review requests, and
-DONE reports back to the sender/lead over AMQ. Default off;
-<strong>exactly one lead</strong>; the lead is a team member,
-<strong>never the operator</strong>. <code>--lead ROLE</code> implies
-<code>--orchestrated</code>; with <code>--orchestrated</code> alone a
-single-member team self-selects and a team with a <code>cto</code>
-defaults to <code>cto</code>. The <code>team_profile_plan</code> /
-<code>team_plan</code> JSON envelopes carry
-<code>orchestrated</code>/<code>lead</code>. If
-<code>team-rules.md</code> already exists, <code>new team</code> leaves
-it untouched, so regenerate with
-<code>amq-squad team rules init --force</code> to pick up the norm.</p>
-<p>Execution modes make the ownership boundary machine-readable:</p>
-<ul>
-<li><code>global_orchestrator</code>: control-plane only. It may
-preview, select a target project/profile/session, create or register a
-project lead/team, route gates, poll when wake is unavailable, and
-report evidence. It must not inspect or edit project code directly
-unless explicitly converted to <code>direct_lead_session</code>.</li>
-<li><code>project_lead</code>: one visible project-root lead owns
-implementation, tests, child delegation, blockers, and final evidence.
-This is the default orchestrated project execution mode.</li>
-<li><code>project_team</code>: a visible project-root team with a
-visible lead and visible members. Use it only when the operator
-intentionally wants to inspect multiple project agents.</li>
-<li><code>direct_lead_session</code>: the current session is explicitly
-the project lead and may mutate the target project. This is appropriate
-for single-project quick work from the project root, not for
-NOC/control-root workflows.</li>
-</ul>
-<p>Lead mode is a separate implementation posture on top of the
-execution mode. <code>--lead-mode builder</code> is the compatibility
-default: the visible project lead may edit and commit within the
-execution boundary. <code>--lead-mode planner</code> makes the lead
-planner/reviewer-only: <code>status --json</code>, bootstrap, and goal
-draft surfaces report <code>implementation_allowed:false</code>, the
-bootstrap explicitly tells the lead not to edit files, run
-write-formatters, or commit, and implementation must be delegated over
-durable AMQ tasks. In planner mode <code>mutable_actor</code> is the
-single non-lead implementer role when there is exactly one; otherwise it
-is the explicit sentinel <code>delegated_workers</code>.</p>
-<p>Because <code>target_project_root</code> is where the project lead
-actually edits code — and from a neutral control root there is no
-reliable <code>owner/repo</code> → local-path mapping — amq-squad never
-silently guesses it for a <code>global_orchestrator</code> run.
-<code>team init --mode global_orchestrator</code> <strong>requires an
-explicit <code>--target-project-root</code></strong> and refuses to
-default to the current directory. <code>goal draft</code> classifies the
-value in <code>target_project_root_source</code>: <code>provided</code>
-(explicit), <code>resolved_unconfirmed</code> (exactly one local
-checkout matched by git remote <code>owner/repo</code> under the control
-root — a proposal that still must be confirmed or passed explicitly),
-<code>unresolved</code> (no single match; pass
-<code>--target-project-root</code>), or <code>default</code> (non-global
-mode, the lead runs inside the project). A
-<code>resolved_unconfirmed</code> match is a hint, not a
-confirmation.</p>
-<p><code>team init --mode ... --lead-mode ...</code> persists this
-contract in the profile, and <code>goal draft</code> generates matching
-<code>team init</code> and visible-lead prompts.
-<code>status --json</code> and the multi-session board JSON expose
-<code>execution.mode</code>, <code>control_root</code>,
-<code>target_project_root</code>, <code>visible_lead</code>,
-<code>visible_team_members</code>, <code>lead_mode</code>,
-<code>mutable_actor</code>, <code>implementation_allowed</code>,
-<code>goal_binding</code>, <code>visibility_topology</code>,
-<code>polling_required</code>, <code>mode_error</code>, and
-<code>version_compatibility</code> so clients do not infer who is
-allowed to mutate files. They also expose
-<code>operator_delivery.poll_required</code>,
-<code>operator_delivery.durable_amq</code>, and
-<code>operator_delivery.wake_supported</code>; a virtual/non-runnable
-operator handle always has <code>wake_supported=false</code>, so
-operator-facing updates and gates require polling/draining instead of
-wake delivery.</p>
-<p>Merge and lifecycle authority is explicit in the same status surface.
-<code>execution.release_readiness.merge_authority.default_actor</code>
-is <code>visible_lead</code>, and <code>worker_policy</code> is
-<code>workers_do_not_merge_by_default</code>: workers can report
-readiness evidence, but they do not merge, push, tag, release, close
-issues, or run other irreversible lifecycle actions from AMQ prose. The
-documented alternative is a verifiable authorization artifact that binds
-the operator/lead approval to the same subject, head SHA, and
-gate/evidence thread; otherwise a worker escalates the request back to
-the visible lead. This answers <strong>who</strong> owns the action
-path, while the exact-head review, <code>verify merge</code>, normalized
-evidence, and operator gate rules still answer <strong>when</strong>
-merge-ready can be claimed.</p>
-<p>The operator normally steers the workstream through the
-lead/orchestrator. The operator can steer the lead directly from amq-noc
-(v0.8.0+), or with plain AMQ: a <strong>directive</strong> arrives on
-the lead's operator p2p thread as a <code>--kind todo</code> message
-whose subject starts with <code>DIRECTIVE:</code>. The lead treats
-directives as operator steering with priority over child reports,
-acknowledges on the same thread, and never treats one as a gate answer
-(a directive never clears a <code>gate/&lt;topic&gt;</code> thread).
-Direct operator-to-worker messages are exceptional; when they affect
-scope, priority, merge readiness, release state, or external actions,
-the worker reports them to the lead before acting or includes the
-lead/thread metadata in the AMQ report.</p>
-<p>For NOC and orchestrator visibility, leads must surface blockers and
-approval requests immediately on the operator/orchestrator-visible
-surface. Approval requests use stable <code>gate/&lt;topic&gt;</code>
-threads; blockers use an operator-visible status or question. A blocker
-or approval request is not complete if it exists only in a child pane,
-internal worker thread, or hidden gate.</p>
-<p>When the top-level orchestrator or NOC is not wake-enabled, it must
-poll the visible goal leads instead of waiting for wake delivery. The
-operating contract is one <code>/goal</code> per visible lead; leads
-push status, blockers, approval requests, and final evidence to
-AMQ/NOC-visible surfaces; the parent orchestrator or NOC polls each
-lead's inbox, gate threads, and <code>status --json</code> on a cadence;
-child agents remain internal unless the lead escalates them. When a
-<code>global_orchestrator</code> owns more than one active or recently
-active workstream in one conversation, it keeps an in-conversation board
-and refreshes it after every poll, gate answer, spawn, stop, final
-report, or recovery action. The board records run name, repo,
-profile/session, lead and pane id, state (<code>running</code>,
-<code>gated</code>, <code>blocked</code>, <code>paused</code>,
-<code>stale</code>, <code>done</code>, <code>closed</code>), last
-checked time, next poll or wake source, current gate/blocker, last
-action, next action, and deterministic polling commands. Closed runs are
-demoted with <code>next action: none - closed</code> so they stop
-competing with active gates or stale runs. For
-<code>poll_required=true</code>, use deterministic commands such as
-<code>amq-squad monitor --once --json</code>, scoped
-<code>status --json</code>, <code>operator status</code>,
-<code>next --json</code>, and root-correct gate-thread reads. Recovery
-uses native amq-squad paths first (<code>dispatch</code> or drain-only
-<code>send</code> re-nudges, <code>resume</code> or
-<code>actions[]</code>, native <code>/goal resume</code> for understood
-blockers); raw <code>tmux send-keys Enter</code> is a recorded last
-resort after operator direction or when native recovery is unavailable.
-When <code>operator_delivery.poll_required=true</code>, the same polling
-rule applies to the virtual operator mailbox: lead reports, blockers,
-and approval gates are durable AMQ records, and no client should claim
-wake support for the non-runnable operator recipient.
-<code>status --json</code> exposes <code>goal_binding</code> so the NOC
-can tell whether a visible lead has verified native <code>/goal</code>
-binding (<code>native_goal</code>), a generated but not-yet-launched
-native plan (<code>native_goal_pending</code> in
-<code>goal draft --json</code>), a live project lead missing native
-evidence (<code>native_goal_missing</code>), or the explicit AMQ task +
-brief + task-store fallback (<code>amq_task_brief</code>). Recovery for
-a missing visible lead uses <code>amq-squad goal deliver</code>, which
-is a first-class native <code>/goal</code> control action with delivery
-receipt evidence; ordinary <code>amq-squad send</code> remains
-busy-guarded for normal prompts.</p>
-<p>For an existing profile, use
-<code>amq-squad team lead set &lt;role&gt;</code> to opt into
-orchestration without rebuilding the roster,
-<code>team lead clear</code> to return to a flat squad, and
-<code>team lead show --json</code> for discovery. A lead that is already
-running in an operator-owned pane can register itself with
-<code>amq-squad lead register --role &lt;role&gt; --session &lt;session&gt;</code>;
-this writes an explicit external launch record so <code>status</code> /
-<code>focus</code> / <code>send</code> can target the pane. Project-lead
-registration is fail-closed: the current pane must already prove the
-exact project/profile/session/role through runtime identity, matching
-launch record, native goal binding, or explicit
-<code>--adopt-project-lead</code> from the actual project-lead pane. A
-global-orchestrator/NOC pane cannot be adopted as project
-<code>cto</code> merely by passing <code>--role cto</code>;
-status/resume report <code>lead_role_boundary_violation</code> and tell
-the operator to launch/resume a real project lead in a sibling tab/new
-managed pane, or keep the current pane as global orchestrator only. By
-default, registration also starts or repairs the lead's AMQ wake
-sidecar; pass <code>--wake</code> to make that default explicit,
-<code>--no-require-wake</code> to warn instead of failing, or
-<code>--wake-inject-via</code> with repeated
-<code>--wake-inject-arg</code> for external wake injectors.
-<code>--no-wake</code> remains normal for global orchestrator/NOC
-pollers, but project-lead <code>--no-wake</code> requires the explicit
-escape hatch <code>--compat-no-wake --reason &lt;why&gt;</code> and
-records that reason. External lead records are visible and directable,
-but lifecycle commands do not own them: <code>stop</code> reports that
-the pane must be stopped manually, <code>rm</code> /
-<code>archive</code> leave it open, and <code>resume</code> asks the
-operator to run <code>lead register</code> again instead of replaying
-the pane.</p>
-<h2 id="verbs">Verbs</h2>
-<p>Team-level verbs:</p>
-<pre class="text"><code>amq-squad new team [--project DIR] [--sync] [--dry-run [--json]] [team init options]
-                                  Create the default team profile. Alias for
-                                  team init.
-                                  --dry-run previews the profile, rules path,
-                                  workstream, trust, and member roster without
-                                  writing files. Add --json for a
-                                  team_profile_plan envelope.
-                                  Add --sync to also write CLAUDE.md / AGENTS.md
-                                  managed pointer stubs. --roles accepts IDs,
-                                  menu numbers, or all; --session sets the
-                                  initial shared workstream; --operator sets
-                                  the virtual operator handle; --no-operator
-                                  disables operator gates;
-                                  --orchestrated [--lead ROLE] wires lead-agent
-                                  orchestration (default off; one lead, a team
-                                  member, never the operator);
-                                  --project targets a team-home without cd.
-amq-squad new profile NAME [--project DIR] [--sync] [--dry-run [--json]] [team init options]
-                                  Create a named team profile. Alias for
-                                  team init --profile NAME. Supports --sync,
-                                  --roles IDs, menu numbers, all, and
-                                  role=binary overrides, plus --session for
-                                  the initial shared workstream.
-amq-squad roles [--json]
-                                  List built-in role IDs, menu numbers, default
-                                  CLIs, and short profile copy for team creation.
-amq-squad new session [--project DIR] [--profile NAME] [&lt;session&gt;] [up options]
-                                  Create NEW work. Alias for up, with the same
-                                  refusal when the session already exists.
-                                  Supports --profile and --seed-from for named
-                                  profiles and seeded briefs. --project targets
-                                  a team-home without cd.
-
-amq-squad team init [--project DIR] [--profile NAME] [--roles a,b|numbers|all] [--binary role=bin,...]
-                     [--session ws] [--trust sandboxed|approve-for-me|trusted] [--orchestrated [--lead ROLE]]
-                     [--lead-mode builder|planner]
-                     [--mode project_lead|project_team|direct_lead_session|global_orchestrator]
-                     [--model role=model,...] [--codex-args ...] [--claude-args ...] [--dry-run [--json]]
-                                  Write a team profile and seed .amq-squad/team-rules.md.
-                                  --dry-run builds and prints the profile plan
-                                  without writing team.json or team-rules.md.
-                                  Add --json for a team_profile_plan envelope.
-                                  --orchestrated [--lead ROLE] opts the squad
-                                  into lead-agent orchestration (see Orchestration).
-                                  --project targets a team-home without cd.
-amq-squad team rules templates
-                                  List available team-rules templates.
-amq-squad team rules init [--project DIR] [--profile NAME]
-                     [--template auto|dev-only|product-squad|scrum|custom] [--force]
-                                  Seed or refresh .amq-squad/team-rules.md.
-                                  auto selects from the configured roster:
-                                  dev-only for engineering teams,
-                                  product-squad when product/design roles are
-                                  present, scrum for Scrum accountabilities,
-                                  and custom otherwise. --profile renders a
-                                  named profile while keeping team-rules.md
-                                  shared per team-home.
-amq-squad team rules show [--project DIR]
-                                  Print .amq-squad/team-rules.md.
-amq-squad team lead set &lt;role&gt; [--project DIR] [--profile NAME] [--lead-mode builder|planner]
-amq-squad team lead clear [--project DIR] [--profile NAME]
-amq-squad team lead show [--project DIR] [--profile NAME] [--json]
-                                  Mutate or inspect the profile&#39;s orchestration
-                                  lead. `set` validates that &lt;role&gt; is a team
-                                  member and records orchestrated=true.
-                                  --lead-mode planner makes that lead
-                                  planner/reviewer-only; builder is default.
-                                  `clear` returns the profile to flat mode.
-amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]
-                        [--disable-all-hooks] [--force] [--dry-run]
-                                  Generate .amq-squad/overlays/&lt;role&gt;.claude.json
-                                  and wire the member&#39;s claude_args to load it
-                                  via --settings: trim a worker&#39;s plugin/hook
-                                  surface in a same-cwd squad. --workers targets
-                                  every claude member (orchestration lead
-                                  excluded). Plan emission fails fast when a
-                                  referenced --settings file is missing.
-amq-squad team sync [--project DIR] [--apply] [--allow-outside]
-                                  Sync the pointer stub into CLAUDE.md and AGENTS.md.
-                                  Exit 1 on drift when --apply is not set.
-amq-squad team profiles [--project DIR] [--json]
-                                  List configured profiles (default + named).
-amq-squad team rm [PROFILE] [--project DIR] [--profile NAME] [--dry-run] [--yes|-y]
-                                  Delete one team profile config. Prompts by
-                                  default and does not delete AMQ sessions,
-                                  briefs, team-rules.md, or pointer stubs.
-
-amq-squad global start [--root DIR] [--agent claude|codex] [--name WINDOW]
-                       [--model M] [--codex-args A] [--claude-args A] [--go]
-                                  Stand up a global/NOC orchestrator: a poller
-                                  (no wake) at a neutral root that supervises
-                                  many runs. Preview by default; --go opens a
-                                  tmux window and launches the agent.
-amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
-                    [--roles r,...] [--binary role=bin,...] [--model role=model,...]
-                    [--lead-mode builder|planner]
-                    [--codex-args A] [--claude-args A]
-                    [--visibility sibling-tabs|detached|current] [--external-lead]
-                    [--goal TEXT] [--seed-from REF] [--go]
-                                  Create one orchestrated run: wraps new team
-                                  (if --roles) then up, so the namespace is typed
-                                  once. Preview by default (runs --dry-run
-                                  validation); --go creates. Visibility defaults
-                                  to sibling-tabs in the current tmux session;
-                                  use --visibility detached for hidden workers.
-                                  With --goal, --go waits for the lead to be
-                                  status-live with an alive tmux pane before
-                                  delivery. If delivery cannot complete, it
-                                  exits non-zero and prints an exact
-                                  `goal start ... --role &lt;lead&gt; --yes` retry
-                                  command.
-                                  With --external-lead, the current tmux pane is
-                                  bound as the configured lead and only the
-                                  remaining workers are spawned. This mode must
-                                  run from the lead member&#39;s project root and
-                                  does not register or re-point a separate
-                                  orchestrator handle.
-amq-squad up [&lt;session&gt;] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
-             [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
-             [--terminal tmux] [--target current-window|new-window|new-session]
-             [--layout vertical|horizontal|tiled] [--terminal-session name]
-             [--stagger 750ms] [--no-bootstrap] [--force-duplicate] [--no-gitignore]
-                                  NEW work. Bring the configured team up live (tmux) or
-                                  print the plan with --dry-run. REFUSES a session that
-                                  already exists (use `resume`, or `up --reset` to start
-                                  over). The name comes from the &lt;session&gt; positional or
-                                  --session (both is an error); inferred otherwise. With
-                                  no --seed-from the brief is AUTO-STUBBED (with a
-                                  one-line notice) so CI/send-keys flows keep working.
-                                  --project targets a team-home without cd.
-amq-squad stop (--role R | --all) [--project DIR] [--force] [--close-panes]
-                                  Stop members: SIGTERM the live, binary-matched
-                                  agent PID (--force = SIGKILL), reap the wake
-                                  sidecar, flip presence offline. On-disk state is
-                                  preserved, so the session stays resumable.
-                                  --project targets a team-home without cd.
-                                  --close-panes also closes each stopped agent&#39;s
-                                  tmux pane (default: keep, so final output stays
-                                  readable; resume re-creates panes).
-                                  (The &#39;down&#39; alias was removed in 2.0.)
-amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
-                 [--exec] [--dry-run] [--force-duplicate]
-                 [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted]
-                 [--model role=model,...]
-                 [--codex-args args] [--claude-args args]
-                                  Re-orient an existing session. Reattaches a saved
-                                  conversation if present; otherwise re-runs bootstrap so
-                                  the agent re-reads its brief + AMQ history (it does NOT
-                                  replay prior hidden reasoning). Plan-only by default;
-                                  classifies each member as live / restore / launch fresh
-                                  / blocked and prints copy-pasteable commands. With
-                                  --exec it opens them through the terminal backend, like
-                                  `up`. --project targets a team-home without cd. Use
-                                  `fork --from &lt;current&gt; --as &lt;new&gt;` for a NEW workstream.
-amq-squad fork --from &lt;current&gt; --as &lt;new&gt; [--project DIR] [--force-duplicate]
-                                  Plan fresh launches in a new workstream branched off
-                                  the current one. Plan-only; does not copy launch
-                                  records, briefs, conversations, or team.json. The
-                                  workstream brief at .amq-squad/briefs/&lt;new&gt;.md is
-                                  created or preserved by the subsequent
-                                  `up --session &lt;new&gt;` (or `agent up`) live launch.
-                                  --project targets a team-home without cd.
-amq-squad rm &lt;session&gt; [--project DIR] [--profile NAME] [--yes] [--force] [--keep-panes]
-                                  Permanently remove a finished session (its AMQ root dir
-                                  + brief). Previews + prompts
-                                  (default No) unless --yes; refuses a live session unless
-                                  --force; never touches a sibling session. Closes the
-                                  torn-down agents&#39; tmux panes by default (live agents
-                                  excluded); --keep-panes to leave them. --project
-                                  targets a team-home without cd; --profile selects the
-                                  profile/session namespace.
-amq-squad archive &lt;session&gt; [--project DIR] [--profile NAME] [--yes] [--force] [--keep-panes]
-                                  Move a finished session aside instead of deleting it
-                                  (to &lt;baseRoot&gt;/.archive/&lt;session&gt;/, recoverable).
-                                  Confirm-gated; refuses a live session unless --force.
-                                  Closes the agents&#39; tmux panes by default; --keep-panes
-                                  to leave them. --project targets a team-home without cd;
-                                  --profile selects the profile/session namespace.
-amq-squad status [--project DIR] [--json]
-                                  Multi-session BOARD over every discovered session
-amq-squad status --session NAME [--project DIR] [--json]
-                                  (rolled-up state, agent health, brief, last-activity).
-                                  With --session: the single-session detail table. The
-                                  bare `amq-squad` runs the board too. --project targets
-                                  a team-home without cd.
-amq-squad brief --session NAME [--project DIR] [--json]
-                                  Print the full workstream brief and classify it as
-                                  missing, stub, or real. --project targets a team-home
-                                  without cd.
-amq-squad brief seed --session NAME --seed-from REF [--project DIR] [--force]
-                                  Write a workstream brief from file:&lt;path&gt;,
-                                  issue:&lt;n&gt;, or gh:owner/repo#&lt;n&gt; without
-                                  launching the team. Use --dry-run to preview.
-amq-squad task add --title T [--desc D] [--depends-on id,...] [--assign role] [--json] --session S
-amq-squad task list [--status S] [--json] --session S
-amq-squad task show &lt;id&gt; [--json] --session S
-amq-squad task claim &lt;id&gt; --me HANDLE [--json] --session S
-amq-squad task done &lt;id&gt; --me HANDLE [--evidence E] [--json] --session S
-amq-squad task fail|block &lt;id&gt; --me HANDLE [--reason R] [--json] --session S
-amq-squad task reset &lt;id&gt; --me HANDLE [--reason R] [--json] --session S
-                                  Native pull-based, dependency-gated task store
-                                  under .amq-squad/tasks/&lt;session&gt;/ for the
-                                  default profile or
-                                  .amq-squad/tasks/&lt;profile&gt;/&lt;session&gt;/ for
-                                  named profiles. A task is
-                                  claimable only once its --depends-on tasks are
-                                  completed. Terminal/reset transitions on an
-                                  assigned task require the assignee&#39;s --me.
-                                  All subcommands require --session.
-amq-squad activity set --session S --me HANDLE --phase PHASE [--task ID] [--detail TEXT] [--profile P] [--json]
-amq-squad activity clear --session S --me HANDLE [--profile P] [--json]
-                                  Write or clear
-                                  &lt;amq-root&gt;/agents/&lt;handle&gt;/activity.json
-                                  atomically. Status and console surface this as
-                                  an honest busy/current-task signal with
-                                  source and quality; stale or malformed files
-                                  degrade to unknown rather than progress.
-amq-squad dispatch --session S --role R --subject SUBJ --body BODY [--create-task | --task ID] [--json]
-                                  Queue a durable AMQ message and best-effort
-                                  drain nudge. Plain dispatch stays AMQ-only;
-                                  --create-task creates and links a native task,
-                                  while --task links an existing task id. A
-                                  task-backed dispatch auto-claims a pending
-                                  task for the target handle after the durable
-                                  send and task link succeed.
-amq-squad lead register [--role ROLE] [--session S] [--project DIR] [--profile NAME]
-                         [--wake|--no-wake] [--require-wake|--no-require-wake]
-                         [--adopt-project-lead] [--compat-no-wake --reason TEXT]
-                         [--wake-inject-via PATH] [--wake-inject-arg ARG]
-                                  Adopt the current tmux pane as an
-                                  operator-owned external lead for an
-                                  orchestrated profile. The pane becomes
-                                  visible/directable in status/focus/send JSON,
-                                  but stop/rm/archive/resume do not kill,
-                                  close, or replay it.
-amq-squad console [--project DIR] [--session NAME] [--refresh 2s] [--at-risk-wait 5m]
-                  [--review-age 15m] [--once]
-                                  Mission Control TUI over this project. Renders
-                                  to /dev/tty (stdout stays clean). --once prints
-                                  a single static board to stdout for CI / non-TTY.
-                                  --project targets a team-home without cd.
-amq-squad notify [--project DIR] [--profile NAME] [--session NAME]
-                 [--renotify-after 30m] [--dry-run] [--json]
-                                  Emit de-duplicated operator attention items for
-                                  live needs-you gates, with inspect/respond
-                                  commands. Does not approve or clear gates.
-amq-squad history [--json] [--project a,b]
-                                  Restorable launch records across known projects.
-amq-squad threads --session NAME [--project DIR] [--limit N] [--json]
-                                  One collapsed row per AMQ thread in the
-                                  workstream (read-only).
-amq-squad thread --session NAME --id THREAD [--project DIR] [--include-body=false] [--json]
-                                  Read one AMQ thread transcript (read-only; does
-                                  not move unread mail).
-amq-squad doctor [--project DIR] [--profile NAME|--all-profiles] [--json]
-                                  AMQ version, AMQ ops diagnostics, the amq-squad
-                                  on PATH vs this build (version skew — spawned
-                                  agents inherit the PATH binary), Codex/Claude
-                                  plugin cache and skill-version alignment,
-                                  profile config, tmux, wake, marker integrity,
-                                  and pointer-sync drift.
-amq-squad amq env [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Show the AMQ context amq-squad resolved for
-                                  this project/session.
-amq-squad amq ops [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Run `amq doctor --ops` under the resolved
-                                  squad AMQ environment.
-amq-squad amq route --to HANDLE [--project DIR] [--session NAME] [--me HANDLE]
-                    [--target-project NAME] [--target-session NAME] [--json]
-                                  Explain an AMQ route before sending,
-                                  including cross-project/session context.
-amq-squad amq who|presence [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Inspect AMQ sessions, agents, and presence.
-amq-squad amq receipts list --me HANDLE [--project DIR] [--session NAME] [--msg-id ID] [--json]
-amq-squad amq receipts wait --me HANDLE --msg-id ID [--stage drained|dlq] [--timeout 60s]
-                                  Inspect or wait for AMQ delivery receipts.
-amq-squad amq dlq list --me HANDLE [--project DIR] [--session NAME] [--json]
-amq-squad amq dlq read --id ID --me HANDLE [--project DIR] [--session NAME] [--json]
-amq-squad amq dlq retry --id ID --me HANDLE [--project DIR] [--session NAME]
-amq-squad amq dlq retry-all|purge --me HANDLE [--project DIR] [--session NAME]
-                                  Inspect/repair DLQ state. `read`/`retry` take
-                                  `--id ID`; `purge` takes `--older-than DUR`.
-                                  Mutating retry/purge commands preview and
-                                  prompt by default.
-amq-squad amq cleanup --session NAME --tmp-older-than 36h [--project DIR]
-                                  Confirm-gated AMQ tmp cleanup for one
-                                  session.
-amq-squad version [--json]        Print the installed amq-squad version.
-amq-squad completion &lt;bash|zsh|fish&gt;
-                                  Print a shell completion script to stdout.</code></pre>
-<p>Single-agent primitives:</p>
-<pre class="text"><code>amq-squad agent up &lt;binary&gt; [--project DIR] [--role R] [--session ws] [--team-profile NAME]
-                            [--conversation ref] [--no-bootstrap]
-                            [--trust sandboxed|approve-for-me|trusted] [--model NAME]
-                            [--codex-args ...] [--claude-args ...]
-                            [--force-duplicate] [--no-gitignore] [-- &lt;native flags&gt;]
-                                  Launch one agent. Writes launch.json + role.md
-                                  in the AMQ mailbox, injects bootstrap, then execs
-                                  amq coop exec. --project targets a team-home
-                                  without cd.
-amq-squad agent resume &lt;role&gt; [--project a,b]
-                                  Replay one saved launch record.</code></pre>
-<p>For <code>agent up</code>, recognized launcher flags after
-<code>&lt;binary&gt;</code> (such as <code>--role</code>,
-<code>--session</code>, <code>--trust</code>, <code>--model</code>,
-<code>--codex-args</code>, <code>--claude-args</code>,
-<code>--help</code>) keep flowing into the launcher; unrecognized flags
-and the first non-flag positional are treated as child args. Use
-<code>--</code> for an explicit child boundary.
-<code>amq-squad agent up codex --help</code> prints launcher help;
-<code>amq-squad agent up codex -- --help</code> passes native help to
-the child. <code>--codex-args</code> and <code>--claude-args</code>
-accept dash-prefixed values such as
-<code>--codex-args '--enable goals'</code>.</p>
-<p>Global output flags work before or after the subcommand:
-<code>--quiet</code>, <code>--verbose</code>,
-<code>--color auto|always|never</code>. <code>NO_COLOR</code> overrides
-<code>--color=always</code>. <code>--quiet</code> and
-<code>--verbose</code> are mutually exclusive.</p>
-<h2 id="status-board-and-mission-control-console">Status board and
-Mission Control console</h2>
-<p><code>amq-squad status</code> (and the bare <code>amq-squad</code>)
-prints a <strong>multi-session board</strong> over every discovered
-session — docker-ps / <code>git branch -v</code> style: session name,
-rolled-up state (running / stopped / degraded), agent health (N/M alive
-+ at-risk), a one-line brief, and last-activity. Add
-<code>--session NAME</code> for the single-session detail table.</p>
-<p>Per-agent rows may include activity from
-<code>&lt;amq-root&gt;/agents/&lt;handle&gt;/activity.json</code>,
-written by <code>amq-squad activity set</code> or cheap task-transition
-stamps. <code>status --json</code> exposes this under
-<code>records[].activity</code> with <code>source</code>
-(<code>heartbeat-file</code>, <code>task-store</code>, or
-<code>unknown</code>) and <code>quality</code> (<code>fresh</code>,
-<code>stale</code>, or <code>unknown</code>) so clients can distinguish
-an agent-written heartbeat from task-store ownership fallback.</p>
-<p>Managed child rows may also include
-<code>records[].local_input</code> when a read-only pane-tail blind-spot
-detection heuristic sees a local approval/input prompt. This is not a
-coordination or progress primitive: capture failures, dead panes, and
-unparseable tails produce no field, so absence means "not observed", not
-"not blocked". When present, <code>data.warnings[]</code> includes
-<code>kind:"local_input_blocked"</code> with the role, pane, prompt
-summary, and recovery guidance; destructive prompts require an operator
-decision or a non-destructive alternative.</p>
-<p>Status warnings also include aged operator gates when a poll-required
-operator decision would otherwise sit silently. Gate escalation bands
-are <code>initial</code>, <code>reminder</code> at 30 minutes, and
-<code>strong-warning</code> at 2 hours; warning kinds are
-<code>operator_gate_reminder</code> and
-<code>operator_gate_strong_warning</code>, with a suggested
-<code>amq-squad thread ... --include-body</code> inspection command.</p>
-<p><code>amq-squad console</code> is the project-scoped Mission Control
-TUI for the current team-home.</p>
-<div class="sourceCode" id="cb25"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console                    <span class="co"># interactive TUI on /dev/tty</span></span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--once</span>             <span class="co"># single static board to stdout (CI / no TTY)</span></span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--project</span> ~/Code/app <span class="at">--once</span></span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96 <span class="at">--at-risk-wait</span> 5m</span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--filter</span> needs-you</span></code></pre></div>
-<p>The console gives you:</p>
-<ul>
-<li>a <strong>board</strong> of all sessions, grouped attention-first
-(needs-you &gt; blocked &gt; gated &gt; at-risk &gt; running &gt;
-stopped),</li>
-<li>per-session <strong>detail</strong> with each agent's liveness and a
-<strong>collapsed-thread bus</strong> ("qa ↔︎ cto blocked · subject N
-msgs · 7m"),</li>
-<li>aged operator gates rendered distinctly as
-<code>needs-you/reminder</code> or
-<code>needs-you/strong-warning</code>, using the pending gate age rather
-than later thread chatter,</li>
-<li><strong>peek</strong> (<code>space</code>) for a read-only view of
-an agent's recent output, unread inbox, and what it is blocked on,</li>
-<li>an <strong>action palette</strong> (<code>a</code>) with copy-ready
-commands such as <code>focus</code>, <code>send</code>,
-<code>resume</code>, <code>stop</code>, <code>task list</code>, and
-<code>dispatch</code>; the console never runs commands directly. This is
-the user-facing closure for #220.</li>
-<li>a <strong>triage rollup</strong> headline
-(<code>N needs-you threads · N blocked threads · N gated threads · N at-risk threads</code>)
-and <code>/</code>-filters (<code>needs-you</code>,
-<code>needs-user</code>, <code>gated</code>, <code>at-risk</code>,
-<code>blocked</code>, <code>stale-blocked</code>, <code>unread</code>,
-<code>agent:&lt;h&gt;</code>, <code>model:&lt;m&gt;</code>,
-<code>session:&lt;n&gt;</code>, <code>label:&lt;l&gt;</code>,
-<code>orchestrator:&lt;o&gt;</code>).</li>
-</ul>
-<p>It renders to <code>/dev/tty</code>, so <code>stdout</code> stays
-clean for the other verbs. With <code>--once</code> it emits one static
-board to stdout and exits — use this when there is no terminal
-attached.</p>
-<h2 id="amq-diagnostics">AMQ diagnostics</h2>
-<p><code>amq-squad amq ...</code> is a project-aware wrapper around AMQ
-diagnostics. It resolves the same AMQ root, base root, session, and
-handle that the squad launcher uses, then delegates to AMQ.</p>
-<p>amq-squad v2.18.0 requires AMQ 0.41.0 or newer. That floor includes
-AMQ wake input-queue draining before CR injection, receipt-confirmed
-send/reply waits, absolute roots from <code>amq env --json</code>, plus
-the earlier wake-inject stale-process fix, eval-safe
-<code>amq env --export</code>, reserved human <code>user</code> mailbox
-behavior, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file
-hardening.</p>
-<p>Read-only diagnostics run directly:</p>
-<div class="sourceCode" id="cb26"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
-<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96 <span class="at">--json</span></span>
-<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span>
-<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq who <span class="at">--session</span> issue-96</span>
-<span id="cb26-5"><a href="#cb26-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq presence <span class="at">--session</span> issue-96</span>
-<span id="cb26-6"><a href="#cb26-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq receipts list <span class="at">--session</span> issue-96 <span class="at">--me</span> cto</span></code></pre></div>
-<p>Mutating maintenance stays preview-first and confirm-gated:</p>
-<div class="sourceCode" id="cb27"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq dlq retry <span class="at">--session</span> issue-96 <span class="at">--me</span> qa <span class="at">--id</span> dlq_123</span>
-<span id="cb27-2"><a href="#cb27-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq dlq retry-all <span class="at">--session</span> issue-96 <span class="at">--me</span> qa <span class="at">--dry-run</span></span>
-<span id="cb27-3"><a href="#cb27-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq dlq purge <span class="at">--session</span> issue-96 <span class="at">--me</span> qa <span class="at">--older-than</span> 168h</span>
-<span id="cb27-4"><a href="#cb27-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq cleanup <span class="at">--session</span> issue-96 <span class="at">--tmp-older-than</span> 36h</span></code></pre></div>
-<p>Use route diagnostics before uncertain cross-project sends, receipt
-waits for important handoffs, and DLQ/cleanup only when debugging stuck
-delivery or stale temporary files.</p>
-<h2 id="json-envelopes">JSON envelopes</h2>
-<p>amq-squad's own verbs that produce machine-readable output accept
-<code>--json</code> and emit a schema-versioned envelope on stdout.
-Diagnostics stay on stderr; stdout under <code>--json</code> is pure
-JSON. (Some <code>amq-squad amq …</code> wrappers emit an amq-squad
-envelope — e.g. <code>amq env --json</code> is kind <code>amq_env</code>
-— while others delegate to AMQ's own JSON.)</p>
-<p>Team discovery payloads include derived operator metadata for
-external clients: <code>operator.enabled</code>,
-<code>operator.handle</code> when enabled,
-<code>operator.runnable=false</code>, and
-<code>capabilities.operator_gates</code>.</p>
-<p>Goal, team-plan, status, and board payloads also include an
-<code>execution</code> object when execution ownership is relevant. The
-mode-safe fields name the control root, target project root,
-profile/session namespace, visible lead/team, mutable actor, whether
-implementation is allowed, goal binding, topology, polling requirement,
-mode errors, and runtime-vs-target version compatibility.
-<code>status --json</code> and <code>doctor --json</code> also include a
-<code>versions</code> object with the running binary, the
-<code>amq-squad</code> found on <code>PATH</code>, Codex and Claude
-plugin-cache manifest versions, the loaded skill marker where
-detectable, and per-source <code>matches_running</code> / warning
-details. <code>up</code> emits the same mismatch warnings before launch
-when it can detect them.</p>
-<div class="sourceCode" id="cb28"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-2"><a href="#cb28-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> history <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-3"><a href="#cb28-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-4"><a href="#cb28-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-5"><a href="#cb28-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team profiles <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-6"><a href="#cb28-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> roles <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-7"><a href="#cb28-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--subject</span> <span class="st">&quot;Review&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span> <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-8"><a href="#cb28-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> task add <span class="at">--title</span> <span class="st">&quot;Review PR&quot;</span> <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-9"><a href="#cb28-9" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> task claim t1 <span class="at">--me</span> qa <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-10"><a href="#cb28-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> activity set <span class="at">--session</span> issue-96 <span class="at">--me</span> qa <span class="at">--task</span> t1 <span class="at">--phase</span> testing <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-11"><a href="#cb28-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add qa <span class="at">--binary</span> codex <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-12"><a href="#cb28-12" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--dry-run</span> <span class="at">--json</span> <span class="at">--roles</span> cto,qa <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-13"><a href="#cb28-13" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--sync</span> <span class="at">--dry-run</span> <span class="at">--json</span> <span class="at">--roles</span> cto,qa <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-14"><a href="#cb28-14" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up <span class="at">--dry-run</span> <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span>
-<span id="cb28-15"><a href="#cb28-15" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version <span class="at">--json</span> <span class="kw">|</span> <span class="ex">jq</span> .</span></code></pre></div>
-<p>Envelope shape:</p>
-<div class="sourceCode" id="cb29"><pre
-class="sourceCode json"><code class="sourceCode json"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;schema_version&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
-<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;&lt;verb&gt;&quot;</span><span class="fu">,</span></span>
-<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;data&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="er">/*</span> <span class="er">verb-specific</span> <span class="er">payload</span> <span class="er">*/</span> <span class="fu">}</span></span>
-<span id="cb29-5"><a href="#cb29-5" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>High-value mutating commands also support JSON success envelopes for
-orchestrators and NOC tooling. Initial stable mutator envelopes include
-<code>dispatch</code>, <code>task add</code>, task transitions
-(<code>claim</code>, <code>done</code>, <code>fail</code>,
-<code>block</code>), <code>activity set/clear</code>, and
-<code>team member add/rm</code>. Human output remains unchanged when
-<code>--json</code> is not passed. This is the user-facing closure for
-#222.</p>
-<h2 id="runtime-control-tmux">Runtime control (tmux)</h2>
-<p>The experimental iTerm2 launch backend is available on macOS with
-<code>--terminal iterm2 --target new-window</code>. It records
-backend-neutral terminal identity and supports window focus by recorded
-iTerm2 window id. Prompt injection, capture, busy detection, goal
-delivery, and pane-nudge dispatch stay disabled for iTerm2 until #374
-proves safe behavior; durable AMQ dispatch still queues normally. Manual
-smoke steps live in <a
-href="docs/iterm2-tier-b-smoke.md"><code>docs/iterm2-tier-b-smoke.md</code></a>.</p>
-<p>The experimental macOS Terminal.app backend is available with
-<code>--terminal terminal --target new-window</code>. It is Tier C
-launch-only: it records backend-neutral Terminal.app metadata when
-AppleScript exposes it and reports PID liveness, but focus, prompt
-injection, capture, busy detection, goal delivery, and safe close remain
-unavailable until follow-up spikes prove stable addressing and safe
-input semantics. Durable AMQ dispatch still queues normally; pane nudges
-are skipped with the Terminal.app safety reason. Manual smoke steps live
-in <a
-href="docs/terminal-app-tier-c-smoke.md"><code>docs/terminal-app-tier-c-smoke.md</code></a>.</p>
-<p>amq-squad owns the tmux execution/control contract for a team so
-external clients (such as amq-noc) can make agents actionable without
-scraping tmux or reconstructing pane layouts themselves.</p>
-<p>When an agent is launched inside tmux, its launch record persists the
-<strong>exact tmux identity</strong> of its pane — <code>session</code>,
-<code>window_id</code>, <code>window_name</code>, <code>pane_id</code>,
-and how the pane was created (<code>target</code>). Pane and window ids
-(<code>%265</code>, <code>@42</code>) are stable control addresses;
-window names are labels and are never used to target control.</p>
-<p><code>status --session NAME --json</code>,
-<code>history --json</code>, and <code>resume --json</code> expose that
-identity as a <code>tmux</code> block plus a computed
-<code>pane_alive</code> (does the recorded pane still exist?). Those
-<code>status --session NAME --json</code> members also carry an
-<code>actions</code> array of stable, project-scoped commands a client
-can render or copy, each with an <code>available</code> flag. The same
-shared action catalog feeds the console palette, and selected AMQ-facing
-commands resolve project/session/root/identity through the shared AMQ
-context helper; together these are the user-facing closure for #223:</p>
-<div class="sourceCode" id="cb30"><pre
-class="sourceCode json"><code class="sourceCode json"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb30-2"><a href="#cb30-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;role&quot;</span><span class="fu">:</span> <span class="st">&quot;cto&quot;</span><span class="fu">,</span></span>
-<span id="cb30-3"><a href="#cb30-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;status&quot;</span><span class="fu">:</span> <span class="st">&quot;live&quot;</span><span class="fu">,</span></span>
-<span id="cb30-4"><a href="#cb30-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;tmux&quot;</span><span class="fu">:</span> <span class="fu">{</span> <span class="dt">&quot;session&quot;</span><span class="fu">:</span> <span class="st">&quot;main&quot;</span><span class="fu">,</span> <span class="dt">&quot;window_id&quot;</span><span class="fu">:</span> <span class="st">&quot;@42&quot;</span><span class="fu">,</span> <span class="dt">&quot;pane_id&quot;</span><span class="fu">:</span> <span class="st">&quot;%265&quot;</span><span class="fu">,</span></span>
-<span id="cb30-5"><a href="#cb30-5" aria-hidden="true" tabindex="-1"></a>            <span class="dt">&quot;target&quot;</span><span class="fu">:</span> <span class="st">&quot;current-window&quot;</span><span class="fu">,</span> <span class="dt">&quot;pane_alive&quot;</span><span class="fu">:</span> <span class="kw">true</span> <span class="fu">},</span></span>
-<span id="cb30-6"><a href="#cb30-6" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;actions&quot;</span><span class="fu">:</span> <span class="ot">[</span></span>
-<span id="cb30-7"><a href="#cb30-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;focus&quot;</span><span class="fu">,</span>  <span class="dt">&quot;available&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;command&quot;</span><span class="fu">:</span> <span class="st">&quot;amq-squad focus --project DIR --session issue-96 --role cto&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb30-8"><a href="#cb30-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;send&quot;</span><span class="fu">,</span>   <span class="dt">&quot;available&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;command&quot;</span><span class="fu">:</span> <span class="st">&quot;amq-squad send --project DIR --session issue-96 --role cto --body-file -&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb30-9"><a href="#cb30-9" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;goal_deliver&quot;</span><span class="fu">,</span> <span class="dt">&quot;available&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;command&quot;</span><span class="fu">:</span> <span class="st">&quot;amq-squad goal deliver --project DIR --session issue-96 --role cto --goal &lt;goal&gt;&quot;</span> <span class="fu">}</span><span class="ot">,</span></span>
-<span id="cb30-10"><a href="#cb30-10" aria-hidden="true" tabindex="-1"></a>    <span class="fu">{</span> <span class="dt">&quot;kind&quot;</span><span class="fu">:</span> <span class="st">&quot;resume&quot;</span><span class="fu">,</span> <span class="dt">&quot;available&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">,</span> <span class="dt">&quot;command&quot;</span><span class="fu">:</span> <span class="st">&quot;amq-squad resume --project DIR --session issue-96 --exec&quot;</span> <span class="fu">}</span></span>
-<span id="cb30-11"><a href="#cb30-11" aria-hidden="true" tabindex="-1"></a>  <span class="ot">]</span></span>
-<span id="cb30-12"><a href="#cb30-12" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<p>The <code>tmux</code> block is present only when the agent has a
-known tmux identity (absent otherwise — e.g. an agent not launched under
-tmux). Its presence means "has a recorded pane", not "is reachable": a
-pane that has since died still carries a <code>tmux</code> block with
-<code>pane_alive: false</code>, so use <code>pane_alive</code> (and each
-<code>actions[].available</code> flag) for whether control is currently
-possible. <code>status --session NAME --json</code> and
-<code>resume --json</code> (and the <code>focus</code>/<code>send</code>
-verbs) <strong>adopt</strong> a live agent's pane even when it was
-launched <em>outside</em> amq-squad's tmux backend (a raw
-<code>tmux new-window</code>): the recorded, verified agent pid is
-matched into a live pane's process subtree, so
-<code>focus</code>/<code>send</code>/<code>attach_control</code> and
-<code>pane_alive</code> work for it too. (<code>history --json</code>
-reflects persisted launch records only and does not adopt.) Launching
-through amq-squad is still preferred (it records the role, binary, and
-brief, not just a pane).</p>
-<p>High-level control verbs target the exact pane id (falling back to a
-neutral title/cwd resolver) and are all project-scoped:</p>
-<div class="sourceCode" id="cb31"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto   <span class="co"># bring the agent&#39;s pane into view</span></span>
-<span id="cb31-2"><a href="#cb31-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96              <span class="co"># focus the session</span></span>
-<span id="cb31-3"><a href="#cb31-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> open <span class="at">--session</span> issue-96               <span class="co"># alias for focus</span></span>
-<span id="cb31-4"><a href="#cb31-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body</span> <span class="st">&quot;please review PR #65&quot;</span></span>
-<span id="cb31-5"><a href="#cb31-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body-file</span> ./prompt.md</span>
-<span id="cb31-6"><a href="#cb31-6" aria-hidden="true" tabindex="-1"></a><span class="fu">cat</span> prompt.md <span class="kw">|</span> <span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body-file</span> <span class="at">-</span></span>
-<span id="cb31-7"><a href="#cb31-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span>      <span class="co"># relaunch the team&#39;s panes</span></span></code></pre></div>
-<p><code>send</code> delivers the prompt deterministically: it stages
-the text in a tmux paste buffer (via stdin, never a shell string) and
-pastes it into the exact pane, then submits a single Enter — so
-multi-line prompts and text with quotes or shell metacharacters arrive
-verbatim. It errors clearly if the target pane is gone.</p>
-<h2 id="exit-codes">Exit codes</h2>
+<p><code>--external-lead</code> is a project-lead binding mode: the
+current tmux pane becomes the configured lead for that run, while
+amq-squad spawns the rest of the team. It must run from the lead
+member's project root. It does not adopt a separate global orchestrator
+handle as the project lead.</p>
+<p>Operational recipes live in <a
+href="docs/global-orchestrator-runbook.md">docs/global-orchestrator-runbook.md</a>
+and <a
+href="docs/operator-cookbook.md">docs/operator-cookbook.md</a>.</p>
+<h2 id="core-concepts">Core concepts</h2>
 <table>
 <thead>
 <tr>
-<th>Code</th>
+<th>Concept</th>
 <th>Meaning</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>0</code></td>
-<td>success</td>
+<td><strong>Project root</strong></td>
+<td>The repository or workspace whose <code>.amq-squad/</code> directory
+owns team state. Most commands default to cwd and accept
+<code>--project DIR</code>.</td>
 </tr>
 <tr>
-<td><code>1</code></td>
-<td>usage / user error (unknown flag, bad argument, missing required
-input)</td>
+<td><strong>Profile</strong></td>
+<td>A team shape. The default profile is
+<code>.amq-squad/team.json</code>; named profiles live under
+<code>.amq-squad/teams/&lt;name&gt;.json</code>.</td>
 </tr>
 <tr>
-<td><code>2</code></td>
-<td>system / runtime error (IO, process, config, environment)</td>
+<td><strong>Session / workstream</strong></td>
+<td>The AMQ namespace for one issue, release, or focused run. Session
+names use lowercase letters, digits, <code>-</code>, and
+<code>_</code>.</td>
 </tr>
 <tr>
-<td><code>3</code></td>
-<td>partial success (some targets succeeded, some failed; e.g.
-<code>stop</code> with mixed stopped + failed)</td>
+<td><strong>Team rules</strong></td>
+<td><code>.amq-squad/team-rules.md</code>, shared norms for all members.
+<code>CLAUDE.md</code> and <code>AGENTS.md</code> only point to it.</td>
+</tr>
+<tr>
+<td><strong>Role file</strong></td>
+<td>Per-agent persona seeded into the AMQ agent directory at launch and
+preserved on later resumes.</td>
+</tr>
+<tr>
+<td><strong>Brief</strong></td>
+<td>The goal/scope/source file for one profile/session namespace, under
+<code>.amq-squad/briefs/</code>.</td>
+</tr>
+<tr>
+<td><strong>Launch record</strong></td>
+<td>Per-agent metadata that records cwd, binary, args, terminal
+identity, wake settings, goal binding, and resume state.</td>
+</tr>
+<tr>
+<td><strong>Task store</strong></td>
+<td>Native dependency-aware task files under
+<code>.amq-squad/tasks/</code>, used by leads to assign and track
+work.</td>
+</tr>
+<tr>
+<td><strong>AMQ thread</strong></td>
+<td>A durable conversation path such as <code>p2p/cto__qa</code> or
+<code>gate/merge-pr-387</code>.</td>
+</tr>
+<tr>
+<td><strong>Operator handle</strong></td>
+<td>Usually <code>user</code>, a non-runnable mailbox for human gates.
+Agents are runnable; the operator handle is not.</td>
 </tr>
 </tbody>
 </table>
-<h2 id="shell-completions">Shell completions</h2>
-<p>GitHub Actions runs <code>make ci</code> on pull requests and pushes
-to <code>main</code>. The workflow installs <code>pandoc</code> so
-formatting, tests, generated HTML freshness, and skill frontmatter
-checks run with the same baseline expected locally. This is the
-user-facing closure for #221.</p>
-<div class="sourceCode" id="cb32"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash <span class="op">&gt;</span> /etc/bash_completion.d/amq-squad</span>
-<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh  <span class="op">&gt;</span> <span class="st">&quot;</span><span class="va">${fpath</span><span class="op">[</span><span class="dv">1</span><span class="op">]</span><span class="va">}</span><span class="st">/_amq-squad&quot;</span></span>
-<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish <span class="op">&gt;</span> ~/.config/fish/completions/amq-squad.fish</span></code></pre></div>
-<p><code>completion zsh</code> is followed by a <code>compinit</code>
-step on most shells.</p>
-<h2 id="custom-roles">Custom roles</h2>
-<p><code>--roles</code>/<code>--personas</code> accept built-in personas
-(<code>cpo, cto, senior-dev, fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm, designer, scribe, lead, agent</code>)
-and <strong>custom roles</strong> that are not in the catalog. A custom
-role is any valid slug (lowercase <code>a-z</code>, <code>0-9</code>,
-<code>-</code>, <code>_</code>) and must carry an explicit
-<code>--binary</code> because there is no catalog default to fall back
-to. Built-in roles keep their catalog defaults unless overridden. Custom
-roles are first-class team members in <code>team.json</code>,
-<code>team-rules.md</code>, the bootstrap prompt, status/history, and
-launch/resume.</p>
-<p>Use <code>lead</code> and <code>agent</code> for persona-light squads
-when you need a generic orchestrator or individual contributor without a
-domain-specific title.</p>
-<div class="sourceCode" id="cb33"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="co"># inline: id + CLI, minimal role.md (generic custom-role fallback text)</span></span>
-<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span>
-<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher,reviewer <span class="at">--binary</span> researcher=codex,reviewer=claude</span>
-<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile discovery <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
-<p>Missing a binary fails clearly:
-<code>custom role "researcher" requires --binary researcher=&lt;cli&gt;</code>.</p>
-<p>For a richer persona, author a <strong>role file</strong> and pass it
-with <code>--role-file</code> (comma-separated) or inline in
-<code>--roles</code>. Supported formats: Markdown with optional YAML
-frontmatter, <code>.yaml</code>, or <code>.json</code>. The
-<code>binary:</code> field satisfies the binary requirement
-(<code>--binary</code> overrides it). The authored document is staged at
-<code>.amq-squad/roles/&lt;id&gt;.md</code> and seeds that agent's
-<code>role.md</code> at launch (later user edits are preserved). A role
-file whose id matches a built-in persona is rejected — pick a different
-id for a custom role.</p>
-<div class="sourceCode" id="cb34"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span>
-<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> <span class="st">&quot;cto,./roles/researcher.md&quot;</span></span></code></pre></div>
-<div class="sourceCode" id="cb35"><pre
-class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb35-1"><a href="#cb35-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb35-2"><a href="#cb35-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
-<span id="cb35-3"><a href="#cb35-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
-<span id="cb35-4"><a href="#cb35-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
-<span id="cb35-5"><a href="#cb35-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
-<span id="cb35-6"><a href="#cb35-6" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb35-7"><a href="#cb35-7" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
-<span id="cb35-8"><a href="#cb35-8" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb35-9"><a href="#cb35-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
-<span id="cb35-10"><a href="#cb35-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
-<p>The <code>amq-squad</code> skill's Role Authoring section walks
-through authoring role files and wiring them into a team.</p>
-<h2 id="trust-and-binary-defaults">Trust and binary defaults</h2>
-<p>Generated launch commands include these per-binary defaults:</p>
+<p>The context model has one source of truth per layer:</p>
 <ul>
-<li><strong>Claude:</strong> <code>--permission-mode auto</code></li>
-<li><strong>Codex:</strong> approve-for-me by default, which uses Codex
-Auto with <code>workspace-write</code>, <code>on-request</code>, and
-<code>approvals_reviewer="auto_review"</code>. Pass
-<code>--trust sandboxed</code> to opt into manual approval/sandbox
-prompts. Pass <code>--trust trusted</code> only for the local power-user
-profile that prepends
-<code>--dangerously-bypass-approvals-and-sandbox</code>.</li>
+<li>Team norms: <code>.amq-squad/team-rules.md</code></li>
+<li>Agent persona: each launched agent's <code>role.md</code></li>
+<li>Workstream brief: <code>.amq-squad/briefs/&lt;session&gt;.md</code>
+or
+<code>.amq-squad/briefs/&lt;profile&gt;/&lt;session&gt;.md</code></li>
 </ul>
-<p>Explicit <code>--trust sandboxed</code>,
-<code>--trust approve-for-me</code>, and <code>--trust trusted</code>
-selections are persisted in the team profile by <code>team init</code>
-and are re-emitted by <code>up</code>, <code>agent up</code>,
-<code>resume</code>, and <code>fork</code>. Combining
-<code>--trust trusted</code> with <code>--no-default-args</code> is
-rejected, as is sandboxed or approve-for-me mode with the bypass flag
-smuggled through <code>--codex-args</code>.</p>
-<p><code>run start</code> uses the same launch trust vocabulary, but its
-default lead autonomy is conservative for release work: trust controls
-local permission prompts, not authorization to push default/protected
-branches, create or push tags, draft or publish GitHub releases, or send
-external communications. Those actions require an explicit bound
-<code>verify action</code> approval. Autonomous release actions are an
-opt-in integration concern for wrappers that deliberately call and
-record that guard; they are never implied by <code>approve-for-me</code>
-or by starting a run without a goal.</p>
-<p>Pass <code>--model NAME</code> to set the native <code>--model</code>
-flag on Codex or Claude. <code>team init --model role=model,...</code>
-persists per-member models. If no explicit model is set, amq-squad looks
-for a global default in <code>AMQ_SQUAD_CONFIG</code>, then
-<code>$XDG_CONFIG_HOME/amq-squad/config.json</code>, then
-<code>~/.amq-squad/config.json</code>; Codex also falls back to local
-Codex config (<code>$CODEX_HOME/config.toml</code>, profile config when
-<code>--profile</code> is present, or
-<code>~/.codex/config.toml</code>). Supported amq-squad config keys are
-<code>model</code>, <code>codex_model</code>, <code>claude_model</code>,
-or a <code>models</code> map keyed by binary name.</p>
-<h3 id="model-binary-and-effort-guidance">Model, binary, and effort
-guidance</h3>
-<p>Context stamp: this guidance reflects the current operator setup as
-of 2026-07-10. Availability, aliases, and pricing are setup-dependent,
-not universal; treat cost as a local tie-breaker, not as list-price
-guidance.</p>
-<p>Defaults are not limits. Agents should escalate binary, model, or
-effort when the output does not meet the bar. For shippable work,
-optimize for <code>intelligence &gt; taste &gt; cost</code>; cost
-matters only after the work is good enough.</p>
+<p><code>amq-squad team sync --apply</code> writes the small managed
+pointer block into <code>CLAUDE.md</code> and <code>AGENTS.md</code>; it
+does not duplicate rules.</p>
+<h2 id="orchestration-protocol-and-safety">Orchestration protocol and
+safety</h2>
+<p>An orchestrated run is a simple loop:</p>
+<ol type="1">
+<li>The lead reads the goal/brief and decomposes work into native
+tasks.</li>
+<li>The lead sends durable AMQ <code>todo</code> messages with
+<code>amq-squad dispatch</code>.</li>
+<li>Workers drain AMQ, ACK/start, push progress, ask questions, request
+reviews, and report DONE on the same durable thread.</li>
+<li>The lead collects reports, verifies evidence, updates the task
+store, and decides whether more work is needed.</li>
+<li>Human-only decisions use <code>gate/&lt;topic&gt;</code> threads
+addressed to the operator handle. The answer is durable evidence, not an
+implicit permission to do unrelated work.</li>
+</ol>
+<p>Safety is part of that protocol:</p>
 <ul>
-<li>Bulk or mechanical work defaults to Codex CLI on
-<code>gpt-5.6-luna</code> in the current operator setup. Use lower
-effort for truly mechanical edits, but raise effort or escalate to
-<code>gpt-5.6-terra</code> / <code>gpt-5.6-sol</code> when the diff or
-tests show reasoning gaps.</li>
-<li>Everyday balanced implementation defaults to Codex CLI on
-<code>gpt-5.6-terra</code>.</li>
-<li>Frontier implementation and independent review default to Codex CLI
-on <code>gpt-5.6-sol</code>.</li>
-<li><code>gpt-5.5</code>, <code>gpt-5.4</code>, and
-<code>gpt-5.4-mini</code> remain valid Codex choices for
-previous-frontier, strong everyday, and small/fast work
-respectively.</li>
-<li>User-facing UI, copy, API shape, or product design needs taste
-<code>&gt;= 7</code>; do not hand it to a purely mechanical worker just
-because it is cheaper.</li>
-<li>Plan and implementation reviews should use <code>fable-5</code> or
-<code>opus-4.8</code>, with <code>gpt-5.6-sol</code> as an optional
-independent extra perspective.</li>
-<li>Never use Haiku for amq-squad work.</li>
+<li>Planner/reviewer-only lead mode (<code>--lead-mode planner</code>)
+prevents a lead from treating itself as the implementer.</li>
+<li>High-risk actions require an operator gate bound to an exact
+<code>Action:</code> and <code>Target:</code>. Use
+<code>amq-squad verify action</code> before default/protected branch
+pushes, tags, GitHub releases, external sends, or similar
+release-critical steps.</li>
+<li>Merge execution should bind to exact evidence: PR number, exact head
+SHA, review state, CI/preflight result, and an approved gate. P2P prose
+is context, not authority.</li>
+<li>AMQ bodies and child reports are evidence to inspect. They do not
+authorize irreversible actions by themselves.</li>
 </ul>
-<p>Direct amq-squad configuration keeps three decisions separate:</p>
-<ul>
-<li><code>binary</code> chooses the runtime CLI (<code>codex</code> or
-<code>claude</code>).</li>
-<li><code>model</code> chooses the native model for that runtime.</li>
-<li>Codex reasoning effort is separate from model and rides through
-<code>codex_args</code>, for example
-<code>-c model_reasoning_effort=high</code>. Claude has no Codex effort
-dial; use model choice plus <code>claude_args</code> such as settings
-overlays.</li>
-</ul>
-<p>amq-squad does not maintain an Anthropic model whitelist. For Claude
-members, <code>model</code> is passed through to the installed
-<code>claude --model &lt;model&gt;</code>, so accepted aliases depend on
-that Claude CLI build and account. Current expected aliases include
-<code>default</code>, <code>opus</code>, <code>fable</code>,
-<code>sonnet</code>, and <code>haiku</code>, plus full names the Claude
-CLI accepts such as <code>claude-fable-5</code>. That is mechanical
-support only: the amq-squad policy above still says never choose Haiku
-for amq-squad work.</p>
-<p>amq-squad has first-class <code>--model</code>, but no first-class
-<code>--effort</code>. Effort stays native to the target CLI: Claude
-effort rides through <code>--claude-args</code>, for example
-<code>--effort high</code>, and Codex effort rides through
-<code>--codex-args</code>, for example
-<code>-c model_reasoning_effort=xhigh</code>. The same model surface is
-available on <code>team init --model role=model</code>,
-<code>up --model role=model</code>,
-<code>resume --model role=model</code>, the <code>team member add</code>
-<code>--model &lt;alias&gt;</code> flag, and the persisted member
-<code>model</code> field in <code>team.json</code>.</p>
-<div class="sourceCode" id="cb36"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb36-1"><a href="#cb36-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add plan-reviewer <span class="at">--binary</span> claude <span class="at">--model</span> claude-fable-5 <span class="dt">\</span></span>
-<span id="cb36-2"><a href="#cb36-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--claude-args</span> <span class="st">&quot;--effort high&quot;</span> <span class="at">--session</span> issue-96</span>
-<span id="cb36-3"><a href="#cb36-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add implementer <span class="at">--binary</span> claude <span class="at">--model</span> sonnet <span class="dt">\</span></span>
-<span id="cb36-4"><a href="#cb36-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--claude-args</span> <span class="st">&quot;--effort medium&quot;</span> <span class="at">--session</span> issue-96</span>
-<span id="cb36-5"><a href="#cb36-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add opus-reviewer <span class="at">--binary</span> claude <span class="at">--model</span> opus <span class="dt">\</span></span>
-<span id="cb36-6"><a href="#cb36-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--claude-args</span> <span class="st">&quot;--effort high&quot;</span> <span class="at">--session</span> issue-96</span>
-<span id="cb36-7"><a href="#cb36-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team member add codex-worker <span class="at">--binary</span> codex <span class="dt">\</span></span>
-<span id="cb36-8"><a href="#cb36-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=xhigh&quot;</span> <span class="at">--session</span> issue-96</span></code></pre></div>
-<p>Use <code>up</code> and <code>resume</code> overrides when the
-profile is durable but a launch needs session-specific model choices.
-Resume overrides apply to members launched fresh during that resume
-plan; already-live members keep their running process.</p>
-<div class="sourceCode" id="cb37"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up issue-96 <span class="at">--model</span> plan-reviewer=claude-fable-5,implementer=sonnet</span>
-<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--model</span> plan-reviewer=opus,implementer=sonnet <span class="at">--exec</span></span></code></pre></div>
-<p>For durable rosters, the same values live in <code>team.json</code>:
-<code>binary</code>, <code>model</code>, per-member
-<code>codex_args</code> / <code>claude_args</code>, or team-level
-<code>binary_args</code> for every member of one binary. Prefer an
-explicit Codex-binary member when the job needs a Codex model such as
-<code>gpt-5.6-sol</code> or <code>gpt-5.6-terra</code>. A thin Claude
-wrapper is only a compatibility pattern for Claude-only workflow or
-subagent systems. In those systems, a Claude workflow/agent
-<code>model:</code> parameter selects a Claude model only; it does not
-select a Codex model or effort level. Keep the wrapper minimal, have it
-delegate the real task to Codex CLI, and make that indirection visible
-in the role/scope so reviewers do not mistake it for a native Claude
-model choice.</p>
-<div class="sourceCode" id="cb38"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--trust</span> trusted</span>
-<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--trust</span> approve-for-me</span>
-<span id="cb38-3"><a href="#cb38-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack <span class="at">--model</span> cto=gpt-5.6-sol,fullstack=fable-5 <span class="dt">\</span></span>
-<span id="cb38-4"><a href="#cb38-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span>
-<span id="cb38-5"><a href="#cb38-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up codex <span class="at">--model</span> gpt-5.6-terra <span class="at">--codex-args</span> <span class="st">&quot;-c model_reasoning_effort=medium&quot;</span></span></code></pre></div>
-<p>amq-squad v2.18.0 requires amq <strong>0.41.0+</strong>. Launches
-pass <code>--require-wake</code> to <code>amq coop exec</code>, so a
-launch <strong>fails at the door</strong> when the AMQ wake sidecar
-cannot start and acquire its lock, instead of surfacing later as a stale
-or orphaned wake. <code>--no-require-wake</code> opts out for
-environments where wake cannot run; the opt-out is persisted in the
-launch record so resume reproduces it. Use <code>--no-gitignore</code>
-on <code>agent up</code>, <code>up</code>, or <code>up --dry-run</code>
-when AMQ coop auto-init should leave <code>.gitignore</code> unchanged;
-the opt-out is persisted in the launch record and replayed by
-<code>agent resume</code>.</p>
-<p>For external-injector wake setups, pass
-<code>--wake-inject-via /absolute/injector</code> and repeat
-<code>--wake-inject-arg=value</code> as needed on <code>agent up</code>,
-<code>up</code>, or <code>up --dry-run</code> launch-plan output.
-<code>lead register</code> accepts the same injector flags for
-externally registered orchestrator panes. For spawned agents, these
-flags are forwarded to <code>amq coop exec</code>, persisted in
-<code>launch.json</code>, and replayed by <code>agent resume</code>; for
-external leads, they are passed to <code>amq wake</code> and stored on
-the external launch record. Use the <code>--flag=value</code> form for
-dash-prefixed injector arguments such as
-<code>--wake-inject-arg=--pane</code>.</p>
-<h2 id="workstreams-and-threads">Workstreams and threads</h2>
-<ul>
-<li><strong>Workstream</strong> = AMQ <code>--session</code>. All
-members in one team run share it.</li>
-<li>AMQ session names are strict: lowercase <code>a-z</code>, digits,
-<code>-</code>, <code>_</code>. Use <code>v0-5-0</code>, not
-<code>v0.5.0</code>.</li>
-<li><strong>Threads</strong> are focused conversations inside a
-workstream. Canonical p2p threads use sorted handles
-(<code>p2p/cto__fullstack</code>); decisions go under
-<code>decision/&lt;topic&gt;</code>.</li>
-</ul>
-<p>Session (workstream) resolution: the <code>&lt;session&gt;</code>
-positional or <code>--session</code> &gt; inference from team members
-and the sanitized team-home directory name. A pinned
-<code>team.json</code> <code>workstream</code> default still gets a
-one-line deprecation warning; pass <code>--session</code> (or the
-positional) or rely on inference instead.</p>
-<h2 id="cross-project-teams">Cross-project teams</h2>
-<p>Members do not have to share a working directory. The dir where you
-run <code>team init</code> becomes the team-home; individual members can
-live in other repos.</p>
-<div class="sourceCode" id="cb39"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb39-1"><a href="#cb39-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
-<span id="cb39-2"><a href="#cb39-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--personas</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
-<p><code>up --dry-run</code> emits a <code>cd &lt;member-cwd&gt;</code>
-per launch command, and <code>team sync --apply --allow-outside</code>
-walks each unique member cwd and writes <code>CLAUDE.md</code> /
-<code>AGENTS.md</code> in each one. Add <code>--project DIR</code> to
-sync another team-home without changing directories. Cwds outside the
-team-home need <code>--allow-outside</code> so a hand-edited
-<code>team.json</code> cannot write into unrelated folders by
-surprise.</p>
-<p>For cross-project AMQ routing, each project's <code>.amqrc</code>
-needs a <code>peers</code> entry pointing at the other project's
-<code>.agent-mail/</code>. <code>team sync</code> does not touch
-<code>.amqrc</code>; that step is manual today.</p>
-<div class="sourceCode" id="cb40"><pre
-class="sourceCode json"><code class="sourceCode json"><span id="cb40-1"><a href="#cb40-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb40-2"><a href="#cb40-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
-<span id="cb40-3"><a href="#cb40-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
-<span id="cb40-4"><a href="#cb40-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb40-5"><a href="#cb40-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
-<span id="cb40-6"><a href="#cb40-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb40-7"><a href="#cb40-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
-<h2 id="messaging-inside-a-squad">Messaging inside a squad</h2>
-<p>Once launched, agents use plain AMQ commands. <code>amq-squad</code>
-injects a routing block into each agent's bootstrap prompt with the live
-roster, handles, threads, and per-agent project context.</p>
-<div class="sourceCode" id="cb41"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb41-1"><a href="#cb41-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> list <span class="at">--new</span></span>
-<span id="cb41-2"><a href="#cb41-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> read <span class="at">--id</span> <span class="op">&lt;</span>id<span class="op">&gt;</span></span>
-<span id="cb41-3"><a href="#cb41-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--include-body</span></span>
-<span id="cb41-4"><a href="#cb41-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb41-5"><a href="#cb41-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="dt">\</span></span>
-<span id="cb41-6"><a href="#cb41-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="dt">\</span></span>
-<span id="cb41-7"><a href="#cb41-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--thread</span> p2p/cto__fullstack <span class="dt">\</span></span>
-<span id="cb41-8"><a href="#cb41-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--kind</span> review_request <span class="dt">\</span></span>
-<span id="cb41-9"><a href="#cb41-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Review: PR&quot;</span> <span class="dt">\</span></span>
-<span id="cb41-10"><a href="#cb41-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body</span> <span class="st">&quot;Please review tests and framing.&quot;</span> <span class="dt">\</span></span>
-<span id="cb41-11"><a href="#cb41-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s</span></code></pre></div>
-<p><code>amq send</code> reads stdin when <code>--body</code> is
-omitted. There is no <code>--body-file</code> flag.</p>
-<h3 id="which-messaging-primitive-should-i-use">Which messaging
-primitive should I use?</h3>
+<p>The deep playbooks are in <a
+href="docs/skills.md">docs/skills.md</a>, <a
+href="docs/operator-cookbook.md">docs/operator-cookbook.md</a>, and <a
+href="docs/verification-gate-adr.md">docs/verification-gate-adr.md</a>.</p>
+<h2 id="terminal-capability-matrix">Terminal capability matrix</h2>
+<p>Runtime capabilities are capability-specific. The tier name is not a
+blanket promise.</p>
 <table>
 <thead>
 <tr>
-<th>Intent</th>
+<th>Backend</th>
+<th>Tier</th>
+<th>Launch/visibility</th>
+<th>Focus</th>
+<th>Send prompt / native goal delivery</th>
+<th>Dispatch</th>
+<th>Stop/resume</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>tmux</td>
+<td>Tier A</td>
+<td>Managed panes in current window, sibling windows, or detached
+session.</td>
+<td>Available only while the recorded pane is live; otherwise reason is
+<code>agent pane is not live</code>.</td>
+<td>Available only while the recorded pane is live; otherwise reason is
+<code>agent pane is not live</code>.</td>
+<td>Always available because durable AMQ dispatch does not require pane
+injection.</td>
+<td>Full managed stop/resume through launch records and tmux pane
+identity.</td>
+</tr>
+<tr>
+<td>iTerm2</td>
+<td>Tier B</td>
+<td>One visible native iTerm2 window per agent. Terminal metadata is
+captured and then stripped from the agent env.</td>
+<td>Available only with a recorded window id and verified agent
+PID/binary liveness. Missing id reports
+<code>iTerm2 window id is unavailable</code>; dead/mismatched process
+reports
+<code>iTerm2 focus requires verified agent PID liveness</code>.</td>
+<td>Disabled:
+<code>iTerm2 prompt/native-goal injection is disabled until #374 proves safe send/capture/busy support</code>.</td>
+<td>Always available because durable AMQ dispatch does not require pane
+injection.</td>
+<td>Agent process stop/resume is managed; native prompt injection is
+not.</td>
+</tr>
+<tr>
+<td>Terminal.app</td>
+<td>Tier C</td>
+<td>Visible native Terminal.app tabs/windows. Window identity is derived
+from the launched tab TTY when available.</td>
+<td>Disabled:
+<code>Terminal.app focus requires stable window/tab addressing; manual focus is required in v2.18.0</code>.</td>
+<td>Disabled:
+<code>Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input</code>.</td>
+<td>Always available because durable AMQ dispatch does not require pane
+injection.</td>
+<td>Agent process stop/resume is managed; native focus/input remain
+manual.</td>
+</tr>
+<tr>
+<td>cmux</td>
+<td>Pending</td>
+<td>Not shipped in v2.18.0.</td>
+<td>Pending #330 re-entry bar.</td>
+<td>Pending #330 re-entry bar.</td>
+<td>Durable AMQ dispatch remains the intended control plane once a
+backend exists.</td>
+<td>Pending #330 re-entry bar.</td>
+</tr>
+</tbody>
+</table>
+<p>Manual smoke flows live in <a
+href="docs/iterm2-tier-b-smoke.md">docs/iterm2-tier-b-smoke.md</a> and
+<a
+href="docs/terminal-app-tier-c-smoke.md">docs/terminal-app-tier-c-smoke.md</a>.
+The capability contract is implemented in
+<code>internal/runtimecontrol</code>.</p>
+<h2 id="command-map">Command map</h2>
+<p>Common setup and run commands:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile review <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--roles</span> cto,qa <span class="at">--lead</span> cto <span class="at">--goal</span> <span class="st">&quot;...&quot;</span> <span class="at">--go</span></span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--external-lead</span> <span class="at">--lead</span> cto <span class="at">--roles</span> cto,qa <span class="at">--go</span></span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
+<p>Lifecycle:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> fork <span class="at">--from</span> issue-96 <span class="at">--as</span> issue-96-review</span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> archive issue-96</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> rm issue-96</span></code></pre></div>
+<p>Coordination:</p>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> task add <span class="at">--session</span> issue-96 <span class="at">--title</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--assign</span> fullstack</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack <span class="at">--task</span> t1 <span class="at">--subject</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> activity set <span class="at">--session</span> issue-96 <span class="at">--me</span> fullstack <span class="at">--task</span> t1 <span class="at">--phase</span> testing</span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> threads <span class="at">--session</span> issue-96</span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> thread <span class="at">--session</span> issue-96 <span class="at">--id</span> p2p/cto__fullstack <span class="at">--include-body</span><span class="op">=</span>false</span></code></pre></div>
+<p>Diagnostics:</p>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96</span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span></code></pre></div>
+<p>Runtime control:</p>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span></span></code></pre></div>
+<p><code>focus</code> and <code>send</code> are runtime capabilities.
+They may be unavailable on native terminal tiers even while durable AMQ
+<code>dispatch</code> remains available.</p>
+<p>Removed 1.x verbs now return usage errors:</p>
+<table>
+<thead>
+<tr>
+<th>Removed</th>
 <th>Use</th>
-<th>Why</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>Supervise a squad</td>
-<td><code>amq-squad status</code>, <code>console</code>,
-<code>task</code>, <code>collect</code></td>
-<td>These resolve the project/profile/session and show the squad model.
-Use <code>collect</code> for lead-side reports when raw AMQ would say
-<code>refusing collect</code> of a <code>lead-owned mailbox</code>; it
-follows the #322 collect-vs-drain contract.</td>
+<td><code>down</code></td>
+<td><code>stop</code></td>
 </tr>
 <tr>
-<td>Tell a live visible lead something now</td>
-<td><code>amq-squad send --session S --role lead --body "..."</code></td>
-<td>This is tmux pane delivery to the recorded live pane. It is
-<strong>not</strong> a durable AMQ protocol message: no
-<code>--kind</code>, no <code>--thread</code>, no mailbox receipt.</td>
+<td><code>launch &lt;binary&gt;</code></td>
+<td><code>agent up &lt;binary&gt;</code></td>
 </tr>
 <tr>
-<td>Assign durable work and wake a recipient</td>
-<td><code>amq-squad dispatch --session S --role worker --kind todo --subject "..." --body "..."</code></td>
-<td>Dispatch queues durable AMQ in the resolved workstream root and
-wakes or nudges the agent to drain it, especially for lead-to-worker
-tasks.</td>
+<td><code>restore</code></td>
+<td><code>history</code> or <code>agent resume</code></td>
 </tr>
 <tr>
-<td>Read or write AMQ mailboxes directly</td>
-<td>Raw <code>amq send/read/drain/thread</code> only inside the correct
-coop/session shell, or with explicit <code>--root</code>; otherwise
-prefer <code>amq-squad amq ...</code>.</td>
-<td>Raw AMQ is mailbox plumbing. From an external pane, the wrong root
-can reproduce the #328 class of namespace mistakes:
-<code>implicit default-profile mutation</code>,
-<code>legacy/default session root</code>, or
-<code>refusing before write</code>.</td>
+<td><code>list</code></td>
+<td><code>status</code> or <code>history</code></td>
+</tr>
+<tr>
+<td><code>team show</code></td>
+<td><code>up --dry-run</code></td>
+</tr>
+<tr>
+<td><code>team launch</code></td>
+<td><code>up</code></td>
 </tr>
 </tbody>
 </table>
-<p>In an orchestrated squad, the operator normally steers the visible
-lead with <code>amq-squad send</code> or an operator directive; the lead
-uses <code>task</code>, <code>dispatch</code>, and <code>collect</code>
-to coordinate workers. A raw <code>amq send --session ...</code> from an
-external pane is ambiguous for named-profile squads because it may write
-the default <code>.agent-mail/&lt;session&gt;</code> while workers drain
-<code>.agent-mail/&lt;profile&gt;/&lt;session&gt;</code>. Use the
-<code>amq-squad amq</code> wrapper or an explicit raw
-<code>--root</code> only when direct mailbox plumbing is
-intentional:</p>
-<div class="sourceCode" id="cb42"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb42-1"><a href="#cb42-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Ambiguous from an external pane:</span></span>
-<span id="cb42-2"><a href="#cb42-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--session</span> issue-96 <span class="at">--to</span> developer <span class="at">--thread</span> p2p/cto__developer <span class="dt">\</span></span>
-<span id="cb42-3"><a href="#cb42-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--kind</span> todo <span class="at">--subject</span> <span class="st">&quot;Task&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span>
-<span id="cb42-4"><a href="#cb42-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb42-5"><a href="#cb42-5" aria-hidden="true" tabindex="-1"></a><span class="co"># Root-resolving wrapper:</span></span>
-<span id="cb42-6"><a href="#cb42-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq send <span class="at">--project</span> /path/to/repo <span class="at">--profile</span> release <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb42-7"><a href="#cb42-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> developer <span class="at">--thread</span> p2p/cto__developer <span class="dt">\</span></span>
-<span id="cb42-8"><a href="#cb42-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--kind</span> todo <span class="at">--subject</span> <span class="st">&quot;Task&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span>
-<span id="cb42-9"><a href="#cb42-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb42-10"><a href="#cb42-10" aria-hidden="true" tabindex="-1"></a><span class="co"># Explicit raw AMQ root:</span></span>
-<span id="cb42-11"><a href="#cb42-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /path/to/repo/.agent-mail/release/issue-96 <span class="dt">\</span></span>
-<span id="cb42-12"><a href="#cb42-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> developer <span class="at">--thread</span> p2p/cto__developer <span class="dt">\</span></span>
-<span id="cb42-13"><a href="#cb42-13" aria-hidden="true" tabindex="-1"></a>  <span class="at">--kind</span> todo <span class="at">--subject</span> <span class="st">&quot;Task&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span></code></pre></div>
-<p>Inside an amq-squad-launched shell, use bare <code>amq</code>
-commands. The launcher already injected <code>AM_ROOT</code>,
-<code>AM_BASE_ROOT</code>, and <code>AM_ME</code>; override them only
-when intentionally inspecting a different project or handle. For
-important handoffs, use
-<code>--wait-for drained --wait-timeout 60s</code> and keep the AMQ
-message id. If routing is unclear, run <code>amq route explain</code> or
-<code>amq-squad amq route --to &lt;handle&gt;</code> first.</p>
-<p>From an external lead or operator-owned pane, prefer the root-correct
-wrapper:
-<code>amq-squad amq send --session &lt;S&gt; --me &lt;handle&gt; ...</code>.
-When <code>--me</code> names a team role/handle, the wrapper verifies
-that role is bound in the namespace before sending; a global
-orchestrator cannot raise gates as <code>cto</code> before a real
-<code>cto</code> exists. When <code>--me</code> or <code>--from</code>
-names the configured operator handle (default <code>user</code>), the
-wrapper refuses the normal send/reply path because the operator is
-mailbox-only; use <code>amq-squad operator answer/directive</code> where
-applicable. Emergency recovery sends or replies as a team role or
-operator handle require the explicit audited override
-<code>--unsafe-send-as --reason &lt;why&gt;</code>.</p>
-<p>For lead-side report collection, prefer
-<code>amq-squad collect --session &lt;S&gt; --me &lt;lead&gt; --timeout 120s --include-body</code>
-over raw <code>amq drain</code>. Raw AMQ <code>drain</code> is
-intentionally destructive: it moves unread files from
-<code>inbox/new</code> to <code>inbox/cur</code> and emits drained
-receipts before the caller has necessarily persisted or displayed the
-body. <code>collect</code> is the kill-safe path for orchestrators: it
-snapshots unread bodies into a profile/session/recipient-scoped journal
-before acknowledging each message. The contract is at-least-once, not
-exactly-once: an interrupted output may replay a body on the next
-collect, but it should not lose the body.</p>
-<h2 id="files-amq-squad-writes">Files amq-squad writes</h2>
-<pre class="text"><code>&lt;project&gt;/.amq-squad/team.json           Default team profile (schema: 3 on new writes).
-&lt;project&gt;/.amq-squad/teams/&lt;name&gt;.json   Named team profiles (schema: 3 on new writes).
-&lt;project&gt;/.amq-squad/team-rules.md       Durable team norms (user-edited).
-&lt;project&gt;/.amq-squad/briefs/&lt;session&gt;.md Workstream brief for the default profile.
-&lt;project&gt;/.amq-squad/briefs/&lt;profile&gt;/&lt;session&gt;.md
-                                         Workstream brief for a named profile.
-&lt;project&gt;/.amq-squad/tasks/&lt;session&gt;/     Task store for the default profile.
-&lt;project&gt;/.amq-squad/tasks/&lt;profile&gt;/&lt;session&gt;/
-                                         Task store for a named profile.
-&lt;project&gt;/.amq-squad/collect-journal/&lt;profile&gt;/&lt;session&gt;/&lt;handle&gt;/
-                                         Kill-safe collect journal. Pending
-                                         entries replay until delivered; delivered
-                                         entries are retained for 7 days or the
-                                         latest 200 entries per recipient.
-&lt;project&gt;/.agent-mail/&lt;session&gt;/          AMQ root for the default profile.
-&lt;project&gt;/.agent-mail/&lt;profile&gt;/&lt;session&gt;/
-                                         AMQ root for a named profile.
-&lt;project&gt;/CLAUDE.md, AGENTS.md           Managed pointer block; user content outside markers preserved.
-&lt;AM_ROOT&gt;/agents/&lt;handle&gt;/extensions/io.github.omriariav.amq-squad/
-                                         Per-agent launch.json and role.md inside the
-                                         AMQ mailbox. Legacy direct-agent records
-                                         remain readable.</code></pre>
-<p><code>&lt;AM_ROOT&gt;</code> is resolved via AMQ's JSON env contract
-(<code>amq env --json</code>).</p>
-<h2 id="removed-legacy-verbs">Removed legacy verbs</h2>
-<p>These verbs are <strong>removed in 2.0</strong>. Invoking one returns
-a usage error (exit 1, not a silent "unknown command"). Use the
-replacement. The full upgrade notes live in <a
-href="MIGRATION.md"><code>MIGRATION.md</code></a>.</p>
+<p>Full upgrade notes live in <code>MIGRATION.md</code>.</p>
+<h2 id="skills-and-model-guidance">Skills and model guidance</h2>
+<p>The skills are the source of truth for agent behavior and current
+model selection guidance.</p>
 <table>
 <thead>
 <tr>
-<th>Removed verb</th>
-<th>Replacement</th>
+<th>Skill</th>
+<th>Use it for</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>amq-squad down</code></td>
-<td><code>amq-squad stop</code></td>
+<td><code>amq-squad</code></td>
+<td>Setup, role authoring, live coordination, draining AMQ, routing
+review requests, status/history/doctor, runtime controls, and lifecycle
+commands.</td>
 </tr>
 <tr>
-<td><code>amq-squad launch &lt;binary&gt;</code></td>
-<td><code>amq-squad agent up &lt;binary&gt;</code></td>
+<td><code>amq-squad-orchestrator</code></td>
+<td>Lead-agent operation: spawn, dispatch, monitor, collect reports,
+coordinate reviews, recover, and produce final evidence.</td>
 </tr>
 <tr>
-<td><code>amq-squad restore</code> (print)</td>
-<td><code>amq-squad history</code></td>
+<td><code>amq-team-setup</code></td>
+<td>Deprecated redirect to <code>amq-squad</code>.</td>
 </tr>
 <tr>
-<td><code>amq-squad restore --exec --role R</code></td>
-<td><code>amq-squad agent resume R</code></td>
-</tr>
-<tr>
-<td><code>amq-squad list</code></td>
-<td><code>amq-squad status</code> (live) or
-<code>amq-squad history</code> (records)</td>
-</tr>
-<tr>
-<td><code>amq-squad team show</code></td>
-<td><code>amq-squad up --dry-run</code></td>
-</tr>
-<tr>
-<td><code>amq-squad team launch</code></td>
-<td><code>amq-squad up</code></td>
-</tr>
-<tr>
-<td><code>amq-squad team launch --fresh --session X</code></td>
-<td><code>amq-squad fork --from &lt;current&gt; --as X</code></td>
+<td><code>amq-squad-role-creator</code></td>
+<td>Deprecated redirect to <code>amq-squad</code>.</td>
 </tr>
 </tbody>
 </table>
-<p>Replay paths that emit copy-paste commands use the modern
-<code>agent up &lt;binary&gt;</code> command shape.</p>
-<h2 id="known-gaps">Known gaps</h2>
+<p>Invoke skills in Claude Code as <code>/amq-squad:&lt;skill&gt;</code>
+and in Codex as <code>$&lt;skill&gt;</code>.</p>
+<p>Model guidance is intentionally skill-owned because it changes faster
+than the binary. For v2.18.0, the guidance points at the gpt-5.6 family
+for Codex-heavy work, uses explicit model/effort overrides per role, and
+treats cost as a tie-breaker after output quality for shippable work.
+Prefer the skill guidance over copying stale model examples from this
+README.</p>
+<p>Deep guide: <a href="docs/skills.md">docs/skills.md</a> (<a
+href="docs/skills.html">HTML</a>).</p>
+<h2 id="customize">Customize</h2>
+<p>Profiles and roles:</p>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,researcher <span class="at">--binary</span> researcher=codex <span class="at">--sync</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto <span class="at">--sync</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead set cto <span class="at">--lead-mode</span> planner</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead clear</span></code></pre></div>
+<p>Custom role files can be Markdown with YAML frontmatter, plain
+Markdown with a <code># Role:</code> heading, or metadata-only
+YAML/JSON. They are staged under
+<code>.amq-squad/roles/&lt;id&gt;.md</code>; launch seeds each agent's
+role file and does not clobber later edits.</p>
+<p>Launch customization:</p>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
+<p>Per-member <code>claude_args</code> / <code>codex_args</code> apply
+native CLI flags to one member and are replayed by resume. Worker
+overlays trim Claude plugin/hook surface for same-cwd squads; Codex
+workers use native Codex profiles via <code>codex_args</code>.</p>
+<p>Trust and binary defaults are explicit. Codex trusted mode is the
+only path that prepends
+<code>--dangerously-bypass-approvals-and-sandbox</code>; the default
+sandboxed mode does not.</p>
+<h2 id="reference-and-moved-details">Reference and moved details</h2>
+<p>This README is the map, not the runbook. Older long-form material is
+preserved or compressed here and lives in the docs below:</p>
+<table>
+<thead>
+<tr>
+<th>Topic</th>
+<th>Where to read</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Operator milestone runs, CLI-only flow, common failures</td>
+<td><a
+href="docs/operator-cookbook.md">docs/operator-cookbook.md</a></td>
+</tr>
+<tr>
+<td>Global orchestrator and external lead runbook</td>
+<td><a
+href="docs/global-orchestrator-runbook.md">docs/global-orchestrator-runbook.md</a></td>
+</tr>
+<tr>
+<td>Skill workflows, AGENT-EVENT protocol, issue-to-merge
+walkthrough</td>
+<td><a href="docs/skills.md">docs/skills.md</a></td>
+</tr>
+<tr>
+<td>Verification-before-merge and gate rationale</td>
+<td><a
+href="docs/verification-gate-adr.md">docs/verification-gate-adr.md</a></td>
+</tr>
+<tr>
+<td>Native task store internals</td>
+<td><a
+href="docs/task-store-design.md">docs/task-store-design.md</a></td>
+</tr>
+<tr>
+<td>JSON action object contract and availability semantics</td>
+<td><a
+href="docs/action-object-contract.md">docs/action-object-contract.md</a></td>
+</tr>
+<tr>
+<td>AMQ swarm interop boundary</td>
+<td><a
+href="docs/amq-swarm-interop.md">docs/amq-swarm-interop.md</a></td>
+</tr>
+<tr>
+<td>iTerm2 and Terminal.app manual smoke checks</td>
+<td><a
+href="docs/iterm2-tier-b-smoke.md">docs/iterm2-tier-b-smoke.md</a>, <a
+href="docs/terminal-app-tier-c-smoke.md">docs/terminal-app-tier-c-smoke.md</a></td>
+</tr>
+<tr>
+<td>Release history</td>
+<td><code>docs/v2.*-release-notes.md</code></td>
+</tr>
+<tr>
+<td>Migration from 1.x verbs</td>
+<td><code>MIGRATION.md</code></td>
+</tr>
+</tbody>
+</table>
+<p>Machine-readable command outputs use JSON envelopes with a
+<code>kind</code> and <code>data</code> payload. Prefer
+<code>--json</code> for automation and the action objects surfaced by
+<code>status --json</code> instead of inferring tmux/window state.</p>
+<p>Exit codes:</p>
 <ul>
-<li>True cross-workstream sends from a setup terminal still depend on
-upstream AMQ semantics tracked in <a
-href="https://github.com/avivsinai/agent-message-queue/issues/96">avivsinai/agent-message-queue#96</a>.
-The normal team flow avoids that path by launching one workstream and
-routing peer conversations with <code>--thread</code>.</li>
-<li>Multi-cwd teams need manual <code>peers</code> config in each
-project's <code>.amqrc</code> for cross-project AMQ routing.
-<code>team sync</code> does not touch <code>.amqrc</code>.</li>
+<li><code>0</code> success</li>
+<li><code>1</code> usage or user error</li>
+<li><code>2</code> system/runtime error</li>
+<li><code>3</code> partial success</li>
 </ul>
-<h2 id="requires">Requires</h2>
+<p>Shell completions are available from the CLI:</p>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
+<h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> binary on <code>PATH</code> (v0.41.0+)</li>
-<li><code>tmux</code> on <code>PATH</code> for
-<code>amq-squad up</code></li>
+<li><code>amq</code> 0.41.x on <code>PATH</code></li>
+<li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
+<li>macOS with iTerm2 for the Tier B backend</li>
+<li>macOS Terminal.app for the Tier C backend</li>
+<li><code>pandoc</code> only when regenerating or checking
+<code>README.html</code></li>
 </ul>
+<p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
+other goal sources happens in the skills or operator tooling; the core
+binary owns team, runtime, and coordination state.</p>
 </body>
 </html>

--- a/README.html
+++ b/README.html
@@ -289,6 +289,8 @@ id="toc-terminal-capability-matrix">Terminal capability matrix</a></li>
 <li><a href="#skills-and-model-guidance"
 id="toc-skills-and-model-guidance">Skills and model guidance</a></li>
 <li><a href="#customize" id="toc-customize">Customize</a></li>
+<li><a href="#cross-project-teams"
+id="toc-cross-project-teams">Cross-project teams</a></li>
 <li><a href="#reference-and-moved-details"
 id="toc-reference-and-moved-details">Reference and moved
 details</a></li>
@@ -335,6 +337,7 @@ matrix</a></li>
 <li><a href="#skills-and-model-guidance">Skills and model
 guidance</a></li>
 <li><a href="#customize">Customize</a></li>
+<li><a href="#cross-project-teams">Cross-project teams</a></li>
 <li><a href="#reference-and-moved-details">Reference and moved
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
@@ -358,8 +361,8 @@ capability model: tmux Tier A, iTerm2 Tier B, Terminal.app Tier C, and
 cmux still pending (#330, #331, #332, #384-#386).</li>
 <li><strong>gpt-5.6 model family guidance</strong> lives in the skills
 as the source of truth for lead/worker selection (#380).</li>
-<li><strong>AMQ 0.41.x baseline</strong> for the coordination primitives
-this release depends on.</li>
+<li><strong>AMQ 0.41.0+ baseline</strong> for the coordination
+primitives this release depends on.</li>
 </ul>
 <h2 id="install">Install</h2>
 <p>Install the v2 module path:</p>
@@ -576,9 +579,19 @@ prevents a lead from treating itself as the implementer.</li>
 <code>amq-squad verify action</code> before default/protected branch
 pushes, tags, GitHub releases, external sends, or similar
 release-critical steps.</li>
+<li><code>verify action</code> is a callable verification boundary, not
+command interception. A caller that bypasses it is not blocked by the
+shell, Git, or GitHub CLI; wrappers that execute high-risk actions must
+call it explicitly.</li>
 <li>Merge execution should bind to exact evidence: PR number, exact head
-SHA, review state, CI/preflight result, and an approved gate. P2P prose
-is context, not authority.</li>
+SHA, review state, CI/preflight result, and an approved gate. Run
+<code>verify merge</code> on normalized exact-head evidence before
+claiming merge readiness.</li>
+<li>Release publication has a separate <code>verify release</code>
+preflight: the final assembled release commit needs exact-SHA CI, a
+developer co-sign from an actor distinct from the release lead, and
+operator release approval. No one signal substitutes for the
+others.</li>
 <li>AMQ bodies and child reports are evidence to inspect. They do not
 authorize irreversible actions by themselves.</li>
 </ul>
@@ -687,17 +700,26 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#
 <span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> activity set <span class="at">--session</span> issue-96 <span class="at">--me</span> fullstack <span class="at">--task</span> t1 <span class="at">--phase</span> testing</span>
 <span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> threads <span class="at">--session</span> issue-96</span>
 <span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> thread <span class="at">--session</span> issue-96 <span class="at">--id</span> p2p/cto__fullstack <span class="at">--include-body</span><span class="op">=</span>false</span></code></pre></div>
-<p>Diagnostics:</p>
+<p>Safety preflights:</p>
 <div class="sourceCode" id="cb11"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor</span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96</span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span></code></pre></div>
-<p>Runtime control:</p>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.18.0 release&quot;</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify merge <span class="at">--evidence</span> merge-evidence.json</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify release <span class="at">--evidence</span> release-evidence.json</span></code></pre></div>
+<p>The action, merge, and final-release-commit contracts are documented
+together in <a
+href="docs/verification-gate-adr.md">docs/verification-gate-adr.md</a>.</p>
+<p>Diagnostics:</p>
 <div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto</span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span></span></code></pre></div>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor</span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96</span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span></code></pre></div>
+<p>Runtime control:</p>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span></span></code></pre></div>
 <p><code>focus</code> and <code>send</code> are runtime capabilities.
 They may be unavailable on native terminal tiers even while durable AMQ
 <code>dispatch</code> remains available.</p>
@@ -779,24 +801,33 @@ Prefer the skill guidance over copying stale model examples from this
 README.</p>
 <p>Deep guide: <a href="docs/skills.md">docs/skills.md</a> (<a
 href="docs/skills.html">HTML</a>).</p>
+<p>That guide also defines goal-first composition modes: manual rosters,
+seeded per-spawn approval, and explicitly bounded autonomous
+composition. Autonomous composition never grants merge, release,
+destructive, or external-send authority.</p>
 <h2 id="customize">Customize</h2>
 <p>Profiles and roles:</p>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,researcher <span class="at">--binary</span> researcher=codex <span class="at">--sync</span></span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto <span class="at">--sync</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead set cto <span class="at">--lead-mode</span> planner</span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead clear</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,researcher <span class="at">--binary</span> researcher=codex <span class="at">--sync</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto <span class="at">--sync</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead set cto <span class="at">--lead-mode</span> planner</span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead clear</span></code></pre></div>
 <p>Custom role files can be Markdown with YAML frontmatter, plain
 Markdown with a <code># Role:</code> heading, or metadata-only
 YAML/JSON. They are staged under
 <code>.amq-squad/roles/&lt;id&gt;.md</code>; launch seeds each agent's
 role file and does not clobber later edits.</p>
 <p>Launch customization:</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
+<p><code>--launcher-args</code> are placed before the normal child
+arguments that carry bootstrap and binary defaults. A wrapper must
+forward its trailing arguments to the real agent, for example by ending
+with <code>exec claude "$@"</code>; otherwise the managed agent can lose
+required startup behavior.</p>
 <p>Per-member <code>claude_args</code> / <code>codex_args</code> apply
 native CLI flags to one member and are replayed by resume. Worker
 overlays trim Claude plugin/hook surface for same-cwd squads; Codex
@@ -805,6 +836,34 @@ workers use native Codex profiles via <code>codex_args</code>.</p>
 only path that prepends
 <code>--dangerously-bypass-approvals-and-sandbox</code>; the default
 sandboxed mode does not.</p>
+<h2 id="cross-project-teams">Cross-project teams</h2>
+<p>Members may work from different repositories while one team-home owns
+the roster. Set a per-member cwd during team creation:</p>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
+<p><code>up --dry-run</code> emits the corresponding
+<code>cd &lt;member-cwd&gt;</code> launch commands.
+<code>team sync --apply --allow-outside</code> writes the managed
+<code>CLAUDE.md</code> / <code>AGENTS.md</code> pointer block in each
+member cwd; <code>--allow-outside</code> is required so a hand-edited
+profile cannot write into unrelated directories silently.</p>
+<p>Cross-project AMQ replies also require each project to declare its
+peers in <code>.amqrc</code>; <code>team sync</code> does not edit this
+file:</p>
+<div class="sourceCode" id="cb17"><pre
+class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
+<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Configure the reciprocal peer entry when both projects need to
+initiate and reply to messages. Use AMQ <code>--project</code> routing
+for another project and <code>--session</code> for another workstream in
+the same project; do not substitute a raw cross-project
+<code>--root</code>, which lacks reply-origin metadata.</p>
 <h2 id="reference-and-moved-details">Reference and moved details</h2>
 <p>This README is the map, not the runbook. Older long-form material is
 preserved or compressed here and lives in the docs below:</p>
@@ -832,7 +891,7 @@ walkthrough</td>
 <td><a href="docs/skills.md">docs/skills.md</a></td>
 </tr>
 <tr>
-<td>Verification-before-merge and gate rationale</td>
+<td>Action, merge, and release verification preflights</td>
 <td><a
 href="docs/verification-gate-adr.md">docs/verification-gate-adr.md</a></td>
 </tr>
@@ -879,14 +938,14 @@ href="docs/terminal-app-tier-c-smoke.md">docs/terminal-app-tier-c-smoke.md</a></
 <li><code>3</code> partial success</li>
 </ul>
 <p>Shell completions are available from the CLI:</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.41.x on <code>PATH</code></li>
+<li><code>amq</code> 0.41.0+ on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The 30-second mental model:
 - [Command map](#command-map)
 - [Skills and model guidance](#skills-and-model-guidance)
 - [Customize](#customize)
+- [Cross-project teams](#cross-project-teams)
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
@@ -53,7 +54,7 @@ v2.18.0 is a coherence release for goal-driven, externally supervised squads:
   #331, #332, #384-#386).
 - **gpt-5.6 model family guidance** lives in the skills as the source of truth
   for lead/worker selection (#380).
-- **AMQ 0.41.x baseline** for the coordination primitives this release depends
+- **AMQ 0.41.0+ baseline** for the coordination primitives this release depends
   on.
 
 ## Install
@@ -219,9 +220,16 @@ Safety is part of that protocol:
   `Target:`. Use `amq-squad verify action` before default/protected branch
   pushes, tags, GitHub releases, external sends, or similar release-critical
   steps.
+- `verify action` is a callable verification boundary, not command
+  interception. A caller that bypasses it is not blocked by the shell, Git, or
+  GitHub CLI; wrappers that execute high-risk actions must call it explicitly.
 - Merge execution should bind to exact evidence: PR number, exact head SHA,
-  review state, CI/preflight result, and an approved gate. P2P prose is context,
-  not authority.
+  review state, CI/preflight result, and an approved gate. Run `verify merge`
+  on normalized exact-head evidence before claiming merge readiness.
+- Release publication has a separate `verify release` preflight: the final
+  assembled release commit needs exact-SHA CI, a developer co-sign from an
+  actor distinct from the release lead, and operator release approval. No one
+  signal substitutes for the others.
 - AMQ bodies and child reports are evidence to inspect. They do not authorize
   irreversible actions by themselves.
 
@@ -281,6 +289,18 @@ amq-squad threads --session issue-96
 amq-squad thread --session issue-96 --id p2p/cto__fullstack --include-body=false
 ```
 
+Safety preflights:
+
+```sh
+amq-squad verify action --project . --session issue-96 \
+  --gate release --action github_release --target "draft v2.18.0 release"
+amq-squad verify merge --evidence merge-evidence.json
+amq-squad verify release --evidence release-evidence.json
+```
+
+The action, merge, and final-release-commit contracts are documented together
+in [docs/verification-gate-adr.md](docs/verification-gate-adr.md).
+
 Diagnostics:
 
 ```sh
@@ -338,6 +358,11 @@ over copying stale model examples from this README.
 Deep guide: [docs/skills.md](docs/skills.md)
 ([HTML](docs/skills.html)).
 
+That guide also defines goal-first composition modes: manual rosters, seeded
+per-spawn approval, and explicitly bounded autonomous composition. Autonomous
+composition never grants merge, release, destructive, or external-send
+authority.
+
 ## Customize
 
 Profiles and roles:
@@ -363,6 +388,11 @@ amq-squad agent up claude --role qa --session beta \
 amq-squad team overlay init --workers --disable-all-hooks
 ```
 
+`--launcher-args` are placed before the normal child arguments that carry
+bootstrap and binary defaults. A wrapper must forward its trailing arguments to
+the real agent, for example by ending with `exec claude "$@"`; otherwise the
+managed agent can lose required startup behavior.
+
 Per-member `claude_args` / `codex_args` apply native CLI flags to one member and
 are replayed by resume. Worker overlays trim Claude plugin/hook surface for
 same-cwd squads; Codex workers use native Codex profiles via `codex_args`.
@@ -370,6 +400,39 @@ same-cwd squads; Codex workers use native Codex profiles via `codex_args`.
 Trust and binary defaults are explicit. Codex trusted mode is the only path that
 prepends `--dangerously-bypass-approvals-and-sandbox`; the default sandboxed
 mode does not.
+
+## Cross-project teams
+
+Members may work from different repositories while one team-home owns the
+roster. Set a per-member cwd during team creation:
+
+```sh
+cd ~/Code/project-a
+amq-squad team init --roles cto,fullstack,qa --cwd qa=~/Code/project-b
+```
+
+`up --dry-run` emits the corresponding `cd <member-cwd>` launch commands.
+`team sync --apply --allow-outside` writes the managed `CLAUDE.md` / `AGENTS.md`
+pointer block in each member cwd; `--allow-outside` is required so a hand-edited
+profile cannot write into unrelated directories silently.
+
+Cross-project AMQ replies also require each project to declare its peers in
+`.amqrc`; `team sync` does not edit this file:
+
+```json
+{
+  "root": ".agent-mail",
+  "project": "project-a",
+  "peers": {
+    "project-b": "/Users/you/Code/project-b/.agent-mail"
+  }
+}
+```
+
+Configure the reciprocal peer entry when both projects need to initiate and
+reply to messages. Use AMQ `--project` routing for another project and
+`--session` for another workstream in the same project; do not substitute a raw
+cross-project `--root`, which lacks reply-origin metadata.
 
 ## Reference and moved details
 
@@ -381,7 +444,7 @@ or compressed here and lives in the docs below:
 | Operator milestone runs, CLI-only flow, common failures | [docs/operator-cookbook.md](docs/operator-cookbook.md) |
 | Global orchestrator and external lead runbook | [docs/global-orchestrator-runbook.md](docs/global-orchestrator-runbook.md) |
 | Skill workflows, AGENT-EVENT protocol, issue-to-merge walkthrough | [docs/skills.md](docs/skills.md) |
-| Verification-before-merge and gate rationale | [docs/verification-gate-adr.md](docs/verification-gate-adr.md) |
+| Action, merge, and release verification preflights | [docs/verification-gate-adr.md](docs/verification-gate-adr.md) |
 | Native task store internals | [docs/task-store-design.md](docs/task-store-design.md) |
 | JSON action object contract and availability semantics | [docs/action-object-contract.md](docs/action-object-contract.md) |
 | AMQ swarm interop boundary | [docs/amq-swarm-interop.md](docs/amq-swarm-interop.md) |
@@ -411,7 +474,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.41.x on `PATH`
+- `amq` 0.41.0+ on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend

--- a/README.md
+++ b/README.md
@@ -1,56 +1,78 @@
 # amq-squad
 
-**amq-squad composes, launches, and drives teams of Claude and Codex agents that coordinate over AMQ.** Hand a lead agent a goal and it builds the team — or design the roster yourself. Orchestration is binary-neutral: a Codex agent can *lead*, not just be led.
+**amq-squad launches and coordinates teams of Claude and Codex agents over
+durable AMQ.** It owns the team layer above
+[AMQ](https://github.com/avivsinai/agent-message-queue) by
+[Aviv Sinai](https://github.com/avivsinai): roles, rosters, briefs, operator
+gates, launch records, and the terminal/runtime controls that keep a squad
+observable.
 
-Built on [AMQ](https://github.com/avivsinai/agent-message-queue) by [Aviv Sinai](https://github.com/avivsinai): AMQ owns messaging between agents; `amq-squad` owns the layer above — who is on the team, what role each agent plays, the shared norms they follow, and how to bring the whole squad up, stop, resume, or fork it into a new workstream.
+The 30-second mental model:
+
+- **AMQ is the durable coordination rail.** Agents communicate through inboxes,
+  threads, receipts, presence, and wake signals.
+- **amq-squad is the project/team layer.** It declares who is on the team, what
+  each role does, which workstream they share, and how to start/stop/resume
+  them.
+- **Terminals are runtime surfaces, not the source of truth.** tmux, iTerm2, and
+  Terminal.app make agents visible and sometimes controllable; durable AMQ
+  dispatch works even when pane injection is unavailable.
+- **Operator gates bind high-risk actions.** Leads may plan, dispatch, review,
+  and collect evidence, but default-branch pushes, tags, releases, external
+  sends, and merges need verified operator approval tied to an exact action and
+  target.
 
 ## Contents
 
-**Start here:** [Install](#install) · [Using amq-squad](#using-amq-squad) · [Quick start](#quick-start)
+- [What's new in v2.18.0](#whats-new-in-v2180)
+- [Install](#install)
+- [Quickstart](#quickstart)
+- [Execution modes](#execution-modes)
+- [Core concepts](#core-concepts)
+- [Orchestration protocol and safety](#orchestration-protocol-and-safety)
+- [Terminal capability matrix](#terminal-capability-matrix)
+- [Command map](#command-map)
+- [Skills and model guidance](#skills-and-model-guidance)
+- [Customize](#customize)
+- [Reference and moved details](#reference-and-moved-details)
+- [Requirements](#requirements)
 
-**Concepts:** [Why](#why) · [Context model](#context-model) · [Goal-first dynamic teams](#goal-first-dynamic-teams) · [Workstreams &amp; threads](#workstreams-and-threads) · [Cross-project teams](#cross-project-teams)
+## What's new in v2.18.0
 
-**Command reference:** [Verbs](#verbs) · [Status board &amp; console](#status-board-and-mission-control-console) · [AMQ diagnostics](#amq-diagnostics) · [Runtime control (tmux)](#runtime-control-tmux) · [JSON envelopes](#json-envelopes) · [Exit codes](#exit-codes) · [Shell completions](#shell-completions) · [Removed legacy verbs](#removed-legacy-verbs)
+v2.18.0 is a coherence release for goal-driven, externally supervised squads:
 
-**Customize:** [Custom roles](#custom-roles) · [Trust &amp; binary defaults](#trust-and-binary-defaults) · [Messaging in a squad](#messaging-inside-a-squad) · [Files amq-squad writes](#files-amq-squad-writes)
-
-**Reference:** [AMQ swarm interop](docs/amq-swarm-interop.md) · [Known gaps](#known-gaps) · [Requires](#requires)
-
-## Why
-
-AMQ is the messaging and process substrate: it sets up mailboxes, routes and threads messages, tracks presence, wakes agents, federates across projects, and execs into `claude` or `codex` via `coop exec`. What it deliberately stays out of is who is on the team and what each agent is for. AMQ does not own:
-
-- **Roles** — which agent is the "CTO" vs "Fullstack" vs "QA" vs "PM" vs "Designer"
-- **The launch contract** — what command originally launched each agent (cwd, binary, flags, workstream), so it can be stopped, resumed, or forked
-- **Durable team norms** — the shared rules each agent reads at session start
-- **The declared roster** — the role-mapped set of peers each agent is handed up front at bootstrap (AMQ can observe who talks to whom after the fact, via presence and threads; it does not declare the intended team a priori)
-
-`amq-squad` owns that layer. It captures roles, roster, and norms at team-setup time (`.amq-squad/team.json`, `.amq-squad/team-rules.md`) and per-agent launch state (`launch.json` + `role.md`) in AMQ's per-agent extension-metadata namespace. AMQ stays domain-agnostic: it adds generic affordances that layers build on (the `extensions/<layer>/` namespace, external wake injection, a reserved `user`/operator handle, `env --json`), which is why amq-squad v2.18.0 requires amq 0.41.0+ — but it still knows nothing about CTOs, rosters, or team rules.
+- **Hard authorization boundary** for high-risk lead actions (#349) and a
+  **planner/reviewer-only lead mode** (#350).
+- **Run start UX**: native `run start`, short flags, default visible sibling
+  tabs, and `run start --external-lead` for binding the current pane as the
+  project lead (#340, #345-#348).
+- **External-orchestrator integration**: read-only evidence lane, adopt-evidence
+  workflow, and Symphony lifecycle hooks (#335-#337).
+- **Terminal platform support** with an explicit runtime capability model:
+  tmux Tier A, iTerm2 Tier B, Terminal.app Tier C, and cmux still pending (#330,
+  #331, #332, #384-#386).
+- **gpt-5.6 model family guidance** lives in the skills as the source of truth
+  for lead/worker selection (#380).
+- **AMQ 0.41.x baseline** for the coordination primitives this release depends
+  on.
 
 ## Install
 
-Install the 2.0 line (note the `/v2` module path):
-
-```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.17.0
-amq-squad version
-```
-
-For the latest 2.x build:
+Install the v2 module path:
 
 ```sh
 go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest
+amq-squad version
 ```
 
-Requires Go 1.25+, the `amq` binary on `PATH` (v0.41.0+), and `tmux` on `PATH` for `amq-squad up`.
+For a pinned release, replace `@latest` with the tag you want, for example:
 
-### Skills (plugin marketplaces)
+```sh
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.18.0
+```
 
-This repo doubles as a plugin marketplace that ships the amq-squad skills for
-both Claude Code and Codex. The primary skills are `amq-squad` and
-`amq-squad-orchestrator`; the older `amq-team-setup` and
-`amq-squad-role-creator` entries remain as redirect stubs. The CLI and the
-skills are versioned together.
+Install the skills from the plugin marketplace when agents should use the
+amq-squad playbooks themselves.
 
 Claude Code:
 
@@ -66,1537 +88,335 @@ codex plugin marketplace add omriariav/amq-squad
 codex plugin add amq-squad@amq-squad
 ```
 
-The Claude marketplace manifest lives at `.claude-plugin/marketplace.json` and
-the Codex one at `.agents/plugins/marketplace.json`; each points at the
-binary-specific plugin under `plugins/claude` and `plugins/codex`. In Claude
-Code, skills are namespaced by plugin, e.g. `/amq-squad:amq-squad`. In Codex,
-invoke them by skill name, e.g. `$amq-squad`.
+The primary skills are `amq-squad` and `amq-squad-orchestrator`. The older
+`amq-team-setup` and `amq-squad-role-creator` skill entries are redirect stubs.
+The CLI and skills are versioned together.
 
-To dogfood the skills from this working tree (instead of the marketplace
-snapshot), run `make dogfood-claude` here: it launches Claude Code with
-`--plugin-dir plugins/claude`, which loads the plugin live from disk and
-shadows the marketplace-installed copy for that session only. Codex has no
-per-session equivalent; it always serves the marketplace snapshot (refresh
-with `codex plugin marketplace upgrade` after merging skill changes).
+## Quickstart
 
-## Using amq-squad
-
-amq-squad has two surfaces, and you use them at different times:
-
-- **The `amq-squad` CLI is for you, the operator.** Design a team, bring it
-  up / stop / resume in tmux, inspect it (`status`, `console`, `doctor`), and
-  control agent panes (`focus`, `send`). Most commands are **project-scoped**
-  (`--project DIR`, default cwd); the session-oriented ones (`up`, `status`,
-  `send`, `stop`, `resume`, ...) are also **session-scoped** (`--session NAME`,
-  the AMQ workstream). A few (`roles`, `doctor`) are neither or project-only.
-- **The skills are for the agents.** They teach a Claude or Codex agent how to
-  drive amq-squad + AMQ from *inside* a session: coordinate with peers, and (as
-  a lead) orchestrate a whole squad. You install them once per marketplace; the
-  agents invoke them by name.
-
-### The CLI in 60 seconds
+The shortest working path for a visible project lead and workers:
 
 ```sh
 cd ~/Code/my-project
-amq-squad new team --roles cto,fullstack,qa --sync   # 1. design the team
-amq-squad new session issue-96                        # 2. bring it up live in tmux
-amq-squad status --session issue-96                   # 3. see who is live
-amq-squad send --session issue-96 --role qa --body "run the smoke suite"   # 4. drive a pane
-amq-squad focus --session issue-96 --role qa          #    watch that agent work
-amq-squad stop --session issue-96 --all               # 5. tear down (stays resumable)
-amq-squad resume --session issue-96 --exec            # 6. bring it back (bare resume = plan only)
+
+# Preview, then create, an orchestrated run. --go is the mutation switch.
+amq-squad run start \
+  --project . \
+  --session issue-96 \
+  --roles cto,fullstack,qa \
+  --lead cto \
+  --goal "fix issue 96" \
+  --go
+
+# Watch the run.
+amq-squad status --session issue-96
+amq-squad console --session issue-96
+
+# Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.
+amq-squad dispatch \
+  --session issue-96 \
+  --role qa \
+  --subject "Run smoke tests" \
+  --body "Validate the current PR and report findings."
+
+# Stop and resume without losing launch records, briefs, or task state.
+amq-squad stop --session issue-96 --all
+amq-squad resume --session issue-96 --exec
 ```
 
-The golden rules: **`up`/`new session` is for NEW work** (it refuses an existing
-session — use `resume` to continue), **`stop` preserves state** (resumable),
-and **control targets the recorded pane id**, never window names. Full surface:
-[Quick start](#quick-start), [Verbs](#verbs), [Runtime control](#runtime-control-tmux).
-
-### The skills, and when to use each
-
-| Skill | Audience | Reach for it when |
-| --- | --- | --- |
-| **`amq-squad`** | operator-facing and member agents | setup, role authoring, and day-to-day coordination: capture a goal, draft the brief, pick roles/profile, sync pointer stubs, drain inboxes, route review/handoff, inspect `status`/`console`/`history`, run `up`/`stop`/`resume`/`fork`, and use tmux runtime control (`focus`/`send`). |
-| **`amq-squad-orchestrator`** | a **lead** agent | running a squad as a *driver*: spawn child agents, dispatch tasks to them over durable AMQ (the busy-guarded pane `send` is the fallback), monitor liveness via `status --json`, collect children's `[AGENT-EVENT]`-over-AMQ reports, and recover. The amq-squad-native equivalent of a hand-rolled tmux spawn protocol. |
-| `amq-team-setup` | redirect stub | deprecated; use `amq-squad` and its Setup section. |
-| `amq-squad-role-creator` | redirect stub | deprecated; use `amq-squad` and its Role Authoring section. |
-
-Invoke a skill in Claude Code as `/amq-squad:<skill>` (e.g.
-`/amq-squad:amq-squad-orchestrator`); in Codex as `$<skill>` (e.g.
-`$amq-squad-orchestrator`). For routine member work use `amq-squad`; only the
-lead agent driving spawnees reaches for `amq-squad-orchestrator`.
-
-**Deeper guide:** [docs/skills.md](docs/skills.md)
-([HTML](docs/skills.html)) walks each skill end to end — when to reach for it,
-how to invoke it, worked examples, a decision table, an issue-to-merge
-walkthrough, and troubleshooting.
-
-## Quick start
+Use `--external-lead` when the current pane is already the project lead and only
+the remaining workers should be spawned:
 
 ```sh
 cd ~/Code/my-project
 
-amq-squad roles                      # list role IDs and menu numbers
-amq-squad new team --dry-run --roles cto,qa
-amq-squad new team --dry-run --json --roles cto,qa
-amq-squad new team --sync --session issue-96
-amq-squad new profile review --roles cto,qa --sync --session review
+amq-squad run start \
+  -p . \
+  -s issue-96 \
+  --roles cto,fullstack,qa \
+  --lead cto \
+  --external-lead \
+  --goal "fix issue 96" \
+  --go
+```
 
-amq-squad up --dry-run               # preview the launch plan
-amq-squad up --project ~/Code/other-app --dry-run
-amq-squad new session issue-96       # NEW work: bring the team up live in tmux
-amq-squad new session issue-98 --seed-from issue:31
-amq-squad new session --project ~/Code/other-app issue-97
+`run start` previews by default; `--go` creates. With `--goal`, it waits until
+the lead is live before delivering the goal. If goal delivery fails, it exits
+non-zero and prints an exact retry command.
 
-amq-squad                            # bare command -> multi-session status board
-amq-squad status --session issue-96  # single-session detail
-amq-squad status --project ~/Code/other-app --session issue-97
-amq-squad console                    # live read-only Mission Control TUI
-amq-squad console --project ~/Code/other-app --once
-amq-squad doctor                     # AMQ / PATH / Codex skill cache / tmux / wake / pointer sync
+Manual setup still works when the team shape is known:
+
+```sh
+amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
+amq-squad new session issue-96 --seed-from issue:96
+```
+
+## Execution modes
+
+amq-squad separates the control root, target project root, visible lead, and
+implementation authority. The mode should be explicit in goal-first runs.
+
+| Mode | What it means | Use it when |
+| --- | --- | --- |
+| `global_orchestrator` | A neutral control-plane session supervises one or more project runs. It previews, creates/registers project leads, routes gates, and watches evidence; it does not edit target project code. | NOC/global coordination across repos or milestones. |
+| `project_lead` | One visible project-root lead owns the run, delegates implementation over durable AMQ tasks, and produces final evidence. | Default for most issue or milestone delivery. |
+| `project_team` | Multiple visible project-root agents are launched as first-class members. | The operator wants to watch and address several roles directly. |
+| `direct_lead_session` | The visible project lead may code directly in the project root. | Single-lead exceptions where delegation would add no value. |
+
+`--external-lead` is a project-lead binding mode: the current tmux pane becomes
+the configured lead for that run, while amq-squad spawns the rest of the team.
+It must run from the lead member's project root. It does not adopt a separate
+global orchestrator handle as the project lead.
+
+Operational recipes live in
+[docs/global-orchestrator-runbook.md](docs/global-orchestrator-runbook.md) and
+[docs/operator-cookbook.md](docs/operator-cookbook.md).
+
+## Core concepts
+
+| Concept | Meaning |
+| --- | --- |
+| **Project root** | The repository or workspace whose `.amq-squad/` directory owns team state. Most commands default to cwd and accept `--project DIR`. |
+| **Profile** | A team shape. The default profile is `.amq-squad/team.json`; named profiles live under `.amq-squad/teams/<name>.json`. |
+| **Session / workstream** | The AMQ namespace for one issue, release, or focused run. Session names use lowercase letters, digits, `-`, and `_`. |
+| **Team rules** | `.amq-squad/team-rules.md`, shared norms for all members. `CLAUDE.md` and `AGENTS.md` only point to it. |
+| **Role file** | Per-agent persona seeded into the AMQ agent directory at launch and preserved on later resumes. |
+| **Brief** | The goal/scope/source file for one profile/session namespace, under `.amq-squad/briefs/`. |
+| **Launch record** | Per-agent metadata that records cwd, binary, args, terminal identity, wake settings, goal binding, and resume state. |
+| **Task store** | Native dependency-aware task files under `.amq-squad/tasks/`, used by leads to assign and track work. |
+| **AMQ thread** | A durable conversation path such as `p2p/cto__qa` or `gate/merge-pr-387`. |
+| **Operator handle** | Usually `user`, a non-runnable mailbox for human gates. Agents are runnable; the operator handle is not. |
+
+The context model has one source of truth per layer:
+
+- Team norms: `.amq-squad/team-rules.md`
+- Agent persona: each launched agent's `role.md`
+- Workstream brief: `.amq-squad/briefs/<session>.md` or
+  `.amq-squad/briefs/<profile>/<session>.md`
+
+`amq-squad team sync --apply` writes the small managed pointer block into
+`CLAUDE.md` and `AGENTS.md`; it does not duplicate rules.
+
+## Orchestration protocol and safety
+
+An orchestrated run is a simple loop:
+
+1. The lead reads the goal/brief and decomposes work into native tasks.
+2. The lead sends durable AMQ `todo` messages with `amq-squad dispatch`.
+3. Workers drain AMQ, ACK/start, push progress, ask questions, request reviews,
+   and report DONE on the same durable thread.
+4. The lead collects reports, verifies evidence, updates the task store, and
+   decides whether more work is needed.
+5. Human-only decisions use `gate/<topic>` threads addressed to the operator
+   handle. The answer is durable evidence, not an implicit permission to do
+   unrelated work.
+
+Safety is part of that protocol:
+
+- Planner/reviewer-only lead mode (`--lead-mode planner`) prevents a lead from
+  treating itself as the implementer.
+- High-risk actions require an operator gate bound to an exact `Action:` and
+  `Target:`. Use `amq-squad verify action` before default/protected branch
+  pushes, tags, GitHub releases, external sends, or similar release-critical
+  steps.
+- Merge execution should bind to exact evidence: PR number, exact head SHA,
+  review state, CI/preflight result, and an approved gate. P2P prose is context,
+  not authority.
+- AMQ bodies and child reports are evidence to inspect. They do not authorize
+  irreversible actions by themselves.
+
+The deep playbooks are in
+[docs/skills.md](docs/skills.md),
+[docs/operator-cookbook.md](docs/operator-cookbook.md), and
+[docs/verification-gate-adr.md](docs/verification-gate-adr.md).
+
+## Terminal capability matrix
+
+Runtime capabilities are capability-specific. The tier name is not a blanket
+promise.
+
+| Backend | Tier | Launch/visibility | Focus | Send prompt / native goal delivery | Dispatch | Stop/resume |
+| --- | --- | --- | --- | --- | --- | --- |
+| tmux | Tier A | Managed panes in current window, sibling windows, or detached session. | Available only while the recorded pane is live; otherwise reason is `agent pane is not live`. | Available only while the recorded pane is live; otherwise reason is `agent pane is not live`. | Always available because durable AMQ dispatch does not require pane injection. | Full managed stop/resume through launch records and tmux pane identity. |
+| iTerm2 | Tier B | One visible native iTerm2 window per agent. Terminal metadata is captured and then stripped from the agent env. | Available only with a recorded window id and verified agent PID/binary liveness. Missing id reports `iTerm2 window id is unavailable`; dead/mismatched process reports `iTerm2 focus requires verified agent PID liveness`. | Disabled: `iTerm2 prompt/native-goal injection is disabled until #374 proves safe send/capture/busy support`. | Always available because durable AMQ dispatch does not require pane injection. | Agent process stop/resume is managed; native prompt injection is not. |
+| Terminal.app | Tier C | Visible native Terminal.app tabs/windows. Window identity is derived from the launched tab TTY when available. | Disabled: `Terminal.app focus requires stable window/tab addressing; manual focus is required in v2.18.0`. | Disabled: `Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input`. | Always available because durable AMQ dispatch does not require pane injection. | Agent process stop/resume is managed; native focus/input remain manual. |
+| cmux | Pending | Not shipped in v2.18.0. | Pending #330 re-entry bar. | Pending #330 re-entry bar. | Durable AMQ dispatch remains the intended control plane once a backend exists. | Pending #330 re-entry bar. |
+
+Manual smoke flows live in
+[docs/iterm2-tier-b-smoke.md](docs/iterm2-tier-b-smoke.md) and
+[docs/terminal-app-tier-c-smoke.md](docs/terminal-app-tier-c-smoke.md). The
+capability contract is implemented in `internal/runtimecontrol`.
+
+## Command map
+
+Common setup and run commands:
+
+```sh
+amq-squad new team --roles cto,qa --sync
+amq-squad new profile review --roles cto,qa --sync
+amq-squad run start -p . -s issue-96 --roles cto,qa --lead cto --goal "..." --go
+amq-squad run start -p . -s issue-96 --external-lead --lead cto --roles cto,qa --go
+amq-squad new session issue-96 --seed-from issue:96
+```
+
+Lifecycle:
+
+```sh
+amq-squad status --session issue-96
+amq-squad console --session issue-96
+amq-squad stop --session issue-96 --all
+amq-squad resume --session issue-96 --exec
+amq-squad fork --from issue-96 --as issue-96-review
+amq-squad archive issue-96
+amq-squad rm issue-96
+```
+
+Coordination:
+
+```sh
+amq-squad task add --session issue-96 --title "Implement fix" --assign fullstack
+amq-squad dispatch --session issue-96 --role fullstack --task t1 --subject "Implement fix" --body "..."
+amq-squad activity set --session issue-96 --me fullstack --task t1 --phase testing
+amq-squad threads --session issue-96
+amq-squad thread --session issue-96 --id p2p/cto__fullstack --include-body=false
+```
+
+Diagnostics:
+
+```sh
+amq-squad doctor
 amq-squad doctor --project ~/Code/other-app --profile release
-amq-squad doctor --project ~/Code/other-app --all-profiles
-amq-squad amq env --session issue-96 # resolved AMQ root/session/handle
-amq-squad amq ops --session issue-96 # AMQ operational diagnostics
-amq-squad amq route --session issue-96 --me cto --to fullstack
-
-amq-squad stop --all                 # SIGTERM the team (--force = SIGKILL); stays resumable
-amq-squad stop --project ~/Code/other-app --all --session issue-97
-amq-squad resume                     # re-orient (plan only; add --exec to relaunch)
-amq-squad resume --project ~/Code/other-app --session issue-97
-amq-squad fork --from issue-96 --as issue-96-review  # branch a fresh workstream
-amq-squad fork --project ~/Code/other-app --from issue-96 --as issue-96-review
-amq-squad rm issue-96                # remove a finished session (confirm-gated; or `archive`)
-```
-
-### Lifecycle
-
-A session moves through one small state machine:
-
-```text
-(none) --up--> running --stop--> stopped --rm/archive--> (none)
-                  ^                  |
-                  +------ resume ----+
-```
-
-- **`up [<name>]`** means NEW work. It refuses a session that already exists — use `resume` to continue it, `up --reset` to start it over, or pick a new name.
-- **`new session [<name>]`** is the create-focused alias for `up [<name>]`. It follows the same NEW-work refusal rules.
-- **`new team`** is the create-focused alias for `team init`.
-- **`new profile NAME`** is the named-profile alias for `team init --profile NAME`.
-- **`stop`** is the primary teardown: SIGTERM the live agents (`--force` = SIGKILL), but PRESERVE all on-disk state so the session stays resumable. (The `down` alias was removed in 2.0.)
-- **`resume`** re-orients a stopped session. If an agent has a saved conversation, amq-squad reattaches it; otherwise it re-runs bootstrap so the agent re-reads its brief and AMQ history. It does NOT replay prior hidden reasoning.
-- **`rm` / `archive`** are the session-destructive ops. Both are confirm-gated (`--yes` to skip the prompt) and refuse a session with live agents unless `--force`. `rm` deletes the session root + brief; `archive` moves them aside, recoverable. `team rm` is separate: it removes one team profile config only.
-- A **restart** is just `stop` then `up` (after `rm`/`archive`) or `resume` for the same session.
-
-### tmux targets
-
-`amq-squad up` defaults to `--target current-window`, which splits the tmux
-window where you run the command. To bring a team up inside an existing tmux
-session such as `main`, switch or attach to the desired window first, then run
-`up` from that pane:
-
-```sh
-tmux switch-client -t main:6
-cd ~/Code/my-project
-amq-squad up --session v1-0-0-qa --terminal tmux --target current-window --layout tiled
-```
-
-Use `--target new-session --terminal-session NAME` only when you want
-amq-squad to create a separate tmux session. `--terminal-session` names the new
-session; it does not select an existing tmux session for `current-window`.
-
-Panes are anchored to the pane you launch from (`$TMUX_PANE`), not to whatever
-window happens to be focused, so a `current-window` launch is safe even under
-iTerm2's `tmux -CC` integration: changing tabs mid-launch will not rehome the
-panes onto an unrelated window. If you launch from outside tmux, `current-window`
-refuses with a hint rather than guessing a target.
-
-`up` is for NEW work and refuses a session that already exists. To continue an
-existing session use `amq-squad resume`; to start it over use `amq-squad up
---reset` (destructive: it tears down and removes the session first, with a
-confirmation prompt unless `--yes`). Add `--force-duplicate` only when stale
-live-agent signals remain and you deliberately want a second agent alongside.
-
-Single-agent primitives:
-
-```sh
-amq-squad agent up codex --role cto --session issue-96
-amq-squad agent resume fullstack
-```
-
-For Claude-binary agents launched in a tmux pane, `agent up`, `up`, and managed
-resume/replay schedule a best-effort `/rename <role>-<session>` injection after
-launch so Claude Code's resume picker shows the squad role/workstream. The
-launch is not blocked if that pane delivery fails. Codex has no equivalent
-slash command, so Codex agents are intentionally unaffected.
-
-The legacy verbs (`down`, `launch`, `restore`, `list`, `team show`, `team launch`) are **removed in 2.0**. Invoking one returns a usage error (exit 1); the replacements are listed in [Removed legacy verbs](#removed-legacy-verbs) and [`MIGRATION.md`](MIGRATION.md).
-
-### Custom launchers
-
-A managed member can be launched through a project-specific wrapper script while
-still receiving AMQ identity, bootstrap, a launch record, and status/resume. Pass
-`--launcher` (and optional `--launcher-args`) on `agent up`, or set `launcher` /
-`launcher_args` on the member in `team.json`:
-
-```sh
-amq-squad agent up claude --role qa --session beta --team-workstream \
-  --launcher /path/claude-pm-os-dev.sh --launcher-args "--pull --workspace /ws"
-```
-
-The launcher is exec'd in place of the binary. `--launcher-args` come first, then
-amq-squad appends the agent's normal child args (bootstrap + defaults), so **the
-launcher script must forward its trailing args to the agent** (e.g. end with
-`exec claude "$@"`). amq-squad refuses with a clear error if the launcher path is
-missing or not executable. `up --dry-run` prints the resolved launcher command.
-
-### Per-member native args and context overlays
-
-A `team.json` member may carry `claude_args` / `codex_args` — extra native CLI
-args applied to **that member only**, appended after the team-level
-`binary_args` so the member value wins by position. The field must match the
-member's binary (`team sync` rejects a mismatch), launch records persist it,
-and resume reproduces it.
-
-The flagship use is the **context-budget overlay** for same-cwd squads: only
-the lead needs the full plugin/hook surface, while workers on smaller-context
-models burn tokens on plugins and per-prompt hook output they never use.
-Generate and wire it in one command (v1.9.0+):
-
-```sh
-amq-squad team overlay init --workers --disable-all-hooks \
-  --disable-plugins gws@workspace,document-skills@anthropics
-```
-
-This writes a Claude settings overlay per worker
-(`.amq-squad/overlays/<role>.claude.json`, human-editable, never clobbered on
-re-runs) and wires `claude_args: ["--settings", <path>]` into the member.
-`--workers` targets every claude member (the orchestration lead is excluded);
-`--role R` targets one. Launch planning (`up`, `resume`, the tmux backend)
-fails fast, naming the member, when a referenced `--settings` file is missing. Codex members use
-the native equivalent: a `$CODEX_HOME/<name>.config.toml` profile wired via
-`codex_args: ["--profile", "<name>"]`.
-
-## Goal-first, dynamic teams
-
-**The shift (2.0).** Until now you *designed a team, then ran it*: `team init` authored a static roster, `up` spawned exactly that roster, and composition was frozen for the session. 2.0 inverts it — **you hand a lead a goal and the lead composes the team**, proposing, spawning, and pruning agents at runtime as the work reveals what it needs. Goal-first changes the default *mental model*; manual still works exactly as before.
-
-The load-bearing constraint, and why this is amq-squad-native rather than "just use Claude Code Agent Teams": **orchestration is binary-neutral — a Codex agent can *lead*, not just be led.** No core primitive depends on `~/.claude/`.
-
-Composition is a spectrum, and **manual stays the floor**:
-
-| Mode | Who composes the team | Status |
-| --- | --- | --- |
-| **Manual** | You design the roster up front (`team init` / the setup wizard). | first-class, unchanged |
-| **Seeded** | The lead **proposes** each spawn from the goal; the **operator approves** it over a `gate/<topic>` thread. | shipped |
-| **Autonomous** | The lead spawns/prunes within an explicit policy, no per-spawn approval. | opt-in MVP |
-
-Three binary-neutral primitives make it work, and all of them round-trip through stop/resume so a resumed session rebuilds the team the lead **built**, not the seed:
-
-- **Mutable roster** — `amq-squad team member add/rm/list` grows or shrinks the team mid-session (atomic, file-locked, re-validated, persisted). Add `--launch --dry-run` or `rm --stop --dry-run` to preview exact runtime actions before running them.
-- **Native task store** — `amq-squad task add/list/show/claim/done/fail/block/reset`: a pull-based, dependency-gated queue under `.amq-squad/tasks/<session>/` for the default profile, or `.amq-squad/tasks/<profile>/<session>/` for named profiles, so a lead of either binary decomposes the goal into claimable work.
-- **Agent activity heartbeats** — `amq-squad activity set/clear`: workers can atomically publish current task/phase activity under their AMQ agent directory. `status --json` and `console` show fresh/stale/unknown activity, with task-store ownership as a weaker source-separated fallback.
-- **Compose-from-goal playbook** — the `amq-squad-orchestrator` skill (in both the Claude and Codex marketplaces) drives propose → approve → `team member add` → `task add` → prune.
-
-AMQ `swarm` interop is supported as an external notification/adoption boundary,
-not as a replacement task store. See
-[docs/amq-swarm-interop.md](docs/amq-swarm-interop.md) for the v2.7.0 decision.
-
-In practice — you stand up an orchestrated squad, then the lead composes and drives it:
-
-```sh
-# You (operator): create an orchestrated team and bring it up, seeded from a goal.
-amq-squad new team --roles cto --orchestrated --lead cto --session issue-96
-amq-squad new session issue-96 --seed-from issue:96 --target new-window
-
-# The cto lead loads the amq-squad-orchestrator skill and, as the work reveals needs:
-amq-squad team member add fullstack --binary codex --session issue-96  # grow the roster
-amq-squad dispatch --session issue-96 --role fullstack --create-task --subject "implement the fix" --body "..."
-```
-
-### Breaking changes
-
-2.0 is a major version; the breaking surface is small and mechanical (full upgrade notes in [`MIGRATION.md`](MIGRATION.md)):
-
-- **Removed verbs** — `down`, `launch`, `restore`, `list`, `team show`, `team launch` now return a usage error. Use `stop`, `agent up`, `history` / `agent resume`, `status` / `history`, `up --dry-run`, and `up` respectively.
-- **`/v2` module path** — install from `github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest` (note the `/v2`).
-- **No data migration** — existing `team.json` (schema v3) loads unchanged.
-
-## Context model
-
-The context model is three durable layers. Each layer has exactly one source of truth.
-
-| Layer | File | Owner |
-| --- | --- | --- |
-| Team norms | `.amq-squad/team-rules.md` | shared, hand-edited |
-| Per-agent persona | `<agent-dir>/role.md` | seeded by launch, then user-editable |
-| Workstream brief | `.amq-squad/briefs/<session>.md` or `.amq-squad/briefs/<profile>/<session>.md` | one per profile/session namespace |
-
-`CLAUDE.md` and `AGENTS.md` carry a small managed pointer block that links to the three layers above; they never duplicate team-rules content. `amq-squad team sync --apply` writes and refreshes that block. Anything outside the markers is yours and is preserved.
-
-```
-<!-- amq-squad:managed:begin -->
-This project uses amq-squad for agent team coordination.
-
-- **Team norms:** `.amq-squad/team-rules.md`
-- **Your role:** when launched via amq-squad, `<your-agent-dir>/role.md` carries your persona.
-- **Active brief:** read `.amq-squad/briefs/<session>.md` for the current workstream (bootstrap names the exact path).
-
-These files are the source of truth. Do not duplicate their content here.
-<!-- amq-squad:managed:end -->
-```
-
-### Workstream briefs
-
-A brief lives at `.amq-squad/briefs/<session>.md` for the default profile, or
-`.amq-squad/briefs/<profile>/<session>.md` for a named profile, and carries the
-goal, scope, and source-of-truth pointers for one profile/session namespace.
-Every team member in that namespace reads the same file.
-
-```sh
-amq-squad up --dry-run --seed-from file:./brief.md     # preview candidate (no write)
-amq-squad up --dry-run --seed-from issue:31            # preview from current-repo issue
-amq-squad up --dry-run --seed-from gh:owner/repo#31    # preview from explicit GH issue
-
-amq-squad up --seed-from issue:31                      # write brief + bring team up
-amq-squad new session issue-96 --seed-from issue:31    # create-focused spelling
-amq-squad up --seed-from issue:31 --force              # overwrite an existing brief
-amq-squad up                                           # preserve existing brief
-amq-squad brief --session issue-96                     # read the current brief
-amq-squad brief seed --session issue-96 --seed-from issue:31
-```
-
-`--seed-from` semantics:
-
-- With `--dry-run`: prints the candidate brief envelope and writes nothing.
-- Without `--dry-run`: writes the selected namespace's brief and brings the team up in the same call. `--seed-from` needs `--force` to overwrite an existing brief; a bare `up` (no `--seed-from`) keeps it.
-
-The `amq-squad` skill's Setup section wraps this in a wizard: it captures a
-goal from **any** source you have — an inline prompt, a local `.md`, a GitHub
-issue or PR, a Jira key, or a doc URL — fetches it agent-side (amq-squad core
-stays tracker-neutral), and drafts a **canonical brief** (Goal / Source / Scope
-/ Out of scope / Acceptance) for you to confirm before it is saved. The brief
-is per-session.
-
-### Goal draft
-
-`amq-squad goal draft` is the fast, preview-first setup helper for repeated
-goal-first runs. It turns a short goal, and optionally a GitHub milestone, into
-a deterministic setup plan without writing files, mutating rosters, creating
-tasks, sending AMQ messages, or launching agents.
-
-```sh
-amq-squad goal draft \
-  --goal "deliver GitHub milestone v2.7.0" \
-  --repo omriariav/amq-squad \
-  --milestone v2.7.0 \
-  --session v2-7-0 \
-  --profile codex-v2-7-0
-
-amq-squad goal draft --goal "fix issue 96" --session issue-96 --json
-```
-
-The draft includes a brief skeleton, proposed roster, task-store plan, seeded
-spawn-gate prompts, initial dispatch prompts, and the equivalent orchestrator
-`/goal --goal` prompt. Use it before the `amq-squad` Setup section or the
-`amq-squad-orchestrator` skill when you want a fast starting point, then review
-and explicitly approve any real setup mutations. Manual setup remains the right
-path when the team shape is already known or the goal needs unusual constraints.
-Execution ownership is explicit in the draft. `--mode project_lead` is the
-default: a visible project-root lead owns implementation and evidence.
-`--mode project_team` makes multiple project-root agents visible to the
-operator. `--mode direct_lead_session` is the explicit single-session exception
-where the current project-root lead may code directly. `--mode
-global_orchestrator` is a control-plane session only; it previews, creates or
-registers a project lead/team, routes approvals, and monitors evidence, but it
-does not inspect or edit project code. `--control-root`, `--target-project-root`,
-and `--target-contract` are emitted in the JSON `execution` object and generated
-prompts so amq-noc can show the mutable actor and version-compatibility state.
-The JSON envelope and generated brief also include `goal_binding`. Drafts prefer
-native binding (`mode: "native_goal_pending"`) by emitting a visible-lead
-`agent up ... -- '/goal ...'` command; `status --json` reports
-`mode: "native_goal"` only after the configured lead's launch record proves that
-native command was used or after `amq-squad goal deliver` records a successful
-native goal-control delivery. A live project lead without native evidence reports
-`mode: "native_goal_missing"`; older/runtime-fallback flows report the explicit
-`mode: "amq_task_brief"`, where the binding is the durable AMQ task, active
-brief, and task store.
-
-`amq-squad goal deliver --goal TEXT --session S --role LEAD` is the
-first-class control path for native Codex `/goal` delivery. It is not the same
-as ordinary `amq-squad send`: normal prompts keep the busy guard, while native
-`/goal` delivery may target a busy Codex lead because the runtime accepts goal
-control messages safely. Successful delivery writes a delivery receipt and
-updates the lead launch record's `goal_binding` source to `goal-control`, so
-`status --json` can report verified native binding. When delivery starts from a
-non-agent operator/global-orchestrator pane, pass
-`--register-orchestrator[=HANDLE]` to add an `orchestrator` team member
-(default handle `orchestrator`), register the current pane as an external lead,
-and start/repair its wake sidecar before delivering the goal. This registers
-the control-plane orchestrator identity only; it does not adopt that pane as the
-project `cto` or other project lead.
-
-#### Wakeable orchestrator identity in one command
-
-From a neutral control root (a pane that is not itself a launched team agent),
-a single confirm-gated command gives the orchestrator a fully wakeable AMQ
-identity. No manual `team member add` or separate `lead register` is needed:
-
-```sh
-amq-squad goal start \
-  --project /path/to/repo \
-  --session v2-15-0 \
-  --register-orchestrator=orchestrator \
-  --goal "deliver GitHub milestone v2.17.0" \
-  --yes
-```
-
-In one verified step this produces (1) a durable `orchestrator` team member,
-(2) a launch record bound to the live control pane, (3) the orchestrator set as
-lead where appropriate, and (4) a running wake sidecar targeting that pane. The
-roster write is deferred until after `--yes` is confirmed (run without `--yes`,
-or with `--dry-run`, to preview without mutating anything). Re-running the same
-command is idempotent: it does not duplicate the member or launch record, and
-re-uses the existing wake sidecar. If the wake sidecar cannot start, the command
-fails loudly rather than reporting an identity it did not create.
-
-Verify the binding with `status --json`. The envelope proves it on two surfaces:
-top-level `goal_binding` reports `mode: "native_goal"` with `verified: true`, and
-the orchestrator's per-member record carries `external: true` together with a
-live wake signal (`status: "wake-live"`, `signals.wake_alive: true`, and
-`signals.wake_pid`). The `external` field lets a client positively identify the
-registered orchestrator instead of inferring it from the lead role alone.
-
-The registered orchestrator's wake sidecar is started so that each inbound
-durable AMQ message injects a drain instruction (via AMQ's `amq wake`
-injector, not a raw `tmux send-keys`). The orchestrator therefore drains and
-acts reactively on wake, with no periodic `amq drain` polling loop, even after
-its own `/goal` reaches a terminal "achieved" state. `status --json` reports
-`wake_auto_drain: true` on that member when the drain injection is configured;
-this is a configuration signal, so a dead sidecar still surfaces as degraded
-(`status` not `wake-live`, `signals.wake_alive: false`) rather than silently
-appearing healthy. The virtual operator (`user`) handle is non-runnable and
-stays poll-only (`operator_delivery.poll_required: true`); auto-drain on wake
-applies to the orchestrator and lead handles, not the operator mailbox.
-
-To keep that wake-driven loop from stalling on routine permission prompts, an
-amq-squad-launched **orchestrated Claude worker** (a configured non-lead role) is
-launched with `gh pr create` pre-authorized, so creating its PR never blocks on a
-prompt. In this slice **PR creation only** is pre-authorized; feature-branch
-`git push` may still prompt and is tracked as future work (it needs a constrained
-wrapper that can enforce current-branch / no-tags / no-extra-refs before it can be
-safely allowlisted). Pushes to default/protected branches, tags, GitHub releases
-(`gh release create`/draft/publish/edit/upload), external sends, and destructive
-git are high-risk actions. Leads must run `amq-squad verify action` with the
-exact action and target before executing them, regardless of trust profile. The
-active allowlist is recorded on the launch record and surfaced in `status --json`
-as `preauthorized_actions` for audit. Pass `--no-preauthorize-inscope` to opt
-out; Codex workers and lead/operator sessions are unaffected.
-
-For an Autonomous preview, opt in explicitly and include a bounded policy:
-
-```sh
-amq-squad goal draft \
-  --goal "deliver GitHub milestone v2.7.0" \
-  --session v2-7-0 \
-  --composition autonomous \
-  --max-agents 4 \
-  --max-total-spawns 3 \
-  --allowed-roles goal-dev,runtime-dev,cli-dev \
-  --budget-turns 20
-```
-
-Autonomous mode is never inferred from the goal text. A profile must be
-orchestrated and must declare `--composition autonomous` with positive
-`--max-agents`, `--max-total-spawns`, and `--budget-turns`, plus either
-`--allowed-roles` or `--allowed-role-classes`. `amq-squad status --json` and the
-status board expose the effective policy, counters, and remaining budget.
-
-Pause or permanently shut off an autonomous profile without editing JSON:
-
-```sh
-amq-squad team autonomous show --json
-amq-squad team autonomous pause
-amq-squad team autonomous resume
-amq-squad team autonomous disable
-```
-
-Autonomous only covers composition decisions inside that policy. It does not
-authorize merges, pushes, releases, destructive filesystem actions, external
-communications, provider side effects, or child-agent self-spawn authority.
-Those still require the normal operator/lead path. The runtime authorization
-path records JSONL audit evidence under
-`.amq-squad/autonomous/<session>/audit.jsonl` and persists policy counters
-before returning an allowed spawn/prune decision. Prune requests must include
-measured idle age, explicit evidence that active task linkage was checked, and
-no linked active tasks; `--idle-reap-minutes` sets the minimum idle age before
-pruning is allowed.
-
-High-risk actions carry a bound operator gate. Before a default/protected branch
-push, tag creation/push, GitHub release draft/publish action, or external send,
-run:
-
-```sh
-amq-squad verify action \
-  --project <repo> --profile <profile> --session <session> \
-  --gate <topic> --action github_release \
-  --target "draft v1.41.0 release for owner/repo" --json
-```
-
-The matching gate question and operator answer must both reference the same
-`Action:` and `Target:`. `verify action` exits `0` only for an approved bound
-answer from the configured operator handle on that exact `gate/<topic>` thread;
-it exits `10` for pending, `11` for denied, `12` for no matching gate, and `13`
-for an unbound or mismatched answer. Its JSON result includes `action`, `target`,
-`gate`, `decision`, `answered_by`, and `message_id`. If the operator approved in
-a live pane, resolve the board with `amq-squad operator answer --gate <topic>
---to <lead> --approved --reason "Action: <kind>\nTarget: <exact-target>"`;
-p2p prose and mirrored ACKs do not satisfy the guard.
-
-This is a callable boundary, not command interception. A lead or wrapper that
-never calls `verify action` is not blocked by the operating system, shell, Git,
-or GitHub CLI. The guard's threat model is confused or overreaching agents that
-use the normal amq-squad CLI path; it is not a tamper-proof security boundary
-against an actor with direct filesystem write access to AMQ mailboxes, who can
-forge message bodies, `Created` timestamps, or message IDs. The harder
-enforcement path is a PATH shim or launch-hook
-interceptor that wraps `git`, `gh`, and external-send commands and forces this
-check before execution. That follow-up is tracked separately in #354 and should be
-referenced from release-hardening work.
-
-Releases carry one additional evidence gate. Before any publish step (`git push`
-of the release commit, `git tag`, `gh release create`), `amq-squad verify
-release --evidence <file>` requires the **final assembled release commit SHA** to
-carry both a **developer co-sign** (a second actor,
-`cosign.distinct_from_release_lead: true`, `cosign.sha` equal to the release
-commit SHA — a co-sign on an earlier per-delta SHA is rejected as stale) and an
-**approved operator release gate**. The two are non-substitutable: an "APPROVED
-to release" operator decision alone never authorizes publish without the
-exact-SHA developer co-sign, and the co-sign never substitutes for the operator
-gate. `verify release` only validates normalized evidence; it never pushes,
-tags, or releases — those remain operator-performed. The release commit's own
-final SHA must pass this gate before it becomes immutable.
-
-### Profiles (schema 3)
-
-Profiles let one team-home hold parallel team shapes (for example a release team and a research team).
-
-```sh
-amq-squad new team --session issue-96        # default profile -> .amq-squad/team.json
-amq-squad new profile release --session qa   # named profile -> .amq-squad/teams/release.json
-amq-squad team profiles                      # list configured profiles
-amq-squad team profiles --project ~/Code/app # list another team-home
-amq-squad team profiles --json
-amq-squad team rm --profile release          # delete one profile config only
-amq-squad up --profile release               # operate on a named profile
-amq-squad doctor --profile release           # check that profile's config, wake, and pointer sync
-```
-
-New `team.json` writes use `schema: 3` (the JSON key in persisted team profiles is `schema`; `schema_version` is reserved for the read-only JSON command envelopes documented below). Schema 1/2 profiles without an `operator` field are still supported and treated as implicit non-runnable `user` operator-gate teams until they are rewritten. Omit `--profile` (or pass `--profile default`) for the default profile.
-
-Default-profile storage remains backward compatible: `.agent-mail/<session>`,
-`.amq-squad/briefs/<session>.md`, and `.amq-squad/tasks/<session>`. Named
-profiles are storage-isolated under `.agent-mail/<profile>/<session>`,
-`.amq-squad/briefs/<profile>/<session>.md`, and
-`.amq-squad/tasks/<profile>/<session>`. Status, thread/threads, notify,
-dispatch, task, brief, launch, resume, and lifecycle commands resolve against
-the selected profile/session namespace rather than scanning a sibling legacy
-session root.
-
-Namespace-safety rule: mutating commands with `--session` in a multi-profile
-project should pass `--profile`. If an unprofiled mutation would write the
-default profile while a named profile already owns that session, amq-squad
-fails closed before writing and tells you to rerun with `--profile <name>` or
-the explicit escape hatch `--profile default`. `status --session <name>` stays
-read-only and warns when the default view is shadowed by a named profile.
-
-Schema 3 adds an optional virtual operator participant for human gates:
-
-```sh
-amq-squad new team --roles cto,qa                 # default operator handle: user
-amq-squad new team --roles cto,qa --operator ops  # custom operator handle
-amq-squad new team --roles cto,qa --no-operator   # explicit opt-out
-```
-
-The operator is not a runnable team member. AMQ 0.38.0+ reserves the conventional `user` mailbox for this human/operator role, and amq-squad v2.18.0 requires AMQ 0.41.0+ overall; custom operator handles use the same amq-squad protocol. JSON discovery derives `operator` and `capabilities.operator_gates`; `capabilities` is not persisted in `team.json`.
-
-Operator gates are structural AMQ handoffs, not authentication. Send human-only decisions or manual actions to the configured operator handle on stable `gate/<topic>` threads, with `--kind question --subject "APPROVAL: <decision>"` for approvals and `--kind decision --subject "DONE: <goal>"` for manual closeout. The operator replies on the same thread with `--kind answer` and subjects such as `APPROVED:`, `DENIED:`, or `ANSWER:`. If the operator answers a pending gate in a live pane/chat instead of AMQ, the lead treats it as operator input, immediately ACKs or mirrors it on the matching `gate/<topic>` thread without spoofing the operator handle, and checks both the live channel and AMQ gate/inbox state before declaring the gate blocked. P2P prose like "pending operator" is evidence only; it is not a gate. `amq-squad notify` surfaces new or stale needs-you gates with inspect/respond commands and de-duplicates unchanged items, but notification output never authorizes or clears a gate.
-
-Unanswered operator gates age through visible escalation bands: `initial` immediately, `reminder` after 30 minutes, and `strong-warning` after 2 hours. The age is measured from the last unanswered operator-facing gate message on the `gate/<topic>` thread, so re-raising a decision starts a fresh clock while later status chatter does not hide the pending gate. `notify` records the last emitted escalation band and bypasses normal de-duplication when a gate crosses into `reminder` or `strong-warning`; `status --json` emits `data.warnings[]` for aged gates, and `console` labels them as `needs-you/reminder` or `needs-you/strong-warning`.
-
-### Orchestration (opt-in)
-
-By default a squad is flat: members coordinate peer-to-peer over AMQ. You can instead run an **orchestrated** squad, where one lead agent spawns, dispatches, and monitors the others and owns the deliverable. It is wired by a structured flag, not by hand-edited prose, so it cannot drift:
-
-```sh
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto
-```
-
-This records `orchestrated`/`lead` in `team.json` and injects a generated `## Orchestration` reporting norm into `.amq-squad/team-rules.md`: the lead loads the `amq-squad-orchestrator` skill, dispatches durable AMQ tasks, and children push ACK/start, progress, blockers, review requests, and DONE reports back to the sender/lead over AMQ. Default off; **exactly one lead**; the lead is a team member, **never the operator**. `--lead ROLE` implies `--orchestrated`; with `--orchestrated` alone a single-member team self-selects and a team with a `cto` defaults to `cto`. The `team_profile_plan` / `team_plan` JSON envelopes carry `orchestrated`/`lead`. If `team-rules.md` already exists, `new team` leaves it untouched, so regenerate with `amq-squad team rules init --force` to pick up the norm.
-
-Execution modes make the ownership boundary machine-readable:
-
-- `global_orchestrator`: control-plane only. It may preview, select a target project/profile/session, create or register a project lead/team, route gates, poll when wake is unavailable, and report evidence. It must not inspect or edit project code directly unless explicitly converted to `direct_lead_session`.
-- `project_lead`: one visible project-root lead owns implementation, tests, child delegation, blockers, and final evidence. This is the default orchestrated project execution mode.
-- `project_team`: a visible project-root team with a visible lead and visible members. Use it only when the operator intentionally wants to inspect multiple project agents.
-- `direct_lead_session`: the current session is explicitly the project lead and may mutate the target project. This is appropriate for single-project quick work from the project root, not for NOC/control-root workflows.
-
-Lead mode is a separate implementation posture on top of the execution mode.
-`--lead-mode builder` is the compatibility default: the visible project lead may
-edit and commit within the execution boundary. `--lead-mode planner` makes the
-lead planner/reviewer-only: `status --json`, bootstrap, and goal draft surfaces
-report `implementation_allowed:false`, the bootstrap explicitly tells the lead
-not to edit files, run write-formatters, or commit, and implementation must be
-delegated over durable AMQ tasks. In planner mode `mutable_actor` is the single
-non-lead implementer role when there is exactly one; otherwise it is the
-explicit sentinel `delegated_workers`.
-
-Because `target_project_root` is where the project lead actually edits code — and from a neutral control root there is no reliable `owner/repo` → local-path mapping — amq-squad never silently guesses it for a `global_orchestrator` run. `team init --mode global_orchestrator` **requires an explicit `--target-project-root`** and refuses to default to the current directory. `goal draft` classifies the value in `target_project_root_source`: `provided` (explicit), `resolved_unconfirmed` (exactly one local checkout matched by git remote `owner/repo` under the control root — a proposal that still must be confirmed or passed explicitly), `unresolved` (no single match; pass `--target-project-root`), or `default` (non-global mode, the lead runs inside the project). A `resolved_unconfirmed` match is a hint, not a confirmation.
-
-`team init --mode ... --lead-mode ...` persists this contract in the profile, and `goal draft` generates matching `team init` and visible-lead prompts. `status --json` and the multi-session board JSON expose `execution.mode`, `control_root`, `target_project_root`, `visible_lead`, `visible_team_members`, `lead_mode`, `mutable_actor`, `implementation_allowed`, `goal_binding`, `visibility_topology`, `polling_required`, `mode_error`, and `version_compatibility` so clients do not infer who is allowed to mutate files. They also expose `operator_delivery.poll_required`, `operator_delivery.durable_amq`, and `operator_delivery.wake_supported`; a virtual/non-runnable operator handle always has `wake_supported=false`, so operator-facing updates and gates require polling/draining instead of wake delivery.
-
-Merge and lifecycle authority is explicit in the same status surface. `execution.release_readiness.merge_authority.default_actor` is `visible_lead`, and `worker_policy` is `workers_do_not_merge_by_default`: workers can report readiness evidence, but they do not merge, push, tag, release, close issues, or run other irreversible lifecycle actions from AMQ prose. The documented alternative is a verifiable authorization artifact that binds the operator/lead approval to the same subject, head SHA, and gate/evidence thread; otherwise a worker escalates the request back to the visible lead. This answers **who** owns the action path, while the exact-head review, `verify merge`, normalized evidence, and operator gate rules still answer **when** merge-ready can be claimed.
-
-The operator normally steers the workstream through the lead/orchestrator. The operator can steer the lead directly from amq-noc (v0.8.0+), or with plain AMQ: a **directive** arrives on the lead's operator p2p thread as a `--kind todo` message whose subject starts with `DIRECTIVE:`. The lead treats directives as operator steering with priority over child reports, acknowledges on the same thread, and never treats one as a gate answer (a directive never clears a `gate/<topic>` thread). Direct operator-to-worker messages are exceptional; when they affect scope, priority, merge readiness, release state, or external actions, the worker reports them to the lead before acting or includes the lead/thread metadata in the AMQ report.
-
-For NOC and orchestrator visibility, leads must surface blockers and approval
-requests immediately on the operator/orchestrator-visible surface. Approval
-requests use stable `gate/<topic>` threads; blockers use an operator-visible
-status or question. A blocker or approval request is not complete if it exists
-only in a child pane, internal worker thread, or hidden gate.
-
-When the top-level orchestrator or NOC is not wake-enabled, it must poll the
-visible goal leads instead of waiting for wake delivery. The operating contract
-is one `/goal` per visible lead; leads push status, blockers, approval requests,
-and final evidence to AMQ/NOC-visible surfaces; the parent orchestrator or NOC
-polls each lead's inbox, gate threads, and `status --json` on a cadence; child
-agents remain internal unless the lead escalates them.
-When a `global_orchestrator` owns more than one active or recently active
-workstream in one conversation, it keeps an in-conversation board and refreshes
-it after every poll, gate answer, spawn, stop, final report, or recovery action.
-The board records run name, repo, profile/session, lead and pane id, state
-(`running`, `gated`, `blocked`, `paused`, `stale`, `done`, `closed`), last
-checked time, next poll or wake source, current gate/blocker, last action, next
-action, and deterministic polling commands. Closed runs are demoted with
-`next action: none - closed` so they stop competing with active gates or stale
-runs. For `poll_required=true`, use deterministic commands such as
-`amq-squad monitor --once --json`, scoped `status --json`, `operator status`,
-`next --json`, and root-correct gate-thread reads. Recovery uses native
-amq-squad paths first (`dispatch` or drain-only `send` re-nudges, `resume` or
-`actions[]`, native `/goal resume` for understood blockers); raw
-`tmux send-keys Enter` is a recorded last resort after operator direction or
-when native recovery is unavailable.
-When `operator_delivery.poll_required=true`, the same polling rule applies to
-the virtual operator mailbox: lead reports, blockers, and approval gates are
-durable AMQ records, and no client should claim wake support for the
-non-runnable operator recipient.
-`status --json` exposes `goal_binding` so the NOC can tell whether a visible
-lead has verified native `/goal` binding (`native_goal`), a generated but
-not-yet-launched native plan (`native_goal_pending` in `goal draft --json`), a
-live project lead missing native evidence (`native_goal_missing`), or the
-explicit AMQ task + brief + task-store fallback (`amq_task_brief`). Recovery for
-a missing visible lead uses `amq-squad goal deliver`, which is a first-class
-native `/goal` control action with delivery receipt evidence; ordinary
-`amq-squad send` remains busy-guarded for normal prompts.
-
-For an existing profile, use `amq-squad team lead set <role>` to opt into
-orchestration without rebuilding the roster, `team lead clear` to return to a
-flat squad, and `team lead show --json` for discovery. A lead that is already
-running in an operator-owned pane can register itself with
-`amq-squad lead register --role <role> --session <session>`; this writes an
-explicit external launch record so `status` / `focus` / `send` can target the
-pane. Project-lead registration is fail-closed: the current pane must already
-prove the exact project/profile/session/role through runtime identity, matching
-launch record, native goal binding, or explicit `--adopt-project-lead` from the
-actual project-lead pane. A global-orchestrator/NOC pane cannot be adopted as
-project `cto` merely by passing `--role cto`; status/resume report
-`lead_role_boundary_violation` and tell the operator to launch/resume a real
-project lead in a sibling tab/new managed pane, or keep the current pane as
-global orchestrator only. By default, registration also starts or repairs the
-lead's AMQ wake sidecar; pass `--wake` to make that default explicit,
-`--no-require-wake` to warn instead of failing, or `--wake-inject-via` with
-repeated `--wake-inject-arg` for external wake injectors. `--no-wake` remains
-normal for global orchestrator/NOC pollers, but project-lead `--no-wake`
-requires the explicit escape hatch `--compat-no-wake --reason <why>` and
-records that reason. External lead records are visible and directable, but
-lifecycle commands do not own them: `stop` reports that the pane must be stopped
-manually, `rm` / `archive` leave it open, and `resume` asks the operator to run
-`lead register` again instead of replaying the pane.
-
-## Verbs
-
-Team-level verbs:
-
-```text
-amq-squad new team [--project DIR] [--sync] [--dry-run [--json]] [team init options]
-                                  Create the default team profile. Alias for
-                                  team init.
-                                  --dry-run previews the profile, rules path,
-                                  workstream, trust, and member roster without
-                                  writing files. Add --json for a
-                                  team_profile_plan envelope.
-                                  Add --sync to also write CLAUDE.md / AGENTS.md
-                                  managed pointer stubs. --roles accepts IDs,
-                                  menu numbers, or all; --session sets the
-                                  initial shared workstream; --operator sets
-                                  the virtual operator handle; --no-operator
-                                  disables operator gates;
-                                  --orchestrated [--lead ROLE] wires lead-agent
-                                  orchestration (default off; one lead, a team
-                                  member, never the operator);
-                                  --project targets a team-home without cd.
-amq-squad new profile NAME [--project DIR] [--sync] [--dry-run [--json]] [team init options]
-                                  Create a named team profile. Alias for
-                                  team init --profile NAME. Supports --sync,
-                                  --roles IDs, menu numbers, all, and
-                                  role=binary overrides, plus --session for
-                                  the initial shared workstream.
-amq-squad roles [--json]
-                                  List built-in role IDs, menu numbers, default
-                                  CLIs, and short profile copy for team creation.
-amq-squad new session [--project DIR] [--profile NAME] [<session>] [up options]
-                                  Create NEW work. Alias for up, with the same
-                                  refusal when the session already exists.
-                                  Supports --profile and --seed-from for named
-                                  profiles and seeded briefs. --project targets
-                                  a team-home without cd.
-
-amq-squad team init [--project DIR] [--profile NAME] [--roles a,b|numbers|all] [--binary role=bin,...]
-                     [--session ws] [--trust sandboxed|approve-for-me|trusted] [--orchestrated [--lead ROLE]]
-                     [--lead-mode builder|planner]
-                     [--mode project_lead|project_team|direct_lead_session|global_orchestrator]
-                     [--model role=model,...] [--codex-args ...] [--claude-args ...] [--dry-run [--json]]
-                                  Write a team profile and seed .amq-squad/team-rules.md.
-                                  --dry-run builds and prints the profile plan
-                                  without writing team.json or team-rules.md.
-                                  Add --json for a team_profile_plan envelope.
-                                  --orchestrated [--lead ROLE] opts the squad
-                                  into lead-agent orchestration (see Orchestration).
-                                  --project targets a team-home without cd.
-amq-squad team rules templates
-                                  List available team-rules templates.
-amq-squad team rules init [--project DIR] [--profile NAME]
-                     [--template auto|dev-only|product-squad|scrum|custom] [--force]
-                                  Seed or refresh .amq-squad/team-rules.md.
-                                  auto selects from the configured roster:
-                                  dev-only for engineering teams,
-                                  product-squad when product/design roles are
-                                  present, scrum for Scrum accountabilities,
-                                  and custom otherwise. --profile renders a
-                                  named profile while keeping team-rules.md
-                                  shared per team-home.
-amq-squad team rules show [--project DIR]
-                                  Print .amq-squad/team-rules.md.
-amq-squad team lead set <role> [--project DIR] [--profile NAME] [--lead-mode builder|planner]
-amq-squad team lead clear [--project DIR] [--profile NAME]
-amq-squad team lead show [--project DIR] [--profile NAME] [--json]
-                                  Mutate or inspect the profile's orchestration
-                                  lead. `set` validates that <role> is a team
-                                  member and records orchestrated=true.
-                                  --lead-mode planner makes that lead
-                                  planner/reviewer-only; builder is default.
-                                  `clear` returns the profile to flat mode.
-amq-squad team overlay init (--role R | --workers) [--disable-plugins id@market,...]
-                        [--disable-all-hooks] [--force] [--dry-run]
-                                  Generate .amq-squad/overlays/<role>.claude.json
-                                  and wire the member's claude_args to load it
-                                  via --settings: trim a worker's plugin/hook
-                                  surface in a same-cwd squad. --workers targets
-                                  every claude member (orchestration lead
-                                  excluded). Plan emission fails fast when a
-                                  referenced --settings file is missing.
-amq-squad team sync [--project DIR] [--apply] [--allow-outside]
-                                  Sync the pointer stub into CLAUDE.md and AGENTS.md.
-                                  Exit 1 on drift when --apply is not set.
-amq-squad team profiles [--project DIR] [--json]
-                                  List configured profiles (default + named).
-amq-squad team rm [PROFILE] [--project DIR] [--profile NAME] [--dry-run] [--yes|-y]
-                                  Delete one team profile config. Prompts by
-                                  default and does not delete AMQ sessions,
-                                  briefs, team-rules.md, or pointer stubs.
-
-amq-squad global start [--root DIR] [--agent claude|codex] [--name WINDOW]
-                       [--model M] [--codex-args A] [--claude-args A] [--go]
-                                  Stand up a global/NOC orchestrator: a poller
-                                  (no wake) at a neutral root that supervises
-                                  many runs. Preview by default; --go opens a
-                                  tmux window and launches the agent.
-amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
-                    [--roles r,...] [--binary role=bin,...] [--model role=model,...]
-                    [--lead-mode builder|planner]
-                    [--codex-args A] [--claude-args A]
-                    [--visibility sibling-tabs|detached|current] [--external-lead]
-                    [--goal TEXT] [--seed-from REF] [--go]
-                                  Create one orchestrated run: wraps new team
-                                  (if --roles) then up, so the namespace is typed
-                                  once. Preview by default (runs --dry-run
-                                  validation); --go creates. Visibility defaults
-                                  to sibling-tabs in the current tmux session;
-                                  use --visibility detached for hidden workers.
-                                  With --goal, --go waits for the lead to be
-                                  status-live with an alive tmux pane before
-                                  delivery. If delivery cannot complete, it
-                                  exits non-zero and prints an exact
-                                  `goal start ... --role <lead> --yes` retry
-                                  command.
-                                  With --external-lead, the current tmux pane is
-                                  bound as the configured lead and only the
-                                  remaining workers are spawned. This mode must
-                                  run from the lead member's project root and
-                                  does not register or re-point a separate
-                                  orchestrator handle.
-amq-squad up [<session>] [--project DIR] [--profile NAME] [--session ws] [--reset [--yes] [--force]]
-             [--dry-run [--json]] [--seed-from file:|issue:|gh: [--force]]
-             [--terminal tmux] [--target current-window|new-window|new-session]
-             [--layout vertical|horizontal|tiled] [--terminal-session name]
-             [--stagger 750ms] [--no-bootstrap] [--force-duplicate] [--no-gitignore]
-                                  NEW work. Bring the configured team up live (tmux) or
-                                  print the plan with --dry-run. REFUSES a session that
-                                  already exists (use `resume`, or `up --reset` to start
-                                  over). The name comes from the <session> positional or
-                                  --session (both is an error); inferred otherwise. With
-                                  no --seed-from the brief is AUTO-STUBBED (with a
-                                  one-line notice) so CI/send-keys flows keep working.
-                                  --project targets a team-home without cd.
-amq-squad stop (--role R | --all) [--project DIR] [--force] [--close-panes]
-                                  Stop members: SIGTERM the live, binary-matched
-                                  agent PID (--force = SIGKILL), reap the wake
-                                  sidecar, flip presence offline. On-disk state is
-                                  preserved, so the session stays resumable.
-                                  --project targets a team-home without cd.
-                                  --close-panes also closes each stopped agent's
-                                  tmux pane (default: keep, so final output stays
-                                  readable; resume re-creates panes).
-                                  (The 'down' alias was removed in 2.0.)
-amq-squad resume [--project DIR] [--profile NAME] [--session ws] [--restore-existing]
-                 [--exec] [--dry-run] [--force-duplicate]
-                 [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted]
-                 [--model role=model,...]
-                 [--codex-args args] [--claude-args args]
-                                  Re-orient an existing session. Reattaches a saved
-                                  conversation if present; otherwise re-runs bootstrap so
-                                  the agent re-reads its brief + AMQ history (it does NOT
-                                  replay prior hidden reasoning). Plan-only by default;
-                                  classifies each member as live / restore / launch fresh
-                                  / blocked and prints copy-pasteable commands. With
-                                  --exec it opens them through the terminal backend, like
-                                  `up`. --project targets a team-home without cd. Use
-                                  `fork --from <current> --as <new>` for a NEW workstream.
-amq-squad fork --from <current> --as <new> [--project DIR] [--force-duplicate]
-                                  Plan fresh launches in a new workstream branched off
-                                  the current one. Plan-only; does not copy launch
-                                  records, briefs, conversations, or team.json. The
-                                  workstream brief at .amq-squad/briefs/<new>.md is
-                                  created or preserved by the subsequent
-                                  `up --session <new>` (or `agent up`) live launch.
-                                  --project targets a team-home without cd.
-amq-squad rm <session> [--project DIR] [--profile NAME] [--yes] [--force] [--keep-panes]
-                                  Permanently remove a finished session (its AMQ root dir
-                                  + brief). Previews + prompts
-                                  (default No) unless --yes; refuses a live session unless
-                                  --force; never touches a sibling session. Closes the
-                                  torn-down agents' tmux panes by default (live agents
-                                  excluded); --keep-panes to leave them. --project
-                                  targets a team-home without cd; --profile selects the
-                                  profile/session namespace.
-amq-squad archive <session> [--project DIR] [--profile NAME] [--yes] [--force] [--keep-panes]
-                                  Move a finished session aside instead of deleting it
-                                  (to <baseRoot>/.archive/<session>/, recoverable).
-                                  Confirm-gated; refuses a live session unless --force.
-                                  Closes the agents' tmux panes by default; --keep-panes
-                                  to leave them. --project targets a team-home without cd;
-                                  --profile selects the profile/session namespace.
-amq-squad status [--project DIR] [--json]
-                                  Multi-session BOARD over every discovered session
-amq-squad status --session NAME [--project DIR] [--json]
-                                  (rolled-up state, agent health, brief, last-activity).
-                                  With --session: the single-session detail table. The
-                                  bare `amq-squad` runs the board too. --project targets
-                                  a team-home without cd.
-amq-squad brief --session NAME [--project DIR] [--json]
-                                  Print the full workstream brief and classify it as
-                                  missing, stub, or real. --project targets a team-home
-                                  without cd.
-amq-squad brief seed --session NAME --seed-from REF [--project DIR] [--force]
-                                  Write a workstream brief from file:<path>,
-                                  issue:<n>, or gh:owner/repo#<n> without
-                                  launching the team. Use --dry-run to preview.
-amq-squad task add --title T [--desc D] [--depends-on id,...] [--assign role] [--json] --session S
-amq-squad task list [--status S] [--json] --session S
-amq-squad task show <id> [--json] --session S
-amq-squad task claim <id> --me HANDLE [--json] --session S
-amq-squad task done <id> --me HANDLE [--evidence E] [--json] --session S
-amq-squad task fail|block <id> --me HANDLE [--reason R] [--json] --session S
-amq-squad task reset <id> --me HANDLE [--reason R] [--json] --session S
-                                  Native pull-based, dependency-gated task store
-                                  under .amq-squad/tasks/<session>/ for the
-                                  default profile or
-                                  .amq-squad/tasks/<profile>/<session>/ for
-                                  named profiles. A task is
-                                  claimable only once its --depends-on tasks are
-                                  completed. Terminal/reset transitions on an
-                                  assigned task require the assignee's --me.
-                                  All subcommands require --session.
-amq-squad activity set --session S --me HANDLE --phase PHASE [--task ID] [--detail TEXT] [--profile P] [--json]
-amq-squad activity clear --session S --me HANDLE [--profile P] [--json]
-                                  Write or clear
-                                  <amq-root>/agents/<handle>/activity.json
-                                  atomically. Status and console surface this as
-                                  an honest busy/current-task signal with
-                                  source and quality; stale or malformed files
-                                  degrade to unknown rather than progress.
-amq-squad dispatch --session S --role R --subject SUBJ --body BODY [--create-task | --task ID] [--json]
-                                  Queue a durable AMQ message and best-effort
-                                  drain nudge. Plain dispatch stays AMQ-only;
-                                  --create-task creates and links a native task,
-                                  while --task links an existing task id. A
-                                  task-backed dispatch auto-claims a pending
-                                  task for the target handle after the durable
-                                  send and task link succeed.
-amq-squad lead register [--role ROLE] [--session S] [--project DIR] [--profile NAME]
-                         [--wake|--no-wake] [--require-wake|--no-require-wake]
-                         [--adopt-project-lead] [--compat-no-wake --reason TEXT]
-                         [--wake-inject-via PATH] [--wake-inject-arg ARG]
-                                  Adopt the current tmux pane as an
-                                  operator-owned external lead for an
-                                  orchestrated profile. The pane becomes
-                                  visible/directable in status/focus/send JSON,
-                                  but stop/rm/archive/resume do not kill,
-                                  close, or replay it.
-amq-squad console [--project DIR] [--session NAME] [--refresh 2s] [--at-risk-wait 5m]
-                  [--review-age 15m] [--once]
-                                  Mission Control TUI over this project. Renders
-                                  to /dev/tty (stdout stays clean). --once prints
-                                  a single static board to stdout for CI / non-TTY.
-                                  --project targets a team-home without cd.
-amq-squad notify [--project DIR] [--profile NAME] [--session NAME]
-                 [--renotify-after 30m] [--dry-run] [--json]
-                                  Emit de-duplicated operator attention items for
-                                  live needs-you gates, with inspect/respond
-                                  commands. Does not approve or clear gates.
-amq-squad history [--json] [--project a,b]
-                                  Restorable launch records across known projects.
-amq-squad threads --session NAME [--project DIR] [--limit N] [--json]
-                                  One collapsed row per AMQ thread in the
-                                  workstream (read-only).
-amq-squad thread --session NAME --id THREAD [--project DIR] [--include-body=false] [--json]
-                                  Read one AMQ thread transcript (read-only; does
-                                  not move unread mail).
-amq-squad doctor [--project DIR] [--profile NAME|--all-profiles] [--json]
-                                  AMQ version, AMQ ops diagnostics, the amq-squad
-                                  on PATH vs this build (version skew — spawned
-                                  agents inherit the PATH binary), Codex/Claude
-                                  plugin cache and skill-version alignment,
-                                  profile config, tmux, wake, marker integrity,
-                                  and pointer-sync drift.
-amq-squad amq env [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Show the AMQ context amq-squad resolved for
-                                  this project/session.
-amq-squad amq ops [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Run `amq doctor --ops` under the resolved
-                                  squad AMQ environment.
-amq-squad amq route --to HANDLE [--project DIR] [--session NAME] [--me HANDLE]
-                    [--target-project NAME] [--target-session NAME] [--json]
-                                  Explain an AMQ route before sending,
-                                  including cross-project/session context.
-amq-squad amq who|presence [--project DIR] [--session NAME] [--me HANDLE] [--json]
-                                  Inspect AMQ sessions, agents, and presence.
-amq-squad amq receipts list --me HANDLE [--project DIR] [--session NAME] [--msg-id ID] [--json]
-amq-squad amq receipts wait --me HANDLE --msg-id ID [--stage drained|dlq] [--timeout 60s]
-                                  Inspect or wait for AMQ delivery receipts.
-amq-squad amq dlq list --me HANDLE [--project DIR] [--session NAME] [--json]
-amq-squad amq dlq read --id ID --me HANDLE [--project DIR] [--session NAME] [--json]
-amq-squad amq dlq retry --id ID --me HANDLE [--project DIR] [--session NAME]
-amq-squad amq dlq retry-all|purge --me HANDLE [--project DIR] [--session NAME]
-                                  Inspect/repair DLQ state. `read`/`retry` take
-                                  `--id ID`; `purge` takes `--older-than DUR`.
-                                  Mutating retry/purge commands preview and
-                                  prompt by default.
-amq-squad amq cleanup --session NAME --tmp-older-than 36h [--project DIR]
-                                  Confirm-gated AMQ tmp cleanup for one
-                                  session.
-amq-squad version [--json]        Print the installed amq-squad version.
-amq-squad completion <bash|zsh|fish>
-                                  Print a shell completion script to stdout.
-```
-
-Single-agent primitives:
-
-```text
-amq-squad agent up <binary> [--project DIR] [--role R] [--session ws] [--team-profile NAME]
-                            [--conversation ref] [--no-bootstrap]
-                            [--trust sandboxed|approve-for-me|trusted] [--model NAME]
-                            [--codex-args ...] [--claude-args ...]
-                            [--force-duplicate] [--no-gitignore] [-- <native flags>]
-                                  Launch one agent. Writes launch.json + role.md
-                                  in the AMQ mailbox, injects bootstrap, then execs
-                                  amq coop exec. --project targets a team-home
-                                  without cd.
-amq-squad agent resume <role> [--project a,b]
-                                  Replay one saved launch record.
-```
-
-For `agent up`, recognized launcher flags after `<binary>` (such as `--role`, `--session`, `--trust`, `--model`, `--codex-args`, `--claude-args`, `--help`) keep flowing into the launcher; unrecognized flags and the first non-flag positional are treated as child args. Use `--` for an explicit child boundary. `amq-squad agent up codex --help` prints launcher help; `amq-squad agent up codex -- --help` passes native help to the child. `--codex-args` and `--claude-args` accept dash-prefixed values such as `--codex-args '--enable goals'`.
-
-Global output flags work before or after the subcommand: `--quiet`, `--verbose`, `--color auto|always|never`. `NO_COLOR` overrides `--color=always`. `--quiet` and `--verbose` are mutually exclusive.
-
-## Status board and Mission Control console
-
-`amq-squad status` (and the bare `amq-squad`) prints a **multi-session board** over every discovered session — docker-ps / `git branch -v` style: session name, rolled-up state (running / stopped / degraded), agent health (N/M alive + at-risk), a one-line brief, and last-activity. Add `--session NAME` for the single-session detail table.
-
-Per-agent rows may include activity from `<amq-root>/agents/<handle>/activity.json`, written by `amq-squad activity set` or cheap task-transition stamps. `status --json` exposes this under `records[].activity` with `source` (`heartbeat-file`, `task-store`, or `unknown`) and `quality` (`fresh`, `stale`, or `unknown`) so clients can distinguish an agent-written heartbeat from task-store ownership fallback.
-
-Managed child rows may also include `records[].local_input` when a read-only pane-tail blind-spot detection heuristic sees a local approval/input prompt. This is not a coordination or progress primitive: capture failures, dead panes, and unparseable tails produce no field, so absence means "not observed", not "not blocked". When present, `data.warnings[]` includes `kind:"local_input_blocked"` with the role, pane, prompt summary, and recovery guidance; destructive prompts require an operator decision or a non-destructive alternative.
-
-Status warnings also include aged operator gates when a poll-required operator decision would otherwise sit silently. Gate escalation bands are `initial`, `reminder` at 30 minutes, and `strong-warning` at 2 hours; warning kinds are `operator_gate_reminder` and `operator_gate_strong_warning`, with a suggested `amq-squad thread ... --include-body` inspection command.
-
-`amq-squad console` is the project-scoped Mission Control TUI for the current team-home.
-
-```sh
-amq-squad console                    # interactive TUI on /dev/tty
-amq-squad console --once             # single static board to stdout (CI / no TTY)
-amq-squad console --project ~/Code/app --once
-amq-squad console --session issue-96 --at-risk-wait 5m
-amq-squad console --filter needs-you
-```
-
-The console gives you:
-
-- a **board** of all sessions, grouped attention-first (needs-you > blocked > gated > at-risk > running > stopped),
-- per-session **detail** with each agent's liveness and a **collapsed-thread bus** ("qa ↔ cto  blocked · subject  N msgs · 7m"),
-- aged operator gates rendered distinctly as `needs-you/reminder` or `needs-you/strong-warning`, using the pending gate age rather than later thread chatter,
-- **peek** (`space`) for a read-only view of an agent's recent output, unread inbox, and what it is blocked on,
-- an **action palette** (`a`) with copy-ready commands such as `focus`, `send`, `resume`, `stop`, `task list`, and `dispatch`; the console never runs commands directly. This is the user-facing closure for #220.
-- a **triage rollup** headline (`N needs-you threads · N blocked threads · N gated threads · N at-risk threads`) and `/`-filters (`needs-you`, `needs-user`, `gated`, `at-risk`, `blocked`, `stale-blocked`, `unread`, `agent:<h>`, `model:<m>`, `session:<n>`, `label:<l>`, `orchestrator:<o>`).
-
-It renders to `/dev/tty`, so `stdout` stays clean for the other verbs. With `--once` it emits one static board to stdout and exits — use this when there is no terminal attached.
-
-## AMQ diagnostics
-
-`amq-squad amq ...` is a project-aware wrapper around AMQ diagnostics. It resolves the same AMQ root, base root, session, and handle that the squad launcher uses, then delegates to AMQ.
-
-amq-squad v2.18.0 requires AMQ 0.41.0 or newer. That floor includes AMQ wake input-queue draining before CR injection, receipt-confirmed send/reply waits, absolute roots from `amq env --json`, plus the earlier wake-inject stale-process fix, eval-safe `amq env --export`, reserved human `user` mailbox behavior, and AMQ 0.40.0's stricter queue/DLQ/receipt/wake metadata file hardening.
-
-Read-only diagnostics run directly:
-
-```sh
 amq-squad amq env --session issue-96
-amq-squad amq ops --session issue-96 --json
+amq-squad amq ops --session issue-96
 amq-squad amq route --session issue-96 --me cto --to fullstack
-amq-squad amq who --session issue-96
-amq-squad amq presence --session issue-96
-amq-squad amq receipts list --session issue-96 --me cto
 ```
 
-Mutating maintenance stays preview-first and confirm-gated:
+Runtime control:
 
 ```sh
-amq-squad amq dlq retry --session issue-96 --me qa --id dlq_123
-amq-squad amq dlq retry-all --session issue-96 --me qa --dry-run
-amq-squad amq dlq purge --session issue-96 --me qa --older-than 168h
-amq-squad amq cleanup --session issue-96 --tmp-older-than 36h
+amq-squad focus --session issue-96 --role cto
+amq-squad send --session issue-96 --role qa --body "run the smoke suite"
 ```
 
-Use route diagnostics before uncertain cross-project sends, receipt waits for important handoffs, and DLQ/cleanup only when debugging stuck delivery or stale temporary files.
+`focus` and `send` are runtime capabilities. They may be unavailable on native
+terminal tiers even while durable AMQ `dispatch` remains available.
 
-## JSON envelopes
+Removed 1.x verbs now return usage errors:
 
-amq-squad's own verbs that produce machine-readable output accept `--json` and emit a schema-versioned envelope on stdout. Diagnostics stay on stderr; stdout under `--json` is pure JSON. (Some `amq-squad amq …` wrappers emit an amq-squad envelope — e.g. `amq env --json` is kind `amq_env` — while others delegate to AMQ's own JSON.)
-
-Team discovery payloads include derived operator metadata for external clients: `operator.enabled`, `operator.handle` when enabled, `operator.runnable=false`, and `capabilities.operator_gates`.
-
-Goal, team-plan, status, and board payloads also include an `execution` object
-when execution ownership is relevant. The mode-safe fields name the control
-root, target project root, profile/session namespace, visible lead/team,
-mutable actor, whether implementation is allowed, goal binding, topology,
-polling requirement, mode errors, and runtime-vs-target version compatibility.
-`status --json` and `doctor --json` also include a `versions` object with the
-running binary, the `amq-squad` found on `PATH`, Codex and Claude plugin-cache
-manifest versions, the loaded skill marker where detectable, and per-source
-`matches_running` / warning details. `up` emits the same mismatch warnings before
-launch when it can detect them.
-
-```sh
-amq-squad status --json | jq .
-amq-squad history --json | jq .
-amq-squad resume --session issue-96 --json | jq .
-amq-squad doctor --json | jq .
-amq-squad team profiles --json | jq .
-amq-squad roles --json | jq .
-amq-squad dispatch --session issue-96 --role qa --subject "Review" --body "..." --json | jq .
-amq-squad task add --title "Review PR" --session issue-96 --json | jq .
-amq-squad task claim t1 --me qa --session issue-96 --json | jq .
-amq-squad activity set --session issue-96 --me qa --task t1 --phase testing --json | jq .
-amq-squad team member add qa --binary codex --json | jq .
-amq-squad team init --dry-run --json --roles cto,qa | jq .
-amq-squad new team --sync --dry-run --json --roles cto,qa | jq .
-amq-squad up --dry-run --json | jq .
-amq-squad version --json | jq .
-```
-
-Envelope shape:
-
-```json
-{
-  "schema_version": 1,
-  "kind": "<verb>",
-  "data": { /* verb-specific payload */ }
-}
-```
-
-High-value mutating commands also support JSON success envelopes for
-orchestrators and NOC tooling. Initial stable mutator envelopes include
-`dispatch`, `task add`, task transitions (`claim`, `done`, `fail`, `block`),
-`activity set/clear`, and `team member add/rm`. Human output remains unchanged
-when `--json` is not passed. This is the user-facing closure for #222.
-
-## Runtime control (tmux)
-
-The experimental iTerm2 launch backend is available on macOS with
-`--terminal iterm2 --target new-window`. It records backend-neutral terminal
-identity and supports window focus by recorded iTerm2 window id. Prompt
-injection, capture, busy detection, goal delivery, and pane-nudge dispatch stay
-disabled for iTerm2 until #374 proves safe behavior; durable AMQ dispatch still
-queues normally. Manual smoke steps live in [`docs/iterm2-tier-b-smoke.md`](docs/iterm2-tier-b-smoke.md).
-
-The experimental macOS Terminal.app backend is available with
-`--terminal terminal --target new-window`. It is Tier C launch-only: it records
-backend-neutral Terminal.app metadata when AppleScript exposes it and reports
-PID liveness, but focus, prompt injection, capture, busy detection, goal
-delivery, and safe close remain unavailable until follow-up spikes prove stable
-addressing and safe input semantics. Durable AMQ dispatch still queues normally;
-pane nudges are skipped with the Terminal.app safety reason. Manual smoke steps
-live in [`docs/terminal-app-tier-c-smoke.md`](docs/terminal-app-tier-c-smoke.md).
-
-amq-squad owns the tmux execution/control contract for a team so external
-clients (such as amq-noc) can make agents actionable without scraping tmux or
-reconstructing pane layouts themselves.
-
-When an agent is launched inside tmux, its launch record persists the **exact
-tmux identity** of its pane — `session`, `window_id`, `window_name`, `pane_id`,
-and how the pane was created (`target`). Pane and window ids (`%265`, `@42`) are
-stable control addresses; window names are labels and are never used to target
-control.
-
-`status --session NAME --json`, `history --json`, and `resume --json` expose that
-identity as a `tmux` block plus a computed `pane_alive` (does the recorded pane
-still exist?). Those `status --session NAME --json` members also carry an
-`actions` array of stable, project-scoped commands a client can render or copy,
-each with an `available` flag. The same shared action catalog feeds the console
-palette, and selected AMQ-facing commands resolve project/session/root/identity
-through the shared AMQ context helper; together these are the user-facing closure
-for #223:
-
-```json
-{
-  "role": "cto",
-  "status": "live",
-  "tmux": { "session": "main", "window_id": "@42", "pane_id": "%265",
-            "target": "current-window", "pane_alive": true },
-  "actions": [
-    { "kind": "focus",  "available": true, "command": "amq-squad focus --project DIR --session issue-96 --role cto" },
-    { "kind": "send",   "available": true, "command": "amq-squad send --project DIR --session issue-96 --role cto --body-file -" },
-    { "kind": "goal_deliver", "available": true, "command": "amq-squad goal deliver --project DIR --session issue-96 --role cto --goal <goal>" },
-    { "kind": "resume", "available": true, "command": "amq-squad resume --project DIR --session issue-96 --exec" }
-  ]
-}
-```
-
-The `tmux` block is present only when the agent has a known tmux identity (absent
-otherwise — e.g. an agent not launched under tmux). Its presence means "has a
-recorded pane", not "is reachable": a pane that has since died still carries a
-`tmux` block with `pane_alive: false`, so use `pane_alive` (and each
-`actions[].available` flag) for whether control is currently possible.
-`status --session NAME --json` and `resume --json` (and the `focus`/`send` verbs)
-**adopt** a live agent's pane
-even when it was launched *outside* amq-squad's tmux backend (a raw
-`tmux new-window`): the recorded, verified agent pid is matched into a live
-pane's process subtree, so `focus`/`send`/`attach_control` and `pane_alive` work
-for it too. (`history --json` reflects persisted launch records only and does
-not adopt.) Launching through amq-squad is still preferred (it records the role,
-binary, and brief, not just a pane).
-
-High-level control verbs target the exact pane id (falling back to a neutral
-title/cwd resolver) and are all project-scoped:
-
-```sh
-amq-squad focus --session issue-96 --role cto   # bring the agent's pane into view
-amq-squad focus --session issue-96              # focus the session
-amq-squad open --session issue-96               # alias for focus
-amq-squad send  --session issue-96 --role cto --body "please review PR #65"
-amq-squad send  --session issue-96 --role qa --body-file ./prompt.md
-cat prompt.md | amq-squad send --session issue-96 --role cto --body-file -
-amq-squad resume --session issue-96 --exec      # relaunch the team's panes
-```
-
-`send` delivers the prompt deterministically: it stages the text in a tmux paste
-buffer (via stdin, never a shell string) and pastes it into the exact pane, then
-submits a single Enter — so multi-line prompts and text with quotes or shell
-metacharacters arrive verbatim. It errors clearly if the target pane is gone.
-
-## Exit codes
-
-| Code | Meaning |
+| Removed | Use |
 | --- | --- |
-| `0` | success |
-| `1` | usage / user error (unknown flag, bad argument, missing required input) |
-| `2` | system / runtime error (IO, process, config, environment) |
-| `3` | partial success (some targets succeeded, some failed; e.g. `stop` with mixed stopped + failed) |
+| `down` | `stop` |
+| `launch <binary>` | `agent up <binary>` |
+| `restore` | `history` or `agent resume` |
+| `list` | `status` or `history` |
+| `team show` | `up --dry-run` |
+| `team launch` | `up` |
 
-## Shell completions
+Full upgrade notes live in `MIGRATION.md`.
 
-GitHub Actions runs `make ci` on pull requests and pushes to `main`. The workflow
-installs `pandoc` so formatting, tests, generated HTML freshness, and skill
-frontmatter checks run with the same baseline expected locally. This is the
-user-facing closure for #221.
+## Skills and model guidance
 
-```sh
-amq-squad completion bash > /etc/bash_completion.d/amq-squad
-amq-squad completion zsh  > "${fpath[1]}/_amq-squad"
-amq-squad completion fish > ~/.config/fish/completions/amq-squad.fish
-```
+The skills are the source of truth for agent behavior and current model
+selection guidance.
 
-`completion zsh` is followed by a `compinit` step on most shells.
-
-## Custom roles
-
-`--roles`/`--personas` accept built-in personas (`cpo, cto, senior-dev,
-fullstack, frontend-dev, backend-dev, mobile-dev, junior-dev, qa, pm,
-designer, scribe, lead, agent`) and **custom roles** that are not in the catalog. A custom role is
-any valid slug (lowercase `a-z`, `0-9`, `-`, `_`) and must carry an explicit
-`--binary` because there is no catalog default to fall back to. Built-in roles
-keep their catalog defaults unless overridden. Custom roles are first-class
-team members in `team.json`, `team-rules.md`, the bootstrap prompt,
-status/history, and launch/resume.
-
-Use `lead` and `agent` for persona-light squads when you need a generic
-orchestrator or individual contributor without a domain-specific title.
-
-```sh
-# inline: id + CLI, minimal role.md (generic custom-role fallback text)
-amq-squad new team --roles researcher --binary researcher=codex
-amq-squad new team --roles researcher,reviewer --binary researcher=codex,reviewer=claude
-amq-squad new profile discovery --roles researcher --binary researcher=codex
-```
-
-Missing a binary fails clearly: `custom role "researcher" requires --binary researcher=<cli>`.
-
-For a richer persona, author a **role file** and pass it with `--role-file`
-(comma-separated) or inline in `--roles`. Supported formats: Markdown with
-optional YAML frontmatter, `.yaml`, or `.json`. The `binary:` field satisfies
-the binary requirement (`--binary` overrides it). The authored document is
-staged at `.amq-squad/roles/<id>.md` and seeds that agent's `role.md` at launch
-(later user edits are preserved). A role file whose id matches a built-in
-persona is rejected — pick a different id for a custom role.
-
-```sh
-amq-squad new team --role-file ./roles/researcher.md --roles cto
-amq-squad team init --roles "cto,./roles/researcher.md"
-```
-
-```markdown
----
-id: researcher
-label: Research Engineer
-binary: codex
-peers: [cto, qa]
----
-# Role: Research Engineer
-
-## Description
-Owns deep technical investigation, prototypes, and written findings.
-```
-
-The `amq-squad` skill's Role Authoring section walks through authoring role
-files and wiring them into a team.
-
-## Trust and binary defaults
-
-Generated launch commands include these per-binary defaults:
-
-- **Claude:** `--permission-mode auto`
-- **Codex:** approve-for-me by default, which uses Codex Auto with `workspace-write`, `on-request`, and `approvals_reviewer="auto_review"`. Pass `--trust sandboxed` to opt into manual approval/sandbox prompts. Pass `--trust trusted` only for the local power-user profile that prepends `--dangerously-bypass-approvals-and-sandbox`.
-
-Explicit `--trust sandboxed`, `--trust approve-for-me`, and `--trust trusted` selections are persisted in the team profile by `team init` and are re-emitted by `up`, `agent up`, `resume`, and `fork`. Combining `--trust trusted` with `--no-default-args` is rejected, as is sandboxed or approve-for-me mode with the bypass flag smuggled through `--codex-args`.
-
-`run start` uses the same launch trust vocabulary, but its default lead autonomy
-is conservative for release work: trust controls local permission prompts, not
-authorization to push default/protected branches, create or push tags, draft or
-publish GitHub releases, or send external communications. Those actions require
-an explicit bound `verify action` approval. Autonomous release actions are an
-opt-in integration concern for wrappers that deliberately call and record that
-guard; they are never implied by `approve-for-me` or by starting a run without a
-goal.
-
-Pass `--model NAME` to set the native `--model` flag on Codex or Claude. `team init --model role=model,...` persists per-member models. If no explicit model is set, amq-squad looks for a global default in `AMQ_SQUAD_CONFIG`, then `$XDG_CONFIG_HOME/amq-squad/config.json`, then `~/.amq-squad/config.json`; Codex also falls back to local Codex config (`$CODEX_HOME/config.toml`, profile config when `--profile` is present, or `~/.codex/config.toml`). Supported amq-squad config keys are `model`, `codex_model`, `claude_model`, or a `models` map keyed by binary name.
-
-### Model, binary, and effort guidance
-
-Context stamp: this guidance reflects the current operator setup as of
-2026-07-10. Availability, aliases, and pricing are setup-dependent, not
-universal; treat cost as a local tie-breaker, not as list-price guidance.
-
-Defaults are not limits. Agents should escalate binary, model, or effort when
-the output does not meet the bar. For shippable work, optimize for
-`intelligence > taste > cost`; cost matters only after the work is good enough.
-
-- Bulk or mechanical work defaults to Codex CLI on `gpt-5.6-luna` in the
-  current operator setup. Use lower effort for truly mechanical edits, but
-  raise effort or escalate to `gpt-5.6-terra` / `gpt-5.6-sol` when the diff or
-  tests show reasoning gaps.
-- Everyday balanced implementation defaults to Codex CLI on `gpt-5.6-terra`.
-- Frontier implementation and independent review default to Codex CLI on
-  `gpt-5.6-sol`.
-- `gpt-5.5`, `gpt-5.4`, and `gpt-5.4-mini` remain valid Codex choices for
-  previous-frontier, strong everyday, and small/fast work respectively.
-- User-facing UI, copy, API shape, or product design needs taste `>= 7`; do
-  not hand it to a purely mechanical worker just because it is cheaper.
-- Plan and implementation reviews should use `fable-5` or `opus-4.8`, with
-  `gpt-5.6-sol` as an optional independent extra perspective.
-- Never use Haiku for amq-squad work.
-
-Direct amq-squad configuration keeps three decisions separate:
-
-- `binary` chooses the runtime CLI (`codex` or `claude`).
-- `model` chooses the native model for that runtime.
-- Codex reasoning effort is separate from model and rides through
-  `codex_args`, for example `-c model_reasoning_effort=high`. Claude has no
-  Codex effort dial; use model choice plus `claude_args` such as settings
-  overlays.
-
-amq-squad does not maintain an Anthropic model whitelist. For Claude members,
-`model` is passed through to the installed `claude --model <model>`, so accepted
-aliases depend on that Claude CLI build and account. Current expected aliases
-include `default`, `opus`, `fable`, `sonnet`, and `haiku`, plus full names the
-Claude CLI accepts such as `claude-fable-5`. That is mechanical support only:
-the amq-squad policy above still says never choose Haiku for amq-squad work.
-
-amq-squad has first-class `--model`, but no first-class `--effort`. Effort stays
-native to the target CLI: Claude effort rides through `--claude-args`, for
-example `--effort high`, and Codex effort rides through `--codex-args`, for
-example `-c model_reasoning_effort=xhigh`. The same model surface is available
-on `team init --model role=model`, `up --model role=model`,
-`resume --model role=model`, the `team member add` `--model <alias>` flag, and
-the persisted member `model` field in `team.json`.
-
-```sh
-amq-squad team member add plan-reviewer --binary claude --model claude-fable-5 \
-  --claude-args "--effort high" --session issue-96
-amq-squad team member add implementer --binary claude --model sonnet \
-  --claude-args "--effort medium" --session issue-96
-amq-squad team member add opus-reviewer --binary claude --model opus \
-  --claude-args "--effort high" --session issue-96
-amq-squad team member add codex-worker --binary codex \
-  --codex-args "-c model_reasoning_effort=xhigh" --session issue-96
-```
-
-Use `up` and `resume` overrides when the profile is durable but a launch needs
-session-specific model choices. Resume overrides apply to members launched fresh
-during that resume plan; already-live members keep their running process.
-
-```sh
-amq-squad up issue-96 --model plan-reviewer=claude-fable-5,implementer=sonnet
-amq-squad resume --session issue-96 --model plan-reviewer=opus,implementer=sonnet --exec
-```
-
-For durable rosters, the same values live in `team.json`: `binary`, `model`,
-per-member `codex_args` / `claude_args`, or team-level `binary_args` for every
-member of one binary. Prefer an explicit Codex-binary member when the job needs
-a Codex model such as `gpt-5.6-sol` or `gpt-5.6-terra`. A thin Claude wrapper is
-only a compatibility pattern for Claude-only workflow or subagent systems. In
-those systems, a Claude workflow/agent `model:` parameter selects a Claude model
-only; it does not select a Codex model or effort level. Keep the wrapper
-minimal, have it delegate the real task to Codex CLI, and make that indirection
-visible in the role/scope so reviewers do not mistake it for a native Claude
-model choice.
-
-```sh
-amq-squad team init --personas cto,fullstack --trust trusted
-amq-squad team init --personas cto,fullstack --trust approve-for-me
-amq-squad team init --personas cto,fullstack --model cto=gpt-5.6-sol,fullstack=fable-5 \
-  --codex-args "-c model_reasoning_effort=medium"
-amq-squad agent up codex --model gpt-5.6-terra --codex-args "-c model_reasoning_effort=medium"
-```
-
-amq-squad v2.18.0 requires amq **0.41.0+**. Launches pass `--require-wake` to
-`amq coop exec`, so a launch **fails at the door** when the AMQ wake sidecar
-cannot start and acquire its lock, instead of surfacing later as a stale or
-orphaned wake. `--no-require-wake` opts out for environments where wake cannot
-run; the opt-out is persisted in the launch record so resume reproduces it.
-Use `--no-gitignore` on `agent up`, `up`, or `up --dry-run` when AMQ coop
-auto-init should leave `.gitignore` unchanged; the opt-out is persisted in the
-launch record and replayed by `agent resume`.
-
-For external-injector wake setups, pass `--wake-inject-via /absolute/injector`
-and repeat `--wake-inject-arg=value` as needed on `agent up`, `up`, or
-`up --dry-run` launch-plan output. `lead register` accepts the same injector
-flags for externally registered orchestrator panes. For spawned agents, these
-flags are forwarded to `amq coop exec`, persisted in `launch.json`, and replayed
-by `agent resume`; for external leads, they are passed to `amq wake` and stored
-on the external launch record.
-Use the `--flag=value` form for dash-prefixed injector arguments such as
-`--wake-inject-arg=--pane`.
-
-## Workstreams and threads
-
-- **Workstream** = AMQ `--session`. All members in one team run share it.
-- AMQ session names are strict: lowercase `a-z`, digits, `-`, `_`. Use `v0-5-0`, not `v0.5.0`.
-- **Threads** are focused conversations inside a workstream. Canonical p2p threads use sorted handles (`p2p/cto__fullstack`); decisions go under `decision/<topic>`.
-
-Session (workstream) resolution: the `<session>` positional or `--session` > inference from team members and the sanitized team-home directory name. A pinned `team.json` `workstream` default still gets a one-line deprecation warning; pass `--session` (or the positional) or rely on inference instead.
-
-## Cross-project teams
-
-Members do not have to share a working directory. The dir where you run `team init` becomes the team-home; individual members can live in other repos.
-
-```sh
-cd ~/Code/project-a
-amq-squad team init --personas cto,fullstack,qa --cwd qa=~/Code/project-b
-```
-
-`up --dry-run` emits a `cd <member-cwd>` per launch command, and `team sync --apply --allow-outside` walks each unique member cwd and writes `CLAUDE.md` / `AGENTS.md` in each one. Add `--project DIR` to sync another team-home without changing directories. Cwds outside the team-home need `--allow-outside` so a hand-edited `team.json` cannot write into unrelated folders by surprise.
-
-For cross-project AMQ routing, each project's `.amqrc` needs a `peers` entry pointing at the other project's `.agent-mail/`. `team sync` does not touch `.amqrc`; that step is manual today.
-
-```json
-{
-  "root": ".agent-mail",
-  "project": "project-a",
-  "peers": {
-    "project-b": "/Users/you/Code/project-b/.agent-mail"
-  }
-}
-```
-
-## Messaging inside a squad
-
-Once launched, agents use plain AMQ commands. `amq-squad` injects a routing block into each agent's bootstrap prompt with the live roster, handles, threads, and per-agent project context.
-
-```sh
-amq list --new
-amq read --id <id>
-amq drain --include-body
-
-amq send \
-  --to fullstack \
-  --thread p2p/cto__fullstack \
-  --kind review_request \
-  --subject "Review: PR" \
-  --body "Please review tests and framing." \
-  --wait-for drained --wait-timeout 60s
-```
-
-`amq send` reads stdin when `--body` is omitted. There is no `--body-file` flag.
-
-### Which messaging primitive should I use?
-
-| Intent | Use | Why |
-| --- | --- | --- |
-| Supervise a squad | `amq-squad status`, `console`, `task`, `collect` | These resolve the project/profile/session and show the squad model. Use `collect` for lead-side reports when raw AMQ would say `refusing collect` of a `lead-owned mailbox`; it follows the #322 collect-vs-drain contract. |
-| Tell a live visible lead something now | `amq-squad send --session S --role lead --body "..."` | This is tmux pane delivery to the recorded live pane. It is **not** a durable AMQ protocol message: no `--kind`, no `--thread`, no mailbox receipt. |
-| Assign durable work and wake a recipient | `amq-squad dispatch --session S --role worker --kind todo --subject "..." --body "..."` | Dispatch queues durable AMQ in the resolved workstream root and wakes or nudges the agent to drain it, especially for lead-to-worker tasks. |
-| Read or write AMQ mailboxes directly | Raw `amq send/read/drain/thread` only inside the correct coop/session shell, or with explicit `--root`; otherwise prefer `amq-squad amq ...`. | Raw AMQ is mailbox plumbing. From an external pane, the wrong root can reproduce the #328 class of namespace mistakes: `implicit default-profile mutation`, `legacy/default session root`, or `refusing before write`. |
-
-In an orchestrated squad, the operator normally steers the visible lead with
-`amq-squad send` or an operator directive; the lead uses `task`, `dispatch`, and
-`collect` to coordinate workers. A raw `amq send --session ...` from an external
-pane is ambiguous for named-profile squads because it may write the default
-`.agent-mail/<session>` while workers drain
-`.agent-mail/<profile>/<session>`. Use the `amq-squad amq` wrapper or an
-explicit raw `--root` only when direct mailbox plumbing is intentional:
-
-```sh
-# Ambiguous from an external pane:
-amq send --session issue-96 --to developer --thread p2p/cto__developer \
-  --kind todo --subject "Task" --body "..."
-
-# Root-resolving wrapper:
-amq-squad amq send --project /path/to/repo --profile release --session issue-96 \
-  --to developer --thread p2p/cto__developer \
-  --kind todo --subject "Task" --body "..."
-
-# Explicit raw AMQ root:
-amq send --root /path/to/repo/.agent-mail/release/issue-96 \
-  --to developer --thread p2p/cto__developer \
-  --kind todo --subject "Task" --body "..."
-```
-
-Inside an amq-squad-launched shell, use bare `amq` commands. The launcher already injected `AM_ROOT`, `AM_BASE_ROOT`, and `AM_ME`; override them only when intentionally inspecting a different project or handle. For important handoffs, use `--wait-for drained --wait-timeout 60s` and keep the AMQ message id. If routing is unclear, run `amq route explain` or `amq-squad amq route --to <handle>` first.
-
-From an external lead or operator-owned pane, prefer the root-correct wrapper:
-`amq-squad amq send --session <S> --me <handle> ...`. When `--me` names a
-team role/handle, the wrapper verifies that role is bound in the namespace
-before sending; a global orchestrator cannot raise gates as `cto` before a real
-`cto` exists. When `--me` or `--from` names the configured operator handle
-(default `user`), the wrapper refuses the normal send/reply path because the
-operator is mailbox-only; use `amq-squad operator answer/directive` where
-applicable. Emergency recovery sends or replies as a team role or operator
-handle require the explicit audited override
-`--unsafe-send-as --reason <why>`.
-
-For lead-side report collection, prefer `amq-squad collect --session <S> --me
-<lead> --timeout 120s --include-body` over raw `amq drain`. Raw AMQ `drain`
-is intentionally destructive: it moves unread files from `inbox/new` to
-`inbox/cur` and emits drained receipts before the caller has necessarily
-persisted or displayed the body. `collect` is the kill-safe path for
-orchestrators: it snapshots unread bodies into a
-profile/session/recipient-scoped journal before acknowledging each message.
-The contract is at-least-once, not exactly-once: an interrupted output may replay
-a body on the next collect, but it should not lose the body.
-
-## Files amq-squad writes
-
-```text
-<project>/.amq-squad/team.json           Default team profile (schema: 3 on new writes).
-<project>/.amq-squad/teams/<name>.json   Named team profiles (schema: 3 on new writes).
-<project>/.amq-squad/team-rules.md       Durable team norms (user-edited).
-<project>/.amq-squad/briefs/<session>.md Workstream brief for the default profile.
-<project>/.amq-squad/briefs/<profile>/<session>.md
-                                         Workstream brief for a named profile.
-<project>/.amq-squad/tasks/<session>/     Task store for the default profile.
-<project>/.amq-squad/tasks/<profile>/<session>/
-                                         Task store for a named profile.
-<project>/.amq-squad/collect-journal/<profile>/<session>/<handle>/
-                                         Kill-safe collect journal. Pending
-                                         entries replay until delivered; delivered
-                                         entries are retained for 7 days or the
-                                         latest 200 entries per recipient.
-<project>/.agent-mail/<session>/          AMQ root for the default profile.
-<project>/.agent-mail/<profile>/<session>/
-                                         AMQ root for a named profile.
-<project>/CLAUDE.md, AGENTS.md           Managed pointer block; user content outside markers preserved.
-<AM_ROOT>/agents/<handle>/extensions/io.github.omriariav.amq-squad/
-                                         Per-agent launch.json and role.md inside the
-                                         AMQ mailbox. Legacy direct-agent records
-                                         remain readable.
-```
-
-`<AM_ROOT>` is resolved via AMQ's JSON env contract (`amq env --json`).
-
-## Removed legacy verbs
-
-These verbs are **removed in 2.0**. Invoking one returns a usage error (exit 1, not a silent "unknown command"). Use the replacement. The full upgrade notes live in [`MIGRATION.md`](MIGRATION.md).
-
-| Removed verb | Replacement |
+| Skill | Use it for |
 | --- | --- |
-| `amq-squad down` | `amq-squad stop` |
-| `amq-squad launch <binary>` | `amq-squad agent up <binary>` |
-| `amq-squad restore` (print) | `amq-squad history` |
-| `amq-squad restore --exec --role R` | `amq-squad agent resume R` |
-| `amq-squad list` | `amq-squad status` (live) or `amq-squad history` (records) |
-| `amq-squad team show` | `amq-squad up --dry-run` |
-| `amq-squad team launch` | `amq-squad up` |
-| `amq-squad team launch --fresh --session X` | `amq-squad fork --from <current> --as X` |
+| `amq-squad` | Setup, role authoring, live coordination, draining AMQ, routing review requests, status/history/doctor, runtime controls, and lifecycle commands. |
+| `amq-squad-orchestrator` | Lead-agent operation: spawn, dispatch, monitor, collect reports, coordinate reviews, recover, and produce final evidence. |
+| `amq-team-setup` | Deprecated redirect to `amq-squad`. |
+| `amq-squad-role-creator` | Deprecated redirect to `amq-squad`. |
 
-Replay paths that emit copy-paste commands use the modern `agent up <binary>` command shape.
+Invoke skills in Claude Code as `/amq-squad:<skill>` and in Codex as
+`$<skill>`.
 
-## Known gaps
+Model guidance is intentionally skill-owned because it changes faster than the
+binary. For v2.18.0, the guidance points at the gpt-5.6 family for Codex-heavy
+work, uses explicit model/effort overrides per role, and treats cost as a
+tie-breaker after output quality for shippable work. Prefer the skill guidance
+over copying stale model examples from this README.
 
-- True cross-workstream sends from a setup terminal still depend on upstream AMQ semantics tracked in [avivsinai/agent-message-queue#96](https://github.com/avivsinai/agent-message-queue/issues/96). The normal team flow avoids that path by launching one workstream and routing peer conversations with `--thread`.
-- Multi-cwd teams need manual `peers` config in each project's `.amqrc` for cross-project AMQ routing. `team sync` does not touch `.amqrc`.
+Deep guide: [docs/skills.md](docs/skills.md)
+([HTML](docs/skills.html)).
 
-## Requires
+## Customize
+
+Profiles and roles:
+
+```sh
+amq-squad new team --roles cto,researcher --binary researcher=codex --sync
+amq-squad new team --role-file ./roles/researcher.md --roles cto --sync
+amq-squad team lead set cto --lead-mode planner
+amq-squad team lead clear
+```
+
+Custom role files can be Markdown with YAML frontmatter, plain Markdown with a
+`# Role:` heading, or metadata-only YAML/JSON. They are staged under
+`.amq-squad/roles/<id>.md`; launch seeds each agent's role file and does not
+clobber later edits.
+
+Launch customization:
+
+```sh
+amq-squad agent up claude --role qa --session beta \
+  --launcher /path/claude-wrapper.sh --launcher-args "--pull --workspace /ws"
+
+amq-squad team overlay init --workers --disable-all-hooks
+```
+
+Per-member `claude_args` / `codex_args` apply native CLI flags to one member and
+are replayed by resume. Worker overlays trim Claude plugin/hook surface for
+same-cwd squads; Codex workers use native Codex profiles via `codex_args`.
+
+Trust and binary defaults are explicit. Codex trusted mode is the only path that
+prepends `--dangerously-bypass-approvals-and-sandbox`; the default sandboxed
+mode does not.
+
+## Reference and moved details
+
+This README is the map, not the runbook. Older long-form material is preserved
+or compressed here and lives in the docs below:
+
+| Topic | Where to read |
+| --- | --- |
+| Operator milestone runs, CLI-only flow, common failures | [docs/operator-cookbook.md](docs/operator-cookbook.md) |
+| Global orchestrator and external lead runbook | [docs/global-orchestrator-runbook.md](docs/global-orchestrator-runbook.md) |
+| Skill workflows, AGENT-EVENT protocol, issue-to-merge walkthrough | [docs/skills.md](docs/skills.md) |
+| Verification-before-merge and gate rationale | [docs/verification-gate-adr.md](docs/verification-gate-adr.md) |
+| Native task store internals | [docs/task-store-design.md](docs/task-store-design.md) |
+| JSON action object contract and availability semantics | [docs/action-object-contract.md](docs/action-object-contract.md) |
+| AMQ swarm interop boundary | [docs/amq-swarm-interop.md](docs/amq-swarm-interop.md) |
+| iTerm2 and Terminal.app manual smoke checks | [docs/iterm2-tier-b-smoke.md](docs/iterm2-tier-b-smoke.md), [docs/terminal-app-tier-c-smoke.md](docs/terminal-app-tier-c-smoke.md) |
+| Release history | `docs/v2.*-release-notes.md` |
+| Migration from 1.x verbs | `MIGRATION.md` |
+
+Machine-readable command outputs use JSON envelopes with a `kind` and `data`
+payload. Prefer `--json` for automation and the action objects surfaced by
+`status --json` instead of inferring tmux/window state.
+
+Exit codes:
+
+- `0` success
+- `1` usage or user error
+- `2` system/runtime error
+- `3` partial success
+
+Shell completions are available from the CLI:
+
+```sh
+amq-squad completion zsh
+amq-squad completion bash
+amq-squad completion fish
+```
+
+## Requirements
 
 - Go 1.25+
-- `amq` binary on `PATH` (v0.41.0+)
-- `tmux` on `PATH` for `amq-squad up`
+- `amq` 0.41.x on `PATH`
+- `tmux` on `PATH` for Tier A managed panes
+- macOS with iTerm2 for the Tier B backend
+- macOS Terminal.app for the Tier C backend
+- `pandoc` only when regenerating or checking `README.html`
+
+amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
+sources happens in the skills or operator tooling; the core binary owns team,
+runtime, and coordination state.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -875,28 +875,91 @@ subject, head SHA, and gate/evidence thread. This answers who owns the
 merge/lifecycle action path; exact-head review,
 <code>verify merge</code>, normalized evidence, and operator gates still
 answer when merge-ready can be claimed.</p>
+<h3 id="composition-modes-and-guardrails">Composition modes and
+guardrails</h3>
+<p>Goal-first composition is opt-in and defaults to seeded mode once
+selected. Manual rosters remain first-class, and a short goal never
+authorizes worker spawning by itself:</p>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th>Contract</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Manual</strong></td>
+<td>The operator defines the roster up front. Runtime composition is not
+required.</td>
+</tr>
+<tr>
+<td><strong>Seeded</strong></td>
+<td>The lead proposes each worker and waits for explicit operator
+approval on a stable <code>gate/spawn-&lt;role&gt;</code> thread before
+adding or launching it.</td>
+</tr>
+<tr>
+<td><strong>Autonomous</strong></td>
+<td>The operator explicitly selects
+<code>--composition autonomous</code> and supplies a bounded policy. The
+runtime may add or prune workers only inside that policy.</td>
+</tr>
+</tbody>
+</table>
+<p>Seeded mode requires a clear <code>APPROVED:</code> answer from the
+configured operator. <code>DENIED:</code>, silence, emoji, or vague
+assent means do not spawn. A live-channel approval must be acknowledged
+or mirrored onto the same durable gate thread without spoofing the
+operator handle. Approval covers that spawn only; it does not authorize
+implementation details, merges, releases, or other side effects.</p>
+<p>After approval, persist the member with <code>team member add</code>
+and launch it through the managed resume/up path so stop, resume, focus,
+and status retain a stable runtime identity. The durable roster and task
+store must rebuild the team the lead created, not merely the initial
+seed.</p>
+<p>Autonomous mode is never inferred. It requires positive
+<code>max-agents</code>, <code>max-total-spawns</code>, and
+<code>budget-turns</code>, plus an allowed-role or allowed-role-class
+boundary; <code>idle-reap-minutes</code> constrains pruning. Before an
+allowed spawn/prune decision returns, the runtime persists policy
+counters and writes
+<code>.amq-squad/autonomous/&lt;session&gt;/audit.jsonl</code>. A prune
+request must carry measured idle age, evidence that active task linkage
+was checked, and proof that no active task remains linked.</p>
+<p>Pause, resume, inspect, or permanently disable the policy without
+editing the profile directly:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
+<p>Autonomous composition grants no authority to merge, push, tag,
+release, perform destructive filesystem operations, send externally,
+invoke provider side effects, or delegate child self-spawn. Those
+actions retain their normal lead/operator gates and verification
+preflights.</p>
 <h3 id="the-loop-spawn--dispatch--monitor--coordinate--recover">The
 loop: spawn → dispatch → monitor → coordinate → recover</h3>
-<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. SPAWN — window-per-agent (captures each child&#39;s pane id into the record)</span></span>
-<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up issue-96 <span class="at">--target</span> new-window</span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
-<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
-<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
-<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
-<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
-<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
-<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
-<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
-<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
-<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
-<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. MONITOR — loop on liveness; the lead stays engaged</span></span>
-<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
-<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead collects safely (does not poll)</span></span>
-<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> collect <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--timeout</span> 120s <span class="at">--include-body</span></span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. SPAWN — window-per-agent (captures each child&#39;s pane id into the record)</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up issue-96 <span class="at">--target</span> new-window</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. MONITOR — loop on liveness; the lead stays engaged</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
+<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead collects safely (does not poll)</span></span>
+<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> collect <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--timeout</span> 120s <span class="at">--include-body</span></span></code></pre></div>
 <h3 id="the-agent-event-over-amq-protocol">The
 <code>[AGENT-EVENT]</code>-over-AMQ protocol</h3>
 <p>The key design point: instead of writing status into a parent pane,
@@ -961,8 +1024,8 @@ directive does not clear <code>gate/&lt;topic&gt;</code> threads.
 Orchestrated teams carry the convention as a generated line in their
 <code>## Orchestration</code> norm.</p>
 <h3 id="recover">Recover</h3>
-<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># re-orient a stalled/stopped session</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># re-orient a stalled/stopped session</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
 <hr />
 <h2 id="role-authoring-inside-amq-squad">Role Authoring Inside
 <code>amq-squad</code></h2>
@@ -977,25 +1040,26 @@ prompt, and status/launch exactly like built-ins.</p>
 <p>Two ways, by how much role guidance you want:</p>
 <p><strong>A. Inline (quick, minimal <code>role.md</code>)</strong> —
 just an id + CLI:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
 <p>A custom role must be a valid slug and <strong>must</strong> carry an
 explicit <code>--binary &lt;role&gt;=&lt;cli&gt;</code> (there is no
 catalog default to fall back to).</p>
 <p><strong>B. From a role file (rich, authored
 <code>role.md</code>)</strong> — Markdown with optional YAML
 frontmatter, <code>.yaml</code>, or <code>.json</code>:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
 <div class="sourceCode" id="cb10"><pre
-class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
-<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
-<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
-<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
-<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
 <p>The id comes from the file (<code>id:</code>, a <code># Role:</code>
 heading, or the filename); the binary from the file's
 <code>binary:</code> field (<code>--binary</code> overrides). The
@@ -1007,9 +1071,9 @@ Preview with <code>--dry-run --json</code> before writing.</p>
 <h2 id="end-to-end-walkthrough">End-to-end walkthrough</h2>
 <p>Shipping GitHub issue #96 with an orchestrated squad, start to
 finish.</p>
-<div class="sourceCode" id="cb11"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
 <ol type="1">
 <li><p><strong>Set up the team</strong> — invoke
 <code>/amq-squad:amq-squad</code> and say <em>"the goal is GitHub issue
@@ -1018,30 +1082,30 @@ canonical brief, shows it for your edit, asks for roles
 (<code>cto</code>, <code>fullstack</code>, <code>qa</code>), asks
 <em>"orchestrated? who leads?"</em> (yes, <code>cto</code>), and creates
 everything:</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="co"># + saves .amq-squad/briefs/issue-96.md (your confirmed brief)</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="co"># + saves .amq-squad/briefs/issue-96.md (your confirmed brief)</span></span></code></pre></div></li>
 <li><p><strong>Launch</strong> — hand off to
 <code>/amq-squad:amq-squad</code> and bring the squad up
 window-per-agent:</p>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up issue-96 <span class="at">--target</span> new-window</span></code></pre></div></li>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> up issue-96 <span class="at">--target</span> new-window</span></code></pre></div></li>
 <li><p><strong>Lead the work</strong> — the <code>cto</code> agent (its
 <code>team-rules.md</code> now carries the orchestration norm, so it
 loads <code>/amq-squad:amq-squad-orchestrator</code>) dispatches to
 <code>fullstack</code>, monitors, and drains pushed reports:</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> <span class="st">&quot;Implement #96 per the brief; push a review_request when ready.&quot;</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> collect <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--timeout</span> 120s <span class="at">--include-body</span></span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> <span class="st">&quot;Review fullstack&#39;s diff on branch X; push review_response.&quot;</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> <span class="st">&quot;Implement #96 per the brief; push a review_request when ready.&quot;</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> collect <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--timeout</span> 120s <span class="at">--include-body</span></span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> <span class="st">&quot;Review fullstack&#39;s diff on branch X; push review_response.&quot;</span></span></code></pre></div></li>
 <li><p><strong>Converge and tear down</strong> — the lead verifies the
 artifacts, owns the merge and lifecycle-action path after the readiness
 gates align, reports up to the human, then:</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--all</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> archive issue-96</span></code></pre></div></li>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--all</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> archive issue-96</span></code></pre></div></li>
 </ol>
 <h2 id="troubleshooting">Troubleshooting</h2>
 <table>
@@ -1110,9 +1174,10 @@ default).</td>
 </tbody>
 </table>
 <p>For anything below the skills — the binary's verbs, JSON envelopes,
-tmux targets, profiles, cross-project teams — see the <a
-href="../README.md">README</a>. Each skill's full instructions live in
-its <code>SKILL.md</code> under
+tmux targets, profiles, and <a
+href="../README.md#cross-project-teams">cross-project teams</a> — see
+the <a href="../README.md">README</a>. Each skill's full instructions
+live in its <code>SKILL.md</code> under
 <code>plugins/{claude,codex}/skills/&lt;skill&gt;/</code>.</p>
 </body>
 </html>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -383,6 +383,52 @@ the same subject, head SHA, and gate/evidence thread. This answers who owns the
 merge/lifecycle action path; exact-head review, `verify merge`, normalized
 evidence, and operator gates still answer when merge-ready can be claimed.
 
+### Composition modes and guardrails
+
+Goal-first composition is opt-in and defaults to seeded mode once selected.
+Manual rosters remain first-class, and a short goal never authorizes worker
+spawning by itself:
+
+| Mode | Contract |
+| --- | --- |
+| **Manual** | The operator defines the roster up front. Runtime composition is not required. |
+| **Seeded** | The lead proposes each worker and waits for explicit operator approval on a stable `gate/spawn-<role>` thread before adding or launching it. |
+| **Autonomous** | The operator explicitly selects `--composition autonomous` and supplies a bounded policy. The runtime may add or prune workers only inside that policy. |
+
+Seeded mode requires a clear `APPROVED:` answer from the configured operator.
+`DENIED:`, silence, emoji, or vague assent means do not spawn. A live-channel
+approval must be acknowledged or mirrored onto the same durable gate thread
+without spoofing the operator handle. Approval covers that spawn only; it does
+not authorize implementation details, merges, releases, or other side effects.
+
+After approval, persist the member with `team member add` and launch it through
+the managed resume/up path so stop, resume, focus, and status retain a stable
+runtime identity. The durable roster and task store must rebuild the team the
+lead created, not merely the initial seed.
+
+Autonomous mode is never inferred. It requires positive `max-agents`,
+`max-total-spawns`, and `budget-turns`, plus an allowed-role or
+allowed-role-class boundary; `idle-reap-minutes` constrains pruning. Before an
+allowed spawn/prune decision returns, the runtime persists policy counters and
+writes `.amq-squad/autonomous/<session>/audit.jsonl`. A prune request must carry
+measured idle age, evidence that active task linkage was checked, and proof that
+no active task remains linked.
+
+Pause, resume, inspect, or permanently disable the policy without editing the
+profile directly:
+
+```sh
+amq-squad team autonomous show --json
+amq-squad team autonomous pause
+amq-squad team autonomous resume
+amq-squad team autonomous disable
+```
+
+Autonomous composition grants no authority to merge, push, tag, release,
+perform destructive filesystem operations, send externally, invoke provider
+side effects, or delegate child self-spawn. Those actions retain their normal
+lead/operator gates and verification preflights.
+
 ### The loop: spawn → dispatch → monitor → coordinate → recover
 
 ```sh
@@ -568,6 +614,7 @@ cd ~/Code/my-project
 | Custom role rejected | A custom role needs an explicit `--binary <role>=<cli>` (no catalog default). |
 
 For anything below the skills — the binary's verbs, JSON envelopes, tmux
-targets, profiles, cross-project teams — see the [README](../README.md). Each
+targets, profiles, and [cross-project teams](../README.md#cross-project-teams)
+— see the [README](../README.md). Each
 skill's full instructions live in its `SKILL.md` under
 `plugins/{claude,codex}/skills/<skill>/`.

--- a/docs/verification-gate-adr.md
+++ b/docs/verification-gate-adr.md
@@ -1,8 +1,8 @@
-# ADR: Verification-before-merge gate
+# ADR: Verification preflights for actions, merges, and releases
 
-Status: Approved for v2.3.0
+Status: Approved incrementally for v2.3.0, v2.14.0, and v2.18.0
 
-Issue: #164
+Issues: #164 (`verify merge`), #285 (`verify release`), #349 (`verify action`)
 
 ## Context
 
@@ -11,18 +11,27 @@ and that merge or other irreversible actions are lead-only. Issue #164 asks for
 a concrete verification gate before merge without coupling amq-squad to GitHub,
 one CI vendor, `gh pr merge`, or a `~/.claude` workflow.
 
-The gate has two parts:
+The verification surface now has three complementary preflights:
+
+- `verify action` resolves a bound operator gate for one high-risk action and
+  exact target;
+- `verify merge` validates normalized CI and review evidence at one exact
+  change head;
+- `verify release` validates the final assembled release commit, its CI,
+  second-actor developer co-sign, and operator release approval.
+
+The merge gate has two parts:
 
 - a deterministic preflight that can answer whether CI is green on the current
   head SHA and whether the review surface is clean;
 - lead judgment about whether the verified artifacts are sufficient to merge,
   plus when an operator gate is required.
 
-## Decision
+## Merge preflight: `verify merge`
 
-Ship a tool-agnostic binary preflight, tentatively `amq-squad verify merge`,
-that validates normalized evidence supplied by the lead. Do not ship a
-provider-specific query or merge action.
+The tool-agnostic `amq-squad verify merge` preflight validates normalized
+evidence supplied by the lead. It does not query a provider or perform the
+merge.
 
 The verb takes an evidence document, for example by `--evidence <file>` or
 stdin, and returns a deterministic result:
@@ -68,23 +77,104 @@ The verb does not:
 - merge, approve, label, close, push, or mutate remote state;
 - read agent-specific config such as `~/.claude`.
 
-## Tool-agnostic Surface
+## Action gate: `verify action`
 
-The preflight learns about CI and review state only through normalized evidence.
-A provider-specific tool, connected MCP app, local script, or human lead can
-collect the facts and emit the evidence schema. amq-squad owns validation of the
-facts, not collection of the facts.
+High-risk actions use a stable operator gate bound to both an action kind and
+an exact target:
+
+```sh
+amq-squad verify action \
+  --project <repo> --profile <profile> --session <session> \
+  --gate <topic> --action github_release \
+  --target "draft v2.18.0 release for owner/repo" --json
+```
+
+Both the gate question and the configured operator's later answer must contain
+matching `Action:` and `Target:` fields. Supported action classes include
+default/protected branch pushes, tag operations, GitHub releases, and external
+sends. A matching `APPROVED:` answer passes; pending, denied, missing, and
+unbound or mismatched answers remain distinct non-zero outcomes.
+
+This is a **callable verification boundary, not command interception**. A lead
+or wrapper that never invokes `verify action` is not blocked by the operating
+system, shell, Git, GitHub CLI, or another provider client. The guard protects
+the normal amq-squad workflow from confused or overreaching execution; it is
+not a tamper-proof security boundary against an actor that can bypass the CLI or
+forge local AMQ mailbox data. Any wrapper that performs a high-risk operation
+must call the preflight before executing that operation.
+
+`verify action` validates the durable gate state only. It never pushes, tags,
+publishes a release, sends externally, or otherwise performs the requested
+action.
+
+## Release preflight: `verify release`
+
+Release publication has a second, non-substitutable evidence gate at the final
+assembled release commit:
+
+```sh
+amq-squad verify release --evidence release-evidence.json --json
+```
+
+The normalized evidence shape is:
+
+```json
+{
+  "subject": "release v2.18.0",
+  "version": "v2.18.0",
+  "release_commit_sha": "<final assembled release commit SHA>",
+  "ci": {
+    "state": "success",
+    "sha": "<release_commit_sha>",
+    "source": "provider/tool",
+    "checked_at": "RFC3339 timestamp"
+  },
+  "cosign": {
+    "state": "approved",
+    "sha": "<release_commit_sha>",
+    "reviewer": "<developer other than release lead>",
+    "distinct_from_release_lead": true,
+    "source": "provider/tool",
+    "checked_at": "RFC3339 timestamp"
+  },
+  "operator_release_approval": {
+    "approved": true,
+    "gate": "gate/<topic>",
+    "source": "operator gate evidence",
+    "checked_at": "RFC3339 timestamp"
+  }
+}
+```
+
+Publish-ready requires all of the following:
+
+- `release_commit_sha` is the final assembled release commit;
+- CI is successful for exactly that SHA;
+- a developer distinct from the release lead co-signs exactly that SHA;
+- operator release approval is present with a gate or source reference.
+
+A co-sign on an earlier per-delta SHA is stale. Operator approval alone never
+substitutes for the exact-SHA co-sign, and the co-sign never substitutes for the
+operator gate. Like the other preflights, `verify release` validates normalized
+evidence only; it never pushes, tags, or publishes.
+
+## Tool-agnostic surface
+
+The merge and release preflights learn about CI, review, co-sign, and approval
+state only through normalized evidence. A provider-specific tool, connected MCP
+app, local script, or human lead can collect the facts and emit the evidence
+schema. amq-squad owns validation of the facts, not collection of the facts.
 
 This keeps the binary neutral while still removing improvisation from the gate:
 different providers can feed the same schema, and the preflight checks the
 provider-independent invariants that matter before merge.
 
 Provider adapters can be added later as optional producers of the evidence
-schema, but they must remain outside the core merge decision path. The stable
-contract is the evidence schema and the `verify merge` result, not any one
+schemas, but they must remain outside the core decision path. The stable
+contracts are the evidence schemas and verification results, not any one
 provider command.
 
-## Judgment That Stays in the Skill
+## Judgment that stays in the skill
 
 The orchestrator skill should continue to say:
 
@@ -94,6 +184,8 @@ The orchestrator skill should continue to say:
   SHA, and review state, not the child's narration;
 - `amq-squad verify merge` is a required deterministic preflight before merge,
   but a passing preflight is not an obligation to merge;
+- `amq-squad verify release` is required on the final assembled release commit
+  before publish, but it never performs the publish;
 - named exceptions, such as sign-off pending, shared infrastructure risk, or
   autonomous wake risk, require an explicit operator gate on a stable
   `gate/<topic>` thread before the lead may proceed.
@@ -103,7 +195,7 @@ the lead to gather evidence with the appropriate connected tool, run the
 preflight, then apply judgment and route any exception through the operator
 gate.
 
-## Rejected Options
+## Rejected options
 
 ### Documentation-only recipe
 
@@ -132,3 +224,7 @@ validation. Optional collectors can come later.
 - A lead can cite an objective preflight result in AMQ review threads.
 - The human/operator still owns merge permission when team rules or exceptions
   require it.
+- Action verification remains explicit and callable rather than pretending the
+  binary intercepts arbitrary shell, Git, provider, or messaging commands.
+- Release evidence cannot collapse operator approval and a second-actor
+  exact-SHA co-sign into one substitutable signal.


### PR DESCRIPTION
## Summary

- Rewrites README.md around the approved v2.18.0 outline: product mental model, what's new, quickstart, execution modes, orchestration protocol/safety, terminal capability matrix, command map, skills/model guidance, customization, and docs map.
- Keeps the README meaningfully shorter: 1602 lines -> 422 lines.
- Regenerates README.html from the new README.

## Notes

- Terminal matrix uses capability-specific semantics and exact runtimecontrol disabled reasons for iTerm2 and Terminal.app.
- Existing long-form material is compressed in README and routed to named docs/ destinations instead of being dropped.
- Includes a v2.18.0 delta block for returning users.

## Validation

- make readme-html
- make skills-check
- make ci
- git diff --check

Head SHA: ee536fd
