### PR TITLE
fix: close wake-helper cleanup race and make the #411 flake attributable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,29 @@ jobs:
           curl -L https://github.com/jgm/pandoc/releases/download/3.8.3/pandoc-3.8.3-1-amd64.deb -o /tmp/pandoc.deb
           sudo dpkg -i /tmp/pandoc.deb
 
+      - name: Run shuffled internal/cli evidence suite
+        shell: bash
+        run: |
+          mkdir -p .ci-artifacts
+          set +e
+          go test -json -shuffle=on -timeout=15m ./internal/cli > .ci-artifacts/internal-cli.json
+          status=$?
+          set -e
+          seed="$(sed -nE 's/.*-test\.shuffle ([0-9]+).*/\1/p' .ci-artifacts/internal-cli.json | head -n 1)"
+          if [[ -z "$seed" ]]; then
+            seed=unknown
+          fi
+          printf 'shuffle_seed=%s\nexit_code=%s\n' "$seed" "$status" | tee .ci-artifacts/internal-cli-metadata.txt
+          exit "$status"
+
+      - name: Upload shuffled internal/cli evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: internal-cli-go-test-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .ci-artifacts/
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Run make ci
         run: make ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,16 @@ jobs:
       - name: Run shuffled internal/cli evidence suite
         shell: bash
         run: |
-          mkdir -p .ci-artifacts
+          mkdir -p ci-artifacts
           set +e
-          go test -json -shuffle=on -timeout=15m ./internal/cli > .ci-artifacts/internal-cli.json
+          go test -json -shuffle=on -timeout=15m ./internal/cli > ci-artifacts/internal-cli.json
           status=$?
           set -e
-          seed="$(sed -nE 's/.*-test\.shuffle ([0-9]+).*/\1/p' .ci-artifacts/internal-cli.json | head -n 1)"
+          seed="$(sed -nE 's/.*-test\.shuffle ([0-9]+).*/\1/p' ci-artifacts/internal-cli.json | head -n 1)"
           if [[ -z "$seed" ]]; then
             seed=unknown
           fi
-          printf 'shuffle_seed=%s\nexit_code=%s\n' "$seed" "$status" | tee .ci-artifacts/internal-cli-metadata.txt
+          printf 'shuffle_seed=%s\nexit_code=%s\n' "$seed" "$status" | tee ci-artifacts/internal-cli-metadata.txt
           exit "$status"
 
       - name: Upload shuffled internal/cli evidence
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: internal-cli-go-test-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .ci-artifacts/
+          path: ci-artifacts/
           if-no-files-found: error
           retention-days: 14
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.txt
 
 # Local scratch / RC build artifacts (never commit)
 amq-squad-rc-*
+/ci-artifacts/
 .pm-os/
 .claude/worktrees/
 

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -50,6 +50,9 @@ var externalLeadWakeReadyTimeout = 5 * time.Second
 var externalLeadWakePollInterval = 50 * time.Millisecond
 var externalLeadWakeStopTimeout = 2 * time.Second
 var externalLeadWakeProcessEvent = func(_ string, _ *exec.Cmd, _ error) {}
+var externalLeadWakeProcessGroupSignal = func(pgid int, signal syscall.Signal) error {
+	return syscall.Kill(-pgid, signal)
+}
 
 type teamLeadData struct {
 	Profile      string `json:"profile"`
@@ -541,7 +544,7 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 				return leadWakeResult{Started: false, Detail: fmt.Sprintf("existing wake accepted for %s at %s", opts.Handle, opts.Root)}, nil
 			}
 			cleanupDetail := ""
-			if stopErr := stopExternalLeadWakeProcessGroup(cmd); stopErr != nil {
+			if stopErr := stopExternalLeadWakeProcessGroupAndWait(cmd); stopErr != nil {
 				cleanupDetail = fmt.Sprintf("failed to stop spawned wake process group %d: %v", cmd.Process.Pid, stopErr)
 			} else {
 				cleanupDetail = fmt.Sprintf("stopped spawned wake process group %d", cmd.Process.Pid)
@@ -593,20 +596,58 @@ func stopExternalLeadWakeProcess(cmd *exec.Cmd, done <-chan error) error {
 	// its leader is reaped. Once Wait completes the leader can no longer add a
 	// descendant, so sweep the process group again to catch that race.
 	finalKillErr := stopExternalLeadWakeProcessGroup(cmd)
+	priorKillSucceeded := killErr == nil || errors.Is(killErr, os.ErrProcessDone)
+	finalKillSucceeded := finalKillErr == nil || errors.Is(finalKillErr, os.ErrProcessDone)
+	if !priorKillSucceeded && !finalKillSucceeded {
+		return killErr
+	}
+	if !finalKillSucceeded && !(priorKillSucceeded && errors.Is(finalKillErr, syscall.EPERM)) {
+		return finalKillErr
+	}
+	return waitExternalLeadWakeProcessGroupGone(cmd, priorKillSucceeded || finalKillSucceeded)
+}
+
+func stopExternalLeadWakeProcessGroupAndWait(cmd *exec.Cmd) error {
+	killErr := stopExternalLeadWakeProcessGroup(cmd)
 	if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
 		return killErr
 	}
-	if finalKillErr != nil && !errors.Is(finalKillErr, os.ErrProcessDone) {
-		// On Darwin a process group containing only already-killed, unreaped
-		// members can return EPERM after the leader's Wait completes. The first
-		// kill succeeded, so do not turn that best-effort final sweep into a
-		// false cleanup failure. A live same-user descendant accepts SIGKILL.
-		if killErr == nil && errors.Is(finalKillErr, syscall.EPERM) {
+	return waitExternalLeadWakeProcessGroupGone(cmd, true)
+}
+
+func waitExternalLeadWakeProcessGroupGone(cmd *exec.Cmd, priorKillSucceeded bool) error {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return nil
+	}
+	pgid := cmd.Process.Pid
+	deadline := time.Now().Add(externalLeadWakeStopTimeout)
+	for {
+		probeErr := externalLeadWakeProcessGroupSignal(pgid, 0)
+		externalLeadWakeProcessEvent("quiescence_probe", cmd, probeErr)
+		if errors.Is(probeErr, syscall.ESRCH) {
 			return nil
 		}
-		return finalKillErr
+		// After a successful SIGKILL, Darwin can report EPERM while only
+		// already-killed, unsignalable group members remain.
+		if priorKillSucceeded && errors.Is(probeErr, syscall.EPERM) {
+			return nil
+		}
+		if probeErr != nil {
+			return fmt.Errorf("probe spawned wake process group %d: %w", pgid, probeErr)
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("timed out waiting for spawned wake process group %d to terminate", pgid)
+		}
+		resignalErr := stopExternalLeadWakeProcessGroup(cmd)
+		if resignalErr == nil || errors.Is(resignalErr, os.ErrProcessDone) {
+			priorKillSucceeded = true
+		} else if priorKillSucceeded && errors.Is(resignalErr, syscall.EPERM) {
+			return nil
+		} else if !errors.Is(resignalErr, syscall.ESRCH) {
+			return resignalErr
+		}
+		time.Sleep(externalLeadWakePollInterval)
 	}
-	return nil
 }
 
 func stopExternalLeadWakeProcessGroup(cmd *exec.Cmd) error {
@@ -618,7 +659,7 @@ func stopExternalLeadWakeProcessGroup(cmd *exec.Cmd) error {
 		return nil
 	}
 	externalLeadWakeProcessEvent("kill_attempt", cmd, nil)
-	err := syscall.Kill(-pid, syscall.SIGKILL)
+	err := externalLeadWakeProcessGroupSignal(pid, syscall.SIGKILL)
 	if err == nil {
 		externalLeadWakeProcessEvent("kill_result", cmd, nil)
 		return nil

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -49,6 +49,7 @@ var externalLeadWakeCommand = exec.Command
 var externalLeadWakeReadyTimeout = 5 * time.Second
 var externalLeadWakePollInterval = 50 * time.Millisecond
 var externalLeadWakeStopTimeout = 2 * time.Second
+var externalLeadWakeProcessEvent = func(_ string, _ *exec.Cmd, _ error) {}
 
 type teamLeadData struct {
 	Profile      string `json:"profile"`
@@ -520,8 +521,13 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 	if err := cmd.Start(); err != nil {
 		return leadWakeResult{}, err
 	}
+	externalLeadWakeProcessEvent("process_started", cmd, nil)
 	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
+	go func() {
+		err := cmd.Wait()
+		externalLeadWakeProcessEvent("process_wait_done", cmd, err)
+		done <- err
+	}()
 
 	deadline := time.Now().Add(externalLeadWakeReadyTimeout)
 	for {
@@ -530,6 +536,7 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 		}
 		select {
 		case err := <-done:
+			externalLeadWakeProcessEvent("done_observed", cmd, err)
 			if err == nil {
 				return leadWakeResult{Started: false, Detail: fmt.Sprintf("existing wake accepted for %s at %s", opts.Handle, opts.Root)}, nil
 			}
@@ -577,12 +584,27 @@ func stopExternalLeadWakeProcess(cmd *exec.Cmd, done <-chan error) error {
 	}
 	killErr := stopExternalLeadWakeProcessGroup(cmd)
 	select {
-	case <-done:
+	case err := <-done:
+		externalLeadWakeProcessEvent("done_observed", cmd, err)
 	case <-time.After(externalLeadWakeStopTimeout):
 		return fmt.Errorf("timed out waiting for process exit")
 	}
+	// The helper can fork after the first group signal is delivered but before
+	// its leader is reaped. Once Wait completes the leader can no longer add a
+	// descendant, so sweep the process group again to catch that race.
+	finalKillErr := stopExternalLeadWakeProcessGroup(cmd)
 	if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
 		return killErr
+	}
+	if finalKillErr != nil && !errors.Is(finalKillErr, os.ErrProcessDone) {
+		// On Darwin a process group containing only already-killed, unreaped
+		// members can return EPERM after the leader's Wait completes. The first
+		// kill succeeded, so do not turn that best-effort final sweep into a
+		// false cleanup failure. A live same-user descendant accepts SIGKILL.
+		if killErr == nil && errors.Is(finalKillErr, syscall.EPERM) {
+			return nil
+		}
+		return finalKillErr
 	}
 	return nil
 }
@@ -595,16 +617,20 @@ func stopExternalLeadWakeProcessGroup(cmd *exec.Cmd) error {
 	if pid <= 0 {
 		return nil
 	}
+	externalLeadWakeProcessEvent("kill_attempt", cmd, nil)
 	err := syscall.Kill(-pid, syscall.SIGKILL)
 	if err == nil {
+		externalLeadWakeProcessEvent("kill_result", cmd, nil)
 		return nil
 	}
 	if errors.Is(err, syscall.ESRCH) {
 		err = cmd.Process.Kill()
 		if errors.Is(err, os.ErrProcessDone) {
+			externalLeadWakeProcessEvent("kill_result", cmd, nil)
 			return nil
 		}
 	}
+	externalLeadWakeProcessEvent("kill_result", cmd, err)
 	return err
 }
 

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -620,9 +622,7 @@ func TestLeadRegisterWakeFailureCanBeNonRequired(t *testing.T) {
 }
 
 func TestStartExternalLeadWakeRequiredTimeoutStopsSpawnedProcess(t *testing.T) {
-	marker := filepath.Join(t.TempDir(), "late-ready")
-	restore := installLeadWakeHelper(t, "spawn-child-late-ready", marker)
-	defer restore()
+	harness := installLeadWakeHelper(t, "spawn-child-late-ready")
 
 	_, err := startExternalLeadWake(leadWakeOptions{
 		ProjectDir: t.TempDir(),
@@ -636,13 +636,11 @@ func TestStartExternalLeadWakeRequiredTimeoutStopsSpawnedProcess(t *testing.T) {
 	if !strings.Contains(err.Error(), "did not become ready") || !strings.Contains(err.Error(), "stopped spawned wake process") {
 		t.Fatalf("timeout error = %v, want stopped-process detail", err)
 	}
-	assertLateReadyMarkerAbsent(t, marker)
+	harness.assertStoppedAfterCleanup(t)
 }
 
 func TestStartExternalLeadWakeNonRequiredTimeoutStopsSpawnedProcessAndReportsNoPID(t *testing.T) {
-	marker := filepath.Join(t.TempDir(), "late-ready")
-	restore := installLeadWakeHelper(t, "spawn-child-late-ready", marker)
-	defer restore()
+	harness := installLeadWakeHelper(t, "spawn-child-late-ready")
 
 	result, err := startExternalLeadWake(leadWakeOptions{
 		ProjectDir: t.TempDir(),
@@ -659,13 +657,11 @@ func TestStartExternalLeadWakeNonRequiredTimeoutStopsSpawnedProcessAndReportsNoP
 	if !strings.Contains(result.Detail, "did not become ready") || !strings.Contains(result.Detail, "stopped spawned wake process") {
 		t.Fatalf("timeout detail = %q, want stopped-process detail", result.Detail)
 	}
-	assertLateReadyMarkerAbsent(t, marker)
+	harness.assertStoppedAfterCleanup(t)
 }
 
 func TestStartExternalLeadWakeRequiredFailureStopsSpawnedProcess(t *testing.T) {
-	marker := filepath.Join(t.TempDir(), "late-ready")
-	restore := installLeadWakeHelper(t, "spawn-child-fail", marker)
-	defer restore()
+	harness := installLeadWakeHelper(t, "spawn-child-fail")
 
 	_, err := startExternalLeadWake(leadWakeOptions{
 		ProjectDir: t.TempDir(),
@@ -679,13 +675,11 @@ func TestStartExternalLeadWakeRequiredFailureStopsSpawnedProcess(t *testing.T) {
 	if !strings.Contains(err.Error(), "stopped spawned wake process") {
 		t.Fatalf("failure error = %v, want stopped-process detail", err)
 	}
-	assertLateReadyMarkerAbsent(t, marker)
+	harness.assertStoppedAfterCleanup(t)
 }
 
 func TestStartExternalLeadWakeNonRequiredFailureStopsSpawnedProcessAndReportsNoPID(t *testing.T) {
-	marker := filepath.Join(t.TempDir(), "late-ready")
-	restore := installLeadWakeHelper(t, "spawn-child-fail", marker)
-	defer restore()
+	harness := installLeadWakeHelper(t, "spawn-child-fail")
 
 	result, err := startExternalLeadWake(leadWakeOptions{
 		ProjectDir: t.TempDir(),
@@ -703,7 +697,7 @@ func TestStartExternalLeadWakeNonRequiredFailureStopsSpawnedProcessAndReportsNoP
 	if !hasFailureReason || !strings.Contains(result.Detail, "stopped spawned wake process") {
 		t.Fatalf("failure detail = %q, want stopped-process detail", result.Detail)
 	}
-	assertLateReadyMarkerAbsent(t, marker)
+	harness.assertStoppedAfterCleanup(t)
 }
 
 func TestLeadRegisterWakeFailureRequiredErrorsBeforeTeamMutation(t *testing.T) {
@@ -741,40 +735,144 @@ func TestLeadRegisterWakeFailureRequiredErrorsBeforeTeamMutation(t *testing.T) {
 	}
 }
 
-func installLeadWakeHelper(t *testing.T, mode, marker string) func() {
+type leadWakeHelperHarness struct {
+	mode        string
+	markerPath  string
+	startedPath string
+	triggerPath string
+	eventsPath  string
+}
+
+type leadWakeHelperEvent struct {
+	Time       string `json:"time"`
+	PID        int    `json:"pid"`
+	PPID       int    `json:"ppid"`
+	PGID       int    `json:"pgid"`
+	TargetPID  int    `json:"target_pid,omitempty"`
+	TargetPGID int    `json:"target_pgid,omitempty"`
+	Mode       string `json:"mode"`
+	Phase      string `json:"phase"`
+	ReadyPath  string `json:"ready_path,omitempty"`
+	MarkerPath string `json:"marker_path"`
+	Error      string `json:"error,omitempty"`
+}
+
+func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 	t.Helper()
+	dir := t.TempDir()
+	harness := &leadWakeHelperHarness{
+		mode:        mode,
+		markerPath:  filepath.Join(dir, "survived-after-cleanup"),
+		startedPath: filepath.Join(dir, "grandchild-started"),
+		triggerPath: filepath.Join(dir, "cleanup-returned"),
+		eventsPath:  filepath.Join(dir, "helper-events.jsonl"),
+	}
 	prevCommand := externalLeadWakeCommand
 	prevTimeout := externalLeadWakeReadyTimeout
 	prevPoll := externalLeadWakePollInterval
 	prevStopTimeout := externalLeadWakeStopTimeout
+	prevProcessEvent := externalLeadWakeProcessEvent
 	exe, err := os.Executable()
 	if err != nil {
 		t.Fatalf("test executable: %v", err)
 	}
 	externalLeadWakeCommand = func(_ string, args ...string) *exec.Cmd {
-		helperArgs := []string{"-test.run=TestLeadWakeHelperProcess", "--", "lead-wake-helper", mode, marker}
+		helperArgs := []string{
+			"-test.run=TestLeadWakeHelperProcess", "--", "lead-wake-helper", mode,
+			harness.markerPath, harness.startedPath, harness.triggerPath, harness.eventsPath,
+		}
 		helperArgs = append(helperArgs, args...)
 		return exec.Command(exe, helperArgs...)
+	}
+	externalLeadWakeProcessEvent = func(phase string, cmd *exec.Cmd, eventErr error) {
+		targetPID := 0
+		if cmd != nil && cmd.Process != nil {
+			targetPID = cmd.Process.Pid
+		}
+		_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, phase, "", harness.markerPath, targetPID, eventErr)
 	}
 	externalLeadWakeReadyTimeout = 20 * time.Millisecond
 	externalLeadWakePollInterval = 2 * time.Millisecond
 	externalLeadWakeStopTimeout = time.Second
-	return func() {
+	t.Cleanup(func() {
 		externalLeadWakeCommand = prevCommand
 		externalLeadWakeReadyTimeout = prevTimeout
 		externalLeadWakePollInterval = prevPoll
 		externalLeadWakeStopTimeout = prevStopTimeout
+		externalLeadWakeProcessEvent = prevProcessEvent
+		if t.Failed() {
+			if events, err := os.ReadFile(harness.eventsPath); err == nil {
+				t.Logf("lead wake helper events:\n%s", events)
+			} else {
+				t.Logf("read lead wake helper events: %v", err)
+			}
+		}
+	})
+	return harness
+}
+
+func (h *leadWakeHelperHarness) assertStoppedAfterCleanup(t *testing.T) {
+	t.Helper()
+	if err := appendLeadWakeHelperEvent(h.eventsPath, h.mode, "cleanup_returned", "", h.markerPath, 0, nil); err != nil {
+		t.Fatalf("record cleanup return: %v", err)
+	}
+	if err := os.WriteFile(h.triggerPath, []byte("cleanup returned\n"), 0o644); err != nil {
+		t.Fatalf("write cleanup trigger: %v", err)
+	}
+	if err := appendLeadWakeHelperEvent(h.eventsPath, h.mode, "trigger_written", "", h.markerPath, 0, nil); err != nil {
+		t.Fatalf("record cleanup trigger: %v", err)
+	}
+
+	deadline := time.Now().Add(250 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(h.markerPath); err == nil {
+			t.Fatalf("post-cleanup survival marker exists at %s; spawned wake process survived cleanup", h.markerPath)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat post-cleanup survival marker: %v", err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if err := appendLeadWakeHelperEvent(h.eventsPath, h.mode, "marker_absent", "", h.markerPath, 0, nil); err != nil {
+		t.Fatalf("record marker absence: %v", err)
 	}
 }
 
-func assertLateReadyMarkerAbsent(t *testing.T, marker string) {
-	t.Helper()
-	time.Sleep(250 * time.Millisecond)
-	if _, err := os.Stat(marker); err == nil {
-		t.Fatalf("late-ready helper marker exists at %s; spawned wake process was not stopped", marker)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stat late-ready helper marker: %v", err)
+func appendLeadWakeHelperEvent(path, mode, phase, readyPath, markerPath string, targetPID int, eventErr error) error {
+	pgid, _ := syscall.Getpgid(0)
+	targetPGID := 0
+	if targetPID > 0 {
+		targetPGID, _ = syscall.Getpgid(targetPID)
 	}
+	event := leadWakeHelperEvent{
+		Time:       time.Now().UTC().Format(time.RFC3339Nano),
+		PID:        os.Getpid(),
+		PPID:       os.Getppid(),
+		PGID:       pgid,
+		TargetPID:  targetPID,
+		TargetPGID: targetPGID,
+		Mode:       mode,
+		Phase:      phase,
+		ReadyPath:  readyPath,
+		MarkerPath: markerPath,
+	}
+	if eventErr != nil {
+		event.Error = eventErr.Error()
+	}
+	line, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	_, writeErr := f.Write(line)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
 }
 
 func TestLeadWakeHelperProcess(t *testing.T) {
@@ -788,19 +886,26 @@ func TestLeadWakeHelperProcess(t *testing.T) {
 	if idx == -1 {
 		return
 	}
-	if len(os.Args) <= idx+3 {
+	if len(os.Args) <= idx+6 {
 		fmt.Fprintln(os.Stderr, "lead wake helper missing args")
 		os.Exit(2)
 	}
 	mode := os.Args[idx+1]
 	marker := os.Args[idx+2]
-	wakeArgs := os.Args[idx+3:]
+	startedPath := os.Args[idx+3]
+	triggerPath := os.Args[idx+4]
+	eventsPath := os.Args[idx+5]
+	wakeArgs := os.Args[idx+6:]
 	readyPath := ""
 	for i := 0; i < len(wakeArgs)-1; i++ {
 		if wakeArgs[i] == "--ready-file" {
 			readyPath = wakeArgs[i+1]
 			break
 		}
+	}
+	if err := appendLeadWakeHelperEvent(eventsPath, mode, "helper_start", readyPath, marker, 0, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "record helper start: %v\n", err)
+		os.Exit(2)
 	}
 	switch mode {
 	case "spawn-child-late-ready", "spawn-child-fail":
@@ -809,27 +914,52 @@ func TestLeadWakeHelperProcess(t *testing.T) {
 			fmt.Fprintf(os.Stderr, "test executable: %v\n", err)
 			os.Exit(2)
 		}
-		childArgs := []string{"-test.run=TestLeadWakeHelperProcess", "--", "lead-wake-helper", "late-ready", marker}
+		childArgs := []string{
+			"-test.run=TestLeadWakeHelperProcess", "--", "lead-wake-helper", "late-ready",
+			marker, startedPath, triggerPath, eventsPath,
+		}
 		childArgs = append(childArgs, wakeArgs...)
 		child := exec.Command(exe, childArgs...)
 		child.Stdout = os.Stderr
 		child.Stderr = os.Stderr
 		if err := child.Start(); err != nil {
+			_ = appendLeadWakeHelperEvent(eventsPath, mode, "child_start_failed", readyPath, marker, 0, err)
 			fmt.Fprintf(os.Stderr, "start child: %v\n", err)
 			os.Exit(2)
 		}
+		_ = appendLeadWakeHelperEvent(eventsPath, mode, "child_started", readyPath, marker, child.Process.Pid, nil)
 		if mode == "spawn-child-fail" {
+			_ = appendLeadWakeHelperEvent(eventsPath, mode, "parent_exit", readyPath, marker, child.Process.Pid, errors.New("exit status 42"))
 			os.Exit(42)
 		}
+		_ = appendLeadWakeHelperEvent(eventsPath, mode, "parent_wait", readyPath, marker, child.Process.Pid, nil)
 		for {
 			time.Sleep(time.Hour)
 		}
 	case "late-ready":
-		time.Sleep(200 * time.Millisecond)
+		if err := os.WriteFile(startedPath, []byte(fmt.Sprintf("%d\n", os.Getpid())), 0o644); err != nil {
+			_ = appendLeadWakeHelperEvent(eventsPath, mode, "started_write_failed", readyPath, marker, 0, err)
+			fmt.Fprintf(os.Stderr, "write started: %v\n", err)
+			os.Exit(2)
+		}
+		_ = appendLeadWakeHelperEvent(eventsPath, mode, "started_written", readyPath, marker, 0, nil)
+		for {
+			if _, err := os.Stat(triggerPath); err == nil {
+				break
+			} else if !errors.Is(err, os.ErrNotExist) {
+				_ = appendLeadWakeHelperEvent(eventsPath, mode, "trigger_stat_failed", readyPath, marker, 0, err)
+				fmt.Fprintf(os.Stderr, "stat trigger: %v\n", err)
+				os.Exit(2)
+			}
+			time.Sleep(time.Millisecond)
+		}
+		_ = appendLeadWakeHelperEvent(eventsPath, mode, "trigger_observed", readyPath, marker, 0, nil)
 		if err := os.WriteFile(marker, []byte("late-ready"), 0o644); err != nil {
+			_ = appendLeadWakeHelperEvent(eventsPath, mode, "marker_write_failed", readyPath, marker, 0, err)
 			fmt.Fprintf(os.Stderr, "write marker: %v\n", err)
 			os.Exit(2)
 		}
+		_ = appendLeadWakeHelperEvent(eventsPath, mode, "marker_written", readyPath, marker, 0, nil)
 		if readyPath != "" {
 			if err := os.WriteFile(readyPath, []byte("ready"), 0o644); err != nil {
 				fmt.Fprintf(os.Stderr, "write ready: %v\n", err)

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -745,17 +745,19 @@ type leadWakeHelperHarness struct {
 }
 
 type leadWakeHelperEvent struct {
-	Time       string `json:"time"`
-	PID        int    `json:"pid"`
-	PPID       int    `json:"ppid"`
-	PGID       int    `json:"pgid"`
-	TargetPID  int    `json:"target_pid,omitempty"`
-	TargetPGID int    `json:"target_pgid,omitempty"`
-	Mode       string `json:"mode"`
-	Phase      string `json:"phase"`
-	ReadyPath  string `json:"ready_path,omitempty"`
-	MarkerPath string `json:"marker_path"`
-	Error      string `json:"error,omitempty"`
+	Time          string `json:"time"`
+	PID           int    `json:"pid"`
+	PPID          int    `json:"ppid"`
+	PGID          int    `json:"pgid"`
+	TargetPID     int    `json:"target_pid,omitempty"`
+	TargetPGID    int    `json:"target_pgid,omitempty"`
+	Mode          string `json:"mode"`
+	Phase         string `json:"phase"`
+	ReadyPath     string `json:"ready_path,omitempty"`
+	MarkerPath    string `json:"marker_path"`
+	ProbeKillZero string `json:"probe_kill_zero,omitempty"`
+	ProbeGetPGID  string `json:"probe_getpgid,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
@@ -803,6 +805,16 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 			}
 		}
 		_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, phase, "", harness.markerPath, targetPID, eventErr)
+		if phase == "kill_result" {
+			childPID, err := readLeadWakeHelperStartedPID(harness.startedPath)
+			if err != nil {
+				_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, "post_kill_probe_unavailable", "", harness.markerPath, 0, err)
+				return
+			}
+			_ = appendLeadWakeHelperProbeEvent(harness.eventsPath, mode, "post_kill_probe_immediate", harness.markerPath, childPID)
+			time.Sleep(2 * time.Millisecond)
+			_ = appendLeadWakeHelperProbeEvent(harness.eventsPath, mode, "post_kill_probe_2ms", harness.markerPath, childPID)
+		}
 	}
 	externalLeadWakeReadyTimeout = 20 * time.Millisecond
 	externalLeadWakePollInterval = 2 * time.Millisecond
@@ -813,7 +825,7 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 		externalLeadWakePollInterval = prevPoll
 		externalLeadWakeStopTimeout = prevStopTimeout
 		externalLeadWakeProcessEvent = prevProcessEvent
-		if t.Failed() {
+		if t.Failed() || testing.Verbose() {
 			if events, err := os.ReadFile(harness.eventsPath); err == nil {
 				t.Logf("lead wake helper events:\n%s", events)
 			} else {
@@ -828,21 +840,10 @@ func waitForLeadWakeHelperStarted(path string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for {
-		data, err := os.ReadFile(path)
-		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
-			if parseErr == nil && pid > 0 {
-				return nil
-			}
-			if parseErr != nil {
-				lastErr = fmt.Errorf("parse started PID: %w", parseErr)
-			} else {
-				lastErr = fmt.Errorf("started PID must be positive, got %d", pid)
-			}
-		} else if errors.Is(err, os.ErrNotExist) {
-			lastErr = err
+		if _, err := readLeadWakeHelperStartedPID(path); err == nil {
+			return nil
 		} else {
-			return fmt.Errorf("read started file: %w", err)
+			lastErr = err
 		}
 		if !time.Now().Before(deadline) {
 			return fmt.Errorf("grandchild did not reach trigger wait phase within %s: %w", timeout, lastErr)
@@ -851,10 +852,99 @@ func waitForLeadWakeHelperStarted(path string, timeout time.Duration) error {
 	}
 }
 
+func readLeadWakeHelperStartedPID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("parse started PID: %w", err)
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("started PID must be positive, got %d", pid)
+	}
+	return pid, nil
+}
+
 func TestWaitForLeadWakeHelperStartedFailsClosed(t *testing.T) {
 	err := waitForLeadWakeHelperStarted(filepath.Join(t.TempDir(), "missing"), 5*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "did not reach trigger wait phase") {
 		t.Fatalf("missing started file err = %v, want bounded fail-closed error", err)
+	}
+}
+
+func TestWaitExternalLeadWakeProcessGroupGoneResignalsUntilESRCH(t *testing.T) {
+	prevSignal := externalLeadWakeProcessGroupSignal
+	prevPoll := externalLeadWakePollInterval
+	prevTimeout := externalLeadWakeStopTimeout
+	t.Cleanup(func() {
+		externalLeadWakeProcessGroupSignal = prevSignal
+		externalLeadWakePollInterval = prevPoll
+		externalLeadWakeStopTimeout = prevTimeout
+	})
+	probes := 0
+	kills := 0
+	externalLeadWakeProcessGroupSignal = func(pgid int, signal syscall.Signal) error {
+		if pgid != 4242 {
+			t.Fatalf("pgid = %d, want 4242", pgid)
+		}
+		if signal == 0 {
+			probes++
+			if probes == 1 {
+				return nil
+			}
+			return syscall.ESRCH
+		}
+		if signal != syscall.SIGKILL {
+			t.Fatalf("signal = %v, want SIGKILL", signal)
+		}
+		kills++
+		return nil
+	}
+	externalLeadWakePollInterval = time.Millisecond
+	externalLeadWakeStopTimeout = 50 * time.Millisecond
+
+	cmd := &exec.Cmd{Process: &os.Process{Pid: 4242}}
+	if err := waitExternalLeadWakeProcessGroupGone(cmd, true); err != nil {
+		t.Fatalf("wait for process group: %v", err)
+	}
+	if probes != 2 || kills != 1 {
+		t.Fatalf("probes/kills = %d/%d, want 2/1", probes, kills)
+	}
+}
+
+func TestWaitExternalLeadWakeProcessGroupGoneTimesOutWhileLive(t *testing.T) {
+	prevSignal := externalLeadWakeProcessGroupSignal
+	prevPoll := externalLeadWakePollInterval
+	prevTimeout := externalLeadWakeStopTimeout
+	t.Cleanup(func() {
+		externalLeadWakeProcessGroupSignal = prevSignal
+		externalLeadWakePollInterval = prevPoll
+		externalLeadWakeStopTimeout = prevTimeout
+	})
+	externalLeadWakeProcessGroupSignal = func(_ int, _ syscall.Signal) error { return nil }
+	externalLeadWakePollInterval = time.Millisecond
+	externalLeadWakeStopTimeout = 5 * time.Millisecond
+
+	cmd := &exec.Cmd{Process: &os.Process{Pid: 4242}}
+	err := waitExternalLeadWakeProcessGroupGone(cmd, true)
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for spawned wake process group") {
+		t.Fatalf("live group err = %v, want bounded timeout", err)
+	}
+}
+
+func TestWaitExternalLeadWakeProcessGroupGoneScopesDarwinEPERMAfterSuccess(t *testing.T) {
+	prevSignal := externalLeadWakeProcessGroupSignal
+	t.Cleanup(func() { externalLeadWakeProcessGroupSignal = prevSignal })
+	externalLeadWakeProcessGroupSignal = func(_ int, _ syscall.Signal) error { return syscall.EPERM }
+	cmd := &exec.Cmd{Process: &os.Process{Pid: 4242}}
+
+	if err := waitExternalLeadWakeProcessGroupGone(cmd, true); err != nil {
+		t.Fatalf("post-success EPERM = %v, want accepted quiescence", err)
+	}
+	if err := waitExternalLeadWakeProcessGroupGone(cmd, false); !errors.Is(err, syscall.EPERM) {
+		t.Fatalf("pre-success EPERM = %v, want EPERM failure", err)
 	}
 }
 
@@ -905,6 +995,44 @@ func appendLeadWakeHelperEvent(path, mode, phase, readyPath, markerPath string, 
 	if eventErr != nil {
 		event.Error = eventErr.Error()
 	}
+	return writeLeadWakeHelperEvent(path, event)
+}
+
+func appendLeadWakeHelperProbeEvent(path, mode, phase, markerPath string, targetPID int) error {
+	pgid, _ := syscall.Getpgid(0)
+	targetPGID, getPGIDErr := syscall.Getpgid(targetPID)
+	killZeroErr := syscall.Kill(targetPID, 0)
+	event := leadWakeHelperEvent{
+		Time:          time.Now().UTC().Format(time.RFC3339Nano),
+		PID:           os.Getpid(),
+		PPID:          os.Getppid(),
+		PGID:          pgid,
+		TargetPID:     targetPID,
+		TargetPGID:    targetPGID,
+		Mode:          mode,
+		Phase:         phase,
+		MarkerPath:    markerPath,
+		ProbeKillZero: probeResult(killZeroErr),
+		ProbeGetPGID:  probePGIDResult(targetPGID, getPGIDErr),
+	}
+	return writeLeadWakeHelperEvent(path, event)
+}
+
+func probeResult(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return err.Error()
+}
+
+func probePGIDResult(pgid int, err error) string {
+	if err == nil {
+		return strconv.Itoa(pgid)
+	}
+	return err.Error()
+}
+
+func writeLeadWakeHelperEvent(path string, event leadWakeHelperEvent) error {
 	line, err := json.Marshal(event)
 	if err != nil {
 		return err

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -737,11 +738,13 @@ func TestLeadRegisterWakeFailureRequiredErrorsBeforeTeamMutation(t *testing.T) {
 }
 
 type leadWakeHelperHarness struct {
-	mode        string
-	markerPath  string
-	startedPath string
-	triggerPath string
-	eventsPath  string
+	mode           string
+	markerPath     string
+	startedPath    string
+	triggerPath    string
+	eventsPath     string
+	deferredMu     sync.Mutex
+	deferredEvents []leadWakeHelperEvent
 }
 
 type leadWakeHelperEvent struct {
@@ -811,9 +814,7 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 				_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, "post_kill_probe_unavailable", "", harness.markerPath, 0, err)
 				return
 			}
-			_ = appendLeadWakeHelperProbeEvent(harness.eventsPath, mode, "post_kill_probe_immediate", harness.markerPath, childPID)
-			time.Sleep(2 * time.Millisecond)
-			_ = appendLeadWakeHelperProbeEvent(harness.eventsPath, mode, "post_kill_probe_2ms", harness.markerPath, childPID)
+			harness.recordImmediateProbe(mode, "post_kill_probe_immediate", childPID)
 		}
 	}
 	externalLeadWakeReadyTimeout = 20 * time.Millisecond
@@ -825,6 +826,9 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 		externalLeadWakePollInterval = prevPoll
 		externalLeadWakeStopTimeout = prevStopTimeout
 		externalLeadWakeProcessEvent = prevProcessEvent
+		if err := harness.flushDeferredEvents(); err != nil {
+			t.Logf("flush deferred lead wake helper events: %v", err)
+		}
 		if t.Failed() || testing.Verbose() {
 			if events, err := os.ReadFile(harness.eventsPath); err == nil {
 				t.Logf("lead wake helper events:\n%s", events)
@@ -950,9 +954,16 @@ func TestWaitExternalLeadWakeProcessGroupGoneScopesDarwinEPERMAfterSuccess(t *te
 
 func (h *leadWakeHelperHarness) assertStoppedAfterCleanup(t *testing.T) {
 	t.Helper()
-	if err := appendLeadWakeHelperEvent(h.eventsPath, h.mode, "cleanup_returned", "", h.markerPath, 0, nil); err != nil {
-		t.Fatalf("record cleanup return: %v", err)
-	}
+	pgid, _ := syscall.Getpgid(0)
+	h.recordDeferredEvent(leadWakeHelperEvent{
+		Time:       time.Now().UTC().Format(time.RFC3339Nano),
+		PID:        os.Getpid(),
+		PPID:       os.Getppid(),
+		PGID:       pgid,
+		Mode:       h.mode,
+		Phase:      "cleanup_returned",
+		MarkerPath: h.markerPath,
+	})
 	if err := os.WriteFile(h.triggerPath, []byte("cleanup returned\n"), 0o644); err != nil {
 		t.Fatalf("write cleanup trigger: %v", err)
 	}
@@ -998,7 +1009,7 @@ func appendLeadWakeHelperEvent(path, mode, phase, readyPath, markerPath string, 
 	return writeLeadWakeHelperEvent(path, event)
 }
 
-func appendLeadWakeHelperProbeEvent(path, mode, phase, markerPath string, targetPID int) error {
+func (h *leadWakeHelperHarness) recordImmediateProbe(mode, phase string, targetPID int) {
 	pgid, _ := syscall.Getpgid(0)
 	targetPGID, getPGIDErr := syscall.Getpgid(targetPID)
 	killZeroErr := syscall.Kill(targetPID, 0)
@@ -1011,11 +1022,32 @@ func appendLeadWakeHelperProbeEvent(path, mode, phase, markerPath string, target
 		TargetPGID:    targetPGID,
 		Mode:          mode,
 		Phase:         phase,
-		MarkerPath:    markerPath,
+		MarkerPath:    h.markerPath,
 		ProbeKillZero: probeResult(killZeroErr),
 		ProbeGetPGID:  probePGIDResult(targetPGID, getPGIDErr),
 	}
-	return writeLeadWakeHelperEvent(path, event)
+	h.deferredMu.Lock()
+	h.deferredEvents = append(h.deferredEvents, event)
+	h.deferredMu.Unlock()
+}
+
+func (h *leadWakeHelperHarness) recordDeferredEvent(event leadWakeHelperEvent) {
+	h.deferredMu.Lock()
+	h.deferredEvents = append(h.deferredEvents, event)
+	h.deferredMu.Unlock()
+}
+
+func (h *leadWakeHelperHarness) flushDeferredEvents() error {
+	h.deferredMu.Lock()
+	events := append([]leadWakeHelperEvent(nil), h.deferredEvents...)
+	h.deferredEvents = nil
+	h.deferredMu.Unlock()
+	for _, event := range events {
+		if err := writeLeadWakeHelperEvent(h.eventsPath, event); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func probeResult(err error) string {

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -784,10 +785,22 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 		helperArgs = append(helperArgs, args...)
 		return exec.Command(exe, helperArgs...)
 	}
+	firstKillAttempt := true
 	externalLeadWakeProcessEvent = func(phase string, cmd *exec.Cmd, eventErr error) {
 		targetPID := 0
 		if cmd != nil && cmd.Process != nil {
 			targetPID = cmd.Process.Pid
+		}
+		if phase == "kill_attempt" && firstKillAttempt {
+			firstKillAttempt = false
+			_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, "waiting_for_started", "", harness.markerPath, targetPID, nil)
+			if err := waitForLeadWakeHelperStarted(harness.startedPath, 2*time.Second); err != nil {
+				// Mark the test failed before allowing cleanup to signal the group,
+				// but keep running so the failed precondition cannot leak helpers.
+				t.Errorf("wake-helper canary precondition: %v", err)
+			} else {
+				_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, "started_observed", "", harness.markerPath, targetPID, nil)
+			}
 		}
 		_ = appendLeadWakeHelperEvent(harness.eventsPath, mode, phase, "", harness.markerPath, targetPID, eventErr)
 	}
@@ -809,6 +822,40 @@ func installLeadWakeHelper(t *testing.T, mode string) *leadWakeHelperHarness {
 		}
 	})
 	return harness
+}
+
+func waitForLeadWakeHelperStarted(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				return nil
+			}
+			if parseErr != nil {
+				lastErr = fmt.Errorf("parse started PID: %w", parseErr)
+			} else {
+				lastErr = fmt.Errorf("started PID must be positive, got %d", pid)
+			}
+		} else if errors.Is(err, os.ErrNotExist) {
+			lastErr = err
+		} else {
+			return fmt.Errorf("read started file: %w", err)
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("grandchild did not reach trigger wait phase within %s: %w", timeout, lastErr)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestWaitForLeadWakeHelperStartedFailsClosed(t *testing.T) {
+	err := waitForLeadWakeHelperStarted(filepath.Join(t.TempDir(), "missing"), 5*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "did not reach trigger wait phase") {
+		t.Fatalf("missing started file err = %v, want bounded fail-closed error", err)
+	}
 }
 
 func (h *leadWakeHelperHarness) assertStoppedAfterCleanup(t *testing.T) {


### PR DESCRIPTION
## Summary

The #411 investigation (qa, this milestone) attributed the intermittent `internal/cli` package-level failure to the wake-helper test harness. Implementing the phase-correct fix then exposed a **genuine production race**: a helper descendant forked into the process group after the first pre-Wait group kill but before the leader was reaped could survive cleanup.

- **Production fix**: `stopExternalLeadWakeProcess` performs a final process-group sweep after the leader's `Wait` completes (no new descendants possible after reap). Darwin `EPERM` from the final sweep after a successful first kill is treated as an already-dead-group artifact, not a cleanup failure.
- **Phase-correct harness**: the late-ready grandchild writes a `started` file and waits for a trigger the test publishes only after cleanup returns; a marker written after the trigger proves genuine survival — scheduler delay can no longer false-fail the assertion.
- **Structured events**: RFC3339Nano JSONL (PID/PPID/PGID, mode, phase, kill attempt/result) dumped via `t.Log` on failure.
- **CI evidence**: `internal/cli` runs with `go test -json -shuffle=on`; the raw JSON, shuffle seed, and real exit code upload under `if: always()` so any future occurrence is attributable.

Evidence: pre-fix phase-correct run reproduced one genuine survivor at seed 1783854665082826000 with full event chronology; post-fix mixed shard `-count=50 -shuffle=on` exit 0; named test `-count=100` exit 0; full suite + `make ci` green at exact head f4ea8b354fb7f93cd0936836409d2327acc74daa.

Fixes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
