### PR TITLE
#393 slice 6: live launch + Global/NOC scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v2.19.0 (development)
+
+- In an interactive TTY, zero-argument `amq-squad run start` now opens the
+  guided wizard instead of returning the historical missing-flag error.
+  Non-TTY and CI invocations remain noninteractive and retain that error.
+- The wizard executes the canonical preview first and then asks
+  `Launch now? [y/N]`; No is the default, and explicit Yes reruns the identical
+  argv with only `--go` appended. It also offers a Global/NOC scope backed by
+  canonical `amq-squad global start`.

--- a/README.html
+++ b/README.html
@@ -388,33 +388,34 @@ together.</p>
 <p>The shortest working path for a visible project lead and workers:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
 <span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Guided, read-only preview. In an interactive terminal, zero-argument</span></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co"># `amq-squad run start` opens the same wizard.</span></span>
-<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> wizard</span>
-<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="co"># Preview, then create, an orchestrated run. --go is the mutation switch.</span></span>
-<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="dt">\</span></span>
-<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> . <span class="dt">\</span></span>
-<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
-<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--lead</span> cto <span class="dt">\</span></span>
-<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="dt">\</span></span>
-<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>  <span class="at">--go</span></span>
-<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a><span class="co"># Watch the run.</span></span>
-<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
-<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
-<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a><span class="co"># Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.</span></span>
-<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="dt">\</span></span>
-<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  <span class="at">--role</span> qa <span class="dt">\</span></span>
-<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Run smoke tests&quot;</span> <span class="dt">\</span></span>
-<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body</span> <span class="st">&quot;Validate the current PR and report findings.&quot;</span></span>
-<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
-<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
-<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Guided preview with an explicit, default-No live confirmation. In an</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co"># interactive terminal, zero-argument `amq-squad run start` opens the same</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="co"># wizard.</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> wizard</span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="co"># Preview, then create, an orchestrated run. --go is the mutation switch.</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="dt">\</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> . <span class="dt">\</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a>  <span class="at">--lead</span> cto <span class="dt">\</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>  <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="dt">\</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>  <span class="at">--go</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="co"># Watch the run.</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="co"># Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="dt">\</span></span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>  <span class="at">--role</span> qa <span class="dt">\</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Run smoke tests&quot;</span> <span class="dt">\</span></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body</span> <span class="st">&quot;Validate the current PR and report findings.&quot;</span></span>
+<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
+<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
+<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
 <p>Use <code>--external-lead</code> when the current pane is already the
 project lead and only the remaining workers should be spawned:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
@@ -442,16 +443,25 @@ delivery, and the final CLI output, so renaming a pane or window is
 safe. A finalization failure never tears down agents and remains visible
 as a status warning.</p>
 <p>In an interactive terminal, <code>amq-squad run start</code> with no
-arguments now opens the guided preview wizard instead of returning the
-old missing-flag usage error. <code>amq-squad wizard</code> and
-<code>run start --interactive</code> are equivalent. The wizard is
-preview-only in the first v2.19.0 slice, is disabled in CI, and never
-triggers when stdin or stderr is not a TTY. Partial flag commands
-without <code>--interactive</code> keep the canonical fail-fast parser
-behavior.</p>
+arguments now opens the guided wizard instead of returning the old
+missing-flag usage error. <code>amq-squad wizard</code> and
+<code>run start --interactive</code> are equivalent. The wizard first
+runs the exact canonical preview, then asks
+<code>Launch now? [y/N]</code>; only an explicit
+<code>y</code>/<code>yes</code> reruns the identical argv with
+<code>--go</code> added. The second call rechecks current state, so a
+collision introduced after preview is still refused. The wizard also
+offers a Global/NOC branch backed by canonical
+<code>amq-squad global start</code>. It is disabled in CI and never
+triggers when stdin or stderr is not a TTY; non-TTY zero-argument calls
+retain the usage error. Partial flag commands without
+<code>--interactive</code> keep fail-fast parser behavior.</p>
+<p>Copy/paste equivalents remain canonical:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">--project</span> . <span class="at">--profile</span> default <span class="at">--session</span> issue-96</span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> global start <span class="at">--root</span> ~/Code <span class="at">--agent</span> claude <span class="at">--name</span> global-orch</span></code></pre></div>
 <p>Manual setup still works when the team shape is known:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
 <h2 id="execution-modes">Execution modes</h2>
 <p>amq-squad separates the control root, target project root, visible
 lead, and implementation authority. The mode should be explicit in
@@ -702,46 +712,47 @@ The capability contract is implemented in
 <code>internal/runtimecontrol</code>.</p>
 <h2 id="command-map">Command map</h2>
 <p>Common setup and run commands:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile review <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--roles</span> cto,qa <span class="at">--lead</span> cto <span class="at">--goal</span> <span class="st">&quot;...&quot;</span> <span class="at">--go</span></span>
-<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--external-lead</span> <span class="at">--lead</span> cto <span class="at">--roles</span> cto,qa <span class="at">--go</span></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile review <span class="at">--roles</span> cto,qa <span class="at">--sync</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--roles</span> cto,qa <span class="at">--lead</span> cto <span class="at">--goal</span> <span class="st">&quot;...&quot;</span> <span class="at">--go</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> run start <span class="at">-p</span> . <span class="at">-s</span> issue-96 <span class="at">--external-lead</span> <span class="at">--lead</span> cto <span class="at">--roles</span> cto,qa <span class="at">--go</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new session issue-96 <span class="at">--seed-from</span> issue:96</span></code></pre></div>
 <p>Lifecycle:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> fork <span class="at">--from</span> issue-96 <span class="at">--as</span> issue-96-review</span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> archive issue-96</span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> rm issue-96</span></code></pre></div>
-<p>Coordination:</p>
 <div class="sourceCode" id="cb10"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> task add <span class="at">--session</span> issue-96 <span class="at">--title</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--assign</span> fullstack</span>
-<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack <span class="at">--task</span> t1 <span class="at">--subject</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span>
-<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> activity set <span class="at">--session</span> issue-96 <span class="at">--me</span> fullstack <span class="at">--task</span> t1 <span class="at">--phase</span> testing</span>
-<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> threads <span class="at">--session</span> issue-96</span>
-<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> thread <span class="at">--session</span> issue-96 <span class="at">--id</span> p2p/cto__fullstack <span class="at">--include-body</span><span class="op">=</span>false</span></code></pre></div>
-<p>Safety preflights:</p>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> console <span class="at">--session</span> issue-96</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> fork <span class="at">--from</span> issue-96 <span class="at">--as</span> issue-96-review</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> archive issue-96</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> rm issue-96</span></code></pre></div>
+<p>Coordination:</p>
 <div class="sourceCode" id="cb11"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.18.0 release&quot;</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify merge <span class="at">--evidence</span> merge-evidence.json</span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify release <span class="at">--evidence</span> release-evidence.json</span></code></pre></div>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> task add <span class="at">--session</span> issue-96 <span class="at">--title</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--assign</span> fullstack</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack <span class="at">--task</span> t1 <span class="at">--subject</span> <span class="st">&quot;Implement fix&quot;</span> <span class="at">--body</span> <span class="st">&quot;...&quot;</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> activity set <span class="at">--session</span> issue-96 <span class="at">--me</span> fullstack <span class="at">--task</span> t1 <span class="at">--phase</span> testing</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> threads <span class="at">--session</span> issue-96</span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> thread <span class="at">--session</span> issue-96 <span class="at">--id</span> p2p/cto__fullstack <span class="at">--include-body</span><span class="op">=</span>false</span></code></pre></div>
+<p>Safety preflights:</p>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.18.0 release&quot;</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify merge <span class="at">--evidence</span> merge-evidence.json</span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify release <span class="at">--evidence</span> release-evidence.json</span></code></pre></div>
 <p>The action, merge, and final-release-commit contracts are documented
 together in <a
 href="docs/verification-gate-adr.md">docs/verification-gate-adr.md</a>.</p>
 <p>Diagnostics:</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor</span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
-<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
-<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96</span>
-<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span></code></pre></div>
-<p>Runtime control:</p>
 <div class="sourceCode" id="cb13"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto</span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span></span></code></pre></div>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> doctor <span class="at">--project</span> ~/Code/other-app <span class="at">--profile</span> release</span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq env <span class="at">--session</span> issue-96</span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq ops <span class="at">--session</span> issue-96</span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> amq route <span class="at">--session</span> issue-96 <span class="at">--me</span> cto <span class="at">--to</span> fullstack</span></code></pre></div>
+<p>Runtime control:</p>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body</span> <span class="st">&quot;run the smoke suite&quot;</span></span></code></pre></div>
 <p><code>focus</code> and <code>send</code> are runtime capabilities.
 They may be unavailable on native terminal tiers even while durable AMQ
 <code>dispatch</code> remains available.</p>
@@ -829,22 +840,22 @@ composition. Autonomous composition never grants merge, release,
 destructive, or external-send authority.</p>
 <h2 id="customize">Customize</h2>
 <p>Profiles and roles:</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,researcher <span class="at">--binary</span> researcher=codex <span class="at">--sync</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto <span class="at">--sync</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead set cto <span class="at">--lead-mode</span> planner</span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead clear</span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,researcher <span class="at">--binary</span> researcher=codex <span class="at">--sync</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto <span class="at">--sync</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead set cto <span class="at">--lead-mode</span> planner</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team lead clear</span></code></pre></div>
 <p>Custom role files can be Markdown with YAML frontmatter, plain
 Markdown with a <code># Role:</code> heading, or metadata-only
 YAML/JSON. They are staged under
 <code>.amq-squad/roles/&lt;id&gt;.md</code>; launch seeds each agent's
 role file and does not clobber later edits.</p>
 <p>Launch customization:</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
 <p><code>--launcher-args</code> are placed before the normal child
 arguments that carry bootstrap and binary defaults. A wrapper must
 forward its trailing arguments to the real agent, for example by ending
@@ -861,9 +872,9 @@ sandboxed mode does not.</p>
 <h2 id="cross-project-teams">Cross-project teams</h2>
 <p>Members may work from different repositories while one team-home owns
 the roster. Set a per-member cwd during team creation:</p>
-<div class="sourceCode" id="cb16"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
 <p><code>up --dry-run</code> emits the corresponding
 <code>cd &lt;member-cwd&gt;</code> launch commands.
 <code>team sync --apply --allow-outside</code> writes the managed
@@ -873,14 +884,14 @@ profile cannot write into unrelated directories silently.</p>
 <p>Cross-project AMQ replies also require each project to declare its
 peers in <code>.amqrc</code>; <code>team sync</code> does not edit this
 file:</p>
-<div class="sourceCode" id="cb17"><pre
-class="sourceCode json"><code class="sourceCode json"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
-<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb17-5"><a href="#cb17-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
-<span id="cb17-6"><a href="#cb17-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb17-7"><a href="#cb17-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
+<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
+<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
+<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Configure the reciprocal peer entry when both projects need to
 initiate and reply to messages. Use AMQ <code>--project</code> routing
 for another project and <code>--session</code> for another workstream in
@@ -960,10 +971,10 @@ href="docs/terminal-app-tier-c-smoke.md">docs/terminal-app-tier-c-smoke.md</a></
 <li><code>3</code> partial success</li>
 </ul>
 <p>Shell completions are available from the CLI:</p>
-<div class="sourceCode" id="cb18"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ The shortest working path for a visible project lead and workers:
 ```sh
 cd ~/Code/my-project
 
-# Guided, read-only preview. In an interactive terminal, zero-argument
-# `amq-squad run start` opens the same wizard.
+# Guided preview with an explicit, default-No live confirmation. In an
+# interactive terminal, zero-argument `amq-squad run start` opens the same
+# wizard.
 amq-squad wizard
 
 # Preview, then create, an orchestrated run. --go is the mutation switch.
@@ -159,11 +160,22 @@ finalization failure never tears down agents and remains visible as a status
 warning.
 
 In an interactive terminal, `amq-squad run start` with no arguments now opens
-the guided preview wizard instead of returning the old missing-flag usage error.
-`amq-squad wizard` and `run start --interactive` are equivalent. The wizard is
-preview-only in the first v2.19.0 slice, is disabled in CI, and never triggers
-when stdin or stderr is not a TTY. Partial flag commands without
-`--interactive` keep the canonical fail-fast parser behavior.
+the guided wizard instead of returning the old missing-flag usage error.
+`amq-squad wizard` and `run start --interactive` are equivalent. The wizard
+first runs the exact canonical preview, then asks `Launch now? [y/N]`; only an
+explicit `y`/`yes` reruns the identical argv with `--go` added. The second call
+rechecks current state, so a collision introduced after preview is still
+refused. The wizard also offers a Global/NOC branch backed by canonical
+`amq-squad global start`. It is disabled in CI and never triggers when stdin or
+stderr is not a TTY; non-TTY zero-argument calls retain the usage error. Partial
+flag commands without `--interactive` keep fail-fast parser behavior.
+
+Copy/paste equivalents remain canonical:
+
+```sh
+amq-squad run start --project . --profile default --session issue-96
+amq-squad global start --root ~/Code --agent claude --name global-orch
+```
 
 Manual setup still works when the team shape is known:
 

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -50,6 +50,21 @@ Wraps `new team` (if `--roles`) → `up`. **Preview by default** (prints the pla
 and runs read-only `--dry-run` validation whose failures surface); `--go`
 creates for real.
 
+The interactive wizard can create either this project-run preview or a
+Global/NOC preview. In a TTY, run `amq-squad wizard` (or zero-argument
+`amq-squad run start`), choose the scope, and review the two canonical commands
+it prints. The preview always runs first. `Launch now? [y/N]` defaults to No;
+only explicit `y`/`yes` reruns the identical argv with one trailing `--go`.
+
+Global/NOC scope collects a neutral root, one `claude` or `codex` agent, model,
+validated effort, extra native arguments excluding effort, and a window name.
+Effort is normalized into the selected binary's existing native argument form
+(`--effort` for Claude or `model_reasoning_effort` for Codex); inactive-binary
+arguments and project roster flags are never serialized. The scope selector and
+Global/NOC questions use the accessible line prompt on the same TTY; project
+answers use Bubble Tea when enabled. Both return to the same default-No consent
+boundary after canonical preview.
+
 ```sh
 # preview (no mutation)
 amq-squad run start -p ~/Code/app -s issue-96 -P release --roles "cto,fullstack,qa"

--- a/docs/v2.19.0-release-notes.md
+++ b/docs/v2.19.0-release-notes.md
@@ -107,3 +107,28 @@ It is not a release announcement.
   warning.
 - Completion metadata, canonical help, dry-run output, and the Bubble Tea and
   numbered wizard flows expose the same values and constraints.
+
+## Preview-to-live wizard and Global/NOC scope, Slice 6
+
+- In a TTY, zero-argument `run start` opens the wizard instead of returning the
+  historical missing-flag error. Non-TTY and CI calls remain noninteractive and
+  retain the canonical error behavior.
+- After collecting answers, the wizard prints and executes the exact canonical
+  preview command. Only after that preview succeeds does it ask
+  `Launch now? [y/N]`. The default, EOF, cancellation, and any answer other than
+  explicit `y`/`yes` do not launch.
+- An affirmative answer invokes the same existing routine with identical argv
+  plus only `--go`. The live call therefore repeats all current-state checks;
+  preview failures never prompt, and a newly introduced collision is refused.
+- Bubble Tea exits its alternate screen before the confirmation is read from
+  the same `/dev/tty`; the numbered/accessibility adapter uses its injected
+  reader and writer for both phases.
+- The first wizard choice selects Project run (default) or Global/NOC. Global
+  scope collects a neutral root, one agent binary, model, validated effort,
+  extra native arguments excluding effort, and
+  window name, displays the poll/no-wake contract, and delegates preview/live
+  calls to canonical `global start`. Project roster/layout flags never enter
+  global argv, and only the selected binary's native-argument flag is emitted.
+- Completion now includes `--wizard-ui`, `--numbered`, and `--accessible`.
+  Canonical copy/paste forms are `amq-squad run start ...` and
+  `amq-squad global start ...`; both remain preview-by-default.

--- a/internal/cli/command_registry.go
+++ b/internal/cli/command_registry.go
@@ -19,7 +19,7 @@ var commandCatalog = []struct {
 	{Name: "goal", Summary: "Draft or apply a preview-first goal setup plan"},
 	{Name: "global", Summary: "Stand up a global/NOC orchestrator (poller) at a neutral root"},
 	{Name: "run", Summary: "Create one orchestrated run in a project (managed spawn)"},
-	{Name: "wizard", Summary: "Guided preview for run start (interactive TTY only)"},
+	{Name: "wizard", Summary: "Guided project/global preview with default-No live confirmation"},
 	{Name: "task", Summary: "Native pull-based task store (add/list/claim/done/fail/block)"},
 	{Name: "verify", Summary: "Deterministic preflight checks (action, merge, release)"},
 	{Name: "operator", Summary: "Show operator inbox and polling-loop status"},

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -164,6 +164,7 @@ var completionVerifySubcommands = []string{
 // guard: `TestCompletionFlagsCoverDispatcher` walks the source tree and
 // fails if a `flag.NewFlagSet` declares a flag missing here.
 var completionCommonFlags = []string{
+	"--accessible",
 	// Root flags (also offered as first-word completions when the user
 	// starts typing `-...` before picking a subcommand).
 	"--help",
@@ -241,6 +242,7 @@ var completionCommonFlags = []string{
 	"--include-body",
 	"--idle-reap-minutes",
 	"--interval",
+	"--interactive",
 	"--json",
 	"--keep-panes",
 	"--kind",
@@ -273,6 +275,7 @@ var completionCommonFlags = []string{
 	"--no-preauthorize-inscope",
 	"--no-require-wake",
 	"--no-wake",
+	"--numbered",
 	"--once",
 	"--older-than",
 	"--operator",
@@ -341,6 +344,7 @@ var completionCommonFlags = []string{
 	"--ttl",
 	"--unsafe-send-as",
 	"--visibility",
+	"--wizard-ui",
 	"--wait-for",
 	"--wait-timeout",
 	"--wake",

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -204,11 +204,15 @@ Usage:
       [--visibility sibling-tabs|detached|current] [--external-lead]
       [--layout-preset lead-left|lead-top|even-grid|one-window-per-agent]
       [--launcher-pane close-after-start|keep]
-      [--goal TEXT] [--seed-from REF] [--interactive] [--go]
+      [--goal TEXT] [--seed-from REF] [--interactive]
+      [--wizard-ui auto|tui|numbered] [--numbered|--accessible] [--go]
 
 With no flags in an interactive terminal, or with --interactive explicitly,
 run start opens the guided preview wizard. Non-TTY and CI invocations never
-prompt. --interactive and --go are mutually exclusive.
+prompt. The wizard previews first and launches only after an explicit yes at
+"Launch now? [y/N]"; the live call adds only --go and rechecks current state.
+Its first choice can instead delegate to canonical global start for a
+Global/NOC poller. --interactive and --go are mutually exclusive.
 
 Managed model: amq-squad spawns the whole team (incl. the lead); panes are
 registered and wake-live automatically. This wraps the create sequence so the

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -23,6 +25,11 @@ var (
 	runStartWizardAccessible       = func() bool { return envTruthy("AMQ_SQUAD_WIZARD_ACCESSIBLE") }
 	runStartNumberedAdapter        func([]string, string) error
 	runStartBubbleAdapter          func([]string, string) error
+	runStartWizardProjectExecute   = runRunStart
+	runStartWizardGlobalExecute    = runGlobalStart
+	runStartWizardConfirm          = promptRunStartWizardLaunch
+	runStartWizardOpenTTY          = func() (io.ReadWriteCloser, error) { return os.OpenFile("/dev/tty", os.O_RDWR, 0) }
+	runStartWizardBubbleProgram    = runwizard.RunBubbleTea
 )
 
 func init() {
@@ -39,11 +46,13 @@ func runWizardCmd(args []string, version string) error {
 		fmt.Fprint(os.Stderr, `amq-squad wizard - guided preview for one orchestrated run
 
 Usage:
-  amq-squad wizard [run start prefill flags] [--wizard-ui auto|tui|numbered]
+  amq-squad wizard [run start prefill flags] [--scope project|global]
+      [--wizard-ui auto|tui|numbered] [--numbered|--accessible]
 
 This is an alias for 'amq-squad run start --interactive'. It requires an
-interactive terminal, never runs in CI, and is preview-only in this release
-slice. The wizard prints and validates the equivalent flag-form command.
+interactive terminal and never runs in CI. It previews first, then asks
+"Launch now? [y/N]"; only an explicit yes calls the same canonical command
+with --go. Project-run and global/NOC scopes are supported.
 TERM=dumb and --wizard-ui numbered use the accessible numbered adapter.
 `)
 		return nil
@@ -153,31 +162,67 @@ func stripWizardUIArgs(args []string) ([]string, string, error) {
 }
 
 func runNumberedRunStartWizard(args []string, version string) error {
+	prefill, err := parseRunStartWizardPrefill(args)
+	if err != nil {
+		return err
+	}
+	reader := bufio.NewReader(runStartWizardInput)
+	scope, cancelled, err := promptRunStartWizardScope(reader, runStartWizardOutput, prefill.Scope)
+	if err != nil || cancelled {
+		return err
+	}
+	prefill.Scope = scope
+	if scope == "global" {
+		spec, collectErr := collectGlobalWizard(reader, runStartWizardOutput, prefill)
+		if collectErr != nil {
+			return collectErr
+		}
+		return finishRunStartWizard(spec, version, reader, runStartWizardOutput)
+	}
 	prefill, opts, err := prepareRunStartWizard(args)
 	if err != nil {
 		return err
 	}
+	prefill.Scope = "project"
 	opts.Defaults = prefill
-	spec, err := runwizard.RunNumbered(runStartWizardInput, runStartWizardOutput, opts)
+	spec, err := runwizard.RunNumbered(reader, runStartWizardOutput, opts)
 	if err != nil {
 		return err
 	}
-	return finishRunStartWizard(spec, version)
+	return finishRunStartWizard(spec, version, reader, runStartWizardOutput)
 }
 
 func runBubbleRunStartWizard(args []string, version string) error {
-	prefill, opts, err := prepareRunStartWizard(args)
+	prefill, err := parseRunStartWizardPrefill(args)
 	if err != nil {
 		return err
 	}
-	opts.Defaults = prefill
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := runStartWizardOpenTTY()
 	if err != nil {
 		fmt.Fprintf(runStartWizardOutput, "Full-screen wizard unavailable (%v); using the numbered adapter.\n", err)
 		return runNumberedRunStartWizard(args, version)
 	}
 	defer tty.Close()
-	result, err := runwizard.RunBubbleTea(tty, tty, opts)
+	reader := bufio.NewReader(tty)
+	scope, cancelled, err := promptRunStartWizardScope(reader, tty, prefill.Scope)
+	if err != nil || cancelled {
+		return err
+	}
+	prefill.Scope = scope
+	if scope == "global" {
+		spec, collectErr := collectGlobalWizard(reader, tty, prefill)
+		if collectErr != nil {
+			return collectErr
+		}
+		return finishRunStartWizard(spec, version, reader, tty)
+	}
+	prefill, opts, err := prepareRunStartWizard(args)
+	if err != nil {
+		return err
+	}
+	prefill.Scope = "project"
+	opts.Defaults = prefill
+	result, err := runStartWizardBubbleProgram(reader, tty, opts)
 	if err != nil {
 		return err
 	}
@@ -185,7 +230,7 @@ func runBubbleRunStartWizard(args []string, version string) error {
 		fmt.Fprintln(runStartWizardOutput, "Wizard cancelled. Nothing changed.")
 		return nil
 	}
-	return finishRunStartWizard(result.Spec, version)
+	return finishRunStartWizard(result.Spec, version, reader, tty)
 }
 
 func prepareRunStartWizard(args []string) (runwizard.Spec, runwizard.NumberedOptions, error) {
@@ -217,7 +262,21 @@ func prepareRunStartWizard(args []string) (runwizard.Spec, runwizard.NumberedOpt
 	return prefill, opts, nil
 }
 
-func finishRunStartWizard(spec runwizard.Spec, version string) error {
+func finishRunStartWizard(spec runwizard.Spec, version string, in io.Reader, out io.Writer) error {
+	if spec.Scope == "global" {
+		canonicalArgs := spec.GlobalArgs()
+		liveArgs := append(append([]string{}, canonicalArgs...), "--go")
+		fmt.Printf("\nEquivalent flag command (preview only):\n  %s\n\n", shellCommand("amq-squad", append([]string{"global", "start"}, canonicalArgs...)...))
+		fmt.Printf("Equivalent flag command (live, only after explicit Yes):\n  %s\n\n", shellCommand("amq-squad", append([]string{"global", "start"}, liveArgs...)...))
+		if err := runStartWizardGlobalExecute(canonicalArgs); err != nil {
+			return err
+		}
+		launch, err := runStartWizardConfirm(in, out)
+		if err != nil || !launch {
+			return err
+		}
+		return runStartWizardGlobalExecute(liveArgs)
+	}
 	preflight := runStartPreflight(runStartPreflightInput{
 		Project:         spec.Project,
 		Profile:         spec.Profile,
@@ -248,14 +307,155 @@ func finishRunStartWizard(spec runwizard.Spec, version string) error {
 		return preflight.Err()
 	}
 	canonicalArgs := spec.Args()
+	liveArgs := append(append([]string{}, canonicalArgs...), "--go")
 	commandArgs := append([]string{"run", "start"}, canonicalArgs...)
 	fmt.Printf("\nEquivalent flag command (preview only):\n  %s\n\n", shellCommand("amq-squad", commandArgs...))
-	return runRunStart(canonicalArgs, version)
+	fmt.Printf("Equivalent flag command (live, only after explicit Yes):\n  %s\n\n", shellCommand("amq-squad", append([]string{"run", "start"}, liveArgs...)...))
+	if err := runStartWizardProjectExecute(canonicalArgs, version); err != nil {
+		return err
+	}
+	launch, err := runStartWizardConfirm(in, out)
+	if err != nil || !launch {
+		return err
+	}
+	return runStartWizardProjectExecute(liveArgs, version)
+}
+
+func promptRunStartWizardLaunch(in io.Reader, out io.Writer) (bool, error) {
+	fmt.Fprint(out, "Launch now? [y/N] ")
+	line, err := readWizardLine(in)
+	if err == io.EOF {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes", nil
+}
+
+func promptRunStartWizardScope(in io.Reader, out io.Writer, current string) (scope string, cancelled bool, err error) {
+	current = strings.ToLower(strings.TrimSpace(current))
+	if current == "project" || current == "global" {
+		return current, false, nil
+	}
+	fmt.Fprint(out, "Scope\n  1) Project run\n  2) Global / NOC orchestrator\nChoose [1]: ")
+	line, err := readWizardLine(in)
+	if err != nil {
+		return "", false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "", "1", "project":
+		return "project", false, nil
+	case "2", "global", "noc":
+		return "global", false, nil
+	case "q", "quit", "cancel":
+		fmt.Fprintln(out, "Wizard cancelled. Nothing changed.")
+		return "", true, nil
+	default:
+		return "", false, usageErrorf("invalid wizard scope %q", strings.TrimSpace(line))
+	}
+}
+
+func collectGlobalWizard(in io.Reader, out io.Writer, spec runwizard.Spec) (runwizard.Spec, error) {
+	if _, ok := in.(*bufio.Reader); !ok {
+		in = bufio.NewReader(in)
+	}
+	spec.Scope = "global"
+	if strings.TrimSpace(spec.GlobalRoot) == "" {
+		if home, homeErr := os.UserHomeDir(); homeErr == nil {
+			spec.GlobalRoot = filepath.Join(home, "Code")
+		} else {
+			return spec, fmt.Errorf("resolve default global root: %w", homeErr)
+		}
+	}
+	var err error
+	if spec.GlobalRoot, err = promptWizardText(in, out, "Neutral root", spec.GlobalRoot); err != nil {
+		return spec, err
+	}
+	if spec.GlobalAgent, err = promptWizardChoice(in, out, "Agent", spec.GlobalAgent, []string{"claude", "codex"}); err != nil {
+		return spec, err
+	}
+	if spec.GlobalModel, err = promptWizardText(in, out, "Model (optional)", spec.GlobalModel); err != nil {
+		return spec, err
+	}
+	efforts := []string{"automatic", "low", "medium", "high"}
+	if spec.GlobalAgent == "codex" {
+		efforts = append(efforts, "minimal", "xhigh")
+	}
+	if spec.GlobalEffort, err = promptWizardChoice(in, out, "Effort", spec.GlobalEffort, efforts); err != nil {
+		return spec, err
+	}
+	if spec.GlobalAgent == "codex" {
+		if spec.GlobalCodexArgs, err = promptWizardText(in, out, "Codex extra native args (excluding effort)", spec.GlobalCodexArgs); err != nil {
+			return spec, err
+		}
+	} else if spec.GlobalClaudeArgs, err = promptWizardText(in, out, "Claude extra native args (excluding effort)", spec.GlobalClaudeArgs); err != nil {
+		return spec, err
+	}
+	if strings.TrimSpace(spec.GlobalWindow) == "" {
+		spec.GlobalWindow = "global-orch"
+	}
+	if spec.GlobalWindow, err = promptWizardText(in, out, "Window name", spec.GlobalWindow); err != nil {
+		return spec, err
+	}
+	fmt.Fprintln(out, "NOC contract: poll explicit project/profile/session namespaces; this global orchestrator owns no wake mailbox.")
+	return spec, nil
+}
+
+func promptWizardText(in io.Reader, out io.Writer, label, current string) (string, error) {
+	fmt.Fprintf(out, "%s [%s]: ", label, current)
+	line, err := readWizardLine(in)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(line) == "" {
+		return current, nil
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func promptWizardChoice(in io.Reader, out io.Writer, label, current string, values []string) (string, error) {
+	if strings.TrimSpace(current) == "" {
+		current = values[0]
+	}
+	fmt.Fprintf(out, "%s (%s) [%s]: ", label, strings.Join(values, "/"), current)
+	line, err := readWizardLine(in)
+	if err != nil {
+		return "", err
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	if line == "" {
+		line = strings.ToLower(strings.TrimSpace(current))
+	}
+	for _, value := range values {
+		if line == value {
+			return line, nil
+		}
+	}
+	return "", usageErrorf("invalid %s %q", strings.ToLower(label), line)
+}
+
+func readWizardLine(in io.Reader) (string, error) {
+	if reader, ok := in.(*bufio.Reader); ok {
+		line, err := reader.ReadString('\n')
+		if err == io.EOF && line != "" {
+			return line, nil
+		}
+		return line, err
+	}
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err == io.EOF && line != "" {
+		return line, nil
+	}
+	return line, err
 }
 
 func parseRunStartWizardPrefill(args []string) (runwizard.Spec, error) {
 	fs := flag.NewFlagSet("run start wizard", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
+	scope := fs.String("scope", "", "")
 	project := fs.String("project", "", "")
 	session := fs.String("session", "", "")
 	profile := fs.String("profile", "", "")
@@ -275,6 +475,9 @@ func parseRunStartWizardPrefill(args []string) (runwizard.Spec, error) {
 	externalLead := fs.Bool("external-lead", false, "")
 	goal := fs.String("goal", "", "")
 	seedFrom := fs.String("seed-from", "", "")
+	globalRoot := fs.String("root", "", "")
+	globalAgent := fs.String("agent", "", "")
+	globalWindow := fs.String("name", "", "")
 	goFlag := fs.Bool("go", false, "")
 	if err := parseFlags(fs, args); err != nil {
 		return runwizard.Spec{}, err
@@ -286,23 +489,31 @@ func parseRunStartWizardPrefill(args []string) (runwizard.Spec, error) {
 		return runwizard.Spec{}, usageErrorf("--interactive cannot be combined with --go; approve launch only at the wizard's final confirmation")
 	}
 	return runwizard.Spec{
-		Project:      *project,
-		Profile:      *profile,
-		Session:      *session,
-		Roles:        *roles,
-		Binary:       *binary,
-		Model:        *model,
-		Effort:       *effort,
-		OperatorMode: *operatorMode,
-		CodexArgs:    *codexArgs,
-		ClaudeArgs:   *claudeArgs,
-		Lead:         *lead,
-		LeadMode:     *leadMode,
-		Visibility:   *visibility,
-		LayoutPreset: *layoutPreset,
-		LauncherPane: *launcherPane,
-		ExternalLead: *externalLead,
-		Goal:         *goal,
-		SeedFrom:     *seedFrom,
+		Scope:            strings.ToLower(strings.TrimSpace(*scope)),
+		Project:          *project,
+		Profile:          *profile,
+		Session:          *session,
+		Roles:            *roles,
+		Binary:           *binary,
+		Model:            *model,
+		Effort:           *effort,
+		OperatorMode:     *operatorMode,
+		CodexArgs:        *codexArgs,
+		ClaudeArgs:       *claudeArgs,
+		Lead:             *lead,
+		LeadMode:         *leadMode,
+		Visibility:       *visibility,
+		LayoutPreset:     *layoutPreset,
+		LauncherPane:     *launcherPane,
+		ExternalLead:     *externalLead,
+		Goal:             *goal,
+		SeedFrom:         *seedFrom,
+		GlobalRoot:       *globalRoot,
+		GlobalAgent:      *globalAgent,
+		GlobalModel:      *model,
+		GlobalEffort:     *effort,
+		GlobalCodexArgs:  *codexArgs,
+		GlobalClaudeArgs: *claudeArgs,
+		GlobalWindow:     *globalWindow,
 	}, nil
 }

--- a/internal/cli/run_start_wizard_live_test.go
+++ b/internal/cli/run_start_wizard_live_test.go
@@ -1,0 +1,302 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+type wizardTestTTY struct {
+	reader *bytes.Reader
+	writes *bytes.Buffer
+}
+
+func (t wizardTestTTY) Read(p []byte) (int, error)  { return t.reader.Read(p) }
+func (t wizardTestTTY) Write(p []byte) (int, error) { return t.writes.Write(p) }
+func (wizardTestTTY) Close() error                  { return nil }
+
+func withWizardExecutionSeams(t *testing.T) (*[][]string, *[][]string) {
+	t.Helper()
+	oldProject := runStartWizardProjectExecute
+	oldGlobal := runStartWizardGlobalExecute
+	oldConfirm := runStartWizardConfirm
+	var projectCalls, globalCalls [][]string
+	runStartWizardProjectExecute = func(args []string, version string) error {
+		projectCalls = append(projectCalls, append([]string(nil), args...))
+		return nil
+	}
+	runStartWizardGlobalExecute = func(args []string) error {
+		globalCalls = append(globalCalls, append([]string(nil), args...))
+		return nil
+	}
+	runStartWizardConfirm = promptRunStartWizardLaunch
+	t.Cleanup(func() {
+		runStartWizardProjectExecute = oldProject
+		runStartWizardGlobalExecute = oldGlobal
+		runStartWizardConfirm = oldConfirm
+	})
+	return &projectCalls, &globalCalls
+}
+
+func validWizardProjectSpec(t *testing.T) runwizard.Spec {
+	t.Helper()
+	return runwizard.Spec{
+		Scope: "project", Project: t.TempDir(), Profile: "default", Session: "issue-393-slice6",
+		Roles: "cto", Binary: "cto=codex", Lead: "cto", LeadMode: "builder",
+		Visibility: visibilityDetached, OperatorMode: "separate_terminal", LauncherPane: launcherPaneKeep,
+	}
+}
+
+func TestFinishWizardProjectPreviewNoIsReadOnly(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	var prompt strings.Builder
+	if err := finishRunStartWizard(validWizardProjectSpec(t), "test", strings.NewReader("\n"), &prompt); err != nil {
+		t.Fatal(err)
+	}
+	if len(*projectCalls) != 1 || hasWizardArg((*projectCalls)[0], "--go") {
+		t.Fatalf("calls = %v", *projectCalls)
+	}
+	if !strings.Contains(prompt.String(), "Launch now? [y/N]") {
+		t.Fatalf("missing default-No confirmation: %q", prompt.String())
+	}
+}
+
+func TestFinishWizardProjectYesAddsOnlyGoAndRechecks(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	runStartWizardConfirm = func(io.Reader, io.Writer) (bool, error) { return true, nil }
+	spec := validWizardProjectSpec(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return finishRunStartWizard(spec, "test", strings.NewReader(""), io.Discard)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOnlyGoDelta(t, *projectCalls)
+	assertPrintedCanonicalPair(t, stdout, "run", "start", (*projectCalls)[0], (*projectCalls)[1])
+	for _, prompt := range []string{"Launch now?", "Scope", "Choose [1]"} {
+		if strings.Contains(stdout, prompt) {
+			t.Fatalf("prompt leaked to stdout: %q in %s", prompt, stdout)
+		}
+	}
+}
+
+func TestFinishWizardPreviewFailureNeverConfirmsOrLaunches(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	runStartWizardProjectExecute = func(args []string, version string) error {
+		*projectCalls = append(*projectCalls, append([]string(nil), args...))
+		return errors.New("preview failed")
+	}
+	confirmed := false
+	runStartWizardConfirm = func(io.Reader, io.Writer) (bool, error) { confirmed = true; return true, nil }
+	err := finishRunStartWizard(validWizardProjectSpec(t), "test", strings.NewReader("y\n"), io.Discard)
+	if err == nil || confirmed || len(*projectCalls) != 1 {
+		t.Fatalf("err=%v confirmed=%t calls=%v", err, confirmed, *projectCalls)
+	}
+}
+
+func TestFinishWizardLiveRechecksAndSurfacesNewCollision(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	runStartWizardConfirm = func(io.Reader, io.Writer) (bool, error) { return true, nil }
+	runStartWizardProjectExecute = func(args []string, version string) error {
+		*projectCalls = append(*projectCalls, append([]string(nil), args...))
+		if len(*projectCalls) == 2 {
+			return errors.New("workstream already exists")
+		}
+		return nil
+	}
+	err := finishRunStartWizard(validWizardProjectSpec(t), "test", strings.NewReader(""), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("second canonical check error = %v calls=%v", err, *projectCalls)
+	}
+	assertOnlyGoDelta(t, *projectCalls)
+}
+
+func TestFinishWizardGlobalNoAndYesDelegateExactCanonicalArgs(t *testing.T) {
+	_, globalCalls := withWizardExecutionSeams(t)
+	spec := runwizard.Spec{Scope: "global", GlobalRoot: "/neutral", GlobalAgent: "codex", GlobalModel: "gpt", GlobalEffort: "high", GlobalCodexArgs: "--search", GlobalWindow: "noc"}
+	if err := finishRunStartWizard(spec, "test", strings.NewReader("\n"), io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if len(*globalCalls) != 1 {
+		t.Fatalf("No calls = %v", *globalCalls)
+	}
+	*globalCalls = nil
+	runStartWizardConfirm = func(io.Reader, io.Writer) (bool, error) { return true, nil }
+	stdout, _, err := captureOutput(t, func() error {
+		return finishRunStartWizard(spec, "test", strings.NewReader(""), io.Discard)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOnlyGoDelta(t, *globalCalls)
+	assertPrintedCanonicalPair(t, stdout, "global", "start", (*globalCalls)[0], (*globalCalls)[1])
+	joined := strings.Join((*globalCalls)[0], " ")
+	for _, forbidden := range []string{"--roles", "--profile", "--visibility", "--launcher-pane"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("global argv leaked %s: %v", forbidden, (*globalCalls)[0])
+		}
+	}
+}
+
+func TestPromptWizardScopeAndConfirmationDefaults(t *testing.T) {
+	var out strings.Builder
+	scope, cancelled, err := promptRunStartWizardScope(strings.NewReader("\n"), &out, "")
+	if err != nil || cancelled || scope != "project" {
+		t.Fatalf("scope=%q cancelled=%t err=%v", scope, cancelled, err)
+	}
+	yes, err := promptRunStartWizardLaunch(strings.NewReader("\n"), &out)
+	if err != nil || yes {
+		t.Fatalf("default confirmation yes=%t err=%v", yes, err)
+	}
+	yes, err = promptRunStartWizardLaunch(strings.NewReader("YES\n"), &out)
+	if err != nil || !yes {
+		t.Fatalf("affirmative confirmation yes=%t err=%v", yes, err)
+	}
+}
+
+func TestWizardCustomFlagsRemainInCompletionCatalog(t *testing.T) {
+	joined := strings.Join(completionCommonFlags, " ")
+	for _, flag := range []string{"--interactive", "--wizard-ui", "--numbered", "--accessible", "--scope"} {
+		if !strings.Contains(joined, flag) {
+			t.Fatalf("completion missing %s", flag)
+		}
+	}
+}
+
+func TestCollectGlobalWizardDefaultsToExistingGlobalNeutralRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	input := strings.NewReader("\n\n\n\n\n\n")
+	spec, err := collectGlobalWizard(input, io.Discard, runwizard.Spec{Scope: "global"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.GlobalRoot != home+"/Code" || spec.GlobalAgent != "claude" || spec.GlobalWindow != "global-orch" {
+		t.Fatalf("global defaults = %+v", spec)
+	}
+}
+
+func TestNumberedGlobalWizardDelegatesPreviewThenDefaultNo(t *testing.T) {
+	_, globalCalls := withWizardExecutionSeams(t)
+	oldInput, oldOutput := runStartWizardInput, runStartWizardOutput
+	t.Cleanup(func() { runStartWizardInput, runStartWizardOutput = oldInput, oldOutput })
+	// root, agent, model, effort, Claude args, window, then default-No confirmation.
+	runStartWizardInput = strings.NewReader(strings.Repeat("\n", 7))
+	var prompts strings.Builder
+	runStartWizardOutput = &prompts
+	if err := runNumberedRunStartWizard([]string{"--scope", "global", "--root", t.TempDir()}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*globalCalls) != 1 || hasWizardArg((*globalCalls)[0], "--go") {
+		t.Fatalf("global calls = %v", *globalCalls)
+	}
+	for _, want := range []string{"NOC contract", "Launch now? [y/N]"} {
+		if !strings.Contains(prompts.String(), want) {
+			t.Fatalf("prompts missing %q: %s", want, prompts.String())
+		}
+	}
+}
+
+func TestNumberedProjectWizardScriptedYesPreservesReaderAndAddsOnlyGo(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	oldInput, oldOutput := runStartWizardInput, runStartWizardOutput
+	t.Cleanup(func() { runStartWizardInput, runStartWizardOutput = oldInput, oldOutput })
+	answers := []string{
+		"",             // scope: project
+		"", "", "", "", // project, profile, session, roles
+		"", "", "", // cto binary/model/effort
+		"", "", "", // senior-dev binary/model/effort
+		"", "", "", // qa binary/model/effort
+		"", "", "", "", "", "", "", "", // lead through seed
+		"YES", // post-preview live confirmation
+	}
+	runStartWizardInput = strings.NewReader(strings.Join(answers, "\n") + "\n")
+	var prompts strings.Builder
+	runStartWizardOutput = &prompts
+	project := t.TempDir()
+	stdout, _, err := captureOutput(t, func() error {
+		return runNumberedRunStartWizard([]string{"--project", project, "--profile", "default", "--session", "issue-393-e2e"}, "test")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOnlyGoDelta(t, *projectCalls)
+	assertPrintedCanonicalPair(t, stdout, "run", "start", (*projectCalls)[0], (*projectCalls)[1])
+	for _, want := range []string{"Scope", "Answers are previewed first", "Launch now? [y/N]"} {
+		if !strings.Contains(prompts.String(), want) {
+			t.Fatalf("prompt channel missing %q:\n%s", want, prompts.String())
+		}
+	}
+	for _, forbidden := range []string{"Scope", "Launch now?", "Project directory"} {
+		if strings.Contains(stdout, forbidden) {
+			t.Fatalf("prompt %q leaked to stdout:\n%s", forbidden, stdout)
+		}
+	}
+}
+
+func TestNumberedWizardScopeCancellationDoesNothing(t *testing.T) {
+	projectCalls, globalCalls := withWizardExecutionSeams(t)
+	oldInput, oldOutput := runStartWizardInput, runStartWizardOutput
+	t.Cleanup(func() { runStartWizardInput, runStartWizardOutput = oldInput, oldOutput })
+	runStartWizardInput = strings.NewReader("q\n")
+	runStartWizardOutput = io.Discard
+	if err := runNumberedRunStartWizard(nil, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*projectCalls) != 0 || len(*globalCalls) != 0 {
+		t.Fatalf("cancel calls project=%v global=%v", *projectCalls, *globalCalls)
+	}
+}
+
+func TestBubbleWizardReturnsFromProgramThenConfirmsOnSameTTY(t *testing.T) {
+	projectCalls, _ := withWizardExecutionSeams(t)
+	oldOpen := runStartWizardOpenTTY
+	oldProgram := runStartWizardBubbleProgram
+	t.Cleanup(func() { runStartWizardOpenTTY, runStartWizardBubbleProgram = oldOpen, oldProgram })
+	tty := wizardTestTTY{reader: bytes.NewReader([]byte("yes\n")), writes: &bytes.Buffer{}}
+	runStartWizardOpenTTY = func() (io.ReadWriteCloser, error) { return tty, nil }
+	spec := validWizardProjectSpec(t)
+	runStartWizardBubbleProgram = func(in io.Reader, out io.Writer, opts runwizard.NumberedOptions) (runwizard.BubbleResult, error) {
+		return runwizard.BubbleResult{Spec: spec}, nil
+	}
+	if err := runBubbleRunStartWizard([]string{"--scope", "project", "--project", spec.Project}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	assertOnlyGoDelta(t, *projectCalls)
+	if !strings.Contains(tty.writes.String(), "Launch now? [y/N]") {
+		t.Fatalf("confirmation not written to same tty: %q", tty.writes.String())
+	}
+}
+
+func assertOnlyGoDelta(t *testing.T, calls [][]string) {
+	t.Helper()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v", calls)
+	}
+	want := append(append([]string(nil), calls[0]...), "--go")
+	if strings.Join(calls[1], "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("live argv delta = %v -> %v, want only --go", calls[0], calls[1])
+	}
+}
+
+func hasWizardArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPrintedCanonicalPair(t *testing.T, stdout, verb, subcommand string, preview, live []string) {
+	t.Helper()
+	previewCommand := shellCommand("amq-squad", append([]string{verb, subcommand}, preview...)...)
+	liveCommand := shellCommand("amq-squad", append([]string{verb, subcommand}, live...)...)
+	if !strings.Contains(stdout, previewCommand) || !strings.Contains(stdout, liveCommand) {
+		t.Fatalf("stdout did not match executed argv\npreview=%s\nlive=%s\nstdout:\n%s", previewCommand, liveCommand, stdout)
+	}
+}

--- a/internal/cli/run_start_wizard_test.go
+++ b/internal/cli/run_start_wizard_test.go
@@ -182,7 +182,7 @@ func TestNumberedWizardRunsCanonicalPreviewWithoutMutation(t *testing.T) {
 			t.Fatalf("preview output missing %q:\n%s", want, stdout)
 		}
 	}
-	if !strings.Contains(prompts.String(), "Preview only: this flow cannot launch agents") {
+	if !strings.Contains(prompts.String(), "Answers are previewed first") {
 		t.Fatalf("prompt output missing preview-only banner:\n%s", prompts.String())
 	}
 	if team.ExistsProfile(project, "review") {

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -308,7 +308,7 @@ func (m BubbleModel) title() string {
 	case stageSeed:
 		return "Optional brief source"
 	case stageConfirm:
-		return "Review the read-only preview"
+		return "Review answers before canonical preview"
 	default:
 		return "Run start wizard"
 	}
@@ -350,7 +350,7 @@ func (m BubbleModel) note() string {
 		}
 		return "Unavailable capability rows stay visible so the future contract is explicit."
 	case stageConfirm:
-		return "Enter runs the existing canonical preview. It cannot launch agents."
+		return "Enter collects these answers and runs preview. Live launch is a later default-No prompt."
 	case stageSeed:
 		return "Accepted forms: file:path · issue:393 · gh:owner/repo#393"
 	}
@@ -487,7 +487,7 @@ func (m BubbleModel) choices() []choice {
 		}
 		return []choice{{value: "close-after-start", label: "Close after successful start"}, {value: "keep", label: "Keep this launcher pane"}}
 	case stageConfirm:
-		return []choice{{value: "preview", label: "Run the canonical read-only preview"}}
+		return []choice{{value: "preview", label: "Run canonical preview, then decide launch separately"}}
 	default:
 		return nil
 	}

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -237,8 +237,8 @@ func TestBubbleModelConfirmationShowsCanonicalReadOnlyBoundary(t *testing.T) {
 	m.configureStage()
 	view := m.View()
 	for _, want := range []string{
-		"Review the read-only preview", "existing profile (authoritative)", "cto=high (launch only)",
-		"detached squad", "Operator", "noc · NOC/global orchestrator owns polling", "Run the canonical read-only preview",
+		"Review answers before canonical preview", "existing profile (authoritative)", "cto=high (launch only)",
+		"detached squad", "Operator", "noc · NOC/global orchestrator owns polling", "Run canonical preview, then decide launch separately",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("confirmation missing %q:\n%s", want, view)

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// NumberedOptions supplies the preview-only line UI with defaults and an
+// NumberedOptions supplies the answer-collection line UI with defaults and an
 // injected project inspector. The callback keeps this package independent from
 // git and team persistence packages.
 type NumberedOptions struct {
@@ -51,11 +51,14 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	if in == nil || out == nil {
 		return Spec{}, fmt.Errorf("wizard numbered UI requires input and output")
 	}
-	r := bufio.NewReader(in)
+	r, ok := in.(*bufio.Reader)
+	if !ok {
+		r = bufio.NewReader(in)
+	}
 	s := opts.Defaults
 
 	fmt.Fprintln(out, "amq-squad run start wizard")
-	fmt.Fprintln(out, "Preview only: this flow cannot launch agents.")
+	fmt.Fprintln(out, "Answers are previewed first. Launch requires a separate explicit Yes after preview succeeds.")
 	fmt.Fprintln(out)
 
 	var err error
@@ -235,7 +238,7 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	}
 
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Answers collected. Running the canonical read-only preview next.")
+	fmt.Fprintln(out, "Answers collected. Running the canonical preview next; live launch is a separate default-No decision.")
 	return s, nil
 }
 

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -34,7 +34,7 @@ func TestRunNumberedEnterThroughDefaults(t *testing.T) {
 		t.Fatalf("visible topology operator default = %q", got.OperatorMode)
 	}
 	text := out.String()
-	for _, want := range []string{"Preview only", "Project directory [/repo]", "builder: lead may implement and delegate (default)", "sibling-tabs: one visible tmux window per agent (default)"} {
+	for _, want := range []string{"Answers are previewed first", "Project directory [/repo]", "builder: lead may implement and delegate (default)", "sibling-tabs: one visible tmux window per agent (default)"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("output missing %q:\n%s", want, text)
 		}
@@ -90,6 +90,32 @@ func TestRunNumberedAcceptsNumberedChoices(t *testing.T) {
 	}
 	if got.OperatorMode != "lead_pane" {
 		t.Fatalf("operator mode = %q", got.OperatorMode)
+	}
+}
+
+func TestRunNumberedReusesCallerReaderAndPreservesFollowingConsent(t *testing.T) {
+	answers := []string{
+		"", "", "", "", // project, profile, session, roles
+		"", "", "", // cto binary/model/effort
+		"", "", "", // senior-dev
+		"", "", "", // qa
+		"", "", "", "", "", "", "", "", // lead through seed
+		"YES",
+	}
+	reader := bufio.NewReader(strings.NewReader(strings.Join(answers, "\n") + "\n"))
+	_, err := RunNumbered(reader, &bytes.Buffer{}, NumberedOptions{
+		Defaults:      Spec{Project: "/repo", Profile: "default", Session: "s"},
+		ProfileExists: func(string, string) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	consent, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(consent) != "YES" {
+		t.Fatalf("following consent = %q", consent)
 	}
 }
 

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -8,24 +8,65 @@ import "strings"
 // adapters may add richer choices, but execution must always flow through Args
 // and the existing run start parser.
 type Spec struct {
-	Project      string
-	Profile      string
-	Session      string
-	Roles        string
-	Binary       string
-	Model        string
-	Effort       string
-	OperatorMode string
-	CodexArgs    string
-	ClaudeArgs   string
-	Lead         string
-	LeadMode     string
-	Visibility   string
-	LayoutPreset string
-	LauncherPane string
-	ExternalLead bool
-	Goal         string
-	SeedFrom     string
+	Scope            string
+	Project          string
+	Profile          string
+	Session          string
+	Roles            string
+	Binary           string
+	Model            string
+	Effort           string
+	OperatorMode     string
+	CodexArgs        string
+	ClaudeArgs       string
+	Lead             string
+	LeadMode         string
+	Visibility       string
+	LayoutPreset     string
+	LauncherPane     string
+	ExternalLead     bool
+	Goal             string
+	SeedFrom         string
+	GlobalRoot       string
+	GlobalAgent      string
+	GlobalModel      string
+	GlobalEffort     string
+	GlobalCodexArgs  string
+	GlobalClaudeArgs string
+	GlobalWindow     string
+}
+
+// GlobalArgs renders only global-start flags. Project roster and topology
+// fields can never leak into this argv.
+func (s Spec) GlobalArgs() []string {
+	args := make([]string, 0, 12)
+	appendValue := func(name, value string) {
+		if value = strings.TrimSpace(value); value != "" {
+			args = append(args, name, value)
+		}
+	}
+	appendValue("--root", s.GlobalRoot)
+	appendValue("--agent", s.GlobalAgent)
+	appendValue("--model", s.GlobalModel)
+	effort := strings.ToLower(strings.TrimSpace(s.GlobalEffort))
+	if effort == "automatic" {
+		effort = ""
+	}
+	if strings.EqualFold(strings.TrimSpace(s.GlobalAgent), "codex") {
+		native := strings.TrimSpace(s.GlobalCodexArgs)
+		if effort != "" {
+			native = strings.TrimSpace(native + " -c model_reasoning_effort=" + effort)
+		}
+		appendValue("--codex-args", native)
+	} else {
+		native := strings.TrimSpace(s.GlobalClaudeArgs)
+		if effort != "" {
+			native = strings.TrimSpace(native + " --effort " + effort)
+		}
+		appendValue("--claude-args", native)
+	}
+	appendValue("--name", s.GlobalWindow)
+	return args
 }
 
 // Args renders the canonical run start argv in a stable order. It never emits

--- a/internal/wizard/spec_test.go
+++ b/internal/wizard/spec_test.go
@@ -2,6 +2,7 @@ package wizard
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +54,36 @@ func TestSpecArgsStableAndPreviewOnly(t *testing.T) {
 		if arg == "--go" || arg == "--interactive" {
 			t.Fatalf("preview-only spec emitted forbidden flag %q", arg)
 		}
+	}
+}
+
+func TestSpecGlobalArgsNeverLeakProjectRunFlags(t *testing.T) {
+	s := Spec{
+		Scope: "global", GlobalRoot: "/neutral", GlobalAgent: "codex", GlobalModel: "gpt",
+		GlobalEffort: "high", GlobalCodexArgs: "--search", GlobalClaudeArgs: "--debug", GlobalWindow: "noc",
+		Project: "/project", Profile: "release", Session: "issue-393", Roles: "cto,qa",
+		Visibility: "current", LayoutPreset: "lead-left", LauncherPane: "close-after-start",
+	}
+	got := strings.Join(s.GlobalArgs(), " ")
+	for _, want := range []string{"--root /neutral", "--agent codex", "--model gpt", "--codex-args --search -c model_reasoning_effort=high", "--name noc"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("global argv %q missing %q", got, want)
+		}
+	}
+	for _, forbidden := range []string{"--project", "--profile", "--session", "--roles", "--visibility", "--layout-preset", "--launcher-pane"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("global argv leaked %q: %s", forbidden, got)
+		}
+	}
+	if strings.Contains(got, "--claude-args") {
+		t.Fatalf("inactive native args leaked: %s", got)
+	}
+}
+
+func TestSpecGlobalClaudeEffortUsesOnlyClaudeNativeArgs(t *testing.T) {
+	got := strings.Join((Spec{GlobalRoot: "/n", GlobalAgent: "claude", GlobalEffort: "medium", GlobalCodexArgs: "--search", GlobalClaudeArgs: "--chrome"}).GlobalArgs(), " ")
+	if !strings.Contains(got, "--claude-args --chrome --effort medium") || strings.Contains(got, "--codex-args") {
+		t.Fatalf("Claude global args = %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds preview-first wizard launch with an explicit `Launch now? [y/N]` gate before canonical `--go` execution.
- Adds Project versus Global/NOC scope and delegates Global/NOC preview/live execution to canonical `global start`.
- Adds completion flags, documentation, and regression coverage for preview failure, cancellation, collision rechecks, and exact live argv.
- This slice remains stacked on Slice 5 until it merges.

## Validation

- `go test ./... -count=1`
- `make ci`

## Current UI limitations

- Global/NOC collection is line-oriented rather than rendered inside the full-screen Bubble Tea flow.
- Final live-launch confirmation occurs after the alternate screen closes and uses the same terminal input.

Part of #393