### PR TITLE
#391 PR 2: self-operator wizard composition + notification events + docs

### DIFF
--- a/README.html
+++ b/README.html
@@ -516,6 +516,17 @@ handle as the project lead.</p>
 href="docs/global-orchestrator-runbook.md">docs/global-orchestrator-runbook.md</a>
 and <a
 href="docs/operator-cookbook.md">docs/operator-cookbook.md</a>.</p>
+<h3 id="bounded-self-operator-mode">Bounded self-operator mode</h3>
+<p><code>self_operator</code> is an explicit, exact-session policy for
+delegated merge-gate approval. New profiles require
+<code>--operator-mode self_operator --self-operator-lead &lt;lead&gt; --self-operator-allow merge</code>;
+there is no default allowlist. Spawn remains human-only until strict
+spawn evidence exists, as do release, tag, publish, external-send, and
+destructive-filesystem gates. The approving lead cannot execute the
+merge; a different strongly verified roster actor must run the final
+verifier. Human denial/intervention and policy pause or revision revoke
+self approval. Notifications are attention-only and never authorize an
+action.</p>
 <h2 id="core-concepts">Core concepts</h2>
 <table>
 <thead>

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ Operational recipes live in
 [docs/global-orchestrator-runbook.md](docs/global-orchestrator-runbook.md) and
 [docs/operator-cookbook.md](docs/operator-cookbook.md).
 
+### Bounded self-operator mode
+
+`self_operator` is an explicit, exact-session policy for delegated merge-gate approval. New profiles require `--operator-mode self_operator --self-operator-lead <lead> --self-operator-allow merge`; there is no default allowlist. Spawn remains human-only until strict spawn evidence exists, as do release, tag, publish, external-send, and destructive-filesystem gates. The approving lead cannot execute the merge; a different strongly verified roster actor must run the final verifier. Human denial/intervention and policy pause or revision revoke self approval. Notifications are attention-only and never authorize an action.
+
 ## Core concepts
 
 | Concept | Meaning |

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -269,6 +269,21 @@ every lifecycle, status, operator, goal, and repair command.
 evidence only; it does not authorize `goal apply`, merge, release, teardown, or
 external side effects.
 
+**Bounded self-operator setup:** For a fresh exact session, use
+`amq-squad run start --operator-mode self_operator --self-operator-lead cto --self-operator-allow merge ...`.
+No allowlist is inferred. Existing profiles are authoritative; change them only
+with `amq-squad team operator set`. Spawn, releases, tags, publishing, external
+sends, and destructive filesystem actions remain human-only. A self-approved
+merge must be executed by a different verified actor. `self_approved` and
+`human_only_gate` notifications are attention-only and never satisfy
+`verify action`.
+
+`team operator set` fails closed when invoked from any tmux pane if the target
+project has no resolvable AMQ root. This is correct but can be rough during
+first-time setup: initialize the project namespace first, then run the policy
+command from a manual/non-agent control plane (outside the squad's agent
+panes).
+
 **When to use `goal apply`:** Use it only after the matching gate has a real
 operator `APPROVED:` answer and the visible lead has a native goal binding.
 `goal apply` verifies both before delivering.

--- a/docs/v2.19.0-release-notes.md
+++ b/docs/v2.19.0-release-notes.md
@@ -79,9 +79,8 @@ It is not a release announcement.
 ## Operator interaction contracts and capability slots, Slice 4
 
 - Team profiles can persist `operator.interaction_mode` as `lead_pane`,
-  `separate_terminal`, or `noc`. The forward-known `self_operator` schema value
-  is readable, but canonical CLI selection remains blocked until #391 adds its
-  bounded authorization policy. Missing legacy values remain `unspecified`.
+  `separate_terminal`, `noc`, or bounded `self_operator`. Missing legacy values
+  remain `unspecified`.
 - `run start --operator-mode` persists the contract only while creating a
   fresh profile. On existing profiles it is validation-only: an explicit value
   must match, and the profile is never rewritten.
@@ -92,9 +91,8 @@ It is not a release announcement.
 - The wizard now asks for the operator contract after topology, defaults visible
   launches to the lead pane and detached launches to a separate terminal, and
   includes the effective contract in confirmation.
-- The #391 self-operator and #390 notification rows are visible capability
-  slots with release labels, but remain unselectable. No self-approval or
-  notification behavior is introduced in this slice.
+- The #391 self-operator and #390 notification rows remain visibly release
+  labeled; self-operator is selectable only with an explicit allowlist.
 
 ## Deterministic tmux layouts, Slice 5
 
@@ -141,3 +139,14 @@ It is not a release announcement.
 - Completion now includes `--wizard-ui`, `--numbered`, and `--accessible`.
   Canonical copy/paste forms are `amq-squad run start ...` and
   `amq-squad global start ...`; both remain preview-by-default.
+
+## Bounded self-operator mode (#391)
+
+- Fresh-profile wizard and `run start` flows persist an exact-session,
+  explicit merge-only policy; no allowlist is preselected.
+- Spawn and immutable high-risk exclusions remain human-only, and a different
+  strongly verified actor must execute a self-approved merge.
+- Status/bootstrap expose revision, allowlist, pause/revocation state, and
+  notification visibility. Existing profiles remain authoritative.
+- `self_approved` and `human_only_gate` are normalized attention-only events;
+  notification delivery has no authorization effect.

--- a/internal/attention/event.go
+++ b/internal/attention/event.go
@@ -17,6 +17,9 @@ type Event struct {
 	Session        string    `json:"session"`
 	Thread         string    `json:"thread,omitempty"`
 	Role           string    `json:"role,omitempty"`
+	GateKind       string    `json:"gate_kind,omitempty"`
+	Actor          string    `json:"actor,omitempty"`
+	PolicyRevision int64     `json:"policy_revision,omitempty"`
 	Subject        string    `json:"subject,omitempty"`
 	Summary        string    `json:"summary"`
 	Escalation     string    `json:"escalation,omitempty"`
@@ -25,6 +28,13 @@ type Event struct {
 	AttentionOnly  bool      `json:"attention_only"`
 	ObservedAt     time.Time `json:"observed_at"`
 	Cleared        bool      `json:"-"`
+}
+
+func SelfApprovedKey(profile, session, thread string) string {
+	return profile + "/" + session + "\x00self_approved\x00" + thread
+}
+func HumanOnlyGateKey(profile, session, thread string) string {
+	return profile + "/" + session + "\x00human_only_gate\x00" + thread
 }
 
 func GateKey(profile, session, thread string) string {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -35,6 +35,7 @@ type bootstrapContext struct {
 	BriefPath        string
 	Operator         team.OperatorView
 	OperatorDelivery operatorDeliveryData
+	SelfOperator     *team.EffectiveSelfOperatorView
 	OperatorGates    bool
 	Execution        *executionModeData
 	PlannerLead      bool
@@ -176,6 +177,11 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 		teamRulesPath = rules.Path(rec.CWD)
 	}
 	operator, operatorGates := bootstrapOperator(rec, teamHome)
+	var selfOperator *team.EffectiveSelfOperatorView
+	if t, err := team.ReadProfile(teamHome, rec.TeamProfile); err == nil && t.Operator != nil && t.Operator.InteractionMode == team.OperatorInteractionSelfOperator {
+		view := team.EffectiveSelfOperator(t, rec.Session)
+		selfOperator = &view
+	}
 	orchestrated, isLead, leadHandle := bootstrapOrchestration(rec, teamHome)
 	currentTeam, warnings := bootstrapCurrentTeam(rec, teamHome)
 	execution := bootstrapExecution(rec, teamHome)
@@ -197,6 +203,7 @@ func bootstrapContextFor(rec launch.Record, agentDir, teamHome string) bootstrap
 		BriefPath:        briefPathForProfile(resolveBriefHome(teamHome, rec.CWD), rec.TeamProfile, rec.Session),
 		Operator:         operator,
 		OperatorDelivery: operatorDeliveryForRecord(rec, teamHome),
+		SelfOperator:     selfOperator,
 		OperatorGates:    operatorGates,
 		Execution:        execution,
 		PlannerLead:      isLead && execution != nil && execution.LeadMode == team.LeadModePlanner && !execution.ImplementationAllowed,

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -61,6 +61,10 @@ Contract: {{.OperatorDelivery.Contract}}
 Guidance: {{.OperatorDelivery.Guidance}}
 Operator notifications: enabled={{.OperatorDelivery.NotificationsEnabled}}; semantics={{.OperatorDelivery.NotificationSemantics}}; sink_types={{.OperatorDelivery.NotificationSinkTypes}}.
 Notification guidance: {{.OperatorDelivery.NotificationGuidance}}
+{{- if .SelfOperator }}
+Self-operator policy: session={{.SelfOperator.Session}} lead={{.SelfOperator.LeadRole}}/{{.SelfOperator.LeadHandle}} enabled={{.SelfOperator.Enabled}} paused={{.SelfOperator.Paused}} revision={{.SelfOperator.PolicyRevision}} allow={{.SelfOperator.AllowedGateKinds}} hash={{.SelfOperator.PolicyHash}}.
+Revocation state is fail-closed: a pause, policy revision/hash change, or human intervention invalidates self approval. Visibility notifications enabled={{.OperatorDelivery.NotificationsEnabled}}; notifications are attention-only and never authorize. Spawn, release, tag, publish, external send, and destructive filesystem remain human-only. A different verified actor must execute a self-approved merge.
+{{- end }}
 {{- if eq .OperatorDelivery.InteractionMode "separate_terminal" }}
 Ready answer command: `amq send --root {{shellQuote .Root}} --me {{.Operator.Handle}} --to <agent-handle> --thread gate/<topic> --kind answer --subject "APPROVED: <decision>"`
 {{- end }}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -309,6 +309,8 @@ var completionCommonFlags = []string{
 	"--run-action",
 	"--seed-from",
 	"--self",
+	"--self-operator-allow",
+	"--self-operator-lead",
 	"--session",
 	"--set",
 	"--scope",

--- a/internal/cli/notify.go
+++ b/internal/cli/notify.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/flock"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/notifier"
+	"github.com/omriariav/amq-squad/v2/internal/operatorauth"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -66,25 +67,28 @@ type notifyDeliverySummary struct {
 }
 
 type operatorAttention struct {
-	EventType   string           `json:"event_type,omitempty"`
-	Key         string           `json:"key"`
-	Profile     string           `json:"profile"`
-	Session     string           `json:"session"`
-	NamespaceID string           `json:"namespace_id"`
-	Thread      string           `json:"thread"`
-	LatestID    string           `json:"latest_id"`
-	From        string           `json:"from,omitempty"`
-	Subject     string           `json:"subject"`
-	Kind        state.Kind       `json:"kind"`
-	Reason      state.AttnReason `json:"reason"`
-	Age         string           `json:"age"`
-	LastEventAt time.Time        `json:"last_event_at,omitempty"`
-	Escalation  string           `json:"escalation,omitempty"`
-	Inspect     string           `json:"inspect"`
-	Respond     string           `json:"respond"`
-	Role        string           `json:"role,omitempty"`
-	Summary     string           `json:"summary,omitempty"`
-	Cleared     bool             `json:"-"`
+	EventType      string           `json:"event_type,omitempty"`
+	Key            string           `json:"key"`
+	Profile        string           `json:"profile"`
+	Session        string           `json:"session"`
+	NamespaceID    string           `json:"namespace_id"`
+	Thread         string           `json:"thread"`
+	LatestID       string           `json:"latest_id"`
+	From           string           `json:"from,omitempty"`
+	Subject        string           `json:"subject"`
+	Kind           state.Kind       `json:"kind"`
+	Reason         state.AttnReason `json:"reason"`
+	Age            string           `json:"age"`
+	LastEventAt    time.Time        `json:"last_event_at,omitempty"`
+	Escalation     string           `json:"escalation,omitempty"`
+	Inspect        string           `json:"inspect"`
+	Respond        string           `json:"respond"`
+	Role           string           `json:"role,omitempty"`
+	GateKind       string           `json:"gate_kind,omitempty"`
+	Actor          string           `json:"actor,omitempty"`
+	PolicyRevision int64            `json:"policy_revision,omitempty"`
+	Summary        string           `json:"summary,omitempty"`
+	Cleared        bool             `json:"-"`
 }
 
 type notifyStateFile struct {
@@ -224,6 +228,7 @@ func executeNotify(n notifyExecution) error {
 	}
 	items := collectOperatorAttention(n.ProjectDir, profile, snap, operator.Handle, strings.TrimSpace(n.Session), now())
 	items = mergeOperatorAttention(items, collectRawOpenGateAttention(n.ProjectDir, profile, snap, operator.Handle, strings.TrimSpace(n.Session), now()))
+	items = mergeOperatorAttention(items, collectSelfOperatorVisibilityAttention(t, n.ProjectDir, profile, snap, strings.TrimSpace(n.Session), now()))
 	workstream, _ := resolveTeamWorkstreamName(t, strings.TrimSpace(n.Session), strings.TrimSpace(n.Session) != "")
 	items = mergeOperatorAttention(items, collectLocalInputAttention(t, profile, workstream, now()))
 	statePath := strings.TrimSpace(n.StatePath)
@@ -238,6 +243,7 @@ func executeNotify(n notifyExecution) error {
 		if e != nil {
 			return e
 		}
+		items = scopedSelfOperatorTombstones(items, prior, profile, strings.TrimSpace(n.Session))
 		notifications, suppressed, next = selectNotifications(items, prior, n.RenotifyAfter, now())
 	} else {
 		err = flock.WithLock(statePath+".lock", func() error {
@@ -245,6 +251,7 @@ func executeNotify(n notifyExecution) error {
 			if e != nil {
 				return e
 			}
+			items = scopedSelfOperatorTombstones(items, prior, profile, strings.TrimSpace(n.Session))
 			notifications, suppressed, next = selectNotifications(items, prior, n.RenotifyAfter, now())
 			return writeNotifyState(statePath, next)
 		})
@@ -294,10 +301,12 @@ func deliverNotificationSinksPersisted(ctx context.Context, projectDir, path str
 	if len(allowed) == 0 {
 		allowed["gate"] = true
 		allowed["local_input_blocked"] = true
+		allowed["self_approved"] = true
+		allowed["human_only_gate"] = true
 	}
 	for _, cfg := range policy.Sinks {
 		for _, item := range items {
-			if item.Cleared || !allowed[item.EventType] || (item.EventType != "gate" && item.EventType != "local_input_blocked") {
+			if item.Cleared || !allowed[item.EventType] || (item.EventType != "gate" && item.EventType != "local_input_blocked" && item.EventType != "self_approved" && item.EventType != "human_only_gate") {
 				continue
 			}
 			token := ""
@@ -333,7 +342,7 @@ func deliverNotificationSinksPersisted(ctx context.Context, projectDir, path str
 				rec.Active = true
 				rec.Fingerprint = item.LatestID
 				st.Items[item.Key] = rec
-				event = attention.Event{SchemaVersion: 1, EventType: item.EventType, Key: item.Key, Fingerprint: item.LatestID, ProjectDir: projectDir, Profile: item.Profile, Session: item.Session, Thread: item.Thread, Role: item.Role, Subject: item.Subject, Summary: item.Summary, Escalation: item.Escalation, Age: item.Age, InspectCommand: item.Inspect, AttentionOnly: true, ObservedAt: now}
+				event = attention.Event{SchemaVersion: 1, EventType: item.EventType, Key: item.Key, Fingerprint: item.LatestID, ProjectDir: projectDir, Profile: item.Profile, Session: item.Session, Thread: item.Thread, Role: item.Role, GateKind: item.GateKind, Actor: item.Actor, PolicyRevision: item.PolicyRevision, Subject: item.Subject, Summary: item.Summary, Escalation: item.Escalation, Age: item.Age, InspectCommand: item.Inspect, AttentionOnly: true, ObservedAt: now}
 				reserved = true
 				return writeNotifyState(path, st)
 			})
@@ -532,6 +541,130 @@ func collectRawOpenGateAttention(projectDir, profile string, snap state.Snapshot
 	return out
 }
 
+// collectSelfOperatorVisibilityAttention emits normalized, attention-only
+// observations. These records never answer a gate and are not consumed by the
+// action verifier.
+func collectSelfOperatorVisibilityAttention(t team.Team, projectDir, profile string, snap state.Snapshot, onlySession string, now time.Time) []operatorAttention {
+	var out []operatorAttention
+	if t.Operator == nil || t.Operator.InteractionMode != team.OperatorInteractionSelfOperator {
+		return nil
+	}
+	profile = squadnamespace.NormalizeProfile(profile)
+	for _, sess := range snap.Sessions {
+		if !squadnamespace.ProfilesEqual(profile, sess.TeamProfile) || onlySession != "" && sess.Name != onlySession {
+			continue
+		}
+		view := team.EffectiveSelfOperator(t, sess.Name)
+		msgs, warnings := state.ScanSessionMessages(sess.Root, func() time.Time { return now })
+		if len(warnings) > 0 {
+			thread := "gate/degraded-scan"
+			out = append(out, operatorAttention{EventType: "human_only_gate", Key: attention.HumanOnlyGateKey(profile, sess.Name, thread), Profile: profile, Session: sess.Name, NamespaceID: sess.NamespaceID, Thread: thread, LatestID: "degraded", Subject: "message scan degraded", Summary: "message scan degraded; visibility fails closed", Inspect: "amq-squad status --project " + notifyShellQuote(projectDir) + " --profile " + notifyShellQuote(profile) + " --session " + notifyShellQuote(sess.Name), LastEventAt: now})
+			continue
+		}
+		var conflict bool
+		msgs, conflict = dedupeSecurityMessages(msgs)
+		byThread := map[string][]state.Message{}
+		for _, msg := range msgs {
+			if strings.HasPrefix(msg.Thread, "gate/") {
+				byThread[msg.Thread] = append(byThread[msg.Thread], msg)
+			}
+		}
+		for thread, threadMsgs := range byThread {
+			inspect := notifyInspectCommand(projectDir, profile, sess.Name, thread)
+			selfItem := operatorAttention{EventType: "self_approved", Key: attention.SelfApprovedKey(profile, sess.Name, thread), Profile: profile, Session: sess.Name, NamespaceID: sess.NamespaceID, Thread: thread, Cleared: true, Inspect: inspect}
+			humanItem := operatorAttention{EventType: "human_only_gate", Key: attention.HumanOnlyGateKey(profile, sess.Name, thread), Profile: profile, Session: sess.Name, NamespaceID: sess.NamespaceID, Thread: thread, Cleared: true, Inspect: inspect}
+			var q *state.Message
+			for i := range threadMsgs {
+				if threadMsgs[i].Kind == state.KindQuestion && (q == nil || messageAfter(threadMsgs[i], *q)) {
+					c := threadMsgs[i]
+					q = &c
+				}
+			}
+			if q == nil {
+				out = append(out, selfItem, humanItem)
+				continue
+			}
+			selfItem.LatestID = q.ID
+			humanItem.LatestID = q.ID
+			selfItem.LastEventAt = q.Created
+			humanItem.LastEventAt = q.Created
+			binding, bindErr := operatorauth.ParseStrictBinding(q.Subject + "\n" + q.Body)
+			humanItem.GateKind = binding.GateKind
+			humanItem.Subject = q.Subject
+			humanItem.Kind = q.Kind
+			if conflict || bindErr != nil {
+				humanItem.Cleared = false
+				humanItem.Summary = "conflicting or malformed gate state requires human attention"
+				out = append(out, selfItem, humanItem)
+				continue
+			}
+			action, target := operatorauth.NormalizeAction(binding.Action), binding.Target
+			facts := []operatorauth.MessageFact{}
+			for i, msg := range threadMsgs {
+				if msg.From != team.EffectiveOperator(t).Handle || !messageAfter(msg, *q) {
+					continue
+				}
+				decision, bound := actionDecisionPending, false
+				if msg.Kind == state.KindAnswer && strictBindingMatches(msg.Subject+"\n"+msg.Body, action, target) {
+					decision = classifyDecision(msg.Subject + "\n" + msg.Body)
+					bound = decision == actionDecisionApproved || decision == actionDecisionDenied
+				}
+				if msg.ApprovalPresent {
+					bound = bound && validTypedHumanApproval(msg, team.EffectiveOperator(t).Handle, q.ID, binding, action, target)
+				}
+				facts = append(facts, operatorauth.MessageFact{ID: msg.ID, From: msg.From, Decision: decision, Bound: bound, After: true, Order: int64(i + 1)})
+			}
+			precedence := operatorauth.ResolvePrecedence(facts, team.EffectiveOperator(t).Handle, view.LeadHandle)
+			if precedence.Decision == actionDecisionApproved || precedence.Decision == actionDecisionDenied {
+				out = append(out, selfItem, humanItem)
+				continue
+			}
+			if precedence.Barrier {
+				humanItem.Cleared = false
+				humanItem.Summary = "human intervention pending; inspect durable gate"
+				out = append(out, selfItem, humanItem)
+				continue
+			}
+			var answer *state.Message
+			for i := range threadMsgs {
+				m := threadMsgs[i]
+				if m.Kind == state.KindAnswer && m.From == view.LeadHandle && messageAfter(m, *q) && (answer == nil || messageAfter(m, *answer)) {
+					c := m
+					answer = &c
+				}
+			}
+			allowed := view.Enabled && binding.GateKind == operatorauth.GateMerge && operatorauth.Evaluate(binding.GateKind, action, view.AllowedGateKinds) == nil
+			validSelf := false
+			if allowed && answer != nil && answer.ApprovalValid && answer.Approval != nil {
+				a := *answer.Approval
+				validSelf = answer.From == view.LeadHandle && a.Source == "self_operator" && a.SelfApproved && a.AnsweredByRole == view.LeadRole && a.AnsweredByHandle == view.LeadHandle && a.QuestionMessageID == q.ID && a.GateKind == binding.GateKind && operatorauth.NormalizeAction(a.Action) == action && a.Target == target && a.PolicyRevision == view.PolicyRevision && a.PolicyHash == view.PolicyHash && validateSelfApprovalReceipt(projectDir, profile, sess.Name, thread, answer.ID, a) == nil && revalidateSelfApprovalEvidence(projectDir, a, target) == nil
+				if validSelf {
+					selfItem.Cleared = false
+					selfItem.LatestID = answer.ID
+					selfItem.Actor = a.AnsweredByHandle
+					selfItem.GateKind = a.GateKind
+					selfItem.PolicyRevision = a.PolicyRevision
+					selfItem.Subject = answer.Subject
+					selfItem.Summary = "self-approved gate observed; human may inspect, intervene, or revoke"
+				}
+			}
+			if !validSelf && (!allowed || answer != nil) {
+				humanItem.Cleared = false
+				humanItem.Summary = "human-only gate requires operator attention; notification does not authorize an answer"
+			}
+			out = append(out, selfItem, humanItem)
+		}
+	}
+	return out
+}
+
+func maxDuration(a, b time.Duration) time.Duration {
+	if b > a {
+		return b
+	}
+	return a
+}
+
 func collectLocalInputAttention(t team.Team, profile, session string, now time.Time) []operatorAttention {
 	if strings.TrimSpace(session) == "" {
 		return nil
@@ -698,6 +831,32 @@ func notifyUnreadBy(th state.ThreadSummary, handle string) bool {
 	return false
 }
 
+func scopedSelfOperatorTombstones(items []operatorAttention, prior notifyStateFile, profile, session string) []operatorAttention {
+	present := map[string]bool{}
+	for _, item := range items {
+		present[item.Key] = true
+	}
+	prefix := squadnamespace.NormalizeProfile(profile) + "/"
+	if session != "" {
+		prefix += session + "\x00"
+	}
+	for key := range prior.Items {
+		if present[key] || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		kind := ""
+		if strings.Contains(key, "\x00self_approved\x00") {
+			kind = "self_approved"
+		} else if strings.Contains(key, "\x00human_only_gate\x00") {
+			kind = "human_only_gate"
+		}
+		if kind != "" {
+			items = append(items, operatorAttention{EventType: kind, Key: key, Cleared: true})
+		}
+	}
+	return items
+}
+
 func selectNotifications(items []operatorAttention, prior notifyStateFile, renotifyAfter time.Duration, now time.Time) ([]operatorAttention, int, notifyStateFile) {
 	next := notifyStateFile{Schema: 2, Items: map[string]notifyStateRecord{}}
 	for key, rec := range prior.Items {
@@ -710,10 +869,14 @@ func selectNotifications(items []operatorAttention, prior notifyStateFile, renot
 		if item.Cleared {
 			rec.Active = false
 			rec.LastObserved = now
+			for id, d := range rec.Deliveries {
+				d.Fingerprint = ""
+				rec.Deliveries[id] = d
+			}
 			next.Items[item.Key] = rec
 			continue
 		}
-		notify := rec.LatestID != item.LatestID || rec.LastNotified.IsZero()
+		notify := !rec.Active || rec.LatestID != item.LatestID || rec.LastNotified.IsZero()
 		if !notify && operatorAttentionEscalated(item, rec) {
 			notify = true
 		}
@@ -864,16 +1027,28 @@ func notifyKey(profile, session, thread string) string {
 
 func deliverNotificationSinks(ctx context.Context, projectDir string, items []operatorAttention, policy team.OperatorNotificationPolicy, st notifyStateFile, renotify time.Duration, now time.Time, force bool) ([]notifier.Result, notifyStateFile) {
 	events := make([]attention.Event, 0, len(items))
+	allowed := map[string]bool{}
+	for _, kind := range policy.Events {
+		allowed[kind] = true
+	}
+	if len(allowed) == 0 {
+		for _, kind := range []string{"gate", "local_input_blocked", "self_approved", "human_only_gate"} {
+			allowed[kind] = true
+		}
+	}
 	for _, item := range items {
 		eventType := item.EventType
 		if eventType == "" {
 			eventType = "gate"
 		}
+		if !allowed[eventType] {
+			continue
+		}
 		summary := item.Summary
 		if summary == "" {
 			summary = "operator answer required"
 		}
-		events = append(events, attention.Event{SchemaVersion: 1, EventType: eventType, Key: item.Key, Fingerprint: item.LatestID, ProjectDir: projectDir, Profile: item.Profile, Session: item.Session, Thread: item.Thread, Role: item.Role, Subject: item.Subject, Summary: summary, Escalation: item.Escalation, Age: item.Age, InspectCommand: item.Inspect, AttentionOnly: true, ObservedAt: now, Cleared: item.Cleared})
+		events = append(events, attention.Event{SchemaVersion: 1, EventType: eventType, Key: item.Key, Fingerprint: item.LatestID, ProjectDir: projectDir, Profile: item.Profile, Session: item.Session, Thread: item.Thread, Role: item.Role, GateKind: item.GateKind, Actor: item.Actor, PolicyRevision: item.PolicyRevision, Subject: item.Subject, Summary: summary, Escalation: item.Escalation, Age: item.Age, InspectCommand: item.Inspect, AttentionOnly: true, ObservedAt: now, Cleared: item.Cleared})
 	}
 	state2 := attention.State{Schema: 2, Items: map[string]attention.Item{}}
 	for key, rec := range st.Items {

--- a/internal/cli/notify_delivery_test.go
+++ b/internal/cli/notify_delivery_test.go
@@ -23,6 +23,28 @@ type deliveryFakeSink struct {
 	calls *int
 }
 
+func TestSelfOperatorEventDeliveryFilterAndRetry(t *testing.T) {
+	old := notificationSinkFactory
+	defer func() { notificationSinkFactory = old }()
+	calls := 0
+	notificationSinkFactory = func(c team.OperatorNotificationSinkConfig) notifier.Sink { return deliveryFakeSink{c.ID, nil, &calls} }
+	p := team.OperatorNotificationPolicy{Enabled: true, Events: []string{"self_approved"}, Sinks: []team.OperatorNotificationSinkConfig{{ID: "desktop", Type: "desktop"}}}
+	item := operatorAttention{EventType: "self_approved", Key: attention.SelfApprovedKey("default", "s", "gate/x"), LatestID: "a1", Profile: "default", Session: "s"}
+	res, st := deliverNotificationSinks(context.Background(), "/project", []operatorAttention{item}, p, notifyStateFile{Schema: 2, Items: map[string]notifyStateRecord{}}, time.Hour, time.Now(), false)
+	if len(res) != 1 || calls != 1 {
+		t.Fatalf("new event not delivered: %v calls=%d", res, calls)
+	}
+	res, _ = deliverNotificationSinks(context.Background(), "/project", []operatorAttention{item}, p, st, time.Hour, time.Now().Add(time.Minute), false)
+	if len(res) != 0 || calls != 1 {
+		t.Fatal("new event dedup failed")
+	}
+	p.Events = []string{"gate"}
+	res, _ = deliverNotificationSinks(context.Background(), "/project", []operatorAttention{item}, p, notifyStateFile{Schema: 2, Items: map[string]notifyStateRecord{}}, time.Hour, time.Now(), false)
+	if len(res) != 0 {
+		t.Fatal("event filter ignored")
+	}
+}
+
 type atomicDeliverySink struct{ calls *int32 }
 
 func (atomicDeliverySink) ID() string { return "desktop" }

--- a/internal/cli/notify_self_operator_test.go
+++ b/internal/cli/notify_self_operator_test.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/attention"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func TestCollectSelfOperatorVisibilityCurrentStateAndClear(t *testing.T) {
+	project, cfg, target, msgs := selfVerifyFixture(t)
+	root := filepath.Join(project, "mail", "s")
+	for _, m := range msgs {
+		writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", m.From), "cur", m, m.Approval)
+	}
+	snap := state.Snapshot{Sessions: []state.Session{{Name: "s", TeamProfile: "default", NamespaceID: "default/s", Root: root}}}
+	old := resolveVerifiedOperatorActor
+	t.Cleanup(func() { resolveVerifiedOperatorActor = old })
+	t.Setenv("AM_ME", "qa")
+	resolveVerifiedOperatorActor = func(_, profile, session, role, handle string) (verifiedOperatorActor, error) {
+		return verifiedOperatorActor{Role: role, Handle: handle}, nil
+	}
+	before := decideVerifyActionWithPolicy(msgs, "gate/merge-398", "protected_branch_push", target, "user", cfg, "s", project, "default")
+	items := collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now())
+	after := decideVerifyActionWithPolicy(msgs, "gate/merge-398", "protected_branch_push", target, "user", cfg, "s", project, "default")
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("collection changed authorization: before=%+v after=%+v", before, after)
+	}
+	if !attentionState(items, "self_approved", false) || !attentionState(items, "human_only_gate", true) {
+		t.Fatalf("valid self state=%+v", items)
+	}
+	answer := state.Message{ID: "h1", From: "user", Thread: "gate/merge-398", Kind: state.KindAnswer, Subject: "DENIED: merge", Body: "Gate-Kind: merge\nAction: protected_branch_push\nTarget: " + target, Created: time.Now().Add(time.Minute)}
+	writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", "user"), "cur", answer, nil)
+	items = collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now().Add(2*time.Minute))
+	if !attentionState(items, "self_approved", true) || !attentionState(items, "human_only_gate", true) {
+		t.Fatalf("resolved denial did not clear=%+v", items)
+	}
+}
+
+func TestCollectHumanOnlyGateConflictAndReopen(t *testing.T) {
+	project := t.TempDir()
+	root := filepath.Join(project, "mail", "s")
+	op := team.DefaultOperator()
+	op.InteractionMode = team.OperatorInteractionSelfOperator
+	op.SelfOperator = &team.SelfOperatorPolicy{LeadRole: "cto", PolicyRevision: 1, Sessions: map[string]team.SelfOperatorSessionPolicy{"s": {Enabled: true, AllowedGateKinds: []string{"merge"}}}}
+	cfg := team.Team{Project: project, Operator: &op, Orchestrated: true, Lead: "cto", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex"}}}
+	q := state.Message{ID: "q1", From: "cto", Thread: "gate/spawn", Kind: state.KindQuestion, Subject: "APPROVAL: spawn", Body: "Gate-Kind: spawn\nAction: spawn\nTarget: worker qa", Created: time.Now()}
+	writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", "cto"), "cur", q, nil)
+	snap := state.Snapshot{Sessions: []state.Session{{Name: "s", TeamProfile: "default", NamespaceID: "default/s", Root: root}}}
+	items := collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now())
+	if !attentionState(items, "human_only_gate", false) {
+		t.Fatalf("pending human-only missing=%+v", items)
+	}
+	q.Subject = "conflict"
+	writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", "qa"), "cur", q, nil)
+	items = collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now())
+	if !attentionState(items, "human_only_gate", false) {
+		t.Fatal("conflict failed open")
+	}
+	_ = os.Remove(filepath.Join(root, "agents", "qa", "inbox", "cur", "q1.md"))
+	a := state.Message{ID: "a1", From: "user", Thread: "gate/spawn", Kind: state.KindAnswer, Subject: "APPROVED: spawn", Body: "Gate-Kind: spawn\nAction: spawn\nTarget: worker qa", Created: time.Now().Add(time.Minute)}
+	writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", "user"), "cur", a, nil)
+	items = collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now())
+	if !attentionState(items, "human_only_gate", true) {
+		t.Fatalf("resolved did not clear=%+v", items)
+	}
+}
+
+func attentionState(items []operatorAttention, kind string, cleared bool) bool {
+	for _, i := range items {
+		if i.EventType == kind && i.Cleared == cleared {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSelfOperatorEventSelectClearReopen(t *testing.T) {
+	now := time.Now()
+	key := "default/s\x00self_approved\x00gate/x"
+	active := operatorAttention{EventType: "self_approved", Key: key, LatestID: "a1"}
+	sel, _, st := selectNotifications([]operatorAttention{active}, notifyStateFile{Schema: 2, Items: map[string]notifyStateRecord{}}, time.Hour, now)
+	if len(sel) != 1 || !st.Items[key].Active {
+		t.Fatal("initial event not selected")
+	}
+	_, _, st = selectNotifications([]operatorAttention{{EventType: "self_approved", Key: key, LatestID: "a1", Cleared: true}}, st, time.Hour, now.Add(time.Minute))
+	if st.Items[key].Active {
+		t.Fatal("clear remained active")
+	}
+	sel, _, st = selectNotifications([]operatorAttention{active}, st, time.Hour, now.Add(2*time.Minute))
+	if len(sel) != 1 || !st.Items[key].Active {
+		t.Fatal("same-fingerprint reopen not selected")
+	}
+}
+
+func TestScopedSelfOperatorTombstonesModeFlipAndRemoval(t *testing.T) {
+	self := attention.SelfApprovedKey("default", "s", "gate/x")
+	human := attention.HumanOnlyGateKey("default", "s", "gate/x")
+	other := attention.SelfApprovedKey("other", "s", "gate/x")
+	prior := notifyStateFile{Schema: 2, Items: map[string]notifyStateRecord{self: {Active: true}, human: {Active: true}, other: {Active: true}}}
+	items := scopedSelfOperatorTombstones(nil, prior, "default", "s")
+	if !attentionState(items, "self_approved", true) || !attentionState(items, "human_only_gate", true) || len(items) != 2 {
+		t.Fatalf("scope tombstones=%+v", items)
+	}
+	_, _, next := selectNotifications(items, prior, time.Hour, time.Now())
+	if next.Items[self].Active || next.Items[human].Active || !next.Items[other].Active {
+		t.Fatalf("scope clear=%+v", next.Items)
+	}
+}
+
+func TestCollectSelfApprovalAdversarialTable(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string, *team.Team, string, *[]state.Message)
+	}{
+		{"wrong sender", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) { (*m)[1].From = "qa" }},
+		{"wrong typed role", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			(*m)[1].Approval.AnsweredByRole = "qa"
+		}},
+		{"stale question id", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			(*m)[1].Approval.QuestionMessageID = "old"
+		}},
+		{"wrong binding", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			(*m)[1].Approval.Target = "PR #398 head deadbee into main"
+		}},
+		{"newer question", func(_ *testing.T, _ string, _ *team.Team, target string, m *[]state.Message) {
+			*m = append(*m, state.Message{ID: "q2", From: "cto", Thread: "gate/merge-398", Kind: state.KindQuestion, Body: "Gate-Kind: merge\nAction: protected_branch_push\nTarget: " + target, Created: time.Now().Add(time.Hour)})
+		}},
+		{"paused", func(_ *testing.T, _ string, c *team.Team, _ string, _ *[]state.Message) {
+			e := c.Operator.SelfOperator.Sessions["s"]
+			e.Paused = true
+			c.Operator.SelfOperator.Sessions["s"] = e
+		}},
+		{"disabled", func(_ *testing.T, _ string, c *team.Team, _ string, _ *[]state.Message) {
+			e := c.Operator.SelfOperator.Sessions["s"]
+			e.Enabled = false
+			c.Operator.SelfOperator.Sessions["s"] = e
+		}},
+		{"stale revision", func(_ *testing.T, _ string, c *team.Team, _ string, _ *[]state.Message) {
+			c.Operator.SelfOperator.PolicyRevision++
+		}},
+		{"stale hash", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			(*m)[1].Approval.PolicyHash = "sha256:stale"
+		}},
+		{"wrong session", func(_ *testing.T, _ string, c *team.Team, _ string, _ *[]state.Message) {
+			e := c.Operator.SelfOperator.Sessions["s"]
+			delete(c.Operator.SelfOperator.Sessions, "s")
+			c.Operator.SelfOperator.Sessions["other"] = e
+		}},
+		{"missing receipt", func(t *testing.T, p string, _ *team.Team, _ string, _ *[]state.Message) {
+			path := filepath.Join(selfApprovalStoreDir(p, "default", "s"), safeGateFile("gate/merge-398")+"-a1.receipt.json")
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"tampered receipt", func(t *testing.T, p string, _ *team.Team, _ string, _ *[]state.Message) {
+			path := filepath.Join(selfApprovalStoreDir(p, "default", "s"), safeGateFile("gate/merge-398")+"-a1.receipt.json")
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = f.WriteString("{}")
+			_ = f.Close()
+		}},
+		{"tampered evidence", func(t *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			f, err := os.OpenFile((*m)[1].Approval.PreflightPath, os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _ = f.WriteString(" ")
+			_ = f.Close()
+		}},
+		{"human approval", func(_ *testing.T, _ string, _ *team.Team, target string, m *[]state.Message) {
+			*m = append(*m, state.Message{ID: "h1", From: "user", Thread: "gate/merge-398", Kind: state.KindAnswer, Subject: "APPROVED: merge", Body: "Gate-Kind: merge\nAction: protected_branch_push\nTarget: " + target, Created: time.Now().Add(time.Hour)})
+		}},
+		{"human barrier", func(_ *testing.T, _ string, _ *team.Team, _ string, m *[]state.Message) {
+			*m = append(*m, state.Message{ID: "h1", From: "user", Thread: "gate/merge-398", Kind: state.KindStatus, Subject: "hold", Created: time.Now().Add(time.Hour)})
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			project, cfg, target, msgs := selfVerifyFixture(t)
+			tc.mutate(t, project, &cfg, target, &msgs)
+			root := filepath.Join(project, "mail", "s")
+			for _, m := range msgs {
+				writeSelfApprovalTestMessage(t, filepath.Join(root, "agents", m.From), "cur", m, m.Approval)
+			}
+			snap := state.Snapshot{Sessions: []state.Session{{Name: "s", TeamProfile: "default", NamespaceID: "default/s", Root: root}}}
+			items := collectSelfOperatorVisibilityAttention(cfg, project, "default", snap, "s", time.Now().Add(2*time.Hour))
+			if attentionState(items, "self_approved", false) {
+				t.Fatalf("invalid self approval emitted: %+v", items)
+			}
+			for _, i := range items {
+				if i.EventType == "self_approved" && i.Key == attention.HumanOnlyGateKey("default", "s", i.Thread) {
+					t.Fatal("event keys collided")
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/operator_mode.go
+++ b/internal/cli/operator_mode.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
@@ -11,9 +10,6 @@ func validateCanonicalOperatorMode(raw string) (string, error) {
 	mode := strings.TrimSpace(raw)
 	if err := team.ValidateOperatorInteractionMode(mode); err != nil {
 		return "", err
-	}
-	if mode == team.OperatorInteractionSelfOperator {
-		return "", fmt.Errorf("operator interaction mode %q is not available; delegated self-approval ships with #391 and no authorization behavior is enabled", mode)
 	}
 	return mode, nil
 }

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -198,7 +198,8 @@ Usage:
   amq-squad run start -p PROJECT -s SESSION [--profile P] [--lead ROLE]
       [--roles "a,b,c"] [--binary "role=bin,..."] [--model "role=model,..."]
       [--effort "role=level,..."]
-      [--operator-mode lead_pane|separate_terminal|noc]
+      [--operator-mode lead_pane|separate_terminal|noc|self_operator]
+      [--self-operator-lead ROLE --self-operator-allow merge]
       [--operator-notifications]
       [--lead-mode builder|planner]
       [--codex-args "..."] [--claude-args "..."]
@@ -228,9 +229,10 @@ binary via --binary and model via --model. --effort normalizes role-specific
 values into the existing per-member CodexArgs or ClaudeArgs fields. For an
 existing profile it is launch-only and never rewrites stored member args; it
 adds no persisted effort field or launch semantics.
-Operator mode accepts lead_pane, separate_terminal, or noc. The forward-known
-self_operator mode remains unavailable until #391 supplies its authorization
-policy.
+Operator mode accepts lead_pane, separate_terminal, noc, or self_operator.
+Fresh self_operator profiles require --self-operator-lead and the explicit
+merge-only --self-operator-allow; no default is inferred and spawn remains
+human-only.
 --operator-notifications is an independent fresh-profile add-on. It configures
 attention-only desktop delivery and never changes who may answer or approve a
 gate. Existing profiles remain authoritative and are never rewritten.
@@ -287,7 +289,9 @@ func runRunStart(args []string, version string) error {
 	binaryFlag := fs.String("binary", "", "per-role binary assignments, e.g. \"fullstack=codex,qa=codex\"")
 	modelFlag := fs.String("model", "", "per-role model overrides, e.g. \"cto=gpt-5.6-sol,fullstack=sonnet\"")
 	effortFlag := fs.String("effort", "", "per-role effort, e.g. \"cto=high,qa=medium\" (launch-only for existing profiles; normalized into native member args)")
-	operatorModeFlag := fs.String("operator-mode", "", "operator interaction contract: lead_pane, separate_terminal, or noc (self_operator is reserved for #391)")
+	operatorModeFlag := fs.String("operator-mode", "", "operator interaction contract: lead_pane, separate_terminal, noc, or self_operator")
+	selfOperatorLeadFlag := fs.String("self-operator-lead", "", "lead role delegated for exact-session self-operator policy")
+	selfOperatorAllowFlag := fs.String("self-operator-allow", "", "explicit self-operator allowlist (v2.19: merge only)")
 	operatorNotifications := fs.Bool("operator-notifications", false, "enable attention-only operator notifications for a newly created profile")
 	codexArgsFlag := fs.String("codex-args", "", "extra args for every Codex member (e.g. reasoning effort)")
 	claudeArgsFlag := fs.String("claude-args", "", "extra args for every Claude member")
@@ -316,11 +320,15 @@ func runRunStart(args []string, version string) error {
 		Binary:                   *binaryFlag,
 		Visibility:               *visibilityFlag,
 		LeadMode:                 *leadModeFlag,
+		Lead:                     *leadFlag,
 		LeadModeSet:              flagWasSet(fs, "lead-mode"),
 		Effort:                   *effortFlag,
 		EffortSet:                flagWasSet(fs, "effort"),
 		OperatorMode:             *operatorModeFlag,
 		OperatorModeSet:          flagWasSet(fs, "operator-mode"),
+		SelfOperatorLead:         *selfOperatorLeadFlag,
+		SelfOperatorAllow:        *selfOperatorAllowFlag,
+		SelfOperatorPolicySet:    flagWasSet(fs, "self-operator-lead") || flagWasSet(fs, "self-operator-allow"),
 		OperatorNotifications:    *operatorNotifications,
 		OperatorNotificationsSet: flagWasSet(fs, "operator-notifications"),
 		LayoutPreset:             *layoutPresetFlag,
@@ -398,6 +406,12 @@ func runRunStart(args []string, version string) error {
 		}
 		if flagWasSet(fs, "operator-mode") {
 			newTeamArgs = append(newTeamArgs, "--operator-mode", strings.TrimSpace(*operatorModeFlag))
+		}
+		if flagWasSet(fs, "self-operator-lead") {
+			newTeamArgs = append(newTeamArgs, "--self-operator-lead", strings.TrimSpace(*selfOperatorLeadFlag))
+		}
+		if flagWasSet(fs, "self-operator-allow") {
+			newTeamArgs = append(newTeamArgs, "--self-operator-allow", strings.TrimSpace(*selfOperatorAllowFlag))
 		}
 		if *operatorNotifications {
 			newTeamArgs = append(newTeamArgs, "--operator-notifications")

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -700,9 +700,9 @@ func TestRunStartExistingOperatorModeValidationDoesNotMutateOrForward(t *testing
 	}
 }
 
-func TestRunStartRejectsUnavailableSelfOperatorMode(t *testing.T) {
+func TestRunStartSelfOperatorRequiresExplicitPolicy(t *testing.T) {
 	err := runRunStart([]string{"-p", t.TempDir(), "-s", "sess", "--roles", "cto", "--operator-mode", "self_operator"}, "test")
-	if err == nil || !strings.Contains(err.Error(), "#391") {
+	if err == nil || !strings.Contains(err.Error(), "exact-session") {
 		t.Fatalf("self_operator error = %v", err)
 	}
 }

--- a/internal/cli/run_start_discovery.go
+++ b/internal/cli/run_start_discovery.go
@@ -193,6 +193,12 @@ func runStartWizardProfiles(project string) ([]runwizard.ProfileSummary, error) 
 			OperatorMode:          team.EffectiveOperator(t).InteractionMode,
 			OperatorNotifications: team.EffectiveOperatorNotifications(t.Operator).Enabled,
 		}
+		if view := team.EffectiveSelfOperator(t, runStartPinnedSession(t)); t.Operator != nil && t.Operator.InteractionMode == team.OperatorInteractionSelfOperator {
+			summary.SelfOperatorLead = view.LeadRole
+			summary.SelfOperatorAllow = strings.Join(view.AllowedGateKinds, ",")
+			summary.SelfOperatorRevision = view.PolicyRevision
+			summary.SelfOperatorPaused = view.Paused
+		}
 		for _, member := range t.Members {
 			summary.Members = append(summary.Members, runwizard.MemberSummary{
 				Role:   member.Role,

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -37,11 +37,15 @@ type runStartPreflightInput struct {
 	Binary                   string
 	Visibility               string
 	LeadMode                 string
+	Lead                     string
 	LeadModeSet              bool
 	Effort                   string
 	EffortSet                bool
 	OperatorMode             string
 	OperatorModeSet          bool
+	SelfOperatorLead         string
+	SelfOperatorAllow        string
+	SelfOperatorPolicySet    bool
 	OperatorNotifications    bool
 	OperatorNotificationsSet bool
 	LayoutPreset             string
@@ -170,7 +174,34 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 	if input.OperatorModeSet {
 		mode, modeErr := validateCanonicalOperatorMode(input.OperatorMode)
 		if modeErr != nil {
-			return add(runStartPreflightInvalidOperatorMode, "invalid --operator-mode: "+modeErr.Error(), "choose lead_pane, separate_terminal, or noc")
+			return add(runStartPreflightInvalidOperatorMode, "invalid --operator-mode: "+modeErr.Error(), "choose lead_pane, separate_terminal, noc, or self_operator")
+		}
+		if mode == team.OperatorInteractionSelfOperator {
+			if r.TeamPresent && !r.FreshRoster {
+				if input.SelfOperatorPolicySet {
+					return add(runStartPreflightExistingOperatorMode, "run start never rewrites an existing self-operator policy", "omit self-operator policy flags and use the authoritative profile", "use amq-squad team operator set to change policy")
+				}
+				existing, readErr := team.ReadProfile(r.Project, r.Profile)
+				if readErr != nil {
+					return add(runStartPreflightExistingOperatorMode, readErr.Error())
+				}
+				view := team.EffectiveSelfOperator(existing, r.Session)
+				if view.LeadRole == "" || len(view.AllowedGateKinds) == 0 {
+					return add(runStartPreflightExistingOperatorMode, "existing self_operator profile has no exact-session policy; run start fails closed", "use amq-squad team operator set for this exact session")
+				}
+			} else {
+				allow := splitCSV(input.SelfOperatorAllow)
+				if strings.TrimSpace(input.SelfOperatorLead) == "" || len(allow) != 1 || allow[0] != "merge" {
+					return add(runStartPreflightInvalidOperatorMode, "self_operator requires an exact-session lead and explicit merge-only allowlist; spawn remains human-only", "pass --self-operator-lead <lead> --self-operator-allow merge")
+				}
+				wantLead := strings.TrimSpace(input.Lead)
+				if wantLead == "" {
+					wantLead = "cto"
+				}
+				if strings.TrimSpace(input.SelfOperatorLead) != wantLead {
+					return add(runStartPreflightInvalidOperatorMode, "self-operator lead must equal the configured fresh-roster lead")
+				}
+			}
 		}
 		if r.TeamPresent && !r.FreshRoster {
 			existing, readErr := team.ReadProfile(r.Project, r.Profile)
@@ -183,6 +214,24 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 					fmt.Sprintf("--operator-mode %s does not match existing profile %q interaction mode %s; run start never rewrites an existing operator contract", mode, r.Profile, persisted),
 					"omit --operator-mode to use the existing profile contract",
 					"create a new named profile with the requested operator mode")
+			}
+		}
+	}
+	if input.SelfOperatorPolicySet && !input.OperatorModeSet {
+		return add(runStartPreflightInvalidOperatorMode, "self-operator policy flags require --operator-mode self_operator")
+	}
+	if input.SelfOperatorPolicySet && input.OperatorModeSet && strings.TrimSpace(input.OperatorMode) != team.OperatorInteractionSelfOperator {
+		return add(runStartPreflightInvalidOperatorMode, "self-operator policy flags require --operator-mode self_operator")
+	}
+	if r.TeamPresent && !r.FreshRoster {
+		existing, readErr := team.ReadProfile(r.Project, r.Profile)
+		if readErr != nil {
+			return add(runStartPreflightExistingOperatorMode, readErr.Error())
+		}
+		if team.EffectiveOperator(existing).InteractionMode == team.OperatorInteractionSelfOperator {
+			view := team.EffectiveSelfOperator(existing, r.Session)
+			if view.LeadRole == "" || len(view.AllowedGateKinds) == 0 {
+				return add(runStartPreflightExistingOperatorMode, "existing self_operator profile has no exact-session policy; run start fails closed", "use amq-squad team operator set for this exact session")
 			}
 		}
 	}

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -286,11 +286,15 @@ func finishRunStartWizard(spec runwizard.Spec, version string, in io.Reader, out
 		Binary:                   spec.Binary,
 		Visibility:               spec.Visibility,
 		LeadMode:                 spec.LeadMode,
+		Lead:                     spec.Lead,
 		LeadModeSet:              strings.TrimSpace(spec.LeadMode) != "",
 		Effort:                   spec.Effort,
 		EffortSet:                strings.TrimSpace(spec.Effort) != "",
 		OperatorMode:             spec.OperatorMode,
 		OperatorModeSet:          strings.TrimSpace(spec.OperatorMode) != "" && strings.TrimSpace(spec.OperatorMode) != team.OperatorInteractionUnspecified,
+		SelfOperatorLead:         spec.SelfOperatorLead,
+		SelfOperatorAllow:        spec.SelfOperatorAllow,
+		SelfOperatorPolicySet:    strings.TrimSpace(spec.SelfOperatorLead) != "" || strings.TrimSpace(spec.SelfOperatorAllow) != "",
 		OperatorNotifications:    spec.OperatorNotificationsRequested,
 		OperatorNotificationsSet: spec.OperatorNotificationsSet,
 		LayoutPreset:             spec.LayoutPreset,
@@ -467,6 +471,8 @@ func parseRunStartWizardPrefill(args []string) (runwizard.Spec, error) {
 	model := fs.String("model", "", "")
 	effort := fs.String("effort", "", "")
 	operatorMode := fs.String("operator-mode", "", "")
+	selfOperatorLead := fs.String("self-operator-lead", "", "")
+	selfOperatorAllow := fs.String("self-operator-allow", "", "")
 	operatorNotifications := fs.Bool("operator-notifications", false, "")
 	codexArgs := fs.String("codex-args", "", "")
 	claudeArgs := fs.String("claude-args", "", "")
@@ -501,6 +507,8 @@ func parseRunStartWizardPrefill(args []string) (runwizard.Spec, error) {
 		Model:                          *model,
 		Effort:                         *effort,
 		OperatorMode:                   *operatorMode,
+		SelfOperatorLead:               *selfOperatorLead,
+		SelfOperatorAllow:              *selfOperatorAllow,
 		OperatorNotifications:          *operatorNotifications,
 		OperatorNotificationsRequested: *operatorNotifications,
 		OperatorNotificationsSet:       flagWasSet(fs, "operator-notifications"),

--- a/internal/cli/self_operator_pr2_test.go
+++ b/internal/cli/self_operator_pr2_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func TestRunStartPreflightSelfOperatorExactPolicy(t *testing.T) {
+	dir := t.TempDir()
+	base := runStartPreflightInput{Project: dir, Profile: "default", Session: "s", Roles: "cto", Lead: "cto", OperatorMode: "self_operator", OperatorModeSet: true, SelfOperatorLead: "cto", SelfOperatorAllow: "merge", SelfOperatorPolicySet: true}
+	if got := runStartPreflight(base); got.Err() != nil {
+		t.Fatalf("valid policy: %v", got.Err())
+	}
+	base.SelfOperatorAllow = "spawn"
+	if got := runStartPreflight(base); got.Err() == nil || !strings.Contains(got.Err().Error(), "spawn remains human-only") {
+		t.Fatalf("spawn policy = %v", got.Err())
+	}
+}
+
+func TestTeamInitWritesExactSessionSelfOperatorPolicy(t *testing.T) {
+	dir := t.TempDir()
+	if err := runTeam([]string{"init", "--project", dir, "--roles", "cto", "--session", "s", "--orchestrated", "--lead", "cto", "--operator-mode", "self_operator", "--self-operator-lead", "cto", "--self-operator-allow", "merge"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	view := team.EffectiveSelfOperator(cfg, "s")
+	if !view.Enabled || view.LeadRole != "cto" || strings.Join(view.AllowedGateKinds, ",") != "merge" || team.EffectiveSelfOperator(cfg, "other").Enabled {
+		t.Fatalf("policy=%+v other=%+v", view, team.EffectiveSelfOperator(cfg, "other"))
+	}
+}
+
+func TestRunStartExistingSelfOperatorUsesAuthoritativeExactSessionPolicy(t *testing.T) {
+	dir := t.TempDir()
+	op := team.DefaultOperator()
+	op.InteractionMode = team.OperatorInteractionSelfOperator
+	op.SelfOperator = &team.SelfOperatorPolicy{LeadRole: "cto", PolicyRevision: 2, Sessions: map[string]team.SelfOperatorSessionPolicy{"s": {Enabled: true, AllowedGateKinds: []string{"merge"}}}}
+	if err := team.Write(dir, team.Team{Operator: &op, Orchestrated: true, Lead: "cto", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "s"}}}); err != nil {
+		t.Fatal(err)
+	}
+	input := runStartPreflightInput{Project: dir, Profile: "default", Session: "s", OperatorMode: "self_operator", OperatorModeSet: true}
+	if got := runStartPreflight(input); got.Err() != nil {
+		t.Fatalf("authoritative policy rejected: %v", got.Err())
+	}
+	input.Session = "other"
+	if got := runStartPreflight(input); got.Err() == nil {
+		t.Fatalf("missing exact policy unexpectedly passed")
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -117,8 +117,10 @@ type statusWarning struct {
 
 type statusOperatorView struct {
 	team.OperatorView
-	CanonicalInbox *statusOperatorInbox `json:"canonical_inbox,omitempty"`
-	Poll           *statusOperatorPoll  `json:"poll,omitempty"`
+	SelfOperator            *team.EffectiveSelfOperatorView `json:"self_operator,omitempty"`
+	VisibilityNotifications bool                            `json:"visibility_notifications"`
+	CanonicalInbox          *statusOperatorInbox            `json:"canonical_inbox,omitempty"`
+	Poll                    *statusOperatorPoll             `json:"poll,omitempty"`
 }
 
 type statusOperatorInbox struct {
@@ -413,6 +415,13 @@ func executeStatus(s statusExecution) error {
 	delivery := operatorDeliveryForTeam(t)
 	if delivery.Enabled {
 		fmt.Fprintf(s.Out, "# operator_delivery: %s\n", operatorDeliverySummary(delivery))
+	}
+	if delivery.InteractionMode == team.OperatorInteractionSelfOperator {
+		v := team.EffectiveSelfOperator(t, workstream)
+		fmt.Fprintf(s.Out, "# self_operator: lead=%s/%s allow=%s revision=%d enabled=%t paused=%t hash=%s visibility_notifications=%t human_only=spawn,release,tag,publish,external_send,destructive_filesystem\n", v.LeadRole, v.LeadHandle, strings.Join(v.AllowedGateKinds, ","), v.PolicyRevision, v.Enabled, v.Paused, v.PolicyHash, delivery.NotificationsEnabled)
+		if !delivery.NotificationsEnabled {
+			fmt.Fprintln(s.Out, "# self_operator_visibility: notifications disabled; inspect durable gate threads manually")
+		}
 	}
 	fmt.Fprintln(s.Out)
 	w := tabwriter.NewWriter(s.Out, 0, 0, 2, ' ', 0)
@@ -732,6 +741,11 @@ func statusOperatorForTeam(t team.Team, ns squadnamespace.Ref) statusOperatorVie
 	op := team.EffectiveOperator(t)
 	contract := team.OperatorContractForMode(op.InteractionMode)
 	out := statusOperatorView{OperatorView: op}
+	if op.InteractionMode == team.OperatorInteractionSelfOperator {
+		view := team.EffectiveSelfOperator(t, ns.Session)
+		out.SelfOperator = &view
+		out.VisibilityNotifications = team.EffectiveOperatorNotifications(t.Operator).Enabled
+	}
 	if !op.Enabled {
 		return out
 	}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -96,7 +96,9 @@ func runTeamInitWithOptions(args []string, opts teamInitRunOptions) error {
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for every Codex member, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for every Claude member, e.g. '--chrome'")
 	operatorFlag := fs.String("operator", team.DefaultOperatorHandle, "virtual operator mailbox handle for human gates (default: user)")
-	operatorModeFlag := fs.String("operator-mode", "", "operator interaction contract: lead_pane, separate_terminal, or noc (self_operator is reserved for #391)")
+	operatorModeFlag := fs.String("operator-mode", "", "operator interaction contract: lead_pane, separate_terminal, noc, or self_operator")
+	selfOperatorLeadFlag := fs.String("self-operator-lead", "", "lead role delegated for exact-session self-operator policy")
+	selfOperatorAllowFlag := fs.String("self-operator-allow", "", "explicit self-operator gate allowlist (v2.19: merge only)")
 	operatorNotifications := fs.Bool("operator-notifications", false, "enable attention-only operator notifications with the default desktop sink")
 	noOperator := fs.Bool("no-operator", false, "disable the virtual operator participant for this profile")
 	orchestratedFlag := fs.Bool("orchestrated", false, "wire the squad for lead-agent orchestration: inject the reporting norm into team-rules.md and mark the lead role")
@@ -122,8 +124,8 @@ func runTeamInitWithOptions(args []string, opts teamInitRunOptions) error {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
 
 Usage:
-  amq-squad team init [--project DIR] [--profile NAME] [--personas id1,id2,...|numbers|all] [--binary persona=cli,...] [--session workstream] [--model role=model,...] [--effort role=level,...] [--trust sandboxed|approve-for-me|trusted] [--operator HANDLE] [--operator-mode lead_pane|separate_terminal|noc] [--operator-notifications] [--no-operator] [--orchestrated [--lead ROLE]] [--lead-mode builder|planner] [--mode project_lead|project_team|direct_lead_session|global_orchestrator] [--composition seeded|autonomous] [--max-agents N --max-total-spawns N --allowed-roles role,... --budget-turns N] [--codex-args args] [--claude-args args] [--dry-run [--json]] [--force]
-  amq-squad team init [--project DIR] [--profile NAME] [--roles id1,id2,...|numbers|all] [--binary role=cli,...] [--session workstream] [--model role=model,...] [--effort role=level,...] [--trust sandboxed|approve-for-me|trusted] [--operator HANDLE] [--operator-mode lead_pane|separate_terminal|noc] [--operator-notifications] [--no-operator] [--orchestrated [--lead ROLE]] [--lead-mode builder|planner] [--mode project_lead|project_team|direct_lead_session|global_orchestrator] [--composition seeded|autonomous] [--max-agents N --max-total-spawns N --allowed-roles role,... --budget-turns N] [--codex-args args] [--claude-args args] [--dry-run [--json]] [--force]
+  amq-squad team init [--project DIR] [--profile NAME] [--personas id1,id2,...|numbers|all] [--session workstream] [--operator-mode lead_pane|separate_terminal|noc|self_operator] [--self-operator-lead ROLE --self-operator-allow merge] [other flags]
+  amq-squad team init [--project DIR] [--profile NAME] [--roles id1,id2,...|numbers|all] [--session workstream] [--operator-mode lead_pane|separate_terminal|noc|self_operator] [--self-operator-lead ROLE --self-operator-allow merge] [other flags]
 
 Without --personas or --roles, prompts interactively: first choose personas,
 then choose the CLI for each persona. Writes the team config under
@@ -151,8 +153,9 @@ The authored document is staged under .amq-squad/roles/<id>.md and seeds that
 agent's role.md at launch.
 
 Operator interaction: --operator-mode accepts lead_pane, separate_terminal,
-or noc. The forward-known self_operator schema value is reserved and cannot be
-selected until #391 supplies its authorization policy.
+noc, or self_operator. Fresh self_operator profiles require an exact
+--self-operator-lead and explicit --self-operator-allow merge. Spawn remains
+human-only and merges require a different verified execution actor.
 --operator-notifications independently enables attention-only delivery through
 the default desktop sink. It never changes the interaction mode or approves a
 gate; run the scoped operator watcher on the host that should show alerts.
@@ -482,6 +485,16 @@ Examples:
 	// default.
 	if executionMode == executionModeGlobalOrchestrator && !flagWasSet(fs, "target-project-root") {
 		return usageErrorf("global_orchestrator requires an explicit --target-project-root: the control root is not the project tree, and amq-squad will not silently use the current directory. Pass the confirmed local checkout path.")
+	}
+	if operator.InteractionMode == team.OperatorInteractionSelfOperator {
+		selfLead := strings.TrimSpace(*selfOperatorLeadFlag)
+		allow := splitCSV(*selfOperatorAllowFlag)
+		if selfLead == "" || selfLead != leadRole || len(allow) != 1 || allow[0] != "merge" {
+			return usageErrorf("self_operator requires --self-operator-lead equal to the configured lead and explicit --self-operator-allow merge; spawn remains human-only")
+		}
+		operator.SelfOperator = &team.SelfOperatorPolicy{LeadRole: selfLead, PolicyRevision: 1, Sessions: map[string]team.SelfOperatorSessionPolicy{workstream: {Enabled: true, AllowedGateKinds: []string{"merge"}}}}
+	} else if flagWasSet(fs, "self-operator-lead") || flagWasSet(fs, "self-operator-allow") {
+		return usageErrorf("--self-operator-lead/--self-operator-allow require --operator-mode self_operator")
 	}
 
 	t := team.Team{

--- a/internal/cli/team_operator_test.go
+++ b/internal/cli/team_operator_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTeamOperatorResumeRejectsDisabledUnpausedSession(t *testing.T) {
+	t.Setenv("TMUX_PANE", "")
 	dir := seedTeam(t, team.Team{Orchestrated: true, Lead: "cto", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "s"}}})
 	cfg, err := team.Read(dir)
 	if err != nil {
@@ -34,6 +35,7 @@ func TestTeamOperatorResumeRejectsDisabledUnpausedSession(t *testing.T) {
 }
 
 func TestTeamOperatorSetPauseResumeRevisionAndModeHistory(t *testing.T) {
+	t.Setenv("TMUX_PANE", "")
 	dir := seedTeam(t, team.Team{Orchestrated: true, Lead: "cto", Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "s"}, {Role: "qa", Handle: "qa", Binary: "codex", Session: "s"}}})
 	if err := runTeamOperator([]string{"set", "--project", dir, "--mode", "self_operator", "--self", "cto", "--session", "s", "--allow", "merge"}); err != nil {
 		t.Fatal(err)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -1046,7 +1046,7 @@ func TestRunTeamInitRejectsOperatorConflicts(t *testing.T) {
 		t.Fatalf("runTeamInit conflicting mode error = %v", err)
 	}
 	err = runTeamInit([]string{"--roles", "cto", "--operator-mode", "self_operator"})
-	if err == nil || !strings.Contains(err.Error(), "#391") {
+	if err == nil || !strings.Contains(err.Error(), "explicit --self-operator-allow merge") {
 		t.Fatalf("runTeamInit self_operator error = %v", err)
 	}
 }

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -251,7 +251,7 @@ func EffectiveOperatorNotifications(op *OperatorConfig) OperatorNotificationPoli
 		p.DeliverySemantics = "attention_only"
 	}
 	if len(p.Events) == 0 {
-		p.Events = []string{"gate", "local_input_blocked"}
+		p.Events = []string{"gate", "local_input_blocked", "self_approved", "human_only_gate"}
 	}
 	if p.Enabled && len(p.Sinks) == 0 {
 		p.Sinks = []OperatorNotificationSinkConfig{{ID: "desktop", Type: "desktop", Timeout: "10s"}}
@@ -276,7 +276,7 @@ func validateOperatorNotifications(op *OperatorConfig) error {
 		return fmt.Errorf("operator.notifications.delivery_semantics: must be attention_only")
 	}
 	for _, event := range p.Events {
-		if event != "gate" && event != "local_input_blocked" {
+		if event != "gate" && event != "local_input_blocked" && event != "self_approved" && event != "human_only_gate" {
 			return fmt.Errorf("operator.notifications.events: unsupported %q", event)
 		}
 	}

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -262,7 +262,7 @@ func TestValidateOperatorInteractionModes(t *testing.T) {
 func TestOperatorNotificationPolicyDefaultsAndValidation(t *testing.T) {
 	op := &OperatorConfig{Enabled: true, Notifications: &OperatorNotificationPolicy{Enabled: true}}
 	p := EffectiveOperatorNotifications(op)
-	if len(p.Events) != 2 || len(p.Sinks) != 1 || p.Sinks[0].ID != "desktop" || p.DeliverySemantics != "attention_only" {
+	if len(p.Events) != 4 || len(p.Sinks) != 1 || p.Sinks[0].ID != "desktop" || p.DeliverySemantics != "attention_only" {
 		t.Fatalf("%+v", p)
 	}
 	base := Team{Operator: op, Members: []Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"}}}

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -27,6 +27,7 @@ const (
 	stageLead
 	stageLeadMode
 	stageOperator
+	stageSelfOperatorAllow
 	stageOperatorNotifications
 	stageTopology
 	stageLayoutPreset
@@ -300,6 +301,8 @@ func (m BubbleModel) title() string {
 		return "Choose the operator interaction contract"
 	case stageOperatorNotifications:
 		return "Choose the independent notification add-on"
+	case stageSelfOperatorAllow:
+		return "Explicit self-operator allowlist"
 	case stageTopology:
 		return "Choose where agents appear"
 	case stageLayoutPreset:
@@ -357,6 +360,8 @@ func (m BubbleModel) note() string {
 			return fmt.Sprintf("Existing profile notification policy is authoritative: %t", m.spec.OperatorNotifications)
 		}
 		return "Attention-only notifications never approve gates or send pane input."
+	case stageSelfOperatorAllow:
+		return "No gate is preselected. Selecting merge opts in explicitly; spawn, release, tag, publish, external send, and destructive filesystem remain human-only. A second verified actor must execute the merge."
 	case stageConfirm:
 		return "Enter collects these answers and runs preview. Live launch is a later default-No prompt."
 	case stageSeed:
@@ -476,7 +481,12 @@ func (m BubbleModel) choices() []choice {
 		return []choice{{value: "builder", label: "Builder · lead may implement and delegate"}, {value: "planner", label: "Planner · lead dispatches and reviews; workers mutate"}}
 	case stageOperator:
 		if m.existingIndex >= 0 {
-			choices := []choice{{value: "continue", label: "Continue with authoritative profile contract · " + defaultString(m.spec.OperatorMode, "unspecified")}}
+			p := m.ctx.Profiles[m.existingIndex]
+			label := "Continue with authoritative profile contract · " + defaultString(m.spec.OperatorMode, "unspecified")
+			if m.spec.OperatorMode == "self_operator" {
+				label += fmt.Sprintf(" · lead=%s allow=%s revision=%d paused=%t notifications=%t", p.SelfOperatorLead, p.SelfOperatorAllow, p.SelfOperatorRevision, p.SelfOperatorPaused, p.OperatorNotifications)
+			}
+			choices := []choice{{value: "continue", label: label}}
 			for _, item := range operatorChoices(m.opts.Capabilities) {
 				if item.capability {
 					item.disabled = true
@@ -491,6 +501,11 @@ func (m BubbleModel) choices() []choice {
 			return []choice{{value: "continue", label: fmt.Sprintf("Continue with authoritative policy · enabled=%t", m.spec.OperatorNotifications)}}
 		}
 		return []choice{{value: "no", label: "No notifications"}, {value: "yes", label: "Attention-only desktop notifications"}}
+	case stageSelfOperatorAllow:
+		if m.spec.SelfOperatorAllow == "merge" {
+			return []choice{{value: "remove", label: "☑ merge · selected explicitly"}, {value: "continue", label: "Continue with explicit merge allowlist"}}
+		}
+		return []choice{{value: "merge", label: "☐ merge · select explicitly (second actor executes)"}}
 	case stageTopology:
 		return []choice{{value: "sibling-tabs", label: "One window per agent"}, {value: "current", label: "Panes in this window"}, {value: "detached", label: "Detached squad"}}
 	case stageLayoutPreset:
@@ -711,6 +726,21 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 			m.transition(stageOperatorNotifications)
 		} else {
 			m.spec.OperatorMode = selected
+			if selected == "self_operator" {
+				m.spec.SelfOperatorLead = m.spec.Lead
+				m.transition(stageSelfOperatorAllow)
+			} else {
+				m.transition(stageOperatorNotifications)
+			}
+		}
+	case stageSelfOperatorAllow:
+		if selected == "merge" {
+			m.spec.SelfOperatorAllow = "merge"
+			m.transition(stageSelfOperatorAllow)
+		} else if selected == "remove" {
+			m.spec.SelfOperatorAllow = ""
+			m.transition(stageSelfOperatorAllow)
+		} else {
 			m.transition(stageOperatorNotifications)
 		}
 	case stageOperatorNotifications:
@@ -790,7 +820,7 @@ func (m BubbleModel) phaseIndex() int {
 		return 0
 	case stageProfile, stageNewProfile, stageSession, stageExistingOverride, stageExistingModel, stageExistingEffort, stageRoles, stageRoleBinary, stageRoleModel, stageRoleEffort, stageLead, stageLeadMode:
 		return 1
-	case stageTopology, stageLayoutPreset, stageOperator, stageOperatorNotifications, stageLauncherPane:
+	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 2
 	case stageGoal, stageSeed:
 		return 3
@@ -808,7 +838,7 @@ func operatorContractSummary(mode string) string {
 	case "noc":
 		return "NOC/global orchestrator owns polling"
 	case "self_operator":
-		return "forward-known only; #391 authorization unavailable"
+		return "exact-session merge-only delegation; human exclusions and second actor remain"
 	default:
 		return "legacy poll-required compatibility"
 	}

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -26,6 +26,34 @@ func TestBubbleModelStartsWithProjectDefaultsAndPhaseRail(t *testing.T) {
 	}
 }
 
+func TestBubbleSelfOperatorAllowBackDeselectReselect(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Lead: "cto"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.stage = stageOperator
+	m.configureStage()
+	m.cursor = 3
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageSelfOperatorAllow || m.spec.SelfOperatorAllow != "" {
+		t.Fatal("allowlist was preselected")
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.spec.SelfOperatorAllow != "merge" || m.stage != stageSelfOperatorAllow {
+		t.Fatal("merge not selected")
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.spec.SelfOperatorAllow != "" {
+		t.Fatal("back did not restore zero selection")
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageOperatorNotifications || m.spec.SelfOperatorAllow != "merge" {
+		t.Fatal("reselect/continue failed")
+	}
+}
+
 func TestBubbleModelExistingProfileOverridesAndExplicitNotificationMismatchArePreserved(t *testing.T) {
 	profile := ProfileSummary{
 		Name: "review", MemberCount: 1, PinnedSession: "review-work", Lead: "cto", LeadMode: "planner", OperatorMode: "separate_terminal",
@@ -146,12 +174,12 @@ func TestBubbleModelCapabilityRowsAreGatedByInjectedCatalog(t *testing.T) {
 	m.configureStage()
 	m.cursor = 3
 	view := m.View()
-	if !strings.Contains(view, "Self-operator / delegated approval") || !strings.Contains(view, "v2.19.0: #391") {
-		t.Fatalf("disabled capability missing from view:\n%s", view)
+	if !strings.Contains(view, "Self-operator / delegated approval") {
+		t.Fatalf("capability missing from view:\n%s", view)
 	}
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if m.stage != stageOperator || m.err == nil || m.spec.OperatorMode != "" {
-		t.Fatalf("disabled selection changed state: stage=%v err=%v spec=%+v", m.stage, m.err, m.spec)
+	if m.stage != stageSelfOperatorAllow || m.spec.OperatorMode != "self_operator" {
+		t.Fatalf("default capability selection failed: stage=%v err=%v spec=%+v", m.stage, m.err, m.spec)
 	}
 
 	caps := DefaultCapabilities()
@@ -166,8 +194,27 @@ func TestBubbleModelCapabilityRowsAreGatedByInjectedCatalog(t *testing.T) {
 	m.configureStage()
 	m.cursor = 3
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	if m.stage != stageOperatorNotifications || m.spec.OperatorMode != "self_operator" {
+	if m.stage != stageSelfOperatorAllow || m.spec.OperatorMode != "self_operator" {
 		t.Fatalf("enabled selection = stage %v mode %q", m.stage, m.spec.OperatorMode)
+	}
+}
+
+func TestBubbleExistingSelfOperatorShowsAuthoritativePolicy(t *testing.T) {
+	p := ProfileSummary{Name: "default", OperatorMode: "self_operator", OperatorNotifications: true, SelfOperatorLead: "cto", SelfOperatorAllow: "merge", SelfOperatorRevision: 7, SelfOperatorPaused: true}
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", OperatorMode: "self_operator", OperatorNotifications: true}, InspectProject: func(string) (ProjectContext, error) {
+		return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{p}}, nil
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.existingIndex = 0
+	m.stage = stageOperator
+	m.configureStage()
+	view := m.View()
+	for _, want := range []string{"lead=cto", "allow=merge", "revision=7", "paused=true", "notifications=true"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("view missing %q: %s", want, view)
+		}
 	}
 }
 

--- a/internal/wizard/capabilities.go
+++ b/internal/wizard/capabilities.go
@@ -31,8 +31,7 @@ type Option struct {
 func DefaultCapabilities() CapabilitySet {
 	return CapabilitySet{
 		CapabilitySelfOperator: {
-			ID: CapabilitySelfOperator, Issue: 391, ShipsIn: "v2.19.0",
-			Reason: "delegated self-approval policy is not implemented",
+			ID: CapabilitySelfOperator, Available: true, Issue: 391, ShipsIn: "v2.19.0",
 		},
 		CapabilityOperatorNotifications: {
 			ID: CapabilityOperatorNotifications, Available: true, Issue: 390, ShipsIn: "v2.19.0",
@@ -45,7 +44,7 @@ func OperatorOptions() []Option {
 		{ID: "lead_pane", Label: "Live in the lead pane", Consequence: "Approve by typing in the lead window; the lead mirrors every decision to gate/<topic>."},
 		{ID: "separate_terminal", Label: "Separate operator terminal", Consequence: "Poll durable gates and answer with explicit operator AMQ replies."},
 		{ID: "noc", Label: "NOC/global board", Consequence: "A global operator board polls and answers this run by explicit namespace."},
-		{ID: "self_operator", Label: "Self-operator / delegated approval", Consequence: "The lead may answer only allowlisted gates; human-only exclusions remain blocked.", Requires: CapabilitySelfOperator},
+		{ID: "self_operator", Label: "Self-operator / delegated approval", Consequence: "The lead may approve only explicitly allowlisted merge gates; spawn, release, tag, publish, external, and destructive gates remain human-only; merges require a second actor.", Requires: CapabilitySelfOperator},
 	}
 }
 

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -35,6 +35,10 @@ type ProfileSummary struct {
 	LeadMode              string
 	OperatorMode          string
 	OperatorNotifications bool
+	SelfOperatorLead      string
+	SelfOperatorAllow     string
+	SelfOperatorRevision  int64
+	SelfOperatorPaused    bool
 	Members               []MemberSummary
 }
 
@@ -220,6 +224,9 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	}
 	if existing {
 		fmt.Fprintf(out, "Operator interaction (authoritative): %s\n", defaultString(s.OperatorMode, "unspecified"))
+		if s.OperatorMode == "self_operator" {
+			fmt.Fprintf(out, "Self-operator policy (authoritative): lead=%s session=%s allow=%s revision=%d paused=%t notifications=%t\n", existingProfile.SelfOperatorLead, s.Session, existingProfile.SelfOperatorAllow, existingProfile.SelfOperatorRevision, existingProfile.SelfOperatorPaused, s.OperatorNotifications)
+		}
 		for _, item := range operatorChoices(opts.Capabilities) {
 			if item.capability {
 				fmt.Fprintf(out, "  - %s\n", item.label)
@@ -228,6 +235,18 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		fmt.Fprintln(out)
 	} else if s.OperatorMode, err = promptOperatorChoice(r, out, opts.Capabilities, defaultOperatorMode(s.OperatorMode, s.Visibility)); err != nil {
 		return Spec{}, err
+	}
+	if !existing && s.OperatorMode == "self_operator" {
+		fmt.Fprintln(out, "Self-operator exclusions: spawn, release, tag, publish, external send, and destructive filesystem remain human-only. A different verified actor must execute an approved merge.")
+		if s.SelfOperatorLead, err = promptText(r, out, "Self-operator lead", defaultString(s.SelfOperatorLead, s.Lead)); err != nil {
+			return Spec{}, err
+		}
+		if s.SelfOperatorAllow, err = promptText(r, out, "Self-operator allowlist (explicitly type merge; no default)", ""); err != nil {
+			return Spec{}, err
+		}
+		if strings.TrimSpace(s.SelfOperatorAllow) != "merge" {
+			return Spec{}, fmt.Errorf("self-operator allowlist must explicitly be merge; spawn and immutable exclusions remain human-only")
+		}
 	}
 	if existing {
 		fmt.Fprintf(out, "Operator notifications (authoritative): %t\n", s.OperatorNotifications)

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -206,11 +206,11 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 
 func TestPromptOperatorChoiceCapabilityGating(t *testing.T) {
 	var out bytes.Buffer
-	_, err := promptOperatorChoice(bufio.NewReader(strings.NewReader("4\n")), &out, nil, "lead_pane")
-	if err == nil || !strings.Contains(err.Error(), "self_operator") {
-		t.Fatalf("disabled choice error = %v", err)
+	mode, err := promptOperatorChoice(bufio.NewReader(strings.NewReader("4\n")), &out, nil, "lead_pane")
+	if err != nil || mode != "self_operator" {
+		t.Fatalf("default capability = %q, %v", mode, err)
 	}
-	for _, want := range []string{"Self-operator / delegated approval", "ships in v2.19.0: #391"} {
+	for _, want := range []string{"Self-operator / delegated approval"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("capability rows missing %q:\n%s", want, out.String())
 		}
@@ -220,7 +220,7 @@ func TestPromptOperatorChoiceCapabilityGating(t *testing.T) {
 	self := caps[CapabilitySelfOperator]
 	self.Available = true
 	caps[CapabilitySelfOperator] = self
-	mode, err := promptOperatorChoice(bufio.NewReader(strings.NewReader("4\n")), &bytes.Buffer{}, caps, "lead_pane")
+	mode, err = promptOperatorChoice(bufio.NewReader(strings.NewReader("4\n")), &bytes.Buffer{}, caps, "lead_pane")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -17,6 +17,8 @@ type Spec struct {
 	Model                          string
 	Effort                         string
 	OperatorMode                   string
+	SelfOperatorLead               string
+	SelfOperatorAllow              string
 	OperatorNotifications          bool
 	OperatorNotificationsRequested bool
 	OperatorNotificationsSet       bool
@@ -91,6 +93,8 @@ func (s Spec) Args() []string {
 	if strings.TrimSpace(s.OperatorMode) != "unspecified" {
 		appendValue("--operator-mode", s.OperatorMode)
 	}
+	appendValue("--self-operator-lead", s.SelfOperatorLead)
+	appendValue("--self-operator-allow", s.SelfOperatorAllow)
 	if s.OperatorNotifications {
 		args = append(args, "--operator-notifications")
 	}

--- a/internal/wizard/spec_test.go
+++ b/internal/wizard/spec_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+func TestSpecSerializesExplicitSelfOperatorPolicy(t *testing.T) {
+	args := Spec{OperatorMode: "self_operator", SelfOperatorLead: "cto", SelfOperatorAllow: "merge"}.Args()
+	got := strings.Join(args, " ")
+	for _, want := range []string{"--operator-mode self_operator", "--self-operator-lead cto", "--self-operator-allow merge"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("args %q missing %q", got, want)
+		}
+	}
+}
+
 func TestSpecArgsStableAndPreviewOnly(t *testing.T) {
 	s := Spec{
 		Project:               "/tmp/my repo",


### PR DESCRIPTION
## Summary

- Enables an explicit merge-only self-operator wizard flow with a zero-default allowlist: authority is granted only after the user actively selects the supported merge capability.
- Fresh-profile setup writes the exact-session policy; existing-profile flows hydrate and display the authoritative exact-session policy without silently rewriting it.
- Adds attention-only `self_approved` and `human_only_gate` visibility events validated against current profile/session/policy state, with scoped tombstones that clear stale events after mode flips, policy removal, or resolution.
- Composes the effective contract through status, bootstrap, completion, README, operator cookbook, and release notes.

## QA follow-ups

- Covers authoritative existing-profile hydration, explicit policy setness, back/deselect/reselect wizard behavior, and exact canonical serialization.
- Adds adversarial current-state validation, conflict/reopen, retry, stale-event suppression, and scoped tombstone tests.

## Design boundary

Spawn remains human-only. It is not exposed through the self-operator wizard until a strict exact-namespace dry-run/budget/depth/role evidence schema can provide the same fail-closed parity as merge verification.

## Validation evidence

- `go test ./... -count=1`
- `make ci`
- Race-focused coverage across attention, CLI notification collection/delivery, team policy, and wizard paths
- Focused exact-session, authoritative-state, adversarial event, tombstone, and navigation regression tests

Part of #391
Refs #391