### PR TITLE
Prepare v2.19.1 release

### DIFF
--- a/README.html
+++ b/README.html
@@ -375,7 +375,7 @@ launched agents (#393).</li>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.1</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.1
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.19.1-release-notes.md
+++ b/docs/v2.19.1-release-notes.md
@@ -1,0 +1,44 @@
+# amq-squad v2.19.1
+
+v2.19.1 is a hotfix release for the v2.19.0 wizard and orchestrated launch. All
+five fixes come directly from live operator dogfooding of the v2.19.0 wizard.
+
+## Fixes
+
+- **The full-screen wizard accepts input again.** Bubble Tea enables terminal
+  raw mode only when its input is the tty file itself; the adapter handed it a
+  wrapping reader, so the terminal stayed cooked, Enter arrived as ctrl+j, and
+  the wizard froze on its first phase. The tty is now passed directly, and
+  typed-ahead bytes buffered by the scope prompt are discarded so they can
+  never auto-answer the explicit "Launch now? [y/N]" confirmation (#421).
+- **Pinned-profile session mismatches fail at the session step.** Choosing an
+  existing profile and typing a session its roster cannot run is now rejected
+  inline with the same guidance the canonical preflight gives, instead of after
+  all five phases. The canonical `existing_profile_session_mismatch` preflight
+  remains authoritative (#423).
+- **Truthful operator-step labels.** Shipped capabilities no longer carry a
+  future-tense "ships in" tag; existing-profile rows say why they are locked
+  (the stored contract decides) and the step explains the mode and how to
+  change it (`amq-squad team operator set`, then relaunch) (#424).
+- **Models are picked from a list.** Both model prompts (fresh roster and
+  existing-profile launch override) offer curated per-binary choices — claude:
+  fable/opus/sonnet/haiku, codex: gpt-5.6-sol/gpt-5.6-terra — with `automatic`
+  or `keep` first and a `custom` free-text escape. Models still pass through to
+  the binary verbatim; the list is a convenience, never an allowlist (#425).
+- **An unconfirmed goal submit no longer aborts the launch.** When the lead is
+  busy (codex queues typed input mid-turn), the goal text is staged in its
+  input and usually submits when the agent goes idle. The orchestrated launch
+  now warns with the staged/queued explanation and the exact re-delivery
+  command and continues, so layout finalization and the launcher-pane policy
+  still run. Hard delivery failures still abort (minimal slice of #427).
+
+## Notes
+
+- The fuller delivery-robustness work (queue-state detection, durable goal
+  fallback, collapsed iTerm2 control-mode warnings) is tracked in #427 for
+  v2.20.0, alongside the wizard resume path (#428) and the amq 0.42.0 review
+  (#420).
+
+## Compatibility
+
+- No schema, flag, or contract changes. `amq` 0.41.0+ remains the floor.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.0** — on your FIRST response of a session, print the line `amq-squad skill v2.19.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 


### PR DESCRIPTION
Release prep for v2.19.1 (hotfix release; five dogfood-driven fixes: #421, #423, #424, #425, and the #427 minimal slice — all merged via #422, #426, #429).

- Version bumps: both plugin manifests → 2.19.1; skill source (`plugins/skills-src`) version marker + startup echo → 2.19.1 with mirrors regenerated via `make skills-generate`; README `go install ...@v2.19.1`; README.html regenerated.
- `docs/v2.19.1-release-notes.md` added.
- `make release-check VERSION=v2.19.1` passes; `make ci` green locally (exit 0 verified).

Operator release authorization on record (2026-07-11 22:37 IDT): "approved all do what you need to release 2.19.1". Tag + GitHub release follow after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)