### PR TITLE
feat: scoped per-role permission allowlists at launch (#401 slice B)

### DIFF
--- a/README.html
+++ b/README.html
@@ -897,10 +897,14 @@ lists in <code>up --dry-run --json</code>. Values beginning with
 <code>--allowedTools=&lt;grant&gt;</code> form. Resume removes the prior
 launcher-owned grant before rebuilding from current policy, so narrowing
 or removing the field revokes old access; the
-<code>--no-preauthorize-inscope</code> choice also survives replay. Keep
-each pattern as narrow as the member's own scratch or review workspace;
-the field is rejected on non-Claude members and is intentionally not a
-team-wide trust switch.</p>
+<code>--no-preauthorize-inscope</code> choice also survives replay.
+Preview commands never embed launcher-owned policy in executable child
+argv: <code>agent up</code> recomputes it from current profile state,
+and launch history records launcher-owned and explicit-native provenance
+separately even when their values are identical. Keep each pattern as
+narrow as the member's own scratch or review workspace; the field is
+rejected on non-Claude members and is intentionally not a team-wide
+trust switch.</p>
 <p>Profiles using <code>permission_allowlist</code> are written as team
 schema 4; profiles without it remain schema 3. v2.20+ readers accept
 both and reject future schemas. Pre-v2.20 binaries do not understand

--- a/README.html
+++ b/README.html
@@ -886,6 +886,16 @@ required startup behavior.</p>
 native CLI flags to one member and are replayed by resume. Worker
 overlays trim Claude plugin/hook surface for same-cwd squads; Codex
 workers use native Codex profiles via <code>codex_args</code>.</p>
+<p>Claude members may also carry an explicit, role-scoped
+<code>permission_allowlist</code>, for example
+<code>"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]</code>.
+amq-squad merges those patterns into one effective
+<code>--allowedTools</code> grant for that member only, records the
+result in launch history, and shows both the configured and effective
+lists in <code>up --dry-run --json</code>. Keep each pattern as narrow
+as the member's own scratch or review workspace; the field is rejected
+on non-Claude members and is intentionally not a team-wide trust
+switch.</p>
 <p>Trust and binary defaults are explicit. Codex trusted mode is the
 only path that prepends
 <code>--dangerously-bypass-approvals-and-sandbox</code>; the default

--- a/README.html
+++ b/README.html
@@ -892,10 +892,22 @@ workers use native Codex profiles via <code>codex_args</code>.</p>
 amq-squad merges those patterns into one effective
 <code>--allowedTools</code> grant for that member only, records the
 result in launch history, and shows both the configured and effective
-lists in <code>up --dry-run --json</code>. Keep each pattern as narrow
-as the member's own scratch or review workspace; the field is rejected
-on non-Claude members and is intentionally not a team-wide trust
-switch.</p>
+lists in <code>up --dry-run --json</code>. Values beginning with
+<code>-</code> are rejected and generated grants use the single-token
+<code>--allowedTools=&lt;grant&gt;</code> form. Resume removes the prior
+launcher-owned grant before rebuilding from current policy, so narrowing
+or removing the field revokes old access; the
+<code>--no-preauthorize-inscope</code> choice also survives replay. Keep
+each pattern as narrow as the member's own scratch or review workspace;
+the field is rejected on non-Claude members and is intentionally not a
+team-wide trust switch.</p>
+<p>Profiles using <code>permission_allowlist</code> are written as team
+schema 4; profiles without it remain schema 3. v2.20+ readers accept
+both and reject future schemas. Pre-v2.20 binaries do not understand
+this field: they can silently ignore it and lossily rewrite a schema-4
+profile. Upgrade every amq-squad binary that may read or write the
+profile before configuring an allowlist, and use
+<code>amq-squad doctor</code> to detect version skew.</p>
 <p>Trust and binary defaults are explicit. Codex trusted mode is the
 only path that prepends
 <code>--dangerously-bypass-approvals-and-sandbox</code>; the default

--- a/README.md
+++ b/README.md
@@ -446,9 +446,20 @@ Claude members may also carry an explicit, role-scoped
 `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
 merges those patterns into one effective `--allowedTools` grant for that member
 only, records the result in launch history, and shows both the configured and
-effective lists in `up --dry-run --json`. Keep each pattern as narrow as the
-member's own scratch or review workspace; the field is rejected on non-Claude
-members and is intentionally not a team-wide trust switch.
+effective lists in `up --dry-run --json`. Values beginning with `-` are rejected
+and generated grants use the single-token `--allowedTools=<grant>` form. Resume
+removes the prior launcher-owned grant before rebuilding from current policy,
+so narrowing or removing the field revokes old access; the
+`--no-preauthorize-inscope` choice also survives replay. Keep each pattern as
+narrow as the member's own scratch or review workspace; the field is rejected
+on non-Claude members and is intentionally not a team-wide trust switch.
+
+Profiles using `permission_allowlist` are written as team schema 4; profiles
+without it remain schema 3. v2.20+ readers accept both and reject future
+schemas. Pre-v2.20 binaries do not understand this field: they can silently
+ignore it and lossily rewrite a schema-4 profile. Upgrade every amq-squad binary
+that may read or write the profile before configuring an allowlist, and use
+`amq-squad doctor` to detect version skew.
 
 Trust and binary defaults are explicit. Codex trusted mode is the only path that
 prepends `--dangerously-bypass-approvals-and-sandbox`; the default sandboxed

--- a/README.md
+++ b/README.md
@@ -450,7 +450,11 @@ effective lists in `up --dry-run --json`. Values beginning with `-` are rejected
 and generated grants use the single-token `--allowedTools=<grant>` form. Resume
 removes the prior launcher-owned grant before rebuilding from current policy,
 so narrowing or removing the field revokes old access; the
-`--no-preauthorize-inscope` choice also survives replay. Keep each pattern as
+`--no-preauthorize-inscope` choice also survives replay. Preview commands never
+embed launcher-owned policy in executable child argv: `agent up` recomputes it
+from current profile state, and launch history records launcher-owned and
+explicit-native provenance separately even when their values are identical.
+Keep each pattern as
 narrow as the member's own scratch or review workspace; the field is rejected
 on non-Claude members and is intentionally not a team-wide trust switch.
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,15 @@ Per-member `claude_args` / `codex_args` apply native CLI flags to one member and
 are replayed by resume. Worker overlays trim Claude plugin/hook surface for
 same-cwd squads; Codex workers use native Codex profiles via `codex_args`.
 
+Claude members may also carry an explicit, role-scoped
+`permission_allowlist`, for example
+`"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
+merges those patterns into one effective `--allowedTools` grant for that member
+only, records the result in launch history, and shows both the configured and
+effective lists in `up --dry-run --json`. Keep each pattern as narrow as the
+member's own scratch or review workspace; the field is rejected on non-Claude
+members and is intentionally not a team-wide trust switch.
+
 Trust and binary defaults are explicit. Codex trusted mode is the only path that
 prepends `--dangerously-bypass-approvals-and-sandbox`; the default sandboxed
 mode does not.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -633,6 +633,13 @@ drain your inbox.</li>
 </tr>
 </tbody>
 </table>
+<p>For a narrow Claude-only permission exception, configure a member's
+<code>permission_allowlist</code> in <code>team.json</code>, for example
+<code>["Bash(rm -rf /tmp/qa-review/*:*)"]</code>. The grant is scoped to
+that exact role, merged with any explicit native
+<code>--allowedTools</code>, visible in dry-run JSON and launch history,
+and replayed by resume. Validation rejects the field for other binaries;
+prefer scratch/worktree-specific patterns over broad command grants.</p>
 <p>Per-member <code>claude_args</code> / <code>codex_args</code> in
 <code>team.json</code> (v1.8.0+) carry native CLI args for one member
 only — the overlay verb above generates the flagship case (a

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -642,12 +642,16 @@ and rebuilt from current policy on resume so removed/narrowed grants are
 revoked. Validation rejects other binaries and values beginning with
 <code>-</code>; generated grants use one
 <code>--allowedTools=&lt;grant&gt;</code> token. The
-<code>--no-preauthorize-inscope</code> bit also round-trips. Prefer
-scratch/worktree- specific patterns over broad command grants. Such
-profiles write schema 4; profiles without the field stay schema 3.
-Upgrade all readers/writers to v2.20+ before configuring it: pre-v2.20
-binaries can silently ignore the field and lossily rewrite the profile.
-Use <code>amq-squad doctor</code> to detect version skew.</p>
+<code>--no-preauthorize-inscope</code> bit also round-trips. Preview
+commands keep launcher policy out of executable child argv;
+<code>agent up</code> recomputes it and the launch record stores
+launcher-owned versus explicit provenance separately, including
+equal-valued grants. Prefer scratch/worktree- specific patterns over
+broad command grants. Such profiles write schema 4; profiles without the
+field stay schema 3. Upgrade all readers/writers to v2.20+ before
+configuring it: pre-v2.20 binaries can silently ignore the field and
+lossily rewrite the profile. Use <code>amq-squad doctor</code> to detect
+version skew.</p>
 <p>Per-member <code>claude_args</code> / <code>codex_args</code> in
 <code>team.json</code> (v1.8.0+) carry native CLI args for one member
 only — the overlay verb above generates the flagship case (a

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -638,8 +638,16 @@ drain your inbox.</li>
 <code>["Bash(rm -rf /tmp/qa-review/*:*)"]</code>. The grant is scoped to
 that exact role, merged with any explicit native
 <code>--allowedTools</code>, visible in dry-run JSON and launch history,
-and replayed by resume. Validation rejects the field for other binaries;
-prefer scratch/worktree-specific patterns over broad command grants.</p>
+and rebuilt from current policy on resume so removed/narrowed grants are
+revoked. Validation rejects other binaries and values beginning with
+<code>-</code>; generated grants use one
+<code>--allowedTools=&lt;grant&gt;</code> token. The
+<code>--no-preauthorize-inscope</code> bit also round-trips. Prefer
+scratch/worktree- specific patterns over broad command grants. Such
+profiles write schema 4; profiles without the field stay schema 3.
+Upgrade all readers/writers to v2.20+ before configuring it: pre-v2.20
+binaries can silently ignore the field and lossily rewrite the profile.
+Use <code>amq-squad doctor</code> to detect version skew.</p>
 <p>Per-member <code>claude_args</code> / <code>codex_args</code> in
 <code>team.json</code> (v1.8.0+) carry native CLI args for one member
 only — the overlay verb above generates the flagship case (a

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -204,7 +204,10 @@ merged with any explicit native `--allowedTools`, visible in dry-run JSON and
 launch history, and rebuilt from current policy on resume so removed/narrowed
 grants are revoked. Validation rejects other binaries and values beginning with
 `-`; generated grants use one `--allowedTools=<grant>` token. The
-`--no-preauthorize-inscope` bit also round-trips. Prefer scratch/worktree-
+`--no-preauthorize-inscope` bit also round-trips. Preview commands keep
+launcher policy out of executable child argv; `agent up` recomputes it and the
+launch record stores launcher-owned versus explicit provenance separately,
+including equal-valued grants. Prefer scratch/worktree-
 specific patterns over broad command grants. Such profiles write schema 4;
 profiles without the field stay schema 3. Upgrade all readers/writers to v2.20+
 before configuring it: pre-v2.20 binaries can silently ignore the field and

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -197,6 +197,13 @@ This is the everyday skill. The lifecycle is one small state machine:
 | Trim worker context (overlays) | `amq-squad team overlay init --workers [--disable-plugins ids] [--disable-all-hooks]` |
 | Tear down (destructive / recoverable) | `amq-squad rm <s>` / `amq-squad archive <s>` |
 
+For a narrow Claude-only permission exception, configure a member's
+`permission_allowlist` in `team.json`, for example
+`["Bash(rm -rf /tmp/qa-review/*:*)"]`. The grant is scoped to that exact role,
+merged with any explicit native `--allowedTools`, visible in dry-run JSON and
+launch history, and replayed by resume. Validation rejects the field for other
+binaries; prefer scratch/worktree-specific patterns over broad command grants.
+
 Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -201,8 +201,14 @@ For a narrow Claude-only permission exception, configure a member's
 `permission_allowlist` in `team.json`, for example
 `["Bash(rm -rf /tmp/qa-review/*:*)"]`. The grant is scoped to that exact role,
 merged with any explicit native `--allowedTools`, visible in dry-run JSON and
-launch history, and replayed by resume. Validation rejects the field for other
-binaries; prefer scratch/worktree-specific patterns over broad command grants.
+launch history, and rebuilt from current policy on resume so removed/narrowed
+grants are revoked. Validation rejects other binaries and values beginning with
+`-`; generated grants use one `--allowedTools=<grant>` token. The
+`--no-preauthorize-inscope` bit also round-trips. Prefer scratch/worktree-
+specific patterns over broad command grants. Such profiles write schema 4;
+profiles without the field stay schema 3. Upgrade all readers/writers to v2.20+
+before configuring it: pre-v2.20 binaries can silently ignore the field and
+lossily rewrite the profile. Use `amq-squad doctor` to detect version skew.
 
 Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -49,7 +49,10 @@ func claudePreauthChildArgs(allow []string) []string {
 	if len(allow) == 0 {
 		return nil
 	}
-	return []string{"--allowedTools", strings.Join(allow, ",")}
+	// native_args.go recognizes the equals-joined alias. Keeping the validated
+	// value in the same argv token prevents it from ever being reinterpreted as
+	// another native option if a malformed profile bypasses validation.
+	return []string{"--allowedTools=" + strings.Join(allow, ",")}
 }
 
 func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string, childArgs []string, includeBuiltIn bool) ([]string, []string, bool) {
@@ -61,6 +64,11 @@ func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string,
 	}
 	actions = appendUniquePermissionPatterns(actions, configured...)
 	if len(actions) == 0 {
+		if explicit, found := collectClaudeAllowedTools(out); found {
+			// Even without launcher-owned policy, canonicalize explicit native
+			// grants into the safe equals form and collapse duplicate aliases.
+			return replaceClaudeAllowedTools(out, explicit), nil, false
+		}
 		return out, nil, false
 	}
 	if childArgsHasAllowedTools(out) {
@@ -70,13 +78,9 @@ func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string,
 			// and launch-record audit fields stay aligned with live launch.
 			return out, actions, false
 		}
-		// Preserve the old conservative behavior for the built-in PR-create
-		// grant: an unrelated explicit --allowedTools remains authoritative. A
-		// member-scoped permission_allowlist is itself explicit configuration,
-		// so merge it with the existing value rather than silently dropping it.
-		if len(configured) == 0 {
-			return out, nil, false
-		}
+		// Recomposition always preserves genuinely explicit native grants while
+		// rebuilding launcher-owned grants from current policy. This is what lets
+		// profile removal/narrowing revoke the old launcher-owned value on replay.
 		actions = appendUniquePermissionPatterns(childArgsAllowedTools(out), actions...)
 	}
 	return replaceClaudeAllowedTools(out, actions), actions, true
@@ -188,11 +192,51 @@ func replaceClaudeAllowedTools(args, actions []string) []string {
 }
 
 func stripTrailingLauncherPreauthArgs(childArgs, preauthorizedActions []string) []string {
-	preauthArgs := claudePreauthChildArgs(preauthorizedActions)
-	if len(preauthArgs) == 0 || !hasTrailingArgs(childArgs, preauthArgs) {
-		return childArgs
+	return stripRecordedLauncherPreauth(childArgs, preauthorizedActions)
+}
+
+// stripRecordedLauncherPreauth removes only the exact launcher-owned grant
+// identified by launch.Record.PreauthorizedActions. It recognizes both the
+// historical two-token spelling and the injection-safe equals spelling. Any
+// independently configured native allowed-tools value remains available via
+// the record's ClaudeArgs/ExplicitAllowedTools and is recomposed with current
+// member policy.
+func stripRecordedLauncherPreauth(args, preauthorizedActions []string) []string {
+	if len(preauthorizedActions) == 0 {
+		return append([]string(nil), args...)
 	}
-	return append([]string(nil), childArgs[:len(childArgs)-len(preauthArgs)]...)
+	want := strings.Join(preauthorizedActions, ",")
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); {
+		arg := args[i]
+		if arg == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
+		spec, inline, ok := nativeValueSpecForArg("claude", arg)
+		if !ok || spec.Canonical != "--allowed-tools" {
+			out = append(out, arg)
+			i++
+			continue
+		}
+		if inline {
+			_, value, _ := strings.Cut(arg, "=")
+			if value == want {
+				i++
+				continue
+			}
+			out = append(out, arg)
+			i++
+			continue
+		}
+		if i+1 < len(args) && args[i+1] == want {
+			i += 2
+			continue
+		}
+		out = append(out, arg)
+		i++
+	}
+	return out
 }
 
 func childArgsHasAllowedTools(args []string) bool {
@@ -203,19 +247,6 @@ func childArgsHasAllowedTools(args []string) bool {
 func childArgsAllowedToolsEquals(args []string, want string) bool {
 	values, found := collectClaudeAllowedTools(args)
 	return found && strings.Join(values, ",") == want
-}
-
-func hasTrailingArgs(args, suffix []string) bool {
-	if len(suffix) == 0 || len(args) < len(suffix) {
-		return false
-	}
-	offset := len(args) - len(suffix)
-	for i := range suffix {
-		if args[offset+i] != suffix[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // claudeWorkerPreauthEligible reports whether an `agent up` launch is an

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -52,14 +52,15 @@ func claudePreauthChildArgs(allow []string) []string {
 	return []string{"--allowedTools", strings.Join(allow, ",")}
 }
 
-func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string, childArgs []string) ([]string, []string, bool) {
+func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string, childArgs []string, includeBuiltIn bool) ([]string, []string, bool) {
 	out := append([]string(nil), childArgs...)
-	if !claudeWorkerPreauthEligible(projectDir, profile, role, binary) {
-		return out, nil, false
+	configured := configuredClaudePermissionAllowlist(projectDir, profile, role, binary)
+	var actions []string
+	if includeBuiltIn && claudeWorkerPreauthEligible(projectDir, profile, role, binary) {
+		actions = appendUniquePermissionPatterns(actions, claudeInScopePreauthAllowlist(session)...)
 	}
-	actions := claudeInScopePreauthAllowlist(session)
-	preauthArgs := claudePreauthChildArgs(actions)
-	if len(preauthArgs) == 0 {
+	actions = appendUniquePermissionPatterns(actions, configured...)
+	if len(actions) == 0 {
 		return out, nil, false
 	}
 	if childArgsHasAllowedTools(out) {
@@ -69,9 +70,121 @@ func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string,
 			// and launch-record audit fields stay aligned with live launch.
 			return out, actions, false
 		}
-		return out, nil, false
+		// Preserve the old conservative behavior for the built-in PR-create
+		// grant: an unrelated explicit --allowedTools remains authoritative. A
+		// member-scoped permission_allowlist is itself explicit configuration,
+		// so merge it with the existing value rather than silently dropping it.
+		if len(configured) == 0 {
+			return out, nil, false
+		}
+		actions = appendUniquePermissionPatterns(childArgsAllowedTools(out), actions...)
 	}
-	return append(out, preauthArgs...), actions, true
+	return replaceClaudeAllowedTools(out, actions), actions, true
+}
+
+func configuredClaudePermissionAllowlist(projectDir, profile, role, binary string) []string {
+	if normalizedAgentBinary(binary) != "claude" || strings.TrimSpace(role) == "" || !team.ExistsProfile(projectDir, profile) {
+		return nil
+	}
+	t, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return nil
+	}
+	m, ok := teamMemberByRole(t, role)
+	if !ok || normalizedAgentBinary(m.Binary) != "claude" {
+		return nil
+	}
+	return appendUniquePermissionPatterns(nil, m.PermissionAllowlist...)
+}
+
+func appendUniquePermissionPatterns(dst []string, patterns ...string) []string {
+	seen := make(map[string]bool, len(dst)+len(patterns))
+	for _, pattern := range dst {
+		seen[pattern] = true
+	}
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" || seen[pattern] {
+			continue
+		}
+		seen[pattern] = true
+		dst = append(dst, pattern)
+	}
+	return dst
+}
+
+func childArgsAllowedTools(args []string) []string {
+	values, _ := collectClaudeAllowedTools(args)
+	return values
+}
+
+// collectClaudeAllowedTools reads every native allowed-tools spelling before
+// the literal -- prompt boundary. Claude treats this option as variadic, while
+// amq-squad emits a single comma-joined value so the effective launch grant is
+// unambiguous and auditable.
+func collectClaudeAllowedTools(args []string) ([]string, bool) {
+	var values []string
+	found := false
+	for i := 0; i < len(args); {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		spec, inline, ok := nativeValueSpecForArg("claude", arg)
+		if !ok || spec.Canonical != "--allowed-tools" {
+			i++
+			continue
+		}
+		found = true
+		if inline {
+			if _, raw, ok := strings.Cut(arg, "="); ok {
+				values = appendUniquePermissionPatterns(values, strings.Split(raw, ",")...)
+			}
+			i++
+			continue
+		}
+		i++
+		for i < len(args) && args[i] != "--" && !strings.HasPrefix(args[i], "-") {
+			values = appendUniquePermissionPatterns(values, strings.Split(args[i], ",")...)
+			i++
+		}
+	}
+	return values, found
+}
+
+func replaceClaudeAllowedTools(args, actions []string) []string {
+	clean := make([]string, 0, len(args)+2)
+	boundary := -1
+	for i := 0; i < len(args); {
+		arg := args[i]
+		if arg == "--" {
+			boundary = len(clean)
+			clean = append(clean, args[i:]...)
+			break
+		}
+		spec, inline, ok := nativeValueSpecForArg("claude", arg)
+		if !ok || spec.Canonical != "--allowed-tools" {
+			clean = append(clean, arg)
+			i++
+			continue
+		}
+		i++
+		if inline {
+			continue
+		}
+		for i < len(args) && args[i] != "--" && !strings.HasPrefix(args[i], "-") {
+			i++
+		}
+	}
+	grant := claudePreauthChildArgs(actions)
+	if boundary < 0 {
+		return append(clean, grant...)
+	}
+	out := make([]string, 0, len(clean)+len(grant))
+	out = append(out, clean[:boundary]...)
+	out = append(out, grant...)
+	out = append(out, clean[boundary:]...)
+	return out
 }
 
 func stripTrailingLauncherPreauthArgs(childArgs, preauthorizedActions []string) []string {
@@ -83,24 +196,13 @@ func stripTrailingLauncherPreauthArgs(childArgs, preauthorizedActions []string) 
 }
 
 func childArgsHasAllowedTools(args []string) bool {
-	for _, arg := range args {
-		if arg == "--allowedTools" || strings.HasPrefix(arg, "--allowedTools=") {
-			return true
-		}
-	}
-	return false
+	_, found := collectClaudeAllowedTools(args)
+	return found
 }
 
 func childArgsAllowedToolsEquals(args []string, want string) bool {
-	for i, arg := range args {
-		if arg == "--allowedTools" && i+1 < len(args) && args[i+1] == want {
-			return true
-		}
-		if strings.TrimPrefix(arg, "--allowedTools=") != arg && strings.TrimPrefix(arg, "--allowedTools=") == want {
-			return true
-		}
-	}
-	return false
+	values, found := collectClaudeAllowedTools(args)
+	return found && strings.Join(values, ",") == want
 }
 
 func hasTrailingArgs(args, suffix []string) bool {

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -56,34 +56,33 @@ func claudePreauthChildArgs(allow []string) []string {
 }
 
 func applyClaudeWorkerPreauth(projectDir, profile, role, binary, session string, childArgs []string, includeBuiltIn bool) ([]string, []string, bool) {
+	launcherActions := claudeLauncherPreauthActions(projectDir, profile, role, binary, session, includeBuiltIn)
+	return applyClaudeWorkerPreauthActions(childArgs, launcherActions)
+}
+
+func applyClaudeWorkerPreauthActions(childArgs, launcherActions []string) ([]string, []string, bool) {
 	out := append([]string(nil), childArgs...)
-	configured := configuredClaudePermissionAllowlist(projectDir, profile, role, binary)
+	explicit, found := collectClaudeAllowedTools(out)
+	if len(launcherActions) == 0 {
+		if found {
+			// Even without launcher-owned policy, canonicalize explicit native
+			// grants into the safe equals form and collapse duplicate aliases.
+			return replaceClaudeAllowedTools(out, explicit), explicit, false
+		}
+		return out, nil, false
+	}
+	// Every allowed-tools value already present in child argv is explicit by
+	// construction. Team preview never embeds launcher policy in that argv.
+	effective := appendUniquePermissionPatterns(explicit, launcherActions...)
+	return replaceClaudeAllowedTools(out, effective), effective, true
+}
+
+func claudeLauncherPreauthActions(projectDir, profile, role, binary, session string, includeBuiltIn bool) []string {
 	var actions []string
 	if includeBuiltIn && claudeWorkerPreauthEligible(projectDir, profile, role, binary) {
 		actions = appendUniquePermissionPatterns(actions, claudeInScopePreauthAllowlist(session)...)
 	}
-	actions = appendUniquePermissionPatterns(actions, configured...)
-	if len(actions) == 0 {
-		if explicit, found := collectClaudeAllowedTools(out); found {
-			// Even without launcher-owned policy, canonicalize explicit native
-			// grants into the safe equals form and collapse duplicate aliases.
-			return replaceClaudeAllowedTools(out, explicit), nil, false
-		}
-		return out, nil, false
-	}
-	if childArgsHasAllowedTools(out) {
-		if childArgsAllowedToolsEquals(out, strings.Join(actions, ",")) {
-			// Team launch previews emit launcher-owned preauth into the copied
-			// command. Treat the exact allowlist as ours so bootstrap eligibility
-			// and launch-record audit fields stay aligned with live launch.
-			return out, actions, false
-		}
-		// Recomposition always preserves genuinely explicit native grants while
-		// rebuilding launcher-owned grants from current policy. This is what lets
-		// profile removal/narrowing revoke the old launcher-owned value on replay.
-		actions = appendUniquePermissionPatterns(childArgsAllowedTools(out), actions...)
-	}
-	return replaceClaudeAllowedTools(out, actions), actions, true
+	return appendUniquePermissionPatterns(actions, configuredClaudePermissionAllowlist(projectDir, profile, role, binary)...)
 }
 
 func configuredClaudePermissionAllowlist(projectDir, profile, role, binary string) []string {
@@ -191,10 +190,6 @@ func replaceClaudeAllowedTools(args, actions []string) []string {
 	return out
 }
 
-func stripTrailingLauncherPreauthArgs(childArgs, preauthorizedActions []string) []string {
-	return stripRecordedLauncherPreauth(childArgs, preauthorizedActions)
-}
-
 // stripRecordedLauncherPreauth removes only the exact launcher-owned grant
 // identified by launch.Record.PreauthorizedActions. It recognizes both the
 // historical two-token spelling and the injection-safe equals spelling. Any
@@ -237,16 +232,6 @@ func stripRecordedLauncherPreauth(args, preauthorizedActions []string) []string 
 		i++
 	}
 	return out
-}
-
-func childArgsHasAllowedTools(args []string) bool {
-	_, found := collectClaudeAllowedTools(args)
-	return found
-}
-
-func childArgsAllowedToolsEquals(args []string, want string) bool {
-	values, found := collectClaudeAllowedTools(args)
-	return found && strings.Join(values, ",") == want
 }
 
 // claudeWorkerPreauthEligible reports whether an `agent up` launch is an

--- a/internal/cli/agent_defaults_test.go
+++ b/internal/cli/agent_defaults_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -79,5 +80,75 @@ func TestClaudeWorkerPreauthEligible(t *testing.T) {
 	})
 	if claudeWorkerPreauthEligible(flat, "", "fullstack", "claude") {
 		t.Fatal("non-orchestrated team must not pre-authorize")
+	}
+}
+
+func TestConfiguredClaudePermissionAllowlistIsStrictlyRoleScoped(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "s", PermissionAllowlist: []string{"Bash(rm -rf /tmp/qa-review/*:*)"}},
+			{Role: "reviewer", Binary: "claude", Handle: "reviewer", Session: "s", PermissionAllowlist: []string{"Bash(rm -rf /tmp/reviewer-work/*:*)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+
+	qaArgs, qaActions, added := applyClaudeWorkerPreauth(dir, "", "qa", "claude", "s", nil, true)
+	if !added || !containsString(qaActions, "Bash(gh pr create:*)") || !containsString(qaActions, "Bash(rm -rf /tmp/qa-review/*:*)") {
+		t.Fatalf("qa actions = %v, added=%v", qaActions, added)
+	}
+	if containsString(qaActions, "Bash(rm -rf /tmp/reviewer-work/*:*)") || strings.Contains(strings.Join(qaArgs, " "), "reviewer-work") {
+		t.Fatalf("reviewer allowlist leaked into qa launch: actions=%v args=%v", qaActions, qaArgs)
+	}
+
+	reviewerArgs, reviewerActions, _ := applyClaudeWorkerPreauth(dir, "", "reviewer", "claude", "s", nil, false)
+	if len(reviewerActions) != 1 || reviewerActions[0] != "Bash(rm -rf /tmp/reviewer-work/*:*)" {
+		t.Fatalf("configured actions with built-in opt-out = %v", reviewerActions)
+	}
+	if strings.Contains(strings.Join(reviewerArgs, " "), "gh pr create") {
+		t.Fatalf("built-in opt-out leaked PR grant: %v", reviewerArgs)
+	}
+
+	if args, actions, added := applyClaudeWorkerPreauth(dir, "", "qa", "codex", "s", nil, true); len(args) != 0 || len(actions) != 0 || added {
+		t.Fatalf("binary mismatch must not receive qa allowlist: args=%v actions=%v added=%v", args, actions, added)
+	}
+}
+
+func TestConfiguredClaudePermissionAllowlistMergesExplicitAllowedTools(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "s"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "s", PermissionAllowlist: []string{"Bash(rm -rf /tmp/qa-review/*:*)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+
+	args, actions, added := applyClaudeWorkerPreauth(dir, "", "qa", "claude", "s", []string{
+		"--allowedTools", "Read(/tmp/qa-review/**)",
+		"--allowed-tools=Edit(/tmp/qa-review/**)",
+		"--", "--allowedTools", "prompt text",
+	}, true)
+	for _, want := range []string{"Read(/tmp/qa-review/**)", "Bash(gh pr create:*)", "Bash(rm -rf /tmp/qa-review/*:*)"} {
+		if !containsString(actions, want) {
+			t.Fatalf("effective actions missing %q: %v", want, actions)
+		}
+	}
+	if !containsString(actions, "Edit(/tmp/qa-review/**)") {
+		t.Fatalf("effective actions missing kebab-case inline grant: %v", actions)
+	}
+	boundary := -1
+	for i, arg := range args {
+		if arg == "--" {
+			boundary = i
+			break
+		}
+	}
+	if !added || boundary < 2 || args[boundary-2] != "--allowedTools" || strings.Count(strings.Join(args[:boundary], " "), "--allowedTools") != 1 || strings.Contains(strings.Join(args[:boundary], " "), "--allowed-tools") {
+		t.Fatalf("merged args = %v, added=%v", args, added)
+	}
+	if got := args[boundary:]; !reflect.DeepEqual(got, []string{"--", "--allowedTools", "prompt text"}) {
+		t.Fatalf("literal prompt boundary changed: %v", got)
 	}
 }

--- a/internal/cli/agent_defaults_test.go
+++ b/internal/cli/agent_defaults_test.go
@@ -35,11 +35,14 @@ func TestClaudePreauthChildArgs(t *testing.T) {
 		t.Fatal("empty allowlist must yield no child args (back-compat)")
 	}
 	args := claudePreauthChildArgs([]string{"Bash(gh pr create:*)", "Bash(git push origin codex/s-:*)"})
-	if len(args) != 2 || args[0] != "--allowedTools" {
-		t.Fatalf("child args = %v, want --allowedTools + comma-joined value", args)
+	if len(args) != 1 || !strings.HasPrefix(args[0], "--allowedTools=") {
+		t.Fatalf("child args = %v, want one equals-joined --allowedTools token", args)
 	}
-	if !strings.Contains(args[1], "gh pr create") || !strings.Contains(args[1], "git push origin codex/s-") {
-		t.Fatalf("allowedTools value missing patterns: %q", args[1])
+	if !strings.Contains(args[0], "gh pr create") || !strings.Contains(args[0], "git push origin codex/s-") {
+		t.Fatalf("allowedTools value missing patterns: %q", args[0])
+	}
+	if spec, inline, ok := nativeValueSpecForArg("claude", args[0]); !ok || !inline || spec.Canonical != "--allowed-tools" {
+		t.Fatalf("native parser does not recognize safe equals form: spec=%+v inline=%v ok=%v", spec, inline, ok)
 	}
 }
 
@@ -145,10 +148,38 @@ func TestConfiguredClaudePermissionAllowlistMergesExplicitAllowedTools(t *testin
 			break
 		}
 	}
-	if !added || boundary < 2 || args[boundary-2] != "--allowedTools" || strings.Count(strings.Join(args[:boundary], " "), "--allowedTools") != 1 || strings.Contains(strings.Join(args[:boundary], " "), "--allowed-tools") {
+	if !added || boundary != 1 || !strings.HasPrefix(args[0], "--allowedTools=") || strings.Count(strings.Join(args[:boundary], " "), "--allowedTools") != 1 || strings.Contains(strings.Join(args[:boundary], " "), "--allowed-tools") {
 		t.Fatalf("merged args = %v, added=%v", args, added)
 	}
 	if got := args[boundary:]; !reflect.DeepEqual(got, []string{"--", "--allowedTools", "prompt text"}) {
 		t.Fatalf("literal prompt boundary changed: %v", got)
+	}
+}
+
+func TestStripRecordedLauncherPreauthRecognizesHistoricalAndSafeForms(t *testing.T) {
+	actions := []string{"Read(/tmp/qa/**)", "Bash(gh pr create:*)"}
+	joined := strings.Join(actions, ",")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "historical camel", args: []string{"--chrome", "--allowedTools", joined}},
+		{name: "historical kebab", args: []string{"--chrome", "--allowed-tools", joined}},
+		{name: "safe camel", args: []string{"--chrome", "--allowedTools=" + joined}},
+		{name: "safe kebab", args: []string{"--chrome", "--allowed-tools=" + joined}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripRecordedLauncherPreauth(tc.args, actions)
+			if !reflect.DeepEqual(got, []string{"--chrome"}) {
+				t.Fatalf("stripRecordedLauncherPreauth(%v) = %v", tc.args, got)
+			}
+		})
+	}
+
+	other := "Read(/tmp/other/**)"
+	args := []string{"--allowedTools=" + other, "--", "--allowedTools=" + joined}
+	if got := stripRecordedLauncherPreauth(args, actions); !reflect.DeepEqual(got, args) {
+		t.Fatalf("different/boundary grants changed: got %v want %v", got, args)
 	}
 }

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -289,43 +289,52 @@ Examples:
 	// slice (no safe pattern form; see claudeInScopePreauthAllowlist); main push,
 	// tags, and releases always stay gated.
 	var preauthorizedActions []string
+	explicitAllowedTools := childArgsAllowedTools(childArgs)
+	preauthInputArgs := append([]string(nil), childArgs...)
 	childArgs, preauthorizedActions, _ = applyClaudeWorkerPreauth(launchPreauthProjectDir(cwd, *teamHome), teamProfileValue, *roleFlag, binary, env.SessionName, childArgs, !*noPreauthInScope)
+	if len(preauthorizedActions) > 0 && childArgsAllowedToolsEquals(preauthInputArgs, strings.Join(preauthorizedActions, ",")) {
+		// A generated team command already carries the exact launcher grant in
+		// its preview argv. It is not an independently explicit native grant.
+		explicitAllowedTools = nil
+	}
 
 	agentDir := filepath.Join(root, "agents", handle)
 	rec := launch.Record{
-		CWD:                  cwd,
-		Binary:               binary,
-		Argv:                 childArgs,
-		Session:              env.SessionName,
-		SharedWorkstream:     *sharedWorkstream,
-		Conversation:         conversationRef,
-		Handle:               handle,
-		Role:                 *roleFlag,
-		Root:                 root,
-		BaseRoot:             env.BaseRoot,
-		RootSource:           env.RootSource,
-		AMQVersion:           env.AMQVersion,
-		CodexArgs:            binaryArgs["codex"],
-		ClaudeArgs:           binaryArgs["claude"],
-		Launcher:             launcher,
-		LauncherArgs:         launcherArgs,
-		Model:                resolvedModel,
-		Trust:                trustMode,
-		NoDefaultArgs:        *noDefaultArgs,
-		SpawnOrigin:          strings.TrimSpace(*spawnOrigin),
-		SpawnDepth:           *spawnDepth,
-		NoRequireWake:        *noRequireWake,
-		NoGitignore:          *noGitignore,
-		Symphony:             *symphony,
-		GoalBinding:          nativeGoalBindingFromArgs(childArgs),
-		PreauthorizedActions: preauthorizedActions,
-		WakeInjectVia:        wakeInjectViaValue,
-		WakeInjectArgs:       wakeInjectArgValues,
-		AgentPID:             os.Getpid(),
-		AgentTTY:             currentLaunchTTY(),
-		StartedAt:            time.Now().UTC(),
-		TeamProfile:          teamProfileValue,
-		TeamHome:             strings.TrimSpace(*teamHome),
+		CWD:                   cwd,
+		Binary:                binary,
+		Argv:                  childArgs,
+		Session:               env.SessionName,
+		SharedWorkstream:      *sharedWorkstream,
+		Conversation:          conversationRef,
+		Handle:                handle,
+		Role:                  *roleFlag,
+		Root:                  root,
+		BaseRoot:              env.BaseRoot,
+		RootSource:            env.RootSource,
+		AMQVersion:            env.AMQVersion,
+		CodexArgs:             binaryArgs["codex"],
+		ClaudeArgs:            binaryArgs["claude"],
+		Launcher:              launcher,
+		LauncherArgs:          launcherArgs,
+		Model:                 resolvedModel,
+		Trust:                 trustMode,
+		NoDefaultArgs:         *noDefaultArgs,
+		NoPreauthorizeInScope: *noPreauthInScope,
+		SpawnOrigin:           strings.TrimSpace(*spawnOrigin),
+		SpawnDepth:            *spawnDepth,
+		NoRequireWake:         *noRequireWake,
+		NoGitignore:           *noGitignore,
+		Symphony:              *symphony,
+		GoalBinding:           nativeGoalBindingFromArgs(childArgs),
+		PreauthorizedActions:  preauthorizedActions,
+		ExplicitAllowedTools:  explicitAllowedTools,
+		WakeInjectVia:         wakeInjectViaValue,
+		WakeInjectArgs:        wakeInjectArgValues,
+		AgentPID:              os.Getpid(),
+		AgentTTY:              currentLaunchTTY(),
+		StartedAt:             time.Now().UTC(),
+		TeamProfile:           teamProfileValue,
+		TeamHome:              strings.TrimSpace(*teamHome),
 	}
 	if rec.TeamHome == "" {
 		rec.TeamHome = rec.CWD

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -289,9 +289,7 @@ Examples:
 	// slice (no safe pattern form; see claudeInScopePreauthAllowlist); main push,
 	// tags, and releases always stay gated.
 	var preauthorizedActions []string
-	if !*noPreauthInScope {
-		childArgs, preauthorizedActions, _ = applyClaudeWorkerPreauth(launchPreauthProjectDir(cwd, *teamHome), teamProfileValue, *roleFlag, binary, env.SessionName, childArgs)
-	}
+	childArgs, preauthorizedActions, _ = applyClaudeWorkerPreauth(launchPreauthProjectDir(cwd, *teamHome), teamProfileValue, *roleFlag, binary, env.SessionName, childArgs, !*noPreauthInScope)
 
 	agentDir := filepath.Join(root, "agents", handle)
 	rec := launch.Record{

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -290,51 +290,47 @@ Examples:
 	// tags, and releases always stay gated.
 	var preauthorizedActions []string
 	explicitAllowedTools := childArgsAllowedTools(childArgs)
-	preauthInputArgs := append([]string(nil), childArgs...)
-	childArgs, preauthorizedActions, _ = applyClaudeWorkerPreauth(launchPreauthProjectDir(cwd, *teamHome), teamProfileValue, *roleFlag, binary, env.SessionName, childArgs, !*noPreauthInScope)
-	if len(preauthorizedActions) > 0 && childArgsAllowedToolsEquals(preauthInputArgs, strings.Join(preauthorizedActions, ",")) {
-		// A generated team command already carries the exact launcher grant in
-		// its preview argv. It is not an independently explicit native grant.
-		explicitAllowedTools = nil
-	}
+	launcherPreauthorizedActions := claudeLauncherPreauthActions(launchPreauthProjectDir(cwd, *teamHome), teamProfileValue, *roleFlag, binary, env.SessionName, !*noPreauthInScope)
+	childArgs, preauthorizedActions, _ = applyClaudeWorkerPreauthActions(childArgs, launcherPreauthorizedActions)
 
 	agentDir := filepath.Join(root, "agents", handle)
 	rec := launch.Record{
-		CWD:                   cwd,
-		Binary:                binary,
-		Argv:                  childArgs,
-		Session:               env.SessionName,
-		SharedWorkstream:      *sharedWorkstream,
-		Conversation:          conversationRef,
-		Handle:                handle,
-		Role:                  *roleFlag,
-		Root:                  root,
-		BaseRoot:              env.BaseRoot,
-		RootSource:            env.RootSource,
-		AMQVersion:            env.AMQVersion,
-		CodexArgs:             binaryArgs["codex"],
-		ClaudeArgs:            binaryArgs["claude"],
-		Launcher:              launcher,
-		LauncherArgs:          launcherArgs,
-		Model:                 resolvedModel,
-		Trust:                 trustMode,
-		NoDefaultArgs:         *noDefaultArgs,
-		NoPreauthorizeInScope: *noPreauthInScope,
-		SpawnOrigin:           strings.TrimSpace(*spawnOrigin),
-		SpawnDepth:            *spawnDepth,
-		NoRequireWake:         *noRequireWake,
-		NoGitignore:           *noGitignore,
-		Symphony:              *symphony,
-		GoalBinding:           nativeGoalBindingFromArgs(childArgs),
-		PreauthorizedActions:  preauthorizedActions,
-		ExplicitAllowedTools:  explicitAllowedTools,
-		WakeInjectVia:         wakeInjectViaValue,
-		WakeInjectArgs:        wakeInjectArgValues,
-		AgentPID:              os.Getpid(),
-		AgentTTY:              currentLaunchTTY(),
-		StartedAt:             time.Now().UTC(),
-		TeamProfile:           teamProfileValue,
-		TeamHome:              strings.TrimSpace(*teamHome),
+		CWD:                          cwd,
+		Binary:                       binary,
+		Argv:                         childArgs,
+		Session:                      env.SessionName,
+		SharedWorkstream:             *sharedWorkstream,
+		Conversation:                 conversationRef,
+		Handle:                       handle,
+		Role:                         *roleFlag,
+		Root:                         root,
+		BaseRoot:                     env.BaseRoot,
+		RootSource:                   env.RootSource,
+		AMQVersion:                   env.AMQVersion,
+		CodexArgs:                    binaryArgs["codex"],
+		ClaudeArgs:                   binaryArgs["claude"],
+		Launcher:                     launcher,
+		LauncherArgs:                 launcherArgs,
+		Model:                        resolvedModel,
+		Trust:                        trustMode,
+		NoDefaultArgs:                *noDefaultArgs,
+		NoPreauthorizeInScope:        *noPreauthInScope,
+		SpawnOrigin:                  strings.TrimSpace(*spawnOrigin),
+		SpawnDepth:                   *spawnDepth,
+		NoRequireWake:                *noRequireWake,
+		NoGitignore:                  *noGitignore,
+		Symphony:                     *symphony,
+		GoalBinding:                  nativeGoalBindingFromArgs(childArgs),
+		PreauthorizedActions:         preauthorizedActions,
+		LauncherPreauthorizedActions: launcherPreauthorizedActions,
+		ExplicitAllowedTools:         explicitAllowedTools,
+		WakeInjectVia:                wakeInjectViaValue,
+		WakeInjectArgs:               wakeInjectArgValues,
+		AgentPID:                     os.Getpid(),
+		AgentTTY:                     currentLaunchTTY(),
+		StartedAt:                    time.Now().UTC(),
+		TeamProfile:                  teamProfileValue,
+		TeamHome:                     strings.TrimSpace(*teamHome),
 	}
 	if rec.TeamHome == "" {
 		rec.TeamHome = rec.CWD
@@ -371,7 +367,14 @@ Examples:
 	// Keep generated bootstrap out of launch.json so restore stays compact
 	// and does not replay stale startup text.
 	effectiveChildArgs := append([]string(nil), childArgs...)
-	bootstrapEligibilityArgs := stripTrailingLauncherPreauthArgs(childArgs, preauthorizedActions)
+	bootstrapEligibilityArgs := childArgs
+	if len(launcherPreauthorizedActions) > 0 {
+		if len(explicitAllowedTools) > 0 {
+			bootstrapEligibilityArgs = replaceClaudeAllowedTools(childArgs, explicitAllowedTools)
+		} else {
+			bootstrapEligibilityArgs = stripRecordedLauncherPreauth(childArgs, preauthorizedActions)
+		}
+	}
 	bootstrapAppended := !*noBootstrap && shouldAppendBootstrapWithDefaults(bootstrapEligibilityArgs, defaultArgs)
 	bootstrapSuppressedReason := ""
 	if bootstrapAppended {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -319,6 +319,76 @@ func TestRunLaunchRecordsExplicitAllowedToolsSeparatelyFromMergedGrant(t *testin
 			t.Fatalf("effective record audit missing %q: %v", want, observed.PreauthorizedActions)
 		}
 	}
+	if containsString(observed.LauncherPreauthorizedActions, "Edit(/tmp/explicit/**)") ||
+		!containsString(observed.LauncherPreauthorizedActions, "Read(/tmp/policy/**)") ||
+		!containsString(observed.LauncherPreauthorizedActions, "Bash(gh pr create:*)") {
+		t.Fatalf("launcher provenance = %v", observed.LauncherPreauthorizedActions)
+	}
+}
+
+func TestExplicitGrantEqualToLauncherPolicySurvivesPolicyRemoval(t *testing.T) {
+	const configured = "Read(/tmp/equal-policy/**)"
+	for _, optOut := range []bool{false, true} {
+		name := "with built-in"
+		if optOut {
+			name = "with built-in opt-out"
+		}
+		t.Run(name, func(t *testing.T) {
+			teamHome := t.TempDir()
+			writeReplayAllowlistTeam(t, teamHome, []string{configured}, true)
+			setupFakeAMQ(t)
+
+			launcherPolicy := []string{configured}
+			if !optOut {
+				launcherPolicy = []string{"Bash(gh pr create:*)", configured}
+			}
+			initialArgs := []string{
+				"--dry-run", "--no-bootstrap", "--team-home", teamHome,
+				"--role", "qa", "--session", "issue-401",
+			}
+			if optOut {
+				initialArgs = append(initialArgs, "--no-preauthorize-inscope")
+			}
+			initialArgs = append(initialArgs, "claude", "--", claudePreauthChildArgs(launcherPolicy)[0])
+
+			var initial launch.Record
+			oldObserver := launchPlanObserver
+			t.Cleanup(func() { launchPlanObserver = oldObserver })
+			launchPlanObserver = func(rec launch.Record, _ []string) { initial = rec }
+			if _, _, err := captureOutput(t, func() error { return runLaunch(initialArgs) }); err != nil {
+				t.Fatalf("initial launch: %v", err)
+			}
+			if !reflect.DeepEqual(initial.ExplicitAllowedTools, launcherPolicy) ||
+				!reflect.DeepEqual(initial.LauncherPreauthorizedActions, launcherPolicy) {
+				t.Fatalf("equal-valued provenance collapsed: explicit=%v launcher=%v want=%v", initial.ExplicitAllowedTools, initial.LauncherPreauthorizedActions, launcherPolicy)
+			}
+
+			// Remove the configured member policy, then replay the exact record.
+			writeReplayAllowlistTeam(t, teamHome, nil, true)
+			var replayed launch.Record
+			launchPlanObserver = func(rec launch.Record, _ []string) { replayed = rec }
+			replayArgs := append([]string{"--dry-run", "--no-bootstrap"}, launchArgsFromRecord(initial)...)
+			if _, _, err := captureOutput(t, func() error { return runLaunch(replayArgs) }); err != nil {
+				t.Fatalf("replay after policy removal: %v", err)
+			}
+			if !reflect.DeepEqual(replayed.ExplicitAllowedTools, launcherPolicy) {
+				t.Fatalf("equal-valued explicit grant was lost: got %v want %v", replayed.ExplicitAllowedTools, launcherPolicy)
+			}
+			wantLauncher := []string(nil)
+			if !optOut {
+				wantLauncher = []string{"Bash(gh pr create:*)"}
+			}
+			if !reflect.DeepEqual(replayed.LauncherPreauthorizedActions, wantLauncher) {
+				t.Fatalf("launcher policy was not revoked structurally: got %v want %v", replayed.LauncherPreauthorizedActions, wantLauncher)
+			}
+			if !containsString(replayed.PreauthorizedActions, configured) {
+				t.Fatalf("surviving explicit value absent from effective audit: %v", replayed.PreauthorizedActions)
+			}
+			if strings.Count(strings.Join(replayed.Argv, " "), "--allowedTools") != 1 {
+				t.Fatalf("replay emitted duplicate allowed-tools flags: %v", replayed.Argv)
+			}
+		})
+	}
 }
 
 func TestReplayRecomposesLauncherGrantFromCurrentPolicy(t *testing.T) {
@@ -371,15 +441,16 @@ func TestReplayRecomposesLauncherGrantFromCurrentPolicy(t *testing.T) {
 			setupFakeAMQ(t)
 			prior := []string{explicit, "Bash(gh pr create:*)", oldGrant}
 			rec := launch.Record{
-				Binary:               "claude",
-				Argv:                 claudePreauthChildArgs(prior),
-				Session:              "issue-401",
-				Handle:               "qa",
-				Role:                 "qa",
-				Root:                 filepath.Join(teamHome, ".agent-mail", "issue-401"),
-				TeamHome:             teamHome,
-				PreauthorizedActions: prior,
-				ExplicitAllowedTools: []string{explicit},
+				Binary:                       "claude",
+				Argv:                         claudePreauthChildArgs(prior),
+				Session:                      "issue-401",
+				Handle:                       "qa",
+				Role:                         "qa",
+				Root:                         filepath.Join(teamHome, ".agent-mail", "issue-401"),
+				TeamHome:                     teamHome,
+				PreauthorizedActions:         prior,
+				LauncherPreauthorizedActions: []string{"Bash(gh pr create:*)", oldGrant},
+				ExplicitAllowedTools:         []string{explicit},
 			}
 
 			var replayed launch.Record

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -235,6 +236,195 @@ func TestRunLaunchBuiltInPreauthOptOutPreservesMemberPermissionAllowlist(t *test
 	}
 }
 
+func TestConfiguredAllowlistOptOutFullRecordReplay(t *testing.T) {
+	teamHome := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-401"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-401", PermissionAllowlist: []string{"Read(/tmp/qa-review/**)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+	setupFakeAMQ(t)
+
+	recordDir := t.TempDir()
+	initial := launch.Record{
+		Binary:                "claude",
+		Argv:                  []string{"--allowedTools=Read(/tmp/qa-review/**)"},
+		Session:               "issue-401",
+		Handle:                "qa",
+		Role:                  "qa",
+		Root:                  filepath.Join(teamHome, ".agent-mail", "issue-401"),
+		TeamHome:              teamHome,
+		NoPreauthorizeInScope: true,
+		PreauthorizedActions:  []string{"Read(/tmp/qa-review/**)"},
+	}
+	if err := launch.Write(recordDir, initial); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := launch.Read(recordDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var replayed launch.Record
+	oldObserver := launchPlanObserver
+	t.Cleanup(func() { launchPlanObserver = oldObserver })
+	launchPlanObserver = func(rec launch.Record, _ []string) { replayed = rec }
+	args := append([]string{"--dry-run", "--no-bootstrap"}, launchArgsFromRecord(stored)...)
+	_, _, err = captureOutput(t, func() error { return runLaunch(args) })
+	if err != nil {
+		t.Fatalf("replay runLaunch: %v", err)
+	}
+	if !replayed.NoPreauthorizeInScope {
+		t.Fatal("replayed launch record lost no-preauthorize-inscope")
+	}
+	if !reflect.DeepEqual(replayed.PreauthorizedActions, []string{"Read(/tmp/qa-review/**)"}) {
+		t.Fatalf("replayed current grant = %v", replayed.PreauthorizedActions)
+	}
+	if strings.Contains(strings.Join(replayed.Argv, " "), "gh pr create") {
+		t.Fatalf("replayed opt-out restored built-in grant: %v", replayed.Argv)
+	}
+}
+
+func TestRunLaunchRecordsExplicitAllowedToolsSeparatelyFromMergedGrant(t *testing.T) {
+	teamHome := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-401"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-401", PermissionAllowlist: []string{"Read(/tmp/policy/**)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+	setupFakeAMQ(t)
+	var observed launch.Record
+	oldObserver := launchPlanObserver
+	t.Cleanup(func() { launchPlanObserver = oldObserver })
+	launchPlanObserver = func(rec launch.Record, _ []string) { observed = rec }
+	_, _, err := captureOutput(t, func() error {
+		return runLaunch([]string{
+			"--dry-run", "--no-bootstrap", "--team-home", teamHome,
+			"--role", "qa", "--session", "issue-401", "claude", "--",
+			"--allowedTools=Edit(/tmp/explicit/**)",
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(observed.ExplicitAllowedTools, []string{"Edit(/tmp/explicit/**)"}) {
+		t.Fatalf("explicit_allowed_tools = %v", observed.ExplicitAllowedTools)
+	}
+	for _, want := range []string{"Edit(/tmp/explicit/**)", "Read(/tmp/policy/**)", "Bash(gh pr create:*)"} {
+		if !containsString(observed.PreauthorizedActions, want) {
+			t.Fatalf("effective record audit missing %q: %v", want, observed.PreauthorizedActions)
+		}
+	}
+}
+
+func TestReplayRecomposesLauncherGrantFromCurrentPolicy(t *testing.T) {
+	const (
+		oldGrant = "Read(/tmp/old-policy/**)"
+		newGrant = "Read(/tmp/new-policy/**)"
+		explicit = "Edit(/tmp/explicit/**)"
+	)
+	tests := []struct {
+		name        string
+		configure   func(t *testing.T, dir string)
+		want        []string
+		wantBuiltin bool
+	}{
+		{
+			name: "A to B",
+			configure: func(t *testing.T, dir string) {
+				writeReplayAllowlistTeam(t, dir, []string{newGrant}, true)
+			},
+			want: []string{explicit, newGrant}, wantBuiltin: true,
+		},
+		{
+			name: "A to empty",
+			configure: func(t *testing.T, dir string) {
+				writeReplayAllowlistTeam(t, dir, nil, true)
+			},
+			want: []string{explicit}, wantBuiltin: true,
+		},
+		{
+			name: "role removed",
+			configure: func(t *testing.T, dir string) {
+				writeReplayAllowlistTeam(t, dir, nil, false)
+			},
+			want: []string{explicit},
+		},
+		{
+			name: "profile removed",
+			configure: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, team.DirName), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []string{explicit},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			teamHome := t.TempDir()
+			tc.configure(t, teamHome)
+			setupFakeAMQ(t)
+			prior := []string{explicit, "Bash(gh pr create:*)", oldGrant}
+			rec := launch.Record{
+				Binary:               "claude",
+				Argv:                 claudePreauthChildArgs(prior),
+				Session:              "issue-401",
+				Handle:               "qa",
+				Role:                 "qa",
+				Root:                 filepath.Join(teamHome, ".agent-mail", "issue-401"),
+				TeamHome:             teamHome,
+				PreauthorizedActions: prior,
+				ExplicitAllowedTools: []string{explicit},
+			}
+
+			var replayed launch.Record
+			oldObserver := launchPlanObserver
+			t.Cleanup(func() { launchPlanObserver = oldObserver })
+			launchPlanObserver = func(got launch.Record, _ []string) { replayed = got }
+			args := append([]string{"--dry-run", "--no-bootstrap"}, launchArgsFromRecord(rec)...)
+			_, _, err := captureOutput(t, func() error { return runLaunch(args) })
+			if err != nil {
+				t.Fatalf("replay runLaunch: %v", err)
+			}
+			joined := strings.Join(replayed.Argv, " ")
+			if strings.Contains(joined, oldGrant) {
+				t.Fatalf("revoked grant survived replay: argv=%v audit=%v", replayed.Argv, replayed.PreauthorizedActions)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("current/explicit grant %q missing: argv=%v audit=%v", want, replayed.Argv, replayed.PreauthorizedActions)
+				}
+			}
+			hasBuiltin := strings.Contains(joined, "Bash(gh pr create:*)")
+			if hasBuiltin != tc.wantBuiltin {
+				t.Fatalf("built-in presence = %v, want %v: argv=%v", hasBuiltin, tc.wantBuiltin, replayed.Argv)
+			}
+			if strings.Count(joined, "--allowedTools") != 1 {
+				t.Fatalf("replay emitted duplicate allowed-tools flags: %v", replayed.Argv)
+			}
+			if tc.wantBuiltin && !reflect.DeepEqual(childArgsAllowedTools(replayed.Argv), replayed.PreauthorizedActions) {
+				t.Fatalf("new record audit is not the current effective grant: argv=%v audit=%v", childArgsAllowedTools(replayed.Argv), replayed.PreauthorizedActions)
+			}
+		})
+	}
+}
+
+func writeReplayAllowlistTeam(t *testing.T, dir string, allow []string, includeQA bool) {
+	t.Helper()
+	members := []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-401"}}
+	if includeQA {
+		members = append(members, team.Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-401", PermissionAllowlist: allow})
+	}
+	if err := team.Write(dir, team.Team{Members: members, Orchestrated: true, Lead: "cto"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateManagedTmuxLaunchRejectsNonTTY(t *testing.T) {
 	t.Setenv(envTmuxTarget, "current-window")
 	t.Setenv("TMUX", "/tmp/tmux-1/default,1,0")
@@ -448,6 +638,28 @@ func TestLaunchArgsFromRecordReplaysNoRequireWake(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("replay args missing --no-require-wake: %v", args)
+	}
+}
+
+func TestLaunchArgsFromRecordReplaysNoPreauthorizeInScope(t *testing.T) {
+	rec := launch.Record{
+		Binary:                "claude",
+		Handle:                "qa",
+		Role:                  "qa",
+		Session:               "issue-401",
+		NoPreauthorizeInScope: true,
+		PreauthorizedActions:  []string{"Read(/tmp/qa-review/**)"},
+		Argv:                  []string{"--allowedTools=Read(/tmp/qa-review/**)"},
+	}
+	args := launchArgsFromRecord(rec)
+	if !containsArg(args, "--no-preauthorize-inscope") {
+		t.Fatalf("replay args missing --no-preauthorize-inscope: %v", args)
+	}
+	if strings.Contains(strings.Join(args, " "), "qa-review") {
+		t.Fatalf("replay args retained launcher-owned grant instead of recomposing current policy: %v", args)
+	}
+	if cmd := emitCommand(rec); !strings.Contains(cmd, "--no-preauthorize-inscope") {
+		t.Fatalf("replay command missing opt-out: %s", cmd)
 	}
 }
 

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -213,6 +213,28 @@ func TestRunLaunchPreauthOptOutAndScope(t *testing.T) {
 	})
 }
 
+func TestRunLaunchBuiltInPreauthOptOutPreservesMemberPermissionAllowlist(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "v2-14-0"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "v2-14-0", PermissionAllowlist: []string{"Bash(rm -rf /tmp/fullstack-review/*:*)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+	setupFakeAMQ(t)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-preauthorize-inscope", "--role", "fullstack", "--session", "v2-14-0", "claude", "p"})
+	})
+	if err != nil {
+		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "fullstack-review") || strings.Contains(stdout, "gh pr create") {
+		t.Fatalf("explicit allowlist should survive built-in opt-out without PR grant:\n%s", stdout)
+	}
+}
+
 func TestValidateManagedTmuxLaunchRejectsNonTTY(t *testing.T) {
 	t.Setenv(envTmuxTarget, "current-window")
 	t.Setenv("TMUX", "/tmp/tmux-1/default,1,0")

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -256,6 +256,9 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if rec.NoDefaultArgs {
 		args = append(args, "--no-default-args")
 	}
+	if rec.NoPreauthorizeInScope {
+		args = append(args, "--no-preauthorize-inscope")
+	}
 	if origin := strings.TrimSpace(rec.SpawnOrigin); origin != "" {
 		args = append(args, "--spawn-origin", origin)
 	}
@@ -317,6 +320,10 @@ func launchArgsFromRecord(rec launch.Record) []string {
 
 func restoreArgvFromRecord(rec launch.Record) []string {
 	argv := append([]string(nil), rec.Argv...)
+	argv = stripRecordedLauncherPreauth(argv, rec.PreauthorizedActions)
+	if normalizedAgentBinary(rec.Binary) == "claude" && len(rec.ExplicitAllowedTools) > 0 {
+		argv = replaceClaudeAllowedTools(argv, rec.ExplicitAllowedTools)
+	}
 	if rec.Conversation != "" {
 		argv = stripConversationRestoreArgs(rec.Binary, argv, rec.Conversation)
 	}
@@ -479,6 +486,9 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	}
 	if rec.NoDefaultArgs {
 		b.WriteString(" --no-default-args")
+	}
+	if rec.NoPreauthorizeInScope {
+		b.WriteString(" --no-preauthorize-inscope")
 	}
 	if origin := strings.TrimSpace(rec.SpawnOrigin); origin != "" {
 		b.WriteString(" --spawn-origin ")

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -320,7 +320,13 @@ func launchArgsFromRecord(rec launch.Record) []string {
 
 func restoreArgvFromRecord(rec launch.Record) []string {
 	argv := append([]string(nil), rec.Argv...)
-	argv = stripRecordedLauncherPreauth(argv, rec.PreauthorizedActions)
+	// New records carry structural provenance. Strip the final merged grant only
+	// when launcher policy contributed, then restore the explicit source below.
+	// Legacy records lack both provenance fields, so retain the historical exact
+	// PreauthorizedActions stripping behavior for backward compatibility.
+	if len(rec.LauncherPreauthorizedActions) > 0 || len(rec.ExplicitAllowedTools) == 0 {
+		argv = stripRecordedLauncherPreauth(argv, rec.PreauthorizedActions)
+	}
 	if normalizedAgentBinary(rec.Binary) == "claude" && len(rec.ExplicitAllowedTools) > 0 {
 		argv = replaceClaudeAllowedTools(argv, rec.ExplicitAllowedTools)
 	}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1342,21 +1342,22 @@ func teamCommandPreview(in emitTeamCommandInput) teamCommandPreviewData {
 	extraDefaultArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, in.BinaryArgs), m.ExtraArgs())
 	modelArgs := modelArgsForBinary(m.Binary, in.Model)
 	defaultArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, extraDefaultArgs, in.TrustMode)
-	childArgs, preauthorized, added := applyClaudeWorkerPreauth(in.TeamHome, in.Profile, m.Role, m.Binary, in.Workstream, defaultArgs, true)
-	bootstrapArgs := stripTrailingLauncherPreauthArgs(childArgs, preauthorized)
+	// Launcher policy is display/audit metadata only at preview time. It must
+	// never ride inside the executable child argv: runLaunch recomputes it from
+	// the current member policy, making every allowed-tools value already in
+	// ChildArgs explicit by construction.
+	launcherActions := claudeLauncherPreauthActions(in.TeamHome, in.Profile, m.Role, m.Binary, in.Workstream, true)
+	explicitActions := childArgsAllowedTools(defaultArgs)
+	preauthorized := appendUniquePermissionPatterns(explicitActions, launcherActions...)
 	bootstrap := "suppressed"
 	if in.NoBootstrap {
 		bootstrap = "disabled"
-	} else if shouldAppendBootstrapWithDefaults(bootstrapArgs, defaultArgs) {
+	} else if shouldAppendBootstrapWithDefaults(defaultArgs, defaultArgs) {
 		bootstrap = "appended"
 	}
-	var launcherAdded []string
-	if added {
-		launcherAdded = claudePreauthChildArgs(preauthorized)
-	}
 	return teamCommandPreviewData{
-		ChildArgs:            childArgs,
-		LauncherAddedArgs:    launcherAdded,
+		ChildArgs:            defaultArgs,
+		LauncherAddedArgs:    claudePreauthChildArgs(launcherActions),
 		PreauthorizedActions: preauthorized,
 		Bootstrap:            bootstrap,
 	}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -596,14 +596,15 @@ type teamInitDryRun struct {
 }
 
 type teamProfilePlanMember struct {
-	Role       string   `json:"role"`
-	Handle     string   `json:"handle"`
-	Binary     string   `json:"binary"`
-	Model      string   `json:"model,omitempty"`
-	CWD        string   `json:"cwd"`
-	Session    string   `json:"session"`
-	ClaudeArgs []string `json:"claude_args,omitempty"`
-	CodexArgs  []string `json:"codex_args,omitempty"`
+	Role                string   `json:"role"`
+	Handle              string   `json:"handle"`
+	Binary              string   `json:"binary"`
+	Model               string   `json:"model,omitempty"`
+	CWD                 string   `json:"cwd"`
+	Session             string   `json:"session"`
+	ClaudeArgs          []string `json:"claude_args,omitempty"`
+	CodexArgs           []string `json:"codex_args,omitempty"`
+	PermissionAllowlist []string `json:"permission_allowlist,omitempty"`
 }
 
 type teamProfilePlan struct {
@@ -699,14 +700,15 @@ func buildTeamProfilePlan(p teamInitDryRun) teamProfilePlan {
 	rows := make([]teamProfilePlanMember, 0, len(p.Team.Members))
 	for _, m := range orderedTeamMembers(p.Team.Members) {
 		rows = append(rows, teamProfilePlanMember{
-			Role:       m.Role,
-			Handle:     m.Handle,
-			Binary:     m.Binary,
-			Model:      m.Model,
-			CWD:        m.EffectiveCWD(p.Team.Project),
-			Session:    m.Session,
-			ClaudeArgs: m.ClaudeArgs,
-			CodexArgs:  m.CodexArgs,
+			Role:                m.Role,
+			Handle:              m.Handle,
+			Binary:              m.Binary,
+			Model:               m.Model,
+			CWD:                 m.EffectiveCWD(p.Team.Project),
+			Session:             m.Session,
+			ClaudeArgs:          m.ClaudeArgs,
+			CodexArgs:           m.CodexArgs,
+			PermissionAllowlist: m.PermissionAllowlist,
 		})
 	}
 	return teamProfilePlan{
@@ -801,6 +803,7 @@ type teamPlanMember struct {
 	CWD                  string   `json:"cwd"`
 	ClaudeArgs           []string `json:"claude_args,omitempty"`
 	CodexArgs            []string `json:"codex_args,omitempty"`
+	PermissionAllowlist  []string `json:"permission_allowlist,omitempty"`
 	ChildArgs            []string `json:"child_args,omitempty"`
 	PreauthorizedActions []string `json:"preauthorized_actions,omitempty"`
 	Bootstrap            string   `json:"bootstrap"`
@@ -967,6 +970,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 				CWD:                  cwd,
 				ClaudeArgs:           m.ClaudeArgs,
 				CodexArgs:            m.CodexArgs,
+				PermissionAllowlist:  m.PermissionAllowlist,
 				ChildArgs:            preview.ChildArgs,
 				PreauthorizedActions: preview.PreauthorizedActions,
 				Bootstrap:            preview.Bootstrap,
@@ -1338,7 +1342,7 @@ func teamCommandPreview(in emitTeamCommandInput) teamCommandPreviewData {
 	extraDefaultArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, in.BinaryArgs), m.ExtraArgs())
 	modelArgs := modelArgsForBinary(m.Binary, in.Model)
 	defaultArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, extraDefaultArgs, in.TrustMode)
-	childArgs, preauthorized, added := applyClaudeWorkerPreauth(in.TeamHome, in.Profile, m.Role, m.Binary, in.Workstream, defaultArgs)
+	childArgs, preauthorized, added := applyClaudeWorkerPreauth(in.TeamHome, in.Profile, m.Role, m.Binary, in.Workstream, defaultArgs, true)
 	bootstrapArgs := stripTrailingLauncherPreauthArgs(childArgs, preauthorized)
 	bootstrap := "suppressed"
 	if in.NoBootstrap {

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -170,12 +170,12 @@ func TestUpDryRunJSONIncludesClaudeWorkerPreauthAndBootstrapStatus(t *testing.T)
 		t.Fatalf("worker bootstrap = %q, want appended", worker.Bootstrap)
 	}
 	joinedArgs := strings.Join(worker.ChildArgs, " ")
-	for _, want := range []string{"--permission-mode auto", "--allowedTools", "Bash(gh pr create:*)"} {
-		if !strings.Contains(joinedArgs, want) {
-			t.Fatalf("worker child_args missing %q: %v", want, worker.ChildArgs)
-		}
-		if !strings.Contains(worker.Command, want) {
-			t.Fatalf("worker command missing %q: %s", want, worker.Command)
+	if !strings.Contains(joinedArgs, "--permission-mode auto") || !strings.Contains(worker.Command, "--permission-mode auto") {
+		t.Fatalf("worker executable defaults missing from plan: %+v", *worker)
+	}
+	for _, forbidden := range []string{"--allowedTools", "Bash(gh pr create:*)"} {
+		if strings.Contains(joinedArgs, forbidden) || strings.Contains(worker.Command, forbidden) {
+			t.Fatalf("launcher policy %q leaked into executable preview argv: %+v", forbidden, *worker)
 		}
 	}
 	if len(worker.PreauthorizedActions) != 1 || !strings.Contains(worker.PreauthorizedActions[0], "gh pr create") {
@@ -214,8 +214,11 @@ func TestUpDryRunPermissionAllowlistIsPerMemberAndAuditable(t *testing.T) {
 		if len(row.PermissionAllowlist) != 1 || row.PermissionAllowlist[0] != own {
 			t.Fatalf("%s permission_allowlist = %v, want %q", row.Role, row.PermissionAllowlist, own)
 		}
-		if !containsString(row.PreauthorizedActions, own) || !strings.Contains(row.Command, own) {
+		if !containsString(row.PreauthorizedActions, own) {
 			t.Fatalf("%s effective grant missing from plan/audit: %+v", row.Role, row)
+		}
+		if strings.Contains(row.Command, own) {
+			t.Fatalf("%s launcher policy leaked into executable command: %+v", row.Role, row)
 		}
 		if strings.Contains(strings.Join(row.PreauthorizedActions, " "), forbidden) || strings.Contains(row.Command, forbidden) {
 			t.Fatalf("%s received another role's allowlist: %+v", row.Role, row)
@@ -259,7 +262,7 @@ func TestUpDryRunCrossCWDClaudeWorkerPreauthMatchesLiveLaunch(t *testing.T) {
 		t.Fatalf("worker cwd = %q, want %q", worker.CWD, workerDir)
 	}
 	planTeamHome := env.Data.TeamHome
-	if worker.Bootstrap != "appended" || !strings.Contains(worker.Command, "--allowedTools") || !strings.Contains(worker.Command, "--team-home "+planTeamHome) {
+	if worker.Bootstrap != "appended" || strings.Contains(worker.Command, "--allowedTools") || !strings.Contains(worker.Command, "--team-home "+planTeamHome) {
 		t.Fatalf("preview did not show cross-cwd preauth+bootstrap correctly: %+v", *worker)
 	}
 
@@ -286,7 +289,6 @@ func TestUpDryRunCrossCWDClaudeWorkerPreauthMatchesLiveLaunch(t *testing.T) {
 			"claude",
 			"--",
 			"--permission-mode", "auto",
-			"--allowedTools", "Bash(gh pr create:*)",
 		})
 	})
 	if err != nil {

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -183,6 +183,46 @@ func TestUpDryRunJSONIncludesClaudeWorkerPreauthAndBootstrapStatus(t *testing.T)
 	}
 }
 
+func TestUpDryRunPermissionAllowlistIsPerMemberAndAuditable(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-401"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-401", PermissionAllowlist: []string{"Bash(rm -rf /tmp/qa-review/*:*)"}},
+			{Role: "reviewer", Binary: "claude", Handle: "reviewer", Session: "issue-401", PermissionAllowlist: []string{"Read(/tmp/reviewer-work/**)"}},
+		},
+		Orchestrated: true,
+		Lead:         "cto",
+	})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"issue-401", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("up --dry-run --json: %v", err)
+	}
+	env := decodeJSONEnvelope[teamPlan](t, stdout)
+	for _, row := range env.Data.Plan {
+		var own, forbidden string
+		switch row.Role {
+		case "qa":
+			own, forbidden = "Bash(rm -rf /tmp/qa-review/*:*)", "reviewer-work"
+		case "reviewer":
+			own, forbidden = "Read(/tmp/reviewer-work/**)", "qa-review"
+		default:
+			continue
+		}
+		if len(row.PermissionAllowlist) != 1 || row.PermissionAllowlist[0] != own {
+			t.Fatalf("%s permission_allowlist = %v, want %q", row.Role, row.PermissionAllowlist, own)
+		}
+		if !containsString(row.PreauthorizedActions, own) || !strings.Contains(row.Command, own) {
+			t.Fatalf("%s effective grant missing from plan/audit: %+v", row.Role, row)
+		}
+		if strings.Contains(strings.Join(row.PreauthorizedActions, " "), forbidden) || strings.Contains(row.Command, forbidden) {
+			t.Fatalf("%s received another role's allowlist: %+v", row.Role, row)
+		}
+	}
+}
+
 func TestUpDryRunCrossCWDClaudeWorkerPreauthMatchesLiveLaunch(t *testing.T) {
 	teamHome := t.TempDir()
 	workerDir := t.TempDir()

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -269,7 +269,7 @@ func TestUpDryRunCrossCWDClaudeWorkerPreauthMatchesLiveLaunch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("up --dry-run text: %v", err)
 	}
-	for _, want := range []string{"#    bootstrap: appended", "#    launcher-added args: --allowedTools 'Bash(gh pr create:*)'"} {
+	for _, want := range []string{"#    bootstrap: appended", "#    launcher-added args: '--allowedTools=Bash(gh pr create:*)'"} {
 		if !strings.Contains(textOut, want) {
 			t.Fatalf("text dry-run missing %q in:\n%s", want, textOut)
 		}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -93,6 +93,10 @@ type Record struct {
 	// audit evidence of exactly what was granted to this role; additive and
 	// omitted for legacy records and launches where no pre-authorization applied.
 	PreauthorizedActions []string `json:"preauthorized_actions,omitempty"`
+	// LauncherPreauthorizedActions records only the built-in and current member
+	// policy contribution. Keeping it separate from ExplicitAllowedTools makes
+	// equal-valued grants retain their source provenance across replay.
+	LauncherPreauthorizedActions []string `json:"launcher_preauthorized_actions,omitempty"`
 	// ExplicitAllowedTools preserves native allowed-tools values that existed
 	// before launcher policy was composed. Replay removes the old merged grant,
 	// then restores these explicit values before applying current policy.

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -49,8 +49,12 @@ type Record struct {
 	Model            string   `json:"model,omitempty"`
 	Trust            string   `json:"trust,omitempty"`
 	NoDefaultArgs    bool     `json:"no_default_args,omitempty"`
-	SpawnOrigin      string   `json:"spawn_origin,omitempty"`
-	SpawnDepth       int      `json:"spawn_depth,omitempty"`
+	// NoPreauthorizeInScope records the --no-preauthorize-inscope choice so a
+	// replay never silently restores the built-in worker grant. Older records
+	// omit the field and retain the historical include-built-in behavior.
+	NoPreauthorizeInScope bool   `json:"no_preauthorize_inscope,omitempty"`
+	SpawnOrigin           string `json:"spawn_origin,omitempty"`
+	SpawnDepth            int    `json:"spawn_depth,omitempty"`
 	// AdoptionMode records how this agent became part of the visible runtime:
 	// managed_window, managed_current_window, managed_session, bare_agent_up,
 	// external, unmanaged. Status treats missing/unknown values fail-closed for
@@ -84,11 +88,15 @@ type Record struct {
 	// a visible lead record carries native evidence.
 	GoalBinding *GoalBinding `json:"goal_binding,omitempty"`
 	// PreauthorizedActions records the effective Claude --allowedTools patterns
-	// amq-squad granted at launch: the narrow built-in worker action plus any
-	// explicit per-member permission_allowlist. It is audit evidence of exactly
-	// what was granted to this role; additive and omitted for legacy records and
-	// launches where no pre-authorization applied.
+	// amq-squad granted at launch: explicit native values plus the narrow
+	// built-in worker action and current per-member permission_allowlist. It is
+	// audit evidence of exactly what was granted to this role; additive and
+	// omitted for legacy records and launches where no pre-authorization applied.
 	PreauthorizedActions []string `json:"preauthorized_actions,omitempty"`
+	// ExplicitAllowedTools preserves native allowed-tools values that existed
+	// before launcher policy was composed. Replay removes the old merged grant,
+	// then restores these explicit values before applying current policy.
+	ExplicitAllowedTools []string `json:"explicit_allowed_tools,omitempty"`
 	// WakeInjectVia and WakeInjectArgs record AMQ 0.37.0 external wake
 	// injector settings so resume/replay can repair and restart the same
 	// digest-bound wake target later.

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -83,13 +83,11 @@ type Record struct {
 	// and NOC/status surfaces must fall back to AMQ task + brief binding unless
 	// a visible lead record carries native evidence.
 	GoalBinding *GoalBinding `json:"goal_binding,omitempty"`
-	// PreauthorizedActions records the in-scope worker actions amq-squad
-	// pre-authorized at launch (#296) — the Claude --allowedTools patterns that
-	// let an orchestrated worker create its PR without a permission prompt. It is
-	// audit evidence of exactly what was granted; feature-branch push (future
-	// work), main-branch push, tags, releases, and destructive git are never in
-	// this list. Additive and omitted for legacy records and launches where no
-	// pre-authorization applied.
+	// PreauthorizedActions records the effective Claude --allowedTools patterns
+	// amq-squad granted at launch: the narrow built-in worker action plus any
+	// explicit per-member permission_allowlist. It is audit evidence of exactly
+	// what was granted to this role; additive and omitted for legacy records and
+	// launches where no pre-authorization applied.
 	PreauthorizedActions []string `json:"preauthorized_actions,omitempty"`
 	// WakeInjectVia and WakeInjectArgs record AMQ 0.37.0 external wake
 	// injector settings so resume/replay can repair and restart the same

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -15,25 +15,26 @@ import (
 func TestWriteReadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	in := Record{
-		CWD:                   "/some/project",
-		Binary:                "claude",
-		Argv:                  []string{"--flag", "value"},
-		Session:               "stream1",
-		SharedWorkstream:      true,
-		Conversation:          "drive-fix",
-		Handle:                "cpo",
-		Role:                  "cpo",
-		Root:                  dir,
-		BaseRoot:              filepath.Dir(dir),
-		RootSource:            "project_amqrc",
-		AMQVersion:            "0.34.0",
-		NoGitignore:           true,
-		NoPreauthorizeInScope: true,
-		ExplicitAllowedTools:  []string{"Read(/tmp/review/**)"},
-		WakeInjectVia:         "/opt/amq-inject",
-		WakeInjectArgs:        []string{"--pane", "%42"},
-		WakePID:               1234,
-		StartedAt:             time.Now().UTC().Truncate(time.Second),
+		CWD:                          "/some/project",
+		Binary:                       "claude",
+		Argv:                         []string{"--flag", "value"},
+		Session:                      "stream1",
+		SharedWorkstream:             true,
+		Conversation:                 "drive-fix",
+		Handle:                       "cpo",
+		Role:                         "cpo",
+		Root:                         dir,
+		BaseRoot:                     filepath.Dir(dir),
+		RootSource:                   "project_amqrc",
+		AMQVersion:                   "0.34.0",
+		NoGitignore:                  true,
+		NoPreauthorizeInScope:        true,
+		LauncherPreauthorizedActions: []string{"Bash(gh pr create:*)"},
+		ExplicitAllowedTools:         []string{"Read(/tmp/review/**)"},
+		WakeInjectVia:                "/opt/amq-inject",
+		WakeInjectArgs:               []string{"--pane", "%42"},
+		WakePID:                      1234,
+		StartedAt:                    time.Now().UTC().Truncate(time.Second),
 	}
 	if err := Write(dir, in); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -69,6 +70,9 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 	if !reflect.DeepEqual(out.ExplicitAllowedTools, in.ExplicitAllowedTools) {
 		t.Errorf("ExplicitAllowedTools = %v, want %v", out.ExplicitAllowedTools, in.ExplicitAllowedTools)
+	}
+	if !reflect.DeepEqual(out.LauncherPreauthorizedActions, in.LauncherPreauthorizedActions) {
+		t.Errorf("LauncherPreauthorizedActions = %v, want %v", out.LauncherPreauthorizedActions, in.LauncherPreauthorizedActions)
 	}
 	if len(out.Argv) != len(in.Argv) {
 		t.Fatalf("Argv len mismatch: %v vs %v", out.Argv, in.Argv)

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -15,23 +15,25 @@ import (
 func TestWriteReadRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	in := Record{
-		CWD:              "/some/project",
-		Binary:           "claude",
-		Argv:             []string{"--flag", "value"},
-		Session:          "stream1",
-		SharedWorkstream: true,
-		Conversation:     "drive-fix",
-		Handle:           "cpo",
-		Role:             "cpo",
-		Root:             dir,
-		BaseRoot:         filepath.Dir(dir),
-		RootSource:       "project_amqrc",
-		AMQVersion:       "0.34.0",
-		NoGitignore:      true,
-		WakeInjectVia:    "/opt/amq-inject",
-		WakeInjectArgs:   []string{"--pane", "%42"},
-		WakePID:          1234,
-		StartedAt:        time.Now().UTC().Truncate(time.Second),
+		CWD:                   "/some/project",
+		Binary:                "claude",
+		Argv:                  []string{"--flag", "value"},
+		Session:               "stream1",
+		SharedWorkstream:      true,
+		Conversation:          "drive-fix",
+		Handle:                "cpo",
+		Role:                  "cpo",
+		Root:                  dir,
+		BaseRoot:              filepath.Dir(dir),
+		RootSource:            "project_amqrc",
+		AMQVersion:            "0.34.0",
+		NoGitignore:           true,
+		NoPreauthorizeInScope: true,
+		ExplicitAllowedTools:  []string{"Read(/tmp/review/**)"},
+		WakeInjectVia:         "/opt/amq-inject",
+		WakeInjectArgs:        []string{"--pane", "%42"},
+		WakePID:               1234,
+		StartedAt:             time.Now().UTC().Truncate(time.Second),
 	}
 	if err := Write(dir, in); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -59,11 +61,14 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root ||
 		out.BaseRoot != in.BaseRoot || out.RootSource != in.RootSource ||
 		out.AMQVersion != in.AMQVersion || out.WakeInjectVia != in.WakeInjectVia ||
-		out.NoGitignore != in.NoGitignore || out.WakePID != in.WakePID {
+		out.NoGitignore != in.NoGitignore || out.NoPreauthorizeInScope != in.NoPreauthorizeInScope || out.WakePID != in.WakePID {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
 	}
 	if !reflect.DeepEqual(out.WakeInjectArgs, in.WakeInjectArgs) {
 		t.Errorf("WakeInjectArgs = %v, want %v", out.WakeInjectArgs, in.WakeInjectArgs)
+	}
+	if !reflect.DeepEqual(out.ExplicitAllowedTools, in.ExplicitAllowedTools) {
+		t.Errorf("ExplicitAllowedTools = %v, want %v", out.ExplicitAllowedTools, in.ExplicitAllowedTools)
 	}
 	if len(out.Argv) != len(in.Argv) {
 		t.Fatalf("Argv len mismatch: %v vs %v", out.Argv, in.Argv)

--- a/internal/team/profiles_test.go
+++ b/internal/team/profiles_test.go
@@ -98,9 +98,9 @@ func TestReadProfileRoundTrip(t *testing.T) {
 	}
 }
 
-// Schema 1 files must still load. Writes always re-emit schema 2 so a
-// future Read sees the upgraded value.
-func TestReadProfileAcceptsSchema1ThenWriteEmitsSchema2(t *testing.T) {
+// Schema 1 files must still load. A write without security-sensitive
+// permission allowlists upgrades only to the compatibility schema 3.
+func TestReadProfileAcceptsSchema1ThenWriteEmitsBaseSchema(t *testing.T) {
 	dir := t.TempDir()
 	teamsDir := filepath.Join(dir, DirName)
 	if err := os.MkdirAll(teamsDir, 0o755); err != nil {
@@ -135,8 +135,8 @@ func TestReadProfileAcceptsSchema1ThenWriteEmitsSchema2(t *testing.T) {
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Schema != SchemaVersion {
-		t.Errorf("on-disk schema after Write = %d, want %d", decoded.Schema, SchemaVersion)
+	if decoded.Schema != BaseSchemaVersion {
+		t.Errorf("on-disk schema after Write = %d, want %d", decoded.Schema, BaseSchemaVersion)
 	}
 }
 

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -19,7 +19,11 @@ import (
 func sortStrings(s []string) { sort.Strings(s) }
 
 const (
-	SchemaVersion         = 3
+	// SchemaVersion is the newest team profile schema this binary understands.
+	// Schema 4 is written only when permission_allowlist is present; profiles
+	// that do not use the security-sensitive feature remain schema 3.
+	SchemaVersion         = 4
+	BaseSchemaVersion     = 3
 	DirName               = ".amq-squad"
 	FileName              = "team.json"
 	TeamsDirName          = "teams"
@@ -740,7 +744,7 @@ func NormalizeForWrite(projectDir, profile string, t Team) (Team, error) {
 			return Team{}, err
 		}
 	}
-	t.Schema = SchemaVersion
+	t.Schema = schemaVersionForWrite(t)
 	t.Project = projectDir
 	if t.Operator == nil {
 		op := DefaultOperator()
@@ -755,6 +759,15 @@ func NormalizeForWrite(projectDir, profile string, t Team) (Team, error) {
 		return Team{}, fmt.Errorf("validate team: %w", err)
 	}
 	return t, nil
+}
+
+func schemaVersionForWrite(t Team) int {
+	for _, member := range t.Members {
+		if len(member.PermissionAllowlist) > 0 {
+			return SchemaVersion
+		}
+	}
+	return BaseSchemaVersion
 }
 
 func normalizeEnabledOperator(op OperatorConfig) OperatorConfig {
@@ -774,8 +787,8 @@ func normalizeEnabledOperator(op OperatorConfig) OperatorConfig {
 }
 
 // WriteProfile atomically persists a named profile under projectDir. The
-// schema field is unconditionally set to the current SchemaVersion so
-// reading a schema 1 file and writing it back upgrades the on-disk shape.
+// schema field is set to 4 only when permission_allowlist is used; otherwise
+// writes stay on schema 3 for compatibility.
 func WriteProfile(projectDir, profile string, t Team) error {
 	path := ProfilePath(projectDir, profile)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -866,6 +879,9 @@ func ListProfiles(projectDir string) ([]string, error) {
 }
 
 func Validate(t Team) error {
+	if t.Schema > SchemaVersion {
+		return fmt.Errorf("unsupported team schema %d: this binary supports through schema %d; upgrade amq-squad before reading or rewriting this profile", t.Schema, SchemaVersion)
+	}
 	if t.Workstream != "" {
 		if err := ValidateSessionName(t.Workstream); err != nil {
 			return fmt.Errorf("workstream: %w", err)
@@ -1287,6 +1303,9 @@ func validateMember(prefix string, m Member) error {
 		}
 		if permission != strings.TrimSpace(permission) {
 			return fmt.Errorf("%s.permission_allowlist[%d]: surrounding whitespace is not allowed", prefix, i)
+		}
+		if strings.HasPrefix(permission, "-") {
+			return fmt.Errorf("%s.permission_allowlist[%d]: values beginning with '-' are not allowed because they can be reinterpreted as native Claude options", prefix, i)
 		}
 		if strings.Contains(permission, ",") {
 			return fmt.Errorf("%s.permission_allowlist[%d]: commas are not allowed (Claude uses comma as the --allowedTools separator)", prefix, i)

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -67,6 +67,12 @@ type Member struct {
 	// never silently apply stale flags.
 	ClaudeArgs []string `json:"claude_args,omitempty"`
 	CodexArgs  []string `json:"codex_args,omitempty"`
+	// PermissionAllowlist is the member-scoped native permission grant applied
+	// at launch. The current implementation translates these patterns to
+	// Claude's --allowedTools and therefore accepts the field only on Claude
+	// members. Keeping it separate from claude_args makes the security-sensitive
+	// grant visible, auditable, and impossible to inherit from another role.
+	PermissionAllowlist []string `json:"permission_allowlist,omitempty"`
 }
 
 // ExtraArgs returns the per-member native CLI args that match the member's
@@ -1274,6 +1280,22 @@ func validateMember(prefix string, m Member) error {
 			return fmt.Errorf("%s.codex_args[%d]: %w", prefix, i, err)
 		}
 	}
+	seenPermissions := map[string]bool{}
+	for i, permission := range m.PermissionAllowlist {
+		if err := ValidateDisplayValue("permission_allowlist", permission); err != nil {
+			return fmt.Errorf("%s.permission_allowlist[%d]: %w", prefix, i, err)
+		}
+		if permission != strings.TrimSpace(permission) {
+			return fmt.Errorf("%s.permission_allowlist[%d]: surrounding whitespace is not allowed", prefix, i)
+		}
+		if strings.Contains(permission, ",") {
+			return fmt.Errorf("%s.permission_allowlist[%d]: commas are not allowed (Claude uses comma as the --allowedTools separator)", prefix, i)
+		}
+		if seenPermissions[permission] {
+			return fmt.Errorf("%s.permission_allowlist[%d]: duplicate permission %q", prefix, i, permission)
+		}
+		seenPermissions[permission] = true
+	}
 	// Binary-match contract: per-member args are bound to the binary they
 	// configure. Rejecting the mismatch (instead of silently ignoring it)
 	// means a member whose binary flips later can never carry stale flags.
@@ -1283,6 +1305,9 @@ func validateMember(prefix string, m Member) error {
 	}
 	if len(m.CodexArgs) > 0 && bin != "codex" {
 		return fmt.Errorf("%s.codex_args: member binary is %q; codex_args applies only to codex members", prefix, m.Binary)
+	}
+	if len(m.PermissionAllowlist) > 0 && bin != "claude" {
+		return fmt.Errorf("%s.permission_allowlist: member binary is %q; permission_allowlist currently applies only to claude members", prefix, m.Binary)
 	}
 	return nil
 }

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -20,7 +20,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		Lead:         "cpo",
 		Members: []Member{
 			{Role: "cpo", Binary: "codex", Handle: "cpo", Session: "stream1"},
-			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "stream2"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "stream2", PermissionAllowlist: []string{"Bash(rm -rf /tmp/fullstack-review/*:*)"}},
 		},
 	}
 	if err := Write(dir, in); err != nil {
@@ -513,6 +513,34 @@ func TestValidateMemberPerMemberArgs(t *testing.T) {
 	blank.ClaudeArgs = []string{"  "}
 	if err := Validate(Team{Members: []Member{blank}}); err == nil || !strings.Contains(err.Error(), "claude_args[0]") {
 		t.Errorf("blank claude_args entry: want display-value error, got %v", err)
+	}
+}
+
+func TestValidateMemberPermissionAllowlist(t *testing.T) {
+	claude := Member{Role: "qa", Binary: "claude", Handle: "qa", Session: "s"}
+	claude.PermissionAllowlist = []string{"Bash(rm -rf /tmp/qa-review/*:*)", "Read(/tmp/qa-review/**)"}
+	if err := Validate(Team{Members: []Member{claude}}); err != nil {
+		t.Fatalf("scoped Claude permission_allowlist should validate: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		member Member
+		want   string
+	}{
+		{"non-Claude", Member{Role: "qa", Binary: "codex", PermissionAllowlist: []string{"Bash(make test:*)"}}, "only to claude"},
+		{"blank", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"  "}}, "cannot be empty"},
+		{"surrounding whitespace", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{" Bash(make test:*)"}}, "surrounding whitespace"},
+		{"comma", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"Read(/a),Read(/b)"}}, "commas are not allowed"},
+		{"duplicate", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"Bash(make test:*)", "Bash(make test:*)"}}, "duplicate permission"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(Team{Members: []Member{tc.member}})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -67,6 +68,67 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 	if out.CreatedAt.IsZero() {
 		t.Error("CreatedAt not set by Write")
+	}
+}
+
+func TestPermissionAllowlistConditionalSchemaWriteAndRead(t *testing.T) {
+	base := Team{Members: []Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "s"}}}
+	plainDir := t.TempDir()
+	if err := Write(plainDir, base); err != nil {
+		t.Fatal(err)
+	}
+	plain, err := Read(plainDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Schema != BaseSchemaVersion {
+		t.Fatalf("profile without permission_allowlist schema = %d, want %d", plain.Schema, BaseSchemaVersion)
+	}
+
+	allowDir := t.TempDir()
+	base.Members[0].PermissionAllowlist = []string{"Read(/tmp/qa-review/**)"}
+	if err := Write(allowDir, base); err != nil {
+		t.Fatal(err)
+	}
+	withAllow, err := Read(allowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withAllow.Schema != SchemaVersion {
+		t.Fatalf("profile with permission_allowlist schema = %d, want %d", withAllow.Schema, SchemaVersion)
+	}
+	if !reflect.DeepEqual(withAllow.Members[0].PermissionAllowlist, base.Members[0].PermissionAllowlist) {
+		t.Fatalf("schema 4 permission_allowlist = %v, want %v", withAllow.Members[0].PermissionAllowlist, base.Members[0].PermissionAllowlist)
+	}
+}
+
+func TestReadAcceptsSchemasThreeAndFourRejectsFuture(t *testing.T) {
+	for _, schema := range []int{BaseSchemaVersion, SchemaVersion} {
+		t.Run(fmt.Sprintf("schema-%d", schema), func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := fmt.Sprintf(`{"schema":%d,"members":[{"role":"qa","binary":"claude","handle":"qa","session":"s"}]}`, schema)
+			if err := os.WriteFile(Path(dir), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Read(dir); err != nil {
+				t.Fatalf("Read schema %d: %v", schema, err)
+			}
+		})
+	}
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{"schema":%d,"members":[]}`, SchemaVersion+1)
+	if err := os.WriteFile(Path(dir), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(dir); err == nil || !strings.Contains(err.Error(), "unsupported team schema") {
+		t.Fatalf("future schema read error = %v, want fail-closed unsupported schema", err)
 	}
 }
 
@@ -531,6 +593,10 @@ func TestValidateMemberPermissionAllowlist(t *testing.T) {
 		{"non-Claude", Member{Role: "qa", Binary: "codex", PermissionAllowlist: []string{"Bash(make test:*)"}}, "only to claude"},
 		{"blank", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"  "}}, "cannot be empty"},
 		{"surrounding whitespace", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{" Bash(make test:*)"}}, "surrounding whitespace"},
+		{"dash", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"-"}}, "beginning with '-'"},
+		{"dash dash", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"--"}}, "beginning with '-'"},
+		{"dangerous option", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"--dangerously-skip-permissions"}}, "beginning with '-'"},
+		{"known value option", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"--model"}}, "beginning with '-'"},
 		{"comma", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"Read(/a),Read(/b)"}}, "commas are not allowed"},
 		{"duplicate", Member{Role: "qa", Binary: "claude", PermissionAllowlist: []string{"Bash(make test:*)", "Bash(make test:*)"}}, "duplicate permission"},
 	}

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -486,7 +486,10 @@ You can also preview a candidate from a deterministic source with
   narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
   Validation rejects this field on non-Claude members and rejects patterns
   beginning with `-`; emission uses one injection-safe
-  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  `--allowedTools=<grant>` token. Preview commands never embed launcher policy
+  in executable child argv: `agent up` recomputes current policy, and launch
+  history stores launcher-owned and explicit-native provenance separately even
+  when the values are identical. Keep patterns scoped to the member's own
   scratch or review workspace; this is not a team-wide trust switch and the
   setup wizard does not author it. Profiles using the field write team schema
   4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -476,6 +476,15 @@ You can also preview a candidate from a deterministic source with
   cutting its per-prompt context cost. Do not hand-edit this: step 5 generates
   and wires it with `amq-squad team overlay init` (v1.9.0+). Plan emission
   validates that every referenced `--settings` file exists.
+- **Per-member permission allowlist**: a Claude member may carry
+  `permission_allowlist`, for example
+  `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
+  merges it with explicit native `--allowedTools`, applies it only to that
+  exact role, shows configured/effective grants in `up --dry-run --json`, and
+  persists the effective list in launch history for resume/audit. Validation
+  rejects this field on non-Claude members. Keep patterns scoped to the
+  member's own scratch or review workspace; this is not a team-wide trust
+  switch and the setup wizard does not author it.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -187,7 +187,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
    - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). An unknown kind (e.g. `--kind handoff`) is **rejected** with a validation error (`--kind must be one of: ...`) and the message is **not sent** — always pass a valid kind.
-   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3 teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
+   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3+ teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 
@@ -481,10 +481,18 @@ You can also preview a candidate from a deterministic source with
   `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
   merges it with explicit native `--allowedTools`, applies it only to that
   exact role, shows configured/effective grants in `up --dry-run --json`, and
-  persists the effective list in launch history for resume/audit. Validation
-  rejects this field on non-Claude members. Keep patterns scoped to the
-  member's own scratch or review workspace; this is not a team-wide trust
-  switch and the setup wizard does not author it.
+  persists the effective list in launch history for resume/audit. Resume strips
+  the prior launcher-owned grant and rebuilds from current policy, so removal or
+  narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
+  Validation rejects this field on non-Claude members and rejects patterns
+  beginning with `-`; emission uses one injection-safe
+  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  scratch or review workspace; this is not a team-wide trust switch and the
+  setup wizard does not author it. Profiles using the field write team schema
+  4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+
+  before configuration: pre-v2.20 binaries can silently ignore the field and
+  lossily rewrite a schema-4 profile. Use `amq-squad doctor` to detect version
+  skew; v2.20+ readers accept schemas 3/4 and reject future schemas.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -472,6 +472,15 @@ You can also preview a candidate from a deterministic source with
   cutting its per-prompt context cost. Do not hand-edit this: step 5 generates
   and wires it with `amq-squad team overlay init` (v1.9.0+). Plan emission
   validates that every referenced `--settings` file exists.
+- **Per-member permission allowlist**: a Claude member may carry
+  `permission_allowlist`, for example
+  `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
+  merges it with explicit native `--allowedTools`, applies it only to that
+  exact role, shows configured/effective grants in `up --dry-run --json`, and
+  persists the effective list in launch history for resume/audit. Validation
+  rejects this field on non-Claude members. Keep patterns scoped to the
+  member's own scratch or review workspace; this is not a team-wide trust
+  switch and the setup wizard does not author it.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -482,7 +482,10 @@ You can also preview a candidate from a deterministic source with
   narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
   Validation rejects this field on non-Claude members and rejects patterns
   beginning with `-`; emission uses one injection-safe
-  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  `--allowedTools=<grant>` token. Preview commands never embed launcher policy
+  in executable child argv: `agent up` recomputes current policy, and launch
+  history stores launcher-owned and explicit-native provenance separately even
+  when the values are identical. Keep patterns scoped to the member's own
   scratch or review workspace; this is not a team-wide trust switch and the
   setup wizard does not author it. Profiles using the field write team schema
   4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -183,7 +183,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
    - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). An unknown kind (e.g. `--kind handoff`) is **rejected** with a validation error (`--kind must be one of: ...`) and the message is **not sent** — always pass a valid kind.
-   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3 teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
+   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3+ teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 
@@ -477,10 +477,18 @@ You can also preview a candidate from a deterministic source with
   `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
   merges it with explicit native `--allowedTools`, applies it only to that
   exact role, shows configured/effective grants in `up --dry-run --json`, and
-  persists the effective list in launch history for resume/audit. Validation
-  rejects this field on non-Claude members. Keep patterns scoped to the
-  member's own scratch or review workspace; this is not a team-wide trust
-  switch and the setup wizard does not author it.
+  persists the effective list in launch history for resume/audit. Resume strips
+  the prior launcher-owned grant and rebuilds from current policy, so removal or
+  narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
+  Validation rejects this field on non-Claude members and rejects patterns
+  beginning with `-`; emission uses one injection-safe
+  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  scratch or review workspace; this is not a team-wide trust switch and the
+  setup wizard does not author it. Profiles using the field write team schema
+  4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+
+  before configuration: pre-v2.20 binaries can silently ignore the field and
+  lossily rewrite a schema-4 profile. Use `amq-squad doctor` to detect version
+  skew; v2.20+ readers accept schemas 3/4 and reject future schemas.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -474,6 +474,15 @@ You can also preview a candidate from a deterministic source with
   cutting its per-prompt context cost. Do not hand-edit this: step 5 generates
   and wires it with `amq-squad team overlay init` (v1.9.0+). Plan emission
   validates that every referenced `--settings` file exists.
+- **Per-member permission allowlist**: a Claude member may carry
+  `permission_allowlist`, for example
+  `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
+  merges it with explicit native `--allowedTools`, applies it only to that
+  exact role, shows configured/effective grants in `up --dry-run --json`, and
+  persists the effective list in launch history for resume/audit. Validation
+  rejects this field on non-Claude members. Keep patterns scoped to the
+  member's own scratch or review workspace; this is not a team-wide trust
+  switch and the setup wizard does not author it.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -484,7 +484,10 @@ You can also preview a candidate from a deterministic source with
   narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
   Validation rejects this field on non-Claude members and rejects patterns
   beginning with `-`; emission uses one injection-safe
-  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  `--allowedTools=<grant>` token. Preview commands never embed launcher policy
+  in executable child argv: `agent up` recomputes current policy, and launch
+  history stores launcher-owned and explicit-native provenance separately even
+  when the values are identical. Keep patterns scoped to the member's own
   scratch or review workspace; this is not a team-wide trust switch and the
   setup wizard does not author it. Profiles using the field write team schema
   4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -185,7 +185,7 @@ All three share the same pane-id control contract, so `focus`/`send`/`status` wo
      ```
    - Decisions: `--thread decision/<topic> --kind decision`.
    - Valid `--kind` values (enforced by `amq`): `brainstorm, review_request, review_response, question, answer, decision, status, todo`. **There is no `handoff` kind** — send a role-to-role handoff as `--kind review_request` (work to take over) or `--kind todo` (a queued task). An unknown kind (e.g. `--kind handoff`) is **rejected** with a validation error (`--kind must be one of: ...`) and the message is **not sent** — always pass a valid kind.
-   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3 teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
+   - **Surfacing to the human:** use the operator handle declared in the current team rules/profile. Default schema-3+ teams use non-runnable handle `user`; custom `--operator HANDLE` teams use that handle; `--no-operator` teams route human-facing asks through the lead/CTO rule instead. Human gates use stable `gate/<topic>` threads, for example `amq send --to <operator> --thread gate/<topic> --subject "APPROVAL: ..." --kind question`.
    - Synchronous wait: append `--wait-for drained --wait-timeout 60s`.
    - Cross-session sends need explicit `--session` and `--thread`; avoid them in normal flow.
 
@@ -479,10 +479,18 @@ You can also preview a candidate from a deterministic source with
   `"permission_allowlist": ["Bash(rm -rf /tmp/qa-review/*:*)"]`. amq-squad
   merges it with explicit native `--allowedTools`, applies it only to that
   exact role, shows configured/effective grants in `up --dry-run --json`, and
-  persists the effective list in launch history for resume/audit. Validation
-  rejects this field on non-Claude members. Keep patterns scoped to the
-  member's own scratch or review workspace; this is not a team-wide trust
-  switch and the setup wizard does not author it.
+  persists the effective list in launch history for resume/audit. Resume strips
+  the prior launcher-owned grant and rebuilds from current policy, so removal or
+  narrowing revokes old access; `--no-preauthorize-inscope` also round-trips.
+  Validation rejects this field on non-Claude members and rejects patterns
+  beginning with `-`; emission uses one injection-safe
+  `--allowedTools=<grant>` token. Keep patterns scoped to the member's own
+  scratch or review workspace; this is not a team-wide trust switch and the
+  setup wizard does not author it. Profiles using the field write team schema
+  4; other profiles remain schema 3. Upgrade every reader/writer to v2.20+
+  before configuration: pre-v2.20 binaries can silently ignore the field and
+  lossily rewrite a schema-4 profile. Use `amq-squad doctor` to detect version
+  skew; v2.20+ readers accept schemas 3/4 and reject future schemas.
 - **Model/binary/effort choice** (context stamp: 2026-07-10, current operator
   setup; setup-dependent, not universal): defaults are not limits; escalate
   when output quality misses the bar. For shippable work use


### PR DESCRIPTION
## Summary

Slice B of #401 — prevent the permission-dialog class entirely for self-inflicted scopes (the v2-19-0 reviewer froze 2+ hours on an `rm -rf` confirmation for its own scratchpad):

- New optional Claude-only member field `permission_allowlist` in team.json — strictly validated (display value, no surrounding whitespace, no commas, no duplicates, binary-bound to claude) and deliberately separate from `claude_args` so the security-sensitive grant is visible, auditable, and impossible to inherit across roles
- Fresh team launch, resume planner, and direct `agent up` resolve only the exact role's patterns and merge them with the narrow built-in grant and any explicit native `--allowedTools` aliases into one canonical comma-joined grant before the `--` boundary; prompt-side bytes preserved
- `--no-preauthorize-inscope` disables only the built-in grant, never explicit member policy
- Dry-run JSON exposes configured `permission_allowlist` + effective `preauthorized_actions`; launch records persist the effective grant for audit/replay
- Docs: scratch/worktree-scoped contract; wizard picker exclusion (#393/#432 territory)

Validation: `go test ./...` exit 0, `make ci` exit 0 at exact head 7a8cd84c6896e42c10bae58694f6068e9b0a6db2 on main d821263.

Part of #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
