### PR TITLE
feat: configurable model/effort catalog per binary - advisory overlays, warn-not-reject (#432)

### DIFF
--- a/README.html
+++ b/README.html
@@ -895,12 +895,34 @@ Markdown with a <code># Role:</code> heading, or metadata-only
 YAML/JSON. They are staged under
 <code>.amq-squad/roles/&lt;id&gt;.md</code>; launch seeds each agent's
 role file and does not clobber later edits.</p>
-<p>Launch customization:</p>
+<p>Model and effort picker suggestions can be overlaid globally in
+<code>~/.amq-squad/catalog.json</code> and per project in
+<code>&lt;team-home&gt;/.amq-squad/catalog.json</code>; the project
+layer wins. The catalog is advisory and is not stored in
+<code>team.json</code>: explicit values still pass through, with a
+warning for an effort tier that is not listed. A version-1 overlay uses
+ordered object entries:</p>
 <div class="sourceCode" id="cb16"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
+class="sourceCode json"><code class="sourceCode json"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;schema_version&quot;</span><span class="fu">:</span> <span class="dv">1</span><span class="fu">,</span></span>
+<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;binaries&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;claude&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;models&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="fu">{</span><span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;opus&quot;</span><span class="fu">,</span> <span class="dt">&quot;label&quot;</span><span class="fu">:</span> <span class="st">&quot;Opus&quot;</span><span class="fu">,</span> <span class="dt">&quot;enabled&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">}</span><span class="ot">]</span><span class="fu">,</span></span>
+<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>      <span class="dt">&quot;efforts&quot;</span><span class="fu">:</span> <span class="ot">[</span><span class="fu">{</span><span class="dt">&quot;value&quot;</span><span class="fu">:</span> <span class="st">&quot;max&quot;</span><span class="fu">,</span> <span class="dt">&quot;label&quot;</span><span class="fu">:</span> <span class="st">&quot;Maximum&quot;</span><span class="fu">,</span> <span class="dt">&quot;enabled&quot;</span><span class="fu">:</span> <span class="kw">true</span><span class="fu">}</span><span class="ot">]</span></span>
+<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>    <span class="fu">}</span></span>
+<span id="cb16-8"><a href="#cb16-8" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb16-9"><a href="#cb16-9" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<p>Matching is case-insensitive while the winning entry's
+<code>value</code> spelling is preserved. Later entries replace the same
+value without moving it; <code>enabled:false</code> hides it. Missing
+files are normal, and a malformed or future schema layer warns and falls
+back to the lower-precedence catalog.</p>
+<p>Launch customization:</p>
+<div class="sourceCode" id="cb17"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent up claude <span class="at">--role</span> qa <span class="at">--session</span> beta <span class="dt">\</span></span>
+<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--launcher</span> /path/claude-wrapper.sh <span class="at">--launcher-args</span> <span class="st">&quot;--pull --workspace /ws&quot;</span></span>
+<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb17-4"><a href="#cb17-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team overlay init <span class="at">--workers</span> <span class="at">--disable-all-hooks</span></span></code></pre></div>
 <p><code>--launcher-args</code> are placed before the normal child
 arguments that carry bootstrap and binary defaults. A wrapper must
 forward its trailing arguments to the real agent, for example by ending
@@ -943,9 +965,9 @@ sandboxed mode does not.</p>
 <h2 id="cross-project-teams">Cross-project teams</h2>
 <p>Members may work from different repositories while one team-home owns
 the roster. Set a per-member cwd during team creation:</p>
-<div class="sourceCode" id="cb17"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/project-a</span>
+<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team init <span class="at">--roles</span> cto,fullstack,qa <span class="at">--cwd</span> qa=~/Code/project-b</span></code></pre></div>
 <p><code>up --dry-run</code> emits the corresponding
 <code>cd &lt;member-cwd&gt;</code> launch commands.
 <code>team sync --apply --allow-outside</code> writes the managed
@@ -955,14 +977,14 @@ profile cannot write into unrelated directories silently.</p>
 <p>Cross-project AMQ replies also require each project to declare its
 peers in <code>.amqrc</code>; <code>team sync</code> does not edit this
 file:</p>
-<div class="sourceCode" id="cb18"><pre
-class="sourceCode json"><code class="sourceCode json"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre
+class="sourceCode json"><code class="sourceCode json"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="fu">{</span></span>
+<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;root&quot;</span><span class="fu">:</span> <span class="st">&quot;.agent-mail&quot;</span><span class="fu">,</span></span>
+<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;project&quot;</span><span class="fu">:</span> <span class="st">&quot;project-a&quot;</span><span class="fu">,</span></span>
+<span id="cb19-4"><a href="#cb19-4" aria-hidden="true" tabindex="-1"></a>  <span class="dt">&quot;peers&quot;</span><span class="fu">:</span> <span class="fu">{</span></span>
+<span id="cb19-5"><a href="#cb19-5" aria-hidden="true" tabindex="-1"></a>    <span class="dt">&quot;project-b&quot;</span><span class="fu">:</span> <span class="st">&quot;/Users/you/Code/project-b/.agent-mail&quot;</span></span>
+<span id="cb19-6"><a href="#cb19-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">}</span></span>
+<span id="cb19-7"><a href="#cb19-7" aria-hidden="true" tabindex="-1"></a><span class="fu">}</span></span></code></pre></div>
 <p>Configure the reciprocal peer entry when both projects need to
 initiate and reply to messages. Use AMQ <code>--project</code> routing
 for another project and <code>--session</code> for another workstream in
@@ -1042,10 +1064,10 @@ href="docs/terminal-app-tier-c-smoke.md">docs/terminal-app-tier-c-smoke.md</a></
 <li><code>3</code> partial success</li>
 </ul>
 <p>Shell completions are available from the CLI:</p>
-<div class="sourceCode" id="cb19"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
-<span id="cb19-2"><a href="#cb19-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
-<span id="cb19-3"><a href="#cb19-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion zsh</span>
+<span id="cb20-2"><a href="#cb20-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion bash</span>
+<span id="cb20-3"><a href="#cb20-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> completion fish</span></code></pre></div>
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>

--- a/README.md
+++ b/README.md
@@ -443,6 +443,30 @@ Custom role files can be Markdown with YAML frontmatter, plain Markdown with a
 `.amq-squad/roles/<id>.md`; launch seeds each agent's role file and does not
 clobber later edits.
 
+Model and effort picker suggestions can be overlaid globally in
+`~/.amq-squad/catalog.json` and per project in
+`<team-home>/.amq-squad/catalog.json`; the project layer wins. The catalog is
+advisory and is not stored in `team.json`: explicit values still pass through,
+with a warning for an effort tier that is not listed. A version-1 overlay uses
+ordered object entries:
+
+```json
+{
+  "schema_version": 1,
+  "binaries": {
+    "claude": {
+      "models": [{"value": "opus", "label": "Opus", "enabled": true}],
+      "efforts": [{"value": "max", "label": "Maximum", "enabled": true}]
+    }
+  }
+}
+```
+
+Matching is case-insensitive while the winning entry's `value` spelling is
+preserved. Later entries replace the same value without moving it;
+`enabled:false` hides it. Missing files are normal, and a malformed or future
+schema layer warns and falls back to the lower-precedence catalog.
+
 Launch customization:
 
 ```sh

--- a/internal/agentcatalog/catalog.go
+++ b/internal/agentcatalog/catalog.go
@@ -1,0 +1,142 @@
+// Package agentcatalog defines the advisory per-binary model and effort
+// catalog shared by CLI validation and wizard pickers. Catalog membership is
+// never launch authority: explicit values may pass through to a supported
+// binary even when they are not listed here.
+package agentcatalog
+
+import "strings"
+
+type Kind string
+
+const (
+	Models  Kind = "models"
+	Efforts Kind = "efforts"
+)
+
+type Entry struct {
+	Value   string `json:"value"`
+	Label   string `json:"label,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+type Binary struct {
+	Models  []Entry `json:"models,omitempty"`
+	Efforts []Entry `json:"efforts,omitempty"`
+}
+
+type Catalog struct {
+	Binaries map[string]Binary `json:"binaries"`
+}
+
+// Builtins returns a fresh catalog in stable picker order.
+func Builtins() Catalog {
+	return Catalog{Binaries: map[string]Binary{
+		"claude": {
+			Models:  entries("fable", "opus", "sonnet", "haiku"),
+			Efforts: entries("low", "medium", "high", "xhigh", "max"),
+		},
+		"codex": {
+			Models:  entries("gpt-5.6-sol", "gpt-5.6-terra"),
+			Efforts: entries("minimal", "low", "medium", "high", "xhigh"),
+		},
+	}}
+}
+
+func entries(values ...string) []Entry {
+	out := make([]Entry, 0, len(values))
+	for _, value := range values {
+		out = append(out, Entry{Value: value, Label: value, Enabled: true})
+	}
+	return out
+}
+
+// Effective turns a zero catalog into the shipped defaults. This keeps older
+// injected ProjectContext fixtures source-compatible while making production
+// callers explicit about overlays.
+func (c Catalog) Effective() Catalog {
+	if len(c.Binaries) == 0 {
+		return Builtins()
+	}
+	return c
+}
+
+func (c Catalog) Entries(binary string, kind Kind) []Entry {
+	c = c.Effective()
+	b, ok := c.Binaries[normalize(binary)]
+	if !ok {
+		return nil
+	}
+	entries := b.Models
+	if kind == Efforts {
+		entries = b.Efforts
+	}
+	out := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Enabled {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// Resolve performs case-insensitive membership lookup and returns the winning
+// entry's canonical spelling.
+func (c Catalog) Resolve(binary string, kind Kind, value string) (Entry, bool) {
+	want := normalize(value)
+	for _, entry := range c.Entries(binary, kind) {
+		if normalize(entry.Value) == want {
+			return entry, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Merge overlays later entries without reordering an existing normalized
+// value. Disabled entries stay in the internal sequence so a higher layer can
+// re-enable them at their original position.
+func Merge(base, overlay Catalog) Catalog {
+	out := clone(base.Effective())
+	for binary, layer := range overlay.Binaries {
+		key := normalize(binary)
+		current := out.Binaries[key]
+		current.Models = mergeEntries(current.Models, layer.Models)
+		current.Efforts = mergeEntries(current.Efforts, layer.Efforts)
+		out.Binaries[key] = current
+	}
+	return out
+}
+
+func mergeEntries(base, overlay []Entry) []Entry {
+	out := append([]Entry(nil), base...)
+	positions := make(map[string]int, len(out))
+	for i, entry := range out {
+		positions[normalize(entry.Value)] = i
+	}
+	for _, entry := range overlay {
+		if entry.Label == "" {
+			entry.Label = entry.Value
+		}
+		key := normalize(entry.Value)
+		if i, ok := positions[key]; ok {
+			out[i] = entry
+			continue
+		}
+		positions[key] = len(out)
+		out = append(out, entry)
+	}
+	return out
+}
+
+func clone(in Catalog) Catalog {
+	out := Catalog{Binaries: make(map[string]Binary, len(in.Binaries))}
+	for binary, values := range in.Binaries {
+		values.Models = append([]Entry(nil), values.Models...)
+		values.Efforts = append([]Entry(nil), values.Efforts...)
+		out.Binaries[normalize(binary)] = values
+	}
+	return out
+}
+
+func normalize(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}

--- a/internal/agentcatalog/catalog_test.go
+++ b/internal/agentcatalog/catalog_test.go
@@ -1,0 +1,48 @@
+package agentcatalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuiltinsIncludeCurrentClaudeAndCodexEffortsInPickerOrder(t *testing.T) {
+	cat := Builtins()
+	values := func(binary string) []string {
+		var out []string
+		for _, entry := range cat.Entries(binary, Efforts) {
+			out = append(out, entry.Value)
+		}
+		return out
+	}
+	if got, want := values("claude"), []string{"low", "medium", "high", "xhigh", "max"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("claude efforts = %v, want %v", got, want)
+	}
+	if got, want := values("codex"), []string{"minimal", "low", "medium", "high", "xhigh"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("codex efforts = %v, want %v", got, want)
+	}
+}
+
+func TestMergePreservesPositionAndCanonicalWinningEntry(t *testing.T) {
+	base := Builtins()
+	global := Catalog{Binaries: map[string]Binary{"Claude": {Efforts: []Entry{
+		{Value: "HIGH", Label: "High global", Enabled: true},
+		{Value: "ultra", Label: "Ultra", Enabled: true},
+	}}}}
+	project := Catalog{Binaries: map[string]Binary{"claude": {Efforts: []Entry{
+		{Value: "high", Label: "High project", Enabled: false},
+		{Value: "ULTRA", Label: "Project ultra", Enabled: true},
+	}}}}
+	got := Merge(Merge(base, global), project)
+	var values []string
+	for _, entry := range got.Entries("CLAUDE", Efforts) {
+		values = append(values, entry.Value)
+	}
+	want := []string{"low", "medium", "xhigh", "max", "ULTRA"}
+	if got := values; !reflect.DeepEqual(got, want) {
+		t.Fatalf("enabled values = %v, want %v", got, want)
+	}
+	entry, ok := got.Resolve("claude", Efforts, "ultra")
+	if !ok || entry.Value != "ULTRA" || entry.Label != "Project ultra" {
+		t.Fatalf("resolved ultra = %+v, %t", entry, ok)
+	}
+}

--- a/internal/cli/agent_catalog.go
+++ b/internal/cli/agent_catalog.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
+)
+
+const agentCatalogSchemaVersion = 1
+
+var agentCatalogUserHomeDir = os.UserHomeDir
+
+type agentCatalogFile struct {
+	SchemaVersion int                               `json:"schema_version"`
+	Binaries      map[string]agentCatalogFileBinary `json:"binaries"`
+}
+
+type agentCatalogFileBinary struct {
+	Models  []agentCatalogFileEntry `json:"models"`
+	Efforts []agentCatalogFileEntry `json:"efforts"`
+}
+
+type agentCatalogFileEntry struct {
+	Value   string `json:"value"`
+	Label   string `json:"label"`
+	Enabled *bool  `json:"enabled"`
+}
+
+func loadAgentCatalog(teamHome string) (agentcatalog.Catalog, []string) {
+	merged := agentcatalog.Builtins()
+	var warnings []string
+	var paths []string
+	if home, err := agentCatalogUserHomeDir(); err != nil {
+		warnings = append(warnings, fmt.Sprintf("resolve home directory: %v; using built-in catalog", err))
+	} else {
+		paths = append(paths, filepath.Join(home, ".amq-squad", "catalog.json"))
+	}
+	if strings.TrimSpace(teamHome) != "" {
+		projectPath := filepath.Join(filepath.Clean(teamHome), ".amq-squad", "catalog.json")
+		if len(paths) == 0 || filepath.Clean(paths[len(paths)-1]) != filepath.Clean(projectPath) {
+			paths = append(paths, projectPath)
+		}
+	}
+	for _, path := range paths {
+		layer, layerWarnings, ok := readAgentCatalogLayer(path)
+		warnings = append(warnings, layerWarnings...)
+		if ok {
+			merged = agentcatalog.Merge(merged, layer)
+		}
+	}
+	return merged, warnings
+}
+
+func readAgentCatalogLayer(path string) (agentcatalog.Catalog, []string, bool) {
+	body, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return agentcatalog.Catalog{}, nil, false
+	}
+	if err != nil {
+		return agentcatalog.Catalog{}, []string{fmt.Sprintf("read %s: %v; ignoring this layer", path, err)}, false
+	}
+	var raw agentCatalogFile
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return agentcatalog.Catalog{}, []string{fmt.Sprintf("parse %s: %v; ignoring this layer", path, err)}, false
+	}
+	if raw.SchemaVersion != agentCatalogSchemaVersion {
+		return agentcatalog.Catalog{}, []string{fmt.Sprintf("%s uses unsupported schema_version %d (want %d); ignoring this layer", path, raw.SchemaVersion, agentCatalogSchemaVersion)}, false
+	}
+	layer := agentcatalog.Catalog{Binaries: map[string]agentcatalog.Binary{}}
+	var warnings []string
+	keys := make([]string, 0, len(raw.Binaries))
+	for key := range raw.Binaries {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left, right := strings.ToLower(keys[i]), strings.ToLower(keys[j])
+		if left == right {
+			return keys[i] < keys[j]
+		}
+		return left < right
+	})
+	for _, rawBinary := range keys {
+		binary := strings.ToLower(strings.TrimSpace(rawBinary))
+		if binary == "" || containsControl(binary) {
+			warnings = append(warnings, fmt.Sprintf("%s has invalid binary key %q; ignoring it", path, rawBinary))
+			continue
+		}
+		rawValues := raw.Binaries[rawBinary]
+		models, modelWarnings := convertAgentCatalogEntries(path, binary, "models", rawValues.Models)
+		efforts, effortWarnings := convertAgentCatalogEntries(path, binary, "efforts", rawValues.Efforts)
+		warnings = append(warnings, modelWarnings...)
+		warnings = append(warnings, effortWarnings...)
+		current := layer.Binaries[binary]
+		current.Models = append(current.Models, models...)
+		current.Efforts = append(current.Efforts, efforts...)
+		layer.Binaries[binary] = current
+	}
+	return layer, warnings, true
+}
+
+func convertAgentCatalogEntries(path, binary, kind string, raw []agentCatalogFileEntry) ([]agentcatalog.Entry, []string) {
+	entries := make([]agentcatalog.Entry, 0, len(raw))
+	var warnings []string
+	for i, item := range raw {
+		value := strings.TrimSpace(item.Value)
+		label := strings.TrimSpace(item.Label)
+		if label == "" {
+			label = value
+		}
+		normalized := strings.ToLower(value)
+		if value == "" || containsControl(value) || containsControl(label) || normalized == "automatic" || normalized == "custom" || normalized == "keep" {
+			warnings = append(warnings, fmt.Sprintf("%s %s.%s[%d] has invalid or reserved value %q; ignoring it", path, binary, kind, i, item.Value))
+			continue
+		}
+		enabled := true
+		if item.Enabled != nil {
+			enabled = *item.Enabled
+		}
+		entries = append(entries, agentcatalog.Entry{Value: value, Label: label, Enabled: enabled})
+	}
+	return entries, warnings
+}
+
+func containsControl(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func emitAgentCatalogWarnings(warnings []string) {
+	for _, warning := range warnings {
+		fmt.Fprintf(os.Stderr, "warning: catalog: %s\n", warning)
+	}
+}
+
+func loadAgentCatalogAndWarn(teamHome string) agentcatalog.Catalog {
+	catalog, warnings := loadAgentCatalog(teamHome)
+	emitAgentCatalogWarnings(warnings)
+	return catalog
+}

--- a/internal/cli/agent_catalog_test.go
+++ b/internal/cli/agent_catalog_test.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
+)
+
+func TestLoadAgentCatalogMergesGlobalThenProjectWithoutCacheBleed(t *testing.T) {
+	home := t.TempDir()
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+	writeCatalogFixture(t, filepath.Join(home, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"claude": {"efforts": [{"value":"ultra","label":"Global ultra"}]}}
+}`)
+	writeCatalogFixture(t, filepath.Join(projectA, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"CLAUDE": {"efforts": [
+    {"value":"HIGH","label":"Project high","enabled":false},
+    {"value":"ULTRA","label":"Project ultra"}
+  ]}}
+}`)
+
+	catA, warnings := loadAgentCatalog(projectA)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if got, want := catalogValues(catA, "claude", agentcatalog.Efforts), []string{"low", "medium", "xhigh", "max", "ULTRA"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("project A values = %v, want %v", got, want)
+	}
+	catB, warnings := loadAgentCatalog(projectB)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if got, want := catalogValues(catB, "claude", agentcatalog.Efforts), []string{"low", "medium", "high", "xhigh", "max", "ultra"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("project B values = %v, want %v", got, want)
+	}
+}
+
+func TestLoadAgentCatalogBadLayersWarnAndFallBack(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+	writeCatalogFixture(t, filepath.Join(home, ".amq-squad", "catalog.json"), `{bad`)
+	writeCatalogFixture(t, filepath.Join(project, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"claude": {"efforts": [
+    {"value":"custom"}, {"value":"future","enabled":true}
+  ]}}
+}`)
+	cat, warnings := loadAgentCatalog(project)
+	if len(warnings) != 2 || !strings.Contains(strings.Join(warnings, "\n"), "parse") || !strings.Contains(strings.Join(warnings, "\n"), "reserved") {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if _, ok := cat.Resolve("claude", agentcatalog.Efforts, "future"); !ok {
+		t.Fatal("valid project entry should survive invalid sibling and malformed global layer")
+	}
+	if _, ok := cat.Resolve("claude", agentcatalog.Efforts, "custom"); ok {
+		t.Fatal("reserved entry should be ignored")
+	}
+}
+
+func TestLoadAgentCatalogUnreadableLayerWarnsAndContinues(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+	if err := os.MkdirAll(filepath.Join(home, ".amq-squad", "catalog.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalogFixture(t, filepath.Join(project, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"claude": {"efforts": [{"value":"future"}]}}
+}`)
+
+	cat, warnings := loadAgentCatalog(project)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "read ") || !strings.Contains(warnings[0], "ignoring this layer") {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if _, ok := cat.Resolve("claude", agentcatalog.Efforts, "future"); !ok {
+		t.Fatal("read failure in global layer blocked valid project overlay")
+	}
+}
+
+func TestLoadAgentCatalogMissingIsSilentAndUnknownSchemaFallsBack(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+
+	cat, warnings := loadAgentCatalog(project)
+	if len(warnings) != 0 {
+		t.Fatalf("missing files warnings = %v", warnings)
+	}
+	if got, want := catalogValues(cat, "claude", agentcatalog.Efforts), []string{"low", "medium", "high", "xhigh", "max"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("built-in fallback = %v, want %v", got, want)
+	}
+
+	writeCatalogFixture(t, filepath.Join(project, ".amq-squad", "catalog.json"), `{
+  "schema_version": 2,
+  "binaries": {"claude": {"efforts": [{"value":"future"}]}}
+}`)
+	cat, warnings = loadAgentCatalog(project)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "unsupported schema_version 2") {
+		t.Fatalf("schema warnings = %v", warnings)
+	}
+	if _, ok := cat.Resolve("claude", agentcatalog.Efforts, "future"); ok {
+		t.Fatal("unsupported layer changed the effective catalog")
+	}
+}
+
+func TestLoadAgentCatalogCaseVariantBinaryKeysMergeDeterministically(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+	writeCatalogFixture(t, filepath.Join(project, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {
+    "CLAUDE": {"efforts": [{"value":"high","label":"Upper high","enabled":false}]},
+    "claude": {"efforts": [{"value":"HIGH","label":"Lower high"},{"value":"future"}]}
+  }
+}`)
+
+	cat, warnings := loadAgentCatalog(project)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v", warnings)
+	}
+	if got, want := catalogValues(cat, "claude", agentcatalog.Efforts), []string{"low", "medium", "HIGH", "xhigh", "max", "future"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("values = %v, want %v", got, want)
+	}
+	entry, ok := cat.Resolve("claude", agentcatalog.Efforts, "high")
+	if !ok || entry.Value != "HIGH" || entry.Label != "Lower high" {
+		t.Fatalf("resolved high = %+v, %t", entry, ok)
+	}
+}
+
+func catalogValues(cat agentcatalog.Catalog, binary string, kind agentcatalog.Kind) []string {
+	var out []string
+	for _, entry := range cat.Entries(binary, kind) {
+		out = append(out, entry.Value)
+	}
+	return out
+}
+
+func writeCatalogFixture(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -2,28 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 const effortAutomatic = "automatic"
-
-var effortOptionsByBinary = map[string]map[string]bool{
-	"codex": {
-		"minimal": true,
-		"low":     true,
-		"medium":  true,
-		"high":    true,
-		"xhigh":   true,
-	},
-	"claude": {
-		"low":    true,
-		"medium": true,
-		"high":   true,
-	},
-}
 
 // parseEffortOverrides parses the wizard-facing role=effort flag. Effort is
 // deliberately not a persisted field: callers normalize each value into the
@@ -35,7 +22,7 @@ func parseEffortOverrides(raw string) (map[string]string, error) {
 	}
 	overrides = lowercaseKeys(overrides)
 	for role, value := range overrides {
-		value = strings.ToLower(strings.TrimSpace(value))
+		value = strings.TrimSpace(value)
 		if value == "" {
 			return nil, fmt.Errorf("parse --effort: role %q has an empty effort", role)
 		}
@@ -59,34 +46,51 @@ func validateEffortOverrideKeys(overrides map[string]string, selected map[string
 }
 
 func effortArgsForBinary(binary, effort string) ([]string, error) {
+	args, _, err := effortArgsForBinaryCatalog(binary, effort, agentcatalog.Builtins())
+	return args, err
+}
+
+// effortArgsForBinaryCatalog translates any explicit tier for a supported
+// binary. The bool reports catalog membership; an unknown tier is advisory,
+// not an error, and retains its exact trimmed spelling.
+func effortArgsForBinaryCatalog(binary, effort string, catalog agentcatalog.Catalog) ([]string, bool, error) {
 	binary = normalizedAgentBinary(binary)
-	effort = strings.ToLower(strings.TrimSpace(effort))
-	if effort == "" || effort == effortAutomatic {
-		return nil, nil
+	effort = strings.TrimSpace(effort)
+	if effort == "" {
+		return nil, false, fmt.Errorf("--effort cannot be empty; use %q to clear native effort args", effortAutomatic)
 	}
-	options, ok := effortOptionsByBinary[binary]
-	if !ok {
-		return nil, fmt.Errorf("--effort cannot target binary %q; choose codex or claude", binary)
+	if strings.EqualFold(effort, effortAutomatic) {
+		return nil, true, nil
 	}
-	if !options[effort] {
-		allowed := make([]string, 0, len(options)+1)
-		allowed = append(allowed, effortAutomatic)
-		for option := range options {
-			allowed = append(allowed, option)
-		}
-		sort.Strings(allowed)
-		return nil, fmt.Errorf("unsupported %s effort %q (want %s)", binary, effort, strings.Join(allowed, ", "))
+	if binary != "codex" && binary != "claude" {
+		return nil, false, fmt.Errorf("--effort cannot target binary %q; choose codex or claude", binary)
+	}
+	known := false
+	if entry, ok := catalog.Resolve(binary, agentcatalog.Efforts, effort); ok {
+		effort = entry.Value
+		known = true
 	}
 	if binary == "codex" {
-		return []string{"-c", "model_reasoning_effort=" + effort}, nil
+		return []string{"-c", "model_reasoning_effort=" + effort}, known, nil
 	}
-	return []string{"--effort", effort}, nil
+	return []string{"--effort", effort}, known, nil
 }
 
 func applyMemberEffort(member *team.Member, effort string) error {
-	args, err := effortArgsForBinary(member.Binary, effort)
+	return applyMemberEffortCatalog(member, effort, agentcatalog.Builtins())
+}
+
+func applyMemberEffortCatalog(member *team.Member, effort string, catalog agentcatalog.Catalog) error {
+	return applyMemberEffortCatalogMode(member, effort, catalog, true)
+}
+
+func applyMemberEffortCatalogMode(member *team.Member, effort string, catalog agentcatalog.Catalog, warnUnknown bool) error {
+	args, known, err := effortArgsForBinaryCatalog(member.Binary, effort, catalog)
 	if err != nil {
 		return fmt.Errorf("--effort %s=%s: %w", member.Role, effort, err)
+	}
+	if len(args) > 0 && !known && warnUnknown {
+		fmt.Fprintf(os.Stderr, "warning: effort %s=%s is not in the merged catalog for %s; passing the exact value through, and the underlying binary may reject it\n", member.Role, strings.TrimSpace(effort), normalizedAgentBinary(member.Binary))
 	}
 	if len(args) == 0 {
 		return nil
@@ -101,18 +105,20 @@ func applyMemberEffort(member *team.Member, effort string) error {
 }
 
 func memberEffort(member team.Member) string {
+	binary := normalizedAgentBinary(member.Binary)
 	args := member.ExtraArgs()
 	for i := 0; i < len(args); i++ {
-		if args[i] == "-c" && i+1 < len(args) && strings.HasPrefix(args[i+1], "model_reasoning_effort=") {
-			return strings.TrimPrefix(args[i+1], "model_reasoning_effort=")
+		if binary == "codex" {
+			if value, consumed, ok := codexEffortArg(args, i); ok {
+				return value
+			} else if consumed {
+				i++
+			}
 		}
-		if strings.HasPrefix(args[i], "model_reasoning_effort=") {
-			return strings.TrimPrefix(args[i], "model_reasoning_effort=")
-		}
-		if args[i] == "--effort" && i+1 < len(args) {
+		if binary == "claude" && args[i] == "--effort" && i+1 < len(args) {
 			return args[i+1]
 		}
-		if strings.HasPrefix(args[i], "--effort=") {
+		if binary == "claude" && strings.HasPrefix(args[i], "--effort=") {
 			return strings.TrimPrefix(args[i], "--effort=")
 		}
 	}
@@ -123,6 +129,14 @@ func memberEffort(member team.Member) string {
 // native effort arguments replaced. It never writes the profile and preserves
 // all unrelated per-member args.
 func applyLaunchEffortOverrides(members []team.Member, overrides map[string]string) ([]team.Member, error) {
+	return applyLaunchEffortOverridesCatalog(members, overrides, agentcatalog.Builtins())
+}
+
+func applyLaunchEffortOverridesCatalog(members []team.Member, overrides map[string]string, catalog agentcatalog.Catalog) ([]team.Member, error) {
+	return applyLaunchEffortOverridesCatalogMode(members, overrides, catalog, true)
+}
+
+func applyLaunchEffortOverridesCatalogMode(members []team.Member, overrides map[string]string, catalog agentcatalog.Catalog, warnUnknown bool) ([]team.Member, error) {
 	if len(overrides) == 0 {
 		return append([]team.Member(nil), members...), nil
 	}
@@ -152,7 +166,7 @@ func applyLaunchEffortOverrides(members []team.Member, overrides map[string]stri
 		case "claude":
 			out[i].ClaudeArgs = stripNativeEffortArgs(out[i].ClaudeArgs, "claude")
 		}
-		if err := applyMemberEffort(&out[i], effort); err != nil {
+		if err := applyMemberEffortCatalogMode(&out[i], effort, catalog, warnUnknown); err != nil {
 			return nil, err
 		}
 	}
@@ -164,11 +178,10 @@ func stripNativeEffortArgs(args []string, binary string) []string {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if binary == "codex" {
-			if arg == "-c" && i+1 < len(args) && strings.HasPrefix(args[i+1], "model_reasoning_effort=") {
-				i++
-				continue
-			}
-			if strings.HasPrefix(arg, "model_reasoning_effort=") {
+			if _, consumed, ok := codexEffortArg(args, i); ok {
+				if consumed {
+					i++
+				}
 				continue
 			}
 		}
@@ -184,4 +197,30 @@ func stripNativeEffortArgs(args []string, binary string) []string {
 		out = append(out, arg)
 	}
 	return out
+}
+
+// codexEffortArg recognizes every supported split and inline spelling of the
+// Codex config option. consumed reports whether the next argv token belongs to
+// the current option, even when it names a different config key.
+func codexEffortArg(args []string, index int) (value string, consumed bool, ok bool) {
+	arg := args[index]
+	spec, inline, known := nativeValueSpecForArg("codex", arg)
+	if !known || spec.Canonical != "--config" {
+		if strings.HasPrefix(arg, "model_reasoning_effort=") {
+			return strings.TrimPrefix(arg, "model_reasoning_effort="), false, true
+		}
+		return "", false, false
+	}
+	raw := ""
+	if inline {
+		raw = compactNativeValue(arg)
+	} else if index+1 < len(args) {
+		raw = args[index+1]
+		consumed = true
+	}
+	key, value, found := strings.Cut(raw, "=")
+	if !found || strings.TrimSpace(key) != "model_reasoning_effort" {
+		return "", consumed, false
+	}
+	return value, consumed, true
 }

--- a/internal/cli/effort_test.go
+++ b/internal/cli/effort_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -199,4 +201,123 @@ func TestTeamMemberAddEffortDryRunJSONAndLiveParity(t *testing.T) {
 	if len(after.Members) != 2 || !reflect.DeepEqual(after.Members[1].ClaudeArgs, []string{"--effort", "FutureTier"}) {
 		t.Fatalf("live member = %+v", after.Members)
 	}
+}
+
+func TestTeamShowEffortUsesProjectCatalogWithoutPersisting(t *testing.T) {
+	dir := t.TempDir()
+	resumeChdir(t, dir)
+	home := t.TempDir()
+	oldHome := agentCatalogUserHomeDir
+	agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+	if err := team.Write(dir, team.Team{
+		Workstream: "sess",
+		Members: []team.Member{{
+			Role: "qa", Binary: "claude", Handle: "qa", Session: "sess",
+			ClaudeArgs: []string{"--chrome", "--effort", "low"},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeCatalogFixture(t, filepath.Join(dir, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"claude": {"efforts": [{"value":"ProjectTier","label":"Project tier"}]}}
+}`)
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamShow([]string{"--json", "--no-bootstrap", "--effort", "qa=projecttier"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(stdout)) || !strings.Contains(stdout, "--effort ProjectTier") {
+		t.Fatalf("team show JSON did not use the project catalog's canonical effort:\n%s", stdout)
+	}
+	if strings.Contains(stderr, "not in the merged catalog") {
+		t.Fatalf("known project effort warned as custom: %q", stderr)
+	}
+	stored, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stored.Members[0].ClaudeArgs, []string{"--chrome", "--effort", "low"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("team show mutated stored args: got %#v want %#v", got, want)
+	}
+}
+
+func TestTeamMemberAddEffortKnownAutomaticAndAtomicFailure(t *testing.T) {
+	t.Run("known project tier is canonicalized", func(t *testing.T) {
+		dir := t.TempDir()
+		home := t.TempDir()
+		oldHome := agentCatalogUserHomeDir
+		agentCatalogUserHomeDir = func() (string, error) { return home, nil }
+		t.Cleanup(func() { agentCatalogUserHomeDir = oldHome })
+		if err := team.Write(dir, team.Team{Workstream: "sess", Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"}}}); err != nil {
+			t.Fatal(err)
+		}
+		writeCatalogFixture(t, filepath.Join(dir, ".amq-squad", "catalog.json"), `{
+  "schema_version": 1,
+  "binaries": {"claude": {"efforts": [{"value":"ProjectTier"}]}}
+}`)
+		_, stderr, err := captureOutput(t, func() error {
+			return runTeamMember([]string{"add", "qa", "--project", dir, "--binary", "claude", "--effort", "projecttier"})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(stderr, "not in the merged catalog") {
+			t.Fatalf("known effort warning = %q", stderr)
+		}
+		cfg, err := team.Read(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := cfg.Members[1].ClaudeArgs, []string{"--effort", "ProjectTier"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("known effort args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("automatic strips supplied native effort", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := team.Write(dir, team.Team{Workstream: "sess", Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"}}}); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := captureOutput(t, func() error {
+			return runTeamMember([]string{"add", "qa", "--project", dir, "--binary", "claude", "--claude-args", "--chrome --effort low", "--effort", "automatic"})
+		}); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := team.Read(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := cfg.Members[1].ClaudeArgs, []string{"--chrome"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("automatic args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("structural failure leaves profile byte exact", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := team.Write(dir, team.Team{Workstream: "sess", Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"}}}); err != nil {
+			t.Fatal(err)
+		}
+		path := team.ProfilePath(dir, team.DefaultProfile)
+		before, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = captureOutput(t, func() error {
+			return runTeamMember([]string{"add", "qa", "--project", dir, "--binary", "claude", "--handle", "cto", "--effort", "FutureTier"})
+		})
+		if err == nil || !strings.Contains(err.Error(), "handle") {
+			t.Fatalf("structural failure = %v", err)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(after, before) {
+			t.Fatal("failed member add changed the profile")
+		}
+	})
 }

--- a/internal/cli/effort_test.go
+++ b/internal/cli/effort_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -8,7 +9,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
-func TestEffortArgsForBinaryNormalizesWithoutNewSemantics(t *testing.T) {
+func TestEffortArgsForBinaryIncludesCurrentClaudeTiers(t *testing.T) {
 	for _, tc := range []struct {
 		binary string
 		effort string
@@ -16,6 +17,8 @@ func TestEffortArgsForBinaryNormalizesWithoutNewSemantics(t *testing.T) {
 	}{
 		{binary: "codex", effort: "high", want: []string{"-c", "model_reasoning_effort=high"}},
 		{binary: "claude", effort: "medium", want: []string{"--effort", "medium"}},
+		{binary: "claude", effort: "xhigh", want: []string{"--effort", "xhigh"}},
+		{binary: "claude", effort: "max", want: []string{"--effort", "max"}},
 		{binary: "codex", effort: "automatic", want: nil},
 	} {
 		got, err := effortArgsForBinary(tc.binary, tc.effort)
@@ -50,14 +53,46 @@ func TestTeamInitEffortPersistsOnlyExistingMemberArgs(t *testing.T) {
 	}
 }
 
-func TestTeamInitEffortRejectsRoleAndBinaryMismatches(t *testing.T) {
+func TestTeamInitEffortKnownAndCustomWarningContract(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		effort      string
+		want        string
+		wantWarning bool
+	}{
+		{name: "claude xhigh", effort: "xhigh", want: "xhigh"},
+		{name: "claude max canonical", effort: "MAX", want: "max"},
+		{name: "future exact", effort: "FutureTier", want: "FutureTier", wantWarning: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, stderr, err := captureOutput(t, func() error {
+				return runNew([]string{"team", "--project", dir, "--session", "sess", "--roles", "qa", "--binary", "qa=claude", "--effort", "qa=" + tc.effort})
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Contains(stderr, "not in the merged catalog"); got != tc.wantWarning {
+				t.Fatalf("warning=%t stderr=%q", got, stderr)
+			}
+			cfg, err := team.Read(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := []string{"--effort", tc.want}; !reflect.DeepEqual(cfg.Members[0].ClaudeArgs, want) {
+				t.Fatalf("args=%#v want=%#v", cfg.Members[0].ClaudeArgs, want)
+			}
+		})
+	}
+}
+
+func TestTeamInitEffortRejectsUnknownRole(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		args   []string
 		needle string
 	}{
 		{name: "unknown role", args: []string{"--roles", "cto", "--effort", "qa=high"}, needle: "not selected"},
-		{name: "claude xhigh", args: []string{"--roles", "qa", "--binary", "qa=claude", "--effort", "qa=xhigh"}, needle: "unsupported claude effort"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -70,22 +105,44 @@ func TestTeamInitEffortRejectsRoleAndBinaryMismatches(t *testing.T) {
 	}
 }
 
+func TestUnknownSupportedEffortWarnsAndPreservesExactSpelling(t *testing.T) {
+	member := team.Member{Role: "qa", Binary: "claude"}
+	_, stderr, err := captureOutput(t, func() error {
+		return applyMemberEffort(&member, "  FutureTier  ")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"--effort", "FutureTier"}; !reflect.DeepEqual(member.ClaudeArgs, want) {
+		t.Fatalf("claude args = %#v, want %#v", member.ClaudeArgs, want)
+	}
+	if strings.Count(stderr, "not in the merged catalog") != 1 || !strings.Contains(stderr, "FutureTier") {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if _, err := effortArgsForBinary("other", "FutureTier"); err == nil || !strings.Contains(err.Error(), "choose codex or claude") {
+		t.Fatalf("unsupported binary error = %v", err)
+	}
+	if _, err := effortArgsForBinary("claude", "  "); err == nil || !strings.Contains(err.Error(), "cannot be empty") {
+		t.Fatalf("empty effort error = %v", err)
+	}
+}
+
 func TestApplyLaunchEffortOverridesReplacesNativeArgsWithoutMutatingProfile(t *testing.T) {
 	members := []team.Member{
-		{Role: "cto", Binary: "codex", CodexArgs: []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--search"}},
+		{Role: "cto", Binary: "codex", CodexArgs: []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--config=model_reasoning_effort=medium", "-cmodel_reasoning_effort=max", "-c", "model=preserved", "--search"}},
 		{Role: "qa", Binary: "claude", ClaudeArgs: []string{"--chrome", "--effort=medium", "--debug"}},
 	}
 	got, err := applyLaunchEffortOverrides(members, map[string]string{"cto": "xhigh", "qa": "automatic"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := []string{"--profile", "fast", "--search", "-c", "model_reasoning_effort=xhigh"}; !reflect.DeepEqual(got[0].CodexArgs, want) {
+	if want := []string{"--profile", "fast", "-c", "model=preserved", "--search", "-c", "model_reasoning_effort=xhigh"}; !reflect.DeepEqual(got[0].CodexArgs, want) {
 		t.Fatalf("cto args = %#v, want %#v", got[0].CodexArgs, want)
 	}
 	if want := []string{"--chrome", "--debug"}; !reflect.DeepEqual(got[1].ClaudeArgs, want) {
 		t.Fatalf("qa args = %#v, want %#v", got[1].ClaudeArgs, want)
 	}
-	if want := []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--search"}; !reflect.DeepEqual(members[0].CodexArgs, want) {
+	if want := []string{"--profile", "fast", "-c", "model_reasoning_effort=low", "--config=model_reasoning_effort=medium", "-cmodel_reasoning_effort=max", "-c", "model=preserved", "--search"}; !reflect.DeepEqual(members[0].CodexArgs, want) {
 		t.Fatalf("stored cto args mutated: %#v", members[0].CodexArgs)
 	}
 	if want := []string{"--chrome", "--effort=medium", "--debug"}; !reflect.DeepEqual(members[1].ClaudeArgs, want) {
@@ -97,5 +154,49 @@ func TestApplyLaunchEffortOverridesRejectsUnknownProfileRole(t *testing.T) {
 	_, err := applyLaunchEffortOverrides([]team.Member{{Role: "cto", Binary: "codex"}}, map[string]string{"qa": "high"})
 	if err == nil || !strings.Contains(err.Error(), "not present in the selected profile") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestTeamMemberAddEffortDryRunJSONAndLiveParity(t *testing.T) {
+	dir := t.TempDir()
+	if err := team.Write(dir, team.Team{
+		Workstream: "sess",
+		Members:    []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "sess"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"add", "qa", "--project", dir, "--binary", "claude", "--effort", "FutureTier", "--dry-run", "--json"}
+	stdout, stderr, err := captureOutput(t, func() error { return runTeamMember(args) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(stdout)) || !strings.Contains(stdout, `"preview"`) {
+		t.Fatalf("dry-run JSON = %q", stdout)
+	}
+	if strings.Count(stderr, "not in the merged catalog") != 1 {
+		t.Fatalf("dry-run stderr = %q", stderr)
+	}
+	before, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.Members) != 1 {
+		t.Fatalf("dry-run wrote profile: %+v", before.Members)
+	}
+
+	liveArgs := []string{"add", "qa", "--project", dir, "--binary", "claude", "--effort", "FutureTier", "--json"}
+	stdout, stderr, err = captureOutput(t, func() error { return runTeamMember(liveArgs) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(stdout)) || strings.Count(stderr, "not in the merged catalog") != 1 {
+		t.Fatalf("live JSON/stdout=%q stderr=%q", stdout, stderr)
+	}
+	after, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Members) != 2 || !reflect.DeepEqual(after.Members[1].ClaudeArgs, []string{"--effort", "FutureTier"}) {
+		t.Fatalf("live member = %+v", after.Members)
 	}
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -212,8 +212,8 @@ Usage:
   amq-squad new profile NAME [--project DIR] [--sync] [--dry-run [--json]] [team init options]
 
 This delegates to 'amq-squad team init --profile NAME'. It is the named-profile
-counterpart to 'amq-squad new team', so it inherits role selection, --binary
-overrides, --dry-run, --json, --project, and --sync.
+counterpart to 'amq-squad new team', so it inherits role selection, --binary,
+--model, --effort, --dry-run, --json, --project, and --sync.
 
 Examples:
   amq-squad roles
@@ -239,6 +239,7 @@ func newProfileTeamArgs(args []string) ([]string, error) {
 		"--claude-args": true,
 		"--codex-args":  true,
 		"--cwd":         true,
+		"--effort":      true,
 		"--lead":        true,
 		"--model":       true,
 		"--operator":    true,

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -278,6 +278,35 @@ func TestRunNewProfileDelegatesToNamedTeamInit(t *testing.T) {
 	}
 }
 
+func TestRunNewProfileForwardsEffortOverride(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runNew([]string{
+			"profile", "review",
+			"--roles", "qa",
+			"--binary", "qa=claude",
+			"--effort", "qa=max",
+			"--session", "review-main",
+		})
+	})
+	if err != nil {
+		t.Fatalf("new profile review --effort: %v\nstderr:\n%s", err, stderr)
+	}
+
+	cfg, err := team.ReadProfile(dir, "review")
+	if err != nil {
+		t.Fatalf("read named team config: %v", err)
+	}
+	if len(cfg.Members) != 1 {
+		t.Fatalf("members = %d, want 1", len(cfg.Members))
+	}
+	if got := strings.Join(cfg.Members[0].ClaudeArgs, " "); got != "--effort max" {
+		t.Fatalf("qa claude_args = %q, want %q", got, "--effort max")
+	}
+}
+
 func TestRunNewTeamRejectsProfileSessionCollisionBeforeWrite(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -19,6 +19,7 @@ func runResume(args []string) error {
 	noBootstrap := fs.Bool("no-bootstrap", false, "emit fresh launch commands that skip the generated bootstrap prompt")
 	trustRaw := fs.String("trust", "", "Codex trust profile for fresh members: approve-for-me (default), sandboxed, or trusted")
 	modelFlag := fs.String("model", "", "per-persona model overrides for fresh members, e.g. cto=gpt-5.6-sol,fullstack=sonnet")
+	effortFlag := fs.String("effort", "", "per-persona effort overrides for launch-fresh members, e.g. cto=xhigh,fullstack=max")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for fresh members, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
 	projectFlag := fs.String("project", "", "project/team-home directory to resume (default: cwd)")
@@ -40,6 +41,7 @@ Usage:
                    [--dry-run] [--json] [--force-duplicate]
                    [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted]
                    [--model role=model,...]
+                   [--effort role=level,...]
                    [--codex-args args] [--claude-args args]
                    [--exec [--terminal tmux] [--target current-window|new-window|new-session]
                            [--layout vertical|horizontal|tiled]
@@ -151,6 +153,7 @@ Examples:
 		TrustRaw:         *trustRaw,
 		ExplicitTrust:    flagWasSet(fs, "trust"),
 		ModelRaw:         *modelFlag,
+		EffortRaw:        *effortFlag,
 		CodexArgsRaw:     *codexArgsRaw,
 		ClaudeArgsRaw:    *claudeArgsRaw,
 		DryRun:           *dryRun,

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,54 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
+
+func TestRunResumeEffortIsFreshOnlyAndJSONSafe(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{{
+			Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96",
+			ClaudeArgs: []string{"--chrome", "--effort", "low"},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runResume([]string{"--json", "--effort", "qa=FutureTier"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("resume JSON is polluted:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "FutureTier") || strings.Contains(stdout, "--effort low") {
+		t.Fatalf("fresh command did not replace stored effort exactly:\n%s", stdout)
+	}
+	if strings.Count(stderr, "not in the merged catalog") != 1 {
+		t.Fatalf("warning count/stderr = %q", stderr)
+	}
+	stored, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(stored.Members[0].ClaudeArgs, " "); got != "--chrome --effort low" {
+		t.Fatalf("resume preview mutated profile args: %q", got)
+	}
+
+	writeMemberLaunchRecord(t, base, "issue-96", "qa", launch.Record{
+		CWD: dir, Binary: "claude", Role: "qa", StartedAt: time.Now(),
+	})
+	_, _, err = captureOutput(t, func() error {
+		return runResume([]string{"--effort", "qa=max"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "qa (restore)") || !strings.Contains(err.Error(), "only to launch-fresh") {
+		t.Fatalf("restore-target effort error = %v", err)
+	}
+}
 
 func TestRunResumeRequiresTeam(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -61,6 +61,154 @@ func TestRunResumeEffortIsFreshOnlyAndJSONSafe(t *testing.T) {
 	}
 }
 
+func TestRunResumeEffortRejectsLiveAndMixedActionsBeforeExec(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		members    []team.Member
+		liveRole   string
+		effort     string
+		wantTarget string
+	}{
+		{
+			name:       "live target",
+			members:    []team.Member{{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"}},
+			liveRole:   "qa",
+			effort:     "qa=max",
+			wantTarget: "qa (live)",
+		},
+		{
+			name: "mixed targets",
+			members: []team.Member{
+				{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+				{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96"},
+			},
+			liveRole:   "cto",
+			effort:     "qa=max,cto=high",
+			wantTarget: "cto (live)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			base := setupFakeAMQSessionRoots(t)
+			resumeChdir(t, dir)
+			if err := team.Write(dir, team.Team{Workstream: "issue-96", Members: tc.members}); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(team.ProfilePath(dir, team.DefaultProfile))
+			if err != nil {
+				t.Fatal(err)
+			}
+			agentDir := filepath.Join(base, "issue-96", "agents", tc.liveRole)
+			if err := os.MkdirAll(agentDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			myPID := os.Getpid()
+			writeWakeLock(t, agentDir, wakeLockFile{PID: myPID, Root: filepath.Join(base, "issue-96")})
+			oldProbe := defaultDuplicateLaunchProbe
+			defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+				PIDAlive: func(pid int) bool { return pid == myPID },
+				ProcessMatch: func(pid int, predicate func(string) bool) bool {
+					return predicate("amq wake --me " + tc.liveRole + " --root " + filepath.Join(base, "issue-96"))
+				},
+				Now: time.Now,
+			}
+			oldRun := runTmuxLaunchPlanForResume
+			called := false
+			runTmuxLaunchPlanForResume = func(tmuxLaunchPlan) error {
+				called = true
+				return nil
+			}
+			t.Cleanup(func() {
+				defaultDuplicateLaunchProbe = oldProbe
+				runTmuxLaunchPlanForResume = oldRun
+			})
+
+			_, _, err = captureOutput(t, func() error {
+				return runResume([]string{"--exec", "--effort", tc.effort})
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantTarget) || !strings.Contains(err.Error(), "only to launch-fresh") {
+				t.Fatalf("effort action rejection = %v", err)
+			}
+			if called {
+				t.Fatal("mixed invalid effort targets reached the tmux executor")
+			}
+			after, err := os.ReadFile(team.ProfilePath(dir, team.DefaultProfile))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Fatal("rejected resume effort changed the profile")
+			}
+		})
+	}
+}
+
+func TestRunResumeEffortPreviewExecCommandParity(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{{
+			Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-96",
+			ClaudeArgs: []string{"--chrome", "--effort", "low"},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(team.ProfilePath(dir, team.DefaultProfile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview, _, err := captureOutput(t, func() error {
+		return runResume([]string{"--effort", "qa=max"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldRun := runTmuxLaunchPlanForResume
+	oldVerify := verifyResumeExecLaunchRecordsNow
+	var executed tmuxLaunchPlan
+	runTmuxLaunchPlanForResume = func(plan tmuxLaunchPlan) error {
+		executed = plan
+		return nil
+	}
+	verifyResumeExecLaunchRecordsNow = func(checks []resumeExecLaunchCheck, _ map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+		results := make([]resumeExecLaunchResult, 0, len(checks))
+		for _, check := range checks {
+			results = append(results, resumeExecLaunchResult{Check: check, State: resumeExecLaunchStateLaunched})
+		}
+		return results
+	}
+	t.Cleanup(func() {
+		runTmuxLaunchPlanForResume = oldRun
+		verifyResumeExecLaunchRecordsNow = oldVerify
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runResume([]string{"--exec", "--stagger", "0", "--effort", "qa=max"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(executed.Panes) != 1 {
+		t.Fatalf("executed panes = %+v", executed.Panes)
+	}
+	command := executed.Panes[0].Command
+	if !strings.Contains(command, "--chrome") || !strings.Contains(command, "--effort max") || strings.Contains(command, "--effort low") {
+		t.Fatalf("executed effort command = %q", command)
+	}
+	if !strings.Contains(preview, command) {
+		t.Fatalf("preview/exec command mismatch:\npreview:\n%s\nexec: %s", preview, command)
+	}
+	after, err := os.ReadFile(team.ProfilePath(dir, team.DefaultProfile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("resume preview/exec effort override persisted to the profile")
+	}
+}
+
 func TestRunResumeRequiresTeam(t *testing.T) {
 	dir := t.TempDir()
 	resumeChdir(t, dir)

--- a/internal/cli/run_start_discovery.go
+++ b/internal/cli/run_start_discovery.go
@@ -34,6 +34,7 @@ func inspectRunStartWizardProject(project string) (runwizard.ProjectContext, err
 		Project:           root,
 		PreferredBinaries: map[string]string{},
 	}
+	ctx.Catalog = loadAgentCatalogAndWarn(root)
 	for _, entry := range catalog.All() {
 		ctx.PreferredBinaries[entry.ID] = entry.PreferredBinary
 	}

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
 	"github.com/omriariav/amq-squad/v2/internal/catalog"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
@@ -246,6 +247,7 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 	}
 	if input.EffortSet {
 		var effortErr error
+		agentCatalog := loadAgentCatalogAndWarn(r.Project)
 		if r.TeamPresent && !r.FreshRoster {
 			efforts, parseErr := parseEffortOverrides(input.Effort)
 			if parseErr != nil {
@@ -253,10 +255,10 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 			} else if existing, readErr := team.ReadProfile(r.Project, r.Profile); readErr != nil {
 				effortErr = fmt.Errorf("read team profile %q: %w", r.Profile, readErr)
 			} else {
-				_, effortErr = applyLaunchEffortOverrides(existing.Members, efforts)
+				_, effortErr = applyLaunchEffortOverridesCatalogMode(existing.Members, efforts, agentCatalog, false)
 			}
 		} else {
-			effortErr = validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort)
+			effortErr = validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort, agentCatalog)
 		}
 		if effortErr != nil {
 			return add(runStartPreflightInvalidEffort, effortErr.Error(), "use role=automatic|low|medium|high assignments")
@@ -265,7 +267,7 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 	return r
 }
 
-func validateRunStartFreshEffort(rolesRaw, binaryRaw, effortRaw string) error {
+func validateRunStartFreshEffort(rolesRaw, binaryRaw, effortRaw string, agentCatalog agentcatalog.Catalog) error {
 	efforts, err := parseEffortOverrides(effortRaw)
 	if err != nil {
 		return err
@@ -304,7 +306,7 @@ func validateRunStartFreshEffort(rolesRaw, binaryRaw, effortRaw string) error {
 		if binary == "" {
 			continue // team init owns the missing-binary error for custom roles.
 		}
-		if _, err := effortArgsForBinary(binary, effort); err != nil {
+		if _, _, err := effortArgsForBinaryCatalog(binary, effort, agentCatalog); err != nil {
 			return fmt.Errorf("--effort %s=%s: %w", role, effort, err)
 		}
 	}

--- a/internal/cli/run_start_preflight_test.go
+++ b/internal/cli/run_start_preflight_test.go
@@ -36,9 +36,19 @@ func TestRunStartPreflightExistingProfileEffortIsLaunchOnlyAndValid(t *testing.T
 	if err := team.WriteProfile(dir, team.DefaultProfile, team.Team{Project: dir, Members: []team.Member{{Role: "cto", Binary: "codex", Session: "sess"}}}); err != nil {
 		t.Fatal(err)
 	}
-	result := runStartPreflight(runStartPreflightInput{Project: dir, Session: "sess", Visibility: "sibling-tabs", Effort: "cto=high", EffortSet: true})
+	var result runStartPreflightResult
+	_, stderr, err := captureOutput(t, func() error {
+		result = runStartPreflight(runStartPreflightInput{Project: dir, Session: "sess", Visibility: "sibling-tabs", Effort: "cto=FutureTier", EffortSet: true})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(result.Issues) != 0 {
 		t.Fatalf("preflight = %+v", result)
+	}
+	if strings.Contains(stderr, "not in the merged catalog") {
+		t.Fatalf("preflight must validate quietly so the command surface warns once: %q", stderr)
 	}
 	stored, err := team.ReadProfile(dir, team.DefaultProfile)
 	if err != nil {
@@ -49,12 +59,14 @@ func TestRunStartPreflightExistingProfileEffortIsLaunchOnlyAndValid(t *testing.T
 	}
 }
 
-func TestRunStartPreflightValidatesEffortAgainstSelectedBinary(t *testing.T) {
+func TestRunStartPreflightAcceptsCurrentAndCustomEffortForSupportedBinary(t *testing.T) {
 	dir := t.TempDir()
-	result := runStartPreflight(runStartPreflightInput{
-		Project: dir, Session: "sess", Roles: "qa", Binary: "qa=claude", Visibility: "sibling-tabs", Effort: "qa=xhigh", EffortSet: true,
-	})
-	if len(result.Issues) != 1 || result.Issues[0].Code != runStartPreflightInvalidEffort || !strings.Contains(result.Issues[0].Detail, "unsupported claude effort") {
-		t.Fatalf("preflight = %+v", result)
+	for _, effort := range []string{"xhigh", "max", "FutureTier"} {
+		result := runStartPreflight(runStartPreflightInput{
+			Project: dir, Session: "sess", Roles: "qa", Binary: "qa=claude", Visibility: "sibling-tabs", Effort: "qa=" + effort, EffortSet: true,
+		})
+		if len(result.Issues) != 0 {
+			t.Fatalf("effort %q preflight = %+v", effort, result)
+		}
 	}
 }

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -268,6 +268,7 @@ func prepareRunStartWizard(args []string) (runwizard.Spec, runwizard.NumberedOpt
 	}
 	opts := runwizard.NumberedOptions{
 		InspectProject: runStartWizardInspectProject,
+		LoadCatalog:    loadAgentCatalogAndWarn,
 		ProfileExists: func(project, profile string) bool {
 			return team.ExistsProfile(strings.TrimSpace(project), strings.TrimSpace(profile))
 		},

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -257,6 +257,7 @@ Examples:
 	if err != nil {
 		return fmt.Errorf("getwd: %w", err)
 	}
+	agentCatalog := loadAgentCatalogAndWarn(cwd)
 
 	profileExists := team.ExistsProfile(cwd, profile)
 	if profileExists && !*force && !*dryRun {
@@ -440,7 +441,7 @@ Examples:
 			m.Model = strings.TrimSpace(model)
 		}
 		if effort, ok := effortOverrides[id]; ok {
-			if err := applyMemberEffort(&m, effort); err != nil {
+			if err := applyMemberEffortCatalog(&m, effort, agentCatalog); err != nil {
 				return err
 			}
 		}
@@ -747,7 +748,7 @@ func runTeamShow(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team show - print the launch commands for this project's team
 
 Usage:
-  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted] [--model role=model,...] [--codex-args args] [--claude-args args] [--force-duplicate] [--no-gitignore] [--symphony] [--json]
+  amq-squad team show [--session name] [--fresh] [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted] [--model role=model,...] [--effort role=level,...] [--codex-args args] [--claude-args args] [--force-duplicate] [--no-gitignore] [--symphony] [--json]
 
 Examples:
   amq-squad team show
@@ -842,6 +843,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 	if len(t.Members) == 0 {
 		return fmt.Errorf("team has no members")
 	}
+	agentCatalog := loadAgentCatalogAndWarn(projectDir)
 	workstream, err := resolveTeamWorkstreamName(t, opts.RequestedSession, opts.ExplicitSession)
 	if err != nil {
 		return err
@@ -864,7 +866,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
 	}
 	t.Members = active
-	t.Members, err = applyLaunchEffortOverrides(t.Members, opts.EffortOverrides)
+	t.Members, err = applyLaunchEffortOverridesCatalog(t.Members, opts.EffortOverrides, agentCatalog)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -128,6 +128,7 @@ Usage:
     [--target current-window|new-window|new-session] [--layout vertical|horizontal|tiled]
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|approve-for-me|trusted] [--model role=model,...]
+    [--effort role=level,...]
     [--codex-args args] [--claude-args args]
     [--force-duplicate] [--no-gitignore] [--symphony] [--dry-run]
 
@@ -193,6 +194,7 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 	if len(t.Members) == 0 {
 		return fmt.Errorf("team has no members")
 	}
+	agentCatalog := loadAgentCatalogAndWarn(cwd)
 	workstream, err := resolveTeamWorkstreamName(t, opts.Workstream, explicitSession)
 	if err != nil {
 		return err
@@ -206,7 +208,7 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 		return fmt.Errorf("no team members are pinned to session %q (all %d member(s) belong to other sessions)", workstream, len(t.Members))
 	}
 	t.Members = active
-	t.Members, err = applyLaunchEffortOverrides(t.Members, opts.EffortOverrides)
+	t.Members, err = applyLaunchEffortOverridesCatalog(t.Members, opts.EffortOverrides, agentCatalog)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -26,7 +26,7 @@ func runTeamMember(args []string) error {
 
 Usage:
   amq-squad team member add <role> --binary <claude|codex> [--handle H]
-      [--session S] [--model M] [--claude-args "…"] [--codex-args "…"]
+      [--session S] [--model M] [--effort E] [--claude-args "…"] [--codex-args "…"]
       [--spawn-origin NAME] [--spawn-depth N]
       [--project DIR] [--profile NAME] [--launch] [--target new-window] [--dry-run] [--json]
   amq-squad team member rm <role> [--project DIR] [--profile NAME]
@@ -151,6 +151,7 @@ func runTeamMemberAdd(args []string) error {
 	handleFlag := fs.String("handle", "", "AMQ handle (defaults to the role)")
 	sessionFlag := fs.String("session", "", "AMQ workstream session (defaults to the team's existing session)")
 	modelFlag := fs.String("model", "", "native model name passed to the binary")
+	effortFlag := fs.String("effort", "", "native effort tier for this member; automatic emits no effort arg")
 	spawnOriginFlag := fs.String("spawn-origin", "", "override recorded composition origin (default: AM_ME or operator/manual)")
 	spawnDepthFlag := fs.Int("spawn-depth", -1, "override recorded composition depth (default: inferred from origin)")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this member")
@@ -208,6 +209,7 @@ func runTeamMemberAdd(args []string) error {
 	if err != nil {
 		return err
 	}
+	agentCatalog := loadAgentCatalogAndWarn(projectDir)
 
 	var added team.Member
 	buildAdded := func(t team.Team) (team.Member, error) {
@@ -247,6 +249,16 @@ func runTeamMemberAdd(args []string) error {
 		} else {
 			added.CodexArgs = codexArgs
 		}
+		if flagWasSet(fs, "effort") {
+			if bin == "claude" {
+				added.ClaudeArgs = stripNativeEffortArgs(added.ClaudeArgs, bin)
+			} else {
+				added.CodexArgs = stripNativeEffortArgs(added.CodexArgs, bin)
+			}
+			if err := applyMemberEffortCatalog(&added, *effortFlag, agentCatalog); err != nil {
+				return team.Member{}, err
+			}
+		}
 		return added, nil
 	}
 	if *dryRunFlag {
@@ -257,6 +269,12 @@ func runTeamMemberAdd(args []string) error {
 		added, err = buildAdded(t)
 		if err != nil {
 			return err
+		}
+		if *jsonOut {
+			return printJSONEnvelope("team_member_add", mutationResult{
+				Command: "team member add", Status: "preview", Project: projectDir,
+				Session: added.Session, Profile: profile, Role: added.Role, Handle: added.Handle,
+			})
 		}
 		fmt.Printf("# preview: would add %s (%s) to profile %s\n", added.Role, added.Binary, profile)
 		if *launchFlag {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -82,6 +83,7 @@ func runTeamResume(args []string) error {
 	noBootstrap := fs.Bool("no-bootstrap", false, "emit fresh launch commands that skip the generated bootstrap prompt")
 	trustRaw := fs.String("trust", "", "Codex trust profile for fresh members: approve-for-me (default), sandboxed, or trusted")
 	modelFlag := fs.String("model", "", "per-persona model overrides for fresh members, e.g. cto=gpt-5.6-sol,fullstack=sonnet")
+	effortFlag := fs.String("effort", "", "per-persona effort overrides for launch-fresh members, e.g. cto=xhigh,fullstack=max")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for fresh members, e.g. '--enable goals'")
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for fresh members, e.g. '--chrome'")
 	projectFlag := fs.String("project", "", "project/team-home directory to plan (default: cwd)")
@@ -96,6 +98,7 @@ Usage:
                         [--restore-existing] [--dry-run] [--json] [--force-duplicate]
                         [--no-bootstrap] [--trust sandboxed|approve-for-me|trusted]
                         [--model role=model,...]
+                        [--effort role=level,...]
                         [--codex-args args] [--claude-args args]
 
 Inspects .amq-squad/team.json plus local launch history and live-agent
@@ -169,6 +172,7 @@ Examples:
 		TrustRaw:         *trustRaw,
 		ExplicitTrust:    flagWasSet(fs, "trust"),
 		ModelRaw:         *modelFlag,
+		EffortRaw:        *effortFlag,
 		CodexArgsRaw:     *codexArgsRaw,
 		ClaudeArgsRaw:    *claudeArgsRaw,
 		DryRun:           *dryRun,
@@ -197,6 +201,7 @@ type resumeExecution struct {
 	TrustRaw      string
 	ExplicitTrust bool
 	ModelRaw      string
+	EffortRaw     string
 	CodexArgsRaw  string
 	ClaudeArgsRaw string
 	DryRun        bool
@@ -346,6 +351,10 @@ func executeResume(r resumeExecution) error {
 		return fmt.Errorf("parse --model: %w", err)
 	}
 	modelOverrides = lowercaseKeys(modelOverrides)
+	effortOverrides, err := parseEffortOverrides(r.EffortRaw)
+	if err != nil {
+		return err
+	}
 	binaryArgs, err := parseBinaryArgFlags(r.CodexArgsRaw, r.ClaudeArgsRaw)
 	if err != nil {
 		return err
@@ -401,6 +410,9 @@ func executeResume(r resumeExecution) error {
 	if err := validateModelOverrideKeys(modelOverrides, memberRoles); err != nil {
 		return err
 	}
+	if err := validateEffortOverrideKeys(effortOverrides, memberRoles); err != nil {
+		return err
+	}
 
 	// Optional --role subset: restrict the plan (and --exec) to the named roles.
 	// Validate each against the roster up front so a typo fails clearly instead
@@ -437,12 +449,13 @@ func executeResume(r resumeExecution) error {
 
 	squadBin := teamSquadBin()
 	plans := make([]resumePlan, 0, len(t.Members))
+	planInputs := make(map[string]memberPlanInput, len(t.Members))
 	recordCount := 0
 	for _, m := range orderedTeamMembers(t.Members) {
 		if len(roleSelected) > 0 && !roleSelected[strings.ToLower(m.Role)] {
 			continue
 		}
-		plan, err := planMemberResume(memberPlanInput{
+		input := memberPlanInput{
 			Member:         m,
 			Team:           t,
 			Workstream:     workstream,
@@ -455,17 +468,55 @@ func executeResume(r resumeExecution) error {
 			ModelOverrides: modelOverrides,
 			Profile:        r.Profile,
 			Probe:          probe,
-		})
+		}
+		plan, err := planMemberResume(input)
 		if err != nil {
 			return err
 		}
 		if plan.HasRestoreRecord {
 			recordCount++
 		}
+		planInputs[strings.ToLower(strings.TrimSpace(plan.Role))] = input
 		plans = append(plans, plan)
 	}
 	if namespaceConflict != nil {
 		plans = blockResumePlansForNamespaceConflict(plans, namespaceConflict)
+	}
+	if len(effortOverrides) > 0 {
+		planIndexes := make(map[string]int, len(plans))
+		for i, plan := range plans {
+			planIndexes[strings.ToLower(strings.TrimSpace(plan.Role))] = i
+		}
+		var invalid []string
+		for role := range effortOverrides {
+			index, ok := planIndexes[role]
+			if !ok {
+				invalid = append(invalid, fmt.Sprintf("%s (not selected)", role))
+				continue
+			}
+			plan := plans[index]
+			if plan.Action != resumeFresh {
+				invalid = append(invalid, fmt.Sprintf("%s (%s)", role, plan.Action))
+			}
+		}
+		if len(invalid) > 0 {
+			sort.Strings(invalid)
+			return fmt.Errorf("--effort applies only to launch-fresh members; override target(s) are not launch-fresh: %s", strings.Join(invalid, ", "))
+		}
+		agentCatalog := loadAgentCatalogAndWarn(r.ProjectDir)
+		for role, effort := range effortOverrides {
+			input := planInputs[role]
+			switch normalizedAgentBinary(input.Member.Binary) {
+			case "codex":
+				input.Member.CodexArgs = stripNativeEffortArgs(input.Member.CodexArgs, "codex")
+			case "claude":
+				input.Member.ClaudeArgs = stripNativeEffortArgs(input.Member.ClaudeArgs, "claude")
+			}
+			if err := applyMemberEffortCatalog(&input.Member, effort, agentCatalog); err != nil {
+				return err
+			}
+			plans[planIndexes[role]].Command = freshLaunchCommand(input)
+		}
 	}
 
 	// --restore-existing checks that restorable records EXIST for the

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -48,6 +48,7 @@ Usage:
     [--layout vertical|horizontal|tiled]
     [--terminal-session name] [--stagger 750ms] [--no-bootstrap]
     [--trust sandboxed|approve-for-me|trusted] [--model role=model,...]
+    [--effort role=level,...]
     [--codex-args args] [--claude-args args]
     [--force-duplicate] [--no-gitignore] [--symphony]
     [--seed-from REF [--force]] [--dry-run]

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -656,6 +656,40 @@ func TestRunUpLiveHonorsBackendFlags(t *testing.T) {
 	}
 }
 
+func TestRunUpCustomEffortIsLaunchOnlyAndWarns(t *testing.T) {
+	backend := useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{
+			Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-98",
+			ClaudeArgs: []string{"--chrome", "--effort", "low"},
+		}},
+	})
+
+	_, stderr, err := captureOutput(t, func() error {
+		return runUp([]string{"--terminal", "fake", "--session", "issue-98", "--effort", "qa=FutureTier", "--no-attach"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(stderr, "not in the merged catalog") != 1 {
+		t.Fatalf("stderr = %q", stderr)
+	}
+	if len(backend.teams) != 1 {
+		t.Fatalf("backend teams = %d", len(backend.teams))
+	}
+	if want := []string{"--chrome", "--effort", "FutureTier"}; !reflect.DeepEqual(backend.teams[0].Members[0].ClaudeArgs, want) {
+		t.Fatalf("effective args = %#v, want %#v", backend.teams[0].Members[0].ClaudeArgs, want)
+	}
+	stored, err := team.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"--chrome", "--effort", "low"}; !reflect.DeepEqual(stored.Members[0].ClaudeArgs, want) {
+		t.Fatalf("profile args mutated: %#v", stored.Members[0].ClaudeArgs)
+	}
+}
+
 // TestRunUpDryRunDoesNotCallBackend guards the contract that --dry-run on
 // `up` is the launch-command preview, never the tmux backend dry-run.
 func TestRunUpDryRunDoesNotCallBackend(t *testing.T) {

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -18,7 +18,9 @@ const (
 	stageGlobalRoot
 	stageGlobalAgent
 	stageGlobalModel
+	stageGlobalModelCustom
 	stageGlobalEffort
+	stageGlobalEffortCustom
 	stageGlobalNativeArgs
 	stageGlobalWindow
 	stageProfile
@@ -29,13 +31,17 @@ const (
 	stageExistingModel
 	stageExistingModelCustom
 	stageExistingEffort
+	stageExistingEffortCustom
 	stageResumeMember
 	stageResumeModelCustom
+	stageResumeEffort
+	stageResumeEffortCustom
 	stageRoles
 	stageRoleBinary
 	stageRoleModel
 	stageRoleModelCustom
 	stageRoleEffort
+	stageRoleEffortCustom
 	stageLead
 	stageLeadMode
 	stageOperator
@@ -312,8 +318,12 @@ func (m BubbleModel) title() string {
 		return "Which agent should run the global orchestrator?"
 	case stageGlobalModel:
 		return "Model for the global orchestrator"
+	case stageGlobalModelCustom:
+		return "Custom model for the global orchestrator"
 	case stageGlobalEffort:
 		return "Effort for the global orchestrator"
+	case stageGlobalEffortCustom:
+		return "Custom effort for the global orchestrator"
 	case stageGlobalNativeArgs:
 		return "Extra native arguments"
 	case stageGlobalWindow:
@@ -334,6 +344,8 @@ func (m BubbleModel) title() string {
 		return "Custom model override · " + m.currentMember().Role
 	case stageExistingEffort:
 		return "Effort override · " + m.currentMember().Role
+	case stageExistingEffortCustom:
+		return "Custom effort override · " + m.currentMember().Role
 	case stageResumeMember:
 		member := m.currentResumeMember()
 		if member.Action == MemberActionFresh {
@@ -342,6 +354,10 @@ func (m BubbleModel) title() string {
 		return "Resume action · " + member.Role
 	case stageResumeModelCustom:
 		return "Custom model for fresh " + m.currentResumeMember().Role
+	case stageResumeEffort:
+		return "Effort for fresh " + m.currentResumeMember().Role
+	case stageResumeEffortCustom:
+		return "Custom effort for fresh " + m.currentResumeMember().Role
 	case stageRoles:
 		return "Choose fresh-roster roles"
 	case stageRoleBinary:
@@ -352,6 +368,8 @@ func (m BubbleModel) title() string {
 		return "Custom model · " + m.currentRole()
 	case stageRoleEffort:
 		return "Effort · " + m.currentRole()
+	case stageRoleEffortCustom:
+		return "Custom effort · " + m.currentRole()
 	case stageLead:
 		return "Choose the visible lead"
 	case stageLeadMode:
@@ -395,9 +413,13 @@ func (m BubbleModel) note() string {
 	case stageGlobalAgent:
 		return "The global orchestrator coordinates project namespaces but owns no project wake mailbox."
 	case stageGlobalModel:
-		return "Leave blank to let the selected agent choose its default model."
+		return "Catalog choices are suggestions; Custom accepts any model name."
+	case stageGlobalModelCustom:
+		return "Enter any model name, or leave blank for automatic."
 	case stageGlobalEffort:
-		return "Automatic lets the selected agent choose its default reasoning effort."
+		return "Catalog choices are suggestions; Custom accepts any effort tier."
+	case stageGlobalEffortCustom:
+		return "Unknown tiers are passed through exactly and may still be rejected by the underlying binary."
 	case stageGlobalNativeArgs:
 		return "These arguments pass to the selected agent; effort is controlled separately."
 	case stageGlobalWindow:
@@ -418,7 +440,9 @@ func (m BubbleModel) note() string {
 	case stageExistingModelCustom:
 		return "Enter a model for this launch only, or leave blank to keep the profile value."
 	case stageExistingEffort:
-		return "This replaces only the native effort args in the in-memory launch plan."
+		return "Catalog choices are suggestions. This replaces only the native effort args in the in-memory launch plan."
+	case stageExistingEffortCustom:
+		return "Enter any effort tier for this launch only; amq-squad warns but passes unknown tiers through."
 	case stageResumeMember:
 		member := m.currentResumeMember()
 		switch member.Action {
@@ -427,16 +451,24 @@ func (m BubbleModel) note() string {
 		case MemberActionRestore:
 			return fmt.Sprintf("Saved launch is read-only: binary=%s · model=%s · effort=%s · saved extra args=%s", defaultString(member.SavedBinary, member.Binary), defaultString(member.SavedModel, "automatic"), defaultString(member.SavedEffort, "automatic"), FormatSavedNativeArgs(member.SavedNativeArgs))
 		default:
-			return "Only launch-fresh members may receive a model override; resume offers no effort override."
+			return "Only launch-fresh members may receive model or effort overrides."
 		}
 	case stageResumeModelCustom:
 		return "This model applies only to the fresh member; leave blank to keep the stored profile model."
+	case stageResumeEffort:
+		return "This effort applies only to the launch-fresh member; catalog choices are advisory."
+	case stageResumeEffortCustom:
+		return "Unknown tiers pass through exactly; restored and live members remain immutable."
 	case stageRoles:
 		return "Comma-separated role ids. Defaults are shown in the field."
 	case stageRoleModel:
 		return "Models pass through to the selected binary verbatim; custom accepts any name."
 	case stageRoleModelCustom:
 		return "Enter any model name, or leave blank for automatic."
+	case stageRoleEffort:
+		return "Catalog choices are suggestions; Custom accepts any tier for the selected binary."
+	case stageRoleEffortCustom:
+		return "Enter any effort tier, or leave blank for automatic."
 	case stageTopology:
 		return "The diagram is the topology that the canonical visibility flag selects."
 	case stageLayoutPreset:
@@ -506,6 +538,7 @@ func (m BubbleModel) summary() string {
 		} else {
 			parts = append(parts, "Commands  unavailable: "+err.Error())
 		}
+		parts = append(parts, effortCatalogWarnings(m.spec, m.ctx)...)
 		return strings.Join(parts, "\n")
 	}
 	parts := []string{
@@ -557,13 +590,14 @@ func (m BubbleModel) summary() string {
 	} else {
 		parts = append(parts, "Commands  unavailable: "+err.Error())
 	}
+	parts = append(parts, effortCatalogWarnings(m.spec, m.ctx)...)
 	parts = append(parts, "", TopologyPreview(m.spec.Visibility))
 	return strings.Join(parts, "\n")
 }
 
 func (m BubbleModel) isTextStage() bool {
 	switch m.stage {
-	case stageProject, stageGlobalRoot, stageGlobalModel, stageGlobalNativeArgs, stageGlobalWindow, stageNewProfile, stageSession, stageExistingModelCustom, stageResumeModelCustom, stageRoles, stageRoleModelCustom, stageLead, stageGoal, stageSeed:
+	case stageProject, stageGlobalRoot, stageGlobalModelCustom, stageGlobalEffortCustom, stageGlobalNativeArgs, stageGlobalWindow, stageNewProfile, stageSession, stageExistingModelCustom, stageExistingEffortCustom, stageResumeModelCustom, stageResumeEffortCustom, stageRoles, stageRoleModelCustom, stageRoleEffortCustom, stageLead, stageGoal, stageSeed:
 		return true
 	default:
 		return false
@@ -581,9 +615,12 @@ func (m *BubbleModel) configureStage() {
 		value = m.spec.Project
 	case stageGlobalRoot:
 		value = m.spec.GlobalRoot
-	case stageGlobalModel:
+	case stageGlobalModelCustom:
 		value = m.spec.GlobalModel
-		placeholder = "optional"
+		placeholder = "leave blank for automatic"
+	case stageGlobalEffortCustom:
+		value = m.spec.GlobalEffort
+		placeholder = "leave blank for automatic"
 	case stageGlobalNativeArgs:
 		if strings.EqualFold(m.spec.GlobalAgent, "codex") {
 			value = m.spec.GlobalCodexArgs
@@ -598,15 +635,24 @@ func (m *BubbleModel) configureStage() {
 	case stageSession:
 		value = defaultString(m.newSessionPrefill, m.ctx.SessionSuggestion)
 	case stageExistingModelCustom:
-		value = parseAssignments(m.spec.Model)[m.currentMember().Role]
+		value = defaultString(parseAssignments(m.spec.Model)[m.currentMember().Role], m.currentMember().Model)
 		placeholder = "leave blank to keep " + defaultString(m.currentMember().Model, "automatic")
+	case stageExistingEffortCustom:
+		value = defaultString(parseAssignments(m.spec.Effort)[m.currentMember().Role], m.currentMember().Effort)
+		placeholder = "leave blank to keep " + defaultString(m.currentMember().Effort, effortAutomatic)
 	case stageResumeModelCustom:
-		value = parseAssignments(m.spec.Model)[m.currentResumeMember().Role]
+		value = defaultString(parseAssignments(m.spec.Model)[m.currentResumeMember().Role], m.currentResumeMember().Model)
 		placeholder = "leave blank to keep " + defaultString(m.currentResumeMember().Model, "automatic")
+	case stageResumeEffortCustom:
+		value = defaultString(parseAssignments(m.spec.Effort)[m.currentResumeMember().Role], m.currentResumeMember().Effort)
+		placeholder = "leave blank to keep " + defaultString(m.currentResumeMember().Effort, effortAutomatic)
 	case stageRoles:
 		value = defaultString(m.spec.Roles, "cto,senior-dev,qa")
 	case stageRoleModelCustom:
 		value = parseAssignments(m.spec.Model)[m.currentRole()]
+		placeholder = "leave blank for automatic"
+	case stageRoleEffortCustom:
+		value = parseAssignments(m.spec.Effort)[m.currentRole()]
 		placeholder = "leave blank for automatic"
 	case stageLead:
 		value = defaultString(m.spec.Lead, defaultLead(m.roleOrder))
@@ -632,8 +678,10 @@ func (m BubbleModel) choices() []choice {
 		return []choice{{value: "project", label: "Project squad"}, {value: "global", label: "Global / NOC orchestrator"}}
 	case stageGlobalAgent:
 		return []choice{{value: "claude", label: "Claude"}, {value: "codex", label: "Codex"}}
+	case stageGlobalModel:
+		return modelChoicesCatalog(m.spec.GlobalAgent, m.ctx.Catalog)
 	case stageGlobalEffort:
-		return effortChoices(m.spec.GlobalAgent)
+		return effortChoicesCatalog(m.spec.GlobalAgent, m.ctx.Catalog)
 	case stageProfile:
 		choices := make([]choice, 0, len(m.ctx.Profiles)+1)
 		for _, profile := range m.ctx.Profiles {
@@ -654,21 +702,24 @@ func (m BubbleModel) choices() []choice {
 	case stageExistingOverride:
 		return []choice{{value: "keep", label: "Keep profile model and effort"}, {value: "override", label: "Override this role for this launch only"}}
 	case stageExistingModel:
-		return existingOverrideModelChoices(m.currentMember())
+		return existingOverrideModelChoicesCatalog(m.currentMember(), m.ctx.Catalog)
 	case stageExistingEffort:
-		return effortChoices(m.currentMember().Binary)
+		return existingOverrideEffortChoices(m.currentMember(), m.ctx.Catalog)
 	case stageResumeMember:
 		member := m.currentResumeMember()
 		if member.Action == MemberActionFresh {
-			return existingOverrideModelChoices(MemberSummary{Role: member.Role, Binary: member.Binary, Model: member.Model, Effort: member.Effort})
+			return existingOverrideModelChoicesCatalog(MemberSummary{Role: member.Role, Binary: member.Binary, Model: member.Model, Effort: member.Effort}, m.ctx.Catalog)
 		}
 		return []choice{{value: "continue", label: fmt.Sprintf("Continue · %s remains %s", member.Role, member.Action)}}
+	case stageResumeEffort:
+		member := m.currentResumeMember()
+		return existingOverrideEffortChoices(MemberSummary{Role: member.Role, Binary: member.Binary, Model: member.Model, Effort: member.Effort}, m.ctx.Catalog)
 	case stageRoleBinary:
 		return []choice{{value: "codex", label: "Codex"}, {value: "claude", label: "Claude"}}
 	case stageRoleModel:
-		return modelChoices(parseAssignments(m.spec.Binary)[m.currentRole()])
+		return modelChoicesCatalog(parseAssignments(m.spec.Binary)[m.currentRole()], m.ctx.Catalog)
 	case stageRoleEffort:
-		return effortChoices(parseAssignments(m.spec.Binary)[m.currentRole()])
+		return effortChoicesCatalog(parseAssignments(m.spec.Binary)[m.currentRole()], m.ctx.Catalog)
 	case stageLeadMode:
 		return []choice{{value: "builder", label: "Builder · lead may implement and delegate"}, {value: "planner", label: "Planner · lead dispatches and reviews; workers mutate"}}
 	case stageOperator:
@@ -717,14 +768,6 @@ func (m BubbleModel) choices() []choice {
 	}
 }
 
-func effortChoices(binary string) []choice {
-	choices := []choice{{value: "automatic", label: "Automatic"}, {value: "low", label: "Low"}, {value: "medium", label: "Medium"}, {value: "high", label: "High"}}
-	if strings.EqualFold(binary, "codex") {
-		choices = append(choices, choice{value: "minimal", label: "Minimal"}, choice{value: "xhigh", label: "Extra high"})
-	}
-	return choices
-}
-
 func (m BubbleModel) defaultCursor() int {
 	choices := m.choices()
 	want := ""
@@ -733,8 +776,10 @@ func (m BubbleModel) defaultCursor() int {
 		want = defaultString(strings.ToLower(strings.TrimSpace(m.spec.Scope)), "project")
 	case stageGlobalAgent:
 		want = defaultString(strings.ToLower(strings.TrimSpace(m.spec.GlobalAgent)), "claude")
+	case stageGlobalModel:
+		want = defaultModelChoiceCatalog(m.spec.GlobalModel, m.spec.GlobalAgent, m.ctx.Catalog)
 	case stageGlobalEffort:
-		want = defaultString(strings.ToLower(strings.TrimSpace(m.spec.GlobalEffort)), effortAutomatic)
+		want = defaultEffortChoiceCatalog(m.spec.GlobalEffort, m.spec.GlobalAgent, m.ctx.Catalog, effortAutomatic)
 	case stageProfile:
 		want = m.spec.Profile
 		if findProfile(m.ctx.Profiles, want) < 0 {
@@ -745,24 +790,36 @@ func (m BubbleModel) defaultCursor() int {
 	case stageExistingModel:
 		// An empty override maps to automatic, which this list omits; the
 		// find-loop then falls through to keep at index zero.
-		want = defaultModelChoice(parseAssignments(m.spec.Model)[m.currentMember().Role], m.currentMember().Binary)
+		want = defaultModelChoiceCatalog(parseAssignments(m.spec.Model)[m.currentMember().Role], m.currentMember().Binary, m.ctx.Catalog)
 	case stageExistingEffort:
-		want = defaultString(m.currentMember().Effort, effortAutomatic)
+		prefill := parseAssignments(m.spec.Effort)[m.currentMember().Role]
+		if strings.TrimSpace(prefill) == "" {
+			want = effortKeepChoice
+		} else {
+			want = defaultEffortChoiceCatalog(prefill, m.currentMember().Binary, m.ctx.Catalog, effortKeepChoice)
+		}
 	case stageResumeMember:
 		if m.currentResumeMember().Action == MemberActionFresh {
-			want = defaultModelChoice(parseAssignments(m.spec.Model)[m.currentResumeMember().Role], m.currentResumeMember().Binary)
+			want = defaultModelChoiceCatalog(parseAssignments(m.spec.Model)[m.currentResumeMember().Role], m.currentResumeMember().Binary, m.ctx.Catalog)
 		} else {
 			want = "continue"
 		}
+	case stageResumeEffort:
+		prefill := parseAssignments(m.spec.Effort)[m.currentResumeMember().Role]
+		if strings.TrimSpace(prefill) == "" {
+			want = effortKeepChoice
+		} else {
+			want = defaultEffortChoiceCatalog(prefill, m.currentResumeMember().Binary, m.ctx.Catalog, effortKeepChoice)
+		}
 	case stageRoleModel:
-		want = defaultModelChoice(parseAssignments(m.spec.Model)[m.currentRole()], parseAssignments(m.spec.Binary)[m.currentRole()])
+		want = defaultModelChoiceCatalog(parseAssignments(m.spec.Model)[m.currentRole()], parseAssignments(m.spec.Binary)[m.currentRole()], m.ctx.Catalog)
 	case stageRoleBinary:
 		want = parseAssignments(m.spec.Binary)[m.currentRole()]
 		if want == "" {
 			want = m.ctx.PreferredBinaries[m.currentRole()]
 		}
 	case stageRoleEffort:
-		want = defaultString(parseAssignments(m.spec.Effort)[m.currentRole()], effortAutomatic)
+		want = defaultEffortChoiceCatalog(parseAssignments(m.spec.Effort)[m.currentRole()], parseAssignments(m.spec.Binary)[m.currentRole()], m.ctx.Catalog, effortAutomatic)
 	case stageLeadMode:
 		want = defaultString(m.spec.LeadMode, "builder")
 	case stageOperator:
@@ -824,10 +881,16 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.spec.GlobalRoot = value
+		if m.opts.LoadCatalog != nil {
+			m.ctx.Catalog = m.opts.LoadCatalog(value)
+		}
 		m.transition(stageGlobalAgent)
-	case stageGlobalModel:
-		m.spec.GlobalModel = value
+	case stageGlobalModelCustom:
+		m.spec.GlobalModel = strings.TrimSpace(value)
 		m.transition(stageGlobalEffort)
+	case stageGlobalEffortCustom:
+		m.spec.GlobalEffort = strings.TrimSpace(value)
+		m.transition(stageGlobalNativeArgs)
 	case stageGlobalNativeArgs:
 		if strings.EqualFold(m.spec.GlobalAgent, "codex") {
 			m.spec.GlobalCodexArgs = value
@@ -871,11 +934,25 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 			m.spec.Model = removeAssignment(m.spec.Model, m.currentMember().Role)
 		}
 		m.transition(stageExistingEffort)
+	case stageExistingEffortCustom:
+		if value != "" && !strings.EqualFold(value, effortAutomatic) {
+			m.spec.Effort = setAssignment(m.spec.Effort, m.currentMember().Role, value)
+		} else {
+			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentMember().Role)
+		}
+		m.nextExistingMember()
 	case stageResumeModelCustom:
 		if value != "" {
 			m.spec.Model = setAssignment(m.spec.Model, m.currentResumeMember().Role, value)
 		} else {
 			m.spec.Model = removeAssignment(m.spec.Model, m.currentResumeMember().Role)
+		}
+		m.transition(stageResumeEffort)
+	case stageResumeEffortCustom:
+		if value != "" && !strings.EqualFold(value, effortAutomatic) {
+			m.spec.Effort = setAssignment(m.spec.Effort, m.currentResumeMember().Role, value)
+		} else {
+			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentResumeMember().Role)
 		}
 		m.nextResumeMember()
 	case stageRoles:
@@ -901,6 +978,18 @@ func (m BubbleModel) commitText() (tea.Model, tea.Cmd) {
 			m.spec.Model = setAssignment(m.spec.Model, m.currentRole(), value)
 		}
 		m.transition(stageRoleEffort)
+	case stageRoleEffortCustom:
+		if value == "" || strings.EqualFold(value, effortAutomatic) {
+			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentRole())
+		} else {
+			m.spec.Effort = setAssignment(m.spec.Effort, m.currentRole(), value)
+		}
+		m.roleIndex++
+		if m.roleIndex < len(m.roleOrder) {
+			m.transition(stageRoleBinary)
+		} else {
+			m.transition(stageLead)
+		}
 	case stageLead:
 		if value == "" {
 			m.err = fmt.Errorf("lead cannot be empty")
@@ -943,13 +1032,28 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 	case stageGlobalAgent:
 		m.spec.GlobalAgent = selected
 		m.transition(stageGlobalModel)
-	case stageGlobalEffort:
-		if selected == effortAutomatic {
-			m.spec.GlobalEffort = ""
-		} else {
-			m.spec.GlobalEffort = selected
+	case stageGlobalModel:
+		switch selected {
+		case modelCustomChoice:
+			m.transition(stageGlobalModelCustom)
+		case effortAutomatic:
+			m.spec.GlobalModel = ""
+			m.transition(stageGlobalEffort)
+		default:
+			m.spec.GlobalModel = selected
+			m.transition(stageGlobalEffort)
 		}
-		m.transition(stageGlobalNativeArgs)
+	case stageGlobalEffort:
+		switch selected {
+		case effortCustomChoice:
+			m.transition(stageGlobalEffortCustom)
+		case effortAutomatic:
+			m.spec.GlobalEffort = ""
+			m.transition(stageGlobalNativeArgs)
+		default:
+			m.spec.GlobalEffort = selected
+			m.transition(stageGlobalNativeArgs)
+		}
 	case stageProfile:
 		if selected == "__create__" {
 			if strings.TrimSpace(m.spec.Profile) != "" && findProfile(m.ctx.Profiles, m.spec.Profile) < 0 {
@@ -1007,8 +1111,16 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 			m.transition(stageExistingEffort)
 		}
 	case stageExistingEffort:
-		m.spec.Effort = setAssignment(m.spec.Effort, m.currentMember().Role, selected)
-		m.nextExistingMember()
+		switch selected {
+		case effortCustomChoice:
+			m.transition(stageExistingEffortCustom)
+		case effortKeepChoice:
+			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentMember().Role)
+			m.nextExistingMember()
+		default:
+			m.spec.Effort = setAssignment(m.spec.Effort, m.currentMember().Role, selected)
+			m.nextExistingMember()
+		}
 	case stageResumeMember:
 		member := m.currentResumeMember()
 		if member.Action != MemberActionFresh {
@@ -1020,9 +1132,21 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 			m.transition(stageResumeModelCustom)
 		case modelKeepChoice:
 			m.spec.Model = removeAssignment(m.spec.Model, member.Role)
-			m.nextResumeMember()
+			m.transition(stageResumeEffort)
 		default:
 			m.spec.Model = setAssignment(m.spec.Model, member.Role, selected)
+			m.transition(stageResumeEffort)
+		}
+	case stageResumeEffort:
+		member := m.currentResumeMember()
+		switch selected {
+		case effortCustomChoice:
+			m.transition(stageResumeEffortCustom)
+		case effortKeepChoice:
+			m.spec.Effort = removeAssignment(m.spec.Effort, member.Role)
+			m.nextResumeMember()
+		default:
+			m.spec.Effort = setAssignment(m.spec.Effort, member.Role, selected)
 			m.nextResumeMember()
 		}
 	case stageRoleBinary:
@@ -1040,6 +1164,10 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 			m.transition(stageRoleEffort)
 		}
 	case stageRoleEffort:
+		if selected == effortCustomChoice {
+			m.transition(stageRoleEffortCustom)
+			break
+		}
 		if selected == effortAutomatic {
 			m.spec.Effort = removeAssignment(m.spec.Effort, m.currentRole())
 		} else {
@@ -1271,9 +1399,9 @@ func (m BubbleModel) phaseIndex() int {
 		switch m.stage {
 		case stageScope, stageGlobalRoot:
 			return 0
-		case stageGlobalAgent, stageGlobalModel:
+		case stageGlobalAgent, stageGlobalModel, stageGlobalModelCustom:
 			return 1
-		case stageGlobalEffort, stageGlobalNativeArgs, stageGlobalWindow:
+		case stageGlobalEffort, stageGlobalEffortCustom, stageGlobalNativeArgs, stageGlobalWindow:
 			return 2
 		default:
 			return 3
@@ -1284,7 +1412,7 @@ func (m BubbleModel) phaseIndex() int {
 		return 0
 	case stageProfile, stageNewProfile, stageExistingSession, stageSession:
 		return 1
-	case stageExistingOverride, stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageResumeMember, stageResumeModelCustom, stageRoles, stageRoleBinary, stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageLead, stageLeadMode:
+	case stageExistingOverride, stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom, stageResumeMember, stageResumeModelCustom, stageResumeEffort, stageResumeEffortCustom, stageRoles, stageRoleBinary, stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageRoleEffortCustom, stageLead, stageLeadMode:
 		return 2
 	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 3

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -1412,12 +1412,12 @@ func (m BubbleModel) phaseIndex() int {
 		return 0
 	case stageProfile, stageNewProfile, stageExistingSession, stageSession:
 		return 1
-	case stageExistingOverride, stageRoles, stageRoleBinary, stageLead, stageLeadMode:
-		return 2
-	case stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom,
+	case stageExistingOverride, stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom,
 		stageResumeMember, stageResumeModelCustom, stageResumeEffort, stageResumeEffortCustom,
 		stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageRoleEffortCustom,
-		stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
+		stageRoles, stageRoleBinary, stageLead, stageLeadMode:
+		return 2
+	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 3
 	case stageGoal, stageSeed, stageResumeBrief:
 		return 4

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -1412,9 +1412,12 @@ func (m BubbleModel) phaseIndex() int {
 		return 0
 	case stageProfile, stageNewProfile, stageExistingSession, stageSession:
 		return 1
-	case stageExistingOverride, stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom, stageResumeMember, stageResumeModelCustom, stageResumeEffort, stageResumeEffortCustom, stageRoles, stageRoleBinary, stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageRoleEffortCustom, stageLead, stageLeadMode:
+	case stageExistingOverride, stageRoles, stageRoleBinary, stageLead, stageLeadMode:
 		return 2
-	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
+	case stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom,
+		stageResumeMember, stageResumeModelCustom, stageResumeEffort, stageResumeEffortCustom,
+		stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageRoleEffortCustom,
+		stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 3
 	case stageGoal, stageSeed, stageResumeBrief:
 		return 4

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
 )
 
 // flattenBubbleView strips the panel border and collapses the word-wrap that
@@ -101,7 +102,7 @@ func TestBubbleModelExistingProfileOverridesAndExplicitNotificationMismatchArePr
 	}
 	m.input.SetValue("launch-model")
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
-	m.cursor = 3 // high
+	m.cursor = 4 // high
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.stage != stageTopology || m.spec.OperatorMode != "separate_terminal" {
 		t.Fatalf("topology stage = %v mode %q", m.stage, m.spec.OperatorMode)
@@ -257,9 +258,10 @@ func TestBubbleResumeActionScopedControls(t *testing.T) {
 		state   RunState
 		members []SessionMemberSummary
 		model   string
+		effort  string
 	}{
 		{name: "all restore", records: 2, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore, SavedModel: "saved", SavedEffort: "high", SavedNativeArgs: []string{"--saved"}}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}},
-		{name: "restore fresh", records: 1, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Action: MemberActionFresh}}, model: "qa=gpt-5.6-sol"},
+		{name: "restore fresh", records: 1, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Action: MemberActionFresh}}, model: "qa=gpt-5.6-sol", effort: "qa=xhigh"},
 		{name: "live fresh", state: RunStatePartly, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionLive}, {Role: "qa", Binary: "codex", Action: MemberActionFresh}}, model: "qa=gpt-5.6-sol"},
 		{name: "live restore", records: 1, state: RunStatePartly, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionLive}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}},
 	}
@@ -287,8 +289,21 @@ func TestBubbleResumeActionScopedControls(t *testing.T) {
 					m.cursor = 1
 				}
 				m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+				if member.Action == MemberActionFresh {
+					if m.stage != stageResumeEffort {
+						t.Fatalf("fresh member effort stage=%v", m.stage)
+					}
+					if tt.effort != "" {
+						for i, item := range m.choices() {
+							if item.value == "xhigh" {
+								m.cursor = i
+							}
+						}
+					}
+					m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+				}
 			}
-			if m.stage != stageTopology || m.spec.Model != tt.model || m.spec.Effort != "" {
+			if m.stage != stageTopology || m.spec.Model != tt.model || m.spec.Effort != tt.effort {
 				t.Fatalf("post-member state stage=%v spec=%+v", m.stage, m.spec)
 			}
 			for _, wantStage := range []bubbleStage{stageLayoutPreset, stageOperator, stageOperatorNotifications, stageResumeBrief, stageConfirm} {
@@ -421,6 +436,143 @@ func TestGlobalBranchRunsThroughBothRealAdaptersToIdenticalReview(t *testing.T) 
 	}
 	if !strings.Contains(bubble.Spec.Scope, "global") || bubble.Spec.Backend != BackendGlobalStart {
 		t.Fatalf("bubble did not complete the global backend: %+v", bubble.Spec)
+	}
+}
+
+func TestGlobalCatalogChoicesMatchAcrossAdapters(t *testing.T) {
+	catalog := agentcatalog.Merge(agentcatalog.Builtins(), agentcatalog.Catalog{Binaries: map[string]agentcatalog.Binary{
+		"claude": {
+			Models:  []agentcatalog.Entry{{Value: "NeoModel", Label: "Neo model", Enabled: true}},
+			Efforts: []agentcatalog.Entry{{Value: "UltraTier", Label: "Ultra tier", Enabled: true}},
+		},
+	}})
+	loaded := []string{}
+	load := func(root string) agentcatalog.Catalog {
+		loaded = append(loaded, root)
+		return catalog
+	}
+	defaults := Spec{Scope: "project", GlobalRoot: "/neutral", GlobalAgent: "claude", GlobalWindow: "global-orch"}
+	m, err := NewBubbleModel(NumberedOptions{Defaults: defaults, LoadCatalog: load})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // global scope
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // root + catalog load
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // claude
+	if m.stage != stageGlobalModel {
+		t.Fatalf("global model stage = %v", m.stage)
+	}
+	for i, item := range m.choices() {
+		if item.value == "NeoModel" {
+			m.cursor = i
+		}
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i, item := range m.choices() {
+		if item.value == "UltraTier" {
+			m.cursor = i
+		}
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // native args
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // window
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // review
+
+	var numberedOut bytes.Buffer
+	numbered, err := RunNumbered(strings.NewReader("2\n\n\n6\n7\n\n\n"), &numberedOut, NumberedOptions{Defaults: defaults, LoadCatalog: load})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(m.spec, numbered) {
+		t.Fatalf("catalog adapter specs differ:\nbubble=%+v\nnumbered=%+v", m.spec, numbered)
+	}
+	if m.spec.GlobalModel != "NeoModel" || m.spec.GlobalEffort != "UltraTier" {
+		t.Fatalf("catalog selections = %+v", m.spec)
+	}
+	if got, want := loaded, []string{"/neutral", "/neutral"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("catalog roots = %v, want %v", got, want)
+	}
+	for _, want := range []string{"Neo model", "Ultra tier", "NeoModel", "UltraTier"} {
+		if !strings.Contains(numberedOut.String(), want) {
+			t.Fatalf("numbered output missing %q:\n%s", want, numberedOut.String())
+		}
+	}
+}
+
+func TestGlobalCustomEffortIsPreservedAndWarnedInBothReviews(t *testing.T) {
+	defaults := Spec{Scope: "project", GlobalRoot: "/neutral", GlobalAgent: "claude", GlobalEffort: "FutureTier", GlobalWindow: "global-orch"}
+	m, err := NewBubbleModel(NumberedOptions{Defaults: defaults})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyDown}, {Type: tea.KeyEnter}, // global
+		{Type: tea.KeyEnter}, // root
+		{Type: tea.KeyEnter}, // agent
+		{Type: tea.KeyEnter}, // automatic model
+		{Type: tea.KeyEnter}, // custom effort row
+		{Type: tea.KeyEnter}, // exact custom effort text
+		{Type: tea.KeyEnter}, // native args
+		{Type: tea.KeyEnter}, // window
+	} {
+		m = updateBubble(t, m, key)
+	}
+	if m.stage != stageConfirm || m.spec.GlobalEffort != "FutureTier" {
+		t.Fatalf("bubble custom global state = stage %v spec %+v", m.stage, m.spec)
+	}
+	if review := m.summary(); !strings.Contains(review, "Warning: effort global=FutureTier") || !strings.Contains(review, "passed through exactly") {
+		t.Fatalf("bubble review missing custom warning:\n%s", review)
+	}
+
+	var out bytes.Buffer
+	numbered, err := RunNumbered(strings.NewReader("2\n\n\n\n\n\n\n\n"), &out, NumberedOptions{Defaults: defaults})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numbered.GlobalEffort != "FutureTier" || !strings.Contains(out.String(), "Warning: effort global=FutureTier") {
+		t.Fatalf("numbered custom result=%+v output:\n%s", numbered, out.String())
+	}
+}
+
+func TestBubbleResumeUsesInjectedCatalogAndPrefillsStoredCustomValues(t *testing.T) {
+	catalog := agentcatalog.Merge(agentcatalog.Builtins(), agentcatalog.Catalog{Binaries: map[string]agentcatalog.Binary{
+		"claude": {
+			Models:  []agentcatalog.Entry{{Value: "NeoModel", Enabled: true}},
+			Efforts: []agentcatalog.Entry{{Value: "UltraTier", Enabled: true}},
+		},
+	}})
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.ctx.Catalog = catalog
+	m.spec.ResumeMembers = []SessionMemberSummary{{Role: "qa", Binary: "claude", Action: MemberActionFresh, Model: "StoredModel", Effort: "StoredTier"}}
+	m.spec.Model = "qa=NeoModel"
+	m.spec.Effort = "qa=UltraTier"
+	m.roleIndex = 0
+	m.stage = stageResumeMember
+	m.configureStage()
+	if got := m.choices()[m.cursor].value; got != "NeoModel" {
+		t.Fatalf("resume model default = %q, want injected catalog value", got)
+	}
+	m.stage = stageResumeEffort
+	m.configureStage()
+	if got := m.choices()[m.cursor].value; got != "UltraTier" {
+		t.Fatalf("resume effort default = %q, want injected catalog value", got)
+	}
+
+	m.spec.Model = ""
+	m.stage = stageResumeModelCustom
+	m.configureStage()
+	if got := m.input.Value(); got != "StoredModel" {
+		t.Fatalf("custom model prefill = %q, want stored value", got)
+	}
+	m.spec.Effort = ""
+	m.stage = stageResumeEffortCustom
+	m.configureStage()
+	if got := m.input.Value(); got != "StoredTier" {
+		t.Fatalf("custom effort prefill = %q, want stored value", got)
 	}
 }
 
@@ -766,7 +918,10 @@ func TestBubbleModelBackRestoresProjectContext(t *testing.T) {
 	m, err := NewBubbleModel(NumberedOptions{
 		Defaults: Spec{Project: "/one"},
 		InspectProject: func(project string) (ProjectContext, error) {
-			return ProjectContext{Project: project, OriginSlug: strings.TrimPrefix(project, "/")}, nil
+			value := strings.TrimPrefix(project, "/")
+			return ProjectContext{Project: project, OriginSlug: value, Catalog: agentcatalog.Catalog{Binaries: map[string]agentcatalog.Binary{
+				"claude": {Efforts: []agentcatalog.Entry{{Value: value, Enabled: true}}},
+			}}}, nil
 		},
 	})
 	if err != nil {
@@ -778,9 +933,17 @@ func TestBubbleModelBackRestoresProjectContext(t *testing.T) {
 	if m.ctx.OriginSlug != "two" {
 		t.Fatalf("new context = %+v", m.ctx)
 	}
+	if _, ok := m.ctx.Catalog.Resolve("claude", agentcatalog.Efforts, "two"); !ok {
+		t.Fatalf("project catalog was not injected: %+v", m.ctx.Catalog)
+	}
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEsc})
 	if m.stage != stageProject || m.spec.Project != "/one" || m.ctx.OriginSlug != "" || m.input.Value() != "/two" {
 		t.Fatalf("restored project state = stage %v spec %+v ctx %+v input %q", m.stage, m.spec, m.ctx, m.input.Value())
+	}
+	m.input.SetValue("/three")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if _, ok := m.ctx.Catalog.Resolve("claude", agentcatalog.Efforts, "three"); !ok {
+		t.Fatalf("changed project did not refresh catalog: %+v", m.ctx.Catalog)
 	}
 }
 
@@ -837,6 +1000,35 @@ func TestBubbleModelOffersModelsPerBinaryWithCustomEscape(t *testing.T) {
 	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.stage != stageRoleEffort || m.spec.Model != "cto=gpt-5.7-experimental" {
 		t.Fatalf("custom model = stage %v model %q", m.stage, m.spec.Model)
+	}
+}
+
+func TestBubbleModelOffersCurrentClaudeEffortsWithCustomEscape(t *testing.T) {
+	m, err := NewBubbleModel(NumberedOptions{Defaults: Spec{Project: "/repo", Roles: "qa", Binary: "qa=claude"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.roleOrder = []string{"qa"}
+	m.stage = stageRoleEffort
+	m.configureStage()
+	view := flattenBubbleView(m.View())
+	for _, want := range []string{"automatic", "low", "medium", "high", "xhigh", "max", "custom"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("claude effort list missing %q:\n%s", want, view)
+		}
+	}
+	m.cursor = len(m.choices()) - 1
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.stage != stageRoleEffortCustom {
+		t.Fatalf("custom effort stage = %v", m.stage)
+	}
+	m.input.SetValue("FutureTier")
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.spec.Effort != "qa=FutureTier" {
+		t.Fatalf("custom effort = %q", m.spec.Effort)
+	}
+	if review := m.summary(); !strings.Contains(review, "Warning: effort qa=FutureTier") {
+		t.Fatalf("custom effort warning missing from summary:\n%s", review)
 	}
 }
 

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -360,16 +360,43 @@ func TestBubblePhaseRailsAreScopeSpecific(t *testing.T) {
 	}
 	for _, branch := range []struct {
 		name   string
-		stages []bubbleStage
+		stages []struct {
+			stage bubbleStage
+			want  int
+		}
 	}{
-		{name: "project existing", stages: []bubbleStage{stageProject, stageProfile, stageResumeMember, stageTopology, stageResumeBrief, stageConfirm}},
-		{name: "project new", stages: []bubbleStage{stageProject, stageNewProfile, stageRoleBinary, stageOperator, stageGoal, stageConfirm}},
+		{name: "project existing", stages: []struct {
+			stage bubbleStage
+			want  int
+		}{{stageProject, 0}, {stageProfile, 1}, {stageResumeMember, 3}, {stageTopology, 3}, {stageResumeBrief, 4}, {stageConfirm, 5}}},
+		{name: "project new", stages: []struct {
+			stage bubbleStage
+			want  int
+		}{{stageProject, 0}, {stageNewProfile, 1}, {stageRoleBinary, 2}, {stageRoleModel, 3}, {stageOperator, 3}, {stageGoal, 4}, {stageConfirm, 5}}},
 	} {
 		t.Run(branch.name, func(t *testing.T) {
-			for want, stage := range branch.stages {
+			for _, item := range branch.stages {
+				project.stage = item.stage
+				if got := project.phaseIndex(); got != item.want {
+					t.Fatalf("stage=%v index=%d want=%d", item.stage, got, item.want)
+				}
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name   string
+		stages []bubbleStage
+	}{
+		{name: "existing start catalog controls", stages: []bubbleStage{stageExistingModel, stageExistingModelCustom, stageExistingEffort, stageExistingEffortCustom}},
+		{name: "resume catalog controls", stages: []bubbleStage{stageResumeMember, stageResumeModelCustom, stageResumeEffort, stageResumeEffortCustom}},
+		{name: "fresh roster catalog controls", stages: []bubbleStage{stageRoleModel, stageRoleModelCustom, stageRoleEffort, stageRoleEffortCustom}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, stage := range tc.stages {
 				project.stage = stage
-				if got := project.phaseIndex(); got != want {
-					t.Fatalf("stage=%v index=%d want=%d", stage, got, want)
+				if got := project.phaseIndex(); got != 3 {
+					t.Fatalf("stage=%v index=%d want Run controls index 3", stage, got)
 				}
 			}
 		})
@@ -497,6 +524,138 @@ func TestGlobalCatalogChoicesMatchAcrossAdapters(t *testing.T) {
 		if !strings.Contains(numberedOut.String(), want) {
 			t.Fatalf("numbered output missing %q:\n%s", want, numberedOut.String())
 		}
+	}
+}
+
+func TestProjectCatalogChoicesMatchAcrossAdapters(t *testing.T) {
+	catalog := agentcatalog.Merge(agentcatalog.Builtins(), agentcatalog.Catalog{Binaries: map[string]agentcatalog.Binary{
+		"claude": {Efforts: []agentcatalog.Entry{
+			{Value: "medium", Label: "medium", Enabled: false},
+			{Value: "UltraTier", Label: "Ultra tier", Enabled: true},
+		}},
+	}})
+	existing := ProfileSummary{
+		Name: "release", MemberCount: 1, OperatorMode: "lead_pane",
+		Members:  []MemberSummary{{Role: "qa", Binary: "claude", Effort: "low"}},
+		Sessions: []SessionSummary{discoveredFreshSession("s", SessionSourceMemberPin, 1)},
+	}
+	resumeMembers := []SessionMemberSummary{{Role: "qa", Binary: "claude", Effort: "low", Action: MemberActionFresh}}
+	resume := ProfileSummary{
+		Name: "release", MemberCount: 1, OperatorMode: "lead_pane",
+		Members: []MemberSummary{{Role: "qa", Binary: "claude", Effort: "low"}},
+		Sessions: []SessionSummary{{
+			Name: "s", Source: SessionSourceMemberPin, Fingerprint: "fp", Fresh: 1,
+			Members:        resumeMembers,
+			Classification: RunClassification{State: RunStateStopped, Backend: BackendResume, Executable: true},
+		}},
+	}
+
+	choiceLabels := func(items []choice) []string {
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			out = append(out, item.label)
+		}
+		return out
+	}
+	numberedPromptLabels := func(t *testing.T, output, prompt string) []string {
+		t.Helper()
+		startToken := "\n" + prompt + ":\n"
+		start := strings.Index(output, startToken)
+		if start < 0 {
+			t.Fatalf("numbered output missing %q prompt:\n%s", prompt, output)
+		}
+		block := output[start+len(startToken):]
+		end := strings.Index(block, "Choose [")
+		if end < 0 {
+			t.Fatalf("numbered output missing chooser after %q:\n%s", prompt, output)
+		}
+		var labels []string
+		for _, line := range strings.Split(block[:end], "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			_, label, ok := strings.Cut(line, ") ")
+			if !ok {
+				t.Fatalf("unexpected numbered choice line %q", line)
+			}
+			labels = append(labels, strings.TrimSuffix(label, " (default)"))
+		}
+		return labels
+	}
+
+	for _, tc := range []struct {
+		name       string
+		defaults   Spec
+		ctx        ProjectContext
+		input      string
+		prompt     string
+		bubble     BubbleModel
+		wantValues []string
+	}{
+		{
+			name:     "fresh roster",
+			defaults: Spec{Scope: "project", Project: "/repo", Profile: "new", Session: "s", Roles: "qa", Binary: "qa=claude", Lead: "qa"},
+			ctx:      ProjectContext{Project: "/repo", Catalog: catalog},
+			input:    strings.Repeat("\n", 24),
+			prompt:   "qa effort",
+			bubble: BubbleModel{
+				spec: Spec{Binary: "qa=claude"}, ctx: ProjectContext{Catalog: catalog},
+				stage: stageRoleEffort, roleOrder: []string{"qa"}, roleIndex: 0,
+			},
+			wantValues: []string{"automatic", "low", "high", "xhigh", "max", "UltraTier", "custom"},
+		},
+		{
+			name:     "existing start",
+			defaults: Spec{Scope: "project", Project: "/repo", Profile: "release"},
+			ctx:      ProjectContext{Project: "/repo", Catalog: catalog, Profiles: []ProfileSummary{existing}},
+			input:    strings.Join([]string{"", "", "", "2"}, "\n") + "\n" + strings.Repeat("\n", 20),
+			prompt:   "qa effort override",
+			bubble: BubbleModel{
+				ctx:   ProjectContext{Catalog: catalog, Profiles: []ProfileSummary{existing}},
+				stage: stageExistingEffort, existingIndex: 0, roleIndex: 0,
+			},
+			wantValues: []string{"keep", "low", "high", "xhigh", "max", "UltraTier", "custom"},
+		},
+		{
+			name:     "resume fresh member",
+			defaults: Spec{Scope: "project", Project: "/repo", Profile: "release"},
+			ctx:      ProjectContext{Project: "/repo", Catalog: catalog, Profiles: []ProfileSummary{resume}},
+			input:    strings.Repeat("\n", 20),
+			prompt:   "qa fresh-launch effort",
+			bubble: BubbleModel{
+				spec: Spec{ResumeMembers: resumeMembers}, ctx: ProjectContext{Catalog: catalog},
+				stage: stageResumeEffort, roleIndex: 0,
+			},
+			wantValues: []string{"keep", "low", "high", "xhigh", "max", "UltraTier", "custom"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			values := make([]string, 0, len(tc.bubble.choices()))
+			for _, item := range tc.bubble.choices() {
+				values = append(values, item.value)
+			}
+			if !reflect.DeepEqual(values, tc.wantValues) {
+				t.Fatalf("bubble values = %v, want %v", values, tc.wantValues)
+			}
+
+			var out bytes.Buffer
+			_, err := RunNumbered(strings.NewReader(tc.input), &out, NumberedOptions{
+				Defaults: tc.defaults,
+				InspectProject: func(string) (ProjectContext, error) {
+					return tc.ctx, nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := numberedPromptLabels(t, out.String(), tc.prompt), choiceLabels(tc.bubble.choices()); !reflect.DeepEqual(got, want) {
+				t.Fatalf("adapter labels differ:\nnumbered=%v\nbubble=%v", got, want)
+			}
+			if strings.Contains(strings.Join(choiceLabels(tc.bubble.choices()), "\n"), "medium") {
+				t.Fatal("disabled project catalog entry leaked into a wizard adapter")
+			}
+		})
 	}
 }
 

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -368,11 +368,11 @@ func TestBubblePhaseRailsAreScopeSpecific(t *testing.T) {
 		{name: "project existing", stages: []struct {
 			stage bubbleStage
 			want  int
-		}{{stageProject, 0}, {stageProfile, 1}, {stageResumeMember, 3}, {stageTopology, 3}, {stageResumeBrief, 4}, {stageConfirm, 5}}},
+		}{{stageProject, 0}, {stageProfile, 1}, {stageResumeMember, 2}, {stageTopology, 3}, {stageResumeBrief, 4}, {stageConfirm, 5}}},
 		{name: "project new", stages: []struct {
 			stage bubbleStage
 			want  int
-		}{{stageProject, 0}, {stageNewProfile, 1}, {stageRoleBinary, 2}, {stageRoleModel, 3}, {stageOperator, 3}, {stageGoal, 4}, {stageConfirm, 5}}},
+		}{{stageProject, 0}, {stageNewProfile, 1}, {stageRoleBinary, 2}, {stageRoleModel, 2}, {stageOperator, 3}, {stageGoal, 4}, {stageConfirm, 5}}},
 	} {
 		t.Run(branch.name, func(t *testing.T) {
 			for _, item := range branch.stages {
@@ -395,12 +395,94 @@ func TestBubblePhaseRailsAreScopeSpecific(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, stage := range tc.stages {
 				project.stage = stage
-				if got := project.phaseIndex(); got != 3 {
-					t.Fatalf("stage=%v index=%d want Run controls index 3", stage, got)
+				if got := project.phaseIndex(); got != 2 {
+					t.Fatalf("stage=%v index=%d want Team index 2", stage, got)
 				}
 			}
 		})
 	}
+}
+
+func TestBubbleProjectPhaseRailNeverRegressesAcrossMultiMemberFlows(t *testing.T) {
+	walk := func(t *testing.T, m BubbleModel, next func(BubbleModel) tea.KeyMsg) []bubbleStage {
+		t.Helper()
+		stages := []bubbleStage{m.stage}
+		previous := m.phaseIndex()
+		for step := 0; step < 64 && m.stage != stageConfirm; step++ {
+			m = updateBubble(t, m, next(m))
+			current := m.phaseIndex()
+			stages = append(stages, m.stage)
+			if current < previous {
+				t.Fatalf("phase rail regressed at step %d: stage %v index %d -> stage %v index %d; walk=%v", step, stages[len(stages)-2], previous, m.stage, current, stages)
+			}
+			previous = current
+		}
+		if m.stage != stageConfirm {
+			t.Fatalf("flow did not reach review; final stage=%v walk=%v", m.stage, stages)
+		}
+		return stages
+	}
+	countStage := func(stages []bubbleStage, want bubbleStage) int {
+		count := 0
+		for _, stage := range stages {
+			if stage == want {
+				count++
+			}
+		}
+		return count
+	}
+
+	t.Run("fresh multi-role roster", func(t *testing.T) {
+		m, err := NewBubbleModel(NumberedOptions{
+			Defaults: Spec{
+				Scope: "project", Project: "/repo", Profile: "new", Session: "s",
+				Roles: "cto,qa", Binary: "cto=codex,qa=claude", Lead: "cto",
+			},
+			InspectProject: func(string) (ProjectContext, error) {
+				return ProjectContext{Project: "/repo"}, nil
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		stages := walk(t, m, func(BubbleModel) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyEnter} })
+		for _, stage := range []bubbleStage{stageRoleBinary, stageRoleModel, stageRoleEffort} {
+			if got := countStage(stages, stage); got != 2 {
+				t.Fatalf("stage %v visits=%d want=2; walk=%v", stage, got, stages)
+			}
+		}
+	})
+
+	t.Run("existing multi-member launch overrides", func(t *testing.T) {
+		profile := ProfileSummary{
+			Name: "release", MemberCount: 2, OperatorMode: "lead_pane",
+			Members: []MemberSummary{
+				{Role: "cto", Binary: "codex", Model: "gpt-5.6-sol", Effort: "high"},
+				{Role: "qa", Binary: "claude", Model: "sonnet", Effort: "medium"},
+			},
+			Sessions: []SessionSummary{discoveredFreshSession("s", SessionSourceMemberPin, 2)},
+		}
+		m, err := NewBubbleModel(NumberedOptions{
+			Defaults: Spec{Scope: "project", Project: "/repo", Profile: "release"},
+			InspectProject: func(string) (ProjectContext, error) {
+				return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		stages := walk(t, m, func(current BubbleModel) tea.KeyMsg {
+			if current.stage == stageExistingOverride && current.cursor == 0 {
+				return tea.KeyMsg{Type: tea.KeyDown}
+			}
+			return tea.KeyMsg{Type: tea.KeyEnter}
+		})
+		for _, stage := range []bubbleStage{stageExistingOverride, stageExistingModel, stageExistingEffort} {
+			if got := countStage(stages, stage); got < 2 {
+				t.Fatalf("stage %v visits=%d want at least 2; walk=%v", stage, got, stages)
+			}
+		}
+	})
 }
 
 func TestGlobalBranchRunsThroughBothRealAdaptersToIdenticalReview(t *testing.T) {

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/agentcatalog"
 )
 
 // ErrCancelled reports an explicit q/quit/cancel answer from the numbered
@@ -18,6 +20,7 @@ var ErrCancelled = errors.New("wizard cancelled")
 type NumberedOptions struct {
 	Defaults       Spec
 	InspectProject func(project string) (ProjectContext, error)
+	LoadCatalog    func(root string) agentcatalog.Catalog
 	ProfileExists  func(project, profile string) bool
 	Capabilities   CapabilitySet
 	StartAtProfile bool
@@ -32,6 +35,7 @@ type ProjectContext struct {
 	NewProfileSuggestion string
 	Profiles             []ProfileSummary
 	PreferredBinaries    map[string]string
+	Catalog              agentcatalog.Catalog
 }
 
 type ProfileSummary struct {
@@ -88,7 +92,7 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		}
 		if s.Scope == "global" {
 			s.Backend = BackendGlobalStart
-			return runNumberedGlobal(r, out, s)
+			return runNumberedGlobal(r, out, s, opts.LoadCatalog)
 		}
 		s.Backend = BackendRunStart
 		if s.Project, err = promptText(r, out, "Project directory", s.Project); err != nil {
@@ -154,6 +158,7 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		s.LeadMode = ""
 		if existingProfile != nil && s.Backend == BackendResume {
 			modelOverrides := map[string]string{}
+			effortOverrides := map[string]string{}
 			memberOrder := make([]string, 0, len(s.ResumeMembers))
 			for _, member := range s.ResumeMembers {
 				memberOrder = append(memberOrder, member.Role)
@@ -163,7 +168,8 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 				case MemberActionRestore:
 					fmt.Fprintf(out, "%s restores saved launch %s read-only (binary=%s model=%s effort=%s saved extra args=%s).\n", member.Role, defaultString(member.SavedLaunchIdentity, "recorded"), defaultString(member.SavedBinary, member.Binary), defaultString(member.SavedModel, "automatic"), defaultString(member.SavedEffort, "automatic"), FormatSavedNativeArgs(member.SavedNativeArgs))
 				case MemberActionFresh:
-					modelSel, promptErr := promptChoice(r, out, member.Role+" fresh-launch model", existingOverrideModelChoices(MemberSummary{Role: member.Role, Binary: member.Binary, Model: member.Model, Effort: member.Effort}), modelKeepChoice)
+					summary := MemberSummary{Role: member.Role, Binary: member.Binary, Model: member.Model, Effort: member.Effort}
+					modelSel, promptErr := promptChoice(r, out, member.Role+" fresh-launch model", existingOverrideModelChoicesCatalog(summary, ctx.Catalog), modelKeepChoice)
 					if promptErr != nil {
 						return Spec{}, promptErr
 					}
@@ -178,10 +184,25 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 					} else if modelSel != modelKeepChoice {
 						modelOverrides[member.Role] = modelSel
 					}
+					effortSel, effortErr := promptChoice(r, out, member.Role+" fresh-launch effort", existingOverrideEffortChoices(summary, ctx.Catalog), effortKeepChoice)
+					if effortErr != nil {
+						return Spec{}, effortErr
+					}
+					if effortSel == effortCustomChoice {
+						custom, customErr := promptOptionalOverride(r, out, member.Role+" fresh-launch effort", defaultString(member.Effort, effortAutomatic))
+						if customErr != nil {
+							return Spec{}, customErr
+						}
+						if custom != "" && !strings.EqualFold(custom, effortAutomatic) {
+							effortOverrides[member.Role] = custom
+						}
+					} else if effortSel != effortKeepChoice {
+						effortOverrides[member.Role] = effortSel
+					}
 				}
 			}
 			s.Model = renderAssignments(memberOrder, modelOverrides)
-			s.Effort = ""
+			s.Effort = renderAssignments(memberOrder, effortOverrides)
 			s.OperatorMode = defaultString(existingProfile.OperatorMode, "unspecified")
 			s.OperatorNotifications = existingProfile.OperatorNotifications
 		} else if existingProfile != nil {
@@ -207,7 +228,7 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 				if override != "override" {
 					continue
 				}
-				modelSel, promptErr := promptChoice(r, out, member.Role+" model override", existingOverrideModelChoices(member), modelKeepChoice)
+				modelSel, promptErr := promptChoice(r, out, member.Role+" model override", existingOverrideModelChoicesCatalog(member, ctx.Catalog), modelKeepChoice)
 				if promptErr != nil {
 					return Spec{}, promptErr
 				}
@@ -222,15 +243,21 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 				} else if modelSel != modelKeepChoice {
 					modelOverrides[member.Role] = modelSel
 				}
-				effortChoices := []choice{{value: "automatic", label: "automatic: ignore stored effort for this launch"}, {value: "low", label: "low"}, {value: "medium", label: "medium"}, {value: "high", label: "high"}}
-				if member.Binary == "codex" {
-					effortChoices = append(effortChoices, choice{value: "minimal", label: "minimal"}, choice{value: "xhigh", label: "xhigh"})
-				}
-				effort, promptErr := promptChoice(r, out, member.Role+" effort override", effortChoices, defaultString(member.Effort, effortAutomatic))
+				effort, promptErr := promptChoice(r, out, member.Role+" effort override", existingOverrideEffortChoices(member, ctx.Catalog), effortKeepChoice)
 				if promptErr != nil {
 					return Spec{}, promptErr
 				}
-				effortOverrides[member.Role] = effort
+				if effort == effortCustomChoice {
+					custom, customErr := promptOptionalOverride(r, out, member.Role+" effort override", defaultString(member.Effort, effortAutomatic))
+					if customErr != nil {
+						return Spec{}, customErr
+					}
+					if custom != "" {
+						effortOverrides[member.Role] = custom
+					}
+				} else if effort != effortKeepChoice {
+					effortOverrides[member.Role] = effort
+				}
 			}
 			s.Model = renderAssignments(memberOrder, modelOverrides)
 			s.Effort = renderAssignments(memberOrder, effortOverrides)
@@ -260,7 +287,7 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 			if err != nil {
 				return Spec{}, err
 			}
-			model, promptErr := promptChoice(r, out, role+" model", modelChoices(binaryValues[role]), defaultModelChoice(modelPrefill[role], binaryValues[role]))
+			model, promptErr := promptChoice(r, out, role+" model", modelChoicesCatalog(binaryValues[role], ctx.Catalog), defaultModelChoiceCatalog(modelPrefill[role], binaryValues[role], ctx.Catalog))
 			if promptErr != nil {
 				return Spec{}, promptErr
 			}
@@ -272,13 +299,14 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 			if model != "" && !strings.EqualFold(model, effortAutomatic) {
 				modelValues[role] = model
 			}
-			effortChoices := []choice{{value: "automatic", label: "automatic: let the binary choose"}, {value: "low", label: "low"}, {value: "medium", label: "medium"}, {value: "high", label: "high"}}
-			if binaryValues[role] == "codex" {
-				effortChoices = append(effortChoices, choice{value: "minimal", label: "minimal"}, choice{value: "xhigh", label: "xhigh"})
-			}
-			effort, promptErr := promptChoice(r, out, role+" effort", effortChoices, defaultString(effortPrefill[role], "automatic"))
+			effort, promptErr := promptChoice(r, out, role+" effort", effortChoicesCatalog(binaryValues[role], ctx.Catalog), defaultEffortChoiceCatalog(effortPrefill[role], binaryValues[role], ctx.Catalog, effortAutomatic))
 			if promptErr != nil {
 				return Spec{}, promptErr
+			}
+			if effort == effortCustomChoice {
+				if effort, promptErr = promptText(r, out, role+" effort tier", defaultString(effortPrefill[role], effortAutomatic)); promptErr != nil {
+					return Spec{}, promptErr
+				}
 			}
 			if effort != effortAutomatic {
 				effortValues[role] = effort
@@ -372,12 +400,15 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Review")
+	for _, warning := range effortCatalogWarnings(s, ctx) {
+		fmt.Fprintln(out, warning)
+	}
 	fmt.Fprintf(out, "Goal excerpt:\n%s\nSeed source: %s\nPreview command: %s\nLive command: %s\n", GoalExcerpt(goal), displayValue(seed), previewCommand, liveCommand)
 	fmt.Fprintln(out, "Answers collected. Running the canonical preview next; live launch is a separate default-No decision.")
 	return s, nil
 }
 
-func runNumberedGlobal(r *bufio.Reader, out io.Writer, s Spec) (Spec, error) {
+func runNumberedGlobal(r *bufio.Reader, out io.Writer, s Spec, loadCatalog func(string) agentcatalog.Catalog) (Spec, error) {
 	var err error
 	fmt.Fprintln(out, "This is a neutral control root, not a project profile or session.")
 	if s.GlobalRoot, err = promptText(r, out, "Where should the global orchestrator run?", s.GlobalRoot); err != nil {
@@ -386,21 +417,42 @@ func runNumberedGlobal(r *bufio.Reader, out io.Writer, s Spec) (Spec, error) {
 	if strings.TrimSpace(s.GlobalRoot) == "" {
 		return Spec{}, fmt.Errorf("global root cannot be empty")
 	}
+	catalog := agentcatalog.Builtins()
+	if loadCatalog != nil {
+		catalog = loadCatalog(s.GlobalRoot)
+	}
 	if s.GlobalAgent, err = promptChoice(r, out, "Which agent should run the global orchestrator?", []choice{
 		{value: "claude", label: "Claude"},
 		{value: "codex", label: "Codex"},
 	}, defaultString(strings.ToLower(strings.TrimSpace(s.GlobalAgent)), "claude")); err != nil {
 		return Spec{}, err
 	}
-	if s.GlobalModel, err = promptText(r, out, "Model (optional)", s.GlobalModel); err != nil {
+	model, err := promptChoice(r, out, "Model", modelChoicesCatalog(s.GlobalAgent, catalog), defaultModelChoiceCatalog(s.GlobalModel, s.GlobalAgent, catalog))
+	if err != nil {
 		return Spec{}, err
 	}
-	if s.GlobalEffort, err = promptChoice(r, out, "Effort", effortChoices(s.GlobalAgent), defaultString(strings.ToLower(strings.TrimSpace(s.GlobalEffort)), effortAutomatic)); err != nil {
+	if model == modelCustomChoice {
+		if model, err = promptText(r, out, "Custom model", s.GlobalModel); err != nil {
+			return Spec{}, err
+		}
+	}
+	if strings.EqualFold(model, effortAutomatic) {
+		model = ""
+	}
+	s.GlobalModel = strings.TrimSpace(model)
+	effort, err := promptChoice(r, out, "Effort", effortChoicesCatalog(s.GlobalAgent, catalog), defaultEffortChoiceCatalog(s.GlobalEffort, s.GlobalAgent, catalog, effortAutomatic))
+	if err != nil {
 		return Spec{}, err
 	}
-	if s.GlobalEffort == effortAutomatic {
-		s.GlobalEffort = ""
+	if effort == effortCustomChoice {
+		if effort, err = promptText(r, out, "Custom effort", s.GlobalEffort); err != nil {
+			return Spec{}, err
+		}
 	}
+	if strings.EqualFold(effort, effortAutomatic) {
+		effort = ""
+	}
+	s.GlobalEffort = strings.TrimSpace(effort)
 	if s.GlobalAgent == "codex" {
 		if s.GlobalCodexArgs, err = promptText(r, out, "Codex extra native args (excluding effort)", s.GlobalCodexArgs); err != nil {
 			return Spec{}, err
@@ -425,6 +477,9 @@ func runNumberedGlobal(r *bufio.Reader, out io.Writer, s Spec) (Spec, error) {
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Review")
+	for _, warning := range effortCatalogWarnings(s, ProjectContext{Catalog: catalog}) {
+		fmt.Fprintln(out, warning)
+	}
 	fmt.Fprintf(out, "Scope: Global / NOC orchestrator\nNeutral root: %s\nAgent: %s\nModel: %s\nEffort: %s\nWindow: %s\nNOC contract: poll explicit project/profile/session namespaces; this global orchestrator owns no wake mailbox.\nPreview command: %s\nLive command: %s\n", s.GlobalRoot, s.GlobalAgent, displayValue(s.GlobalModel), defaultString(s.GlobalEffort, effortAutomatic), s.GlobalWindow, previewCommand, liveCommand)
 	fmt.Fprintln(out, "Answers collected. Running the canonical preview next; live launch is a separate default-No decision.")
 	return s, nil
@@ -438,28 +493,24 @@ func displayValue(value string) string {
 }
 
 const (
-	effortAutomatic   = "automatic"
-	modelCustomChoice = "custom"
-	modelKeepChoice   = "keep"
+	effortAutomatic    = "automatic"
+	modelCustomChoice  = "custom"
+	modelKeepChoice    = "keep"
+	effortCustomChoice = "custom"
+	effortKeepChoice   = "keep"
 )
 
 // modelChoices offers common models per binary. Models pass through to the
 // binary verbatim, so this list is a convenience, never an allowlist; the
 // custom row keeps free-text entry available.
 func modelChoices(binary string) []choice {
+	return modelChoicesCatalog(binary, agentcatalog.Builtins())
+}
+
+func modelChoicesCatalog(binary string, catalog agentcatalog.Catalog) []choice {
 	choices := []choice{{value: effortAutomatic, label: "automatic: let the binary choose"}}
-	if strings.EqualFold(binary, "claude") {
-		choices = append(choices,
-			choice{value: "fable", label: "fable"},
-			choice{value: "opus", label: "opus"},
-			choice{value: "sonnet", label: "sonnet"},
-			choice{value: "haiku", label: "haiku"},
-		)
-	} else {
-		choices = append(choices,
-			choice{value: "gpt-5.6-sol", label: "gpt-5.6-sol"},
-			choice{value: "gpt-5.6-terra", label: "gpt-5.6-terra"},
-		)
+	for _, entry := range catalog.Entries(binary, agentcatalog.Models) {
+		choices = append(choices, choice{value: entry.Value, label: entry.Label})
 	}
 	return append(choices, choice{value: modelCustomChoice, label: "custom: type a model name"})
 }
@@ -468,8 +519,12 @@ func modelChoices(binary string) []choice {
 // keep replaces automatic because clearing the override falls back to the
 // stored profile value, not to the binary's default.
 func existingOverrideModelChoices(member MemberSummary) []choice {
+	return existingOverrideModelChoicesCatalog(member, agentcatalog.Builtins())
+}
+
+func existingOverrideModelChoicesCatalog(member MemberSummary, catalog agentcatalog.Catalog) []choice {
 	choices := []choice{{value: modelKeepChoice, label: "keep profile model: " + defaultString(member.Model, "automatic")}}
-	for _, item := range modelChoices(member.Binary) {
+	for _, item := range modelChoicesCatalog(member.Binary, catalog) {
 		if item.value != effortAutomatic {
 			choices = append(choices, item)
 		}
@@ -478,16 +533,102 @@ func existingOverrideModelChoices(member MemberSummary) []choice {
 }
 
 func defaultModelChoice(prefill, binary string) string {
+	return defaultModelChoiceCatalog(prefill, binary, agentcatalog.Builtins())
+}
+
+func defaultModelChoiceCatalog(prefill, binary string, catalog agentcatalog.Catalog) string {
 	prefill = strings.TrimSpace(prefill)
 	if prefill == "" {
 		return effortAutomatic
 	}
-	for _, item := range modelChoices(binary) {
+	for _, item := range modelChoicesCatalog(binary, catalog) {
 		if strings.EqualFold(item.value, prefill) {
 			return item.value
 		}
 	}
 	return modelCustomChoice
+}
+
+func effortChoicesCatalog(binary string, catalog agentcatalog.Catalog) []choice {
+	choices := []choice{{value: effortAutomatic, label: "automatic: let the binary choose"}}
+	for _, entry := range catalog.Entries(binary, agentcatalog.Efforts) {
+		choices = append(choices, choice{value: entry.Value, label: entry.Label})
+	}
+	return append(choices, choice{value: effortCustomChoice, label: "custom: type an effort tier"})
+}
+
+func existingOverrideEffortChoices(member MemberSummary, catalog agentcatalog.Catalog) []choice {
+	choices := []choice{{value: effortKeepChoice, label: "keep profile effort: " + defaultString(member.Effort, effortAutomatic)}}
+	for _, entry := range catalog.Entries(member.Binary, agentcatalog.Efforts) {
+		choices = append(choices, choice{value: entry.Value, label: entry.Label})
+	}
+	return append(choices, choice{value: effortCustomChoice, label: "custom: type an effort tier"})
+}
+
+func defaultEffortChoiceCatalog(prefill, binary string, catalog agentcatalog.Catalog, fallback string) string {
+	prefill = strings.TrimSpace(prefill)
+	if prefill == "" {
+		return fallback
+	}
+	if strings.EqualFold(prefill, effortAutomatic) {
+		return effortAutomatic
+	}
+	for _, entry := range catalog.Entries(binary, agentcatalog.Efforts) {
+		if strings.EqualFold(entry.Value, prefill) {
+			return entry.Value
+		}
+	}
+	return effortCustomChoice
+}
+
+func effortCatalogWarnings(s Spec, ctx ProjectContext) []string {
+	type target struct {
+		role, binary, effort string
+	}
+	var targets []target
+	if strings.EqualFold(s.Scope, "global") {
+		targets = append(targets, target{role: "global", binary: s.GlobalAgent, effort: s.GlobalEffort})
+	} else if s.Backend == BackendResume {
+		efforts := parseAssignments(s.Effort)
+		for _, member := range s.ResumeMembers {
+			if member.Action == MemberActionFresh {
+				targets = append(targets, target{role: member.Role, binary: member.Binary, effort: efforts[member.Role]})
+			}
+		}
+	} else if s.ProfileBranch == ProfileBranchExisting {
+		efforts := parseAssignments(s.Effort)
+		if index := findProfile(ctx.Profiles, s.Profile); index >= 0 {
+			for _, member := range ctx.Profiles[index].Members {
+				targets = append(targets, target{role: member.Role, binary: member.Binary, effort: efforts[member.Role]})
+			}
+		}
+	} else {
+		binaries := parseAssignments(s.Binary)
+		efforts := parseAssignments(s.Effort)
+		for _, role := range splitAssignmentsList(s.Roles) {
+			targets = append(targets, target{role: role, binary: binaries[role], effort: efforts[role]})
+		}
+	}
+
+	seen := map[string]bool{}
+	var warnings []string
+	for _, item := range targets {
+		binary := strings.ToLower(strings.TrimSpace(item.binary))
+		effort := strings.TrimSpace(item.effort)
+		if effort == "" || strings.EqualFold(effort, effortAutomatic) || (binary != "codex" && binary != "claude") {
+			continue
+		}
+		if _, ok := ctx.Catalog.Resolve(binary, agentcatalog.Efforts, effort); ok {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(item.role)) + "\x00" + strings.ToLower(effort)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		warnings = append(warnings, fmt.Sprintf("Warning: effort %s=%s is not in the merged catalog for %s; it will be passed through exactly and may be rejected by the underlying binary.", item.role, effort, binary))
+	}
+	return warnings
 }
 
 func promptProfile(r *bufio.Reader, out io.Writer, current string, ctx ProjectContext) (string, *ProfileSummary, error) {

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -100,6 +100,28 @@ func TestRunNumberedAcceptsNumberedChoices(t *testing.T) {
 	}
 }
 
+func TestRunNumberedClaudeEffortCustomEscapePreservesSpelling(t *testing.T) {
+	answers := []string{
+		"", "", "", "", // project, profile, session, roles
+		"2", "", "7", "FutureTier", // claude, automatic model, custom effort + exact tier
+		"", "", "", "", "", "", "", "", "", // lead through seed
+	}
+	var out bytes.Buffer
+	got, err := RunNumbered(strings.NewReader("\n"+strings.Join(answers, "\n")+"\n"), &out, NumberedOptions{
+		Defaults:      Spec{Project: "/repo", Profile: "default", Session: "s", Roles: "qa"},
+		ProfileExists: func(string, string) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Binary != "qa=claude" || got.Effort != "qa=FutureTier" {
+		t.Fatalf("custom effort answers = %+v", got)
+	}
+	if !strings.Contains(out.String(), "Warning: effort qa=FutureTier") {
+		t.Fatalf("custom effort warning missing from review:\n%s", out.String())
+	}
+}
+
 func TestRunNumberedReusesCallerReaderAndPreservesFollowingConsent(t *testing.T) {
 	answers := []string{
 		"", "", "", "", // project, profile, session, roles
@@ -390,10 +412,11 @@ func TestRunNumberedResumeActionScopedControls(t *testing.T) {
 		members []SessionMemberSummary
 		input   string
 		model   string
+		effort  string
 	}{
 		{name: "all restore", records: 2, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore, SavedBinary: "codex", SavedModel: "saved", SavedEffort: "high", SavedNativeArgs: []string{"--saved"}}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}, input: "\n\n\n\n"},
-		{name: "restore fresh", records: 1, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Model: "stored", Action: MemberActionFresh}}, input: "\n\n2\n\n\n", model: "qa=gpt-5.6-sol"},
-		{name: "live fresh no records", state: RunStatePartly, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionLive}, {Role: "qa", Binary: "codex", Action: MemberActionFresh}}, input: "\n\n2\n\n\n", model: "qa=gpt-5.6-sol"},
+		{name: "restore fresh", records: 1, state: RunStateStopped, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Model: "stored", Action: MemberActionFresh}}, input: "\n\n2\n6\n\n\n", model: "qa=gpt-5.6-sol", effort: "qa=xhigh"},
+		{name: "live fresh no records", state: RunStatePartly, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionLive}, {Role: "qa", Binary: "codex", Action: MemberActionFresh}}, input: "\n\n2\n\n\n\n", model: "qa=gpt-5.6-sol"},
 		{name: "live restore", records: 1, state: RunStatePartly, members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionLive}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}, input: "\n\n\n\n"},
 	}
 	for _, tt := range tests {
@@ -411,7 +434,7 @@ func TestRunNumberedResumeActionScopedControls(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got.Model != tt.model || got.Effort != "" || got.Backend != BackendResume || got.RecordCount != tt.records {
+			if got.Model != tt.model || got.Effort != tt.effort || got.Backend != BackendResume || got.RecordCount != tt.records {
 				t.Fatalf("resume answers=%+v", got)
 			}
 			if strings.Contains(out.String(), "effort override") || strings.Contains(out.String(), "Override cto at launch") {
@@ -500,7 +523,7 @@ func TestRunNumberedExistingProfileCollectsLaunchOnlyOverrides(t *testing.T) {
 		"2",            // override cto
 		"4",            // model override: custom
 		"launch-model", // custom launch-only model
-		"4",            // high effort
+		"5",            // high effort
 		"",             // topology
 		"",             // one-window layout
 		"",             // close launcher

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -119,9 +119,9 @@ type Spec struct {
 }
 
 // ResumeArgs renders the canonical plan-only resume argv. The restore guard is
-// a direct statement about matching history, and model overrides are validated
-// and restricted to launch-fresh members because live and restore actions are
-// immutable.
+// a direct statement about matching history, and model/effort overrides are
+// validated and restricted to launch-fresh members because live and restore
+// actions are immutable.
 func (s Spec) ResumeArgs() ([]string, error) {
 	if s.Backend != BackendResume || !s.RunExecutable || s.ProfileBranch != ProfileBranchExisting {
 		return nil, fmt.Errorf("resume arguments require an executable existing-profile resume selection")
@@ -135,8 +135,8 @@ func (s Spec) ResumeArgs() ([]string, error) {
 	if s.RecordCount < 0 || s.RestoreExisting != (s.RecordCount > 0) {
 		return nil, fmt.Errorf("resume restore guard is inconsistent with matching record count %d", s.RecordCount)
 	}
-	if strings.TrimSpace(s.Effort) != "" || strings.TrimSpace(s.CodexArgs) != "" || strings.TrimSpace(s.ClaudeArgs) != "" || strings.TrimSpace(s.LauncherPane) != "" || strings.TrimSpace(s.Goal) != "" || strings.TrimSpace(s.SeedFrom) != "" {
-		return nil, fmt.Errorf("resume answer model contains unsupported effort, native-arg, launcher, goal, or seed controls")
+	if strings.TrimSpace(s.CodexArgs) != "" || strings.TrimSpace(s.ClaudeArgs) != "" || strings.TrimSpace(s.LauncherPane) != "" || strings.TrimSpace(s.Goal) != "" || strings.TrimSpace(s.SeedFrom) != "" {
+		return nil, fmt.Errorf("resume answer model contains unsupported native-arg, launcher, goal, or seed controls")
 	}
 	args := make([]string, 0, 16)
 	appendValue := func(name, value string) {
@@ -150,12 +150,17 @@ func (s Spec) ResumeArgs() ([]string, error) {
 	if s.RecordCount > 0 {
 		args = append(args, "--restore-existing")
 	}
-	models, err := parseResumeModelAssignments(s.Model)
+	models, err := parseResumeAssignments("model", s.Model)
 	if err != nil {
 		return nil, err
 	}
-	roles := make([]string, 0, len(s.ResumeMembers))
-	allowed := make(map[string]string)
+	efforts, err := parseResumeAssignments("effort", s.Effort)
+	if err != nil {
+		return nil, err
+	}
+	freshRoles := make([]string, 0, len(s.ResumeMembers))
+	allowedModels := make(map[string]string)
+	allowedEfforts := make(map[string]string)
 	actions := make(map[string]MemberAction, len(s.ResumeMembers))
 	runnable := 0
 	for _, member := range s.ResumeMembers {
@@ -174,9 +179,12 @@ func (s Spec) ResumeArgs() ([]string, error) {
 		if member.Action != MemberActionFresh {
 			continue
 		}
+		freshRoles = append(freshRoles, member.Role)
 		if value := strings.TrimSpace(models[member.Role]); value != "" {
-			roles = append(roles, member.Role)
-			allowed[member.Role] = value
+			allowedModels[member.Role] = value
+		}
+		if value := strings.TrimSpace(efforts[member.Role]); value != "" {
+			allowedEfforts[member.Role] = value
 		}
 	}
 	if runnable == 0 {
@@ -188,7 +196,14 @@ func (s Spec) ResumeArgs() ([]string, error) {
 			return nil, fmt.Errorf("resume model override for %q is not allowed for action %q", role, action)
 		}
 	}
-	appendValue("--model", renderAssignments(roles, allowed))
+	for role := range efforts {
+		action, exists := actions[role]
+		if !exists || action != MemberActionFresh {
+			return nil, fmt.Errorf("resume effort override for %q is not allowed for action %q", role, action)
+		}
+	}
+	appendValue("--model", renderAssignments(freshRoles, allowedModels))
+	appendValue("--effort", renderAssignments(freshRoles, allowedEfforts))
 	target, layout, err := resumePlacement(s.Visibility, s.LayoutPreset)
 	if err != nil {
 		return nil, err
@@ -226,7 +241,7 @@ func resumePlacement(visibility, layout string) (string, string, error) {
 	}
 }
 
-func parseResumeModelAssignments(raw string) (map[string]string, error) {
+func parseResumeAssignments(kind, raw string) (map[string]string, error) {
 	out := map[string]string{}
 	for _, item := range strings.Split(raw, ",") {
 		item = strings.TrimSpace(item)
@@ -236,10 +251,10 @@ func parseResumeModelAssignments(raw string) (map[string]string, error) {
 		role, value, ok := strings.Cut(item, "=")
 		role, value = strings.ToLower(strings.TrimSpace(role)), strings.TrimSpace(value)
 		if !ok || role == "" || value == "" {
-			return nil, fmt.Errorf("invalid resume model assignment %q", item)
+			return nil, fmt.Errorf("invalid resume %s assignment %q", kind, item)
 		}
 		if _, exists := out[role]; exists {
-			return nil, fmt.Errorf("duplicate resume model assignment for %q", role)
+			return nil, fmt.Errorf("duplicate resume %s assignment for %q", kind, role)
 		}
 		out[role] = value
 	}
@@ -258,7 +273,7 @@ func (s Spec) GlobalArgs() []string {
 	appendValue("--root", s.GlobalRoot)
 	appendValue("--agent", s.GlobalAgent)
 	appendValue("--model", s.GlobalModel)
-	effort := strings.ToLower(strings.TrimSpace(s.GlobalEffort))
+	effort := strings.TrimSpace(s.GlobalEffort)
 	if effort == "automatic" {
 		effort = ""
 	}

--- a/internal/wizard/spec_test.go
+++ b/internal/wizard/spec_test.go
@@ -94,8 +94,8 @@ func TestSpecGlobalArgsNeverLeakProjectRunFlags(t *testing.T) {
 }
 
 func TestSpecGlobalClaudeEffortUsesOnlyClaudeNativeArgs(t *testing.T) {
-	got := strings.Join((Spec{GlobalRoot: "/n", GlobalAgent: "claude", GlobalEffort: "medium", GlobalCodexArgs: "--search", GlobalClaudeArgs: "--chrome"}).GlobalArgs(), " ")
-	if !strings.Contains(got, "--claude-args --chrome --effort medium") || strings.Contains(got, "--codex-args") {
+	got := strings.Join((Spec{GlobalRoot: "/n", GlobalAgent: "claude", GlobalEffort: "FutureTier", GlobalCodexArgs: "--search", GlobalClaudeArgs: "--chrome"}).GlobalArgs(), " ")
+	if !strings.Contains(got, "--claude-args --chrome --effort FutureTier") || strings.Contains(got, "--codex-args") {
 		t.Fatalf("Claude global args = %s", got)
 	}
 }
@@ -133,18 +133,19 @@ func TestResumeArgsCanonicalComposition(t *testing.T) {
 		records int
 		members []SessionMemberSummary
 		model   string
+		effort  string
 		vis     string
 		layout  string
 		want    []string
 	}{
 		{name: "all restore", records: 2, members: []SessionMemberSummary{{Role: "cto", Action: MemberActionRestore}, {Role: "qa", Action: MemberActionRestore}}, vis: "sibling-tabs", layout: "one-window-per-agent", want: []string{"--project", "/repo", "--profile", "release", "--session", "s", "--restore-existing", "--target", "new-window", "--layout", "tiled"}},
-		{name: "restore plus fresh", records: 1, members: []SessionMemberSummary{{Role: "cto", Action: MemberActionRestore}, {Role: "qa", Action: MemberActionFresh}}, model: "qa=gpt", vis: "current", layout: "lead-top", want: []string{"--project", "/repo", "--profile", "release", "--session", "s", "--restore-existing", "--model", "qa=gpt", "--target", "current-window", "--layout", "horizontal"}},
+		{name: "restore plus fresh", records: 1, members: []SessionMemberSummary{{Role: "cto", Action: MemberActionRestore}, {Role: "qa", Action: MemberActionFresh}}, model: "qa=gpt", effort: "qa=FutureTier", vis: "current", layout: "lead-top", want: []string{"--project", "/repo", "--profile", "release", "--session", "s", "--restore-existing", "--model", "qa=gpt", "--effort", "qa=FutureTier", "--target", "current-window", "--layout", "horizontal"}},
 		{name: "live plus fresh no records", members: []SessionMemberSummary{{Role: "cto", Action: MemberActionLive}, {Role: "qa", Action: MemberActionFresh}}, model: "qa=gpt", vis: "detached", want: []string{"--project", "/repo", "--profile", "release", "--session", "s", "--model", "qa=gpt", "--target", "new-session", "--layout", "tiled"}},
 		{name: "live plus restore", records: 1, members: []SessionMemberSummary{{Role: "cto", Action: MemberActionLive}, {Role: "qa", Action: MemberActionRestore}}, vis: "current", layout: "even-grid", want: []string{"--project", "/repo", "--profile", "release", "--session", "s", "--restore-existing", "--target", "current-window", "--layout", "tiled"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Spec{Backend: BackendResume, Project: "/repo", Profile: "release", ProfileBranch: ProfileBranchExisting, Session: "s", RunExecutable: true, RunState: RunStateStopped, RecordCount: tt.records, RestoreExisting: tt.records > 0, DiscoveryFingerprint: "fp", ResumeMembers: tt.members, Model: tt.model, Visibility: tt.vis, LayoutPreset: tt.layout}
+			s := Spec{Backend: BackendResume, Project: "/repo", Profile: "release", ProfileBranch: ProfileBranchExisting, Session: "s", RunExecutable: true, RunState: RunStateStopped, RecordCount: tt.records, RestoreExisting: tt.records > 0, DiscoveryFingerprint: "fp", ResumeMembers: tt.members, Model: tt.model, Effort: tt.effort, Visibility: tt.vis, LayoutPreset: tt.layout}
 			got, err := s.ResumeArgs()
 			if err != nil {
 				t.Fatal(err)
@@ -161,7 +162,8 @@ func TestResumeArgsRejectsSemanticLeakage(t *testing.T) {
 	tests := map[string]func(*Spec){
 		"live model":                   func(s *Spec) { s.Model = "cto=gpt" },
 		"unknown model":                func(s *Spec) { s.Model = "other=gpt" },
-		"effort":                       func(s *Spec) { s.Effort = "qa=high" },
+		"live effort":                  func(s *Spec) { s.Effort = "cto=high" },
+		"unknown effort":               func(s *Spec) { s.Effort = "other=high" },
 		"native args":                  func(s *Spec) { s.CodexArgs = "--search" },
 		"launcher":                     func(s *Spec) { s.LauncherPane = "keep" },
 		"goal":                         func(s *Spec) { s.Goal = "replace brief" },


### PR DESCRIPTION
Implements the accepted #432 acceptance spec (qa spec 2026-07-12T20-04-13 + brief Decisions entry).

## Scope
- Schema-v1 advisory catalog overlay FILES: built-ins in code < ~/.amq-squad/catalog.json < <team-home>/.amq-squad/catalog.json - explicitly not team.json fields, no schema bump; effort persists as opaque native args
- Warn-not-reject: unknown effort tiers for supported binaries warn once on stderr and pass through with exact trimmed spelling; unsupported binaries still error; automatic stays special; JSON stdout stays pure
- Claude built-ins gain xhigh/max; deterministic offline config, no wizard-time help probing
- Surfaces: team init/new-profile, team member add, up/show, resume --effort role=value parity (fresh-only, action-scoped errors for live/restore); catalog-backed numbered/Bubble/global wizard screens in the current Run controls phase
- PR #448 scope-first/lazy-discovery invariants retained (rev-4 entrypoint tests untouched)

## Provenance
- Exact commit: b9bc904a82b59a6f28522491857e8e78d4f1c37a (parent 5094aef, current main tip)
- Implemented by senior-dev; published by cto (lead) under standing approval gate/standing-approval-v2-20-0
- Implementer validation: no-amq go test -race ./... PASS; make ci PASS; agentcatalog/wizard/cli suites PASS; git diff --check PASS

Independent exact-head reviews (cto + qa spec-conformance) to follow before merge consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)