### PR TITLE
fix: stop refuses named-profile teardown when legacy/default AMQ root exists (#344)

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -62,6 +63,8 @@ type processTerminator interface {
 type signalTerminator struct {
 	sig syscall.Signal
 }
+
+type stopTerminatorFactory func(force bool) processTerminator
 
 // newSignalTerminator returns a terminator that sends SIGTERM by default, or
 // SIGKILL when force is set. `stop` genuinely terminates the agent: SIGTERM
@@ -116,6 +119,14 @@ func signalNameOf(term processTerminator) string {
 // recoverable via `amq-squad resume`. --force escalates to SIGKILL for agents
 // that ignore SIGTERM.
 func runStop(args []string) error {
+	return runStopWithDeps(args, func(force bool) processTerminator {
+		return newSignalTerminator(force)
+	}, defaultDuplicateLaunchProbe)
+}
+
+// runStopWithDeps keeps the production stop dependencies immutable while
+// allowing parser-to-execution tests to supply inert process controls.
+func runStopWithDeps(args []string, terminatorForForce stopTerminatorFactory, probe duplicateLaunchProbe) error {
 	fs := flag.NewFlagSet("stop", flag.ContinueOnError)
 	sessionName := fs.String("session", "", "AMQ workstream session name (default: team workstream)")
 	role := fs.String("role", "", "narrow to a single configured role")
@@ -157,6 +168,7 @@ func runStop(args []string) error {
 	return executeDown(downExecution{
 		Verb:             "stop",
 		ProjectDir:       projectDir,
+		ExplicitProject:  flagWasSet(fs, "project"),
 		RequestedSession: *sessionName,
 		ExplicitSession:  flagWasSet(fs, "session"),
 		ExplicitProfile:  flagWasSet(fs, "profile"),
@@ -166,8 +178,8 @@ func runStop(args []string) error {
 		// default=SIGTERM; --force=SIGKILL escalation for agents that ignore
 		// SIGTERM. The PID-liveness + binary-match guards still apply, so a
 		// reused/foreign PID is never signaled regardless of --force.
-		Terminator: newSignalTerminator(*force),
-		Probe:      defaultDuplicateLaunchProbe,
+		Terminator: terminatorForForce(*force),
+		Probe:      probe,
 		Out:        os.Stdout,
 		ClosePanes: *closePanes,
 	})
@@ -206,6 +218,7 @@ Examples:
 type downExecution struct {
 	Verb             string
 	ProjectDir       string
+	ExplicitProject  bool
 	RequestedSession string
 	ExplicitSession  bool
 	ExplicitProfile  bool
@@ -241,12 +254,34 @@ func executeDown(d downExecution) error {
 	if err != nil {
 		return err
 	}
-	if err := ensureNoNamespaceConflict(verb, d.ProjectDir, d.Profile, workstream, d.ExplicitProfile); err != nil {
+	exactStopScope := exactStopNamespaceScope{
+		Verb:            verb,
+		ProjectDir:      d.ProjectDir,
+		Profile:         d.Profile,
+		Session:         workstream,
+		Role:            d.Role,
+		All:             d.All,
+		ExplicitProject: d.ExplicitProject,
+		ExplicitProfile: d.ExplicitProfile,
+		ExplicitSession: d.ExplicitSession,
+	}
+	exceptionUsed, err := ensureNoNamespaceConflictForStop(exactStopScope)
+	if err != nil {
 		return err
 	}
 	targets, err := selectDownMembers(t, d.Role, d.All)
 	if err != nil {
 		return err
+	}
+	// The exact-stop namespace exception is deliberately stricter than the
+	// historical stop path. Before any watcher, PID, wake, presence, or pane
+	// mutation, prove that every selected launch record belongs to the requested
+	// named namespace. The validation is exception-only so legacy records keep
+	// their established compatibility outside this narrow recovery path.
+	if exceptionUsed {
+		if err := validateExactStopLaunchRecords(t, d.Profile, workstream, targets); err != nil {
+			return err
+		}
 	}
 	finalStop := d.All || noOperationalUntargetedMembers(t, d.Profile, workstream, targets, d.Probe)
 	watcherStopped := false
@@ -258,8 +293,12 @@ func executeDown(d downExecution) error {
 	}
 
 	reports := make([]downReport, 0, len(targets))
+	var exceptionScope *exactStopNamespaceScope
+	if exceptionUsed {
+		exceptionScope = &exactStopScope
+	}
 	for _, m := range targets {
-		reports = append(reports, terminateMember(t, d.Profile, m, workstream, d.Terminator, d.Probe))
+		reports = append(reports, terminateMember(t, d.Profile, m, workstream, d.Terminator, d.Probe, exceptionScope))
 	}
 	if d.ClosePanes {
 		closeDownedPanes(reports, workstream)
@@ -275,6 +314,52 @@ func executeDown(d downExecution) error {
 		}
 	}
 	return renderErr
+}
+
+func validateExactStopLaunchRecords(t team.Team, profile, workstream string, targets []team.Member) error {
+	for _, m := range targets {
+		cwd := m.EffectiveCWD(t.Project)
+		env, err := resolveAMQEnvForTeamProfile(cwd, profile, workstream, m.Handle)
+		if err != nil {
+			return fmt.Errorf("stop refused: resolve named namespace for role %q: %w", m.Role, err)
+		}
+		handle := m.Handle
+		if env.Me != "" {
+			handle = env.Me
+		}
+		expectedRoot := absoluteAMQRoot(cwd, env.Root)
+		agentDir := filepath.Join(expectedRoot, "agents", handle)
+		rec, err := launch.Read(agentDir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("stop refused: read launch record for role %q before exact named-profile teardown: %w", m.Role, err)
+		}
+		if err := validateExactStopLaunchRecord(rec, m, handle, profile, workstream, expectedRoot); err != nil {
+			return fmt.Errorf("stop refused: launch record for role %q failed exact named-profile identity validation: %w", m.Role, err)
+		}
+	}
+	return nil
+}
+
+func validateExactStopLaunchRecord(rec launch.Record, member team.Member, handle, profile, workstream, expectedRoot string) error {
+	if !squadnamespace.ProfilesEqual(profile, rec.TeamProfile) {
+		return fmt.Errorf("profile %q does not match requested profile %q", squadnamespace.NormalizeProfile(rec.TeamProfile), squadnamespace.NormalizeProfile(profile))
+	}
+	if strings.TrimSpace(rec.Session) != strings.TrimSpace(workstream) {
+		return fmt.Errorf("session %q does not match requested session %q", rec.Session, workstream)
+	}
+	if !sameResolvedDir(rec.Root, expectedRoot) {
+		return fmt.Errorf("root %q does not match requested root %q", rec.Root, expectedRoot)
+	}
+	if rec.Role != "" && !strings.EqualFold(strings.TrimSpace(rec.Role), strings.TrimSpace(member.Role)) {
+		return fmt.Errorf("role %q does not match requested role %q", rec.Role, member.Role)
+	}
+	if rec.Handle != "" && !strings.EqualFold(strings.TrimSpace(rec.Handle), strings.TrimSpace(handle)) {
+		return fmt.Errorf("handle %q does not match requested handle %q", rec.Handle, handle)
+	}
+	return nil
 }
 
 func downReportsConfirmed(reports []downReport) bool {
@@ -360,7 +445,7 @@ func selectDownMembers(t team.Team, role string, all bool) ([]team.Member, error
 	return nil, fmt.Errorf("unknown role %q; team has: %s", role, strings.Join(names, ", "))
 }
 
-func terminateMember(t team.Team, profile string, m team.Member, workstream string, term processTerminator, probe duplicateLaunchProbe) downReport {
+func terminateMember(t team.Team, profile string, m team.Member, workstream string, term processTerminator, probe duplicateLaunchProbe, exactStopScope *exactStopNamespaceScope) downReport {
 	report := downReport{Role: m.Role, Handle: m.Handle, Binary: m.Binary}
 	cwd := m.EffectiveCWD(t.Project)
 	env, err := resolveAMQEnvForTeamProfile(cwd, profile, workstream, m.Handle)
@@ -388,11 +473,19 @@ func terminateMember(t team.Team, profile string, m team.Member, workstream stri
 		report.Detail = "read launch record: " + err.Error()
 		return report
 	}
+	if exactStopScope != nil {
+		if err := validateExactStopLaunchRecord(rec, m, handle, exactStopScope.Profile, exactStopScope.Session, root); err != nil {
+			report.Status = downStatusFailed
+			report.Detail = "launch record failed exact named-profile identity validation: " + err.Error()
+			return report
+		}
+	}
 	if rec.Tmux != nil {
 		report.PaneID = rec.Tmux.PaneID
 	}
 	report.CWD = compareCWD(cwd, rec.CWD)
 	report.PID = rec.AgentPID
+	strictWakeRoot := exactStopScope != nil
 	if rec.External {
 		report.Status = downStatusMaybeLive
 		if report.PaneID != "" {
@@ -411,7 +504,7 @@ func terminateMember(t team.Team, profile string, m team.Member, workstream stri
 			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
 			return report
 		}
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, term, probe)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = "no pid captured at launch; " + cleaned.summary()
@@ -427,7 +520,7 @@ func terminateMember(t team.Team, profile string, m team.Member, workstream stri
 		return report
 	}
 	if !probe.PIDAlive(rec.AgentPID) {
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, term, probe)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = fmt.Sprintf("recorded pid %d is not alive; %s", rec.AgentPID, cleaned.summary())
@@ -447,7 +540,7 @@ func terminateMember(t team.Team, profile string, m team.Member, workstream stri
 		binary = m.Binary
 	}
 	if binary == "" || !probe.ProcessMatch(rec.AgentPID, agentProcessMatcher(binary)) {
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, term, probe)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = fmt.Sprintf("pid %d does not match expected binary %q (PID reuse); %s", rec.AgentPID, binary, cleaned.summary())
@@ -478,7 +571,7 @@ func terminateMember(t team.Team, profile string, m team.Member, workstream stri
 	// that as downStatusFailed so renderDownReports counts it correctly;
 	// without this, the per-member detail says "wake survived" but the summary
 	// still reads as a clean success.
-	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, term, probe)
+	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, term, probe)
 	if cleaned.failed() {
 		report.Status = downStatusFailed
 		report.Detail = fmt.Sprintf("%s sent to pid %d; %s", sigName, rec.AgentPID, cleaned.summary())
@@ -544,7 +637,7 @@ func (r reapResult) summary() string {
 // include it in user-visible reports. Errors during cleanup are best-effort
 // and do not propagate: the goal is to unblock the next launch, not to
 // guarantee atomicity.
-func reapStaleArtifacts(agentDir, handle, root string, term processTerminator, probe duplicateLaunchProbe) reapResult {
+func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, term processTerminator, probe duplicateLaunchProbe) reapResult {
 	var result reapResult
 	if agentDir == "" {
 		return result
@@ -565,6 +658,13 @@ func reapStaleArtifacts(agentDir, handle, root string, term processTerminator, p
 			// Corrupt lock: no PID to verify, safe to remove.
 			canRemoveLock = true
 		case lock.PID <= 0:
+			canRemoveLock = true
+		case strictRoot && strings.TrimSpace(lock.Root) != "" && !rootsMatch(lock.Root, root):
+			// The exact named-profile stop exception trusts only the selected
+			// root. A lock copied or poisoned with an explicit legacy/foreign
+			// root is stale for this named agent dir; never inspect or signal
+			// the PID it names. Empty roots retain the historical selected-root
+			// fallback for older locks.
 			canRemoveLock = true
 		case !probe.PIDAlive(lock.PID):
 			canRemoveLock = true

--- a/internal/cli/namespace_conflict.go
+++ b/internal/cli/namespace_conflict.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimeaction"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -100,6 +101,51 @@ func suggestedCollisionProfile(profile, session string) string {
 type namespaceConflictOverrideOptions struct {
 	Allowed bool
 	Reason  string
+}
+
+// exactStopNamespaceScope is the complete proof required to treat a durable
+// legacy/default root as evidence rather than a blocker for one deterministic
+// teardown. It is shared by the stop guard and status action filtering so the
+// executable command and the advertised action cannot drift.
+type exactStopNamespaceScope struct {
+	Verb            string
+	ProjectDir      string
+	Profile         string
+	Session         string
+	Role            string
+	All             bool
+	ExplicitProject bool
+	ExplicitProfile bool
+	ExplicitSession bool
+}
+
+func allowsExactNamedProfileStop(conflict *namespaceConflictData, scope exactStopNamespaceScope) bool {
+	profile := squadnamespace.NormalizeProfile(scope.Profile)
+	session := strings.TrimSpace(scope.Session)
+	role := strings.TrimSpace(scope.Role)
+	selectorValid := (role != "") != scope.All
+	expectedRoot := squadnamespace.AMQRoot(scope.ProjectDir, profile, session)
+	return conflict != nil &&
+		strings.EqualFold(strings.TrimSpace(scope.Verb), "stop") &&
+		conflict.Kind == "legacy_session_root" &&
+		squadnamespace.ProfilesEqual(conflict.Profile, profile) &&
+		strings.TrimSpace(conflict.Session) == session &&
+		sameResolvedDir(conflict.RequestedAMQRoot, expectedRoot) &&
+		scope.ExplicitProject && strings.TrimSpace(scope.ProjectDir) != "" &&
+		scope.ExplicitProfile && profile != team.DefaultProfile && strings.TrimSpace(scope.Profile) != "" &&
+		scope.ExplicitSession && session != "" && selectorValid
+}
+
+// ensureNoNamespaceConflictForStop preserves the shared fail-closed guard and
+// bypasses only its one legacy-session-root result for an exact named-profile
+// stop. All other operations and conflict kinds continue through the global
+// policy unchanged.
+func ensureNoNamespaceConflictForStop(scope exactStopNamespaceScope) (bool, error) {
+	conflict := namespaceConflictForProfileSession(scope.ProjectDir, scope.Profile, scope.Session)
+	if allowsExactNamedProfileStop(conflict, scope) {
+		return true, nil
+	}
+	return false, ensureNoNamespaceConflict("stop", scope.ProjectDir, scope.Profile, scope.Session, scope.ExplicitProfile)
 }
 
 type namespaceConflictAuditRecord struct {
@@ -427,7 +473,7 @@ func legacyMailboxSkeletonDir(rel string) bool {
 	}
 }
 
-func disableNamespaceConflictActions(actions []runtimeActionJSON, conflict *namespaceConflictData) []runtimeActionJSON {
+func disableNamespaceConflictActions(actions []runtimeActionJSON, conflict *namespaceConflictData, exactStopScope exactStopNamespaceScope) []runtimeActionJSON {
 	if conflict == nil {
 		return actions
 	}
@@ -436,8 +482,14 @@ func disableNamespaceConflictActions(actions []runtimeActionJSON, conflict *name
 		if !actionBlockedByNamespaceConflict(out[i]) {
 			continue
 		}
+		if (out[i].Kind == "stop" || out[i].Kind == "stop_close_panes") && allowsExactNamedProfileStop(conflict, exactStopScope) {
+			// Skip only the namespace-conflict disable. Never force-enable an
+			// action that another policy already made unavailable.
+			continue
+		}
 		out[i].Available = false
 		out[i].Reason = conflict.Detail
+		runtimeaction.SyncUnavailableReason(&out[i])
 	}
 	return out
 }

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -576,7 +576,6 @@ func TestNamedProfileConflictBlocksDirectRuntimeCommands(t *testing.T) {
 		{"goal deliver", func() error {
 			return runGoal([]string{"deliver", "--profile", "review", "--session", "main", "--role", "cto", "--goal", "ship"})
 		}},
-		{"stop", func() error { return runStop([]string{"--profile", "review", "--session", "main", "--all"}) }},
 		{"up", func() error {
 			return runUp([]string{"--profile", "review", "--session", "main", "--terminal", "fake", "--no-bootstrap"})
 		}},

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -359,13 +359,23 @@ func executeStatus(s statusExecution) error {
 	if s.JSON {
 		ns := squadnamespace.Resolve(t.Project, s.Profile, workstream)
 		conflict := namespaceConflictForProfileSession(t.Project, s.Profile, workstream)
+		exactStopScope := exactStopNamespaceScope{
+			Verb:            "stop",
+			ProjectDir:      t.Project,
+			Profile:         s.Profile,
+			Session:         workstream,
+			All:             true,
+			ExplicitProject: true,
+			ExplicitProfile: squadnamespace.NormalizeProfile(s.Profile) != team.DefaultProfile,
+			ExplicitSession: true,
+		}
 		// Attach the stable action commands a client can render/copy per member.
 		for i := range rows {
 			rows[i].Namespace = ns
-			rows[i].Actions = disableNamespaceConflictActions(policyAwareMemberActionsForRow(t, s.Profile, workstream, rows[i]), conflict)
+			rows[i].Actions = disableNamespaceConflictActions(policyAwareMemberActionsForRow(t, s.Profile, workstream, rows[i]), conflict, exactStopScope)
 		}
 		ctx := newSessionStatusContext(t, s.Profile, workstream, firstLiveTmuxSession(rows))
-		ctx.Actions = disableNamespaceConflictActions(ctx.Actions, conflict)
+		ctx.Actions = disableNamespaceConflictActions(ctx.Actions, conflict, exactStopScope)
 		binding := goalBindingForStatus(ns, ctx, rows)
 		operatorView := statusOperatorForTeam(t, ns)
 		applyGoalBindingOpenBlockers(&operatorView, binding)

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -386,12 +386,13 @@ func TestExecuteStatusIsolatesForeignProfileLaunchRecord(t *testing.T) {
 	}
 }
 
-func TestExecuteStatusJSONNamedProfileDisablesActionsOnLegacySessionRootConflict(t *testing.T) {
+func TestExecuteStatusJSONNamedProfileKeepsExactStopActionsOnLegacySessionRootConflict(t *testing.T) {
 	setupFakeAMQSessionRoots(t)
 	dir := t.TempDir()
 	seedProfile(t, dir, "release", team.Team{
+		Project: dir,
 		Members: []team.Member{
-			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main"},
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "main", CWD: dir},
 		},
 		Orchestrated: true,
 		Lead:         "cto",
@@ -403,6 +404,17 @@ func TestExecuteStatusJSONNamedProfileDisablesActionsOnLegacySessionRootConflict
 	if err := os.WriteFile(filepath.Join(legacyAgentDir, "inbox"), []byte("legacy durable state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	namedRoot := filepath.Join(dir, ".agent-mail", "release", "main")
+	if err := launch.Write(filepath.Join(namedRoot, "agents", "cto"), launch.Record{
+		CWD: dir, Binary: "codex", Handle: "cto", Role: "cto", Session: "main",
+		Root: namedRoot, TeamProfile: "release", AgentPID: 5555,
+		Tmux: &launch.TmuxInfo{Session: "tmux-main", PaneID: "%55"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	swapStatusPaneLister(t, []tmuxpane.TmuxPane{{
+		PaneID: "%55", CWD: dir, Command: "codex", Title: paneTitleToken("main", "cto"),
+	}}, nil)
 
 	out, err := runStatusExec(t, statusExecution{
 		ProjectDir:       dir,
@@ -410,7 +422,7 @@ func TestExecuteStatusJSONNamedProfileDisablesActionsOnLegacySessionRootConflict
 		RequestedSession: "main",
 		ExplicitSession:  true,
 		JSON:             true,
-		Probe:            statusProbe(nil, nil, time.Now()),
+		Probe:            statusProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now()),
 	})
 	if err != nil {
 		t.Fatalf("status --json: %v\n%s", err, out)
@@ -419,25 +431,42 @@ func TestExecuteStatusJSONNamedProfileDisablesActionsOnLegacySessionRootConflict
 	if env.Data.NamespaceConflict == nil || env.Data.NamespaceConflict.Kind != "legacy_session_root" {
 		t.Fatalf("namespace conflict missing: %+v", env.Data.NamespaceConflict)
 	}
-	for _, action := range env.Data.Actions {
-		switch action.Kind {
-		case "resume_current_window", "resume_new_session", "stop", "stop_close_panes", "attach_control":
-			if action.Available || !strings.Contains(action.Reason, "legacy/default session root") {
-				t.Fatalf("action %s should be unavailable with conflict reason: %+v", action.Kind, action)
-			}
-		case "status", "task_list":
-			if !action.Available {
-				t.Fatalf("read-only action %s should remain available: %+v", action.Kind, action)
-			}
+	if env.Data.NamespaceConflict.RequestedAMQRoot != namedRoot ||
+		env.Data.NamespaceConflict.ConflictingAMQRoot != filepath.Join(dir, ".agent-mail", "main") {
+		t.Fatalf("namespace conflict roots = %+v", env.Data.NamespaceConflict)
+	}
+	sessionActions := actionsByKind(env.Data.Actions)
+	for _, kind := range []string{"status", "resume_preview", "stop", "stop_close_panes", "task_list"} {
+		if action := sessionActions[kind]; !action.Available {
+			t.Fatalf("session action %s should remain available: %+v", kind, action)
 		}
+	}
+	for _, kind := range []string{"resume_current_window", "resume_new_session", "attach_control"} {
+		action := sessionActions[kind]
+		if action.Available || !strings.Contains(action.Reason, "legacy/default session root") || action.UnavailableReason != action.Reason {
+			t.Fatalf("session action %s should be conflict-blocked with canonical reason: %+v", kind, action)
+		}
+	}
+	wantStop := "amq-squad stop --project " + shellQuote(dir) + " --profile release --session main --all"
+	if got := sessionActions["stop"].Command; got != wantStop {
+		t.Fatalf("stop command = %q, want %q", got, wantStop)
+	}
+	if got := sessionActions["stop_close_panes"].Command; got != wantStop+" --close-panes" {
+		t.Fatalf("stop_close_panes command = %q", got)
 	}
 	if len(env.Data.Records) != 1 {
 		t.Fatalf("records = %d", len(env.Data.Records))
 	}
-	for _, action := range env.Data.Records[0].Actions {
-		if (action.Kind == "resume" || action.Kind == "focus" || action.Kind == "send") &&
-			(action.Available || !strings.Contains(action.Reason, "legacy/default session root")) {
-			t.Fatalf("member action %s should be unavailable with conflict reason: %+v", action.Kind, action)
+	memberActions := actionsByKind(env.Data.Records[0].Actions)
+	for _, kind := range []string{"focus", "send", "goal_deliver", "dispatch", "resume"} {
+		action := memberActions[kind]
+		if action.Available || !strings.Contains(action.Reason, "legacy/default session root") || action.UnavailableReason != action.Reason {
+			t.Fatalf("member action %s should be conflict-blocked with canonical reason: %+v", kind, action)
+		}
+	}
+	for _, kind := range []string{"status", "task_list"} {
+		if action := memberActions[kind]; !action.Available {
+			t.Fatalf("member action %s should remain available: %+v", kind, action)
 		}
 	}
 }

--- a/internal/cli/stop_namespace_conflict_test.go
+++ b/internal/cli/stop_namespace_conflict_test.go
@@ -1,0 +1,617 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+const (
+	exactStopProfile = "plane-cli"
+	exactStopSession = "plane-cli"
+)
+
+type legacyTreeEntry struct {
+	Mode  os.FileMode
+	IsDir bool
+	Data  string
+}
+
+func stopRunnerForTest(term processTerminator, probe duplicateLaunchProbe) func([]string) error {
+	return func(args []string) error {
+		return runStopWithDeps(args, func(bool) processTerminator { return term }, probe)
+	}
+}
+
+func swapTeamMemberStopRunner(t *testing.T, runner func([]string) error) {
+	t.Helper()
+	old := teamMemberStop
+	teamMemberStop = runner
+	t.Cleanup(func() { teamMemberStop = old })
+}
+
+func seedExactStopProject(t *testing.T, members []team.Member) (projectDir, namedRoot, legacyRoot string) {
+	t.Helper()
+	setupFakeAMQSessionRoots(t)
+	projectDir = t.TempDir()
+	resumeChdir(t, projectDir)
+	seedProfile(t, projectDir, exactStopProfile, team.Team{
+		Project:    projectDir,
+		Workstream: exactStopSession,
+		Members:    members,
+	})
+	namedRoot = squadnamespace.AMQRoot(projectDir, exactStopProfile, exactStopSession)
+	legacyRoot = squadnamespace.AMQRoot(projectDir, team.DefaultProfile, exactStopSession)
+
+	legacyFiles := map[string]string{
+		filepath.Join(legacyRoot, "agents", "legacy", "inbox", "new", "message.md"): "legacy inbox bytes\x00\n",
+		filepath.Join(legacyRoot, "agents", "legacy", "presence.json"):              `{"schema":1,"handle":"legacy","status":"active"}`,
+		filepath.Join(legacyRoot, "agents", "legacy", ".wake.lock"):                 `{"pid":9191,"root":"legacy-root"}`,
+		filepath.Join(legacyRoot, "threads", "legacy.md"):                           "legacy thread\n",
+	}
+	for path, data := range legacyFiles {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return projectDir, namedRoot, legacyRoot
+}
+
+func writeExactStopRecord(t *testing.T, namedRoot string, member team.Member, pid int, paneID string) string {
+	t.Helper()
+	agentDir := filepath.Join(namedRoot, "agents", member.Handle)
+	rec := launch.Record{
+		CWD:         member.CWD,
+		Binary:      member.Binary,
+		Handle:      member.Handle,
+		Role:        member.Role,
+		Session:     exactStopSession,
+		Root:        namedRoot,
+		TeamProfile: exactStopProfile,
+		AgentPID:    pid,
+		StartedAt:   time.Now().UTC(),
+	}
+	if paneID != "" {
+		rec.Tmux = &launch.TmuxInfo{Session: "tmux-plane", PaneID: paneID}
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	return agentDir
+}
+
+func snapshotLegacyTree(t *testing.T, legacyRoot, namedRoot string) map[string]legacyTreeEntry {
+	t.Helper()
+	out := map[string]legacyTreeEntry{}
+	err := filepath.WalkDir(legacyRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if sameResolvedDir(path, namedRoot) {
+			return filepath.SkipDir
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(legacyRoot, path)
+		if err != nil {
+			return err
+		}
+		item := legacyTreeEntry{Mode: info.Mode(), IsDir: entry.IsDir()}
+		if !entry.IsDir() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			item.Data = string(data)
+		}
+		out[rel] = item
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func assertLegacyTreeUnchanged(t *testing.T, before map[string]legacyTreeEntry, legacyRoot, namedRoot string) {
+	t.Helper()
+	after := snapshotLegacyTree(t, legacyRoot, namedRoot)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("legacy/default state changed\nbefore: %#v\nafter:  %#v", before, after)
+	}
+}
+
+func exactStopArgs(projectDir string, extra ...string) []string {
+	args := []string{"--project", projectDir, "--profile", exactStopProfile, "--session", exactStopSession}
+	return append(args, extra...)
+}
+
+func TestAllowsExactNamedProfileStopMatrix(t *testing.T) {
+	project := t.TempDir()
+	root := squadnamespace.AMQRoot(project, exactStopProfile, exactStopSession)
+	conflict := &namespaceConflictData{
+		Kind:             "legacy_session_root",
+		Profile:          exactStopProfile,
+		Session:          exactStopSession,
+		RequestedAMQRoot: root,
+	}
+	valid := exactStopNamespaceScope{
+		Verb: "stop", ProjectDir: project, Profile: exactStopProfile, Session: exactStopSession,
+		All: true, ExplicitProject: true, ExplicitProfile: true, ExplicitSession: true,
+	}
+	if !allowsExactNamedProfileStop(conflict, valid) {
+		t.Fatal("fully explicit named legacy-root stop should be allowed")
+	}
+
+	tests := map[string]func(*namespaceConflictData, *exactStopNamespaceScope){
+		"nil conflict":              func(c *namespaceConflictData, _ *exactStopNamespaceScope) { *c = namespaceConflictData{} },
+		"future conflict kind":      func(c *namespaceConflictData, _ *exactStopNamespaceScope) { c.Kind = "future_kind" },
+		"creation collision":        func(c *namespaceConflictData, _ *exactStopNamespaceScope) { c.Kind = "profile_session_root_collision" },
+		"conflict profile mismatch": func(c *namespaceConflictData, _ *exactStopNamespaceScope) { c.Profile = "other" },
+		"conflict session mismatch": func(c *namespaceConflictData, _ *exactStopNamespaceScope) { c.Session = "other" },
+		"conflict root mismatch": func(c *namespaceConflictData, _ *exactStopNamespaceScope) {
+			c.RequestedAMQRoot = filepath.Join(project, "other")
+		},
+		"different verb":     func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.Verb = "resume" },
+		"project inferred":   func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.ExplicitProject = false },
+		"profile inferred":   func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.ExplicitProfile = false },
+		"session inferred":   func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.ExplicitSession = false },
+		"project empty":      func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.ProjectDir = "" },
+		"profile default":    func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.Profile = team.DefaultProfile },
+		"profile empty":      func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.Profile = "" },
+		"session empty":      func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.Session = "" },
+		"selector missing":   func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.All = false },
+		"selectors both set": func(_ *namespaceConflictData, s *exactStopNamespaceScope) { s.Role = "cto" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotConflict := *conflict
+			gotScope := valid
+			mutate(&gotConflict, &gotScope)
+			var candidate *namespaceConflictData = &gotConflict
+			if name == "nil conflict" {
+				candidate = nil
+			}
+			if allowsExactNamedProfileStop(candidate, gotScope) {
+				t.Fatal("non-exact stop scope unexpectedly allowed")
+			}
+		})
+	}
+
+	roleScope := valid
+	roleScope.All = false
+	roleScope.Role = "cto"
+	if !allowsExactNamedProfileStop(conflict, roleScope) {
+		t.Fatal("role-scoped exact stop should be allowed")
+	}
+}
+
+func TestRunStopExactNamedProfileConflictStopsAllAndPreservesLegacyState(t *testing.T) {
+	members := []team.Member{
+		{Role: "cto", Binary: "codex", Handle: "cto"},
+		{Role: "qa", Binary: "codex", Handle: "qa"},
+	}
+	project, namedRoot, legacyRoot := seedExactStopProject(t, members)
+	now := time.Now().UTC()
+	alive := map[int]bool{}
+	match := map[int]bool{}
+	for i, member := range members {
+		pid := 1100 + i
+		wakePID := 2100 + i
+		agentDir := writeExactStopRecord(t, namedRoot, member, pid, "")
+		writeWakeLock(t, agentDir, wakeLockFile{PID: wakePID, Root: namedRoot})
+		writePresence(t, agentDir, presenceFile{Schema: 1, Handle: member.Handle, Status: "active", LastSeen: now})
+		alive[pid], alive[wakePID] = true, true
+		match[pid], match[wakePID] = true, true
+	}
+	legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+	term := &recordingTerminator{}
+	stop := stopRunnerForTest(term, downFakeProbe(alive, match))
+	swapStatusPaneLister(t, nil, nil)
+
+	stdout, _, err := captureOutput(t, func() error {
+		return stop(exactStopArgs(project, "--all"))
+	})
+	if err != nil {
+		t.Fatalf("exact named-profile stop: %v\n%s", err, stdout)
+	}
+	wantCalls := []int{1100, 2100, 1101, 2101}
+	if !reflect.DeepEqual(term.calls, wantCalls) {
+		t.Fatalf("terminate calls = %v, want %v", term.calls, wantCalls)
+	}
+	for _, member := range members {
+		agentDir := filepath.Join(namedRoot, "agents", member.Handle)
+		if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+			t.Fatalf("named wake lock for %s was not removed: %v", member.Role, err)
+		}
+		presence, err := readPresenceForEntry(agentDir)
+		if err != nil || presence.Status != "offline" {
+			t.Fatalf("named presence for %s = %+v / %v, want offline", member.Role, presence, err)
+		}
+	}
+	assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+}
+
+func TestExactNamedProfileStopWakeLockRootValidation(t *testing.T) {
+	t.Run("explicit legacy root is removed without touching its wake pid", func(t *testing.T) {
+		member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+		agentDir := writeExactStopRecord(t, namedRoot, member, 8100, "")
+		writeWakeLock(t, agentDir, wakeLockFile{PID: 8200, Root: legacyRoot})
+		writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now()})
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		legacyWakeArgs := "amq wake --me cto --root " + legacyRoot
+		if !wakeProcessMatcher("cto", legacyRoot)(legacyWakeArgs) {
+			t.Fatal("fixture must describe a matching legacy-root wake")
+		}
+
+		var processMatchCalls []int
+		probe := duplicateLaunchProbe{
+			PIDAlive: func(pid int) bool { return pid == 8100 || pid == 8200 },
+			ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+				processMatchCalls = append(processMatchCalls, pid)
+				switch pid {
+				case 8100:
+					return predicate("codex --search")
+				case 8200:
+					return predicate(legacyWakeArgs)
+				default:
+					return false
+				}
+			},
+			Now: time.Now,
+		}
+		term := &recordingTerminator{}
+		stop := stopRunnerForTest(term, probe)
+		swapStatusPaneLister(t, nil, nil)
+
+		stdout, _, err := captureOutput(t, func() error {
+			return stop(exactStopArgs(project, "--all"))
+		})
+		if err != nil {
+			t.Fatalf("poisoned wake-lock stop: %v\n%s", err, stdout)
+		}
+		if !reflect.DeepEqual(processMatchCalls, []int{8100}) {
+			t.Fatalf("ProcessMatch calls = %v, poisoned legacy wake pid must not be inspected", processMatchCalls)
+		}
+		if !reflect.DeepEqual(term.calls, []int{8100}) {
+			t.Fatalf("signals = %v, want only named agent pid", term.calls)
+		}
+		if _, statErr := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(statErr) {
+			t.Fatalf("poisoned named-dir wake lock was not removed: %v", statErr)
+		}
+		presence, readErr := readPresenceForEntry(agentDir)
+		if readErr != nil || presence.Status != "offline" {
+			t.Fatalf("named presence = %+v / %v, want offline", presence, readErr)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+
+	t.Run("empty root falls back to selected named root", func(t *testing.T) {
+		member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+		project, namedRoot, _ := seedExactStopProject(t, []team.Member{member})
+		agentDir := writeExactStopRecord(t, namedRoot, member, 8300, "")
+		writeWakeLock(t, agentDir, wakeLockFile{PID: 8301})
+		probe := duplicateLaunchProbe{
+			PIDAlive: func(pid int) bool { return pid == 8300 || pid == 8301 },
+			ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+				if pid == 8300 {
+					return predicate("codex --search")
+				}
+				return pid == 8301 && predicate("amq wake --me cto --root "+namedRoot)
+			},
+			Now: time.Now,
+		}
+		term := &recordingTerminator{}
+		stop := stopRunnerForTest(term, probe)
+		swapStatusPaneLister(t, nil, nil)
+		if _, _, err := captureOutput(t, func() error { return stop(exactStopArgs(project, "--all")) }); err != nil {
+			t.Fatalf("empty-root wake stop: %v", err)
+		}
+		if !reflect.DeepEqual(term.calls, []int{8300, 8301}) {
+			t.Fatalf("signals = %v, want named agent and selected-root wake", term.calls)
+		}
+		if _, statErr := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(statErr) {
+			t.Fatalf("empty-root wake lock was not removed: %v", statErr)
+		}
+	})
+}
+
+func TestRunStopExactNamedProfileRoleAndClosePane(t *testing.T) {
+	members := []team.Member{
+		{Role: "cto", Binary: "codex", Handle: "cto"},
+		{Role: "qa", Binary: "codex", Handle: "qa"},
+	}
+	project, namedRoot, legacyRoot := seedExactStopProject(t, members)
+	writeExactStopRecord(t, namedRoot, members[0], 3100, "%31")
+	writeExactStopRecord(t, namedRoot, members[1], 3200, "%32")
+	legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+	term := &recordingTerminator{}
+	stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{3100: true, 3200: true}, map[int]bool{3100: true, 3200: true}))
+	swapStatusPaneLister(t, nil, nil)
+	closed := swapPaneCloser(t)
+	swapPaneInspectorMatching(t, exactStopSession, map[string]string{"%31": "cto", "%32": "qa"})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return stop(exactStopArgs(project, "--role", "cto", "--close-panes"))
+	})
+	if err != nil {
+		t.Fatalf("role exact stop: %v\n%s", err, stdout)
+	}
+	if !reflect.DeepEqual(term.calls, []int{3100}) {
+		t.Fatalf("terminate calls = %v, want only cto", term.calls)
+	}
+	if !reflect.DeepEqual(*closed, []string{"%31"}) {
+		t.Fatalf("closed panes = %v, want only cto pane", *closed)
+	}
+	assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+}
+
+func TestRunStopExactNamedProfileRequiresEveryScopeFlag(t *testing.T) {
+	for _, omitted := range []string{"project", "profile", "session"} {
+		t.Run("omit "+omitted, func(t *testing.T) {
+			member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+			project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+			writeExactStopRecord(t, namedRoot, member, 4100, "")
+			if omitted == "profile" {
+				seedProfile(t, project, team.DefaultProfile, team.Team{
+					Project: project, Workstream: exactStopSession,
+					Members: []team.Member{member},
+				})
+			}
+			legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+			term := &recordingTerminator{}
+			stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{4100: true}, map[int]bool{4100: true}))
+			swapStatusPaneLister(t, nil, nil)
+
+			args := []string{"--project", project, "--profile", exactStopProfile, "--session", exactStopSession, "--all"}
+			filtered := make([]string, 0, len(args))
+			for i := 0; i < len(args); i++ {
+				if args[i] == "--"+omitted {
+					i++
+					continue
+				}
+				filtered = append(filtered, args[i])
+			}
+			_, _, err := captureOutput(t, func() error { return stop(filtered) })
+			if err == nil || (!strings.Contains(err.Error(), "legacy/default session root") && !strings.Contains(err.Error(), "default-profile")) {
+				t.Fatalf("omitted %s should fail closed, got %v", omitted, err)
+			}
+			if len(term.calls) != 0 {
+				t.Fatalf("omitted %s signaled pids: %v", omitted, term.calls)
+			}
+			assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+		})
+	}
+}
+
+func TestRunStopImplicitDefaultRefusesMultipleNamedOwners(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	project := t.TempDir()
+	resumeChdir(t, project)
+	member := team.Member{Role: "cto", Binary: "codex", Handle: "cto", Session: exactStopSession}
+	seedProfile(t, project, team.DefaultProfile, team.Team{
+		Project: project, Workstream: exactStopSession, Members: []team.Member{member},
+	})
+	type sentinel struct {
+		path string
+		data string
+	}
+	var sentinels []sentinel
+	for _, profile := range []string{"product", "release"} {
+		seedProfile(t, project, profile, team.Team{
+			Project: project, Workstream: exactStopSession, Members: []team.Member{member},
+		})
+		path := filepath.Join(squadnamespace.AMQRoot(project, profile, exactStopSession), "agents", "cto", "inbox.md")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		data := "named owner " + profile + "\n"
+		if err := os.WriteFile(path, []byte(data), 0o640); err != nil {
+			t.Fatal(err)
+		}
+		sentinels = append(sentinels, sentinel{path: path, data: data})
+	}
+	term := &recordingTerminator{}
+	stop := stopRunnerForTest(term, downFakeProbe(nil, nil))
+	swapStatusPaneLister(t, nil, nil)
+
+	_, _, err := captureOutput(t, func() error {
+		return stop([]string{"--project", project, "--session", exactStopSession, "--all"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple named profiles") {
+		t.Fatalf("implicit default stop should refuse multiple named owners, got %v", err)
+	}
+	if len(term.calls) != 0 {
+		t.Fatalf("implicit default stop signaled pids: %v", term.calls)
+	}
+	for _, item := range sentinels {
+		got, readErr := os.ReadFile(item.path)
+		if readErr != nil || string(got) != item.data {
+			t.Fatalf("named owner sentinel changed at %s: %q / %v", item.path, got, readErr)
+		}
+	}
+	if _, statErr := os.Stat(squadnamespace.AMQRoot(project, team.DefaultProfile, exactStopSession)); !os.IsNotExist(statErr) {
+		t.Fatalf("refused implicit-default stop created legacy root: %v", statErr)
+	}
+}
+
+func TestExactNamedProfileStopLaunchIdentityMismatchFailsBeforeMutation(t *testing.T) {
+	tests := map[string]func(*launch.Record, string){
+		"profile": func(rec *launch.Record, _ string) { rec.TeamProfile = "other" },
+		"session": func(rec *launch.Record, _ string) { rec.Session = "other" },
+		"root":    func(rec *launch.Record, project string) { rec.Root = filepath.Join(project, "other") },
+		"role":    func(rec *launch.Record, _ string) { rec.Role = "other" },
+		"handle":  func(rec *launch.Record, _ string) { rec.Handle = "other" },
+	}
+	for field, mutate := range tests {
+		t.Run(field, func(t *testing.T) {
+			member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+			project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+			agentDir := writeExactStopRecord(t, namedRoot, member, 5100, "%51")
+			rec, err := launch.Read(agentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mutate(&rec, project)
+			if err := launch.Write(agentDir, rec); err != nil {
+				t.Fatal(err)
+			}
+			writeWakeLock(t, agentDir, wakeLockFile{PID: 5101, Root: namedRoot})
+			writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now()})
+			legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+			term := &recordingTerminator{}
+			stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{5100: true, 5101: true}, map[int]bool{5100: true, 5101: true}))
+			swapStatusPaneLister(t, nil, nil)
+			closed := swapPaneCloser(t)
+
+			_, _, err = captureOutput(t, func() error {
+				return stop(exactStopArgs(project, "--all", "--close-panes"))
+			})
+			if err == nil || !strings.Contains(err.Error(), "identity validation") {
+				t.Fatalf("%s mismatch should fail identity validation, got %v", field, err)
+			}
+			if len(term.calls) != 0 || len(*closed) != 0 {
+				t.Fatalf("%s mismatch mutated runtime: signals=%v panes=%v", field, term.calls, *closed)
+			}
+			if _, statErr := os.Stat(wakeLockPath(agentDir)); statErr != nil {
+				t.Fatalf("%s mismatch removed wake lock: %v", field, statErr)
+			}
+			presence, readErr := readPresenceForEntry(agentDir)
+			if readErr != nil || presence.Status != "active" {
+				t.Fatalf("%s mismatch changed presence: %+v / %v", field, presence, readErr)
+			}
+			assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+		})
+	}
+}
+
+func TestExactNamedProfileStopSafetyRegressions(t *testing.T) {
+	t.Run("reused pid is not signaled", func(t *testing.T) {
+		member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+		writeExactStopRecord(t, namedRoot, member, 6100, "")
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		term := &recordingTerminator{}
+		stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{6100: true}, map[int]bool{6100: false}))
+		swapStatusPaneLister(t, nil, nil)
+		stdout, _, err := captureOutput(t, func() error { return stop(exactStopArgs(project, "--all")) })
+		if err != nil {
+			t.Fatalf("reused pid stop: %v\n%s", err, stdout)
+		}
+		if len(term.calls) != 0 || !strings.Contains(stdout, "PID reuse") {
+			t.Fatalf("reused pid result signals=%v output=%s", term.calls, stdout)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+
+	t.Run("dead agent cleanup stays in named root", func(t *testing.T) {
+		member := team.Member{Role: "cto", Binary: "codex", Handle: "cto"}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+		agentDir := writeExactStopRecord(t, namedRoot, member, 6200, "")
+		writeWakeLock(t, agentDir, wakeLockFile{PID: 6201, Root: namedRoot})
+		writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now()})
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		term := &recordingTerminator{}
+		stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{6200: false, 6201: true}, map[int]bool{6201: true}))
+		swapStatusPaneLister(t, nil, nil)
+		stdout, _, err := captureOutput(t, func() error { return stop(exactStopArgs(project, "--all")) })
+		if err != nil {
+			t.Fatalf("dead cleanup: %v\n%s", err, stdout)
+		}
+		if !reflect.DeepEqual(term.calls, []int{6201}) || !strings.Contains(stdout, "cleaned") {
+			t.Fatalf("dead cleanup signals=%v output=%s", term.calls, stdout)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+
+	t.Run("mixed failure is partial and failed pane stays open", func(t *testing.T) {
+		members := []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto"},
+			{Role: "qa", Binary: "codex", Handle: "qa"},
+		}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, members)
+		writeExactStopRecord(t, namedRoot, members[0], 6300, "%63")
+		writeExactStopRecord(t, namedRoot, members[1], 6301, "%64")
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		term := &recordingTerminator{failOn: map[int]error{6301: errors.New("denied")}}
+		stop := stopRunnerForTest(term, downFakeProbe(map[int]bool{6300: true, 6301: true}, map[int]bool{6300: true, 6301: true}))
+		swapStatusPaneLister(t, nil, nil)
+		closed := swapPaneCloser(t)
+		swapPaneInspectorMatching(t, exactStopSession, map[string]string{"%63": "cto", "%64": "qa"})
+		stdout, _, err := captureOutput(t, func() error {
+			return stop(exactStopArgs(project, "--all", "--close-panes"))
+		})
+		var partial *PartialError
+		if !errors.As(err, &partial) {
+			t.Fatalf("mixed stop error = %T %v, want PartialError\n%s", err, err, stdout)
+		}
+		if !reflect.DeepEqual(*closed, []string{"%63"}) {
+			t.Fatalf("closed panes = %v, failed qa pane must remain", *closed)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+}
+
+func TestTeamMemberRmStopExactNamedConflictAndMissingSession(t *testing.T) {
+	t.Run("explicit member session stops then removes", func(t *testing.T) {
+		member := team.Member{Role: "qa", Binary: "codex", Handle: "qa", Session: exactStopSession}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+		writeExactStopRecord(t, namedRoot, member, 7100, "")
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		term := &recordingTerminator{}
+		swapTeamMemberStopRunner(t, stopRunnerForTest(term, downFakeProbe(map[int]bool{7100: true}, map[int]bool{7100: true})))
+		swapStatusPaneLister(t, nil, nil)
+		_, _, err := captureOutput(t, func() error {
+			return runTeamMember([]string{"rm", "qa", "--project", project, "--profile", exactStopProfile, "--stop"})
+		})
+		if err != nil {
+			t.Fatalf("team member rm --stop: %v", err)
+		}
+		if !reflect.DeepEqual(term.calls, []int{7100}) {
+			t.Fatalf("signals = %v, want qa pid", term.calls)
+		}
+		cfg, err := team.ReadProfile(project, exactStopProfile)
+		if err != nil || len(cfg.Members) != 0 {
+			t.Fatalf("roster after remove = %+v / %v", cfg.Members, err)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+
+	t.Run("missing member session refuses and preserves roster", func(t *testing.T) {
+		member := team.Member{Role: "qa", Binary: "codex", Handle: "qa"}
+		project, namedRoot, legacyRoot := seedExactStopProject(t, []team.Member{member})
+		writeExactStopRecord(t, namedRoot, member, 7200, "")
+		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
+		term := &recordingTerminator{}
+		swapTeamMemberStopRunner(t, stopRunnerForTest(term, downFakeProbe(map[int]bool{7200: true}, map[int]bool{7200: true})))
+		swapStatusPaneLister(t, nil, nil)
+		_, _, err := captureOutput(t, func() error {
+			return runTeamMember([]string{"rm", "qa", "--project", project, "--profile", exactStopProfile, "--stop"})
+		})
+		if err == nil || !strings.Contains(err.Error(), "legacy/default session root") {
+			t.Fatalf("missing session should fail closed, got %v", err)
+		}
+		if len(term.calls) != 0 {
+			t.Fatalf("missing session signaled pids: %v", term.calls)
+		}
+		cfg, readErr := team.ReadProfile(project, exactStopProfile)
+		if readErr != nil || len(cfg.Members) != 1 || cfg.Members[0].Role != "qa" {
+			t.Fatalf("roster changed after refused stop: %+v / %v", cfg.Members, readErr)
+		}
+		assertLegacyTreeUnchanged(t, legacyBefore, legacyRoot, namedRoot)
+	})
+}


### PR DESCRIPTION
Implements the accepted #344 spec (qa spec 2026-07-12T19-59-42, exact named-profile stop exception). Final v2.20.0 milestone issue.

## Scope
- Stop-only `legacy_session_root` exception requiring explicit project + named non-default profile + session, role XOR all; fail-closed on omissions/default-profile/multiple owners
- Launch-record identity preflight (profile/session/root + nonempty role/handle) before watcher teardown, revalidated on the actual record before any PID/wake/presence/pane mutation
- Exception-confined wake-root cleanup (review-found blocker: a poisoned named wake lock pointing at the legacy root could escape confinement — fixed with strict root confinement + real-matcher regression)
- Status reuses the same predicate for exact stop actions; global namespace guard unchanged; team member rm semantics covered

## Provenance
- Exact commit: df892f2fcfd95b992700747fc8e3961081f357d5 (parent 8b5b0a5, current main tip)
- Implemented by senior-dev; published by cto (lead) under standing approval gate/standing-approval-v2-20-0
- qa APPROVED at exact head pre-push (msg 2026-07-13T14-01-52.800Z, no findings: focused x20, no-amq race, make ci); senior-dev internal review APPROVED after blocker fix
- Implementer validation: full internal/cli 95.9s PASS, go test ./... PASS, make ci PASS

CI at this exact head runs on this PR; merge follows CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)