### PR TITLE
fix: harden deterministic tmux layout finalization

### DIFF
--- a/internal/cli/layout_finalize.go
+++ b/internal/cli/layout_finalize.go
@@ -132,26 +132,25 @@ func layoutFinalizationScript(plan layoutFinalizationPlan) string {
 	lines := []string{
 		"fail() { mkdir -p " + shellQuote(warningDir) + "; printf '%s\\n' \"$1\" > " + shellQuote(plan.WarningPath) + "; exit 0; }",
 		fmt.Sprintf("ticks=0; while kill -0 %d 2>/dev/null; do ticks=$((ticks+1)); [ \"$ticks\" -ge %d ] && fail 'layout finalization timed out waiting for parent CLI exit'; sleep 0.05; done", plan.ParentPID, layoutFinalizationWaitTicks),
-		"tmux display-message -p -t " + shellQuote(plan.LeadPaneID) + " '#{pane_id}' >/dev/null 2>&1 || fail 'layout finalization skipped: lead pane is missing'",
-		"tmux display-message -p -t " + shellQuote(plan.LeadWindowID) + " '#{window_id}' >/dev/null 2>&1 || fail 'layout finalization skipped: lead window is missing'",
+		"lead_pane_probe=$(tmux display-message -p -t " + shellQuote(plan.LeadPaneID) + " " + shellQuote(tmuxRunShellFormat("#{pane_id}")) + " 2>/dev/null); [ \"$lead_pane_probe\" = " + shellQuote(plan.LeadPaneID) + " ] || fail 'layout finalization skipped: lead pane is missing'",
+		"lead_window_probe=$(tmux display-message -p -t " + shellQuote(plan.LeadWindowID) + " " + shellQuote(tmuxRunShellFormat("#{window_id}")) + " 2>/dev/null); [ \"$lead_window_probe\" = " + shellQuote(plan.LeadWindowID) + " ] || fail 'layout finalization skipped: lead window is missing'",
 	}
 	if plan.Selection.LauncherPane == launcherPaneCloseAfterStart && plan.LauncherPaneID != "" && plan.LauncherPaneID != plan.LeadPaneID {
-		lines = append(lines, "if tmux display-message -p -t "+shellQuote(plan.LauncherPaneID)+" '#{pane_id}' >/dev/null 2>&1; then tmux kill-pane -t "+shellQuote(plan.LauncherPaneID)+" || fail 'layout finalization could not close launcher pane'; fi")
+		lines = append(lines, "launcher_probe=$(tmux display-message -p -t "+shellQuote(plan.LauncherPaneID)+" "+shellQuote(tmuxRunShellFormat("#{pane_id}"))+" 2>/dev/null); if [ \"$launcher_probe\" = "+shellQuote(plan.LauncherPaneID)+" ]; then tmux kill-pane -t "+shellQuote(plan.LauncherPaneID)+" || fail 'layout finalization could not close launcher pane'; fi")
 	}
-	if plan.Selection.LeadMain {
-		lines = append(lines,
-			"main=$(tmux list-panes -t "+shellQuote(plan.LeadWindowID)+" -F '#{pane_id}' | head -n 1); [ -n \"$main\" ] || fail 'layout finalization could not resolve main pane by exact window id'",
-			"[ \"$main\" = "+shellQuote(plan.LeadPaneID)+" ] || tmux swap-pane -s "+shellQuote(plan.LeadPaneID)+" -t \"$main\" || fail 'layout finalization could not move lead into main pane'",
-		)
-	}
+	paneDimension := ""
+	panePosition := ""
 	if plan.Selection.MainPaneOption != "" {
 		dimension := "window_width"
+		paneDimension = "pane_width"
+		panePosition = "pane_left"
 		minimum, reserve := 20, 10
 		if plan.Selection.MainPaneOption == "main-pane-height" {
-			dimension, minimum, reserve = "window_height", 8, 4
+			dimension, paneDimension, minimum, reserve = "window_height", "pane_height", 8, 4
+			panePosition = "pane_top"
 		}
 		lines = append(lines,
-			"total=$(tmux display-message -p -t "+shellQuote(plan.LeadWindowID)+" '#{"+dimension+"}'); case \"$total\" in ''|*[!0-9]*) fail 'layout finalization could not read window dimension';; esac",
+			"total=$(tmux display-message -p -t "+shellQuote(plan.LeadWindowID)+" "+shellQuote(tmuxRunShellFormat("#{"+dimension+"}"))+"); case \"$total\" in ''|*[!0-9]*) fail 'layout finalization could not read window dimension';; esac",
 			fmt.Sprintf("main_size=$((total*60/100)); [ \"$main_size\" -lt %d ] && main_size=%d; max_size=$((total-%d)); [ \"$max_size\" -lt 1 ] && max_size=1; [ \"$main_size\" -gt \"$max_size\" ] && main_size=$max_size", minimum, minimum, reserve),
 			"tmux set-option -w -t "+shellQuote(plan.LeadWindowID)+" "+shellQuote(plan.Selection.MainPaneOption)+" \"$main_size\" || fail 'layout finalization could not set main pane dimension'",
 		)
@@ -159,12 +158,31 @@ func layoutFinalizationScript(plan layoutFinalizationPlan) string {
 	if plan.Selection.FinalLayout != "" {
 		lines = append(lines, "tmux select-layout -t "+shellQuote(plan.LeadWindowID)+" "+shellQuote(plan.Selection.FinalLayout)+" || fail 'layout finalization could not apply layout'")
 	}
+	if plan.Selection.LeadMain {
+		mainPaneFormat := tmuxRunShellFormat("#{pane_id} #{" + panePosition + "} #{" + paneDimension + "}")
+		lines = append(lines,
+			"main=$(tmux list-panes -t "+shellQuote(plan.LeadWindowID)+" -F "+shellQuote(mainPaneFormat)+" | awk -v size=\"$main_size\" '$2 == 0 && $3 == size { print $1; exit }'); [ -n \"$main\" ] || fail 'layout finalization could not resolve main pane by exact geometry'",
+			"[ \"$main\" = "+shellQuote(plan.LeadPaneID)+" ] || tmux swap-pane -d -s "+shellQuote(plan.LeadPaneID)+" -t \"$main\" || fail 'layout finalization could not move lead into main pane'",
+		)
+	}
+	if paneDimension != "" {
+		lines = append(lines,
+			"actual=$(tmux display-message -p -t "+shellQuote(plan.LeadPaneID)+" "+shellQuote(tmuxRunShellFormat("#{"+paneDimension+"}"))+"); case \"$actual\" in ''|*[!0-9]*) fail 'layout finalization could not read lead pane dimension';; esac",
+			"[ \"$actual\" -eq \"$main_size\" ] || fail \"layout finalization lead pane dimension mismatch: expected $main_size, got $actual\"",
+		)
+	}
 	lines = append(lines,
 		"tmux select-window -t "+shellQuote(plan.LeadWindowID)+" || fail 'layout finalization could not focus lead window'",
 		"tmux select-pane -t "+shellQuote(plan.LeadPaneID)+" || fail 'layout finalization could not focus lead pane'",
 		"rm -f "+shellQuote(plan.WarningPath),
 	)
 	return strings.Join(lines, "; ")
+}
+
+// tmux run-shell expands formats before it starts the shell. Doubling the hash
+// preserves one literal format token for the nested tmux client in that shell.
+func tmuxRunShellFormat(format string) string {
+	return strings.ReplaceAll(format, "#{", "##{")
 }
 
 func layoutFinalizationWarningPath(project, profile, session string) string {

--- a/internal/cli/layout_finalize_test.go
+++ b/internal/cli/layout_finalize_test.go
@@ -87,8 +87,10 @@ func TestLayoutFinalizationScriptExactIDsBoundedAndRenameAgnostic(t *testing.T) 
 	}
 	script := layoutFinalizationScript(plan)
 	for _, want := range []string{
-		"kill -0 4242", "-ge 200", "tmux kill-pane -t '%1'", "tmux list-panes -t '@7'", "tmux swap-pane -s '%3'",
+		"kill -0 4242", "-ge 200", "tmux kill-pane -t '%1'", "tmux list-panes -t '@7'", "tmux swap-pane -d -s '%3'",
 		"tmux set-option -w -t '@7' main-pane-width", "total*60/100", "tmux select-layout -t '@7' main-vertical", "tmux select-pane -t '%3'",
+		"lead_pane_probe=$(tmux display-message -p -t '%3' '##{pane_id}'", "[ \"$lead_pane_probe\" = '%3' ] || fail 'layout finalization skipped: lead pane is missing'",
+		"lead_window_probe=$(tmux display-message -p -t '@7' '##{window_id}'", "[ \"$lead_window_probe\" = '@7' ] || fail 'layout finalization skipped: lead window is missing'",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("script missing %q:\n%s", want, script)
@@ -96,6 +98,23 @@ func TestLayoutFinalizationScriptExactIDsBoundedAndRenameAgnostic(t *testing.T) 
 	}
 	if strings.Index(script, "timed out waiting") > strings.Index(script, "tmux kill-pane") {
 		t.Fatalf("timeout guard must precede launcher close:\n%s", script)
+	}
+	setOption := strings.Index(script, "tmux set-option")
+	selectLayout := strings.Index(script, "tmux select-layout")
+	resolveMain := strings.Index(script, "main=$(tmux list-panes")
+	swapLead := strings.Index(script, "tmux swap-pane")
+	verifyLead := strings.Index(script, "actual=$(tmux display-message")
+	if setOption < 0 || selectLayout < setOption || resolveMain < selectLayout || swapLead < resolveMain || verifyLead < swapLead {
+		t.Fatalf("finalizer must size and apply the layout before moving and verifying the exact lead pane:\n%s", script)
+	}
+	if !strings.Contains(script, "'##{pane_width}'") || !strings.Contains(script, "lead pane dimension mismatch: expected $main_size, got $actual") {
+		t.Fatalf("finalizer must verify the lead received the requested main width:\n%s", script)
+	}
+	if !strings.Contains(script, "'##{pane_id} ##{pane_left} ##{pane_width}'") || !strings.Contains(script, "awk -v size=\"$main_size\" '$2 == 0 && $3 == size") || strings.Contains(script, "head -n 1") {
+		t.Fatalf("finalizer must resolve the post-layout main pane by geometry, not enumeration order:\n%s", script)
+	}
+	if strings.Contains(script, "'##{pane_id}' >/dev/null") || strings.Contains(script, "'##{window_id}' >/dev/null") {
+		t.Fatalf("liveness probes must reject empty or wrong successful output, not trust tmux exit status:\n%s", script)
 	}
 	if strings.LastIndex(script, "rm -f") < strings.LastIndex(script, "select-pane") {
 		t.Fatalf("successful helper must clear its warning only after layout and focus:\n%s", script)
@@ -107,11 +126,32 @@ func TestLayoutFinalizationScriptExactIDsBoundedAndRenameAgnostic(t *testing.T) 
 	}
 }
 
+func TestLayoutFinalizationScriptVerifiesLeadTopGeometryAfterReflow(t *testing.T) {
+	selection := runStartLayoutSelection{
+		Preset: layoutPresetLeadTop, LauncherPane: launcherPaneCloseAfterStart,
+		FinalLayout: "main-horizontal", MainPaneOption: "main-pane-height", MainPaneValue: "60%", LeadMain: true,
+	}
+	plan := layoutFinalizationPlan{
+		Selection: selection, ParentPID: 4242, LauncherPaneID: "%1", LeadPaneID: "%3", LeadWindowID: "@7",
+		WarningPath: "/tmp/amq-layout/default/issue-393.warning",
+	}
+	script := layoutFinalizationScript(plan)
+	selectLayout := strings.Index(script, "tmux select-layout -t '@7' main-horizontal")
+	swapLead := strings.Index(script, "tmux swap-pane -d -s '%3'")
+	verifyLead := strings.Index(script, "'##{pane_height}'")
+	if selectLayout < 0 || swapLead < selectLayout || verifyLead < swapLead {
+		t.Fatalf("lead-top finalizer must reflow before moving and verifying the lead:\n%s", script)
+	}
+	if !strings.Contains(script, "'##{pane_id} ##{pane_top} ##{pane_height}'") {
+		t.Fatalf("lead-top finalizer must resolve the main pane by top/height geometry:\n%s", script)
+	}
+}
+
 func TestLayoutFinalizationLauncherSafetyAndWindowPreset(t *testing.T) {
 	selection := runStartLayoutSelection{Preset: layoutPresetOneWindowPerAgent, LauncherPane: launcherPaneCloseAfterStart}
 	base := layoutFinalizationPlan{Selection: selection, ParentPID: 1, LauncherPaneID: "%1", LeadPaneID: "%2", LeadWindowID: "@2", WarningPath: "/tmp/w.warning"}
 	script := layoutFinalizationScript(base)
-	if !strings.Contains(script, "if tmux display-message") || !strings.Contains(script, "tmux kill-pane -t '%1'") {
+	if !strings.Contains(script, "launcher_probe=$(tmux display-message") || !strings.Contains(script, "[ \"$launcher_probe\" = '%1' ]") || !strings.Contains(script, "tmux kill-pane -t '%1'") {
 		t.Fatalf("missing idempotent launcher close:\n%s", script)
 	}
 	if strings.Contains(script, "select-layout") || !strings.Contains(script, "select-window -t '@2'") {
@@ -192,7 +232,10 @@ func TestScheduleLayoutFinalizationUsesBackgroundRunShell(t *testing.T) {
 		return layoutFinalizationRunCommand("tmux", "run-shell", "-b", script)
 	}
 	plan := layoutFinalizationPlan{
-		Selection: runStartLayoutSelection{Preset: layoutPresetEvenGrid, LauncherPane: launcherPaneKeep, FinalLayout: "tiled"},
+		Selection: runStartLayoutSelection{
+			Preset: layoutPresetLeadLeft, LauncherPane: launcherPaneCloseAfterStart,
+			FinalLayout: "main-vertical", MainPaneOption: "main-pane-width", MainPaneValue: "60%", LeadMain: true,
+		},
 		ParentPID: 1, LauncherPaneID: "%1", LeadPaneID: "%2", LeadWindowID: "@1",
 		WarningPath: layoutFinalizationWarningPath(t.TempDir(), team.DefaultProfile, "issue-393"),
 	}
@@ -204,6 +247,17 @@ func TestScheduleLayoutFinalizationUsesBackgroundRunShell(t *testing.T) {
 	}
 	if !strings.Contains(gotArgs[2], "while kill -0 1") || !strings.Contains(gotArgs[2], "-ge 200") {
 		t.Fatalf("scheduled helper lacks bounded parent wait: %q", gotArgs[2])
+	}
+	for _, escaped := range []string{
+		"'##{pane_id}'", "'##{window_id}'", "'##{window_width}'",
+		"'##{pane_id} ##{pane_left} ##{pane_width}'", "'##{pane_width}'",
+	} {
+		if !strings.Contains(gotArgs[2], escaped) {
+			t.Fatalf("scheduled run-shell helper lacks escaped nested format %q: %q", escaped, gotArgs[2])
+		}
+	}
+	if strings.Contains(strings.ReplaceAll(gotArgs[2], "##{", ""), "#{") {
+		t.Fatalf("scheduled run-shell helper contains an unescaped nested tmux format: %q", gotArgs[2])
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix the deterministic tmux layout finalizer so the configured lead reliably receives the 60% main pane and failures remain observable without tearing down launched agents.

This addresses three defects found during the issue #393 release smoke:

1. **Main-pane inversion.** The helper used `list-panes | head` as a proxy for the pane occupying the main slot. Pane enumeration order can differ from the post-layout geometry, leaving the worker at 60% and the lead at 40%. The helper now resolves the actual main slot after layout by its left/width or top/height geometry, swaps the exact recorded lead into it with `swap-pane -d`, and verifies the lead's final dimension before clearing the warning.
2. **False-positive liveness probes.** tmux 3.6a may return success from `display-message` for a missing exact target. Lead pane/window probes now require the returned value to equal the expected exact `%pane` or `@window` ID. Launcher close uses the same exact-output guard.
3. **Nested format expansion.** The outer `tmux run-shell` expanded inner `#{...}` formats before the shell executed, corrupting exact-ID and geometry probes. All nested tmux formats now pass through one helper that emits `##{...}`, preserving literal `#{...}` for the inner tmux client.

## Validation

- Targeted layout/run-start tests pass.
- `go test ./...` passes.
- `make ci` passes, including vet, the full test suite, generated-document checks, and all eight skill manifest checks.
- Scheduler regression inspects the actual `tmux run-shell -b <script>` argument and rejects any unescaped nested tmux format.
- Exact-ID, geometry, warning, launcher-safety, lead-left, and lead-top regressions are included.

## Fresh pre-merge smoke

The full pre-merge matrix passed at exact head `f8a2177f30aa3458f69397e37eb625a4f4155d25`. Evidence is retained under:

`/private/tmp/amq-393-smoke-f8a2177f/evidence`

The matrix covers the layout presets, exact lead geometry, launcher close/keep behavior, rename tolerance, Claude bootstrap/liveness, warning lifecycle, and injected failure behavior.

**A merged-main smoke rerun is still required before release readiness is declared.** This PR intentionally reports the exact-head pre-merge result only.
