### PR TITLE
Continue the launch when the goal submit is unconfirmed

### DIFF
--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/role"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // orchestrateTmuxRun executes a tmux command. It is a package var so tests can
@@ -1040,6 +1042,19 @@ func deliverRunStartGoalWhenReady(opts runStartGoalDeliveryOptions) error {
 		"--yes",
 	}
 	if err := runStartGoalWithVersion(args, opts.Version); err != nil {
+		// An unconfirmed pane submit is ambiguous, not a failure (see
+		// classifyNudgeResult): the goal text is pasted in the lead's input,
+		// and a busy agent queues typed input until it goes idle. Aborting
+		// here would also skip layout finalization and the launcher-pane
+		// policy, punishing a likely success. Warn and continue; hard
+		// delivery errors still abort.
+		var unconfirmed *tmuxpane.SubmitUnconfirmedError
+		if errors.As(err, &unconfirmed) {
+			fmt.Fprintf(os.Stderr, "warning: goal submission was not confirmed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "warning: the goal text is staged in the lead's input; a busy agent queues it and submits when idle (or after one manual Enter). Continuing the launch — layout finalization and the launcher-pane policy still run.\n")
+			fmt.Fprintf(os.Stderr, "If the goal never appears, re-deliver with:\n  %s\n", retryCmd)
+			return nil
+		}
 		printRunStartGoalRetry(retryCmd)
 		return fmt.Errorf("goal delivery failed after lead became ready: %w", err)
 	}

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1037,6 +1038,46 @@ func TestRunStartGoGoalDeliveryFailureAfterReadyPrintsRetryCommand(t *testing.T)
 		" --profile default --session sess --role cto --goal 'ship it' --yes"
 	if !strings.Contains(stderr, wantCmd) {
 		t.Fatalf("stderr missing retry command\nwant: %s\nstderr:\n%s", wantCmd, stderr)
+	}
+}
+
+func TestRunStartGoUnconfirmedGoalSubmitWarnsAndContinues(t *testing.T) {
+	// A SubmitUnconfirmedError is ambiguous, not a failure: the goal text is
+	// staged in the lead's input and a busy agent queues it (#427). The launch
+	// must warn and continue so layout finalization and the launcher-pane
+	// policy still run; only hard delivery errors abort.
+	dir := t.TempDir()
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"team", "--project", dir, "--session", "sess", "--roles", "cto", "--orchestrated", "--lead", "cto"})
+	}); err != nil {
+		t.Fatalf("setup new team: %v", err)
+	}
+
+	unconfirmed := fmt.Errorf("goal start: %w", &tmuxpane.SubmitUnconfirmedError{PaneID: "%26", Attempts: 3})
+	stubRunStartGoalDelivery(t,
+		func(args []string, version string) error { return nil },
+		func(args []string, version string) error { return unconfirmed },
+		func(project, profile, session, role string) (runStartLeadReadiness, error) {
+			return runStartLeadReadiness{Ready: true, Detail: "live"}, nil
+		},
+		func(time.Duration) {},
+		time.Now,
+	)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runRunStart([]string{"-p", dir, "-s", "sess", "--visibility", "detached", "--goal", "ship it", "--go"}, "test")
+	})
+	if err != nil {
+		t.Fatalf("unconfirmed submit must not abort the launch, got %v", err)
+	}
+	for _, want := range []string{
+		"warning: goal submission was not confirmed",
+		"Continuing the launch",
+		"amq-squad goal start --project " + shellQuote(dir) + " --profile default --session sess --role cto --goal 'ship it' --yes",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr)
+		}
 	}
 }
 


### PR DESCRIPTION
Minimal v2.19.1 slice of #427 (operator-approved scope; the fuller queue-state detection and durable fallback stay in #427 for v2.20.0).

## Problem

The operator's first real wizard launch spawned the team fine, but goal delivery surfaced `SubmitUnconfirmedError` (codex lead was mid-bootstrap and queues typed input — "tab to queue message"). The orchestrated path treated that soft, documented-as-ambiguous signal as a hard failure: launch exited non-zero, layout finalization never ran, and `--launcher-pane close-after-start` silently didn't close the pane.

## Fix

`deliverRunStartGoalWhenReady` now matches `errors.As(&tmuxpane.SubmitUnconfirmedError)` — mirroring `classifyNudgeResult` in dispatch, which already treats this error as ambiguous — and warns + continues: it explains the goal text is staged/queued in the lead's input, prints the exact re-delivery command, and lets layout finalization and the launcher-pane policy run. Hard delivery errors (dead pane, paste leak, tmux denied) still abort. Covers both call sites (managed and external-lead) since the softening lives inside the shared helper.

## Verification

- New test `TestRunStartGoUnconfirmedGoalSubmitWarnsAndContinues`: wrapped SubmitUnconfirmedError → launch succeeds, stderr carries the warning + retry command. Existing hard-failure test (`TestRunStartGoGoalDeliveryFailureAfterReadyPrintsRetryCommand`) still passes unchanged.
- gofmt clean, `go vet` clean, `go test ./...` green, `make ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)