### PR TITLE
Hand the raw TTY to Bubble Tea so the wizard accepts input

### DIFF
--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -222,7 +222,9 @@ func runBubbleRunStartWizard(args []string, version string) error {
 	}
 	prefill.Scope = "project"
 	opts.Defaults = prefill
-	result, err := runStartWizardBubbleProgram(reader, tty, opts)
+	// Bubble Tea enables raw mode only when its input is the tty file itself;
+	// a wrapping reader leaves the terminal cooked and every key is swallowed.
+	result, err := runStartWizardBubbleProgram(tty, tty, opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -224,6 +224,14 @@ func runBubbleRunStartWizard(args []string, version string) error {
 	opts.Defaults = prefill
 	// Bubble Tea enables raw mode only when its input is the tty file itself;
 	// a wrapping reader leaves the terminal cooked and every key is swallowed.
+	// The scope prompt's reader may have over-read past its line; drop that
+	// typeahead so it cannot resurface at the launch confirmation and answer
+	// it on the user's behalf.
+	if buffered := reader.Buffered(); buffered > 0 {
+		if _, err := reader.Discard(buffered); err != nil {
+			return err
+		}
+	}
 	result, err := runStartWizardBubbleProgram(tty, tty, opts)
 	if err != nil {
 		return err

--- a/internal/cli/run_start_wizard_live_test.go
+++ b/internal/cli/run_start_wizard_live_test.go
@@ -325,6 +325,31 @@ func TestBubbleWizardHandsRawTTYToProgramNotAWrapper(t *testing.T) {
 	}
 }
 
+func TestBubbleWizardTypeaheadCannotAnswerLaunchConfirm(t *testing.T) {
+	// The scope prompt's bufio reader can over-read past its own line. Those
+	// typed-ahead bytes never reach the bubble program (which reads the raw
+	// tty directly) and must not leak into "Launch now? [y/N]" as an
+	// accidental yes.
+	projectCalls, _ := withWizardExecutionSeams(t)
+	oldOpen := runStartWizardOpenTTY
+	oldProgram := runStartWizardBubbleProgram
+	t.Cleanup(func() { runStartWizardOpenTTY, runStartWizardBubbleProgram = oldOpen, oldProgram })
+	// "1\n" answers the scope prompt; "y\n" is typeahead the bufio reader
+	// buffers in the same fill and must discard before the confirmation.
+	tty := wizardTestTTY{reader: bytes.NewReader([]byte("1\ny\n")), writes: &bytes.Buffer{}}
+	runStartWizardOpenTTY = func() (io.ReadWriteCloser, error) { return tty, nil }
+	spec := validWizardProjectSpec(t)
+	runStartWizardBubbleProgram = func(in io.Reader, out io.Writer, opts runwizard.NumberedOptions) (runwizard.BubbleResult, error) {
+		return runwizard.BubbleResult{Spec: spec}, nil
+	}
+	if err := runBubbleRunStartWizard([]string{"--project", spec.Project}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(*projectCalls) != 1 || hasWizardArg((*projectCalls)[0], "--go") {
+		t.Fatalf("typeahead answered the launch confirmation: calls = %v", *projectCalls)
+	}
+}
+
 func assertOnlyGoDelta(t *testing.T, calls [][]string) {
 	t.Helper()
 	if len(calls) != 2 {

--- a/internal/cli/run_start_wizard_live_test.go
+++ b/internal/cli/run_start_wizard_live_test.go
@@ -297,6 +297,34 @@ func TestBubbleWizardReturnsFromProgramThenConfirmsOnSameTTY(t *testing.T) {
 	}
 }
 
+func TestBubbleWizardHandsRawTTYToProgramNotAWrapper(t *testing.T) {
+	// Bubble Tea enables raw mode only when its input asserts to term.File
+	// (the tty *os.File itself). Passing any wrapping reader leaves the
+	// terminal cooked: keys are line-buffered and enter arrives as ctrl+j,
+	// freezing the wizard on its first phase (#421).
+	withWizardExecutionSeams(t)
+	oldOpen := runStartWizardOpenTTY
+	oldProgram := runStartWizardBubbleProgram
+	t.Cleanup(func() { runStartWizardOpenTTY, runStartWizardBubbleProgram = oldOpen, oldProgram })
+	tty := wizardTestTTY{reader: bytes.NewReader([]byte("\n")), writes: &bytes.Buffer{}}
+	runStartWizardOpenTTY = func() (io.ReadWriteCloser, error) { return tty, nil }
+	var gotIn io.Reader
+	var gotOut io.Writer
+	runStartWizardBubbleProgram = func(in io.Reader, out io.Writer, opts runwizard.NumberedOptions) (runwizard.BubbleResult, error) {
+		gotIn, gotOut = in, out
+		return runwizard.BubbleResult{Cancelled: true}, nil
+	}
+	if err := runBubbleRunStartWizard([]string{"--scope", "project", "--project", t.TempDir()}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if in, ok := gotIn.(wizardTestTTY); !ok || in != tty {
+		t.Fatalf("bubble program input = %T, want the exact tty from runStartWizardOpenTTY", gotIn)
+	}
+	if out, ok := gotOut.(wizardTestTTY); !ok || out != tty {
+		t.Fatalf("bubble program output = %T, want the exact tty from runStartWizardOpenTTY", gotOut)
+	}
+}
+
 func assertOnlyGoDelta(t *testing.T, calls [][]string) {
 	t.Helper()
 	if len(calls) != 2 {


### PR DESCRIPTION
Fixes #421.

## Problem

`amq-squad wizard` (TUI adapter) rendered phase 1 and then ignored every key — enter, arrows, esc all dead; only ctrl+c escaped. Reported live by the operator on v2.19.0.

## Root cause

`runBubbleRunStartWizard` opened `/dev/tty`, wrapped it in a `bufio.Reader` for the scope prompt, and passed **that wrapper** to Bubble Tea. Bubble Tea v1.3.10 enables raw mode only when its input asserts to `term.File` (`tty_unix.go:17`); a `bufio.Reader` fails that, so the terminal stayed in cooked mode: keystrokes were line-buffered by the tty driver and enter arrived as `\n` → parsed as ctrl+j, which the wizard's key handler ignores. Unit tests drive `Update()` with synthetic `tea.KeyMsg` values and never exercised the input plumbing.

## Fix

Pass the tty itself to the Bubble Tea program (`runStartWizardBubbleProgram(tty, tty, opts)`); the line-oriented scope and launch-confirm prompts keep their reader.

Regression test: `TestBubbleWizardHandsRawTTYToProgramNotAWrapper` asserts the bubble program receives the exact object returned by `runStartWizardOpenTTY` — fails on the old code (which handed over a `*bufio.Reader`).

## Verification

- gofmt clean, `go test ./...` green, `make ci` green locally.
- v2.19.1-rc.1 built from this branch is installed locally; operator is dogfooding the wizard interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)