### PR TITLE
Prepare v2.19.0 release

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2180" id="toc-whats-new-in-v2180">What's new
-in v2.18.0</a></li>
+<li><a href="#whats-new-in-v2190" id="toc-whats-new-in-v2190">What's new
+in v2.19.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2180">What's new in v2.18.0</a></li>
+<li><a href="#whats-new-in-v2190">What's new in v2.19.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,27 +342,32 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2180">What's new in v2.18.0</h2>
-<p>v2.18.0 is a coherence release for goal-driven, externally supervised
-squads:</p>
+<h2 id="whats-new-in-v2190">What's new in v2.19.0</h2>
+<p>v2.19.0 makes squad startup guided, observable, and safer to
+supervise:</p>
 <ul>
-<li><strong>Hard authorization boundary</strong> for high-risk lead
-actions (#349) and a <strong>planner/reviewer-only lead mode</strong>
-(#350).</li>
-<li><strong>Run start UX</strong>: native <code>run start</code>, short
-flags, default visible sibling tabs, and
-<code>run start --external-lead</code> for binding the current pane as
-the project lead (#340, #345-#348).</li>
-<li><strong>External-orchestrator integration</strong>: read-only
-evidence lane, adopt-evidence workflow, and Symphony lifecycle hooks
-(#335-#337).</li>
-<li><strong>Terminal platform support</strong> with an explicit runtime
-capability model: tmux Tier A, iTerm2 Tier B, Terminal.app Tier C, and
-cmux still pending (#330, #331, #332, #384-#386).</li>
-<li><strong>gpt-5.6 model family guidance</strong> lives in the skills
-as the source of truth for lead/worker selection (#380).</li>
-<li><strong>AMQ 0.41.0+ baseline</strong> for the coordination
-primitives this release depends on.</li>
+<li><strong>Interactive <code>run start</code> wizard</strong> with
+Bubble Tea and numbered/accessibility adapters, structured preflight,
+Project and Global/NOC flows, explicit preview-to-live confirmation, and
+deterministic tmux layouts (#393).</li>
+<li><strong>Attention-only operator notifications</strong> with
+profile-scoped desktop or direct-argv sinks, delivery de-duplication,
+gate escalation, and wizard/setup configuration that never grants
+approval (#390).</li>
+<li><strong>Bounded self-operator mode</strong> for explicit,
+exact-session merge approval. Spawn, release, tag, publish,
+external-send, and destructive actions remain human-only, and the
+approving lead cannot execute its own merge (#391).</li>
+<li><strong>Bootstrap and launch hardening</strong> with identity-bound
+bootstrap completion attestation and single-pass native Claude/Codex
+argv composition (#396).</li>
+<li><strong>Wake-friendly orchestration waits</strong>: collect briefly
+for an imminent ACK or report, then park/end the turn for longer work
+and operator gates (#404).</li>
+<li><strong>Deterministic layout finalization hardening</strong> keeps
+the configured lead in the main tmux pane, verifies exact pane/window
+identity, and preserves observable warnings without tearing down
+launched agents (#393).</li>
 </ul>
 <h2 id="install">Install</h2>
 <p>Install the v2 module path:</p>
@@ -370,7 +375,7 @@ primitives this release depends on.</li>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.18.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -701,7 +706,7 @@ not.</td>
 <td>Visible native Terminal.app tabs/windows. Window identity is derived
 from the launched tab TTY when available.</td>
 <td>Disabled:
-<code>Terminal.app focus requires stable window/tab addressing; manual focus is required in v2.18.0</code>.</td>
+<code>Terminal.app focus requires stable window/tab addressing; manual focus is required</code>.</td>
 <td>Disabled:
 <code>Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input</code>.</td>
 <td>Always available because durable AMQ dispatch does not require pane
@@ -712,7 +717,7 @@ manual.</td>
 <tr>
 <td>cmux</td>
 <td>Pending</td>
-<td>Not shipped in v2.18.0.</td>
+<td>No backend is shipped.</td>
 <td>Pending #330 re-entry bar.</td>
 <td>Pending #330 re-entry bar.</td>
 <td>Durable AMQ dispatch remains the intended control plane once a
@@ -753,7 +758,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#
 <p>Safety preflights:</p>
 <div class="sourceCode" id="cb12"><pre
 class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.18.0 release&quot;</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.19.0 release&quot;</span></span>
 <span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify merge <span class="at">--evidence</span> merge-evidence.json</span>
 <span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify release <span class="at">--evidence</span> release-evidence.json</span></code></pre></div>
 <p>The action, merge, and final-release-commit contracts are documented
@@ -844,11 +849,10 @@ coordinate reviews, recover, and produce final evidence.</td>
 <p>Invoke skills in Claude Code as <code>/amq-squad:&lt;skill&gt;</code>
 and in Codex as <code>$&lt;skill&gt;</code>.</p>
 <p>Model guidance is intentionally skill-owned because it changes faster
-than the binary. For v2.18.0, the guidance points at the gpt-5.6 family
-for Codex-heavy work, uses explicit model/effort overrides per role, and
-treats cost as a tie-breaker after output quality for shippable work.
-Prefer the skill guidance over copying stale model examples from this
-README.</p>
+than the binary. For v2.19.0, use the current model family and per-role
+model/effort recommendations in the installed skills; treat cost as a
+tie-breaker after output quality for shippable work. Prefer that
+guidance over copying model examples from this README.</p>
 <p>Deep guide: <a href="docs/skills.md">docs/skills.md</a> (<a
 href="docs/skills.html">HTML</a>).</p>
 <p>That guide also defines goal-first composition modes: manual rosters,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.18.0](#whats-new-in-v2180)
+- [What's new in v2.19.0](#whats-new-in-v2190)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,24 +38,26 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.18.0
+## What's new in v2.19.0
 
-v2.18.0 is a coherence release for goal-driven, externally supervised squads:
+v2.19.0 makes squad startup guided, observable, and safer to supervise:
 
-- **Hard authorization boundary** for high-risk lead actions (#349) and a
-  **planner/reviewer-only lead mode** (#350).
-- **Run start UX**: native `run start`, short flags, default visible sibling
-  tabs, and `run start --external-lead` for binding the current pane as the
-  project lead (#340, #345-#348).
-- **External-orchestrator integration**: read-only evidence lane, adopt-evidence
-  workflow, and Symphony lifecycle hooks (#335-#337).
-- **Terminal platform support** with an explicit runtime capability model:
-  tmux Tier A, iTerm2 Tier B, Terminal.app Tier C, and cmux still pending (#330,
-  #331, #332, #384-#386).
-- **gpt-5.6 model family guidance** lives in the skills as the source of truth
-  for lead/worker selection (#380).
-- **AMQ 0.41.0+ baseline** for the coordination primitives this release depends
-  on.
+- **Interactive `run start` wizard** with Bubble Tea and numbered/accessibility
+  adapters, structured preflight, Project and Global/NOC flows, explicit
+  preview-to-live confirmation, and deterministic tmux layouts (#393).
+- **Attention-only operator notifications** with profile-scoped desktop or
+  direct-argv sinks, delivery de-duplication, gate escalation, and wizard/setup
+  configuration that never grants approval (#390).
+- **Bounded self-operator mode** for explicit, exact-session merge approval.
+  Spawn, release, tag, publish, external-send, and destructive actions remain
+  human-only, and the approving lead cannot execute its own merge (#391).
+- **Bootstrap and launch hardening** with identity-bound bootstrap completion
+  attestation and single-pass native Claude/Codex argv composition (#396).
+- **Wake-friendly orchestration waits**: collect briefly for an imminent ACK or
+  report, then park/end the turn for longer work and operator gates (#404).
+- **Deterministic layout finalization hardening** keeps the configured lead in
+  the main tmux pane, verifies exact pane/window identity, and preserves
+  observable warnings without tearing down launched agents (#393).
 
 ## Install
 
@@ -69,7 +71,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.18.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -289,8 +291,8 @@ promise.
 | --- | --- | --- | --- | --- | --- | --- |
 | tmux | Tier A | Managed panes in current window, sibling windows, or detached session. | Available only while the recorded pane is live; otherwise reason is `agent pane is not live`. | Available only while the recorded pane is live; otherwise reason is `agent pane is not live`. | Always available because durable AMQ dispatch does not require pane injection. | Full managed stop/resume through launch records and tmux pane identity. |
 | iTerm2 | Tier B | One visible native iTerm2 window per agent. Terminal metadata is captured and then stripped from the agent env. | Available only with a recorded window id and verified agent PID/binary liveness. Missing id reports `iTerm2 window id is unavailable`; dead/mismatched process reports `iTerm2 focus requires verified agent PID liveness`. | Disabled: `iTerm2 prompt/native-goal injection is disabled until #374 proves safe send/capture/busy support`. | Always available because durable AMQ dispatch does not require pane injection. | Agent process stop/resume is managed; native prompt injection is not. |
-| Terminal.app | Tier C | Visible native Terminal.app tabs/windows. Window identity is derived from the launched tab TTY when available. | Disabled: `Terminal.app focus requires stable window/tab addressing; manual focus is required in v2.18.0`. | Disabled: `Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input`. | Always available because durable AMQ dispatch does not require pane injection. | Agent process stop/resume is managed; native focus/input remain manual. |
-| cmux | Pending | Not shipped in v2.18.0. | Pending #330 re-entry bar. | Pending #330 re-entry bar. | Durable AMQ dispatch remains the intended control plane once a backend exists. | Pending #330 re-entry bar. |
+| Terminal.app | Tier C | Visible native Terminal.app tabs/windows. Window identity is derived from the launched tab TTY when available. | Disabled: `Terminal.app focus requires stable window/tab addressing; manual focus is required`. | Disabled: `Terminal.app prompt/native-goal injection is disabled until #375 proves safe Accessibility-based input`. | Always available because durable AMQ dispatch does not require pane injection. | Agent process stop/resume is managed; native focus/input remain manual. |
+| cmux | Pending | No backend is shipped. | Pending #330 re-entry bar. | Pending #330 re-entry bar. | Durable AMQ dispatch remains the intended control plane once a backend exists. | Pending #330 re-entry bar. |
 
 Manual smoke flows live in
 [docs/iterm2-tier-b-smoke.md](docs/iterm2-tier-b-smoke.md) and
@@ -335,7 +337,7 @@ Safety preflights:
 
 ```sh
 amq-squad verify action --project . --session issue-96 \
-  --gate release --action github_release --target "draft v2.18.0 release"
+  --gate release --action github_release --target "draft v2.19.0 release"
 amq-squad verify merge --evidence merge-evidence.json
 amq-squad verify release --evidence release-evidence.json
 ```
@@ -392,10 +394,10 @@ Invoke skills in Claude Code as `/amq-squad:<skill>` and in Codex as
 `$<skill>`.
 
 Model guidance is intentionally skill-owned because it changes faster than the
-binary. For v2.18.0, the guidance points at the gpt-5.6 family for Codex-heavy
-work, uses explicit model/effort overrides per role, and treats cost as a
-tie-breaker after output quality for shippable work. Prefer the skill guidance
-over copying stale model examples from this README.
+binary. For v2.19.0, use the current model family and per-role model/effort
+recommendations in the installed skills; treat cost as a tie-breaker after
+output quality for shippable work. Prefer that guidance over copying model
+examples from this README.
 
 Deep guide: [docs/skills.md](docs/skills.md)
 ([HTML](docs/skills.html)).

--- a/docs/v2.19.0-release-notes.md
+++ b/docs/v2.19.0-release-notes.md
@@ -1,152 +1,165 @@
-# amq-squad v2.19.0 development notes
+# amq-squad v2.19.0
 
-This document tracks user-visible changes while v2.19.0 is under development.
-It is not a release announcement.
+v2.19.0 closes all five issues in the milestone. It adds a guided launch path,
+attention-only operator notifications, bounded self-operator approval, stronger
+bootstrap observability, deterministic tmux layouts, and a wake-friendly wait
+posture for long-running orchestration.
 
-## Operator notification configuration, #390 PR 2
+## Highlights
 
-- `team init --operator-notifications` persists the default desktop,
-  attention-only policy; `run start` forwards it only for new profiles.
-- Existing profile policy remains authoritative. Wizard discovery/preflight
-  never rewrites it, and the toggle is independent from interaction mode.
-- Numbered and Bubble Tea flows expose the add-on. Status/bootstrap show
-  semantics, sink types, and watcher-host guidance without secrets.
+- **Guided preview-to-live launches.** `amq-squad wizard` and interactive
+  zero-argument `run start` share one structured preflight and canonical argv
+  path. Operators can use the full-screen Bubble Tea UI or the numbered,
+  accessible fallback; choose Project or Global/NOC scope; inspect topology and
+  policy; and launch only after an explicit default-No confirmation (#393).
+- **Deterministic tmux layouts.** Four presets (`lead-left`, `lead-top`,
+  `even-grid`, and `one-window-per-agent`) use exact pane/window identities.
+  Finalization keeps the configured lead in the main slot, survives rename and
+  liveness edge cases, and records a warning instead of tearing down agents
+  when best-effort layout work fails (#393).
+- **Operator attention without implicit authority.** Profile-scoped desktop
+  and direct-argv sinks receive normalized gate, escalation, and conservative
+  local-input events. Delivery is de-duplicated, command sinks receive
+  versioned JSON on stdin without a shell, and notifications never approve an
+  action (#390).
+- **Bounded self-operator approval.** Fresh profiles can explicitly grant an
+  exact-session, merge-only allowlist. Spawn, release, tag, publish,
+  external-send, and destructive actions remain human-only; human intervention
+  or policy changes revoke prior self approval; and a different strongly
+  verified actor must execute the merge (#391).
+- **Observable bootstrap and composed native argv.** Verified roster actors can
+  acknowledge completed bootstrap steps through strict identity/session/launch
+  markers. Native Claude and Codex arguments are composed once with
+  last-layer-wins singleton handling while repeatable, unknown, and literal
+  `--` tails preserve order (#396).
+- **Short-collect-then-park.** Skills now reserve short `collect` waits for an
+  ACK or genuinely imminent report, park/end the turn for work measured in
+  minutes, avoid live-operator gate self-deadlocks, and leave stall detection to
+  `monitor idle_with_active_task` (#404).
 
-## Operator attention notification pipeline, #390 PR 1
+## Issue and PR ledger
 
-- Added profile-scoped, attention-only notification policy primitives with
-  desktop and direct-argv command sinks. Command hooks receive versioned JSON
-  on stdin and are never executed through a shell.
-- `notify --deliver` is an explicit, default-off adapter over the same
-  persisted per-sink de-duplication state used by `operator watch`;
-  `--force-resend` requires delivery, and dry-run remains side-effect free.
-- Notification state advances to schema 2 independently of team.json schema 3,
-  retaining schema-1 manual-surface history without claiming external delivery.
-- In addition to filed gate-created and gate-staleness events, PR 1 includes the
-  approved `local_input_blocked` scope expansion observed during dogfood. It
-  reuses the conservative managed non-lead pane eligibility/detection contract,
-  preserves active state when capture is unknown, and never sends pane input or
-  grants approval.
+The release comprises exactly 13 merged PRs across the five milestone issues:
 
-## Interactive `run start` preview, Slice 1
+| Milestone issue | PR | Merge SHA | Result |
+| --- | --- | --- | --- |
+| #393 Interactive `run start` wizard | #394 | `df6d0e09c0002f609bdd2d36be1d78946f045ef2` | Preview-only wizard core. |
+| #393 Interactive `run start` wizard | #395 | `3b3745a22102348e4954fc5632d48341f4f09efa` | Structured preflight and team flow. |
+| #393 Interactive `run start` wizard | #397 | `7170c35b865c492cbae1916f6c7679b40901845e` | Bubble Tea UI and numbered/accessibility fallback. |
+| #393 Interactive `run start` wizard | #398 | `a42b068e6ea8944a6182a825b1c8fc8806892e60` | Operator interaction contracts and capability slots. |
+| #393 Interactive `run start` wizard | #399 | `1480b9f3b7bde720381ac3138d3bee11aa80a165` | Layout presets and launcher finalization. |
+| #393 Interactive `run start` wizard | #400 | `1f4177a7e737ab955a4600a2649ee469299c99a2` | Live confirmation and Global/NOC scope. |
+| #393 Interactive `run start` wizard | #412 | `78b6ad94f9d9b110890bb7811e460f11da7e8231` | Corrective deterministic-layout finalizer hardening. |
+| #390 Operator notification hook | #405 | `25ab4d20196e9656c87c08e6a961c99244308c06` | Attention pipeline, sinks, policy, and watch integration. |
+| #390 Operator notification hook | #406 | `c730fc71b53e6d700d8c0d6b50b18638fff5abd7` | Notification setup, status, and wizard composition. |
+| #391 Self-operator mode | #407 | `d10dd2df3f72911e60387eed34b6943fe8af3995` | Exact-session policy, approval path, and verifier. |
+| #391 Self-operator mode | #408 | `d7c99b4914dd69d0e1a942d29dd86cf513aaff0e` | Setup/visibility, wizard composition, and attention events. |
+| #396 Bootstrap delivery/ack visibility | #409 | `b52c03cf29a80c7a57e90b6f2d33c3a558ebc1e6` | Advisory bootstrap attestation plus single-pass native argv composition. |
+| #404 Short collect then park | #410 | `89a7f9051b33e67198fa77ccdd90f3374365fcc5` | Wake-friendly wait posture across source skills and generated Claude/Codex mirrors. |
 
-- `amq-squad wizard` and `amq-squad run start --interactive` open a guided,
-  numbered preview flow in an interactive terminal.
-- Zero-argument `amq-squad run start` changes from a missing-flag usage error
-  to the same wizard when stdin and stderr are TTYs and CI is not detected.
-- Non-TTY and CI invocations never prompt. Zero-argument non-TTY behavior keeps
-  the existing usage error, and partial flag commands stay canonical unless
-  `--interactive` is explicit.
-- Slice 1 is preview-only by construction. It prints a copyable flag-form
-  command and calls the existing `run start` preview path. It cannot emit or
-  execute `--go`.
-- `--interactive` combined with `--go` is rejected before reading input.
+## Launch wizard and interaction contracts
 
-## Structured wizard preflight and team flow, Slice 2
-
-- The wizard detects the nearest git root without network access and shows the
-  origin slug when configured. Session suggestions prefer an existing
-  profile's shared member session, then recognizable version/issue branch
-  tokens, then the sanitized project basename.
-- Existing profiles are listed with member count and pinned session. Their
-  roster, binaries, stored model/effort arguments, lead, and lead mode remain
-  authoritative; choosing a new profile enters the fresh-roster flow.
-- Run-start preflight now returns structured collision codes, details, and safe
-  suggested edits. The canonical CLI still fails closed through the same
-  checks, without UI error-string parsing or force/reset suggestions.
-- Fresh rosters accept `--effort role=level,...`. This is a new flag with zero
-  new semantics: values normalize only into the existing per-member
-  `codex_args` (`model_reasoning_effort`) or `claude_args` (`--effort`) fields.
-  No new persisted effort field or launch behavior is introduced.
-
-## Bubble Tea wizard and accessible fallback, Slice 3
-
-- Eligible terminals now use a full-screen Bubble Tea flow with arrow-key
-  navigation, back/cancel controls, a phase rail, topology diagrams, and a
-  final confirmation screen that still invokes only the canonical read-only
-  preview.
+- The wizard detects the nearest git root without network access and suggests a
+  session from an existing profile, recognizable branch token, or sanitized
+  project name. Existing profile state remains authoritative and is never
+  silently rewritten.
+- Fresh rosters accept role-specific binaries, models, and effort. The
+  `--effort role=level,...` convenience flag normalizes into existing native
+  Claude/Codex argument fields; it introduces no new persisted effort field.
+- Existing-profile model and effort overrides apply only to an in-memory launch
+  copy. Structured collision results expose stable codes, details, and safe
+  suggested edits without offering force/reset shortcuts.
 - `TERM=dumb`, `AMQ_SQUAD_WIZARD_ACCESSIBLE=1`, `--numbered`, and
-  `--wizard-ui numbered` select the plain numbered adapter. Operators can force
-  the full-screen adapter with `--wizard-ui tui`.
-- Both adapters use the same `Spec`, project inspection, and canonical
-  preflight. Existing profiles now explicitly ask, role by role, whether to
-  override model or effort for this launch. These overrides are applied to an
-  in-memory roster copy and never rewrite the stored profile.
-- Topology previews have golden coverage for sibling windows, current-window
-  panes, and detached operation. Cancellation exits without running preview or
-  mutating team state.
+  `--wizard-ui numbered` select the plain adapter. `--wizard-ui tui` forces the
+  full-screen adapter when the terminal is eligible.
+- Preview and live execution use the same canonical command. Preview failures
+  never prompt; only explicit `y`/`yes` adds `--go`; and the live call repeats
+  current-state checks so a new collision still fails closed.
+- Operator interaction modes (`lead_pane`, `separate_terminal`, `noc`, and
+  bounded `self_operator`) drive one shared ownership/polling contract across
+  setup, status, bootstrap, team rules, and both wizard adapters.
 
-## Operator interaction contracts and capability slots, Slice 4
+## Notification and authorization boundaries
 
-- Team profiles can persist `operator.interaction_mode` as `lead_pane`,
-  `separate_terminal`, `noc`, or bounded `self_operator`. Missing legacy values
-  remain `unspecified`.
-- `run start --operator-mode` persists the contract only while creating a
-  fresh profile. On existing profiles it is validation-only: an explicit value
-  must match, and the profile is never rewritten.
-- Status, bootstrap, operator-loop reporting, team previews, and generated team
-  rules derive polling and ownership from one contract mapping. Lead-pane mode
-  requires durable gate mirroring without separate polling; separate-terminal
-  mode is operator-polled; NOC mode is polled by the global/NOC orchestrator.
-- The wizard now asks for the operator contract after topology, defaults visible
-  launches to the lead pane and detached launches to a separate terminal, and
-  includes the effective contract in confirmation.
-- The #391 self-operator and #390 notification rows remain visibly release
-  labeled; self-operator is selectable only with an explicit allowlist.
+- Notification policy is profile-scoped. `team init
+  --operator-notifications` enables the default desktop attention policy for a
+  new profile; existing profiles remain authoritative.
+- `notify --deliver` and `operator watch` share per-sink reservation and
+  delivery state. `--force-resend` requires delivery, while dry-run remains
+  side-effect free. Notification state uses schema 2 independently of
+  `team.json` schema 3.
+- `local_input_blocked` eligibility remains conservative: managed non-lead
+  panes only, active state preserved when capture is unknown, and no pane input
+  or approval action.
+- Self-operator evidence is bound to the current project/profile/session,
+  question, action, target, policy revision, and verified actor. Notifications
+  are visibility only and cannot substitute for verifier evidence.
 
-## Deterministic tmux layouts, Slice 5
+## Bootstrap and wait behavior
 
-- `run start` and both wizard adapters accept `--layout-preset lead-left`,
-  `lead-top`, `even-grid`, or `one-window-per-agent`, plus
-  `--launcher-pane close-after-start|keep`. Omitting both flags preserves the
-  previous visibility and launcher behavior.
-- Presets map to one canonical spawn topology and final layout. Managed presets
-  close the launcher by default; external-lead and detached runs force it to
-  remain open. Contradictions are rejected before any pane is spawned.
-- The tmux backend can return the exact pane and window IDs synchronously. The
-  finalizer is scheduled only after spawn, optional goal delivery, and final
-  output; it waits for the parent CLI process to exit before closing or moving
-  panes. It never discovers agents from asynchronous launch records or targets
-  rename-sensitive labels.
-- Finalization is best-effort and bounded. A missing pane, timeout, or tmux
-  failure leaves launched agents running and persists a `layout_finalization`
-  warning for text and JSON status. Successful finalization clears a stale
-  warning.
-- Completion metadata, canonical help, dry-run output, and the Bubble Tea and
-  numbered wizard flows expose the same values and constraints.
+- Bootstrap acknowledgement is advisory observability, not a launch blocker.
+  Status and doctor distinguish grace, overdue, legacy, and not-required states;
+  strict marker permissions and identity/session/launch binding reject stale or
+  malformed acknowledgements.
+- Native argv composition recognizes singleton spans across team defaults,
+  launch overrides, and member args. The last layer wins for a singleton;
+  repeatables, unknown arguments, and prompt boundaries remain ordered.
+- A short `collect --timeout 120s` is appropriate immediately after dispatch
+  for an ACK or imminent report. For longer implementation, review, or operator
+  waits, end the turn and rely on wake. Never background `collect` or `drain`,
+  because competing readers consume mailbox state.
 
-## Preview-to-live wizard and Global/NOC scope, Slice 6
+## Validation and release evidence
 
-- In a TTY, zero-argument `run start` opens the wizard instead of returning the
-  historical missing-flag error. Non-TTY and CI calls remain noninteractive and
-  retain the canonical error behavior.
-- After collecting answers, the wizard prints and executes the exact canonical
-  preview command. Only after that preview succeeds does it ask
-  `Launch now? [y/N]`. The default, EOF, cancellation, and any answer other than
-  explicit `y`/`yes` do not launch.
-- An affirmative answer invokes the same existing routine with identical argv
-  plus only `--go`. The live call therefore repeats all current-state checks;
-  preview failures never prompt, and a newly introduced collision is refused.
-- Bubble Tea exits its alternate screen before the confirmation is read from
-  the same `/dev/tty`; the numbered/accessibility adapter uses its injected
-  reader and writer for both phases.
-- The first wizard choice selects Project run (default) or Global/NOC. Global
-  scope collects a neutral root, one agent binary, model, validated effort,
-  extra native arguments excluding effort, and
-  window name, displays the poll/no-wake contract, and delegates preview/live
-  calls to canonical `global start`. Project roster/layout flags never enter
-  global argv, and only the selected binary's native-argument flag is emitted.
-- Completion now includes `--wizard-ui`, `--numbered`, and `--accessible`.
-  Canonical copy/paste forms are `amq-squad run start ...` and
-  `amq-squad global start ...`; both remain preview-by-default.
+- Every merged feature/fix PR reported `go test ./...` and `make ci`; focused
+  suites cover wizard state and canonical argv, notification reservation and
+  delivery, self-operator policy/evidence, bootstrap markers, native argument
+  composition, and deterministic layout scheduling.
+- The #393 pre-merge tmux matrix passed at exact head
+  `f8a2177f30aa3458f69397e37eb625a4f4155d25`, with retained evidence at
+  `/private/tmp/amq-393-smoke-f8a2177f/evidence`.
+- A fresh shipped-code matrix then passed at
+  `c42c1ea20020b908f91f6b400575107d2eb1ae0f`. Its tree is identical to the
+  merged-main #412 commit
+  `78b6ad94f9d9b110890bb7811e460f11da7e8231`; evidence is retained at
+  `/private/tmp/amq-393-smoke-c42c1ea/evidence`. The matrix covers all four
+  presets, managed launcher close/rename, external-lead keep, real-Claude
+  bootstrap/liveness, warning clear, and the natural tmux 3.6a empty-output
+  second-probe failure while surviving agents remain live.
+- The release-prep gate includes generated skill mirrors and README HTML,
+  whitespace validation, the full CI target, exact v2.19.0 release metadata
+  validation, a version-stamped build, and an exact `amq-squad v2.19.0` runtime
+  version check.
 
-## Bounded self-operator mode (#391)
+## Follow-ups and explicit non-claims
 
-- Fresh-profile wizard and `run start` flows persist an exact-session,
-  explicit merge-only policy; no allowlist is preselected.
-- Spawn and immutable high-risk exclusions remain human-only, and a different
-  strongly verified actor must execute a self-approved merge.
-- Status/bootstrap expose revision, allowlist, pause/revocation state, and
-  notification visibility. Existing profiles remain authoritative.
-- `self_approved` and `human_only_gate` are normalized attention-only events;
-  notification delivery has no authorization effect.
+- Bootstrap attestation improves detection but does not prove the root cause of
+  the originally missed Claude bootstrap. Delivery, client startup, prompt
+  handling, and timing remain possible causes; older builds should configure
+  native model/effort arguments in one layer and manually confirm READY.
+- #411 remains open for v2.20 after three unattributed sightings. A sanitized,
+  isolated `count=20` run passed in 1178.415s package time and 1186.29s wall
+  time, so the evidence does not attribute the sightings to one cause or
+  justify a stronger reliability claim.
+- Self-approved spawn remains disabled until an exact-namespace dry-run,
+  budget, depth, and role evidence schema can match merge verification's
+  fail-closed contract.
+- Existing-profile self-operator prefill mismatch behavior was verified. The
+  remaining regression gap is test coverage only, not a known behavior defect.
+- Global/NOC data collection remains line-oriented rather than embedded in the
+  full-screen UI, and final live confirmation occurs after the alternate screen
+  closes.
+- Native-terminal limitations remain capability-specific: cmux has no shipped
+  backend; Terminal.app focus/input remains manual; and the existing follow-ups
+  for cmux, native send/capture/busy detection, close support, cross-platform
+  GUI backends, and non-tmux local-input detection remain open (#373-#379).
+
+## Compatibility
+
+- amq-squad v2.19.0 retains the amq 0.41.0+ floor introduced in v2.18.0.
+- Go 1.25+ remains required.
+- tmux remains Tier A. iTerm2 Tier B and Terminal.app Tier C are macOS-only and
+  degrade according to their advertised capabilities; cmux remains pending.
+- The Claude/Codex plugin manifests, source skill marker, generated skill
+  mirrors, pinned install example, and release metadata are versioned together
+  at v2.19.0.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.18.0** — on your FIRST response of a session, print the line `amq-squad skill v2.18.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.18.0** — on your FIRST response of a session, print the line `amq-squad skill v2.18.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.18.0** — on your FIRST response of a session, print the line `amq-squad skill v2.18.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 


### PR DESCRIPTION
v2.19.0 release preparation: version bumps (plugin/source/mirrors), README/HTML regeneration, and finalized release notes carrying the full milestone ledger — 5 issues (#393, #390, #391, #396, #404) across 13 merged PRs (#394 #395 #397 #398 #399 #400 #405 #406 #407 #408 #409 #410 #412), plus follow-ups (#411 flaky-test hunt, wizard existing-profile self-operator mismatch regression).

Head 130c77c42ecad791159948fde47ecfd87c85cab6 on main 78b6ad94. All generation/diff/CI/release-check/build/version gates green at this head. Created by the lead under resolved gate/release-prep-pr (standing approval gate/standing-approval-v2-19-0); dual review + distinct-actor co-sign + verify release preflight follow before the operator-gated tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)