### PR TITLE
feat: wizard discovery foundation - backend state, run classification, discovery fingerprint (#431, #428 slice 1)

### DIFF
--- a/docs/issue-431-428-wizard-decision-tree-design.md
+++ b/docs/issue-431-428-wizard-decision-tree-design.md
@@ -503,7 +503,8 @@ Core invariants:
   verbatim.
 - Every screen has consequence copy understandable without source knowledge.
 - Discovery, navigation, and preview remain non-mutating; only explicit Yes
-  after an unchanged second fingerprint check invokes `--go` or `--exec`.
+  invokes `--go` or `--exec`. For existing-profile branches, that Yes follows
+  an unchanged second fingerprint check.
 - Catalog-backed model/effort choices are injected so #432 can change their
   source without restructuring the decision tree.
 

--- a/internal/cli/run_start_discovery.go
+++ b/internal/cli/run_start_discovery.go
@@ -218,3 +218,23 @@ func runStartPinnedSession(t team.Team) string {
 	}
 	return strings.TrimSpace(t.Workstream)
 }
+
+// classifyRunStartWizardExistingProfile adapts the shared resume planner's
+// internal action vocabulary to the UI package's backend-neutral discovery
+// contract. The wizard never reimplements liveness or restore selection.
+func classifyRunStartWizardExistingProfile(memberCount, recordCount int, plans []resumePlan, namespaceAmbiguous bool) runwizard.RunClassification {
+	actions := make([]runwizard.MemberAction, 0, len(plans))
+	for _, plan := range plans {
+		switch plan.Action {
+		case resumeLive:
+			actions = append(actions, runwizard.MemberActionLive)
+		case resumeRestore:
+			actions = append(actions, runwizard.MemberActionRestore)
+		case resumeFresh:
+			actions = append(actions, runwizard.MemberActionFresh)
+		default:
+			actions = append(actions, runwizard.MemberActionBlocked)
+		}
+	}
+	return runwizard.ClassifyExistingRun(memberCount, recordCount, actions, namespaceAmbiguous)
+}

--- a/internal/cli/run_start_discovery_test.go
+++ b/internal/cli/run_start_discovery_test.go
@@ -73,3 +73,14 @@ func TestRunStartWizardProfilesExposePinnedRosterFacts(t *testing.T) {
 		t.Fatalf("member efforts = %+v", profiles[0].Members)
 	}
 }
+
+func TestClassifyRunStartWizardExistingProfileUsesSharedPlannerActions(t *testing.T) {
+	got := classifyRunStartWizardExistingProfile(2, 0, []resumePlan{{Action: resumeLive}, {Action: resumeFresh}}, false)
+	if got.State != "partly_running" || got.Backend != "resume" || !got.Executable || got.RestoreExisting {
+		t.Fatalf("live+fresh/no-record classification = %+v", got)
+	}
+	blocked := classifyRunStartWizardExistingProfile(1, 1, []resumePlan{{Action: resumeBlocked}}, false)
+	if blocked.State != "blocked" || blocked.Executable {
+		t.Fatalf("blocked planner action = %+v", blocked)
+	}
+}

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -263,6 +263,9 @@ func prepareRunStartWizard(args []string) (runwizard.Spec, runwizard.NumberedOpt
 	if strings.TrimSpace(prefill.Profile) == "" {
 		prefill.Profile = team.DefaultProfile
 	}
+	if prefill.Backend == "" {
+		prefill.Backend = runwizard.BackendRunStart
+	}
 	opts := runwizard.NumberedOptions{
 		InspectProject: inspectRunStartWizardProject,
 		ProfileExists: func(project, profile string) bool {
@@ -378,6 +381,7 @@ func collectGlobalWizard(in io.Reader, out io.Writer, spec runwizard.Spec) (runw
 		in = bufio.NewReader(in)
 	}
 	spec.Scope = "global"
+	spec.Backend = runwizard.BackendGlobalStart
 	if strings.TrimSpace(spec.GlobalRoot) == "" {
 		if home, homeErr := os.UserHomeDir(); homeErr == nil {
 			spec.GlobalRoot = filepath.Join(home, "Code")

--- a/internal/wizard/discovery.go
+++ b/internal/wizard/discovery.go
@@ -85,15 +85,28 @@ type DiscoveryMember struct {
 }
 
 type DiscoveryOperator struct {
-	InteractionMode string   `json:"interaction_mode"`
-	Handle          string   `json:"handle"`
-	Delivery        string   `json:"delivery"`
-	SelfLead        string   `json:"self_lead"`
-	SelfAllow       []string `json:"self_allow"`
-	SelfRevision    int64    `json:"self_revision"`
-	SelfPaused      bool     `json:"self_paused"`
-	Notifications   bool     `json:"notifications"`
-	NotificationSem string   `json:"notification_semantics"`
+	Enabled         bool                        `json:"enabled"`
+	InteractionMode string                      `json:"interaction_mode"`
+	Handle          string                      `json:"handle"`
+	SelfLead        string                      `json:"self_lead"`
+	SelfAllow       []string                    `json:"self_allow"`
+	SelfRevision    int64                       `json:"self_revision"`
+	SelfPaused      bool                        `json:"self_paused"`
+	Notifications   DiscoveryNotificationPolicy `json:"notifications"`
+}
+
+type DiscoveryNotificationPolicy struct {
+	Enabled           bool                        `json:"enabled"`
+	DeliverySemantics string                      `json:"delivery_semantics"`
+	Events            []string                    `json:"events"`
+	Sinks             []DiscoveryNotificationSink `json:"sinks"`
+}
+
+type DiscoveryNotificationSink struct {
+	ID      string   `json:"id"`
+	Type    string   `json:"type"`
+	Argv    []string `json:"argv"`
+	Timeout string   `json:"timeout"`
 }
 
 type DiscoveryBrief struct {
@@ -112,34 +125,52 @@ type DiscoveryMemberPlan struct {
 	Blocker             string       `json:"blocker"`
 }
 
+// DiscoveryNamespaceFact is one independently mutable input to namespace
+// conflict detection. Result strings alone are insufficient: adding durable
+// state or changing a profile pin must invalidate a reviewed fingerprint even
+// when the rendered conflict label does not change.
+type DiscoveryNamespaceFact struct {
+	Profile            string `json:"profile"`
+	Session            string `json:"session"`
+	AMQRoot            string `json:"amq_root"`
+	DurableState       bool   `json:"durable_state"`
+	ProfilePinsSession bool   `json:"profile_pins_session"`
+}
+
 // DiscoveryFingerprintInput contains every existing-profile fact that can
 // affect the wizard decision or command. Roster and plan order are preserved;
 // set-like facts are sorted in the canonical copy before hashing.
 type DiscoveryFingerprintInput struct {
-	Profile            string                `json:"profile"`
-	Roster             []DiscoveryMember     `json:"roster"`
-	Lead               string                `json:"lead"`
-	LeadMode           string                `json:"lead_mode"`
-	Operator           DiscoveryOperator     `json:"operator"`
-	Session            string                `json:"session"`
-	SessionSource      string                `json:"session_source"`
-	Brief              DiscoveryBrief        `json:"brief"`
-	NamespaceConflicts []string              `json:"namespace_conflicts"`
-	RecordIDs          []string              `json:"record_ids"`
-	RecordCount        int                   `json:"record_count"`
-	MemberPlans        []DiscoveryMemberPlan `json:"member_plans"`
+	Profile                 string                   `json:"profile"`
+	Roster                  []DiscoveryMember        `json:"roster"`
+	Lead                    string                   `json:"lead"`
+	LeadMode                string                   `json:"lead_mode"`
+	Operator                DiscoveryOperator        `json:"operator"`
+	Session                 string                   `json:"session"`
+	SessionSource           string                   `json:"session_source"`
+	MatchingHistorySessions []string                 `json:"matching_history_sessions"`
+	Brief                   DiscoveryBrief           `json:"brief"`
+	NamespaceConflicts      []string                 `json:"namespace_conflicts"`
+	NamespaceFacts          []DiscoveryNamespaceFact `json:"namespace_facts"`
+	RecordIDs               []string                 `json:"record_ids"`
+	RecordCount             int                      `json:"record_count"`
+	MemberPlans             []DiscoveryMemberPlan    `json:"member_plans"`
 }
 
 func DiscoveryFingerprint(input DiscoveryFingerprintInput) string {
 	canonical := input
 	canonical.NamespaceConflicts = sortedCopy(input.NamespaceConflicts)
+	canonical.NamespaceFacts = canonicalNamespaceFacts(input.NamespaceFacts)
 	canonical.RecordIDs = sortedCopy(input.RecordIDs)
+	canonical.MatchingHistorySessions = sortedCopy(input.MatchingHistorySessions)
 	canonical.Operator.SelfAllow = sortedCopy(input.Operator.SelfAllow)
-	canonical.Roster = append([]DiscoveryMember(nil), input.Roster...)
+	canonical.Operator.Notifications.Events = sortedCopy(input.Operator.Notifications.Events)
+	canonical.Operator.Notifications.Sinks = canonicalNotificationSinks(input.Operator.Notifications.Sinks)
+	canonical.Roster = append([]DiscoveryMember{}, input.Roster...)
 	for i := range canonical.Roster {
-		canonical.Roster[i].NativeArgs = append([]string(nil), input.Roster[i].NativeArgs...)
+		canonical.Roster[i].NativeArgs = orderedCopy(input.Roster[i].NativeArgs)
 	}
-	canonical.MemberPlans = append([]DiscoveryMemberPlan(nil), input.MemberPlans...)
+	canonical.MemberPlans = append([]DiscoveryMemberPlan{}, input.MemberPlans...)
 	for i := range canonical.MemberPlans {
 		canonical.MemberPlans[i].LivenessSignals = sortedCopy(input.MemberPlans[i].LivenessSignals)
 	}
@@ -149,7 +180,31 @@ func DiscoveryFingerprint(input DiscoveryFingerprintInput) string {
 }
 
 func sortedCopy(values []string) []string {
-	out := append([]string(nil), values...)
+	out := append([]string{}, values...)
 	sort.Strings(out)
 	return out
+}
+
+func orderedCopy(values []string) []string {
+	return append([]string{}, values...)
+}
+
+func canonicalNotificationSinks(values []DiscoveryNotificationSink) []DiscoveryNotificationSink {
+	out := append([]DiscoveryNotificationSink{}, values...)
+	for i := range out {
+		out[i].Argv = orderedCopy(out[i].Argv)
+	}
+	sort.Slice(out, func(i, j int) bool { return canonicalJSON(out[i]) < canonicalJSON(out[j]) })
+	return out
+}
+
+func canonicalNamespaceFacts(values []DiscoveryNamespaceFact) []DiscoveryNamespaceFact {
+	out := append([]DiscoveryNamespaceFact{}, values...)
+	sort.Slice(out, func(i, j int) bool { return canonicalJSON(out[i]) < canonicalJSON(out[j]) })
+	return out
+}
+
+func canonicalJSON(value any) string {
+	b, _ := json.Marshal(value)
+	return string(b)
 }

--- a/internal/wizard/discovery.go
+++ b/internal/wizard/discovery.go
@@ -1,0 +1,155 @@
+package wizard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+)
+
+type RunState string
+
+const (
+	RunStateNotStarted RunState = "not_started"
+	RunStateRunning    RunState = "running"
+	RunStateStopped    RunState = "stopped"
+	RunStatePartly     RunState = "partly_running"
+	RunStateBlocked    RunState = "blocked"
+)
+
+type MemberAction string
+
+const (
+	MemberActionLive    MemberAction = "live"
+	MemberActionRestore MemberAction = "restore"
+	MemberActionFresh   MemberAction = "launch_fresh"
+	MemberActionBlocked MemberAction = "blocked"
+)
+
+type RunClassification struct {
+	State           RunState
+	Backend         Backend
+	Executable      bool
+	RestoreExisting bool
+	Detail          string
+}
+
+// ClassifyExistingRun applies the approved first-match precedence. The result
+// is mutually exclusive: one call returns exactly one state/backend contract.
+func ClassifyExistingRun(memberCount, recordCount int, actions []MemberAction, ambiguous bool) RunClassification {
+	if memberCount <= 0 || recordCount < 0 || len(actions) != memberCount {
+		return blockedClassification("profile has no members or the planner did not return one action per member")
+	}
+	counts := map[MemberAction]int{}
+	for _, action := range actions {
+		counts[action]++
+	}
+	if ambiguous || counts[MemberActionBlocked] > 0 {
+		return blockedClassification("profile/session/namespace resolution or a member action is blocked")
+	}
+	if counts[MemberActionLive] == memberCount {
+		return RunClassification{State: RunStateRunning, Detail: "every configured member is live"}
+	}
+	if counts[MemberActionLive] == 0 && recordCount == 0 && counts[MemberActionFresh] == memberCount {
+		return RunClassification{State: RunStateNotStarted, Backend: BackendRunStart, Executable: true, Detail: "no matching launch records; every member is launch-fresh"}
+	}
+	recoverable := counts[MemberActionRestore] + counts[MemberActionFresh]
+	if counts[MemberActionLive] > 0 && recoverable > 0 && counts[MemberActionLive]+recoverable == memberCount {
+		return RunClassification{
+			State:           RunStatePartly,
+			Backend:         BackendResume,
+			Executable:      true,
+			RestoreExisting: recordCount > 0,
+			Detail:          "live members stay running while missing members restore or launch fresh",
+		}
+	}
+	if counts[MemberActionLive] == 0 && recordCount > 0 && recoverable > 0 && recoverable == memberCount {
+		return RunClassification{State: RunStateStopped, Backend: BackendResume, Executable: true, RestoreExisting: true, Detail: "no members are live and matching launch history exists"}
+	}
+	return blockedClassification("discovery facts do not match an executable run state")
+}
+
+func blockedClassification(detail string) RunClassification {
+	return RunClassification{State: RunStateBlocked, Detail: detail}
+}
+
+type DiscoveryMember struct {
+	Role       string   `json:"role"`
+	Handle     string   `json:"handle"`
+	Binary     string   `json:"binary"`
+	CWD        string   `json:"cwd"`
+	Session    string   `json:"session"`
+	NativeArgs []string `json:"native_args"`
+	Model      string   `json:"model"`
+	Effort     string   `json:"effort"`
+}
+
+type DiscoveryOperator struct {
+	InteractionMode string   `json:"interaction_mode"`
+	Handle          string   `json:"handle"`
+	Delivery        string   `json:"delivery"`
+	SelfLead        string   `json:"self_lead"`
+	SelfAllow       []string `json:"self_allow"`
+	SelfRevision    int64    `json:"self_revision"`
+	SelfPaused      bool     `json:"self_paused"`
+	Notifications   bool     `json:"notifications"`
+	NotificationSem string   `json:"notification_semantics"`
+}
+
+type DiscoveryBrief struct {
+	Path          string `json:"path"`
+	Source        string `json:"source"`
+	Provenance    string `json:"provenance"`
+	ContentDigest string `json:"content_digest"`
+}
+
+type DiscoveryMemberPlan struct {
+	Role                string       `json:"role"`
+	Action              MemberAction `json:"action"`
+	LivenessStatus      string       `json:"liveness_status"`
+	LivenessSignals     []string     `json:"liveness_signals"`
+	SavedLaunchIdentity string       `json:"saved_launch_identity"`
+	Blocker             string       `json:"blocker"`
+}
+
+// DiscoveryFingerprintInput contains every existing-profile fact that can
+// affect the wizard decision or command. Roster and plan order are preserved;
+// set-like facts are sorted in the canonical copy before hashing.
+type DiscoveryFingerprintInput struct {
+	Profile            string                `json:"profile"`
+	Roster             []DiscoveryMember     `json:"roster"`
+	Lead               string                `json:"lead"`
+	LeadMode           string                `json:"lead_mode"`
+	Operator           DiscoveryOperator     `json:"operator"`
+	Session            string                `json:"session"`
+	SessionSource      string                `json:"session_source"`
+	Brief              DiscoveryBrief        `json:"brief"`
+	NamespaceConflicts []string              `json:"namespace_conflicts"`
+	RecordIDs          []string              `json:"record_ids"`
+	RecordCount        int                   `json:"record_count"`
+	MemberPlans        []DiscoveryMemberPlan `json:"member_plans"`
+}
+
+func DiscoveryFingerprint(input DiscoveryFingerprintInput) string {
+	canonical := input
+	canonical.NamespaceConflicts = sortedCopy(input.NamespaceConflicts)
+	canonical.RecordIDs = sortedCopy(input.RecordIDs)
+	canonical.Operator.SelfAllow = sortedCopy(input.Operator.SelfAllow)
+	canonical.Roster = append([]DiscoveryMember(nil), input.Roster...)
+	for i := range canonical.Roster {
+		canonical.Roster[i].NativeArgs = append([]string(nil), input.Roster[i].NativeArgs...)
+	}
+	canonical.MemberPlans = append([]DiscoveryMemberPlan(nil), input.MemberPlans...)
+	for i := range canonical.MemberPlans {
+		canonical.MemberPlans[i].LivenessSignals = sortedCopy(input.MemberPlans[i].LivenessSignals)
+	}
+	payload, _ := json.Marshal(canonical)
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func sortedCopy(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/wizard/discovery_test.go
+++ b/internal/wizard/discovery_test.go
@@ -18,15 +18,21 @@ func TestClassifyExistingRunPrecedenceAndRestoreGuard(t *testing.T) {
 		wantRestore bool
 	}{
 		{name: "empty profile", wantState: RunStateBlocked},
+		{name: "negative record count", members: 1, records: -1, actions: []MemberAction{MemberActionFresh}, wantState: RunStateBlocked},
 		{name: "ambiguous namespace wins", members: 1, actions: []MemberAction{MemberActionLive}, ambiguous: true, wantState: RunStateBlocked},
 		{name: "blocked member wins", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionBlocked}, wantState: RunStateBlocked},
 		{name: "all live", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionLive}, wantState: RunStateRunning},
 		{name: "all fresh no records", members: 2, actions: []MemberAction{MemberActionFresh, MemberActionFresh}, wantState: RunStateNotStarted, wantBackend: BackendRunStart, wantExec: true},
 		{name: "live fresh no records", members: 2, actions: []MemberAction{MemberActionLive, MemberActionFresh}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true},
 		{name: "live restore", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionRestore}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true, wantRestore: true},
+		{name: "live restore zero records", members: 2, actions: []MemberAction{MemberActionLive, MemberActionRestore}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true},
+		{name: "partly live restore fresh", members: 3, records: 2, actions: []MemberAction{MemberActionLive, MemberActionRestore, MemberActionFresh}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true, wantRestore: true},
 		{name: "stopped all restore", members: 2, records: 2, actions: []MemberAction{MemberActionRestore, MemberActionRestore}, wantState: RunStateStopped, wantBackend: BackendResume, wantExec: true, wantRestore: true},
+		{name: "stopped all fresh with records", members: 2, records: 1, actions: []MemberAction{MemberActionFresh, MemberActionFresh}, wantState: RunStateStopped, wantBackend: BackendResume, wantExec: true, wantRestore: true},
 		{name: "stopped mixed restore fresh", members: 2, records: 1, actions: []MemberAction{MemberActionRestore, MemberActionFresh}, wantState: RunStateStopped, wantBackend: BackendResume, wantExec: true, wantRestore: true},
 		{name: "all restore without records inconsistent", members: 2, actions: []MemberAction{MemberActionRestore, MemberActionRestore}, wantState: RunStateBlocked},
+		{name: "unknown action", members: 1, records: 1, actions: []MemberAction{"unknown"}, wantState: RunStateBlocked},
+		{name: "mixed known unknown", members: 2, records: 1, actions: []MemberAction{MemberActionFresh, "unknown"}, wantState: RunStateBlocked},
 		{name: "planner cardinality mismatch", members: 2, actions: []MemberAction{MemberActionFresh}, wantState: RunStateBlocked},
 	}
 	for _, tc := range tests {
@@ -48,6 +54,10 @@ func TestDiscoveryFingerprintCanonicalizesSetsButPreservesRosterOrder(t *testing
 	reorderedSets.RecordIDs[0], reorderedSets.RecordIDs[1] = reorderedSets.RecordIDs[1], reorderedSets.RecordIDs[0]
 	reorderedSets.NamespaceConflicts[0], reorderedSets.NamespaceConflicts[1] = reorderedSets.NamespaceConflicts[1], reorderedSets.NamespaceConflicts[0]
 	reorderedSets.Operator.SelfAllow[0], reorderedSets.Operator.SelfAllow[1] = reorderedSets.Operator.SelfAllow[1], reorderedSets.Operator.SelfAllow[0]
+	reorderedSets.Operator.Notifications.Events[0], reorderedSets.Operator.Notifications.Events[1] = reorderedSets.Operator.Notifications.Events[1], reorderedSets.Operator.Notifications.Events[0]
+	reorderedSets.Operator.Notifications.Sinks[0], reorderedSets.Operator.Notifications.Sinks[1] = reorderedSets.Operator.Notifications.Sinks[1], reorderedSets.Operator.Notifications.Sinks[0]
+	reorderedSets.MatchingHistorySessions[0], reorderedSets.MatchingHistorySessions[1] = reorderedSets.MatchingHistorySessions[1], reorderedSets.MatchingHistorySessions[0]
+	reorderedSets.NamespaceFacts[0], reorderedSets.NamespaceFacts[1] = reorderedSets.NamespaceFacts[1], reorderedSets.NamespaceFacts[0]
 	reorderedSets.MemberPlans[0].LivenessSignals[0], reorderedSets.MemberPlans[0].LivenessSignals[1] = reorderedSets.MemberPlans[0].LivenessSignals[1], reorderedSets.MemberPlans[0].LivenessSignals[0]
 	if got, want := DiscoveryFingerprint(reorderedSets), DiscoveryFingerprint(base); got != want {
 		t.Fatalf("set ordering changed fingerprint: got %s want %s", got, want)
@@ -56,6 +66,16 @@ func TestDiscoveryFingerprintCanonicalizesSetsButPreservesRosterOrder(t *testing
 	reorderedRoster.Roster[0], reorderedRoster.Roster[1] = reorderedRoster.Roster[1], reorderedRoster.Roster[0]
 	if DiscoveryFingerprint(reorderedRoster) == DiscoveryFingerprint(base) {
 		t.Fatal("roster order is a decision fact and must change the fingerprint")
+	}
+	reorderedPlans := cloneFingerprintInput(t, base)
+	reorderedPlans.MemberPlans[0], reorderedPlans.MemberPlans[1] = reorderedPlans.MemberPlans[1], reorderedPlans.MemberPlans[0]
+	if DiscoveryFingerprint(reorderedPlans) == DiscoveryFingerprint(base) {
+		t.Fatal("member-plan order is a decision fact and must change the fingerprint")
+	}
+	reorderedArgs := cloneFingerprintInput(t, base)
+	reorderedArgs.Roster[0].NativeArgs = []string{"high", "--effort"}
+	if DiscoveryFingerprint(reorderedArgs) == DiscoveryFingerprint(base) {
+		t.Fatal("native-argument order is a decision fact and must change the fingerprint")
 	}
 }
 
@@ -67,21 +87,60 @@ func TestDiscoveryFingerprintChangesForEveryDecisionInputClass(t *testing.T) {
 		"native args": func(v *DiscoveryFingerprintInput) {
 			v.Roster[0].NativeArgs = append(v.Roster[0].NativeArgs, "--search")
 		},
-		"stored model":       func(v *DiscoveryFingerprintInput) { v.Roster[0].Model = "new-model" },
-		"stored effort":      func(v *DiscoveryFingerprintInput) { v.Roster[0].Effort = "xhigh" },
-		"lead":               func(v *DiscoveryFingerprintInput) { v.Lead = "qa" },
-		"lead mode":          func(v *DiscoveryFingerprintInput) { v.LeadMode = "builder" },
-		"operator":           func(v *DiscoveryFingerprintInput) { v.Operator.InteractionMode = "separate_terminal" },
-		"notifications":      func(v *DiscoveryFingerprintInput) { v.Operator.Notifications = false },
-		"session":            func(v *DiscoveryFingerprintInput) { v.Session = "other" },
-		"session source":     func(v *DiscoveryFingerprintInput) { v.SessionSource = "history" },
+		"stored model":     func(v *DiscoveryFingerprintInput) { v.Roster[0].Model = "new-model" },
+		"stored effort":    func(v *DiscoveryFingerprintInput) { v.Roster[0].Effort = "xhigh" },
+		"lead":             func(v *DiscoveryFingerprintInput) { v.Lead = "qa" },
+		"lead mode":        func(v *DiscoveryFingerprintInput) { v.LeadMode = "builder" },
+		"operator enabled": func(v *DiscoveryFingerprintInput) { v.Operator.Enabled = false },
+		"operator mode":    func(v *DiscoveryFingerprintInput) { v.Operator.InteractionMode = "separate_terminal" },
+		"notification enabled": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Enabled = false
+		},
+		"notification semantics": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.DeliverySemantics = "delivery"
+		},
+		"notification event": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Events = append(v.Operator.Notifications.Events, "new-event")
+		},
+		"notification sink id": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Sinks[0].ID = "other"
+		},
+		"notification sink type": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Sinks[0].Type = "command"
+		},
+		"notification sink argv": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Sinks[0].Argv = append(v.Operator.Notifications.Sinks[0].Argv, "--urgent")
+		},
+		"notification sink timeout": func(v *DiscoveryFingerprintInput) {
+			v.Operator.Notifications.Sinks[0].Timeout = "20s"
+		},
+		"session":        func(v *DiscoveryFingerprintInput) { v.Session = "other" },
+		"session source": func(v *DiscoveryFingerprintInput) { v.SessionSource = "history" },
+		"history session set": func(v *DiscoveryFingerprintInput) {
+			v.MatchingHistorySessions = append(v.MatchingHistorySessions, "history-c")
+		},
 		"brief identity":     func(v *DiscoveryFingerprintInput) { v.Brief.Path = "/other" },
 		"brief content":      func(v *DiscoveryFingerprintInput) { v.Brief.ContentDigest = "changed" },
 		"namespace conflict": func(v *DiscoveryFingerprintInput) { v.NamespaceConflicts = append(v.NamespaceConflicts, "legacy-root") },
-		"record identity":    func(v *DiscoveryFingerprintInput) { v.RecordIDs[0] = "record-x" },
-		"record count":       func(v *DiscoveryFingerprintInput) { v.RecordCount++ },
-		"member action":      func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].Action = MemberActionRestore },
-		"liveness verdict":   func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].LivenessStatus = "stale" },
+		"namespace fact profile": func(v *DiscoveryFingerprintInput) {
+			v.NamespaceFacts[0].Profile = "other"
+		},
+		"namespace fact session": func(v *DiscoveryFingerprintInput) {
+			v.NamespaceFacts[0].Session = "other"
+		},
+		"namespace fact root": func(v *DiscoveryFingerprintInput) {
+			v.NamespaceFacts[0].AMQRoot = "/other"
+		},
+		"namespace fact durable state": func(v *DiscoveryFingerprintInput) {
+			v.NamespaceFacts[0].DurableState = !v.NamespaceFacts[0].DurableState
+		},
+		"namespace fact profile pin": func(v *DiscoveryFingerprintInput) {
+			v.NamespaceFacts[0].ProfilePinsSession = !v.NamespaceFacts[0].ProfilePinsSession
+		},
+		"record identity":  func(v *DiscoveryFingerprintInput) { v.RecordIDs[0] = "record-x" },
+		"record count":     func(v *DiscoveryFingerprintInput) { v.RecordCount++ },
+		"member action":    func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].Action = MemberActionRestore },
+		"liveness verdict": func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].LivenessStatus = "stale" },
 		"liveness signal": func(v *DiscoveryFingerprintInput) {
 			v.MemberPlans[0].LivenessSignals = append(v.MemberPlans[0].LivenessSignals, "presence")
 		},
@@ -99,18 +158,47 @@ func TestDiscoveryFingerprintChangesForEveryDecisionInputClass(t *testing.T) {
 	}
 }
 
+func TestDiscoveryFingerprintCanonicalizesNilAndEmptyCollections(t *testing.T) {
+	tests := []struct {
+		name string
+		a    DiscoveryFingerprintInput
+		b    DiscoveryFingerprintInput
+	}{
+		{name: "roster", a: DiscoveryFingerprintInput{Roster: nil}, b: DiscoveryFingerprintInput{Roster: []DiscoveryMember{}}},
+		{name: "native args", a: DiscoveryFingerprintInput{Roster: []DiscoveryMember{{NativeArgs: nil}}}, b: DiscoveryFingerprintInput{Roster: []DiscoveryMember{{NativeArgs: []string{}}}}},
+		{name: "self allow", a: DiscoveryFingerprintInput{Operator: DiscoveryOperator{SelfAllow: nil}}, b: DiscoveryFingerprintInput{Operator: DiscoveryOperator{SelfAllow: []string{}}}},
+		{name: "notification events", a: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Events: nil}}}, b: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Events: []string{}}}}},
+		{name: "notification sinks", a: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Sinks: nil}}}, b: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Sinks: []DiscoveryNotificationSink{}}}}},
+		{name: "notification sink argv", a: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Sinks: []DiscoveryNotificationSink{{ID: "x", Argv: nil}}}}}, b: DiscoveryFingerprintInput{Operator: DiscoveryOperator{Notifications: DiscoveryNotificationPolicy{Sinks: []DiscoveryNotificationSink{{ID: "x", Argv: []string{}}}}}}},
+		{name: "history sessions", a: DiscoveryFingerprintInput{MatchingHistorySessions: nil}, b: DiscoveryFingerprintInput{MatchingHistorySessions: []string{}}},
+		{name: "namespace conflicts", a: DiscoveryFingerprintInput{NamespaceConflicts: nil}, b: DiscoveryFingerprintInput{NamespaceConflicts: []string{}}},
+		{name: "namespace facts", a: DiscoveryFingerprintInput{NamespaceFacts: nil}, b: DiscoveryFingerprintInput{NamespaceFacts: []DiscoveryNamespaceFact{}}},
+		{name: "record ids", a: DiscoveryFingerprintInput{RecordIDs: nil}, b: DiscoveryFingerprintInput{RecordIDs: []string{}}},
+		{name: "member plans", a: DiscoveryFingerprintInput{MemberPlans: nil}, b: DiscoveryFingerprintInput{MemberPlans: []DiscoveryMemberPlan{}}},
+		{name: "liveness signals", a: DiscoveryFingerprintInput{MemberPlans: []DiscoveryMemberPlan{{LivenessSignals: nil}}}, b: DiscoveryFingerprintInput{MemberPlans: []DiscoveryMemberPlan{{LivenessSignals: []string{}}}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, want := DiscoveryFingerprint(tc.a), DiscoveryFingerprint(tc.b); got != want {
+				t.Fatalf("nil/empty mismatch: got %s want %s", got, want)
+			}
+		})
+	}
+}
+
 func fingerprintFixture() DiscoveryFingerprintInput {
 	return DiscoveryFingerprintInput{
 		Profile: "release",
 		Roster: []DiscoveryMember{
-			{Role: "cto", Handle: "cto", Binary: "codex", CWD: "/repo", Session: "s", NativeArgs: []string{"--search"}, Model: "gpt", Effort: "high"},
+			{Role: "cto", Handle: "cto", Binary: "codex", CWD: "/repo", Session: "s", NativeArgs: []string{"--effort", "high"}, Model: "gpt", Effort: "high"},
 			{Role: "qa", Handle: "qa", Binary: "claude", CWD: "/repo", Session: "s", NativeArgs: []string{"--chrome"}, Model: "sonnet", Effort: "medium"},
 		},
 		Lead: "cto", LeadMode: "planner",
-		Operator: DiscoveryOperator{InteractionMode: "lead_pane", Handle: "user", Delivery: "durable_amq", SelfLead: "cto", SelfAllow: []string{"merge", "spawn"}, SelfRevision: 2, Notifications: true, NotificationSem: "attention_only"},
-		Session:  "s", SessionSource: "member_pin",
+		Operator: DiscoveryOperator{Enabled: true, InteractionMode: "lead_pane", Handle: "user", SelfLead: "cto", SelfAllow: []string{"merge", "spawn"}, SelfRevision: 2, Notifications: DiscoveryNotificationPolicy{Enabled: true, DeliverySemantics: "attention_only", Events: []string{"gate", "local_input_blocked"}, Sinks: []DiscoveryNotificationSink{{ID: "desktop", Type: "desktop", Timeout: "10s"}, {ID: "audit", Type: "command", Argv: []string{"notify", "--json"}, Timeout: "5s"}}}},
+		Session:  "s", SessionSource: "member_pin", MatchingHistorySessions: []string{"history-b", "history-a"},
 		Brief:              DiscoveryBrief{Path: "/repo/.amq-squad/briefs/s.md", Source: "seed", Provenance: "issue:431", ContentDigest: "abc"},
 		NamespaceConflicts: []string{"b", "a"}, RecordIDs: []string{"record-2", "record-1"}, RecordCount: 2,
+		NamespaceFacts: []DiscoveryNamespaceFact{{Profile: "release", Session: "s", AMQRoot: "/repo/.agent-mail/release/s", DurableState: true, ProfilePinsSession: true}, {Profile: "default", Session: "s", AMQRoot: "/repo/.agent-mail/s", DurableState: true}},
 		MemberPlans: []DiscoveryMemberPlan{
 			{Role: "cto", Action: MemberActionLive, LivenessStatus: "live", LivenessSignals: []string{"wake", "pid"}, SavedLaunchIdentity: "launch-cto"},
 			{Role: "qa", Action: MemberActionRestore, LivenessStatus: "stale", SavedLaunchIdentity: "launch-qa"},

--- a/internal/wizard/discovery_test.go
+++ b/internal/wizard/discovery_test.go
@@ -1,0 +1,132 @@
+package wizard
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClassifyExistingRunPrecedenceAndRestoreGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		members     int
+		records     int
+		actions     []MemberAction
+		ambiguous   bool
+		wantState   RunState
+		wantBackend Backend
+		wantExec    bool
+		wantRestore bool
+	}{
+		{name: "empty profile", wantState: RunStateBlocked},
+		{name: "ambiguous namespace wins", members: 1, actions: []MemberAction{MemberActionLive}, ambiguous: true, wantState: RunStateBlocked},
+		{name: "blocked member wins", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionBlocked}, wantState: RunStateBlocked},
+		{name: "all live", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionLive}, wantState: RunStateRunning},
+		{name: "all fresh no records", members: 2, actions: []MemberAction{MemberActionFresh, MemberActionFresh}, wantState: RunStateNotStarted, wantBackend: BackendRunStart, wantExec: true},
+		{name: "live fresh no records", members: 2, actions: []MemberAction{MemberActionLive, MemberActionFresh}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true},
+		{name: "live restore", members: 2, records: 1, actions: []MemberAction{MemberActionLive, MemberActionRestore}, wantState: RunStatePartly, wantBackend: BackendResume, wantExec: true, wantRestore: true},
+		{name: "stopped all restore", members: 2, records: 2, actions: []MemberAction{MemberActionRestore, MemberActionRestore}, wantState: RunStateStopped, wantBackend: BackendResume, wantExec: true, wantRestore: true},
+		{name: "stopped mixed restore fresh", members: 2, records: 1, actions: []MemberAction{MemberActionRestore, MemberActionFresh}, wantState: RunStateStopped, wantBackend: BackendResume, wantExec: true, wantRestore: true},
+		{name: "all restore without records inconsistent", members: 2, actions: []MemberAction{MemberActionRestore, MemberActionRestore}, wantState: RunStateBlocked},
+		{name: "planner cardinality mismatch", members: 2, actions: []MemberAction{MemberActionFresh}, wantState: RunStateBlocked},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyExistingRun(tc.members, tc.records, tc.actions, tc.ambiguous)
+			if got.State != tc.wantState || got.Backend != tc.wantBackend || got.Executable != tc.wantExec || got.RestoreExisting != tc.wantRestore {
+				t.Fatalf("classification = %+v, want state=%s backend=%s exec=%t restore=%t", got, tc.wantState, tc.wantBackend, tc.wantExec, tc.wantRestore)
+			}
+			if got.State == "" || (got.State == RunStateBlocked && got.Detail == "") {
+				t.Fatalf("classification must be exhaustive and diagnostic: %+v", got)
+			}
+		})
+	}
+}
+
+func TestDiscoveryFingerprintCanonicalizesSetsButPreservesRosterOrder(t *testing.T) {
+	base := fingerprintFixture()
+	reorderedSets := cloneFingerprintInput(t, base)
+	reorderedSets.RecordIDs[0], reorderedSets.RecordIDs[1] = reorderedSets.RecordIDs[1], reorderedSets.RecordIDs[0]
+	reorderedSets.NamespaceConflicts[0], reorderedSets.NamespaceConflicts[1] = reorderedSets.NamespaceConflicts[1], reorderedSets.NamespaceConflicts[0]
+	reorderedSets.Operator.SelfAllow[0], reorderedSets.Operator.SelfAllow[1] = reorderedSets.Operator.SelfAllow[1], reorderedSets.Operator.SelfAllow[0]
+	reorderedSets.MemberPlans[0].LivenessSignals[0], reorderedSets.MemberPlans[0].LivenessSignals[1] = reorderedSets.MemberPlans[0].LivenessSignals[1], reorderedSets.MemberPlans[0].LivenessSignals[0]
+	if got, want := DiscoveryFingerprint(reorderedSets), DiscoveryFingerprint(base); got != want {
+		t.Fatalf("set ordering changed fingerprint: got %s want %s", got, want)
+	}
+	reorderedRoster := cloneFingerprintInput(t, base)
+	reorderedRoster.Roster[0], reorderedRoster.Roster[1] = reorderedRoster.Roster[1], reorderedRoster.Roster[0]
+	if DiscoveryFingerprint(reorderedRoster) == DiscoveryFingerprint(base) {
+		t.Fatal("roster order is a decision fact and must change the fingerprint")
+	}
+}
+
+func TestDiscoveryFingerprintChangesForEveryDecisionInputClass(t *testing.T) {
+	base := fingerprintFixture()
+	want := DiscoveryFingerprint(base)
+	tests := map[string]func(*DiscoveryFingerprintInput){
+		"roster identity": func(v *DiscoveryFingerprintInput) { v.Roster[0].Handle = "other" },
+		"native args": func(v *DiscoveryFingerprintInput) {
+			v.Roster[0].NativeArgs = append(v.Roster[0].NativeArgs, "--search")
+		},
+		"stored model":       func(v *DiscoveryFingerprintInput) { v.Roster[0].Model = "new-model" },
+		"stored effort":      func(v *DiscoveryFingerprintInput) { v.Roster[0].Effort = "xhigh" },
+		"lead":               func(v *DiscoveryFingerprintInput) { v.Lead = "qa" },
+		"lead mode":          func(v *DiscoveryFingerprintInput) { v.LeadMode = "builder" },
+		"operator":           func(v *DiscoveryFingerprintInput) { v.Operator.InteractionMode = "separate_terminal" },
+		"notifications":      func(v *DiscoveryFingerprintInput) { v.Operator.Notifications = false },
+		"session":            func(v *DiscoveryFingerprintInput) { v.Session = "other" },
+		"session source":     func(v *DiscoveryFingerprintInput) { v.SessionSource = "history" },
+		"brief identity":     func(v *DiscoveryFingerprintInput) { v.Brief.Path = "/other" },
+		"brief content":      func(v *DiscoveryFingerprintInput) { v.Brief.ContentDigest = "changed" },
+		"namespace conflict": func(v *DiscoveryFingerprintInput) { v.NamespaceConflicts = append(v.NamespaceConflicts, "legacy-root") },
+		"record identity":    func(v *DiscoveryFingerprintInput) { v.RecordIDs[0] = "record-x" },
+		"record count":       func(v *DiscoveryFingerprintInput) { v.RecordCount++ },
+		"member action":      func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].Action = MemberActionRestore },
+		"liveness verdict":   func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].LivenessStatus = "stale" },
+		"liveness signal": func(v *DiscoveryFingerprintInput) {
+			v.MemberPlans[0].LivenessSignals = append(v.MemberPlans[0].LivenessSignals, "presence")
+		},
+		"saved launch identity": func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].SavedLaunchIdentity = "launch-x" },
+		"member blocker":        func(v *DiscoveryFingerprintInput) { v.MemberPlans[0].Blocker = "conflict" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := cloneFingerprintInput(t, base)
+			mutate(&changed)
+			if got := DiscoveryFingerprint(changed); got == want {
+				t.Fatalf("%s delta did not change fingerprint %s", name, got)
+			}
+		})
+	}
+}
+
+func fingerprintFixture() DiscoveryFingerprintInput {
+	return DiscoveryFingerprintInput{
+		Profile: "release",
+		Roster: []DiscoveryMember{
+			{Role: "cto", Handle: "cto", Binary: "codex", CWD: "/repo", Session: "s", NativeArgs: []string{"--search"}, Model: "gpt", Effort: "high"},
+			{Role: "qa", Handle: "qa", Binary: "claude", CWD: "/repo", Session: "s", NativeArgs: []string{"--chrome"}, Model: "sonnet", Effort: "medium"},
+		},
+		Lead: "cto", LeadMode: "planner",
+		Operator: DiscoveryOperator{InteractionMode: "lead_pane", Handle: "user", Delivery: "durable_amq", SelfLead: "cto", SelfAllow: []string{"merge", "spawn"}, SelfRevision: 2, Notifications: true, NotificationSem: "attention_only"},
+		Session:  "s", SessionSource: "member_pin",
+		Brief:              DiscoveryBrief{Path: "/repo/.amq-squad/briefs/s.md", Source: "seed", Provenance: "issue:431", ContentDigest: "abc"},
+		NamespaceConflicts: []string{"b", "a"}, RecordIDs: []string{"record-2", "record-1"}, RecordCount: 2,
+		MemberPlans: []DiscoveryMemberPlan{
+			{Role: "cto", Action: MemberActionLive, LivenessStatus: "live", LivenessSignals: []string{"wake", "pid"}, SavedLaunchIdentity: "launch-cto"},
+			{Role: "qa", Action: MemberActionRestore, LivenessStatus: "stale", SavedLaunchIdentity: "launch-qa"},
+		},
+	}
+}
+
+func cloneFingerprintInput(t *testing.T, input DiscoveryFingerprintInput) DiscoveryFingerprintInput {
+	t.Helper()
+	b, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out DiscoveryFingerprintInput
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -4,11 +4,23 @@ package wizard
 
 import "strings"
 
+// Backend is the canonical command family selected by the answer model. The
+// UI records it explicitly so execution never infers resume-vs-start from a
+// profile merely existing at some later point in time.
+type Backend string
+
+const (
+	BackendRunStart    Backend = "run_start"
+	BackendResume      Backend = "resume"
+	BackendGlobalStart Backend = "global_start"
+)
+
 // Spec is the headless, serializable answer model for a project run. Later UI
 // adapters may add richer choices, but execution must always flow through Args
 // and the existing run start parser.
 type Spec struct {
 	Scope                          string
+	Backend                        Backend
 	Project                        string
 	Profile                        string
 	Session                        string

--- a/internal/wizard/spec_test.go
+++ b/internal/wizard/spec_test.go
@@ -115,3 +115,14 @@ func TestSpecArgsOmitsLegacyUnspecifiedOperatorMode(t *testing.T) {
 		t.Fatalf("Args() = %#v, want %#v", got, want)
 	}
 }
+
+func TestSpecCarriesExplicitBackendWithoutAffectingLegacyRunStartArgs(t *testing.T) {
+	s := Spec{Backend: BackendResume, Project: "/repo", Profile: "release", Session: "s"}
+	if s.Backend != BackendResume {
+		t.Fatalf("backend = %q", s.Backend)
+	}
+	want := []string{"--project", "/repo", "--profile", "release", "--session", "s"}
+	if got := s.Args(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy run-start args changed while adding explicit backend: %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Slice 1 of 5 implementing the approved wizard design (docs/issue-431-428-wizard-decision-tree-design.md, PR #434):

- Explicit wizard **Backend** state (run start / resume / global start) in the answer model
- **ClassifyExistingRun**: mutually exclusive, exhaustive first-match precedence over member actions + record count (blocked → running → not-started → partly-running → stopped), fail-closed to blocked for uncovered combinations; `RestoreExisting` emitted only when matching records exist (live+fresh/no-record repair omits it)
- **DiscoveryFingerprint**: deterministic SHA-256 over the full existing-profile decision input (roster/native args/model/effort, lead/mode, operator + notification policy, session source, brief identity/digest, namespace facts, record identities/count, complete member plan/liveness/blockers) with canonical sorting of set-like fields
- Design-doc wording nit from the rev-1 review folded in (fingerprint invariant scoped to existing-profile branches)

Validation: `go test ./...` exit 0 and `make ci` exit 0 at exact head ba8f9ce830630653e03a4639c308f961607ec646, rebased on main d821263.

Part of #431 / #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
