### PR TITLE
Wizard UX follow-ups: early session check, truthful operator labels, model pickers

### DIFF
--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -611,6 +611,13 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 			m.history = m.history[:len(m.history)-1]
 			return m, nil
 		}
+		if m.existingIndex >= 0 {
+			if mismatch := pinnedSessionMismatch(m.ctx.Profiles[m.existingIndex], value); mismatch != nil {
+				m.err = mismatch
+				m.history = m.history[:len(m.history)-1]
+				return m, nil
+			}
+		}
 		m.spec.Session = value
 		if m.existingIndex >= 0 {
 			m.spec.Roles, m.spec.Binary, m.spec.Model, m.spec.Effort, m.spec.Lead, m.spec.LeadMode = "", "", "", "", "", ""

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -19,10 +19,12 @@ const (
 	stageSession
 	stageExistingOverride
 	stageExistingModel
+	stageExistingModelCustom
 	stageExistingEffort
 	stageRoles
 	stageRoleBinary
 	stageRoleModel
+	stageRoleModelCustom
 	stageRoleEffort
 	stageLead
 	stageLeadMode
@@ -283,6 +285,8 @@ func (m BubbleModel) title() string {
 		return "Launch-time override · " + m.currentMember().Role
 	case stageExistingModel:
 		return "Model override · " + m.currentMember().Role
+	case stageExistingModelCustom:
+		return "Custom model override · " + m.currentMember().Role
 	case stageExistingEffort:
 		return "Effort override · " + m.currentMember().Role
 	case stageRoles:
@@ -291,6 +295,8 @@ func (m BubbleModel) title() string {
 		return "Binary · " + m.currentRole()
 	case stageRoleModel:
 		return "Model · " + m.currentRole()
+	case stageRoleModelCustom:
+		return "Custom model · " + m.currentRole()
 	case stageRoleEffort:
 		return "Effort · " + m.currentRole()
 	case stageLead:
@@ -331,13 +337,17 @@ func (m BubbleModel) note() string {
 		member := m.currentMember()
 		return fmt.Sprintf("Profile values stay untouched: model=%s · effort=%s", defaultString(member.Model, "automatic"), defaultString(member.Effort, "automatic"))
 	case stageExistingModel:
+		return "Keep uses the stored profile value; a pick applies to this launch only."
+	case stageExistingModelCustom:
 		return "Enter a model for this launch only, or leave blank to keep the profile value."
 	case stageExistingEffort:
 		return "This replaces only the native effort args in the in-memory launch plan."
 	case stageRoles:
 		return "Comma-separated role ids. Defaults are shown in the field."
 	case stageRoleModel:
-		return "Use automatic to let the selected binary choose."
+		return "Models pass through to the selected binary verbatim; custom accepts any name."
+	case stageRoleModelCustom:
+		return "Enter any model name, or leave blank for automatic."
 	case stageTopology:
 		return "The diagram is the topology that the canonical visibility flag selects."
 	case stageLayoutPreset:
@@ -407,7 +417,7 @@ func (m BubbleModel) summary() string {
 
 func (m BubbleModel) isTextStage() bool {
 	switch m.stage {
-	case stageProject, stageNewProfile, stageSession, stageExistingModel, stageRoles, stageRoleModel, stageLead, stageGoal, stageSeed:
+	case stageProject, stageNewProfile, stageSession, stageExistingModelCustom, stageRoles, stageRoleModelCustom, stageLead, stageGoal, stageSeed:
 		return true
 	default:
 		return false
@@ -433,12 +443,14 @@ func (m *BubbleModel) configureStage() {
 		if value == "" {
 			value = m.ctx.SessionSuggestion
 		}
-	case stageExistingModel:
+	case stageExistingModelCustom:
+		value = parseAssignments(m.spec.Model)[m.currentMember().Role]
 		placeholder = "leave blank to keep " + defaultString(m.currentMember().Model, "automatic")
 	case stageRoles:
 		value = defaultString(m.spec.Roles, "cto,senior-dev,qa")
-	case stageRoleModel:
-		value = defaultString(parseAssignments(m.spec.Model)[m.currentRole()], "automatic")
+	case stageRoleModelCustom:
+		value = parseAssignments(m.spec.Model)[m.currentRole()]
+		placeholder = "leave blank for automatic"
 	case stageLead:
 		value = defaultString(m.spec.Lead, defaultLead(m.roleOrder))
 	case stageGoal:
@@ -472,10 +484,14 @@ func (m BubbleModel) choices() []choice {
 		return choices
 	case stageExistingOverride:
 		return []choice{{value: "keep", label: "Keep profile model and effort"}, {value: "override", label: "Override this role for this launch only"}}
+	case stageExistingModel:
+		return existingOverrideModelChoices(m.currentMember())
 	case stageExistingEffort:
 		return effortChoices(m.currentMember().Binary)
 	case stageRoleBinary:
 		return []choice{{value: "codex", label: "Codex"}, {value: "claude", label: "Claude"}}
+	case stageRoleModel:
+		return modelChoices(parseAssignments(m.spec.Binary)[m.currentRole()])
 	case stageRoleEffort:
 		return effortChoices(parseAssignments(m.spec.Binary)[m.currentRole()])
 	case stageLeadMode:
@@ -538,8 +554,14 @@ func (m BubbleModel) defaultCursor() int {
 	switch m.stage {
 	case stageProfile:
 		want = defaultString(m.spec.Profile, "default")
+	case stageExistingModel:
+		// An empty override maps to automatic, which this list omits; the
+		// find-loop then falls through to keep at index zero.
+		want = defaultModelChoice(parseAssignments(m.spec.Model)[m.currentMember().Role], m.currentMember().Binary)
 	case stageExistingEffort:
 		want = defaultString(m.currentMember().Effort, effortAutomatic)
+	case stageRoleModel:
+		want = defaultModelChoice(parseAssignments(m.spec.Model)[m.currentRole()], parseAssignments(m.spec.Binary)[m.currentRole()])
 	case stageRoleBinary:
 		want = parseAssignments(m.spec.Binary)[m.currentRole()]
 		if want == "" {
@@ -635,7 +657,7 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 		} else {
 			m.transition(stageRoles)
 		}
-	case stageExistingModel:
+	case stageExistingModelCustom:
 		if value != "" {
 			m.spec.Model = setAssignment(m.spec.Model, m.currentMember().Role, value)
 		} else {
@@ -658,8 +680,8 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 		}
 		m.roleIndex = 0
 		m.transition(stageRoleBinary)
-	case stageRoleModel:
-		if value == "" || strings.EqualFold(value, "automatic") {
+	case stageRoleModelCustom:
+		if value == "" || strings.EqualFold(value, effortAutomatic) {
 			m.spec.Model = removeAssignment(m.spec.Model, m.currentRole())
 		} else {
 			m.spec.Model = setAssignment(m.spec.Model, m.currentRole(), value)
@@ -709,12 +731,34 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 		} else {
 			m.nextExistingMember()
 		}
+	case stageExistingModel:
+		switch selected {
+		case modelCustomChoice:
+			m.transition(stageExistingModelCustom)
+		case modelKeepChoice:
+			m.spec.Model = removeAssignment(m.spec.Model, m.currentMember().Role)
+			m.transition(stageExistingEffort)
+		default:
+			m.spec.Model = setAssignment(m.spec.Model, m.currentMember().Role, selected)
+			m.transition(stageExistingEffort)
+		}
 	case stageExistingEffort:
 		m.spec.Effort = setAssignment(m.spec.Effort, m.currentMember().Role, selected)
 		m.nextExistingMember()
 	case stageRoleBinary:
 		m.spec.Binary = setAssignment(m.spec.Binary, m.currentRole(), selected)
 		m.transition(stageRoleModel)
+	case stageRoleModel:
+		switch selected {
+		case modelCustomChoice:
+			m.transition(stageRoleModelCustom)
+		case effortAutomatic:
+			m.spec.Model = removeAssignment(m.spec.Model, m.currentRole())
+			m.transition(stageRoleEffort)
+		default:
+			m.spec.Model = setAssignment(m.spec.Model, m.currentRole(), selected)
+			m.transition(stageRoleEffort)
+		}
 	case stageRoleEffort:
 		if selected == effortAutomatic {
 			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentRole())
@@ -827,7 +871,7 @@ func (m BubbleModel) phaseIndex() int {
 	switch m.stage {
 	case stageProject:
 		return 0
-	case stageProfile, stageNewProfile, stageSession, stageExistingOverride, stageExistingModel, stageExistingEffort, stageRoles, stageRoleBinary, stageRoleModel, stageRoleEffort, stageLead, stageLeadMode:
+	case stageProfile, stageNewProfile, stageSession, stageExistingOverride, stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageRoles, stageRoleBinary, stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageLead, stageLeadMode:
 		return 1
 	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 2

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -352,7 +352,8 @@ func (m BubbleModel) note() string {
 		return "Close is scheduled only after successful spawn, goal delivery, and final output."
 	case stageOperator:
 		if m.existingIndex >= 0 {
-			return "Existing profile contract is authoritative: " + defaultString(m.spec.OperatorMode, "unspecified")
+			mode := defaultString(m.spec.OperatorMode, "unspecified")
+			return "Existing profile contract is authoritative: " + mode + " · " + operatorContractSummary(mode) + ". Change it with 'amq-squad team operator set', then relaunch."
 		}
 		return "Unavailable capability rows stay visible so the future contract is explicit."
 	case stageOperatorNotifications:
@@ -490,6 +491,7 @@ func (m BubbleModel) choices() []choice {
 			for _, item := range operatorChoices(m.opts.Capabilities) {
 				if item.capability {
 					item.disabled = true
+					item.label += " [locked: the stored profile contract decides]"
 					choices = append(choices, item)
 				}
 			}

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -9,6 +9,13 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// flattenBubbleView strips the panel border and collapses the word-wrap that
+// lipgloss applies, so tests can assert full phrases regardless of wrap points.
+func flattenBubbleView(view string) string {
+	replaced := strings.NewReplacer("│", " ", "╭", " ", "╮", " ", "╰", " ", "╯", " ", "─", " ").Replace(view)
+	return strings.Join(strings.Fields(replaced), " ")
+}
+
 func TestBubbleModelStartsWithProjectDefaultsAndPhaseRail(t *testing.T) {
 	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{
 		Project: "/repo", Profile: "default", Session: "issue-393", Visibility: "sibling-tabs",
@@ -94,11 +101,14 @@ func TestBubbleModelExistingProfileOverridesAndExplicitNotificationMismatchArePr
 	if m.stage != stageOperator {
 		t.Fatalf("stage = %v, want operator", m.stage)
 	}
-	operatorView := m.View()
-	for _, want := range []string{"Self-operator / delegated approval", "v2.19.0: #391"} {
+	operatorView := flattenBubbleView(m.View())
+	for _, want := range []string{"Self-operator / delegated approval", "locked: the stored profile contract decides", "Change it with 'amq-squad team operator set'"} {
 		if !strings.Contains(operatorView, want) {
 			t.Fatalf("existing operator view missing %q:\n%s", want, operatorView)
 		}
+	}
+	if strings.Contains(operatorView, "ships in") {
+		t.Fatalf("shipped capability still advertised as future:\n%s", operatorView)
 	}
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.stage != stageOperatorNotifications {

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -86,6 +86,11 @@ func TestBubbleModelExistingProfileOverridesAndExplicitNotificationMismatchArePr
 	if m.stage != stageExistingModel {
 		t.Fatalf("stage = %v, want existing model", m.stage)
 	}
+	m.cursor = 3 // custom: type a model name
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageExistingModelCustom {
+		t.Fatalf("stage = %v, want existing model custom", m.stage)
+	}
 	m.input.SetValue("launch-model")
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	m.cursor = 3 // high
@@ -334,12 +339,52 @@ func TestBubbleModelBlankExistingModelRemovesEarlierLaunchOverride(t *testing.T)
 	}
 	m.ctx.Profiles = []ProfileSummary{{Name: "review", Members: []MemberSummary{{Role: "cto", Binary: "codex"}}}}
 	m.existingIndex = 0
-	m.stage = stageExistingModel
+	m.stage = stageExistingModelCustom
 	m.configureStage()
 	m.input.SetValue("")
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.spec.Model != "" {
 		t.Fatalf("cleared model override = %q", m.spec.Model)
+	}
+}
+
+func TestBubbleModelOffersModelsPerBinaryWithCustomEscape(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Roles: "cto", Binary: "cto=claude"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.roleOrder = []string{"cto"}
+	m.stage = stageRoleModel
+	m.configureStage()
+	view := flattenBubbleView(m.View())
+	for _, want := range []string{"automatic", "opus", "sonnet", "haiku", "custom"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("claude model list missing %q:\n%s", want, view)
+		}
+	}
+	m.cursor = 2 // sonnet
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageRoleEffort || m.spec.Model != "cto=sonnet" {
+		t.Fatalf("curated pick = stage %v model %q", m.stage, m.spec.Model)
+	}
+
+	m, err = NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Roles: "cto", Binary: "cto=codex"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.roleOrder = []string{"cto"}
+	m.stage = stageRoleModel
+	m.configureStage()
+	choices := m.choices()
+	m.cursor = len(choices) - 1 // custom
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageRoleModelCustom {
+		t.Fatalf("custom escape = stage %v", m.stage)
+	}
+	m.input.SetValue("gpt-5.7-experimental")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageRoleEffort || m.spec.Model != "cto=gpt-5.7-experimental" {
+		t.Fatalf("custom model = stage %v model %q", m.stage, m.spec.Model)
 	}
 }
 

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -357,12 +357,12 @@ func TestBubbleModelOffersModelsPerBinaryWithCustomEscape(t *testing.T) {
 	m.stage = stageRoleModel
 	m.configureStage()
 	view := flattenBubbleView(m.View())
-	for _, want := range []string{"automatic", "opus", "sonnet", "haiku", "custom"} {
+	for _, want := range []string{"automatic", "fable", "opus", "sonnet", "haiku", "custom"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("claude model list missing %q:\n%s", want, view)
 		}
 	}
-	m.cursor = 2 // sonnet
+	m.cursor = 3 // sonnet
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.stage != stageRoleEffort || m.spec.Model != "cto=sonnet" {
 		t.Fatalf("curated pick = stage %v model %q", m.stage, m.spec.Model)

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -129,6 +129,42 @@ func TestBubbleModelExistingProfileOverridesAndExplicitNotificationMismatchArePr
 	}
 }
 
+func TestBubbleModelRejectsSessionThePinnedProfileCannotRun(t *testing.T) {
+	profile := ProfileSummary{
+		Name: "default", MemberCount: 1, PinnedSession: "issue-136",
+		Members: []MemberSummary{{Role: "cto", Binary: "codex"}},
+	}
+	m, err := NewBubbleModel(NumberedOptions{
+		Defaults: Spec{Project: "/repo", Profile: "default"},
+		InspectProject: func(string) (ProjectContext, error) {
+			return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // project
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // profile: default
+	if m.stage != stageSession {
+		t.Fatalf("stage = %v, want session", m.stage)
+	}
+	m.input.SetValue("issue-218")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageSession || m.err == nil {
+		t.Fatalf("mismatched session advanced: stage=%v err=%v", m.stage, m.err)
+	}
+	for _, want := range []string{"issue-136", "issue-218", "named profile"} {
+		if !strings.Contains(m.err.Error(), want) {
+			t.Fatalf("mismatch guidance missing %q: %v", want, m.err)
+		}
+	}
+	m.input.SetValue("issue-136")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageExistingOverride || m.spec.Session != "issue-136" {
+		t.Fatalf("pinned session refused: stage=%v session=%q", m.stage, m.spec.Session)
+	}
+}
+
 func TestBubbleModelHydratesEnabledAuthoritativeNotifications(t *testing.T) {
 	profile := ProfileSummary{
 		Name: "review", PinnedSession: "review-work", OperatorMode: "noc", OperatorNotifications: true,

--- a/internal/wizard/capabilities.go
+++ b/internal/wizard/capabilities.go
@@ -70,17 +70,6 @@ func OptionAvailabilityLabel(caps CapabilitySet, option Option) string {
 	return "unavailable"
 }
 
-func CapabilityReleaseLabel(caps CapabilitySet, option Option) string {
-	if option.Requires == "" {
-		return ""
-	}
-	capability := caps[option.Requires]
-	if capability.ShipsIn != "" && capability.Issue > 0 {
-		return fmt.Sprintf("ships in %s: #%d", capability.ShipsIn, capability.Issue)
-	}
-	return ""
-}
-
 func effectiveCapabilities(caps CapabilitySet) CapabilitySet {
 	if caps == nil {
 		return DefaultCapabilities()
@@ -95,12 +84,10 @@ func operatorChoices(caps CapabilitySet) []choice {
 	for _, option := range options {
 		availability := OptionAvailabilityLabel(caps, option)
 		label := option.Label + " · " + option.Consequence
-		release := CapabilityReleaseLabel(caps, option)
-		if release == "" {
-			release = availability
-		}
-		if release != "" {
-			label += " [" + release + "]"
+		// The ships-in provenance appears only while the capability is
+		// genuinely unavailable; a shipped feature must not read as future.
+		if availability != "" {
+			label += " [" + availability + "]"
 		}
 		if option.Blocked {
 			label += " [" + option.BlockReason + "]"

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -309,6 +309,7 @@ func modelChoices(binary string) []choice {
 	choices := []choice{{value: effortAutomatic, label: "automatic: let the binary choose"}}
 	if strings.EqualFold(binary, "claude") {
 		choices = append(choices,
+			choice{value: "fable", label: "fable"},
 			choice{value: "opus", label: "opus"},
 			choice{value: "sonnet", label: "sonnet"},
 			choice{value: "haiku", label: "haiku"},

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -233,13 +233,14 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		return Spec{}, err
 	}
 	if existing {
-		fmt.Fprintf(out, "Operator interaction (authoritative): %s\n", defaultString(s.OperatorMode, "unspecified"))
+		mode := defaultString(s.OperatorMode, "unspecified")
+		fmt.Fprintf(out, "Operator interaction (authoritative): %s · %s. Change it with 'amq-squad team operator set', then relaunch.\n", mode, operatorContractSummary(mode))
 		if s.OperatorMode == "self_operator" {
 			fmt.Fprintf(out, "Self-operator policy (authoritative): lead=%s session=%s allow=%s revision=%d paused=%t notifications=%t\n", existingProfile.SelfOperatorLead, s.Session, existingProfile.SelfOperatorAllow, existingProfile.SelfOperatorRevision, existingProfile.SelfOperatorPaused, s.OperatorNotifications)
 		}
 		for _, item := range operatorChoices(opts.Capabilities) {
 			if item.capability {
-				fmt.Fprintf(out, "  - %s\n", item.label)
+				fmt.Fprintf(out, "  - %s [locked: the stored profile contract decides]\n", item.label)
 			}
 		}
 		fmt.Fprintln(out)

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -144,12 +144,20 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 				if override != "override" {
 					continue
 				}
-				model, promptErr := promptOptionalOverride(r, out, member.Role+" model override", defaultString(member.Model, "automatic"))
+				modelSel, promptErr := promptChoice(r, out, member.Role+" model override", existingOverrideModelChoices(member), modelKeepChoice)
 				if promptErr != nil {
 					return Spec{}, promptErr
 				}
-				if model != "" {
-					modelOverrides[member.Role] = model
+				if modelSel == modelCustomChoice {
+					custom, customErr := promptOptionalOverride(r, out, member.Role+" model override", defaultString(member.Model, "automatic"))
+					if customErr != nil {
+						return Spec{}, customErr
+					}
+					if custom != "" {
+						modelOverrides[member.Role] = custom
+					}
+				} else if modelSel != modelKeepChoice {
+					modelOverrides[member.Role] = modelSel
 				}
 				effortChoices := []choice{{value: "automatic", label: "automatic: ignore stored effort for this launch"}, {value: "low", label: "low"}, {value: "medium", label: "medium"}, {value: "high", label: "high"}}
 				if member.Binary == "codex" {
@@ -189,11 +197,16 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 			if err != nil {
 				return Spec{}, err
 			}
-			model, promptErr := promptText(r, out, role+" model", defaultString(modelPrefill[role], "automatic"))
+			model, promptErr := promptChoice(r, out, role+" model", modelChoices(binaryValues[role]), defaultModelChoice(modelPrefill[role], binaryValues[role]))
 			if promptErr != nil {
 				return Spec{}, promptErr
 			}
-			if model != "" && !strings.EqualFold(model, "automatic") {
+			if model == modelCustomChoice {
+				if model, promptErr = promptText(r, out, role+" model name", defaultString(modelPrefill[role], "automatic")); promptErr != nil {
+					return Spec{}, promptErr
+				}
+			}
+			if model != "" && !strings.EqualFold(model, effortAutomatic) {
 				modelValues[role] = model
 			}
 			effortChoices := []choice{{value: "automatic", label: "automatic: let the binary choose"}, {value: "low", label: "low"}, {value: "medium", label: "medium"}, {value: "high", label: "high"}}
@@ -283,7 +296,57 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	return s, nil
 }
 
-const effortAutomatic = "automatic"
+const (
+	effortAutomatic   = "automatic"
+	modelCustomChoice = "custom"
+	modelKeepChoice   = "keep"
+)
+
+// modelChoices offers common models per binary. Models pass through to the
+// binary verbatim, so this list is a convenience, never an allowlist; the
+// custom row keeps free-text entry available.
+func modelChoices(binary string) []choice {
+	choices := []choice{{value: effortAutomatic, label: "automatic: let the binary choose"}}
+	if strings.EqualFold(binary, "claude") {
+		choices = append(choices,
+			choice{value: "opus", label: "opus"},
+			choice{value: "sonnet", label: "sonnet"},
+			choice{value: "haiku", label: "haiku"},
+		)
+	} else {
+		choices = append(choices,
+			choice{value: "gpt-5.6-sol", label: "gpt-5.6-sol"},
+			choice{value: "gpt-5.6-terra", label: "gpt-5.6-terra"},
+		)
+	}
+	return append(choices, choice{value: modelCustomChoice, label: "custom: type a model name"})
+}
+
+// existingOverrideModelChoices frames the same list for a launch-only override:
+// keep replaces automatic because clearing the override falls back to the
+// stored profile value, not to the binary's default.
+func existingOverrideModelChoices(member MemberSummary) []choice {
+	choices := []choice{{value: modelKeepChoice, label: "keep profile model: " + defaultString(member.Model, "automatic")}}
+	for _, item := range modelChoices(member.Binary) {
+		if item.value != effortAutomatic {
+			choices = append(choices, item)
+		}
+	}
+	return choices
+}
+
+func defaultModelChoice(prefill, binary string) string {
+	prefill = strings.TrimSpace(prefill)
+	if prefill == "" {
+		return effortAutomatic
+	}
+	for _, item := range modelChoices(binary) {
+		if strings.EqualFold(item.value, prefill) {
+			return item.value
+		}
+	}
+	return modelCustomChoice
+}
 
 // pinnedSessionMismatch mirrors run start's existing_profile_session_mismatch
 // preflight at answer time: a pinned roster runs only its pinned workstream,

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -98,8 +98,18 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	if strings.TrimSpace(sessionDefault) == "" {
 		sessionDefault = ctx.SessionSuggestion
 	}
-	if s.Session, err = promptText(r, out, "Workstream session", sessionDefault); err != nil {
-		return Spec{}, err
+	for {
+		if s.Session, err = promptText(r, out, "Workstream session", sessionDefault); err != nil {
+			return Spec{}, err
+		}
+		if existingProfile == nil {
+			break
+		}
+		mismatch := pinnedSessionMismatch(*existingProfile, s.Session)
+		if mismatch == nil {
+			break
+		}
+		fmt.Fprintf(out, "Check: %v\n", mismatch)
 	}
 
 	existing := existingProfile != nil || (opts.ProfileExists != nil && opts.ProfileExists(s.Project, s.Profile))
@@ -273,6 +283,20 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 }
 
 const effortAutomatic = "automatic"
+
+// pinnedSessionMismatch mirrors run start's existing_profile_session_mismatch
+// preflight at answer time: a pinned roster runs only its pinned workstream,
+// so a different session must be rejected before the user invests in the
+// remaining phases. Best-effort — the summary carries one inferred pin, so
+// the canonical preflight stays authoritative.
+func pinnedSessionMismatch(profile ProfileSummary, session string) error {
+	pinned := strings.TrimSpace(profile.PinnedSession)
+	session = strings.TrimSpace(session)
+	if (profile.MemberCount == 0 && len(profile.Members) == 0) || pinned == "" || pinned == session {
+		return nil
+	}
+	return fmt.Errorf("profile %q runs only its pinned workstream %s; use %s, or pick a named profile for %s instead", profile.Name, pinned, pinned, session)
+}
 
 func promptProfile(r *bufio.Reader, out io.Writer, current string, ctx ProjectContext) (string, *ProfileSummary, error) {
 	if len(ctx.Profiles) == 0 {

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -204,6 +204,63 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 	}
 }
 
+func TestRunNumberedOffersModelListWithCustomEscape(t *testing.T) {
+	input := strings.Join([]string{
+		"",    // project
+		"",    // profile
+		"",    // session
+		"cto", // single role
+		"2",   // claude binary
+		"3",   // sonnet from the claude list
+		"",    // effort
+		"",    // lead
+		"",    // lead mode
+		"",    // topology
+		"",    // layout
+		"",    // operator contract
+		"",    // notifications
+		"",    // launcher
+		"",    // goal
+		"",    // seed
+	}, "\n") + "\n"
+	var out bytes.Buffer
+	got, err := RunNumbered(strings.NewReader(input), &out, NumberedOptions{
+		Defaults:      Spec{Project: "/repo", Profile: "default", Session: "s"},
+		ProfileExists: func(string, string) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "cto=sonnet" {
+		t.Fatalf("curated model pick = %q", got.Model)
+	}
+	for _, want := range []string{"opus", "sonnet", "haiku", "custom: type a model name"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("model list missing %q:\n%s", want, out.String())
+		}
+	}
+
+	custom := strings.Join([]string{
+		"", "", "", "cto",
+		"",                     // codex binary
+		"4",                    // custom escape (automatic, sol, terra, custom)
+		"gpt-5.7-experimental", // free text
+		// effort, lead, lead mode, topology, layout, operator,
+		// notifications, launcher, goal, seed
+		"", "", "", "", "", "", "", "", "", "",
+	}, "\n") + "\n"
+	got, err = RunNumbered(strings.NewReader(custom), &bytes.Buffer{}, NumberedOptions{
+		Defaults:      Spec{Project: "/repo", Profile: "default", Session: "s"},
+		ProfileExists: func(string, string) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "cto=gpt-5.7-experimental" {
+		t.Fatalf("custom model = %q", got.Model)
+	}
+}
+
 func TestRunNumberedRepromptsSessionThePinnedProfileCannotRun(t *testing.T) {
 	input := strings.Join([]string{
 		"",          // project
@@ -279,7 +336,8 @@ func TestRunNumberedExistingProfileCollectsLaunchOnlyOverrides(t *testing.T) {
 		"",             // existing profile
 		"",             // pinned session
 		"2",            // override cto
-		"launch-model", // launch-only model
+		"4",            // model override: custom
+		"launch-model", // custom launch-only model
 		"4",            // high effort
 		"",             // topology
 		"",             // one-window layout

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -204,6 +204,41 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 	}
 }
 
+func TestRunNumberedRepromptsSessionThePinnedProfileCannotRun(t *testing.T) {
+	input := strings.Join([]string{
+		"",          // project
+		"",          // profile: default (existing)
+		"issue-218", // rejected: pinned to issue-136
+		"",          // retry accepts the pinned default
+		"",          // keep cto profile values
+		"",          // topology
+		"",          // one-window layout
+		"",          // close launcher
+		"",          // goal
+		"",          // seed
+	}, "\n") + "\n"
+	var out bytes.Buffer
+	got, err := RunNumbered(strings.NewReader(input), &out, NumberedOptions{
+		Defaults: Spec{Project: "/repo", Visibility: "sibling-tabs"},
+		InspectProject: func(string) (ProjectContext, error) {
+			return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{
+				{Name: "default", MemberCount: 1, PinnedSession: "issue-136", Members: []MemberSummary{{Role: "cto", Binary: "codex"}}},
+			}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Session != "issue-136" {
+		t.Fatalf("session = %q, want the pinned issue-136", got.Session)
+	}
+	for _, want := range []string{"Check:", "pinned workstream issue-136", "named profile"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("re-prompt output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
 func TestPromptOperatorChoiceCapabilityGating(t *testing.T) {
 	var out bytes.Buffer
 	mode, err := promptOperatorChoice(bufio.NewReader(strings.NewReader("4\n")), &out, nil, "lead_pane")

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -197,7 +197,7 @@ func TestRunNumberedListsExistingProfilesAndUsesPinnedSession(t *testing.T) {
 	if got.OperatorMode != "noc" {
 		t.Fatalf("existing operator mode = %q", got.OperatorMode)
 	}
-	for _, want := range []string{"origin omriariav/amq-squad", "review: 3 member(s), session review-work", "cto: codex, model=automatic, effort=high", "Operator interaction (authoritative): noc", "ships in v2.19.0: #391"} {
+	for _, want := range []string{"origin omriariav/amq-squad", "review: 3 member(s), session review-work", "cto: codex, model=automatic, effort=high", "Operator interaction (authoritative): noc · NOC/global orchestrator owns polling. Change it with 'amq-squad team operator set', then relaunch.", "Self-operator / delegated approval", "[locked: the stored profile contract decides]"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -211,7 +211,7 @@ func TestRunNumberedOffersModelListWithCustomEscape(t *testing.T) {
 		"",    // session
 		"cto", // single role
 		"2",   // claude binary
-		"3",   // sonnet from the claude list
+		"4",   // sonnet from the claude list (automatic, fable, opus, sonnet, haiku, custom)
 		"",    // effort
 		"",    // lead
 		"",    // lead mode
@@ -234,7 +234,7 @@ func TestRunNumberedOffersModelListWithCustomEscape(t *testing.T) {
 	if got.Model != "cto=sonnet" {
 		t.Fatalf("curated model pick = %q", got.Model)
 	}
-	for _, want := range []string{"opus", "sonnet", "haiku", "custom: type a model name"} {
+	for _, want := range []string{"fable", "opus", "sonnet", "haiku", "custom: type a model name"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("model list missing %q:\n%s", want, out.String())
 		}


### PR DESCRIPTION
Fixes #423, #424, #425 — the three wizard UX issues the operator hit while dogfooding v2.19.1-rc.2. One commit per issue for reviewability.

## Commit 1 — #423: reject a session the pinned profile cannot run at the session step
The wizard knew the selected existing profile's pinned workstream and still let the user finish all five phases before `run start` preflight refused with `existing_profile_session_mismatch`. Now mirrored at answer time via `pinnedSessionMismatch` (best-effort — canonical preflight stays authoritative): the bubble adapter shows the inline `Check:` error and stays on the session stage; the numbered adapter prints the check and re-prompts.

## Commit 2 — #424: truthful operator-step labels
`operatorChoices` appended the `[ships in v2.19.0: #391]` provenance to every capability row, so the existing-profile flow rendered a **shipped** feature as disabled-and-future. The ships-in bracket now appears only while a capability is genuinely unavailable; existing-profile rows say why they're locked (`[locked: the stored profile contract decides]`), and the step explains the mode in plain terms plus how to change it (`amq-squad team operator set`, then relaunch). Removed the now-unused `CapabilityReleaseLabel`.

## Commit 3 — #425: model pickers with custom escape
Both model prompts (fresh-roster and existing-profile launch override) were free text while binary/effort were pickers. Curated per-binary lists (claude: opus/sonnet/haiku; codex: gpt-5.6-sol/gpt-5.6-terra), `automatic`/`keep` first, and a `custom` row that falls back to the old text input. Models still pass through to the binary verbatim — the list is a convenience, never an allowlist. Both adapters.

## Verification
- gofmt clean, `go vet` clean, `go test ./...` green (23 packages), `make ci` green locally.
- New tests: bubble + numbered session-mismatch rejection; locked-label and no-"ships in" assertions; curated pick + custom escape in both adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)