### PR TITLE
#393 slice 3: Bubble Tea wizard UX

### DIFF
--- a/docs/v2.19.0-release-notes.md
+++ b/docs/v2.19.0-release-notes.md
@@ -33,3 +33,20 @@ It is not a release announcement.
   new semantics: values normalize only into the existing per-member
   `codex_args` (`model_reasoning_effort`) or `claude_args` (`--effort`) fields.
   No new persisted effort field or launch behavior is introduced.
+
+## Bubble Tea wizard and accessible fallback, Slice 3
+
+- Eligible terminals now use a full-screen Bubble Tea flow with arrow-key
+  navigation, back/cancel controls, a phase rail, topology diagrams, and a
+  final confirmation screen that still invokes only the canonical read-only
+  preview.
+- `TERM=dumb`, `AMQ_SQUAD_WIZARD_ACCESSIBLE=1`, `--numbered`, and
+  `--wizard-ui numbered` select the plain numbered adapter. Operators can force
+  the full-screen adapter with `--wizard-ui tui`.
+- Both adapters use the same `Spec`, project inspection, and canonical
+  preflight. Existing profiles now explicitly ask, role by role, whether to
+  override model or effort for this launch. These overrides are applied to an
+  in-memory roster copy and never rewrite the stored profile.
+- Topology previews have golden coverage for sibling windows, current-window
+  panes, and detached operation. Cancellation exits without running preview or
+  mutating team state.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -118,3 +118,70 @@ func memberEffort(member team.Member) string {
 	}
 	return effortAutomatic
 }
+
+// applyLaunchEffortOverrides returns an ephemeral roster copy with only the
+// native effort arguments replaced. It never writes the profile and preserves
+// all unrelated per-member args.
+func applyLaunchEffortOverrides(members []team.Member, overrides map[string]string) ([]team.Member, error) {
+	if len(overrides) == 0 {
+		return append([]team.Member(nil), members...), nil
+	}
+	known := make(map[string]bool, len(members))
+	for _, member := range members {
+		known[strings.ToLower(strings.TrimSpace(member.Role))] = true
+	}
+	var unknown []string
+	for role := range overrides {
+		if !known[strings.ToLower(strings.TrimSpace(role))] {
+			unknown = append(unknown, role)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("--effort names role(s) not present in the selected profile: %s", strings.Join(unknown, ", "))
+	}
+	out := append([]team.Member(nil), members...)
+	for i := range out {
+		effort, ok := overrides[strings.ToLower(strings.TrimSpace(out[i].Role))]
+		if !ok {
+			continue
+		}
+		switch normalizedAgentBinary(out[i].Binary) {
+		case "codex":
+			out[i].CodexArgs = stripNativeEffortArgs(out[i].CodexArgs, "codex")
+		case "claude":
+			out[i].ClaudeArgs = stripNativeEffortArgs(out[i].ClaudeArgs, "claude")
+		}
+		if err := applyMemberEffort(&out[i], effort); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func stripNativeEffortArgs(args []string, binary string) []string {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if binary == "codex" {
+			if arg == "-c" && i+1 < len(args) && strings.HasPrefix(args[i+1], "model_reasoning_effort=") {
+				i++
+				continue
+			}
+			if strings.HasPrefix(arg, "model_reasoning_effort=") {
+				continue
+			}
+		}
+		if binary == "claude" {
+			if arg == "--effort" && i+1 < len(args) {
+				i++
+				continue
+			}
+			if strings.HasPrefix(arg, "--effort=") {
+				continue
+			}
+		}
+		out = append(out, arg)
+	}
+	return out
+}

--- a/internal/cli/effort_test.go
+++ b/internal/cli/effort_test.go
@@ -69,3 +69,33 @@ func TestTeamInitEffortRejectsRoleAndBinaryMismatches(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyLaunchEffortOverridesReplacesNativeArgsWithoutMutatingProfile(t *testing.T) {
+	members := []team.Member{
+		{Role: "cto", Binary: "codex", CodexArgs: []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--search"}},
+		{Role: "qa", Binary: "claude", ClaudeArgs: []string{"--chrome", "--effort=medium", "--debug"}},
+	}
+	got, err := applyLaunchEffortOverrides(members, map[string]string{"cto": "xhigh", "qa": "automatic"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"--profile", "fast", "--search", "-c", "model_reasoning_effort=xhigh"}; !reflect.DeepEqual(got[0].CodexArgs, want) {
+		t.Fatalf("cto args = %#v, want %#v", got[0].CodexArgs, want)
+	}
+	if want := []string{"--chrome", "--debug"}; !reflect.DeepEqual(got[1].ClaudeArgs, want) {
+		t.Fatalf("qa args = %#v, want %#v", got[1].ClaudeArgs, want)
+	}
+	if want := []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--search"}; !reflect.DeepEqual(members[0].CodexArgs, want) {
+		t.Fatalf("stored cto args mutated: %#v", members[0].CodexArgs)
+	}
+	if want := []string{"--chrome", "--effort=medium", "--debug"}; !reflect.DeepEqual(members[1].ClaudeArgs, want) {
+		t.Fatalf("stored qa args mutated: %#v", members[1].ClaudeArgs)
+	}
+}
+
+func TestApplyLaunchEffortOverridesRejectsUnknownProfileRole(t *testing.T) {
+	_, err := applyLaunchEffortOverrides([]team.Member{{Role: "cto", Binary: "codex"}}, map[string]string{"qa": "high"})
+	if err == nil || !strings.Contains(err.Error(), "not present in the selected profile") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -116,7 +116,7 @@ func runGlobalStart(args []string) error {
 	// Build the agent argv: binary, then model, then the matching per-binary
 	// passthrough. Global start remains a single-agent surface, so effort rides
 	// directly in --codex-args / --claude-args; the role-mapped --effort flag is
-	// only meaningful while forming a project roster.
+	// only meaningful for a multi-role project run.
 	agentArgv := []string{*agent}
 	if strings.TrimSpace(*model) != "" {
 		agentArgv = append(agentArgv, "--model", strings.TrimSpace(*model))
@@ -216,9 +216,10 @@ registered and wake-live automatically. This wraps the create sequence so the
 Visibility defaults to sibling-tabs: agents open as sibling tmux windows in the
 current visible tmux session (requires a visible tmux pane when --go is used).
 Pass --visibility detached for hidden workers in a separate tmux session. Choose
-binary via --binary and model via --model. For a fresh roster, --effort
-normalizes role-specific values into the existing per-member CodexArgs or
-ClaudeArgs fields; it adds no persisted effort field or launch semantics.
+binary via --binary and model via --model. --effort normalizes role-specific
+values into the existing per-member CodexArgs or ClaudeArgs fields. For an
+existing profile it is launch-only and never rewrites stored member args; it
+adds no persisted effort field or launch semantics.
 
 Preview by default (prints the plan and runs read-only --dry-run validation, so
 its failures surface honestly); pass --go to create for real.
@@ -271,7 +272,7 @@ func runRunStart(args []string, version string) error {
 	rolesFlag := fs.String("roles", "", "create the roster first: comma-separated role ids")
 	binaryFlag := fs.String("binary", "", "per-role binary assignments, e.g. \"fullstack=codex,qa=codex\"")
 	modelFlag := fs.String("model", "", "per-role model overrides, e.g. \"cto=gpt-5.6-sol,fullstack=sonnet\"")
-	effortFlag := fs.String("effort", "", "per-role effort for a fresh roster, e.g. \"cto=high,qa=medium\" (normalized into native member args)")
+	effortFlag := fs.String("effort", "", "per-role effort, e.g. \"cto=high,qa=medium\" (launch-only for existing profiles; normalized into native member args)")
 	codexArgsFlag := fs.String("codex-args", "", "extra args for every Codex member (e.g. reasoning effort)")
 	claudeArgsFlag := fs.String("claude-args", "", "extra args for every Claude member")
 	visibilityFlag := fs.String("visibility", visibilitySiblingTabs, "spawn topology: sibling-tabs (visible default), detached (hidden), or current")
@@ -368,6 +369,9 @@ func runRunStart(args []string, version string) error {
 		upArgs = append(upArgs, "--seed-from", *seedFlag)
 	}
 	upArgs = appendPassthroughArgs(upArgs, *modelFlag, *codexArgsFlag, *claudeArgsFlag)
+	if teamPresent && strings.TrimSpace(*effortFlag) != "" {
+		upArgs = append(upArgs, "--effort", *effortFlag)
+	}
 
 	leadModeDisplay := leadMode
 	if !flagWasSet(fs, "lead-mode") && teamPresent {
@@ -456,6 +460,7 @@ func runRunStart(args []string, version string) error {
 				TeamPresent: teamPresent,
 				Visibility:  visibility,
 				Model:       *modelFlag,
+				Effort:      *effortFlag,
 				CodexArgs:   *codexArgsFlag,
 				ClaudeArgs:  *claudeArgsFlag,
 				Version:     version,
@@ -485,14 +490,14 @@ func runRunStart(args []string, version string) error {
 		} else if len(newTeamArgs) > 0 {
 			quietNotice("profile %q already exists; skipping new team (using existing roster)\n", profileOrDefault(*profileFlag))
 		}
-		if err := validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, externalLeadRole, *modelFlag, *codexArgsFlag, *claudeArgsFlag); err != nil {
+		if err := validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, externalLeadRole, *modelFlag, *effortFlag, *codexArgsFlag, *claudeArgsFlag); err != nil {
 			return err
 		}
 		quietNotice("binding current pane as external lead %s...\n", externalLeadRole)
 		if err := runStartRegisterExternalLead(project, profile, session, externalLeadRole); err != nil {
 			return err
 		}
-		opts, err := runStartTeamLaunchOptions(visibility, session, profile, externalSeedContent, false, false, externalLeadRole, true, *modelFlag, *codexArgsFlag, *claudeArgsFlag)
+		opts, err := runStartTeamLaunchOptions(visibility, session, profile, externalSeedContent, false, false, externalLeadRole, true, *modelFlag, *effortFlag, *codexArgsFlag, *claudeArgsFlag)
 		if err != nil {
 			return err
 		}
@@ -599,6 +604,7 @@ type runStartExternalLeadPreviewOptions struct {
 	TeamPresent bool
 	Visibility  string
 	Model       string
+	Effort      string
 	CodexArgs   string
 	ClaudeArgs  string
 	Version     string
@@ -616,7 +622,7 @@ func runStartExternalLeadPreview(opts runStartExternalLeadPreviewOptions) error 
 		return nil
 	}
 	if opts.TeamPresent {
-		if err := validateRunStartExternalLeadWorkerLaunch(opts.Project, opts.Visibility, opts.Session, opts.Profile, opts.Lead, opts.Model, opts.CodexArgs, opts.ClaudeArgs); err != nil {
+		if err := validateRunStartExternalLeadWorkerLaunch(opts.Project, opts.Visibility, opts.Session, opts.Profile, opts.Lead, opts.Model, opts.Effort, opts.CodexArgs, opts.ClaudeArgs); err != nil {
 			return fmt.Errorf("worker spawn dry-run failed: %w", err)
 		}
 		fmt.Print("\nPreview OK. Re-run with --external-lead --go to bind this pane as lead and spawn remaining workers.\n")
@@ -625,25 +631,30 @@ func runStartExternalLeadPreview(opts runStartExternalLeadPreviewOptions) error 
 	return usageErrorf("no team profile %q in %s and no --roles given; pass --roles to create one or create the team first", opts.Profile, opts.Project)
 }
 
-func runStartTeamLaunchOptions(visibility, session, profile, seedContent string, seedForce, dryRun bool, externalLeadRole string, allowLeadOnly bool, modelRaw, codexArgsRaw, claudeArgsRaw string) (teamLaunchOptions, error) {
+func runStartTeamLaunchOptions(visibility, session, profile, seedContent string, seedForce, dryRun bool, externalLeadRole string, allowLeadOnly bool, modelRaw, effortRaw, codexArgsRaw, claudeArgsRaw string) (teamLaunchOptions, error) {
 	modelOverrides, err := parseKV(modelRaw)
 	if err != nil {
 		return teamLaunchOptions{}, fmt.Errorf("parse --model: %w", err)
 	}
 	modelOverrides = lowercaseKeys(modelOverrides)
+	effortOverrides, err := parseEffortOverrides(effortRaw)
+	if err != nil {
+		return teamLaunchOptions{}, err
+	}
 	binaryArgs, err := parseBinaryArgFlags(codexArgsRaw, claudeArgsRaw)
 	if err != nil {
 		return teamLaunchOptions{}, err
 	}
 	opts := teamLaunchOptions{
-		Terminal:       "tmux",
-		Target:         "current-window",
-		Layout:         "vertical",
-		Workstream:     session,
-		Stagger:        750 * time.Millisecond,
-		SquadBin:       teamSquadBin(),
-		BinaryArgs:     binaryArgs,
-		ModelOverrides: modelOverrides,
+		Terminal:        "tmux",
+		Target:          "current-window",
+		Layout:          "vertical",
+		Workstream:      session,
+		Stagger:         750 * time.Millisecond,
+		SquadBin:        teamSquadBin(),
+		BinaryArgs:      binaryArgs,
+		ModelOverrides:  modelOverrides,
+		EffortOverrides: effortOverrides,
 	}
 	if err := applyLaunchVisibility(&opts, visibility, false, false, false, true); err != nil {
 		return teamLaunchOptions{}, err
@@ -794,8 +805,8 @@ func authorizeRunStartExternalLeadAdoption(project, profile, session, lead strin
 	return err
 }
 
-func validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, lead, modelRaw, codexArgsRaw, claudeArgsRaw string) error {
-	launchOpts, err := runStartTeamLaunchOptions(visibility, session, profile, "", false, true, lead, true, modelRaw, codexArgsRaw, claudeArgsRaw)
+func validateRunStartExternalLeadWorkerLaunch(project, visibility, session, profile, lead, modelRaw, effortRaw, codexArgsRaw, claudeArgsRaw string) error {
+	launchOpts, err := runStartTeamLaunchOptions(visibility, session, profile, "", false, true, lead, true, modelRaw, effortRaw, codexArgsRaw, claudeArgsRaw)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -756,6 +756,34 @@ func TestRunStartExistingProfileMixedPinsProceed(t *testing.T) {
 	}
 }
 
+func TestRunStartExistingProfileEffortOverrideIsLaunchOnly(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Project:      "",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{{
+			Role: "cto", Binary: "codex", Handle: "cto", Session: "sess",
+			CodexArgs: []string{"--profile", "fast", "-c", "model_reasoning_effort=low"},
+		}},
+	})
+	out, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--effort", "cto=xhigh"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("preview error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "model_reasoning_effort=xhigh") || strings.Contains(out, "model_reasoning_effort=low") {
+		t.Fatalf("preview did not replace stored effort args:\n%s", out)
+	}
+	stored, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := memberEffort(stored.Members[0]); got != "low" {
+		t.Fatalf("stored profile effort changed to %q", got)
+	}
+}
+
 func TestRunStartGoGoalWaitsForLeadReadiness(t *testing.T) {
 	dir := t.TempDir()
 	if _, _, err := captureOutput(t, func() error {

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -17,6 +17,7 @@ type previewFlags struct {
 	fresh          *bool
 	trustRaw       *string
 	model          *string
+	effort         *string
 	codexArgsRaw   *string
 	claudeArgsRaw  *string
 	forceDuplicate *bool
@@ -33,6 +34,7 @@ func registerPreviewFlags(fs *flag.FlagSet) *previewFlags {
 		fresh:          fs.Bool("fresh", false, "fail if the selected workstream session already exists"),
 		trustRaw:       fs.String("trust", "", "Codex trust profile for this run: approve-for-me (default), sandboxed, or trusted"),
 		model:          fs.String("model", "", "per-persona model overrides for this run, e.g. cto=gpt-5.6-sol,fullstack=sonnet"),
+		effort:         fs.String("effort", "", "per-persona launch-only effort overrides, e.g. cto=high,qa=medium"),
 		codexArgsRaw:   fs.String("codex-args", "", "extra Codex args for this run, e.g. '--enable goals'"),
 		claudeArgsRaw:  fs.String("claude-args", "", "extra Claude args for this run, e.g. '--chrome'"),
 		forceDuplicate: fs.Bool("force-duplicate", false, "include --force-duplicate in emitted launch commands"),
@@ -54,6 +56,10 @@ func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) 
 		return emitTeamOptions{}, fmt.Errorf("parse --model: %w", err)
 	}
 	modelOverrides = lowercaseKeys(modelOverrides)
+	effortOverrides, err := parseEffortOverrides(*p.effort)
+	if err != nil {
+		return emitTeamOptions{}, err
+	}
 	binaryArgs, err := parseBinaryArgFlags(*p.codexArgsRaw, *p.claudeArgsRaw)
 	if err != nil {
 		return emitTeamOptions{}, err
@@ -75,6 +81,7 @@ func (p *previewFlags) toEmitOptions(fs *flag.FlagSet) (emitTeamOptions, error) 
 		RequestedTrust:   trustMode,
 		ExplicitTrust:    flagWasSet(fs, "trust"),
 		ModelOverrides:   modelOverrides,
+		EffortOverrides:  effortOverrides,
 		ForceDuplicate:   *p.forceDuplicate,
 		NoGitignore:      *p.noGitignore,
 		Symphony:         *p.symphony,
@@ -129,6 +136,7 @@ func buildLiveLaunchOptions(fs *flag.FlagSet, pf *previewFlags, lf *liveLaunchFl
 		BinaryArgs:      emit.ExtraBinaryArgs,
 		Trust:           emit.RequestedTrust,
 		ModelOverrides:  emit.ModelOverrides,
+		EffortOverrides: emit.EffortOverrides,
 		ForceDuplicate:  emit.ForceDuplicate,
 		NoGitignore:     emit.NoGitignore,
 		Symphony:        emit.Symphony,

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -21,7 +21,6 @@ const (
 	runStartPreflightMissingRoster           = "missing_roster"
 	runStartPreflightInvalidLeadMode         = "invalid_lead_mode"
 	runStartPreflightExistingProfileLeadMode = "existing_profile_lead_mode"
-	runStartPreflightExistingProfileEffort   = "existing_profile_effort"
 	runStartPreflightInvalidEffort           = "invalid_effort"
 )
 
@@ -145,13 +144,20 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 			fmt.Sprintf("run amq-squad team lead set <role> --lead-mode %s before starting", leadMode))
 	}
 	if input.EffortSet {
-		if !r.FreshRoster {
-			return add(runStartPreflightExistingProfileEffort,
-				"--effort applies only when run start creates a fresh roster; existing member CodexArgs/ClaudeArgs remain authoritative",
-				"keep the existing profile effort settings",
-				"create a new named profile to choose different per-role effort")
+		var effortErr error
+		if r.TeamPresent && !r.FreshRoster {
+			efforts, parseErr := parseEffortOverrides(input.Effort)
+			if parseErr != nil {
+				effortErr = parseErr
+			} else if existing, readErr := team.ReadProfile(r.Project, r.Profile); readErr != nil {
+				effortErr = fmt.Errorf("read team profile %q: %w", r.Profile, readErr)
+			} else {
+				_, effortErr = applyLaunchEffortOverrides(existing.Members, efforts)
+			}
+		} else {
+			effortErr = validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort)
 		}
-		if effortErr := validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort); effortErr != nil {
+		if effortErr != nil {
 			return add(runStartPreflightInvalidEffort, effortErr.Error(), "use role=automatic|low|medium|high assignments")
 		}
 	}

--- a/internal/cli/run_start_preflight_test.go
+++ b/internal/cli/run_start_preflight_test.go
@@ -31,14 +31,21 @@ func TestRunStartPreflightReturnsStructuredPinnedSessionMismatch(t *testing.T) {
 	}
 }
 
-func TestRunStartPreflightEffortIsFreshRosterOnly(t *testing.T) {
+func TestRunStartPreflightExistingProfileEffortIsLaunchOnlyAndValid(t *testing.T) {
 	dir := t.TempDir()
 	if err := team.WriteProfile(dir, team.DefaultProfile, team.Team{Project: dir, Members: []team.Member{{Role: "cto", Binary: "codex", Session: "sess"}}}); err != nil {
 		t.Fatal(err)
 	}
 	result := runStartPreflight(runStartPreflightInput{Project: dir, Session: "sess", Visibility: "sibling-tabs", Effort: "cto=high", EffortSet: true})
-	if len(result.Issues) != 1 || result.Issues[0].Code != runStartPreflightExistingProfileEffort {
+	if len(result.Issues) != 0 {
 		t.Fatalf("preflight = %+v", result)
+	}
+	stored, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := memberEffort(stored.Members[0]); got != effortAutomatic {
+		t.Fatalf("preflight mutated stored effort to %q", got)
 	}
 }
 

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -19,10 +19,16 @@ var (
 	runStartWizardStderrIsTerminal           = stderrIsTerminal
 	runStartWizardInCI                       = detectedCI
 	runStartWizardRunner           func([]string, string) error
+	runStartWizardTerm             = func() string { return os.Getenv("TERM") }
+	runStartWizardAccessible       = func() bool { return envTruthy("AMQ_SQUAD_WIZARD_ACCESSIBLE") }
+	runStartNumberedAdapter        func([]string, string) error
+	runStartBubbleAdapter          func([]string, string) error
 )
 
 func init() {
-	runStartWizardRunner = runNumberedRunStartWizard
+	runStartNumberedAdapter = runNumberedRunStartWizard
+	runStartBubbleAdapter = runBubbleRunStartWizard
+	runStartWizardRunner = runAdaptiveRunStartWizard
 }
 
 // runWizardCmd is the discoverable alias for run start --interactive. It owns
@@ -33,11 +39,12 @@ func runWizardCmd(args []string, version string) error {
 		fmt.Fprint(os.Stderr, `amq-squad wizard - guided preview for one orchestrated run
 
 Usage:
-  amq-squad wizard [run start prefill flags]
+  amq-squad wizard [run start prefill flags] [--wizard-ui auto|tui|numbered]
 
 This is an alias for 'amq-squad run start --interactive'. It requires an
 interactive terminal, never runs in CI, and is preview-only in this release
 slice. The wizard prints and validates the equivalent flag-form command.
+TERM=dumb and --wizard-ui numbered use the accessible numbered adapter.
 `)
 		return nil
 	}
@@ -103,37 +110,114 @@ func detectedCI() bool {
 	return false
 }
 
-func runNumberedRunStartWizard(args []string, version string) error {
-	prefill, err := parseRunStartWizardPrefill(args)
+func envTruthy(key string) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	return value != "" && value != "0" && value != "false" && value != "no"
+}
+
+func runAdaptiveRunStartWizard(args []string, version string) error {
+	rest, mode, err := stripWizardUIArgs(args)
 	if err != nil {
 		return err
+	}
+	if mode == "numbered" || (mode == "auto" && (strings.EqualFold(strings.TrimSpace(runStartWizardTerm()), "dumb") || runStartWizardAccessible())) {
+		return runStartNumberedAdapter(rest, version)
+	}
+	return runStartBubbleAdapter(rest, version)
+}
+
+func stripWizardUIArgs(args []string) ([]string, string, error) {
+	mode := "auto"
+	rest := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--numbered" || arg == "--accessible":
+			mode = "numbered"
+		case arg == "--wizard-ui":
+			if i+1 >= len(args) {
+				return nil, "", usageErrorf("--wizard-ui requires auto, tui, or numbered")
+			}
+			i++
+			mode = strings.ToLower(strings.TrimSpace(args[i]))
+		case strings.HasPrefix(arg, "--wizard-ui="):
+			mode = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(arg, "--wizard-ui=")))
+		default:
+			rest = append(rest, arg)
+		}
+	}
+	if mode != "auto" && mode != "tui" && mode != "numbered" {
+		return nil, "", usageErrorf("unsupported --wizard-ui %q (want auto, tui, or numbered)", mode)
+	}
+	return rest, mode, nil
+}
+
+func runNumberedRunStartWizard(args []string, version string) error {
+	prefill, opts, err := prepareRunStartWizard(args)
+	if err != nil {
+		return err
+	}
+	opts.Defaults = prefill
+	spec, err := runwizard.RunNumbered(runStartWizardInput, runStartWizardOutput, opts)
+	if err != nil {
+		return err
+	}
+	return finishRunStartWizard(spec, version)
+}
+
+func runBubbleRunStartWizard(args []string, version string) error {
+	prefill, opts, err := prepareRunStartWizard(args)
+	if err != nil {
+		return err
+	}
+	opts.Defaults = prefill
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		fmt.Fprintf(runStartWizardOutput, "Full-screen wizard unavailable (%v); using the numbered adapter.\n", err)
+		return runNumberedRunStartWizard(args, version)
+	}
+	defer tty.Close()
+	result, err := runwizard.RunBubbleTea(tty, tty, opts)
+	if err != nil {
+		return err
+	}
+	if result.Cancelled {
+		fmt.Fprintln(runStartWizardOutput, "Wizard cancelled. Nothing changed.")
+		return nil
+	}
+	return finishRunStartWizard(result.Spec, version)
+}
+
+func prepareRunStartWizard(args []string) (runwizard.Spec, runwizard.NumberedOptions, error) {
+	prefill, err := parseRunStartWizardPrefill(args)
+	if err != nil {
+		return runwizard.Spec{}, runwizard.NumberedOptions{}, err
 	}
 	if strings.TrimSpace(prefill.Project) == "" {
 		cwd, getwdErr := os.Getwd()
 		if getwdErr != nil {
-			return fmt.Errorf("getwd: %w", getwdErr)
+			return runwizard.Spec{}, runwizard.NumberedOptions{}, fmt.Errorf("getwd: %w", getwdErr)
 		}
 		prefill.Project = cwd
 	}
 	initialContext, err := inspectRunStartWizardProject(prefill.Project)
 	if err != nil {
-		return err
+		return runwizard.Spec{}, runwizard.NumberedOptions{}, err
 	}
 	prefill.Project = initialContext.Project
 	if strings.TrimSpace(prefill.Profile) == "" {
 		prefill.Profile = team.DefaultProfile
 	}
-
-	spec, err := runwizard.RunNumbered(runStartWizardInput, runStartWizardOutput, runwizard.NumberedOptions{
-		Defaults:       prefill,
+	opts := runwizard.NumberedOptions{
 		InspectProject: inspectRunStartWizardProject,
 		ProfileExists: func(project, profile string) bool {
 			return team.ExistsProfile(strings.TrimSpace(project), strings.TrimSpace(profile))
 		},
-	})
-	if err != nil {
-		return err
 	}
+	return prefill, opts, nil
+}
+
+func finishRunStartWizard(spec runwizard.Spec, version string) error {
 	preflight := runStartPreflight(runStartPreflightInput{
 		Project:         spec.Project,
 		Profile:         spec.Profile,

--- a/internal/cli/run_start_wizard_test.go
+++ b/internal/cli/run_start_wizard_test.go
@@ -189,3 +189,64 @@ func TestNumberedWizardRunsCanonicalPreviewWithoutMutation(t *testing.T) {
 		t.Fatal("preview-only wizard created a team profile")
 	}
 }
+
+func TestAdaptiveRunStartWizardSelectsUIAndStripsAdapterFlags(t *testing.T) {
+	prevTerm := runStartWizardTerm
+	prevAccessible := runStartWizardAccessible
+	prevNumbered := runStartNumberedAdapter
+	prevBubble := runStartBubbleAdapter
+	t.Cleanup(func() {
+		runStartWizardTerm = prevTerm
+		runStartWizardAccessible = prevAccessible
+		runStartNumberedAdapter = prevNumbered
+		runStartBubbleAdapter = prevBubble
+	})
+
+	var used string
+	var gotArgs []string
+	runStartNumberedAdapter = func(args []string, _ string) error {
+		used, gotArgs = "numbered", append([]string(nil), args...)
+		return nil
+	}
+	runStartBubbleAdapter = func(args []string, _ string) error {
+		used, gotArgs = "tui", append([]string(nil), args...)
+		return nil
+	}
+
+	for _, tc := range []struct {
+		name       string
+		term       string
+		accessible bool
+		args       []string
+		wantUI     string
+	}{
+		{name: "default TUI", term: "xterm-256color", args: []string{"--project", "/repo"}, wantUI: "tui"},
+		{name: "dumb terminal", term: "dumb", args: []string{"--project", "/repo"}, wantUI: "numbered"},
+		{name: "accessibility environment", term: "xterm", accessible: true, args: []string{"--project", "/repo"}, wantUI: "numbered"},
+		{name: "explicit numbered", term: "xterm", args: []string{"--wizard-ui", "numbered", "--project", "/repo"}, wantUI: "numbered"},
+		{name: "numbered alias", term: "xterm", args: []string{"--numbered", "--project", "/repo"}, wantUI: "numbered"},
+		{name: "explicit TUI beats dumb fallback", term: "dumb", accessible: true, args: []string{"--wizard-ui=tui", "--project", "/repo"}, wantUI: "tui"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			used, gotArgs = "", nil
+			runStartWizardTerm = func() string { return tc.term }
+			runStartWizardAccessible = func() bool { return tc.accessible }
+			if err := runAdaptiveRunStartWizard(tc.args, "test"); err != nil {
+				t.Fatal(err)
+			}
+			if used != tc.wantUI {
+				t.Fatalf("adapter = %q, want %q", used, tc.wantUI)
+			}
+			if !reflect.DeepEqual(gotArgs, []string{"--project", "/repo"}) {
+				t.Fatalf("adapter args = %#v", gotArgs)
+			}
+		})
+	}
+}
+
+func TestAdaptiveRunStartWizardRejectsUnknownUI(t *testing.T) {
+	err := runAdaptiveRunStartWizard([]string{"--wizard-ui", "graphical"}, "test")
+	if err == nil || !strings.Contains(err.Error(), "unsupported --wizard-ui") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -740,6 +740,7 @@ type emitTeamOptions struct {
 	RequestedTrust   string
 	ExplicitTrust    bool
 	ModelOverrides   map[string]string
+	EffortOverrides  map[string]string
 	ForceDuplicate   bool
 	NoGitignore      bool
 	Symphony         bool
@@ -819,6 +820,10 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
 	}
 	t.Members = active
+	t.Members, err = applyLaunchEffortOverrides(t.Members, opts.EffortOverrides)
+	if err != nil {
+		return err
+	}
 	members := orderedTeamMembers(t.Members)
 	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.ExtraBinaryArgs)
 	trustMode, err := resolveTeamTrustMode(t, opts.RequestedTrust, opts.ExplicitTrust)

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -28,6 +28,7 @@ type teamLaunchOptions struct {
 	BinaryArgs      map[string][]string
 	Trust           string
 	ModelOverrides  map[string]string
+	EffortOverrides map[string]string
 	ForceDuplicate  bool
 	NoGitignore     bool
 	Symphony        bool
@@ -187,6 +188,10 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
 	}
 	t.Members = active
+	t.Members, err = applyLaunchEffortOverrides(t.Members, opts.EffortOverrides)
+	if err != nil {
+		return err
+	}
 	trustMode, err := resolveTeamTrustMode(t, opts.Trust, explicitTrust)
 	if err != nil {
 		return err

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -525,6 +526,7 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 			"--no-bootstrap",
 			"--trust", "trusted",
 			"--model", "cto=gpt-5",
+			"--effort", "cto=xhigh",
 			"--codex-args=--profile fast",
 			"--claude-args=--chrome",
 			"--force-duplicate",
@@ -569,6 +571,12 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 	}
 	if opts.ModelOverrides["cto"] != "gpt-5" {
 		t.Errorf("ModelOverrides[cto] = %q, want gpt-5", opts.ModelOverrides["cto"])
+	}
+	if opts.EffortOverrides["cto"] != "xhigh" {
+		t.Errorf("EffortOverrides[cto] = %q, want xhigh", opts.EffortOverrides["cto"])
+	}
+	if got := backend.teams[0].Members[0].CodexArgs; !reflect.DeepEqual(got, []string{"-c", "model_reasoning_effort=xhigh"}) {
+		t.Errorf("effective cto CodexArgs = %#v", got)
 	}
 	if got := opts.BinaryArgs["codex"]; len(got) == 0 || got[len(got)-1] != "fast" {
 		t.Errorf("codex BinaryArgs = %v, want trailing 'fast'", got)

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -1,0 +1,776 @@
+package wizard
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type bubbleStage int
+
+const (
+	stageProject bubbleStage = iota
+	stageProfile
+	stageNewProfile
+	stageSession
+	stageExistingOverride
+	stageExistingModel
+	stageExistingEffort
+	stageRoles
+	stageRoleBinary
+	stageRoleModel
+	stageRoleEffort
+	stageLead
+	stageLeadMode
+	stageTopology
+	stageGoal
+	stageSeed
+	stageConfirm
+)
+
+type BubbleResult struct {
+	Spec      Spec
+	Cancelled bool
+}
+
+type bubbleSnapshot struct {
+	spec          Spec
+	ctx           ProjectContext
+	stage         bubbleStage
+	cursor        int
+	existingIndex int
+	roleOrder     []string
+	roleIndex     int
+	inputValue    string
+}
+
+// BubbleModel is the full-screen adapter over the same Spec and project facts
+// used by RunNumbered. It owns navigation only; it cannot preview or launch.
+type BubbleModel struct {
+	opts NumberedOptions
+	spec Spec
+	ctx  ProjectContext
+
+	stage         bubbleStage
+	cursor        int
+	existingIndex int
+	roleOrder     []string
+	roleIndex     int
+	input         textinput.Model
+	history       []bubbleSnapshot
+
+	width     int
+	height    int
+	err       error
+	done      bool
+	cancelled bool
+}
+
+var (
+	wizardAccent = lipgloss.AdaptiveColor{Light: "#416B88", Dark: "#78A9C4"}
+	wizardSignal = lipgloss.AdaptiveColor{Light: "#8A641E", Dark: "#D6A550"}
+	wizardText   = lipgloss.AdaptiveColor{Light: "#20272D", Dark: "#D8DEE4"}
+	wizardMuted  = lipgloss.AdaptiveColor{Light: "#66717A", Dark: "#7D8790"}
+	wizardBorder = lipgloss.AdaptiveColor{Light: "#AAB5BC", Dark: "#4E5A63"}
+
+	styleWizardTitle = lipgloss.NewStyle().Bold(true).Foreground(wizardAccent)
+	styleWizardStep  = lipgloss.NewStyle().Bold(true).Foreground(wizardText)
+	styleWizardMuted = lipgloss.NewStyle().Foreground(wizardMuted)
+	styleWizardPick  = lipgloss.NewStyle().Bold(true).Foreground(wizardSignal)
+	styleWizardPanel = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(wizardBorder).Padding(1, 2)
+)
+
+func NewBubbleModel(opts NumberedOptions) (BubbleModel, error) {
+	s := opts.Defaults
+	ctx := ProjectContext{Project: s.Project}
+	var err error
+	if opts.InspectProject != nil {
+		ctx, err = opts.InspectProject(s.Project)
+		if err != nil {
+			return BubbleModel{}, err
+		}
+		if strings.TrimSpace(ctx.Project) != "" {
+			s.Project = ctx.Project
+		}
+	}
+	input := textinput.New()
+	input.CharLimit = 512
+	input.Width = 64
+	m := BubbleModel{
+		opts:          opts,
+		spec:          s,
+		ctx:           ctx,
+		stage:         stageProject,
+		existingIndex: -1,
+		input:         input,
+		width:         88,
+		height:        28,
+	}
+	m.configureStage()
+	return m, nil
+}
+
+func RunBubbleTea(in io.Reader, out io.Writer, opts NumberedOptions) (BubbleResult, error) {
+	m, err := NewBubbleModel(opts)
+	if err != nil {
+		return BubbleResult{}, err
+	}
+	program := tea.NewProgram(m, tea.WithInput(in), tea.WithOutput(out), tea.WithAltScreen())
+	final, err := program.Run()
+	if err != nil {
+		return BubbleResult{}, err
+	}
+	result, ok := final.(BubbleModel)
+	if !ok {
+		return BubbleResult{}, fmt.Errorf("wizard returned unexpected model %T", final)
+	}
+	return BubbleResult{Spec: result.spec, Cancelled: result.cancelled}, nil
+}
+
+func (m BubbleModel) Init() tea.Cmd {
+	if m.isTextStage() {
+		return textinput.Blink
+	}
+	return nil
+}
+
+func (m BubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		m.input.Width = maxInt(24, minInt(72, msg.Width-12))
+		return m, nil
+	case tea.KeyMsg:
+		key := msg.String()
+		if key == "ctrl+c" {
+			m.cancelled = true
+			return m, tea.Quit
+		}
+		if key == "esc" {
+			return m.back()
+		}
+		if m.isTextStage() {
+			if key == "enter" {
+				return m.commitText()
+			}
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(msg)
+			return m, cmd
+		}
+		if key == "q" {
+			m.cancelled = true
+			return m, tea.Quit
+		}
+		choices := m.choices()
+		switch key {
+		case "up", "k":
+			if len(choices) > 0 {
+				m.cursor = (m.cursor - 1 + len(choices)) % len(choices)
+			}
+		case "down", "j", "tab":
+			if len(choices) > 0 {
+				m.cursor = (m.cursor + 1) % len(choices)
+			}
+		case "enter", " ":
+			return m.commitChoice()
+		}
+	}
+	return m, nil
+}
+
+func (m BubbleModel) View() string {
+	if m.cancelled {
+		return "Wizard cancelled. Nothing changed.\n"
+	}
+	if m.done {
+		return "Preview choices collected.\n"
+	}
+	width := maxInt(48, minInt(96, m.width-4))
+	var b strings.Builder
+	b.WriteString(styleWizardTitle.Render("amq-squad · run start control deck"))
+	b.WriteString("\n")
+	b.WriteString(m.renderRail())
+	b.WriteString("\n\n")
+	b.WriteString(styleWizardPanel.Width(width - 6).Render(m.renderPanel()))
+	b.WriteString("\n\n")
+	b.WriteString(styleWizardMuted.Render(m.footer()))
+	if m.err != nil {
+		b.WriteString("\n" + styleWizardPick.Render("Check: "+m.err.Error()))
+	}
+	return b.String()
+}
+
+func (m BubbleModel) renderRail() string {
+	current := m.phaseIndex()
+	labels := []string{"Project", "Team", "Topology", "Goal", "Review"}
+	parts := make([]string, 0, len(labels))
+	for i, label := range labels {
+		marker := "○"
+		style := styleWizardMuted
+		if i < current {
+			marker = "●"
+		}
+		if i == current {
+			marker = "◆"
+			style = styleWizardPick
+		}
+		parts = append(parts, style.Render(fmt.Sprintf("%s %d %s", marker, i+1, label)))
+	}
+	return strings.Join(parts, styleWizardMuted.Render("  ─  "))
+}
+
+func (m BubbleModel) renderPanel() string {
+	var b strings.Builder
+	b.WriteString(styleWizardStep.Render(m.title()))
+	if note := m.note(); note != "" {
+		b.WriteString("\n" + styleWizardMuted.Render(note))
+	}
+	b.WriteString("\n\n")
+	if m.isTextStage() {
+		b.WriteString(m.input.View())
+		return b.String()
+	}
+	if m.stage == stageConfirm {
+		b.WriteString(m.summary())
+		b.WriteString("\n\n")
+	}
+	choices := m.choices()
+	for i, item := range choices {
+		cursor := "  "
+		line := item.label
+		if i == m.cursor {
+			cursor = "› "
+			line = styleWizardPick.Render(line)
+		}
+		b.WriteString(cursor + line + "\n")
+	}
+	if m.stage == stageTopology && len(choices) > 0 {
+		selected := choices[minInt(m.cursor, len(choices)-1)].value
+		b.WriteString("\n" + styleWizardMuted.Render(topologyConsequence(selected)) + "\n\n")
+		b.WriteString(TopologyPreview(selected))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m BubbleModel) title() string {
+	switch m.stage {
+	case stageProject:
+		return "Choose the project root"
+	case stageProfile:
+		return "Choose a team profile"
+	case stageNewProfile:
+		return "Name the new profile"
+	case stageSession:
+		return "Choose the workstream session"
+	case stageExistingOverride:
+		return "Launch-time override · " + m.currentMember().Role
+	case stageExistingModel:
+		return "Model override · " + m.currentMember().Role
+	case stageExistingEffort:
+		return "Effort override · " + m.currentMember().Role
+	case stageRoles:
+		return "Choose fresh-roster roles"
+	case stageRoleBinary:
+		return "Binary · " + m.currentRole()
+	case stageRoleModel:
+		return "Model · " + m.currentRole()
+	case stageRoleEffort:
+		return "Effort · " + m.currentRole()
+	case stageLead:
+		return "Choose the visible lead"
+	case stageLeadMode:
+		return "Choose the lead posture"
+	case stageTopology:
+		return "Choose where agents appear"
+	case stageGoal:
+		return "Optional goal text"
+	case stageSeed:
+		return "Optional brief source"
+	case stageConfirm:
+		return "Review the read-only preview"
+	default:
+		return "Run start wizard"
+	}
+}
+
+func (m BubbleModel) note() string {
+	switch m.stage {
+	case stageProject:
+		if m.ctx.OriginSlug != "" {
+			return "Detected origin " + m.ctx.OriginSlug + ". The nearest git root is the default."
+		}
+		return "The nearest git root is the default; no network access is used."
+	case stageExistingOverride:
+		member := m.currentMember()
+		return fmt.Sprintf("Profile values stay untouched: model=%s · effort=%s", defaultString(member.Model, "automatic"), defaultString(member.Effort, "automatic"))
+	case stageExistingModel:
+		return "Enter a model for this launch only, or leave blank to keep the profile value."
+	case stageExistingEffort:
+		return "This replaces only the native effort args in the in-memory launch plan."
+	case stageRoles:
+		return "Comma-separated role ids. Defaults are shown in the field."
+	case stageRoleModel:
+		return "Use automatic to let the selected binary choose."
+	case stageTopology:
+		return "The diagram is the topology that the canonical visibility flag selects."
+	case stageConfirm:
+		return "Enter runs the existing canonical preview. It cannot launch agents."
+	case stageSeed:
+		return "Accepted forms: file:path · issue:393 · gh:owner/repo#393"
+	}
+	return ""
+}
+
+func (m BubbleModel) footer() string {
+	if m.isTextStage() {
+		return "enter continue · esc back · ctrl+c cancel"
+	}
+	return "↑/↓ choose · enter continue · esc back · q cancel"
+}
+
+func (m BubbleModel) summary() string {
+	parts := []string{
+		"Project   " + m.spec.Project,
+		"Profile   " + defaultString(m.spec.Profile, "default"),
+		"Session   " + m.spec.Session,
+	}
+	if m.spec.Roles != "" {
+		parts = append(parts, "Roster    "+m.spec.Roles, "Lead      "+m.spec.Lead+" · "+m.spec.LeadMode)
+	} else {
+		parts = append(parts, "Roster    existing profile (authoritative)")
+	}
+	if m.spec.Model != "" {
+		parts = append(parts, "Models    "+m.spec.Model+" (launch only)")
+	}
+	if m.spec.Effort != "" {
+		parts = append(parts, "Effort    "+m.spec.Effort+" (launch only)")
+	}
+	parts = append(parts, "Topology  "+m.spec.Visibility, "", TopologyPreview(m.spec.Visibility))
+	return strings.Join(parts, "\n")
+}
+
+func (m BubbleModel) isTextStage() bool {
+	switch m.stage {
+	case stageProject, stageNewProfile, stageSession, stageExistingModel, stageRoles, stageRoleModel, stageLead, stageGoal, stageSeed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *BubbleModel) configureStage() {
+	m.err = nil
+	m.cursor = 0
+	m.input.Blur()
+	value := ""
+	placeholder := ""
+	switch m.stage {
+	case stageProject:
+		value = m.spec.Project
+	case stageNewProfile:
+		value = defaultString(m.ctx.NewProfileSuggestion, "squad-"+defaultString(m.ctx.SessionSuggestion, "project"))
+	case stageSession:
+		value = m.spec.Session
+		if value == "" && m.existingIndex >= 0 {
+			value = m.ctx.Profiles[m.existingIndex].PinnedSession
+		}
+		if value == "" {
+			value = m.ctx.SessionSuggestion
+		}
+	case stageExistingModel:
+		placeholder = "leave blank to keep " + defaultString(m.currentMember().Model, "automatic")
+	case stageRoles:
+		value = defaultString(m.spec.Roles, "cto,senior-dev,qa")
+	case stageRoleModel:
+		value = defaultString(parseAssignments(m.spec.Model)[m.currentRole()], "automatic")
+	case stageLead:
+		value = defaultString(m.spec.Lead, defaultLead(m.roleOrder))
+	case stageGoal:
+		value = m.spec.Goal
+		placeholder = "optional"
+	case stageSeed:
+		value = m.spec.SeedFrom
+		placeholder = "optional"
+	}
+	if m.isTextStage() {
+		m.input.SetValue(value)
+		m.input.Placeholder = placeholder
+		m.input.CursorEnd()
+		m.input.Focus()
+	}
+	m.cursor = m.defaultCursor()
+}
+
+func (m BubbleModel) choices() []choice {
+	switch m.stage {
+	case stageProfile:
+		choices := make([]choice, 0, len(m.ctx.Profiles)+2)
+		for _, profile := range m.ctx.Profiles {
+			pinned := defaultString(profile.PinnedSession, "un-pinned")
+			choices = append(choices, choice{value: profile.Name, label: fmt.Sprintf("%s · %d member(s) · session %s", profile.Name, profile.MemberCount, pinned)})
+		}
+		if len(m.ctx.Profiles) == 0 || findProfile(m.ctx.Profiles, "default") < 0 {
+			choices = append(choices, choice{value: "default", label: "default · create a fresh roster"})
+		}
+		choices = append(choices, choice{value: "__create__", label: "create a named profile"})
+		return choices
+	case stageExistingOverride:
+		return []choice{{value: "keep", label: "Keep profile model and effort"}, {value: "override", label: "Override this role for this launch only"}}
+	case stageExistingEffort:
+		return effortChoices(m.currentMember().Binary)
+	case stageRoleBinary:
+		return []choice{{value: "codex", label: "Codex"}, {value: "claude", label: "Claude"}}
+	case stageRoleEffort:
+		return effortChoices(parseAssignments(m.spec.Binary)[m.currentRole()])
+	case stageLeadMode:
+		return []choice{{value: "builder", label: "Builder · lead may implement and delegate"}, {value: "planner", label: "Planner · lead dispatches and reviews; workers mutate"}}
+	case stageTopology:
+		return []choice{{value: "sibling-tabs", label: "One window per agent"}, {value: "current", label: "Panes in this window"}, {value: "detached", label: "Detached squad"}}
+	case stageConfirm:
+		return []choice{{value: "preview", label: "Run the canonical read-only preview"}}
+	default:
+		return nil
+	}
+}
+
+func effortChoices(binary string) []choice {
+	choices := []choice{{value: "automatic", label: "Automatic"}, {value: "low", label: "Low"}, {value: "medium", label: "Medium"}, {value: "high", label: "High"}}
+	if strings.EqualFold(binary, "codex") {
+		choices = append(choices, choice{value: "minimal", label: "Minimal"}, choice{value: "xhigh", label: "Extra high"})
+	}
+	return choices
+}
+
+func (m BubbleModel) defaultCursor() int {
+	choices := m.choices()
+	want := ""
+	switch m.stage {
+	case stageProfile:
+		want = defaultString(m.spec.Profile, "default")
+	case stageExistingEffort:
+		want = defaultString(m.currentMember().Effort, effortAutomatic)
+	case stageRoleBinary:
+		want = parseAssignments(m.spec.Binary)[m.currentRole()]
+		if want == "" {
+			want = m.ctx.PreferredBinaries[m.currentRole()]
+		}
+	case stageRoleEffort:
+		want = defaultString(parseAssignments(m.spec.Effort)[m.currentRole()], effortAutomatic)
+	case stageLeadMode:
+		want = defaultString(m.spec.LeadMode, "builder")
+	case stageTopology:
+		want = defaultString(m.spec.Visibility, "sibling-tabs")
+	}
+	for i, item := range choices {
+		if item.value == want {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
+	value := strings.TrimSpace(m.input.Value())
+	m.pushHistory()
+	switch m.stage {
+	case stageProject:
+		if value == "" {
+			m.err = fmt.Errorf("project cannot be empty")
+			m.history = m.history[:len(m.history)-1]
+			return m, nil
+		}
+		ctx := ProjectContext{Project: value}
+		var err error
+		if m.opts.InspectProject != nil {
+			ctx, err = m.opts.InspectProject(value)
+			if err != nil {
+				m.err = err
+				m.history = m.history[:len(m.history)-1]
+				return m, nil
+			}
+		}
+		m.ctx = ctx
+		m.spec.Project = defaultString(ctx.Project, value)
+		m.transition(stageProfile)
+	case stageNewProfile:
+		if value == "" {
+			m.err = fmt.Errorf("profile cannot be empty")
+			m.history = m.history[:len(m.history)-1]
+			return m, nil
+		}
+		m.spec.Profile = value
+		m.existingIndex = -1
+		m.transition(stageSession)
+	case stageSession:
+		if value == "" {
+			m.err = fmt.Errorf("session cannot be empty")
+			m.history = m.history[:len(m.history)-1]
+			return m, nil
+		}
+		m.spec.Session = value
+		if m.existingIndex >= 0 {
+			m.spec.Roles, m.spec.Binary, m.spec.Model, m.spec.Effort, m.spec.Lead, m.spec.LeadMode = "", "", "", "", "", ""
+			m.roleIndex = 0
+			if len(m.ctx.Profiles[m.existingIndex].Members) == 0 {
+				m.transition(stageTopology)
+			} else {
+				m.transition(stageExistingOverride)
+			}
+		} else {
+			m.transition(stageRoles)
+		}
+	case stageExistingModel:
+		if value != "" {
+			m.spec.Model = setAssignment(m.spec.Model, m.currentMember().Role, value)
+		} else {
+			m.spec.Model = removeAssignment(m.spec.Model, m.currentMember().Role)
+		}
+		m.transition(stageExistingEffort)
+	case stageRoles:
+		m.roleOrder = splitAssignmentsList(value)
+		if len(m.roleOrder) == 0 {
+			m.err = fmt.Errorf("choose at least one role")
+			m.history = m.history[:len(m.history)-1]
+			return m, nil
+		}
+		m.spec.Roles = strings.Join(m.roleOrder, ",")
+		m.spec.Binary = renderAssignments(m.roleOrder, parseAssignments(m.spec.Binary))
+		m.spec.Model = renderAssignments(m.roleOrder, parseAssignments(m.spec.Model))
+		m.spec.Effort = renderAssignments(m.roleOrder, parseAssignments(m.spec.Effort))
+		if !containsString(m.roleOrder, m.spec.Lead) {
+			m.spec.Lead = ""
+		}
+		m.roleIndex = 0
+		m.transition(stageRoleBinary)
+	case stageRoleModel:
+		if value == "" || strings.EqualFold(value, "automatic") {
+			m.spec.Model = removeAssignment(m.spec.Model, m.currentRole())
+		} else {
+			m.spec.Model = setAssignment(m.spec.Model, m.currentRole(), value)
+		}
+		m.transition(stageRoleEffort)
+	case stageLead:
+		if value == "" {
+			m.err = fmt.Errorf("lead cannot be empty")
+			m.history = m.history[:len(m.history)-1]
+			return m, nil
+		}
+		m.spec.Lead = value
+		m.transition(stageLeadMode)
+	case stageGoal:
+		m.spec.Goal = value
+		m.transition(stageSeed)
+	case stageSeed:
+		m.spec.SeedFrom = value
+		m.transition(stageConfirm)
+	}
+	return m, textinput.Blink
+}
+
+func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
+	choices := m.choices()
+	if len(choices) == 0 {
+		return m, nil
+	}
+	selected := choices[minInt(m.cursor, len(choices)-1)].value
+	m.pushHistory()
+	switch m.stage {
+	case stageProfile:
+		if selected == "__create__" {
+			m.transition(stageNewProfile)
+			break
+		}
+		m.spec.Profile = selected
+		m.existingIndex = findProfile(m.ctx.Profiles, selected)
+		m.transition(stageSession)
+	case stageExistingOverride:
+		if selected == "override" {
+			m.transition(stageExistingModel)
+		} else {
+			m.nextExistingMember()
+		}
+	case stageExistingEffort:
+		m.spec.Effort = setAssignment(m.spec.Effort, m.currentMember().Role, selected)
+		m.nextExistingMember()
+	case stageRoleBinary:
+		m.spec.Binary = setAssignment(m.spec.Binary, m.currentRole(), selected)
+		m.transition(stageRoleModel)
+	case stageRoleEffort:
+		if selected == effortAutomatic {
+			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentRole())
+		} else {
+			m.spec.Effort = setAssignment(m.spec.Effort, m.currentRole(), selected)
+		}
+		m.roleIndex++
+		if m.roleIndex < len(m.roleOrder) {
+			m.transition(stageRoleBinary)
+		} else {
+			m.transition(stageLead)
+		}
+	case stageLeadMode:
+		m.spec.LeadMode = selected
+		m.transition(stageTopology)
+	case stageTopology:
+		m.spec.Visibility = selected
+		m.transition(stageGoal)
+	case stageConfirm:
+		m.done = true
+		return m, tea.Quit
+	}
+	return m, textinput.Blink
+}
+
+func (m *BubbleModel) nextExistingMember() {
+	m.roleIndex++
+	if m.roleIndex < len(m.ctx.Profiles[m.existingIndex].Members) {
+		m.transition(stageExistingOverride)
+	} else {
+		m.transition(stageTopology)
+	}
+}
+
+func (m *BubbleModel) transition(stage bubbleStage) {
+	m.stage = stage
+	m.configureStage()
+}
+
+func (m *BubbleModel) pushHistory() {
+	m.history = append(m.history, bubbleSnapshot{
+		spec:          m.spec,
+		ctx:           m.ctx,
+		stage:         m.stage,
+		cursor:        m.cursor,
+		existingIndex: m.existingIndex,
+		roleOrder:     append([]string(nil), m.roleOrder...),
+		roleIndex:     m.roleIndex,
+		inputValue:    m.input.Value(),
+	})
+}
+
+func (m BubbleModel) back() (tea.Model, tea.Cmd) {
+	if len(m.history) == 0 {
+		m.cancelled = true
+		return m, tea.Quit
+	}
+	last := m.history[len(m.history)-1]
+	m.history = m.history[:len(m.history)-1]
+	m.spec = last.spec
+	m.ctx = last.ctx
+	m.stage = last.stage
+	m.cursor = last.cursor
+	m.existingIndex = last.existingIndex
+	m.roleOrder = append([]string(nil), last.roleOrder...)
+	m.roleIndex = last.roleIndex
+	m.configureStage()
+	m.cursor = last.cursor
+	if m.isTextStage() {
+		m.input.SetValue(last.inputValue)
+		m.input.CursorEnd()
+	}
+	return m, textinput.Blink
+}
+
+func (m BubbleModel) phaseIndex() int {
+	switch m.stage {
+	case stageProject:
+		return 0
+	case stageProfile, stageNewProfile, stageSession, stageExistingOverride, stageExistingModel, stageExistingEffort, stageRoles, stageRoleBinary, stageRoleModel, stageRoleEffort, stageLead, stageLeadMode:
+		return 1
+	case stageTopology:
+		return 2
+	case stageGoal, stageSeed:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (m BubbleModel) currentRole() string {
+	if m.roleIndex < 0 || m.roleIndex >= len(m.roleOrder) {
+		return "role"
+	}
+	return m.roleOrder[m.roleIndex]
+}
+
+func (m BubbleModel) currentMember() MemberSummary {
+	if m.existingIndex < 0 || m.existingIndex >= len(m.ctx.Profiles) {
+		return MemberSummary{Role: "role"}
+	}
+	members := m.ctx.Profiles[m.existingIndex].Members
+	if m.roleIndex < 0 || m.roleIndex >= len(members) {
+		return MemberSummary{Role: "role"}
+	}
+	return members[m.roleIndex]
+}
+
+func findProfile(profiles []ProfileSummary, name string) int {
+	for i := range profiles {
+		if profiles[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func defaultLead(roles []string) string {
+	for _, role := range roles {
+		if role == "cto" {
+			return "cto"
+		}
+	}
+	if len(roles) > 0 {
+		return roles[0]
+	}
+	return "cto"
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func setAssignment(raw, key, value string) string {
+	values := parseAssignments(raw)
+	values[key] = value
+	order := splitAssignmentsList(rawAssignmentKeys(raw) + "," + key)
+	return renderAssignments(order, values)
+}
+
+func removeAssignment(raw, key string) string {
+	values := parseAssignments(raw)
+	delete(values, key)
+	return renderAssignments(splitAssignmentsList(rawAssignmentKeys(raw)), values)
+}
+
+func rawAssignmentKeys(raw string) string {
+	keys := make([]string, 0)
+	for _, item := range strings.Split(raw, ",") {
+		key, _, ok := strings.Cut(item, "=")
+		if ok && strings.TrimSpace(key) != "" {
+			keys = append(keys, strings.TrimSpace(key))
+		}
+	}
+	return strings.Join(keys, ",")
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -1,0 +1,196 @@
+package wizard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestBubbleModelStartsWithProjectDefaultsAndPhaseRail(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{
+		Project: "/repo", Profile: "default", Session: "issue-393", Visibility: "sibling-tabs",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := m.View()
+	for _, want := range []string{
+		"run start control deck", "◆ 1 Project", "○ 2 Team", "Choose the project root", "/repo",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("initial view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestBubbleModelExistingProfileOverridesAreLaunchOnly(t *testing.T) {
+	profile := ProfileSummary{
+		Name: "review", MemberCount: 1, PinnedSession: "review-work", Lead: "cto", LeadMode: "planner",
+		Members: []MemberSummary{{Role: "cto", Binary: "codex", Model: "stored-model", Effort: "medium"}},
+	}
+	m, err := NewBubbleModel(NumberedOptions{
+		Defaults: Spec{Project: "/repo", Profile: "review", Visibility: "sibling-tabs"},
+		InspectProject: func(string) (ProjectContext, error) {
+			return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // project
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // profile
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // pinned session
+	if m.stage != stageExistingOverride {
+		t.Fatalf("stage = %v, want existing override", m.stage)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageExistingModel {
+		t.Fatalf("stage = %v, want existing model", m.stage)
+	}
+	m.input.SetValue("launch-model")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m.cursor = 3 // high
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageTopology {
+		t.Fatalf("stage = %v, want topology", m.stage)
+	}
+	if m.spec.Model != "cto=launch-model" || m.spec.Effort != "cto=high" {
+		t.Fatalf("launch overrides = model %q effort %q", m.spec.Model, m.spec.Effort)
+	}
+	if profile.Members[0].Model != "stored-model" || profile.Members[0].Effort != "medium" {
+		t.Fatalf("source profile mutated: %+v", profile.Members[0])
+	}
+}
+
+func TestBubbleModelBackRestoresChoiceCursor(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Visibility: "sibling-tabs"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.stage = stageTopology
+	m.configureStage()
+	m.cursor = 2
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageGoal {
+		t.Fatalf("stage = %v, want goal", m.stage)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.stage != stageTopology || m.cursor != 2 || m.spec.Visibility != "sibling-tabs" {
+		t.Fatalf("back state = stage %v cursor %d visibility %q", m.stage, m.cursor, m.spec.Visibility)
+	}
+}
+
+func TestBubbleModelBackRestoresProjectContext(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{
+		Defaults: Spec{Project: "/one"},
+		InspectProject: func(project string) (ProjectContext, error) {
+			return ProjectContext{Project: project, OriginSlug: strings.TrimPrefix(project, "/")}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.input.SetValue("/two")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.ctx.OriginSlug != "two" {
+		t.Fatalf("new context = %+v", m.ctx)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.stage != stageProject || m.spec.Project != "/one" || m.ctx.OriginSlug != "one" || m.input.Value() != "/two" {
+		t.Fatalf("restored project state = stage %v spec %+v ctx %+v input %q", m.stage, m.spec, m.ctx, m.input.Value())
+	}
+}
+
+func TestBubbleModelBlankExistingModelRemovesEarlierLaunchOverride(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Model: "cto=launch-model"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.ctx.Profiles = []ProfileSummary{{Name: "review", Members: []MemberSummary{{Role: "cto", Binary: "codex"}}}}
+	m.existingIndex = 0
+	m.stage = stageExistingModel
+	m.configureStage()
+	m.input.SetValue("")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.spec.Model != "" {
+		t.Fatalf("cleared model override = %q", m.spec.Model)
+	}
+}
+
+func TestBubbleModelEditingRolesPrunesAssignmentsAndInvalidLead(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{
+		Project: "/repo", Roles: "cto,qa", Binary: "cto=codex,qa=claude", Model: "cto=gpt,qa=opus", Effort: "cto=high,qa=medium", Lead: "qa",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.stage = stageRoles
+	m.configureStage()
+	m.input.SetValue("cto")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.spec.Binary != "cto=codex" || m.spec.Model != "cto=gpt" || m.spec.Effort != "cto=high" || m.spec.Lead != "" {
+		t.Fatalf("pruned spec = %+v", m.spec)
+	}
+}
+
+func TestBubbleModelCancelDoesNotProducePreview(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.stage = stageProfile
+	m.configureStage()
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if !m.cancelled || m.done {
+		t.Fatalf("cancel state = cancelled %t done %t", m.cancelled, m.done)
+	}
+}
+
+func TestBubbleModelConfirmationShowsCanonicalReadOnlyBoundary(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{
+		Project: "/repo", Profile: "review", Session: "issue-393", Visibility: "detached", Effort: "cto=high",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.stage = stageConfirm
+	m.configureStage()
+	view := m.View()
+	for _, want := range []string{
+		"Review the read-only preview", "existing profile (authoritative)", "cto=high (launch only)",
+		"detached squad", "Run the canonical read-only preview",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("confirmation missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestTopologyPreviewGolden(t *testing.T) {
+	var blocks []string
+	for _, visibility := range []string{"sibling-tabs", "current", "detached"} {
+		blocks = append(blocks, "## "+visibility+"\n"+TopologyPreview(visibility))
+	}
+	got := strings.Join(blocks, "\n\n") + "\n"
+	want, err := os.ReadFile(filepath.Join("testdata", "topology.golden"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != string(want) {
+		t.Fatalf("topology rendering changed\n--- got ---\n%s--- want ---\n%s", got, string(want))
+	}
+}
+
+func updateBubble(t *testing.T, m BubbleModel, msg tea.Msg) BubbleModel {
+	t.Helper()
+	next, _ := m.Update(msg)
+	got, ok := next.(BubbleModel)
+	if !ok {
+		t.Fatalf("Update returned %T", next)
+	}
+	return got
+}

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -104,9 +104,46 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		fmt.Fprintln(out)
 		s.Roles = ""
 		s.Binary = ""
+		s.Model = ""
 		s.Effort = ""
 		s.Lead = ""
 		s.LeadMode = ""
+		if existingProfile != nil {
+			modelOverrides := map[string]string{}
+			effortOverrides := map[string]string{}
+			memberOrder := make([]string, 0, len(existingProfile.Members))
+			for _, member := range existingProfile.Members {
+				memberOrder = append(memberOrder, member.Role)
+				override, choiceErr := promptChoice(r, out, "Override "+member.Role+" at launch", []choice{
+					{value: "keep", label: "keep profile model/effort"},
+					{value: "override", label: "override this role's model/effort for this launch only"},
+				}, "keep")
+				if choiceErr != nil {
+					return Spec{}, choiceErr
+				}
+				if override != "override" {
+					continue
+				}
+				model, promptErr := promptOptionalOverride(r, out, member.Role+" model override", defaultString(member.Model, "automatic"))
+				if promptErr != nil {
+					return Spec{}, promptErr
+				}
+				if model != "" {
+					modelOverrides[member.Role] = model
+				}
+				effortChoices := []choice{{value: "automatic", label: "automatic: ignore stored effort for this launch"}, {value: "low", label: "low"}, {value: "medium", label: "medium"}, {value: "high", label: "high"}}
+				if member.Binary == "codex" {
+					effortChoices = append(effortChoices, choice{value: "minimal", label: "minimal"}, choice{value: "xhigh", label: "xhigh"})
+				}
+				effort, promptErr := promptChoice(r, out, member.Role+" effort override", effortChoices, defaultString(member.Effort, effortAutomatic))
+				if promptErr != nil {
+					return Spec{}, promptErr
+				}
+				effortOverrides[member.Role] = effort
+			}
+			s.Model = renderAssignments(memberOrder, modelOverrides)
+			s.Effort = renderAssignments(memberOrder, effortOverrides)
+		}
 	} else {
 		if s.Roles, err = promptText(r, out, "Roles (comma-separated)", defaultString(s.Roles, "cto,senior-dev,qa")); err != nil {
 			return Spec{}, err
@@ -275,6 +312,15 @@ func promptText(r *bufio.Reader, out io.Writer, label, current string) (string, 
 		return current, nil
 	}
 	return line, nil
+}
+
+func promptOptionalOverride(r *bufio.Reader, out io.Writer, label, current string) (string, error) {
+	fmt.Fprintf(out, "%s [current %s; Enter keeps it]: ", label, current)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", strings.ToLower(label), err)
+	}
+	return strings.TrimSpace(line), nil
 }
 
 func promptChoice(r *bufio.Reader, out io.Writer, label string, choices []choice, current string) (string, error) {

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -113,6 +113,7 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 		"",  // project
 		"2", // select review profile
 		"",  // pinned session
+		"",  // keep cto profile values
 		"",  // topology
 		"",  // goal
 		"",  // seed
@@ -142,5 +143,41 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}
+	}
+}
+
+func TestRunNumberedExistingProfileCollectsLaunchOnlyOverrides(t *testing.T) {
+	input := strings.Join([]string{
+		"",             // project
+		"",             // existing profile
+		"",             // pinned session
+		"2",            // override cto
+		"launch-model", // launch-only model
+		"4",            // high effort
+		"",             // topology
+		"",             // goal
+		"",             // seed
+	}, "\n") + "\n"
+	profile := ProfileSummary{
+		Name: "review", MemberCount: 1, PinnedSession: "review-work",
+		Members: []MemberSummary{{Role: "cto", Binary: "codex", Model: "stored-model", Effort: "low"}},
+	}
+	got, err := RunNumbered(strings.NewReader(input), &bytes.Buffer{}, NumberedOptions{
+		Defaults: Spec{Project: "/repo", Profile: "review", Visibility: "sibling-tabs"},
+		InspectProject: func(string) (ProjectContext, error) {
+			return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "cto=launch-model" || got.Effort != "cto=high" {
+		t.Fatalf("launch overrides = model %q effort %q", got.Model, got.Effort)
+	}
+	if got.Roles != "" || got.Binary != "" || got.Lead != "" || got.LeadMode != "" {
+		t.Fatalf("existing roster mutation leaked into spec: %+v", got)
+	}
+	if profile.Members[0].Model != "stored-model" || profile.Members[0].Effort != "low" {
+		t.Fatalf("profile summary mutated: %+v", profile.Members[0])
 	}
 }

--- a/internal/wizard/previews.go
+++ b/internal/wizard/previews.go
@@ -1,0 +1,32 @@
+package wizard
+
+import "strings"
+
+// TopologyPreview renders the current run-start topology using plain box
+// drawing characters. It is intentionally semantic rather than decorative:
+// the same visibility value that Spec.Args emits selects the diagram.
+func TopologyPreview(visibility string) string {
+	switch strings.TrimSpace(visibility) {
+	case "current":
+		return "┌──── lead ────┬── worker 1 ──┐\n" +
+			"├── worker 2 ──┼── worker 3 ──┤\n" +
+			"└──────────────┴──────────────┘"
+	case "detached":
+		return "operator terminal\n" +
+			"       │\n" +
+			"       └── [ detached squad · attach to view ]"
+	default:
+		return "[ lead ]  [ worker 1 ]  [ worker 2 ]  [ worker 3 ]"
+	}
+}
+
+func topologyConsequence(visibility string) string {
+	switch strings.TrimSpace(visibility) {
+	case "current":
+		return "Split the current tmux window into visible agent panes."
+	case "detached":
+		return "Run agents hidden in a separate tmux session until you attach."
+	default:
+		return "Open one visible tmux window per agent."
+	}
+}

--- a/internal/wizard/testdata/topology.golden
+++ b/internal/wizard/testdata/topology.golden
@@ -1,0 +1,12 @@
+## sibling-tabs
+[ lead ]  [ worker 1 ]  [ worker 2 ]  [ worker 3 ]
+
+## current
+┌──── lead ────┬── worker 1 ──┐
+├── worker 2 ──┼── worker 3 ──┤
+└──────────────┴──────────────┘
+
+## detached
+operator terminal
+       │
+       └── [ detached squad · attach to view ]


### PR DESCRIPTION
## Summary

- add the Bubble Tea interactive wizard with arrow-key navigation, back/cancel behavior, topology previews, and a final confirmation step
- retain the numbered wizard as the accessible and `TERM=dumb` fallback
- prompt existing profiles for launch-only per-role model and effort overrides without mutating stored profiles
- add golden/state-transition coverage for the TUI plus fallback and override tests

## Validation

- `go test ./... -count=1`
- `make ci`

Part of #393