### PR TITLE
fix: harden resume-goal redelivery recovery (#447)

### DIFF
--- a/README.html
+++ b/README.html
@@ -442,7 +442,11 @@ attempts. Command sinks should therefore be idempotent.</p>
 <span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
 <span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> stop <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
-<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
+<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span>
+<span id="cb5-31"><a href="#cb5-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-32"><a href="#cb5-32" aria-hidden="true" tabindex="-1"></a><span class="co"># For a freshly re-oriented lead, explicitly create one new claim-once goal</span></span>
+<span id="cb5-33"><a href="#cb5-33" aria-hidden="true" tabindex="-1"></a><span class="co"># attempt after the launch and original goal evidence are revalidated.</span></span>
+<span id="cb5-34"><a href="#cb5-34" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span> <span class="at">--redeliver-goal</span></span></code></pre></div>
 <p>Use <code>--external-lead</code> when the current pane is already the
 project lead and only the remaining workers should be spawned:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ amq-squad dispatch \
 # Stop and resume without losing launch records, briefs, or task state.
 amq-squad stop --session issue-96 --all
 amq-squad resume --session issue-96 --exec
+
+# For a freshly re-oriented lead, explicitly create one new claim-once goal
+# attempt after the launch and original goal evidence are revalidated.
+amq-squad resume --session issue-96 --exec --redeliver-goal
 ```
 
 Use `--external-lead` when the current pane is already the project lead and only

--- a/internal/autonomy/autonomy.go
+++ b/internal/autonomy/autonomy.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -89,8 +88,7 @@ func authorize(projectDir, profile, session string, req Request) (Outcome, error
 	}
 
 	var out Outcome
-	lockPath := team.ProfilePath(projectDir, profile) + ".lock"
-	err := flock.WithLock(lockPath, func() error {
+	err := team.WithProfileLock(projectDir, profile, func() error {
 		t, err := team.ReadProfile(projectDir, profile)
 		if err != nil {
 			return fmt.Errorf("read team profile: %w", err)
@@ -98,7 +96,7 @@ func authorize(projectDir, profile, session string, req Request) (Outcome, error
 		d := evaluateDecision(t, req)
 		if d.Allowed {
 			applyAllowedCounters(&t, req.Action)
-			if err := team.WriteProfile(projectDir, profile, t); err != nil {
+			if err := team.WriteProfileUnderLock(projectDir, profile, t); err != nil {
 				return fmt.Errorf("write autonomous counters: %w", err)
 			}
 		}

--- a/internal/autonomy/autonomy_test.go
+++ b/internal/autonomy/autonomy_test.go
@@ -144,6 +144,30 @@ func TestAuthorizeSpawnPersistsCountersAndAuditBeforeAllowedReturn(t *testing.T)
 	}
 }
 
+func TestAuthorizeSpawnProfileLockDoesNotSelfDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	if err := team.WriteProfile(dir, team.DefaultProfile, autonomousTeam()); err != nil {
+		t.Fatalf("write team: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := AuthorizeSpawn(dir, team.DefaultProfile, "s1", Request{
+			Role:            "worker",
+			RequestedByRole: "cto",
+			Reason:          "profile lock regression",
+		})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("autonomy authorization self-deadlocked by reacquiring the shared team lock")
+	}
+}
+
 func TestAuthorizePrunePersistsBudgetCounterIdleEvidenceAndAudit(t *testing.T) {
 	dir := t.TempDir()
 	if err := team.WriteProfile(dir, team.DefaultProfile, autonomousTeam()); err != nil {

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -120,6 +120,7 @@ var completionGoalSubcommands = []string{
 	"claim",
 	"deliver",
 	"draft",
+	"retry-attempt",
 	"start",
 }
 
@@ -302,6 +303,7 @@ var completionCommonFlags = []string{
 	"--no-operator",
 	"--no-preauthorize-inscope",
 	"--no-require-wake",
+	"--no-redeliver-goal-prompt",
 	"--no-wake",
 	"--numbered",
 	"--once",
@@ -330,6 +332,9 @@ var completionCommonFlags = []string{
 	"--register-orchestrator",
 	"--reset",
 	"--restore-existing",
+	"--redeliver-goal",
+	"--resume-transition",
+	"--restore-goal-binding",
 	"--review-age",
 	"--role",
 	"--role-file",

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -292,6 +292,9 @@ func (e *goalPostDeliveryBindingError) RetrySafe() bool { return false }
 var goalFallbackAMQSend = sendDurableGoalFallback
 var goalDeliveryReceiptWrite = writeDeliveryReceipt
 var goalLaunchWrite = launch.Write
+var goalLaunchWriteUnderRecordLock = launch.WriteUnderRecordLock
+var goalBeforeOrdinaryBindingCAS = func() {}
+var goalBeforePostDeliveryBindingCAS = func() {}
 var goalBeforeTransitionBindingCAS = func() {}
 var goalBeforeTransitionSendCAS = func() {}
 
@@ -1095,6 +1098,33 @@ func withGoalIdentityWriterLocks(opts goalDeliveryOptions, agentDir string, fn f
 	})
 }
 
+// withCurrentGoalIdentityWriterLocks locks the current profile first, then
+// resolves and locks the current lead record, and finally re-resolves while
+// both locks are held. This prevents ordinary goal delivery from writing a
+// record snapshot that was superseded by resume/register between its original
+// target lookup and its durable binding update.
+func withCurrentGoalIdentityWriterLocks(opts goalDeliveryOptions, fn func(memberRuntime, string) error) error {
+	return team.WithProfileLock(opts.Project, opts.Profile, func() error {
+		locked, workstream, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+		if err != nil {
+			return err
+		}
+		if !locked.HasRecord {
+			return fmt.Errorf("goal delivery requires a current launch record for role %q", opts.Role)
+		}
+		return launch.WithRecordLock(locked.AgentDir, func() error {
+			current, currentWorkstream, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+			if err != nil {
+				return err
+			}
+			if !current.HasRecord || current.AgentDir != locked.AgentDir || currentWorkstream != workstream {
+				return fmt.Errorf("goal delivery refused: current lead identity changed while acquiring writer locks")
+			}
+			return fn(current, currentWorkstream)
+		})
+	})
+}
+
 func executeGoalDelivery(opts goalDeliveryOptions) (result mutationResult, err error) {
 	if err := os.MkdirAll(goalAttemptDir(opts.Project, opts.Profile, opts.Session), 0o755); err != nil {
 		return mutationResult{}, fmt.Errorf("ensure goal delivery lock dir: %w", err)
@@ -1127,19 +1157,19 @@ func executeGoalDeliveryLocked(opts goalDeliveryOptions) (mutationResult, error)
 		opts.AttemptID = transition.NewAttemptID
 		prompt = nativeGoalControlPrompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, receipt.AttemptID)
 	}
-	if transition != nil {
-		var result mutationResult
-		err := withGoalIdentityWriterLocks(opts, mr.AgentDir, func() error {
-			var inner error
-			result, inner = executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, transition)
-			return inner
-		})
-		return result, err
+	if !mr.HasRecord {
+		return executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, transition, false)
 	}
-	return executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, nil)
+	var result mutationResult
+	err = withCurrentGoalIdentityWriterLocks(opts, func(current memberRuntime, currentWorkstream string) error {
+		var inner error
+		result, inner = executeGoalDeliveryResolved(opts, receipt, prompt, current, currentWorkstream, transition, true)
+		return inner
+	})
+	return result, err
 }
 
-func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryReceiptData, prompt string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord) (mutationResult, error) {
+func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryReceiptData, prompt string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord, identityLocksHeld bool) (mutationResult, error) {
 	var err error
 	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
 		return mutationResult{}, fmt.Errorf("%s", reason)
@@ -1213,22 +1243,32 @@ func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryRecei
 	// The transition reservation blocks concurrent delivery while the attempt
 	// and launch binding are published as two durable files.
 	if mr.HasRecord {
-		rec := mr.Record
-		rec.GoalBinding = &launch.GoalBinding{
-			Mode:       "native_goal",
-			NativeGoal: true,
-			Source:     "goal-control",
-			Command:    prompt,
-			Detail:     "native /goal reserved as a claim-once control action",
+		if transition != nil && transition.BindingReserved {
+			receipt.addStage("launch_record_reserved", "existing transition launch binding already reserves the exact claim-once attempt")
+		} else {
+			rec := mr.Record
+			rec.GoalBinding = &launch.GoalBinding{
+				Mode:       "native_goal",
+				NativeGoal: true,
+				Source:     "goal-control",
+				Command:    prompt,
+				Detail:     "native /goal reserved as a claim-once control action",
+			}
+			write := goalLaunchWrite
+			if identityLocksHeld {
+				goalBeforeOrdinaryBindingCAS()
+				write = goalLaunchWriteUnderRecordLock
+			}
+			if err := write(mr.AgentDir, rec); err != nil {
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("reserve launch goal binding after attempt creation: %w", err)}
+			}
+			receipt.addStage("launch_record_reserved", "launch record goal_binding reserved before native /goal delivery")
 		}
-		write := goalLaunchWrite
-		if transition != nil {
-			write = launch.WriteUnderRecordLock
+	}
+	if transition != nil {
+		if err := ensureResumeGoalTransitionBinding(opts, transition, mr.AgentDir); err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
 		}
-		if err := write(mr.AgentDir, rec); err != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("reserve launch goal binding after attempt creation: %w", err)}
-		}
-		receipt.addStage("launch_record_reserved", "launch record goal_binding reserved before native /goal delivery")
 	}
 	var sendSnapshot resumeGoalSendSnapshot
 	if transition != nil {
@@ -1345,6 +1385,9 @@ func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryRecei
 	receipt.Status = "native_goal_delivered"
 	receipt.addStage("native_goal_delivered", "native /goal command delivered without ordinary prompt busy-guard semantics")
 	if mr.HasRecord {
+		if identityLocksHeld {
+			goalBeforePostDeliveryBindingCAS()
+		}
 		rec, readErr := launch.Read(mr.AgentDir)
 		if readErr != nil {
 			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: readErr}
@@ -1354,8 +1397,8 @@ func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryRecei
 		}
 		rec.GoalBinding.Detail = "native /goal delivered as a first-class claim-once control action"
 		write := goalLaunchWrite
-		if transition != nil {
-			write = launch.WriteUnderRecordLock
+		if identityLocksHeld {
+			write = goalLaunchWriteUnderRecordLock
 		}
 		if err := write(mr.AgentDir, rec); err != nil {
 			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: err}

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/state"
@@ -202,7 +203,31 @@ type goalDeliveryOptions struct {
 	Member    team.Member
 	Namespace squadnamespace.Ref
 	Mode      string
+	// ResumeTransitionID is an internal, durable compare-and-swap token. It is
+	// accepted only from resume after the fresh lead launch has been verified.
+	ResumeTransitionID string
 }
+
+type goalDeliveryAttemptError struct {
+	AttemptID   string
+	AttemptPath string
+	Sent        bool
+	State       string
+	Cause       error
+}
+
+func (e *goalDeliveryAttemptError) Error() string {
+	state := "not sent"
+	if e.Sent {
+		state = "delivery may have started"
+	}
+	if e.State != "" {
+		state = e.State
+	}
+	return fmt.Sprintf("goal attempt %s (%s) failed; state=%s: %v", e.AttemptID, e.AttemptPath, state, e.Cause)
+}
+func (e *goalDeliveryAttemptError) Unwrap() error   { return e.Cause }
+func (e *goalDeliveryAttemptError) RetrySafe() bool { return false }
 
 type goalFallbackDelivery struct {
 	MessageID string
@@ -249,10 +274,35 @@ func (e *goalFallbackSentReceiptError) Unwrap() []error {
 
 func (e *goalFallbackSentReceiptError) RetrySafe() bool { return false }
 
+type goalPostDeliveryBindingError struct {
+	AttemptID string
+	Recovery  string
+	Cause     error
+}
+
+func (e *goalPostDeliveryBindingError) Error() string {
+	return fmt.Sprintf("goal attempt %s was delivered but its launch binding could not be marked delivered: %v; do not create a new attempt; inspect the typed attempt and current binding before retrying", e.AttemptID, e.Cause)
+}
+
+func (e *goalPostDeliveryBindingError) Unwrap() error   { return e.Cause }
+func (e *goalPostDeliveryBindingError) RetrySafe() bool { return false }
+
 // goalFallbackAMQSend is the durable half of ambiguous native goal delivery.
 // Tests replace it without needing a real AMQ binary or mailbox tree.
 var goalFallbackAMQSend = sendDurableGoalFallback
 var goalDeliveryReceiptWrite = writeDeliveryReceipt
+var goalLaunchWrite = launch.Write
+var goalBeforeTransitionBindingCAS = func() {}
+var goalBeforeTransitionSendCAS = func() {}
+
+const (
+	goalDeliveryStateNotSent           = "not_sent"
+	goalDeliveryStateNativeQueued      = "native_queued"
+	goalDeliveryStateNativeUnconfirmed = "native_unconfirmed"
+	goalDeliveryStateFallbackSent      = "fallback_sent"
+	goalDeliveryStatePaneFailed        = "pane_failed"
+	goalDeliveryStatePaneDelivered     = "pane_delivered"
+)
 
 const (
 	goalOrchestratorRole          = "orchestrator"
@@ -278,6 +328,8 @@ func runGoalWithVersion(args []string, version string) error {
 		return runGoalDeliver(args[1:])
 	case "claim":
 		return runGoalClaim(args[1:])
+	case "retry-attempt":
+		return runGoalRetryAttempt(args[1:])
 	case "start":
 		return runGoalStart(args[1:])
 	case "apply":
@@ -316,6 +368,7 @@ Subcommands:
   claim     atomically claim one native/AMQ goal delivery attempt
   deliver   deliver a native /goal to the resolved visible lead
   draft     produce a preview-only goal setup plan from a goal description
+  retry-attempt  recover delivery of one already-recorded unclaimed attempt
   start     preview or deliver a goal to the current visible lead
 
 Run 'amq-squad goal <subcommand> --help' for subcommand options and flags.
@@ -423,6 +476,7 @@ func runGoalStart(args []string) error {
 	overrideNamespaceConflict := fs.Bool("override-namespace-conflict", false, "acknowledge a collided namespace and continue, writing an audit record")
 	overrideNamespaceReason := fs.String("reason", "", "required reason when --override-namespace-conflict is set")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned goal_start envelope")
+	resumeTransition := fs.String("resume-transition", "", "internal durable resume-goal transition token")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad goal start - preview or deliver a goal to the visible lead
 
@@ -480,6 +534,7 @@ confirm-gated and requires --yes in this first implementation slice.
 	if err != nil {
 		return err
 	}
+	opts.ResumeTransitionID = strings.TrimSpace(*resumeTransition)
 	if flagWasSet(fs, "register-orchestrator") {
 		if err := registerGoalOrchestrator(opts, *registerOrchestrator, wakeInjectModeValue, flagWasSet(fs, "wake-inject-mode")); err != nil {
 			return err
@@ -962,7 +1017,7 @@ func ensureGoalOrchestratorMember(project, profile, session, handle string) erro
 				Session: session,
 			})
 		}
-		return team.WriteProfile(project, profile, t)
+		return team.WriteProfileUnderLock(project, profile, t)
 	})
 }
 
@@ -1027,7 +1082,32 @@ func sendDurableGoalFallback(opts goalDeliveryOptions) (goalFallbackDelivery, er
 	}, nil
 }
 
-func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
+func goalDeliveryLockPath(opts goalDeliveryOptions) string {
+	return filepath.Join(goalAttemptDir(opts.Project, opts.Profile, opts.Session), "."+sanitizeWorkstreamName(opts.Role)+".delivery.lock")
+}
+
+// withGoalIdentityWriterLocks is entered only while the per-lead goal
+// delivery lock is already held. Keep this order stable across transition and
+// retry paths: goal delivery -> team profile -> launch record.
+func withGoalIdentityWriterLocks(opts goalDeliveryOptions, agentDir string, fn func() error) error {
+	return team.WithProfileLock(opts.Project, opts.Profile, func() error {
+		return launch.WithRecordLock(agentDir, fn)
+	})
+}
+
+func executeGoalDelivery(opts goalDeliveryOptions) (result mutationResult, err error) {
+	if err := os.MkdirAll(goalAttemptDir(opts.Project, opts.Profile, opts.Session), 0o755); err != nil {
+		return mutationResult{}, fmt.Errorf("ensure goal delivery lock dir: %w", err)
+	}
+	err = flock.WithLock(goalDeliveryLockPath(opts), func() error {
+		var inner error
+		result, inner = executeGoalDeliveryLocked(opts)
+		return inner
+	})
+	return result, err
+}
+
+func executeGoalDeliveryLocked(opts goalDeliveryOptions) (mutationResult, error) {
 	receipt := newDeliveryReceipt(opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, opts.Mode, "native_goal")
 	opts.AttemptID = receipt.AttemptID
 	prompt := nativeGoalControlPrompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, receipt.AttemptID)
@@ -1038,27 +1118,151 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 	if err != nil {
 		return mutationResult{}, err
 	}
+	transition, err := validateResumeGoalTransitionForDelivery(opts, mr)
+	if err != nil {
+		return mutationResult{}, err
+	}
+	if transition != nil {
+		receipt.AttemptID = transition.NewAttemptID
+		opts.AttemptID = transition.NewAttemptID
+		prompt = nativeGoalControlPrompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, receipt.AttemptID)
+	}
+	if transition != nil {
+		var result mutationResult
+		err := withGoalIdentityWriterLocks(opts, mr.AgentDir, func() error {
+			var inner error
+			result, inner = executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, transition)
+			return inner
+		})
+		return result, err
+	}
+	return executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, nil)
+}
+
+func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryReceiptData, prompt string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord) (mutationResult, error) {
+	var err error
 	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
 		return mutationResult{}, fmt.Errorf("%s", reason)
 	}
-	panes, err := statusPaneLister()
-	if err != nil {
-		if tmuxpane.IsPermissionDenied(err) {
-			return mutationResult{}, errTmuxAccessDenied()
+	paneID := ""
+	if transition == nil {
+		panes, listErr := statusPaneLister()
+		if listErr != nil {
+			if tmuxpane.IsPermissionDenied(listErr) {
+				return mutationResult{}, errTmuxAccessDenied()
+			}
+			panes = nil
 		}
-		panes = nil
+		var ok bool
+		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
+		if !ok || strings.TrimSpace(paneID) == "" {
+			return mutationResult{}, fmt.Errorf("no live tmux pane found for role %q; cannot deliver native /goal", opts.Role)
+		}
+		receipt.PaneID = paneID
+		receipt.addStage("control_delivery_started", "resolved exact target pane for native /goal control")
+	} else {
+		// Re-resolve all transition-bound identity immediately before the first
+		// durable mutation. The transition's generation facts make this a CAS,
+		// not a reuse of the cached runtime record above.
+		mr, resolvedWorkstream, err = resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+		if err != nil {
+			return mutationResult{}, err
+		}
+		transition, err = validateResumeGoalTransitionForDelivery(opts, mr)
+		if err != nil {
+			return mutationResult{}, err
+		}
 	}
-	paneID, _, ok := resolveControlTarget(mr, resolvedWorkstream, panes)
-	if !ok || strings.TrimSpace(paneID) == "" {
-		return mutationResult{}, fmt.Errorf("no live tmux pane found for role %q; cannot deliver native /goal", opts.Role)
+	attemptPath, pathErr := goalAttemptPath(opts.Project, opts.Profile, opts.Session, receipt.AttemptID)
+	if pathErr != nil {
+		return mutationResult{}, pathErr
 	}
-	receipt.PaneID = paneID
-	receipt.addStage("control_delivery_started", "resolved exact target pane for native /goal control")
-	attemptPath, err := goalAttemptCreate(opts, receipt.AttemptID, receipt.CreatedAt)
-	if err != nil {
-		return mutationResult{}, fmt.Errorf("create claim-once goal attempt: %w", err)
+	if transition != nil {
+		if existing, readErr := readGoalAttempt(attemptPath, receipt.AttemptID); readErr == nil {
+			if validateResumeGoalAttempt(existing, opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, opts.Goal, receipt.AttemptID, opts.Namespace) != nil {
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("preallocated transition attempt is mismatched")}
+			}
+		} else if errors.Is(readErr, os.ErrNotExist) {
+			createdPath, createErr := goalAttemptCreate(opts, receipt.AttemptID, receipt.CreatedAt)
+			if createErr != nil {
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("create preallocated claim-once goal attempt: %w", createErr)}
+			}
+			attemptPath = createdPath
+		} else {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: readErr}
+		}
+	} else {
+		createdPath, createErr := goalAttemptCreate(opts, receipt.AttemptID, receipt.CreatedAt)
+		if createErr != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("create claim-once goal attempt: %w", createErr)}
+		}
+		attemptPath = createdPath
 	}
 	receipt.addStage("attempt_recorded", "claim-once goal attempt recorded at "+attemptPath+"; native and AMQ paths share attempt_id="+receipt.AttemptID)
+	if transition != nil {
+		mr, resolvedWorkstream, err = resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+		if err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
+		}
+		transition, err = validateResumeGoalTransitionForDelivery(opts, mr)
+		if err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
+		}
+		goalBeforeTransitionBindingCAS()
+	}
+	// The transition reservation blocks concurrent delivery while the attempt
+	// and launch binding are published as two durable files.
+	if mr.HasRecord {
+		rec := mr.Record
+		rec.GoalBinding = &launch.GoalBinding{
+			Mode:       "native_goal",
+			NativeGoal: true,
+			Source:     "goal-control",
+			Command:    prompt,
+			Detail:     "native /goal reserved as a claim-once control action",
+		}
+		write := goalLaunchWrite
+		if transition != nil {
+			write = launch.WriteUnderRecordLock
+		}
+		if err := write(mr.AgentDir, rec); err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("reserve launch goal binding after attempt creation: %w", err)}
+		}
+		receipt.addStage("launch_record_reserved", "launch record goal_binding reserved before native /goal delivery")
+	}
+	var sendSnapshot resumeGoalSendSnapshot
+	if transition != nil {
+		_, sendSnapshot, err = captureResumeGoalSendSnapshot(opts, transition, prompt, receipt.AttemptID)
+		if err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
+		}
+	}
+	if opts.ResumeTransitionID != "" {
+		if err := consumeResumeGoalTransition(opts, receipt.AttemptID); err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
+		}
+	}
+	if transition != nil {
+		mr, err = validateResumeGoalSendSnapshot(opts, transition, prompt, receipt.AttemptID, sendSnapshot)
+		if err != nil {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
+		}
+		goalBeforeTransitionSendCAS()
+		panes, listErr := statusPaneLister()
+		if listErr != nil {
+			if tmuxpane.IsPermissionDenied(listErr) {
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: errTmuxAccessDenied()}
+			}
+			panes = nil
+		}
+		var ok bool
+		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
+		if !ok || strings.TrimSpace(paneID) == "" {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("no live tmux pane found for role %q", opts.Role)}
+		}
+		receipt.PaneID = paneID
+		receipt.addStage("control_delivery_started", "revalidated exact transition-bound pane immediately before native /goal control")
+	}
 	if err := sendPromptToPane(paneID, prompt); err != nil {
 		var queued *tmuxpane.QueuedInputError
 		var unconfirmed *tmuxpane.SubmitUnconfirmedError
@@ -1068,7 +1272,7 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 			receipt.addStage("native_goal_queued", "native goal text is known present in the lead input and will submit when the agent goes idle")
 			receipt.addStage("pending_without_amq_action", "durable pending evidence recorded; no actionable AMQ fallback emitted because the native text is known present")
 			if writeErr := goalDeliveryReceiptWrite(opts.Project, opts.Profile, opts.Session, &receipt); writeErr != nil {
-				return mutationResult{}, &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fmt.Errorf("write queued native-goal receipt: %w", writeErr)}
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, Sent: true, State: goalDeliveryStateNativeQueued, Cause: &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fmt.Errorf("write queued native-goal receipt: %w", writeErr)}}
 			}
 			fmt.Fprintf(os.Stderr, "warning: goal queued in the lead's input; it will submit when the agent goes idle. Pending attempt %s was recorded without a second actionable AMQ goal; continuing.\n", receipt.AttemptID)
 			return mutationResult{
@@ -1090,7 +1294,7 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 				receipt.Detail = fmt.Sprintf("native goal submission was unconfirmed and claim-once AMQ fallback failed: %v", fallbackErr)
 				receipt.addStage("failed", receipt.Detail)
 				_ = goalDeliveryReceiptWrite(opts.Project, opts.Profile, opts.Session, &receipt)
-				return mutationResult{}, &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fallbackErr}
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, Sent: true, State: goalDeliveryStateNativeUnconfirmed, Cause: &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fallbackErr}}
 			}
 			receipt.MessageID = fallback.MessageID
 			receipt.Root = fallback.Root
@@ -1103,13 +1307,13 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 			receipt.addStage("claim_once_contract", "native prompt and AMQ todo share attempt_id="+receipt.AttemptID+" under an at-most-once contract: exactly one route may atomically claim it; a claimant crash before activation is observable but never replayed")
 			receipt.addStage("written_to_amq", "single actionable claim-once goal fallback written to the lead inbox")
 			if writeErr := goalDeliveryReceiptWrite(opts.Project, opts.Profile, opts.Session, &receipt); writeErr != nil {
-				return mutationResult{}, &goalFallbackSentReceiptError{
+				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, Sent: true, State: goalDeliveryStateFallbackSent, Cause: &goalFallbackSentReceiptError{
 					MessageID:   fallback.MessageID,
 					Root:        fallback.Root,
 					Thread:      fallback.Thread,
 					DeliveryErr: err,
 					ReceiptErr:  writeErr,
-				}
+				}}
 			}
 			messageID := strings.TrimSpace(fallback.MessageID)
 			if messageID == "" {
@@ -1135,27 +1339,31 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 		receipt.Detail = err.Error()
 		receipt.addStage("failed", err.Error())
 		_ = goalDeliveryReceiptWrite(opts.Project, opts.Profile, opts.Session, &receipt)
-		return mutationResult{}, err
+		return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, Sent: true, State: goalDeliveryStatePaneFailed, Cause: err}
 	}
 	receipt.addStage("pane_settled", "SendPromptToPane waited for target pane output to settle before native /goal control delivery")
 	receipt.Status = "native_goal_delivered"
 	receipt.addStage("native_goal_delivered", "native /goal command delivered without ordinary prompt busy-guard semantics")
 	if mr.HasRecord {
-		rec := mr.Record
-		rec.GoalBinding = &launch.GoalBinding{
-			Mode:       "native_goal",
-			NativeGoal: true,
-			Source:     "goal-control",
-			Command:    prompt,
-			Detail:     "native /goal delivered as a first-class control action",
+		rec, readErr := launch.Read(mr.AgentDir)
+		if readErr != nil {
+			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: readErr}
 		}
-		if err := launch.Write(mr.AgentDir, rec); err != nil {
-			return mutationResult{}, fmt.Errorf("update launch goal binding: %w", err)
+		if rec.GoalBinding == nil || rec.GoalBinding.Command != prompt {
+			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: fmt.Errorf("reserved binding changed after pane delivery")}
 		}
-		receipt.addStage("launch_record_updated", "launch record goal_binding updated from native /goal control delivery")
+		rec.GoalBinding.Detail = "native /goal delivered as a first-class claim-once control action"
+		write := goalLaunchWrite
+		if transition != nil {
+			write = launch.WriteUnderRecordLock
+		}
+		if err := write(mr.AgentDir, rec); err != nil {
+			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: err}
+		}
+		receipt.addStage("launch_record_updated", "reserved launch goal_binding marked delivered")
 	}
 	if err := goalDeliveryReceiptWrite(opts.Project, opts.Profile, opts.Session, &receipt); err != nil {
-		return mutationResult{}, err
+		return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, Sent: true, State: goalDeliveryStatePaneDelivered, Cause: err}
 	}
 	return mutationResult{
 		Command:         "goal deliver",
@@ -1168,6 +1376,15 @@ func executeGoalDelivery(opts goalDeliveryOptions) (mutationResult, error) {
 		Handle:          opts.Member.Handle,
 		DeliveryReceipt: &receipt,
 	}, nil
+}
+
+func goalRetryAttemptCommand(opts goalDeliveryOptions, attemptID string) string {
+	args := []string{"amq-squad", "goal", "retry-attempt", "--project", opts.Project, "--profile", opts.Profile, "--session", opts.Session, "--role", opts.Role, "--attempt-id", attemptID, "--yes"}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func nativeGoalControlPrompt(goal string, t team.Team, profile, session, role string, attemptIDs ...string) string {

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -291,7 +291,6 @@ func (e *goalPostDeliveryBindingError) RetrySafe() bool { return false }
 // Tests replace it without needing a real AMQ binary or mailbox tree.
 var goalFallbackAMQSend = sendDurableGoalFallback
 var goalDeliveryReceiptWrite = writeDeliveryReceipt
-var goalLaunchWrite = launch.Write
 var goalLaunchWriteUnderRecordLock = launch.WriteUnderRecordLock
 var goalBeforeOrdinaryBindingCAS = func() {}
 var goalBeforePostDeliveryBindingCAS = func() {}
@@ -1120,8 +1119,203 @@ func withCurrentGoalIdentityWriterLocks(opts goalDeliveryOptions, fn func(member
 			if !current.HasRecord || current.AgentDir != locked.AgentDir || currentWorkstream != workstream {
 				return fmt.Errorf("goal delivery refused: current lead identity changed while acquiring writer locks")
 			}
+			if memberHandle(current.Member) != memberHandle(opts.Member) || current.Member.Session != opts.Member.Session ||
+				current.Member.Binary != opts.Member.Binary || canonicalPath(current.Member.EffectiveCWD(opts.Project)) != canonicalPath(opts.Member.EffectiveCWD(opts.Project)) {
+				return fmt.Errorf("goal delivery refused: current lead member identity changed while acquiring writer locks")
+			}
 			return fn(current, currentWorkstream)
 		})
+	})
+}
+
+// goalDeliveryReservation is the immutable identity evidence produced while
+// profile and launch-record writer locks are held. External delivery (tmux,
+// AMQ fallback, receipt persistence, and output) must happen only after those
+// locks have been released. The per-delivery lock remains responsible for
+// serializing attempts for this one role/session.
+type goalDeliveryReservation struct {
+	Runtime                memberRuntime
+	Workstream             string
+	Transition             *resumeGoalTransitionRecord
+	AttemptPath            string
+	TeamDigest             string
+	TeamModTime            int64
+	TransitionSendSnapshot *resumeGoalSendSnapshot
+}
+
+func reserveGoalDeliveryAttempt(opts *goalDeliveryOptions, receipt *deliveryReceiptData, transition *resumeGoalTransitionRecord) (string, error) {
+	attemptPath, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, receipt.AttemptID)
+	if err != nil {
+		return "", err
+	}
+	if transition != nil {
+		if existing, readErr := readGoalAttempt(attemptPath, receipt.AttemptID); readErr == nil {
+			if validateResumeGoalAttempt(existing, opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, opts.Goal, receipt.AttemptID, opts.Namespace) != nil {
+				return "", fmt.Errorf("preallocated transition attempt is mismatched")
+			}
+		} else if errors.Is(readErr, os.ErrNotExist) {
+			createdPath, createErr := goalAttemptCreate(*opts, receipt.AttemptID, receipt.CreatedAt)
+			if createErr != nil {
+				return "", fmt.Errorf("create preallocated claim-once goal attempt: %w", createErr)
+			}
+			attemptPath = createdPath
+		} else {
+			return "", readErr
+		}
+	} else {
+		createdPath, createErr := goalAttemptCreate(*opts, receipt.AttemptID, receipt.CreatedAt)
+		if createErr != nil {
+			return "", fmt.Errorf("create claim-once goal attempt: %w", createErr)
+		}
+		attemptPath = createdPath
+	}
+	receipt.addStage("attempt_recorded", "claim-once goal attempt recorded at "+attemptPath+"; native and AMQ paths share attempt_id="+receipt.AttemptID)
+	return attemptPath, nil
+}
+
+// reserveGoalDeliveryIdentity performs the only pre-send profile/record lock
+// phase. It rereads the current member while locked, validates any transition,
+// and atomically merges the exact binding reservation. It deliberately does
+// not discover panes, send input, write receipts, or emit output.
+func reserveGoalDeliveryIdentity(opts *goalDeliveryOptions, receipt *deliveryReceiptData, prompt *string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord) (goalDeliveryReservation, error) {
+	reservation := goalDeliveryReservation{Runtime: mr, Workstream: resolvedWorkstream, Transition: transition}
+	if !mr.HasRecord {
+		attemptPath, err := reserveGoalDeliveryAttempt(opts, receipt, transition)
+		if err != nil {
+			return goalDeliveryReservation{}, err
+		}
+		reservation.AttemptPath = attemptPath
+		return reservation, nil
+	}
+	err := withCurrentGoalIdentityWriterLocks(*opts, func(current memberRuntime, currentWorkstream string) error {
+		currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
+		if err != nil {
+			return fmt.Errorf("reread current team while reserving goal binding: %w", err)
+		}
+		opts.Team = currentTeam
+		opts.Member = current.Member
+		if transition != nil {
+			transition, err = validateResumeGoalTransitionForDelivery(*opts, current)
+			if err != nil {
+				return err
+			}
+			if transition.NewAttemptID != receipt.AttemptID {
+				return fmt.Errorf("resume-goal transition attempt identity changed while reserving binding")
+			}
+		}
+		*prompt = nativeGoalControlPrompt(opts.Goal, currentTeam, opts.Profile, opts.Session, opts.Role, receipt.AttemptID)
+		if reason, disabled := current.nativePromptInjectionDisabledReason(); disabled {
+			return fmt.Errorf("%s", reason)
+		}
+		attemptPath, err := reserveGoalDeliveryAttempt(opts, receipt, transition)
+		if err != nil {
+			return err
+		}
+		rec := current.Record
+		if transition != nil && transition.BindingReserved {
+			receipt.addStage("launch_record_reserved", "existing transition launch binding already reserves the exact claim-once attempt")
+		} else {
+			rec.GoalBinding = &launch.GoalBinding{
+				Mode:       "native_goal",
+				NativeGoal: true,
+				Source:     "goal-control",
+				Command:    *prompt,
+				Detail:     "native /goal reserved as a claim-once control action",
+			}
+			if transition != nil {
+				goalBeforeTransitionBindingCAS()
+			} else {
+				goalBeforeOrdinaryBindingCAS()
+			}
+			if err := goalLaunchWriteUnderRecordLock(current.AgentDir, rec); err != nil {
+				return fmt.Errorf("reserve launch goal binding after attempt creation: %w", err)
+			}
+			receipt.addStage("launch_record_reserved", "launch record goal_binding reserved before native /goal delivery")
+		}
+		if transition != nil {
+			if err := ensureResumeGoalTransitionBinding(*opts, transition, current.AgentDir); err != nil {
+				return err
+			}
+		}
+		teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+		if err != nil {
+			return fmt.Errorf("capture team generation after goal reservation: %w", err)
+		}
+		reservation = goalDeliveryReservation{
+			Runtime:     current,
+			Workstream:  currentWorkstream,
+			Transition:  transition,
+			AttemptPath: attemptPath,
+			TeamDigest:  teamDigest,
+			TeamModTime: teamMod,
+		}
+		if transition != nil {
+			_, snapshot, err := captureResumeGoalSendSnapshot(*opts, transition, *prompt, receipt.AttemptID)
+			if err != nil {
+				return err
+			}
+			reservation.TransitionSendSnapshot = &snapshot
+		}
+		return nil
+	})
+	if err != nil {
+		return goalDeliveryReservation{}, err
+	}
+	return reservation, nil
+}
+
+// validateTransitionGoalDeliveryBeforeSend takes a final, narrow locked
+// snapshot. Pane enumeration and the actual send intentionally happen after
+// the locks are released, so concurrent profile/record writers never wait on
+// tmux or AMQ I/O.
+func validateTransitionGoalDeliveryBeforeSend(opts goalDeliveryOptions, reservation goalDeliveryReservation, prompt string, attemptID string) (memberRuntime, string, error) {
+	var runtime memberRuntime
+	var workstream string
+	err := withCurrentGoalIdentityWriterLocks(opts, func(current memberRuntime, currentWorkstream string) error {
+		transition, err := validateResumeGoalTransitionForDelivery(opts, current)
+		if err != nil {
+			return err
+		}
+		if reservation.Transition == nil || transition.NewAttemptID != reservation.Transition.NewAttemptID {
+			return fmt.Errorf("resume-goal transition identity changed immediately before send")
+		}
+		validated, err := validateResumeGoalSendSnapshot(opts, transition, prompt, attemptID, *reservation.TransitionSendSnapshot)
+		if err != nil {
+			return err
+		}
+		goalBeforeTransitionSendCAS()
+		runtime, workstream = validated, currentWorkstream
+		return nil
+	})
+	return runtime, workstream, err
+}
+
+// markGoalDeliveryBindingDelivered is the only post-send profile/record lock
+// phase. It rereads the current record and merges only the binding detail when
+// the expected binding and team generation are still current, preserving
+// unrelated concurrent record fields instead of overwriting a stale snapshot.
+func markGoalDeliveryBindingDelivered(opts goalDeliveryOptions, reservation goalDeliveryReservation, prompt, attemptID string) error {
+	return withCurrentGoalIdentityWriterLocks(opts, func(current memberRuntime, _ string) error {
+		teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+		if err != nil {
+			return fmt.Errorf("capture team generation after pane delivery: %w", err)
+		}
+		if teamDigest != reservation.TeamDigest || teamMod != reservation.TeamModTime {
+			return fmt.Errorf("team generation changed after pane delivery")
+		}
+		if reason, disabled := current.nativePromptInjectionDisabledReason(); disabled {
+			return fmt.Errorf("%s", reason)
+		}
+		rec := current.Record
+		if rec.GoalBinding == nil || rec.GoalBinding.Mode != "native_goal" || !rec.GoalBinding.NativeGoal || rec.GoalBinding.Source != "goal-control" || rec.GoalBinding.Command != prompt {
+			return fmt.Errorf("reserved binding changed after pane delivery")
+		}
+		goalBeforePostDeliveryBindingCAS()
+		rec.GoalBinding.Detail = "native /goal delivered as a first-class claim-once control action"
+		if err := goalLaunchWriteUnderRecordLock(current.AgentDir, rec); err != nil {
+			return err
+		}
+		return nil
 	})
 }
 
@@ -1157,151 +1351,46 @@ func executeGoalDeliveryLocked(opts goalDeliveryOptions) (mutationResult, error)
 		opts.AttemptID = transition.NewAttemptID
 		prompt = nativeGoalControlPrompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, receipt.AttemptID)
 	}
-	if !mr.HasRecord {
-		return executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, transition, false)
-	}
-	var result mutationResult
-	err = withCurrentGoalIdentityWriterLocks(opts, func(current memberRuntime, currentWorkstream string) error {
-		var inner error
-		result, inner = executeGoalDeliveryResolved(opts, receipt, prompt, current, currentWorkstream, transition, true)
-		return inner
-	})
-	return result, err
+	return executeGoalDeliveryResolved(opts, receipt, prompt, mr, resolvedWorkstream, transition)
 }
 
-func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryReceiptData, prompt string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord, identityLocksHeld bool) (mutationResult, error) {
+func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryReceiptData, prompt string, mr memberRuntime, resolvedWorkstream string, transition *resumeGoalTransitionRecord) (mutationResult, error) {
 	var err error
-	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
-		return mutationResult{}, fmt.Errorf("%s", reason)
+	reservation, err := reserveGoalDeliveryIdentity(&opts, &receipt, &prompt, mr, resolvedWorkstream, transition)
+	if err != nil {
+		attemptPath, _ := goalAttemptPath(opts.Project, opts.Profile, opts.Session, receipt.AttemptID)
+		return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
 	}
-	paneID := ""
-	if transition == nil {
-		panes, listErr := statusPaneLister()
-		if listErr != nil {
-			if tmuxpane.IsPermissionDenied(listErr) {
-				return mutationResult{}, errTmuxAccessDenied()
-			}
-			panes = nil
-		}
-		var ok bool
-		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
-		if !ok || strings.TrimSpace(paneID) == "" {
-			return mutationResult{}, fmt.Errorf("no live tmux pane found for role %q; cannot deliver native /goal", opts.Role)
-		}
-		receipt.PaneID = paneID
-		receipt.addStage("control_delivery_started", "resolved exact target pane for native /goal control")
-	} else {
-		// Re-resolve all transition-bound identity immediately before the first
-		// durable mutation. The transition's generation facts make this a CAS,
-		// not a reuse of the cached runtime record above.
-		mr, resolvedWorkstream, err = resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
-		if err != nil {
-			return mutationResult{}, err
-		}
-		transition, err = validateResumeGoalTransitionForDelivery(opts, mr)
-		if err != nil {
-			return mutationResult{}, err
-		}
-	}
-	attemptPath, pathErr := goalAttemptPath(opts.Project, opts.Profile, opts.Session, receipt.AttemptID)
-	if pathErr != nil {
-		return mutationResult{}, pathErr
-	}
+	mr, resolvedWorkstream, transition = reservation.Runtime, reservation.Workstream, reservation.Transition
+	attemptPath := reservation.AttemptPath
 	if transition != nil {
-		if existing, readErr := readGoalAttempt(attemptPath, receipt.AttemptID); readErr == nil {
-			if validateResumeGoalAttempt(existing, opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, opts.Goal, receipt.AttemptID, opts.Namespace) != nil {
-				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("preallocated transition attempt is mismatched")}
-			}
-		} else if errors.Is(readErr, os.ErrNotExist) {
-			createdPath, createErr := goalAttemptCreate(opts, receipt.AttemptID, receipt.CreatedAt)
-			if createErr != nil {
-				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("create preallocated claim-once goal attempt: %w", createErr)}
-			}
-			attemptPath = createdPath
-		} else {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: readErr}
-		}
-	} else {
-		createdPath, createErr := goalAttemptCreate(opts, receipt.AttemptID, receipt.CreatedAt)
-		if createErr != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("create claim-once goal attempt: %w", createErr)}
-		}
-		attemptPath = createdPath
-	}
-	receipt.addStage("attempt_recorded", "claim-once goal attempt recorded at "+attemptPath+"; native and AMQ paths share attempt_id="+receipt.AttemptID)
-	if transition != nil {
-		mr, resolvedWorkstream, err = resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+		mr, resolvedWorkstream, err = validateTransitionGoalDeliveryBeforeSend(opts, reservation, prompt, receipt.AttemptID)
 		if err != nil {
 			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
 		}
-		transition, err = validateResumeGoalTransitionForDelivery(opts, mr)
-		if err != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
-		}
-		goalBeforeTransitionBindingCAS()
-	}
-	// The transition reservation blocks concurrent delivery while the attempt
-	// and launch binding are published as two durable files.
-	if mr.HasRecord {
-		if transition != nil && transition.BindingReserved {
-			receipt.addStage("launch_record_reserved", "existing transition launch binding already reserves the exact claim-once attempt")
-		} else {
-			rec := mr.Record
-			rec.GoalBinding = &launch.GoalBinding{
-				Mode:       "native_goal",
-				NativeGoal: true,
-				Source:     "goal-control",
-				Command:    prompt,
-				Detail:     "native /goal reserved as a claim-once control action",
-			}
-			write := goalLaunchWrite
-			if identityLocksHeld {
-				goalBeforeOrdinaryBindingCAS()
-				write = goalLaunchWriteUnderRecordLock
-			}
-			if err := write(mr.AgentDir, rec); err != nil {
-				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("reserve launch goal binding after attempt creation: %w", err)}
-			}
-			receipt.addStage("launch_record_reserved", "launch record goal_binding reserved before native /goal delivery")
-		}
-	}
-	if transition != nil {
-		if err := ensureResumeGoalTransitionBinding(opts, transition, mr.AgentDir); err != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
-		}
-	}
-	var sendSnapshot resumeGoalSendSnapshot
-	if transition != nil {
-		_, sendSnapshot, err = captureResumeGoalSendSnapshot(opts, transition, prompt, receipt.AttemptID)
-		if err != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
-		}
-	}
-	if opts.ResumeTransitionID != "" {
 		if err := consumeResumeGoalTransition(opts, receipt.AttemptID); err != nil {
 			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
 		}
 	}
+	// All pane work occurs outside profile and launch-record writer locks. A
+	// concurrent writer may complete here; the post-send phase below will merge
+	// independent record changes or refuse a stale identity without overwriting.
+	panes, listErr := statusPaneLister()
+	if listErr != nil {
+		if tmuxpane.IsPermissionDenied(listErr) {
+			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: errTmuxAccessDenied()}
+		}
+		panes = nil
+	}
+	paneID, _, ok := resolveControlTarget(mr, resolvedWorkstream, panes)
+	if !ok || strings.TrimSpace(paneID) == "" {
+		return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("no live tmux pane found for role %q", opts.Role)}
+	}
+	receipt.PaneID = paneID
 	if transition != nil {
-		mr, err = validateResumeGoalSendSnapshot(opts, transition, prompt, receipt.AttemptID, sendSnapshot)
-		if err != nil {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: err}
-		}
-		goalBeforeTransitionSendCAS()
-		panes, listErr := statusPaneLister()
-		if listErr != nil {
-			if tmuxpane.IsPermissionDenied(listErr) {
-				return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: errTmuxAccessDenied()}
-			}
-			panes = nil
-		}
-		var ok bool
-		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
-		if !ok || strings.TrimSpace(paneID) == "" {
-			return mutationResult{}, &goalDeliveryAttemptError{AttemptID: receipt.AttemptID, AttemptPath: attemptPath, State: goalDeliveryStateNotSent, Cause: fmt.Errorf("no live tmux pane found for role %q", opts.Role)}
-		}
-		receipt.PaneID = paneID
 		receipt.addStage("control_delivery_started", "revalidated exact transition-bound pane immediately before native /goal control")
+	} else {
+		receipt.addStage("control_delivery_started", "resolved exact target pane for native /goal control")
 	}
 	if err := sendPromptToPane(paneID, prompt); err != nil {
 		var queued *tmuxpane.QueuedInputError
@@ -1385,22 +1474,7 @@ func executeGoalDeliveryResolved(opts goalDeliveryOptions, receipt deliveryRecei
 	receipt.Status = "native_goal_delivered"
 	receipt.addStage("native_goal_delivered", "native /goal command delivered without ordinary prompt busy-guard semantics")
 	if mr.HasRecord {
-		if identityLocksHeld {
-			goalBeforePostDeliveryBindingCAS()
-		}
-		rec, readErr := launch.Read(mr.AgentDir)
-		if readErr != nil {
-			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: readErr}
-		}
-		if rec.GoalBinding == nil || rec.GoalBinding.Command != prompt {
-			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: fmt.Errorf("reserved binding changed after pane delivery")}
-		}
-		rec.GoalBinding.Detail = "native /goal delivered as a first-class claim-once control action"
-		write := goalLaunchWrite
-		if identityLocksHeld {
-			write = goalLaunchWriteUnderRecordLock
-		}
-		if err := write(mr.AgentDir, rec); err != nil {
+		if err := markGoalDeliveryBindingDelivered(opts, reservation, prompt, receipt.AttemptID); err != nil {
 			return mutationResult{}, &goalPostDeliveryBindingError{AttemptID: receipt.AttemptID, Recovery: goalRetryAttemptCommand(opts, receipt.AttemptID), Cause: err}
 		}
 		receipt.addStage("launch_record_updated", "reserved launch goal_binding marked delivered")

--- a/internal/cli/goal_attempt.go
+++ b/internal/cli/goal_attempt.go
@@ -77,6 +77,21 @@ type goalRetryCASSnapshot struct {
 	LaunchModTime int64
 }
 
+// goalRetryPostSendIdentityError reports an identity/generation change that
+// happened while the native retry was in flight. The prompt may already be in
+// the pane, so creating another attempt or retrying blindly would be unsafe.
+type goalRetryPostSendIdentityError struct {
+	AttemptID string
+	Cause     error
+}
+
+func (e *goalRetryPostSendIdentityError) Error() string {
+	return fmt.Sprintf("goal retry-attempt %s was sent but current identity/generation changed afterward: %v; do not create or retry another attempt", e.AttemptID, e.Cause)
+}
+
+func (e *goalRetryPostSendIdentityError) Unwrap() error   { return e.Cause }
+func (e *goalRetryPostSendIdentityError) RetrySafe() bool { return false }
+
 func goalAttemptDir(projectDir, profile, session string) string {
 	base := filepath.Join(projectDir, team.DirName, "goal-attempts")
 	if squadnamespace.NormalizeProfile(profile) != team.DefaultProfile {
@@ -465,6 +480,20 @@ func runGoalRetryAttemptLocked(opts goalDeliveryOptions, attemptID string) error
 	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
 		return fmt.Errorf("%s", reason)
 	}
+	// The exact generation/identity check is intentionally a short critical
+	// section. Pane discovery, native input, AMQ fallback, and output run only
+	// after the profile and launch-record locks are released.
+	var sendRuntime memberRuntime
+	if err := withGoalIdentityWriterLocks(opts, mr.AgentDir, func() error {
+		sendRuntime, err = validateGoalRetrySendCAS(opts, attempt, attemptID, cas)
+		if err != nil {
+			return err
+		}
+		goalBeforeRetrySendCAS()
+		return nil
+	}); err != nil {
+		return err
+	}
 	panes, err := statusPaneLister()
 	if err != nil {
 		if tmuxpane.IsPermissionDenied(err) {
@@ -472,12 +501,14 @@ func runGoalRetryAttemptLocked(opts goalDeliveryOptions, attemptID string) error
 		}
 		panes = nil
 	}
-	paneID, _, ok := resolveControlTarget(mr, resolvedWorkstream, panes)
+	paneID, _, ok := resolveControlTarget(sendRuntime, resolvedWorkstream, panes)
 	if !ok || strings.TrimSpace(paneID) == "" {
-		return fmt.Errorf("no live tmux pane found for role %q", opts.Role)
+		return fmt.Errorf("goal retry-attempt refused: exact live pane disappeared before send")
 	}
 	// Claim publication does not share the delivery lock, so re-read at the
-	// last possible point before pane mutation.
+	// last possible point before pane mutation. This check is outside the
+	// identity locks by design: the claim protocol itself is the at-most-once
+	// arbiter, and no writer may be stalled behind tmux work.
 	if claimBytes, claimErr := os.ReadFile(claimPath); claimErr == nil {
 		var claim goalAttemptClaim
 		if json.Unmarshal(claimBytes, &claim) != nil || validateResumeGoalClaim(claim, attempt) != nil {
@@ -487,44 +518,36 @@ func runGoalRetryAttemptLocked(opts goalDeliveryOptions, attemptID string) error
 	} else if !os.IsNotExist(claimErr) {
 		return fmt.Errorf("goal retry-attempt refused: recheck claim: %w", claimErr)
 	}
-	return withGoalIdentityWriterLocks(opts, mr.AgentDir, func() error {
-		mr, err = validateGoalRetrySendCAS(opts, attempt, attemptID, cas)
-		if err != nil {
-			return err
+	opts.Goal = attempt.Goal
+	opts.AttemptID = attemptID
+	if err := sendPromptToPane(paneID, sendRuntime.Record.GoalBinding.Command); err != nil {
+		var queued *tmuxpane.QueuedInputError
+		if errors.As(err, &queued) {
+			fmt.Fprintf(os.Stderr, "warning: existing goal attempt %s is queued in the lead input; do not retry again\n", attemptID)
+			return nil
 		}
-		goalBeforeRetrySendCAS()
-		panes, err = statusPaneLister()
-		if err != nil {
-			if tmuxpane.IsPermissionDenied(err) {
-				return errTmuxAccessDenied()
+		var unconfirmed *tmuxpane.SubmitUnconfirmedError
+		if errors.As(err, &unconfirmed) {
+			fallback, fallbackErr := goalFallbackAMQSend(opts)
+			if fallbackErr != nil {
+				return &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fallbackErr}
 			}
-			panes = nil
+			fmt.Fprintf(os.Stderr, "warning: native retry was unconfirmed; durable fallback %s reuses attempt %s\n", fallback.MessageID, attemptID)
+			return nil
 		}
-		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
-		if !ok || strings.TrimSpace(paneID) == "" {
-			return fmt.Errorf("goal retry-attempt refused: exact live pane disappeared before send")
-		}
-		opts.Goal = attempt.Goal
-		opts.AttemptID = attemptID
-		if err := sendPromptToPane(paneID, mr.Record.GoalBinding.Command); err != nil {
-			var queued *tmuxpane.QueuedInputError
-			if errors.As(err, &queued) {
-				fmt.Fprintf(os.Stderr, "warning: existing goal attempt %s is queued in the lead input; do not retry again\n", attemptID)
-				return nil
-			}
-			var unconfirmed *tmuxpane.SubmitUnconfirmedError
-			if errors.As(err, &unconfirmed) {
-				fallback, fallbackErr := goalFallbackAMQSend(opts)
-				if fallbackErr != nil {
-					return &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fallbackErr}
-				}
-				fmt.Fprintf(os.Stderr, "warning: native retry was unconfirmed; durable fallback %s reuses attempt %s\n", fallback.MessageID, attemptID)
-				return nil
-			}
-			return err
-		}
-		fmt.Printf("Re-delivered existing goal attempt %s to %s; no new attempt was created.\n", attemptID, opts.Role)
-		return nil
+		return err
+	}
+	if err := validateGoalRetryAfterExternalSend(opts, sendRuntime.AgentDir, attempt, attemptID, cas); err != nil {
+		return &goalRetryPostSendIdentityError{AttemptID: attemptID, Cause: err}
+	}
+	fmt.Printf("Re-delivered existing goal attempt %s to %s; no new attempt was created.\n", attemptID, opts.Role)
+	return nil
+}
+
+func validateGoalRetryAfterExternalSend(opts goalDeliveryOptions, agentDir string, attempt goalAttemptRecord, attemptID string, expected goalRetryCASSnapshot) error {
+	return withGoalIdentityWriterLocks(opts, agentDir, func() error {
+		_, err := validateGoalRetrySendCAS(opts, attempt, attemptID, expected)
+		return err
 	})
 }
 

--- a/internal/cli/goal_attempt.go
+++ b/internal/cli/goal_attempt.go
@@ -10,8 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 // goalAttemptRecord is the single durable unit consumed by either an injected
@@ -61,10 +64,18 @@ func (e *invalidExistingGoalClaimError) Error() string {
 }
 
 var (
-	goalAttemptNow    = func() time.Time { return time.Now().UTC() }
-	goalAttemptCreate = createGoalAttempt
-	goalAttemptLink   = os.Link
+	goalAttemptNow         = func() time.Time { return time.Now().UTC() }
+	goalAttemptCreate      = createGoalAttempt
+	goalAttemptLink        = os.Link
+	goalBeforeRetrySendCAS = func() {}
 )
+
+type goalRetryCASSnapshot struct {
+	TeamDigest    string
+	TeamModTime   int64
+	LaunchDigest  string
+	LaunchModTime int64
+}
 
 func goalAttemptDir(projectDir, profile, session string) string {
 	base := filepath.Join(projectDir, team.DirName, "goal-attempts")
@@ -323,4 +334,246 @@ func goalAttemptRecoveryCommand(record goalAttemptRecord) string {
 		quoted = append(quoted, shellQuote(arg))
 	}
 	return strings.Join(quoted, " ")
+}
+
+// runGoalRetryAttempt is the narrow recovery path used after resume has
+// already launched a lead and reserved a new attempt but pane delivery failed.
+// It reuses that exact durable attempt and can never create a third one.
+func runGoalRetryAttempt(args []string) error {
+	fs := flag.NewFlagSet("goal retry-attempt", flag.ContinueOnError)
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	profileFlag := fs.String("profile", "", "team profile (default: default profile)")
+	sessionFlag := fs.String("session", "", "workstream containing the recorded attempt")
+	roleFlag := fs.String("role", "", "lead role whose launch binding reserves the attempt")
+	attemptFlag := fs.String("attempt-id", "", "existing unclaimed goal attempt id")
+	yes := fs.Bool("yes", false, "confirm same-attempt pane delivery without an interactive prompt")
+	registerScopedFlagAliases(fs, projectFlag, sessionFlag, profileFlag)
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad goal retry-attempt - recover one reserved goal delivery
+
+Usage:
+  amq-squad goal retry-attempt --project DIR --profile P --session S --role ROLE --attempt-id ID --yes
+
+This recovery command never creates or resets an attempt. It verifies that the
+current lead binding points to the same durable, still-unclaimed attempt, then
+re-delivers that exact claim-once control prompt.
+`)
+	}
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return usageErrorf("goal retry-attempt takes no positional arguments")
+	}
+	if strings.TrimSpace(*sessionFlag) == "" || strings.TrimSpace(*attemptFlag) == "" {
+		return usageErrorf("goal retry-attempt requires --session and --attempt-id")
+	}
+	if !*yes {
+		return usageErrorf("goal retry-attempt requires --yes after inspecting the reserved attempt")
+	}
+	opts, err := resolveGoalTargetOptions(*projectFlag, *profileFlag, *sessionFlag, *roleFlag, flagWasSet(fs, "project"), flagWasSet(fs, "profile"), true, "goal retry-attempt", namespaceConflictOverrideOptions{})
+	if err != nil {
+		return err
+	}
+	attemptID := strings.TrimSpace(*attemptFlag)
+	if err := os.MkdirAll(goalAttemptDir(opts.Project, opts.Profile, opts.Session), 0o755); err != nil {
+		return err
+	}
+	return flock.WithLock(goalDeliveryLockPath(opts), func() error {
+		return runGoalRetryAttemptLocked(opts, attemptID)
+	})
+}
+
+func runGoalRetryAttemptLocked(opts goalDeliveryOptions, attemptID string) error {
+	currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
+	if err != nil {
+		return fmt.Errorf("goal retry-attempt refused: reread team: %w", err)
+	}
+	lead := strings.TrimSpace(currentTeam.Lead)
+	if lead == "" && len(currentTeam.Members) == 1 {
+		lead = currentTeam.Members[0].Role
+	}
+	member, ok := teamMemberByRole(currentTeam, opts.Role)
+	if !ok || lead != opts.Role || memberHandle(member) != opts.Member.Handle {
+		return fmt.Errorf("goal retry-attempt refused: role is no longer the exact current lead")
+	}
+	if pinned := strings.TrimSpace(member.Session); pinned != "" && pinned != opts.Session {
+		return fmt.Errorf("goal retry-attempt refused: lead session pin changed")
+	}
+	opts.Team = currentTeam
+	opts.Member = member
+	opts.Namespace = squadnamespace.Resolve(opts.Project, opts.Profile, opts.Session)
+	attemptPath, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, attemptID)
+	if err != nil {
+		return err
+	}
+	attempt, err := readGoalAttempt(attemptPath, attemptID)
+	if err != nil {
+		return err
+	}
+	if err := validateResumeGoalAttempt(attempt, opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, attempt.Goal, attemptID, opts.Namespace); err != nil {
+		return fmt.Errorf("goal retry-attempt refused: recorded attempt mismatch: %w", err)
+	}
+	claimPath := goalAttemptClaimPath(attemptPath)
+	if claimBytes, claimErr := os.ReadFile(claimPath); claimErr == nil {
+		var claim goalAttemptClaim
+		if err := json.Unmarshal(claimBytes, &claim); err != nil {
+			return fmt.Errorf("goal retry-attempt refused: existing claim is corrupt")
+		}
+		if err := validateResumeGoalClaim(claim, attempt); err != nil {
+			return fmt.Errorf("goal retry-attempt refused: existing claim is invalid: %w", err)
+		}
+		return usageErrorf("goal retry-attempt refused: attempt %s is already claimed via %s", attemptID, claim.Route)
+	} else if !os.IsNotExist(claimErr) {
+		return fmt.Errorf("goal retry-attempt refused: inspect claim: %w", claimErr)
+	}
+	mr, resolvedWorkstream, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+	if err != nil {
+		return err
+	}
+	if !mr.HasRecord || mr.Record.GoalBinding == nil {
+		return fmt.Errorf("goal retry-attempt refused: current lead launch has no reserved goal binding")
+	}
+	ns := opts.Namespace
+	rec := mr.Record
+	if rec.Role != opts.Role || rec.Handle != memberHandle(member) || rec.Session != opts.Session ||
+		!squadnamespace.ProfilesEqual(rec.TeamProfile, opts.Profile) || canonicalPath(rec.TeamHome) != canonicalPath(opts.Project) ||
+		canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(currentTeam.Project)) ||
+		rec.Binary != member.Binary || rec.Conversation != "" || rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required ||
+		strings.TrimSpace(rec.BootstrapExpectation.LaunchID) == "" || rec.StartedAt.IsZero() || rec.Tmux == nil || rec.Tmux.Target == "adopted" {
+		return fmt.Errorf("goal retry-attempt refused: current launch identity is not the exact fresh lead launch")
+	}
+	if mr.Record.GoalBinding.Mode != "native_goal" || !mr.Record.GoalBinding.NativeGoal || mr.Record.GoalBinding.Source != "goal-control" {
+		return fmt.Errorf("goal retry-attempt refused: current lead binding is not a native goal-control reservation")
+	}
+	goal, boundAttemptID, err := parseGeneratedGoalBinding(mr.Record.GoalBinding.Command)
+	if err != nil || boundAttemptID != attemptID || goal != attempt.Goal {
+		return fmt.Errorf("goal retry-attempt refused: current lead binding does not match attempt %s", attemptID)
+	}
+	if expected := nativeGoalControlPrompt(goal, opts.Team, opts.Profile, opts.Session, opts.Role, attemptID); mr.Record.GoalBinding.Command != expected {
+		return fmt.Errorf("goal retry-attempt refused: current lead binding is not the exact generated command")
+	}
+	teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+	if err != nil {
+		return fmt.Errorf("goal retry-attempt refused: capture team generation: %w", err)
+	}
+	launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(mr.AgentDir))
+	if err != nil {
+		return fmt.Errorf("goal retry-attempt refused: capture launch generation: %w", err)
+	}
+	cas := goalRetryCASSnapshot{TeamDigest: teamDigest, TeamModTime: teamMod, LaunchDigest: launchDigest, LaunchModTime: launchMod}
+	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
+		return fmt.Errorf("%s", reason)
+	}
+	panes, err := statusPaneLister()
+	if err != nil {
+		if tmuxpane.IsPermissionDenied(err) {
+			return errTmuxAccessDenied()
+		}
+		panes = nil
+	}
+	paneID, _, ok := resolveControlTarget(mr, resolvedWorkstream, panes)
+	if !ok || strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("no live tmux pane found for role %q", opts.Role)
+	}
+	// Claim publication does not share the delivery lock, so re-read at the
+	// last possible point before pane mutation.
+	if claimBytes, claimErr := os.ReadFile(claimPath); claimErr == nil {
+		var claim goalAttemptClaim
+		if json.Unmarshal(claimBytes, &claim) != nil || validateResumeGoalClaim(claim, attempt) != nil {
+			return fmt.Errorf("goal retry-attempt refused: claim changed to invalid evidence before delivery")
+		}
+		return usageErrorf("goal retry-attempt refused: attempt %s became claimed via %s before delivery", attemptID, claim.Route)
+	} else if !os.IsNotExist(claimErr) {
+		return fmt.Errorf("goal retry-attempt refused: recheck claim: %w", claimErr)
+	}
+	return withGoalIdentityWriterLocks(opts, mr.AgentDir, func() error {
+		mr, err = validateGoalRetrySendCAS(opts, attempt, attemptID, cas)
+		if err != nil {
+			return err
+		}
+		goalBeforeRetrySendCAS()
+		panes, err = statusPaneLister()
+		if err != nil {
+			if tmuxpane.IsPermissionDenied(err) {
+				return errTmuxAccessDenied()
+			}
+			panes = nil
+		}
+		paneID, _, ok = resolveControlTarget(mr, resolvedWorkstream, panes)
+		if !ok || strings.TrimSpace(paneID) == "" {
+			return fmt.Errorf("goal retry-attempt refused: exact live pane disappeared before send")
+		}
+		opts.Goal = attempt.Goal
+		opts.AttemptID = attemptID
+		if err := sendPromptToPane(paneID, mr.Record.GoalBinding.Command); err != nil {
+			var queued *tmuxpane.QueuedInputError
+			if errors.As(err, &queued) {
+				fmt.Fprintf(os.Stderr, "warning: existing goal attempt %s is queued in the lead input; do not retry again\n", attemptID)
+				return nil
+			}
+			var unconfirmed *tmuxpane.SubmitUnconfirmedError
+			if errors.As(err, &unconfirmed) {
+				fallback, fallbackErr := goalFallbackAMQSend(opts)
+				if fallbackErr != nil {
+					return &goalFallbackDurabilityError{DeliveryErr: err, FallbackErr: fallbackErr}
+				}
+				fmt.Fprintf(os.Stderr, "warning: native retry was unconfirmed; durable fallback %s reuses attempt %s\n", fallback.MessageID, attemptID)
+				return nil
+			}
+			return err
+		}
+		fmt.Printf("Re-delivered existing goal attempt %s to %s; no new attempt was created.\n", attemptID, opts.Role)
+		return nil
+	})
+}
+
+func validateGoalRetrySendCAS(opts goalDeliveryOptions, attempt goalAttemptRecord, attemptID string, expected goalRetryCASSnapshot) (memberRuntime, error) {
+	teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+	if err != nil || teamDigest != expected.TeamDigest || teamMod != expected.TeamModTime {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: team generation changed immediately before send")
+	}
+	currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
+	if err != nil {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: reread team: %w", err)
+	}
+	lead := strings.TrimSpace(currentTeam.Lead)
+	if lead == "" && len(currentTeam.Members) == 1 {
+		lead = currentTeam.Members[0].Role
+	}
+	member, ok := teamMemberByRole(currentTeam, opts.Role)
+	if !ok || lead != opts.Role || memberHandle(member) != opts.Member.Handle || canonicalPath(currentTeam.Project) != canonicalPath(opts.Project) ||
+		member.Session != opts.Member.Session || (member.Session != "" && member.Session != opts.Session) || member.Binary != opts.Member.Binary || canonicalPath(member.EffectiveCWD(currentTeam.Project)) != canonicalPath(opts.Member.EffectiveCWD(opts.Project)) {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: lead team identity changed immediately before send")
+	}
+	mr, _, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+	if err != nil || !mr.HasRecord || mr.Record.GoalBinding == nil {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: launch record unavailable immediately before send")
+	}
+	launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(mr.AgentDir))
+	if err != nil || launchDigest != expected.LaunchDigest || launchMod != expected.LaunchModTime {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: launch generation changed immediately before send")
+	}
+	rec := mr.Record
+	ns := squadnamespace.Resolve(opts.Project, opts.Profile, opts.Session)
+	goal, boundAttemptID, parseErr := parseGeneratedGoalBinding(rec.GoalBinding.Command)
+	if parseErr != nil || boundAttemptID != attemptID || goal != attempt.Goal || rec.GoalBinding.Mode != "native_goal" || !rec.GoalBinding.NativeGoal || rec.GoalBinding.Source != "goal-control" ||
+		rec.Role != opts.Role || rec.Handle != memberHandle(member) || rec.Session != opts.Session || !squadnamespace.ProfilesEqual(rec.TeamProfile, opts.Profile) || canonicalPath(rec.TeamHome) != canonicalPath(opts.Project) ||
+		canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(currentTeam.Project)) || rec.Binary != member.Binary || rec.Conversation != "" ||
+		rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required || strings.TrimSpace(rec.BootstrapExpectation.LaunchID) == "" || rec.StartedAt.IsZero() || rec.Tmux == nil || rec.Tmux.Target == "adopted" ||
+		rec.GoalBinding.Command != nativeGoalControlPrompt(goal, currentTeam, opts.Profile, opts.Session, opts.Role, attemptID) {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: exact launch/binding identity changed immediately before send")
+	}
+	claimPath := goalAttemptClaimPath(mustGoalAttemptPathForRetry(opts, attemptID))
+	if _, err := os.Stat(claimPath); err == nil {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: attempt became claimed immediately before send")
+	} else if !os.IsNotExist(err) {
+		return memberRuntime{}, fmt.Errorf("goal retry-attempt refused: inspect claim immediately before send: %w", err)
+	}
+	return mr, nil
+}
+
+func mustGoalAttemptPathForRetry(opts goalDeliveryOptions, attemptID string) string {
+	path, _ := goalAttemptPath(opts.Project, opts.Profile, opts.Session, attemptID)
+	return path
 }

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -591,6 +591,120 @@ func TestGoalDeliveryUnconfirmedQueuesClaimOnceAMQFallback(t *testing.T) {
 	}
 }
 
+func TestGoalDeliverySerializesOrdinaryLaunchBindingWithConcurrentWriter(t *testing.T) {
+	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	oldHook, oldSend := goalBeforeOrdinaryBindingCAS, sendPromptToPane
+	writerDone := make(chan error, 1)
+	goalBeforeOrdinaryBindingCAS = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- launch.WithRecordLock(agentDir, func() error {
+				rec, err := launch.Read(agentDir)
+				if err != nil {
+					return err
+				}
+				rec.Model = "concurrent-resume-update"
+				return launch.WriteUnderRecordLock(agentDir, rec)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("concurrent writer completed inside ordinary delivery writer lock: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	sendPromptToPane = func(paneID, prompt string) error {
+		select {
+		case err := <-writerDone:
+			t.Fatalf("concurrent writer interleaved before ordinary delivery send: %v", err)
+		default:
+		}
+		return oldSend(paneID, prompt)
+	}
+	t.Cleanup(func() {
+		goalBeforeOrdinaryBindingCAS = oldHook
+		sendPromptToPane = oldSend
+	})
+
+	if _, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely"})
+	}); err != nil {
+		t.Fatalf("ordinary goal delivery: %v", err)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent launch writer did not resume after ordinary delivery")
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("ordinary delivery prompts=%v", *prompts)
+	}
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Model != "concurrent-resume-update" || rec.GoalBinding == nil || !rec.GoalBinding.NativeGoal {
+		t.Fatalf("ordinary delivery lost concurrent launch update: model=%q binding=%+v", rec.Model, rec.GoalBinding)
+	}
+}
+
+func TestGoalDeliverySerializesOrdinaryPostSendBindingWithConcurrentWriter(t *testing.T) {
+	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	oldHook := goalBeforePostDeliveryBindingCAS
+	writerDone := make(chan error, 1)
+	goalBeforePostDeliveryBindingCAS = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- launch.WithRecordLock(agentDir, func() error {
+				rec, err := launch.Read(agentDir)
+				if err != nil {
+					return err
+				}
+				rec.Model = "concurrent-post-send-update"
+				return launch.WriteUnderRecordLock(agentDir, rec)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("concurrent writer completed inside post-send binding RMW: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	t.Cleanup(func() { goalBeforePostDeliveryBindingCAS = oldHook })
+	if _, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely"})
+	}); err != nil {
+		t.Fatalf("ordinary goal delivery: %v", err)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent launch writer did not resume after post-send binding update")
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("ordinary delivery prompts=%v", *prompts)
+	}
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.Model != "concurrent-post-send-update" || rec.GoalBinding == nil || rec.GoalBinding.Detail != "native /goal delivered as a first-class claim-once control action" {
+		t.Fatalf("ordinary post-send RMW lost state: model=%q binding=%+v", rec.Model, rec.GoalBinding)
+	}
+}
+
 func TestGoalClaimIsAtomicAndSecondRouteIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	opts := goalDeliveryOptions{

--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -591,117 +591,72 @@ func TestGoalDeliveryUnconfirmedQueuesClaimOnceAMQFallback(t *testing.T) {
 	}
 }
 
-func TestGoalDeliverySerializesOrdinaryLaunchBindingWithConcurrentWriter(t *testing.T) {
-	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
-	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
-	oldHook, oldSend := goalBeforeOrdinaryBindingCAS, sendPromptToPane
-	writerDone := make(chan error, 1)
-	goalBeforeOrdinaryBindingCAS = func() {
-		started := make(chan struct{})
-		go func() {
-			close(started)
-			writerDone <- launch.WithRecordLock(agentDir, func() error {
-				rec, err := launch.Read(agentDir)
-				if err != nil {
-					return err
+func TestGoalDeliveryReleasesIdentityLocksBeforeBlockedSend(t *testing.T) {
+	for _, kind := range []string{"launch", "team"} {
+		t.Run(kind, func(t *testing.T) {
+			dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+			agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+			oldSend := sendPromptToPane
+			writerDone := make(chan error, 1)
+			sendPromptToPane = func(paneID, prompt string) error {
+				go func() {
+					switch kind {
+					case "launch":
+						writerDone <- launch.WithRecordLock(agentDir, func() error {
+							rec, err := launch.Read(agentDir)
+							if err != nil {
+								return err
+							}
+							rec.Model = "concurrent-send-launch-update"
+							return launch.WriteUnderRecordLock(agentDir, rec)
+						})
+					case "team":
+						writerDone <- team.WithProfileLock(dir, team.DefaultProfile, func() error {
+							current, err := team.ReadProfile(dir, team.DefaultProfile)
+							if err != nil {
+								return err
+							}
+							current.Members[0].Model = "concurrent-send-team-update"
+							return team.WriteProfileUnderLock(dir, team.DefaultProfile, current)
+						})
+					}
+				}()
+				select {
+				case err := <-writerDone:
+					if err != nil {
+						t.Fatalf("%s writer while send blocked: %v", kind, err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("%s writer was blocked by external send", kind)
 				}
-				rec.Model = "concurrent-resume-update"
-				return launch.WriteUnderRecordLock(agentDir, rec)
+				return oldSend(paneID, prompt)
+			}
+			t.Cleanup(func() { sendPromptToPane = oldSend })
+
+			_, _, err := captureOutput(t, func() error {
+				return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely"})
 			})
-		}()
-		<-started
-		select {
-		case err := <-writerDone:
-			t.Fatalf("concurrent writer completed inside ordinary delivery writer lock: %v", err)
-		case <-time.After(50 * time.Millisecond):
-		}
-	}
-	sendPromptToPane = func(paneID, prompt string) error {
-		select {
-		case err := <-writerDone:
-			t.Fatalf("concurrent writer interleaved before ordinary delivery send: %v", err)
-		default:
-		}
-		return oldSend(paneID, prompt)
-	}
-	t.Cleanup(func() {
-		goalBeforeOrdinaryBindingCAS = oldHook
-		sendPromptToPane = oldSend
-	})
-
-	if _, _, err := captureOutput(t, func() error {
-		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely"})
-	}); err != nil {
-		t.Fatalf("ordinary goal delivery: %v", err)
-	}
-	select {
-	case err := <-writerDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("concurrent launch writer did not resume after ordinary delivery")
-	}
-	if len(*prompts) != 1 {
-		t.Fatalf("ordinary delivery prompts=%v", *prompts)
-	}
-	rec, err := launch.Read(agentDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rec.Model != "concurrent-resume-update" || rec.GoalBinding == nil || !rec.GoalBinding.NativeGoal {
-		t.Fatalf("ordinary delivery lost concurrent launch update: model=%q binding=%+v", rec.Model, rec.GoalBinding)
-	}
-}
-
-func TestGoalDeliverySerializesOrdinaryPostSendBindingWithConcurrentWriter(t *testing.T) {
-	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
-	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
-	oldHook := goalBeforePostDeliveryBindingCAS
-	writerDone := make(chan error, 1)
-	goalBeforePostDeliveryBindingCAS = func() {
-		started := make(chan struct{})
-		go func() {
-			close(started)
-			writerDone <- launch.WithRecordLock(agentDir, func() error {
-				rec, err := launch.Read(agentDir)
-				if err != nil {
-					return err
+			if len(*prompts) != 1 {
+				t.Fatalf("ordinary delivery prompts=%v", *prompts)
+			}
+			if kind == "team" {
+				if err == nil || !strings.Contains(err.Error(), "team generation changed after pane delivery") {
+					t.Fatalf("team update must cause explicit stale-generation refusal, got %v", err)
 				}
-				rec.Model = "concurrent-post-send-update"
-				return launch.WriteUnderRecordLock(agentDir, rec)
-			})
-		}()
-		<-started
-		select {
-		case err := <-writerDone:
-			t.Fatalf("concurrent writer completed inside post-send binding RMW: %v", err)
-		case <-time.After(50 * time.Millisecond):
-		}
-	}
-	t.Cleanup(func() { goalBeforePostDeliveryBindingCAS = oldHook })
-	if _, _, err := captureOutput(t, func() error {
-		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "ship safely"})
-	}); err != nil {
-		t.Fatalf("ordinary goal delivery: %v", err)
-	}
-	select {
-	case err := <-writerDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("concurrent launch writer did not resume after post-send binding update")
-	}
-	if len(*prompts) != 1 {
-		t.Fatalf("ordinary delivery prompts=%v", *prompts)
-	}
-	rec, err := launch.Read(agentDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if rec.Model != "concurrent-post-send-update" || rec.GoalBinding == nil || rec.GoalBinding.Detail != "native /goal delivered as a first-class claim-once control action" {
-		t.Fatalf("ordinary post-send RMW lost state: model=%q binding=%+v", rec.Model, rec.GoalBinding)
+				current, readErr := team.ReadProfile(dir, team.DefaultProfile)
+				if readErr != nil || current.Members[0].Model != "concurrent-send-team-update" {
+					t.Fatalf("team writer did not survive blocked send: model=%q err=%v", current.Members[0].Model, readErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("launch update should merge after blocked send: %v", err)
+			}
+			rec, readErr := launch.Read(agentDir)
+			if readErr != nil || rec.Model != "concurrent-send-launch-update" || rec.GoalBinding == nil || rec.GoalBinding.Detail != "native /goal delivered as a first-class claim-once control action" {
+				t.Fatalf("post-send merge lost independent launch update: model=%q binding=%+v err=%v", rec.Model, rec.GoalBinding, readErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -125,6 +126,7 @@ func runLaunch(args []string) error {
 	dryRun := fs.Bool("dry-run", false, "print the coop exec command without executing")
 	launcherRaw := fs.String("launcher", "", "custom launcher to exec instead of <binary> (still receives AMQ env/identity, bootstrap, and a launch record)")
 	launcherArgsRaw := fs.String("launcher-args", "", "args passed to --launcher before the agent's child args; the launcher must forward trailing args to <binary>")
+	restoreGoalBindingRaw := fs.String("restore-goal-binding", "", "internal restore-only goal binding metadata")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad agent up - launch an agent with role metadata
@@ -237,6 +239,14 @@ Examples:
 	if launcher == "" && len(launcherArgs) > 0 {
 		return usageErrorf("--launcher-args requires --launcher")
 	}
+	var restoredGoalBinding *launch.GoalBinding
+	if strings.TrimSpace(*restoreGoalBindingRaw) != "" {
+		var binding launch.GoalBinding
+		if err := json.Unmarshal([]byte(*restoreGoalBindingRaw), &binding); err != nil {
+			return usageErrorf("--restore-goal-binding contains invalid JSON: %v", err)
+		}
+		restoredGoalBinding = &binding
+	}
 	remaining := fs.Args()
 	if len(remaining) == 0 {
 		return usageErrorf("agent up requires a binary (e.g. 'amq-squad agent up codex --role cpo')")
@@ -260,6 +270,9 @@ Examples:
 		if err != nil {
 			return err
 		}
+	}
+	if restoredGoalBinding != nil && nativeGoalBindingFromArgs(childArgs) != nil {
+		return usageErrorf("--restore-goal-binding cannot be combined with a native /goal child argument")
 	}
 
 	handle := *me
@@ -330,7 +343,7 @@ Examples:
 		NoRequireWake:                *noRequireWake,
 		NoGitignore:                  *noGitignore,
 		Symphony:                     *symphony,
-		GoalBinding:                  nativeGoalBindingFromArgs(childArgs),
+		GoalBinding:                  restoredGoalBinding,
 		PreauthorizedActions:         preauthorizedActions,
 		LauncherPreauthorizedActions: launcherPreauthorizedActions,
 		ExplicitAllowedTools:         explicitAllowedTools,
@@ -342,6 +355,9 @@ Examples:
 		StartedAt:                    time.Now().UTC(),
 		TeamProfile:                  teamProfileValue,
 		TeamHome:                     strings.TrimSpace(*teamHome),
+	}
+	if rec.GoalBinding == nil {
+		rec.GoalBinding = nativeGoalBindingFromArgs(childArgs)
 	}
 	if rec.TeamHome == "" {
 		rec.TeamHome = rec.CWD

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -312,6 +313,10 @@ func launchArgsFromRecord(rec launch.Record) []string {
 	if profile := strings.TrimSpace(rec.TeamProfile); profile != "" && profile != team.DefaultProfile {
 		args = append(args, "--team-profile", profile)
 	}
+	if rec.GoalBinding != nil {
+		payload, _ := json.Marshal(rec.GoalBinding) // launch.GoalBinding contains only strings/bools.
+		args = append(args, "--restore-goal-binding", string(payload))
+	}
 	args = append(args, rec.Binary)
 	argv := restoreArgvFromRecord(rec)
 	if len(argv) > 0 {
@@ -323,6 +328,18 @@ func launchArgsFromRecord(rec launch.Record) []string {
 
 func restoreArgvFromRecord(rec launch.Record) []string {
 	argv := append([]string(nil), rec.Argv...)
+	// A saved goal binding is restore metadata, never child input. In
+	// particular, a fresh re-orient must not silently replay the old /goal;
+	// resume owns the explicit claim-once redelivery decision after launch.
+	if rec.GoalBinding != nil && rec.GoalBinding.NativeGoal && rec.GoalBinding.Command != "" {
+		out := argv[:0]
+		for _, arg := range argv {
+			if arg != rec.GoalBinding.Command {
+				out = append(out, arg)
+			}
+		}
+		argv = out
+	}
 	// New records carry structural provenance. Strip the final merged grant only
 	// when launcher policy contributed, then restore the explicit source below.
 	// Legacy records lack both provenance fields, so retain the historical exact
@@ -559,6 +576,11 @@ func emitCommandWithOptions(rec launch.Record, opts emitCommandOptions) string {
 	if profile := strings.TrimSpace(rec.TeamProfile); profile != "" && profile != team.DefaultProfile {
 		b.WriteString(" --team-profile ")
 		b.WriteString(shellQuote(profile))
+	}
+	if rec.GoalBinding != nil {
+		payload, _ := json.Marshal(rec.GoalBinding) // launch.GoalBinding contains only strings/bools.
+		b.WriteString(" --restore-goal-binding ")
+		b.WriteString(shellQuote(string(payload)))
 	}
 	argv := restoreArgvFromRecord(rec)
 	if len(argv) > 0 {

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -10,6 +10,11 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
+var (
+	resumeStdinIsTerminal  = stdinIsTerminal
+	resumeStderrIsTerminal = stderrIsTerminal
+)
+
 func runResume(args []string) error {
 	fs := flag.NewFlagSet("resume", flag.ContinueOnError)
 	sessionFlag := fs.String("session", "", "AMQ workstream session name to resume into (default: team workstream)")
@@ -27,6 +32,8 @@ func runResume(args []string) error {
 	registerScopedFlagAliases(fs, projectFlag, sessionFlag, profileFlag)
 	roleFlag := fs.String("role", "", "comma-separated subset of roles to resume (default: all members)")
 	execMode := fs.Bool("exec", false, "open the planned launch commands in the terminal backend (tmux) instead of printing them")
+	redeliverGoal := fs.Bool("redeliver-goal", false, "after a verified fresh lead re-orient, deliver the saved goal as a new claim-once attempt")
+	suppressGoalPrompt := fs.Bool("no-redeliver-goal-prompt", false, "preserve an upstream wizard No without prompting again")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned resume_plan envelope (liveness + tmux metadata) instead of the human plan")
 	terminal := fs.String("terminal", "tmux", "terminal backend to use with --exec")
 	target := fs.String("target", "current-window", "terminal target with --exec (tmux: current-window, new-window, or new-session)")
@@ -43,7 +50,7 @@ Usage:
                    [--model role=model,...]
                    [--effort role=level,...]
                    [--codex-args args] [--claude-args args]
-                   [--exec [--terminal tmux] [--target current-window|new-window|new-session]
+                   [--exec [--redeliver-goal] [--terminal tmux] [--target current-window|new-window|new-session]
                            [--layout vertical|horizontal|tiled]
                            [--terminal-session name] [--stagger 750ms]]
 
@@ -130,15 +137,23 @@ Examples:
 	if *restoreExisting {
 		mode = resumeModeRestoreExisting
 	}
-	exec := resumeExecOptions{}
+	exec := resumeExecOptions{
+		RedeliverGoal:      *redeliverGoal,
+		RedeliveryExplicit: flagWasSet(fs, "redeliver-goal"),
+	}
 	if *execMode {
 		exec = resumeExecOptions{
-			Enabled:         true,
-			Terminal:        *terminal,
-			Target:          *target,
-			Layout:          *layout,
-			TerminalSession: *terminalSession,
-			Stagger:         *stagger,
+			Enabled:            true,
+			Terminal:           *terminal,
+			Target:             *target,
+			Layout:             *layout,
+			TerminalSession:    *terminalSession,
+			Stagger:            *stagger,
+			RedeliverGoal:      *redeliverGoal,
+			RedeliveryExplicit: flagWasSet(fs, "redeliver-goal"),
+			PromptGoal:         !flagWasSet(fs, "redeliver-goal") && !*suppressGoalPrompt && resumeStdinIsTerminal() && resumeStderrIsTerminal(),
+			PromptIn:           os.Stdin,
+			PromptOut:          os.Stderr,
 		}
 	}
 	return executeResume(resumeExecution{
@@ -159,6 +174,7 @@ Examples:
 		DryRun:           *dryRun,
 		Profile:          profile,
 		JSON:             *jsonOut,
+		GoalRedelivery:   true,
 		Style:            resumePrinterStyle{Label: "resume", FooterVerb: "up"},
 		Exec:             exec,
 	})

--- a/internal/cli/resume_goal.go
+++ b/internal/cli/resume_goal.go
@@ -49,6 +49,11 @@ type resumeGoalTransitionRecord struct {
 	LaunchRecordDigest    string    `json:"launch_record_digest"`
 	LaunchRecordModTime   int64     `json:"launch_record_mod_time_unix_nano"`
 	CreatedAt             time.Time `json:"created_at"`
+	// BindingReserved is runtime-only recovery state. It records that a prior
+	// process durably published this transition's exact new binding before it
+	// crashed, so continuation must reuse the same attempt rather than require
+	// the old binding CAS or create a third attempt.
+	BindingReserved bool `json:"-"`
 }
 
 type resumeGoalTransitionConsumed struct {
@@ -58,11 +63,75 @@ type resumeGoalTransitionConsumed struct {
 	ConsumedAt    time.Time `json:"consumed_at"`
 }
 
+// resumeGoalTransitionBound seals the exact launch-record generation after a
+// transition has installed its new attempt binding. It lets a restarted
+// process distinguish the deliberate post-reservation generation from a later
+// stale/ABA writer without rewriting the immutable transition reservation.
+type resumeGoalTransitionBound struct {
+	SchemaVersion       int       `json:"schema_version"`
+	TransitionID        string    `json:"transition_id"`
+	NewAttemptID        string    `json:"new_attempt_id"`
+	LaunchRecordDigest  string    `json:"launch_record_digest"`
+	LaunchRecordModTime int64     `json:"launch_record_mod_time_unix_nano"`
+	BoundAt             time.Time `json:"bound_at"`
+}
+
 type resumeGoalSendSnapshot struct {
 	TeamDigest    string
 	TeamModTime   int64
 	LaunchDigest  string
 	LaunchModTime int64
+}
+
+// resumeNativeGoalRecovery is read-only evidence that a restored member
+// recorded a native goal which Codex has blocked. Resume never injects the
+// recovery command: the operator must inspect the exact pane before entering
+// /goal resume.
+type resumeNativeGoalRecovery struct {
+	Role     string `json:"role"`
+	Handle   string `json:"handle,omitempty"`
+	Action   string `json:"action"`
+	Detail   string `json:"detail,omitempty"`
+	Guidance string `json:"guidance"`
+}
+
+const nativeGoalBlockedResumeGuidance = "Inspect the exact recovered pane for this profile and session, then enter /goal resume manually. Do not automatically redeliver the saved goal."
+
+func resumeNativeGoalBlockedRecoveries(plans []resumePlan) []resumeNativeGoalRecovery {
+	var recoveries []resumeNativeGoalRecovery
+	for _, plan := range plans {
+		if plan.RestoreRecord == nil || !nativeGoalBindingBlocked(plan.RestoreRecord.GoalBinding) {
+			continue
+		}
+		detail := boundedResumeDisplay(plan.RestoreRecord.GoalBinding.Detail, 240)
+		if detail == "" {
+			detail = "native /goal binding is blocked"
+		}
+		recoveries = append(recoveries, resumeNativeGoalRecovery{
+			Role:     plan.Role,
+			Handle:   plan.Handle,
+			Action:   string(plan.Action),
+			Detail:   detail,
+			Guidance: nativeGoalBlockedResumeGuidance,
+		})
+	}
+	return recoveries
+}
+
+func writeResumeNativeGoalBlockedRecoveries(out io.Writer, recoveries []resumeNativeGoalRecovery) {
+	if len(recoveries) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "# Native goal recovery required")
+	for _, recovery := range recoveries {
+		identity := recovery.Role
+		if recovery.Handle != "" && recovery.Handle != recovery.Role {
+			identity += " (handle " + recovery.Handle + ")"
+		}
+		fmt.Fprintf(out, "# %s (%s): %s\n", identity, recovery.Action, recovery.Detail)
+		fmt.Fprintf(out, "# Recovery: %s\n", recovery.Guidance)
+	}
+	fmt.Fprintln(out)
 }
 
 // buildResumeGoalPlan computes read-only evidence from the exact per-member
@@ -114,6 +183,9 @@ func buildResumeGoalPlan(t team.Team, profile, workstream string, plans []resume
 	}
 	rec := *selected.RestoreRecord
 	result.SavedConversation = rec.Conversation != ""
+	if canonicalPath(rec.TeamHome) != canonicalPath(t.Project) {
+		return finish("lead restore record does not exactly match the configured team home")
+	}
 	if canonicalPath(rec.CWD) == "" || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(t.Project)) {
 		return finish("lead restore record does not exactly match the configured cwd")
 	}
@@ -125,6 +197,9 @@ func buildResumeGoalPlan(t team.Team, profile, workstream string, plans []resume
 	ns := squadnamespace.Resolve(t.Project, profile, workstream)
 	if canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) {
 		return finish("lead restore record does not exactly match the workstream root")
+	}
+	if rec.Tmux != nil && rec.Tmux.Target == "adopted" {
+		return finish("adopted lead pane is not eligible for saved-goal redelivery")
 	}
 	if rec.GoalBinding == nil {
 		return finish("lead restore record has no saved goal binding")
@@ -219,11 +294,26 @@ func buildResumeGoalPlan(t team.Team, profile, workstream string, plans []resume
 			result.TransitionState = "mismatched"
 			return finish("a mismatched durable goal redelivery transition already exists")
 		}
+		result.RecoveryAttemptID = transition.NewAttemptID
 		result.TransitionState = "reserved"
-		if _, consumedErr := os.Stat(resumeGoalTransitionConsumedPath(transitionPath)); consumedErr == nil {
+		consumedPath := resumeGoalTransitionConsumedPath(transitionPath)
+		if consumedBytes, consumedErr := os.ReadFile(consumedPath); consumedErr == nil {
+			var consumed resumeGoalTransitionConsumed
+			if json.Unmarshal(consumedBytes, &consumed) != nil || consumed.SchemaVersion != resumeGoalTransitionSchemaVersion || consumed.TransitionID != transition.TransitionID || consumed.NewAttemptID != transition.NewAttemptID || consumed.ConsumedAt.IsZero() {
+				result.TransitionState = "mismatched"
+				return finish("durable goal redelivery transition completion is mismatched")
+			}
 			result.TransitionState = "consumed"
+			result.Action = "retry"
+			result.RecoveryCommand = resumeGoalRetryCommand(t.Project, profile, workstream, result.LeadRole, transition.NewAttemptID)
+			return finish("a consumed durable goal redelivery transition may have reached the pane; manually retry only its exact claim-once attempt")
+		} else if !os.IsNotExist(consumedErr) {
+			result.TransitionState = "unreadable"
+			return finish("goal redelivery transition completion evidence is unreadable")
 		}
-		return finish("a durable goal redelivery transition already exists; inspect its exact attempt before retrying")
+		result.Action = "continue"
+		result.RecoveryCommand = resumeGoalContinuationCommand(t.Project, profile, workstream, result.LeadRole, result.Goal, transition.TransitionID)
+		return finish("a durable goal redelivery transition is reserved; manually continue its exact claim-once attempt")
 	} else if !os.IsNotExist(readErr) {
 		result.TransitionState = "unreadable"
 		return finish("goal redelivery transition evidence is unreadable")
@@ -253,6 +343,10 @@ func resumeGoalTransitionPath(project, profile, session, transitionID string) (s
 
 func resumeGoalTransitionConsumedPath(path string) string {
 	return strings.TrimSuffix(path, ".json") + ".consumed.json"
+}
+
+func resumeGoalTransitionBoundPath(path string) string {
+	return strings.TrimSuffix(path, ".json") + ".bound.json"
 }
 
 func validateResumeGoalTransitionPlan(tr resumeGoalTransitionRecord, project, profile, session string, plan runwizard.ResumeGoalPlan) error {
@@ -464,6 +558,27 @@ func writeResumeGoalPlan(out io.Writer, plan runwizard.ResumeGoalPlan) {
 	if plan.Eligible {
 		fmt.Fprintln(out, "To redeliver after the lead is verified live, run resume --exec with --redeliver-goal.")
 	}
+	if plan.RecoveryCommand != "" {
+		fmt.Fprintf(out, "Recovery for exact attempt %s (manual; revalidates identity before mutation):\n  %s\n", plan.RecoveryAttemptID, plan.RecoveryCommand)
+	}
+}
+
+func resumeGoalContinuationCommand(project, profile, session, role, goal, transitionID string) string {
+	args := []string{"amq-squad", "goal", "start", "--project", project, "--profile", profile, "--session", session, "--role", role, "--goal", goal, "--resume-transition", transitionID, "--yes"}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func resumeGoalRetryCommand(project, profile, session, role, attemptID string) string {
+	args := []string{"amq-squad", "goal", "retry-attempt", "--project", project, "--profile", profile, "--session", session, "--role", role, "--attempt-id", attemptID, "--yes"}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func promptResumeGoalRedelivery(in io.Reader, out io.Writer, plan runwizard.ResumeGoalPlan) (bool, error) {
@@ -621,7 +736,7 @@ func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr member
 		}
 		for _, entry := range entries {
 			name := entry.Name()
-			if !strings.HasPrefix(name, ".resume-redelivery-") || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".consumed.json") {
+			if !strings.HasPrefix(name, ".resume-redelivery-") || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".consumed.json") || strings.HasSuffix(name, ".bound.json") {
 				continue
 			}
 			path := filepath.Join(dir, name)
@@ -680,8 +795,8 @@ func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr member
 	if _, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, tr.NewAttemptID); err != nil {
 		return nil, fmt.Errorf("goal delivery refused: transition new attempt id is invalid")
 	}
-	if !mr.HasRecord || mr.Record.GoalBinding == nil || digestJSON(*mr.Record.GoalBinding) != tr.OriginalBindingDigest {
-		return nil, fmt.Errorf("goal delivery refused: expected old goal binding compare-and-swap failed")
+	if !mr.HasRecord || mr.Record.GoalBinding == nil {
+		return nil, fmt.Errorf("goal delivery refused: current lead launch has no goal binding")
 	}
 	rec := mr.Record
 	ns := squadnamespace.Resolve(opts.Project, opts.Profile, opts.Session)
@@ -692,9 +807,35 @@ func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr member
 		rec.BootstrapExpectation.LaunchID != tr.LaunchID || !rec.StartedAt.Equal(tr.LaunchStartedAt) || rec.Tmux == nil || rec.Tmux.Target == "adopted" {
 		return nil, fmt.Errorf("goal delivery refused: fresh lead launch identity changed")
 	}
+	if digestJSON(*rec.GoalBinding) == tr.OriginalBindingDigest {
+		tr.BindingReserved = false
+	} else if resumeGoalTransitionReservedBindingMatches(opts, tr, rec.GoalBinding) {
+		tr.BindingReserved = true
+	} else {
+		return nil, fmt.Errorf("goal delivery refused: expected old or exact reserved goal binding compare-and-swap failed")
+	}
 	launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(mr.AgentDir))
-	if err != nil || launchDigest != tr.LaunchRecordDigest || launchMod != tr.LaunchRecordModTime {
+	if err != nil {
+		return nil, fmt.Errorf("goal delivery refused: capture current launch generation: %w", err)
+	}
+	if !tr.BindingReserved && (launchDigest != tr.LaunchRecordDigest || launchMod != tr.LaunchRecordModTime) {
 		return nil, fmt.Errorf("goal delivery refused: launch generation changed after transition reservation")
+	}
+	boundPath := resumeGoalTransitionBoundPath(path)
+	if tr.BindingReserved {
+		boundBytes, boundErr := os.ReadFile(boundPath)
+		if boundErr == nil {
+			var bound resumeGoalTransitionBound
+			if json.Unmarshal(boundBytes, &bound) != nil || validateResumeGoalTransitionBound(bound, tr, launchDigest, launchMod) != nil {
+				return nil, fmt.Errorf("goal delivery refused: reserved launch binding generation changed")
+			}
+		} else if !os.IsNotExist(boundErr) {
+			return nil, fmt.Errorf("goal delivery refused: inspect reserved launch binding generation: %w", boundErr)
+		}
+	} else if _, boundErr := os.Stat(boundPath); boundErr == nil {
+		return nil, fmt.Errorf("goal delivery refused: transition binding completion exists without its reserved binding")
+	} else if !os.IsNotExist(boundErr) {
+		return nil, fmt.Errorf("goal delivery refused: inspect transition binding completion: %w", boundErr)
 	}
 	attemptPath, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, tr.OriginalAttemptID)
 	if err != nil {
@@ -709,6 +850,69 @@ func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr member
 		return nil, fmt.Errorf("goal delivery refused: original claim evidence changed")
 	}
 	return &tr, nil
+}
+
+func resumeGoalTransitionReservedBindingMatches(opts goalDeliveryOptions, tr resumeGoalTransitionRecord, binding *launch.GoalBinding) bool {
+	if binding == nil || binding.Mode != "native_goal" || !binding.NativeGoal || binding.Source != "goal-control" {
+		return false
+	}
+	return binding.Command == nativeGoalControlPrompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, tr.NewAttemptID)
+}
+
+func validateResumeGoalTransitionBound(bound resumeGoalTransitionBound, tr resumeGoalTransitionRecord, launchDigest string, launchMod int64) error {
+	switch {
+	case bound.SchemaVersion != resumeGoalTransitionSchemaVersion:
+		return fmt.Errorf("schema differs")
+	case bound.TransitionID != tr.TransitionID, bound.NewAttemptID != tr.NewAttemptID:
+		return fmt.Errorf("transition identity differs")
+	case bound.LaunchRecordDigest == "", bound.LaunchRecordModTime == 0, bound.BoundAt.IsZero():
+		return fmt.Errorf("generation evidence is incomplete")
+	case bound.LaunchRecordDigest != launchDigest || bound.LaunchRecordModTime != launchMod:
+		return fmt.Errorf("launch generation differs")
+	}
+	return nil
+}
+
+func ensureResumeGoalTransitionBinding(opts goalDeliveryOptions, tr *resumeGoalTransitionRecord, agentDir string) error {
+	if tr == nil {
+		return nil
+	}
+	transitionPath, err := resumeGoalTransitionPath(opts.Project, opts.Profile, opts.Session, tr.TransitionID)
+	if err != nil {
+		return err
+	}
+	digest, modTime, err := readGoalFileGeneration(launch.ExistingPath(agentDir))
+	if err != nil {
+		return fmt.Errorf("capture reserved launch generation: %w", err)
+	}
+	boundPath := resumeGoalTransitionBoundPath(transitionPath)
+	bound := resumeGoalTransitionBound{
+		SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: tr.TransitionID, NewAttemptID: tr.NewAttemptID,
+		LaunchRecordDigest: digest, LaunchRecordModTime: modTime, BoundAt: time.Now().UTC(),
+	}
+	payload, err := json.MarshalIndent(bound, "", "  ")
+	if err != nil {
+		return err
+	}
+	published, err := publishGoalJSON(boundPath, append(payload, '\n'))
+	if err != nil {
+		return fmt.Errorf("publish reserved launch binding generation: %w", err)
+	}
+	if published {
+		return nil
+	}
+	existingBytes, err := os.ReadFile(boundPath)
+	if err != nil {
+		return fmt.Errorf("read concurrent reserved launch binding generation: %w", err)
+	}
+	var existing resumeGoalTransitionBound
+	if err := json.Unmarshal(existingBytes, &existing); err != nil {
+		return fmt.Errorf("parse concurrent reserved launch binding generation: %w", err)
+	}
+	if err := validateResumeGoalTransitionBound(existing, *tr, digest, modTime); err != nil {
+		return fmt.Errorf("reserved launch binding generation changed: %w", err)
+	}
+	return nil
 }
 
 func consumeResumeGoalTransition(opts goalDeliveryOptions, newAttemptID string) error {

--- a/internal/cli/resume_goal.go
+++ b/internal/cli/resume_goal.go
@@ -1,0 +1,942 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/omriariav/amq-squad/v2/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+const resumeGoalPlanSchemaVersion = 1
+
+const resumeGoalTransitionSchemaVersion = 1
+
+type resumeGoalTransitionRecord struct {
+	SchemaVersion         int       `json:"schema_version"`
+	TransitionID          string    `json:"transition_id"`
+	Project               string    `json:"project"`
+	Profile               string    `json:"profile"`
+	Session               string    `json:"session"`
+	Role                  string    `json:"role"`
+	Handle                string    `json:"handle"`
+	MemberSession         string    `json:"member_session"`
+	MemberCWD             string    `json:"member_cwd"`
+	MemberBinary          string    `json:"member_binary"`
+	GoalDigest            string    `json:"goal_digest"`
+	OriginalAttemptID     string    `json:"original_attempt_id"`
+	OriginalBindingDigest string    `json:"original_binding_digest"`
+	OriginalAttemptDigest string    `json:"original_attempt_digest"`
+	OriginalClaimDigest   string    `json:"original_claim_digest"`
+	NewAttemptID          string    `json:"new_attempt_id"`
+	LaunchID              string    `json:"launch_id"`
+	LaunchStartedAt       time.Time `json:"launch_started_at"`
+	TeamRecordDigest      string    `json:"team_record_digest"`
+	TeamRecordModTime     int64     `json:"team_record_mod_time_unix_nano"`
+	LaunchRecordDigest    string    `json:"launch_record_digest"`
+	LaunchRecordModTime   int64     `json:"launch_record_mod_time_unix_nano"`
+	CreatedAt             time.Time `json:"created_at"`
+}
+
+type resumeGoalTransitionConsumed struct {
+	SchemaVersion int       `json:"schema_version"`
+	TransitionID  string    `json:"transition_id"`
+	NewAttemptID  string    `json:"new_attempt_id"`
+	ConsumedAt    time.Time `json:"consumed_at"`
+}
+
+type resumeGoalSendSnapshot struct {
+	TeamDigest    string
+	TeamModTime   int64
+	LaunchDigest  string
+	LaunchModTime int64
+}
+
+// buildResumeGoalPlan computes read-only evidence from the exact per-member
+// restore selection. It never claims or creates an attempt.
+func buildResumeGoalPlan(t team.Team, profile, workstream string, plans []resumePlan, force, noBootstrap bool) runwizard.ResumeGoalPlan {
+	result := runwizard.ResumeGoalPlan{SchemaVersion: resumeGoalPlanSchemaVersion, Action: "unavailable"}
+	lead := strings.TrimSpace(t.Lead)
+	if lead == "" && len(t.Members) == 1 {
+		lead = strings.TrimSpace(t.Members[0].Role)
+	}
+	result.LeadRole = lead
+	finish := func(reason string) runwizard.ResumeGoalPlan {
+		result.Eligible = false
+		result.Reason = reason
+		result.EvidenceDigest = resumeGoalEvidenceDigest(result)
+		return result
+	}
+	finishAs := func(action, reason string) runwizard.ResumeGoalPlan {
+		result.Action = action
+		return finish(reason)
+	}
+	if lead == "" {
+		return finish("team has no configured or inferable lead")
+	}
+	member, ok := teamMemberByRole(t, lead)
+	if !ok {
+		return finish("configured lead is not a current team member")
+	}
+	var selected *resumePlan
+	for i := range plans {
+		if plans[i].Role == lead {
+			selected = &plans[i]
+			break
+		}
+	}
+	if selected == nil {
+		return finish("lead is not selected by this resume plan")
+	}
+	result.LeadHandle = selected.Handle
+	result.LeadResumeAction = string(selected.Action)
+	if force {
+		return finish("forced duplicate resume cannot redeliver a saved goal")
+	}
+	if selected.Action != resumeRestore {
+		return finish("lead is not a fresh re-orient restore")
+	}
+	if selected.RestoreRecord == nil {
+		return finish("lead restore record is unavailable")
+	}
+	rec := *selected.RestoreRecord
+	result.SavedConversation = rec.Conversation != ""
+	if canonicalPath(rec.CWD) == "" || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(t.Project)) {
+		return finish("lead restore record does not exactly match the configured cwd")
+	}
+	if rec.Role != lead || rec.Handle != selected.Handle ||
+		strings.TrimSpace(rec.Session) != strings.TrimSpace(workstream) || !squadnamespace.ProfilesEqual(rec.TeamProfile, profile) ||
+		rec.Binary != member.Binary {
+		return finish("lead restore record identity does not match the selected team member")
+	}
+	ns := squadnamespace.Resolve(t.Project, profile, workstream)
+	if canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) {
+		return finish("lead restore record does not exactly match the workstream root")
+	}
+	if rec.GoalBinding == nil {
+		return finish("lead restore record has no saved goal binding")
+	}
+	result.Action = "blocked"
+	binding := *rec.GoalBinding
+	result.BindingMode = binding.Mode
+	result.BindingNative = binding.NativeGoal
+	result.BindingSource = binding.Source
+	result.BindingDigest = digestJSON(binding)
+	result.BindingCommandDigest = digestBytes([]byte(binding.Command))
+	if binding.Mode != "native_goal" || !binding.NativeGoal || binding.Source != "goal-control" {
+		return finish("saved goal binding is not an original goal-control delivery")
+	}
+	goal, attemptID, err := parseGeneratedGoalBinding(binding.Command)
+	if err != nil {
+		return finish("saved goal binding is invalid: " + err.Error())
+	}
+	if expected := nativeGoalControlPrompt(goal, t, profile, workstream, lead, attemptID); binding.Command != expected {
+		return finish("saved goal binding does not exactly match the generated goal-control command")
+	}
+	result.Goal = goal
+	result.OriginalAttemptID = attemptID
+	if result.SavedConversation {
+		return finishAs("skip", "lead will reattach its saved conversation and keeps the saved goal in context")
+	}
+	if rec.External {
+		return finish("lead restore record is external and not managed by resume")
+	}
+	if noBootstrap {
+		return finish("resume explicitly disables bootstrap re-orientation")
+	}
+	if rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required {
+		return finish("saved lead launch did not have bootstrap re-orientation enabled")
+	}
+	attemptPath, err := goalAttemptPath(t.Project, profile, workstream, attemptID)
+	if err != nil {
+		return finish("saved goal attempt id is invalid")
+	}
+	attemptBytes, err := os.ReadFile(attemptPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.AttemptState = "missing"
+			return finish("original goal attempt record is missing")
+		}
+		result.AttemptState = "unreadable"
+		return finish("original goal attempt record is unreadable")
+	}
+	result.AttemptDigest = digestBytes(attemptBytes)
+	var attempt goalAttemptRecord
+	if err := json.Unmarshal(attemptBytes, &attempt); err != nil {
+		result.AttemptState = "invalid"
+		return finish("original goal attempt record is corrupt")
+	}
+	if err := validateResumeGoalAttempt(attempt, t.Project, profile, workstream, lead, selected.Handle, goal, attemptID, ns); err != nil {
+		result.AttemptState = "mismatched"
+		return finish("original goal attempt record is mismatched: " + err.Error())
+	}
+	result.AttemptState = "recorded"
+	claimPath := goalAttemptClaimPath(attemptPath)
+	claimBytes, err := os.ReadFile(claimPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.ClaimState = "unclaimed"
+			return finish("original goal attempt is not settled: claim is missing")
+		}
+		result.ClaimState = "unreadable"
+		return finish("original goal claim is unreadable")
+	}
+	result.ClaimDigest = digestBytes(claimBytes)
+	var claim goalAttemptClaim
+	if err := json.Unmarshal(claimBytes, &claim); err != nil {
+		result.ClaimState = "invalid"
+		return finish("original goal claim is corrupt")
+	}
+	if err := validateResumeGoalClaim(claim, attempt); err != nil {
+		result.ClaimState = "mismatched"
+		return finish("original goal claim is mismatched: " + err.Error())
+	}
+	result.ClaimState = "claimed"
+	result.ClaimRoute = claim.Route
+	result.TransitionID = resumeGoalTransitionID(result.OriginalAttemptID, result.BindingDigest)
+	transitionPath, err := resumeGoalTransitionPath(t.Project, profile, workstream, result.TransitionID)
+	if err != nil {
+		result.TransitionState = "invalid"
+		return finish("goal redelivery transition identity is invalid")
+	}
+	if transitionBytes, readErr := os.ReadFile(transitionPath); readErr == nil {
+		result.TransitionDigest = digestBytes(transitionBytes)
+		var transition resumeGoalTransitionRecord
+		if json.Unmarshal(transitionBytes, &transition) != nil || validateResumeGoalTransitionPlan(transition, t.Project, profile, workstream, result) != nil {
+			result.TransitionState = "mismatched"
+			return finish("a mismatched durable goal redelivery transition already exists")
+		}
+		result.TransitionState = "reserved"
+		if _, consumedErr := os.Stat(resumeGoalTransitionConsumedPath(transitionPath)); consumedErr == nil {
+			result.TransitionState = "consumed"
+		}
+		return finish("a durable goal redelivery transition already exists; inspect its exact attempt before retrying")
+	} else if !os.IsNotExist(readErr) {
+		result.TransitionState = "unreadable"
+		return finish("goal redelivery transition evidence is unreadable")
+	}
+	result.TransitionState = "absent"
+	result.Action = "redeliver"
+	result.Eligible = true
+	result.Reason = "settled original goal can be redelivered as a new claim-once attempt after lead re-orientation"
+	result.EvidenceDigest = resumeGoalEvidenceDigest(result)
+	return result
+}
+
+func resumeGoalTransitionID(attemptID, bindingDigest string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(attemptID) + "\x00" + bindingDigest))
+	return hex.EncodeToString(sum[:])
+}
+
+func resumeGoalTransitionPath(project, profile, session, transitionID string) (string, error) {
+	if len(transitionID) != 64 {
+		return "", fmt.Errorf("invalid transition id")
+	}
+	if _, err := hex.DecodeString(transitionID); err != nil {
+		return "", fmt.Errorf("invalid transition id")
+	}
+	return filepath.Join(goalAttemptDir(project, profile, session), ".resume-redelivery-"+transitionID+".json"), nil
+}
+
+func resumeGoalTransitionConsumedPath(path string) string {
+	return strings.TrimSuffix(path, ".json") + ".consumed.json"
+}
+
+func validateResumeGoalTransitionPlan(tr resumeGoalTransitionRecord, project, profile, session string, plan runwizard.ResumeGoalPlan) error {
+	switch {
+	case tr.SchemaVersion != resumeGoalTransitionSchemaVersion:
+		return fmt.Errorf("schema differs")
+	case tr.TransitionID != plan.TransitionID:
+		return fmt.Errorf("transition id differs")
+	case canonicalPath(tr.Project) != canonicalPath(project):
+		return fmt.Errorf("project differs")
+	case !squadnamespace.ProfilesEqual(tr.Profile, profile), tr.Session != session:
+		return fmt.Errorf("namespace differs")
+	case tr.Role != plan.LeadRole, tr.Handle != plan.LeadHandle:
+		return fmt.Errorf("lead identity differs")
+	case tr.GoalDigest != digestBytes([]byte(plan.Goal)):
+		return fmt.Errorf("goal differs")
+	case tr.OriginalAttemptID != plan.OriginalAttemptID, tr.OriginalBindingDigest != plan.BindingDigest,
+		tr.OriginalAttemptDigest != plan.AttemptDigest, tr.OriginalClaimDigest != plan.ClaimDigest:
+		return fmt.Errorf("original evidence differs")
+	case strings.TrimSpace(tr.NewAttemptID) == "", strings.TrimSpace(tr.LaunchID) == "", tr.LaunchStartedAt.IsZero(), tr.CreatedAt.IsZero(), tr.MemberCWD == "", tr.MemberBinary == "",
+		tr.TeamRecordDigest == "", tr.TeamRecordModTime == 0, tr.LaunchRecordDigest == "", tr.LaunchRecordModTime == 0:
+		return fmt.Errorf("fresh launch evidence is missing")
+	case tr.NewAttemptID == tr.OriginalAttemptID:
+		return fmt.Errorf("new attempt reuses the original id")
+	}
+	return nil
+}
+
+func validateResumeGoalAttempt(attempt goalAttemptRecord, project, profile, session, role, handle, goal, attemptID string, ns squadnamespace.Ref) error {
+	switch {
+	case attempt.SchemaVersion != 1:
+		return fmt.Errorf("schema_version=%d", attempt.SchemaVersion)
+	case attempt.AttemptID != attemptID:
+		return fmt.Errorf("attempt_id differs")
+	case attempt.Goal != goal:
+		return fmt.Errorf("goal differs")
+	case canonicalPath(attempt.Project) != canonicalPath(project):
+		return fmt.Errorf("project differs")
+	case !squadnamespace.ProfilesEqual(attempt.Profile, profile):
+		return fmt.Errorf("profile differs")
+	case attempt.Session != session:
+		return fmt.Errorf("session differs")
+	case attempt.Namespace != ns:
+		return fmt.Errorf("namespace differs")
+	case attempt.Role != role:
+		return fmt.Errorf("role differs")
+	case attempt.Handle != handle:
+		return fmt.Errorf("handle differs")
+	case attempt.CreatedAt.IsZero():
+		return fmt.Errorf("created_at is missing")
+	}
+	return nil
+}
+
+func validateResumeGoalClaim(claim goalAttemptClaim, attempt goalAttemptRecord) error {
+	switch {
+	case claim.AttemptID != attempt.AttemptID:
+		return fmt.Errorf("attempt_id differs")
+	case claim.Route != "native" && claim.Route != "amq":
+		return fmt.Errorf("route %q is invalid", claim.Route)
+	case claim.ClaimedAt.IsZero():
+		return fmt.Errorf("claimed_at is missing")
+	case claim.ClaimedAt.Before(attempt.CreatedAt):
+		return fmt.Errorf("claimed_at predates the attempt")
+	}
+	return nil
+}
+
+// parseGeneratedGoalBinding is deliberately strict and quote-aware. A literal
+// "--attempt-id" inside the quoted goal remains goal text and cannot spoof the
+// exactly-one generated attempt flag.
+func parseGeneratedGoalBinding(command string) (string, string, error) {
+	tokens, err := splitGeneratedGoalTokens(command)
+	if err != nil {
+		return "", "", err
+	}
+	if len(tokens) == 0 || tokens[0] != "/goal" {
+		return "", "", fmt.Errorf("command is not a generated /goal")
+	}
+	var goal, attemptID string
+	goalCount, attemptCount := 0, 0
+	for i := 1; i < len(tokens); i++ {
+		switch tokens[i] {
+		case "--goal":
+			goalCount++
+			if i+1 >= len(tokens) {
+				return "", "", fmt.Errorf("--goal has no value")
+			}
+			i++
+			goal = tokens[i]
+		case "--attempt-id":
+			attemptCount++
+			if i+1 >= len(tokens) {
+				return "", "", fmt.Errorf("--attempt-id has no value")
+			}
+			i++
+			attemptID = tokens[i]
+		}
+	}
+	if goalCount != 1 || attemptCount != 1 || goal == "" || strings.TrimSpace(attemptID) == "" {
+		return "", "", fmt.Errorf("command must contain exactly one non-empty --goal and --attempt-id")
+	}
+	return goal, attemptID, nil
+}
+
+func splitGeneratedGoalTokens(command string) ([]string, error) {
+	var tokens []string
+	for i := 0; i < len(command); {
+		for i < len(command) && unicode.IsSpace(rune(command[i])) {
+			i++
+		}
+		if i == len(command) {
+			break
+		}
+		if command[i] == '"' {
+			start := i
+			i++
+			escaped := false
+			for i < len(command) {
+				c := command[i]
+				i++
+				if escaped {
+					escaped = false
+					continue
+				}
+				if c == '\\' {
+					escaped = true
+					continue
+				}
+				if c == '"' {
+					break
+				}
+			}
+			if i > len(command) || command[i-1] != '"' {
+				return nil, fmt.Errorf("unterminated quoted token")
+			}
+			if i < len(command) && !unicode.IsSpace(rune(command[i])) {
+				return nil, fmt.Errorf("quoted token has an invalid suffix")
+			}
+			value, err := strconv.Unquote(command[start:i])
+			if err != nil {
+				return nil, fmt.Errorf("invalid quoted token: %w", err)
+			}
+			tokens = append(tokens, value)
+			continue
+		}
+		start := i
+		for i < len(command) && !unicode.IsSpace(rune(command[i])) {
+			if command[i] == '"' {
+				return nil, fmt.Errorf("unexpected quote in bare token")
+			}
+			i++
+		}
+		tokens = append(tokens, command[start:i])
+	}
+	return tokens, nil
+}
+
+func digestBytes(value []byte) string {
+	sum := sha256.Sum256(value)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func digestJSON(value any) string {
+	payload, _ := json.Marshal(value)
+	return digestBytes(payload)
+}
+
+func readGoalFileGeneration(path string) (string, int64, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", 0, err
+	}
+	return digestBytes(payload), info.ModTime().UnixNano(), nil
+}
+
+func resumeGoalEvidenceDigest(plan runwizard.ResumeGoalPlan) string {
+	plan.EvidenceDigest = ""
+	plan.Selected = false // downstream operator intent is not discovery evidence
+	return digestJSON(plan)
+}
+
+func cloneGoalBinding(binding *launch.GoalBinding) *launch.GoalBinding {
+	if binding == nil {
+		return nil
+	}
+	copy := *binding
+	return &copy
+}
+
+func writeResumeGoalPlan(out io.Writer, plan runwizard.ResumeGoalPlan) {
+	if plan.SchemaVersion == 0 {
+		return
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "# recorded goal redelivery")
+	fmt.Fprintf(out, "# lead: %s (%s)\n", plan.LeadRole, plan.LeadHandle)
+	fmt.Fprintf(out, "# eligible: %t\n", plan.Eligible)
+	fmt.Fprintf(out, "# selected: %t\n", plan.Selected)
+	fmt.Fprintf(out, "# action: %s\n", plan.Action)
+	fmt.Fprintf(out, "# reason: %s\n", boundedResumeDisplay(plan.Reason, 240))
+	if plan.Goal != "" {
+		fmt.Fprintf(out, "Recorded goal: %s\n", boundedResumeDisplay(plan.Goal, 240))
+	}
+	if plan.Eligible {
+		fmt.Fprintln(out, "To redeliver after the lead is verified live, run resume --exec with --redeliver-goal.")
+	}
+}
+
+func promptResumeGoalRedelivery(in io.Reader, out io.Writer, plan runwizard.ResumeGoalPlan) (bool, error) {
+	if in == nil {
+		in = os.Stdin
+	}
+	if out == nil {
+		out = os.Stderr
+	}
+	fmt.Fprintf(out, "Recorded goal for %s: %s\nRedeliver it as a new claim-once attempt after the lead is verified live? [y/N] ", plan.LeadRole, boundedResumeDisplay(plan.Goal, 240))
+	line, err := readWizardLine(in)
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func boundedResumeDisplay(value string, maxRunes int) string {
+	quoted := []rune(strconv.QuoteToGraphic(value))
+	if maxRunes > 1 && len(quoted) > maxRunes {
+		quoted = append(quoted[:maxRunes-1], '…')
+	}
+	return string(quoted)
+}
+
+func deliverResumeGoalAfterLaunch(t team.Team, profile, workstream string, results []resumeExecLaunchResult, plan runwizard.ResumeGoalPlan) error {
+	if !plan.Eligible || !plan.Selected {
+		return usageErrorf("resume goal redelivery requires an eligible selected goal plan")
+	}
+	var result *resumeExecLaunchResult
+	for i := range results {
+		if results[i].Check.Role == plan.LeadRole {
+			result = &results[i]
+			break
+		}
+	}
+	if result == nil {
+		return &PartialError{Message: "resume launched members but could not identify the selected lead for goal redelivery"}
+	}
+	check := result.Check
+	if err := reserveResumeGoalTransition(t, profile, workstream, *result, plan); err != nil {
+		return &PartialError{Message: "resume launched the lead but saved goal evidence changed before redelivery; no new attempt was created: " + err.Error(), Cause: err}
+	}
+	args := []string{"start", "--project", t.Project, "--profile", profile, "--session", workstream, "--role", plan.LeadRole, "--goal", plan.Goal, "--resume-transition", plan.TransitionID, "--yes"}
+	if err := runStartGoalWithVersion(args, "dev"); err != nil {
+		message := "resume launched the lead, but post-launch goal redelivery failed: " + err.Error()
+		state, attemptID, attemptPath := resumeGoalDeliveryErrorState(err)
+		switch state {
+		case goalDeliveryStateNativeQueued:
+			message += fmt.Sprintf("\nExact attempt %s is durably recorded at %s and native input is known queued. DO NOT retry or rerun resume; wait for/inspect the claim evidence.", attemptID, attemptPath)
+		case goalDeliveryStateFallbackSent:
+			message += fmt.Sprintf("\nExact attempt %s is durably recorded at %s and the AMQ fallback was already sent. DO NOT retry or rerun resume; inspect that message and claim evidence.", attemptID, attemptPath)
+		case goalDeliveryStatePaneDelivered:
+			message += fmt.Sprintf("\nExact attempt %s was already delivered. DO NOT retry or rerun resume; inspect its binding and claim evidence.", attemptID)
+		default:
+			if recovery := resumeGoalRecoveryFromTypedError(t, profile, workstream, plan.LeadRole, check.AgentDir, err); recovery != "" {
+				message += "\nA new attempt is already reserved. DO NOT rerun resume --redeliver-goal; retry that same attempt with:\n  " + recovery
+			} else {
+				message += "\nDO NOT rerun resume --redeliver-goal until the launch binding and goal-attempt evidence are inspected."
+			}
+		}
+		return &PartialError{Message: message, Cause: err}
+	}
+	return nil
+}
+
+func resumeGoalDeliveryErrorState(err error) (state, attemptID, attemptPath string) {
+	var attemptErr *goalDeliveryAttemptError
+	if errors.As(err, &attemptErr) {
+		return attemptErr.State, attemptErr.AttemptID, attemptErr.AttemptPath
+	}
+	var postErr *goalPostDeliveryBindingError
+	if errors.As(err, &postErr) {
+		return goalDeliveryStatePaneDelivered, postErr.AttemptID, ""
+	}
+	return "", "", ""
+}
+
+func reserveResumeGoalTransition(t team.Team, profile, workstream string, verified resumeExecLaunchResult, plan runwizard.ResumeGoalPlan) error {
+	check := verified.Check
+	opts := goalDeliveryOptions{Project: t.Project, Profile: profile, Session: workstream, Role: plan.LeadRole}
+	if err := os.MkdirAll(goalAttemptDir(t.Project, profile, workstream), 0o755); err != nil {
+		return err
+	}
+	return flock.WithLock(goalDeliveryLockPath(opts), func() error {
+		if info, err := os.Stat(launch.ExistingPath(check.AgentDir)); err != nil || verified.RecordModTime.IsZero() || !info.ModTime().Equal(verified.RecordModTime) {
+			return fmt.Errorf("fresh launch record generation changed after verification (ABA redelivery refused)")
+		}
+		if err := revalidateResumeGoalAfterLaunch(t, profile, workstream, check, plan); err != nil {
+			return err
+		}
+		rec, err := launch.Read(check.AgentDir)
+		if err != nil {
+			return err
+		}
+		if !rec.StartedAt.Equal(verified.RecordStarted) {
+			return fmt.Errorf("fresh launch identity changed after verification")
+		}
+		if info, err := os.Stat(launch.ExistingPath(check.AgentDir)); err != nil || !info.ModTime().Equal(verified.RecordModTime) {
+			return fmt.Errorf("fresh launch record changed during redelivery reservation (ABA redelivery refused)")
+		}
+		currentTeam, err := team.ReadProfile(t.Project, profile)
+		if err != nil {
+			return err
+		}
+		member, ok := teamMemberByRole(currentTeam, plan.LeadRole)
+		if !ok {
+			return fmt.Errorf("lead disappeared before transition reservation")
+		}
+		teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(t.Project, profile))
+		if err != nil {
+			return fmt.Errorf("capture team generation: %w", err)
+		}
+		launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(check.AgentDir))
+		if err != nil {
+			return fmt.Errorf("capture launch generation: %w", err)
+		}
+		path, err := resumeGoalTransitionPath(t.Project, profile, workstream, plan.TransitionID)
+		if err != nil {
+			return err
+		}
+		tr := resumeGoalTransitionRecord{
+			SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: plan.TransitionID,
+			Project: t.Project, Profile: squadnamespace.NormalizeProfile(profile), Session: workstream,
+			Role: plan.LeadRole, Handle: plan.LeadHandle, MemberSession: member.Session, MemberCWD: member.EffectiveCWD(currentTeam.Project), MemberBinary: member.Binary, GoalDigest: digestBytes([]byte(plan.Goal)),
+			OriginalAttemptID: plan.OriginalAttemptID, OriginalBindingDigest: plan.BindingDigest,
+			OriginalAttemptDigest: plan.AttemptDigest, OriginalClaimDigest: plan.ClaimDigest,
+			NewAttemptID: deliveryAttemptID(time.Now().UTC(), "native_goal", plan.LeadRole, plan.LeadHandle),
+			LaunchID:     rec.BootstrapExpectation.LaunchID, LaunchStartedAt: rec.StartedAt.UTC(),
+			TeamRecordDigest: teamDigest, TeamRecordModTime: teamMod, LaunchRecordDigest: launchDigest, LaunchRecordModTime: launchMod,
+			CreatedAt: time.Now().UTC(),
+		}
+		payload, err := json.MarshalIndent(tr, "", "  ")
+		if err != nil {
+			return err
+		}
+		published, err := publishGoalJSON(path, append(payload, '\n'))
+		if err != nil {
+			return fmt.Errorf("publish durable goal redelivery transition: %w", err)
+		}
+		if !published {
+			return fmt.Errorf("durable goal redelivery transition %s already exists; duplicate/ABA redelivery refused", plan.TransitionID)
+		}
+		return nil
+	})
+}
+
+func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr memberRuntime) (*resumeGoalTransitionRecord, error) {
+	dir := goalAttemptDir(opts.Project, opts.Profile, opts.Session)
+	if opts.ResumeTransitionID == "" {
+		entries, err := os.ReadDir(dir)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("inspect goal redelivery transitions: %w", err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if !strings.HasPrefix(name, ".resume-redelivery-") || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".consumed.json") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			if _, err := os.Stat(resumeGoalTransitionConsumedPath(path)); err == nil {
+				continue
+			}
+			return nil, fmt.Errorf("goal delivery refused: an unconsumed durable resume-goal transition already exists at %s", path)
+		}
+		return nil, nil
+	}
+	path, err := resumeGoalTransitionPath(opts.Project, opts.Profile, opts.Session, opts.ResumeTransitionID)
+	if err != nil {
+		return nil, fmt.Errorf("goal delivery refused: %w", err)
+	}
+	if _, err := os.Stat(resumeGoalTransitionConsumedPath(path)); err == nil {
+		return nil, fmt.Errorf("goal delivery refused: resume-goal transition %s was already consumed", opts.ResumeTransitionID)
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("goal delivery refused: inspect transition completion: %w", err)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("goal delivery refused: read durable resume-goal transition: %w", err)
+	}
+	var tr resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &tr); err != nil {
+		return nil, fmt.Errorf("goal delivery refused: durable resume-goal transition is corrupt: %w", err)
+	}
+	currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
+	if err != nil {
+		return nil, fmt.Errorf("goal delivery refused: reread team: %w", err)
+	}
+	lead := strings.TrimSpace(currentTeam.Lead)
+	if lead == "" && len(currentTeam.Members) == 1 {
+		lead = currentTeam.Members[0].Role
+	}
+	member, ok := teamMemberByRole(currentTeam, opts.Role)
+	if !ok || lead != opts.Role || memberHandle(member) != opts.Member.Handle {
+		return nil, fmt.Errorf("goal delivery refused: current lead roster identity changed")
+	}
+	if canonicalPath(currentTeam.Project) != canonicalPath(opts.Project) || member.Session != tr.MemberSession ||
+		(strings.TrimSpace(member.Session) != "" && member.Session != opts.Session) || canonicalPath(member.EffectiveCWD(currentTeam.Project)) != canonicalPath(tr.MemberCWD) || member.Binary != tr.MemberBinary {
+		return nil, fmt.Errorf("goal delivery refused: current lead project/session/member identity changed")
+	}
+	teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+	if err != nil || teamDigest != tr.TeamRecordDigest || teamMod != tr.TeamRecordModTime {
+		return nil, fmt.Errorf("goal delivery refused: team generation changed after transition reservation")
+	}
+	if tr.SchemaVersion != resumeGoalTransitionSchemaVersion || tr.TransitionID != opts.ResumeTransitionID ||
+		canonicalPath(tr.Project) != canonicalPath(opts.Project) || !squadnamespace.ProfilesEqual(tr.Profile, opts.Profile) || tr.Session != opts.Session ||
+		tr.Role != opts.Role || tr.Handle != opts.Member.Handle || tr.GoalDigest != digestBytes([]byte(opts.Goal)) {
+		return nil, fmt.Errorf("goal delivery refused: durable resume-goal transition identity changed")
+	}
+	if tr.NewAttemptID == tr.OriginalAttemptID {
+		return nil, fmt.Errorf("goal delivery refused: transition reuses the original attempt id")
+	}
+	if _, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, tr.NewAttemptID); err != nil {
+		return nil, fmt.Errorf("goal delivery refused: transition new attempt id is invalid")
+	}
+	if !mr.HasRecord || mr.Record.GoalBinding == nil || digestJSON(*mr.Record.GoalBinding) != tr.OriginalBindingDigest {
+		return nil, fmt.Errorf("goal delivery refused: expected old goal binding compare-and-swap failed")
+	}
+	rec := mr.Record
+	ns := squadnamespace.Resolve(opts.Project, opts.Profile, opts.Session)
+	if rec.Role != opts.Role || rec.Handle != opts.Member.Handle || rec.Session != opts.Session ||
+		!squadnamespace.ProfilesEqual(rec.TeamProfile, opts.Profile) || canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) ||
+		canonicalPath(rec.TeamHome) != canonicalPath(opts.Project) || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(currentTeam.Project)) || rec.Binary != member.Binary ||
+		rec.Conversation != "" || rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required ||
+		rec.BootstrapExpectation.LaunchID != tr.LaunchID || !rec.StartedAt.Equal(tr.LaunchStartedAt) || rec.Tmux == nil || rec.Tmux.Target == "adopted" {
+		return nil, fmt.Errorf("goal delivery refused: fresh lead launch identity changed")
+	}
+	launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(mr.AgentDir))
+	if err != nil || launchDigest != tr.LaunchRecordDigest || launchMod != tr.LaunchRecordModTime {
+		return nil, fmt.Errorf("goal delivery refused: launch generation changed after transition reservation")
+	}
+	attemptPath, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, tr.OriginalAttemptID)
+	if err != nil {
+		return nil, err
+	}
+	attemptBytes, err := os.ReadFile(attemptPath)
+	if err != nil || digestBytes(attemptBytes) != tr.OriginalAttemptDigest {
+		return nil, fmt.Errorf("goal delivery refused: original attempt evidence changed")
+	}
+	claimBytes, err := os.ReadFile(goalAttemptClaimPath(attemptPath))
+	if err != nil || digestBytes(claimBytes) != tr.OriginalClaimDigest {
+		return nil, fmt.Errorf("goal delivery refused: original claim evidence changed")
+	}
+	return &tr, nil
+}
+
+func consumeResumeGoalTransition(opts goalDeliveryOptions, newAttemptID string) error {
+	path, err := resumeGoalTransitionPath(opts.Project, opts.Profile, opts.Session, opts.ResumeTransitionID)
+	if err != nil {
+		return err
+	}
+	consumed := resumeGoalTransitionConsumed{SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: opts.ResumeTransitionID, NewAttemptID: newAttemptID, ConsumedAt: time.Now().UTC()}
+	payload, err := json.MarshalIndent(consumed, "", "  ")
+	if err != nil {
+		return err
+	}
+	published, err := publishGoalJSON(resumeGoalTransitionConsumedPath(path), append(payload, '\n'))
+	if err != nil {
+		return fmt.Errorf("publish resume-goal transition completion: %w", err)
+	}
+	if !published {
+		return fmt.Errorf("resume-goal transition %s was concurrently consumed", opts.ResumeTransitionID)
+	}
+	return nil
+}
+
+func captureResumeGoalSendSnapshot(opts goalDeliveryOptions, tr *resumeGoalTransitionRecord, prompt, attemptID string) (memberRuntime, resumeGoalSendSnapshot, error) {
+	if tr == nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("resume goal send requires a transition")
+	}
+	teamDigest, teamMod, err := readGoalFileGeneration(team.ProfilePath(opts.Project, opts.Profile))
+	if err != nil || teamDigest != tr.TeamRecordDigest || teamMod != tr.TeamRecordModTime {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("team generation changed before resume goal send")
+	}
+	currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
+	if err != nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, err
+	}
+	lead := strings.TrimSpace(currentTeam.Lead)
+	if lead == "" && len(currentTeam.Members) == 1 {
+		lead = currentTeam.Members[0].Role
+	}
+	member, ok := teamMemberByRole(currentTeam, opts.Role)
+	if !ok || lead != opts.Role || memberHandle(member) != opts.Member.Handle || canonicalPath(currentTeam.Project) != canonicalPath(opts.Project) ||
+		member.Session != tr.MemberSession || (member.Session != "" && member.Session != opts.Session) || canonicalPath(member.EffectiveCWD(currentTeam.Project)) != canonicalPath(tr.MemberCWD) || member.Binary != tr.MemberBinary {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("lead team identity changed before resume goal send")
+	}
+	mr, _, err := resolveMemberRuntime(opts.Project, opts.Profile, opts.Session, true, opts.Role)
+	if err != nil || !mr.HasRecord || mr.Record.GoalBinding == nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("lead launch record unavailable before resume goal send")
+	}
+	rec := mr.Record
+	ns := squadnamespace.Resolve(opts.Project, opts.Profile, opts.Session)
+	if rec.Role != opts.Role || rec.Handle != opts.Member.Handle || rec.Session != opts.Session || !squadnamespace.ProfilesEqual(rec.TeamProfile, opts.Profile) ||
+		canonicalPath(rec.TeamHome) != canonicalPath(opts.Project) || canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(currentTeam.Project)) ||
+		rec.Binary != member.Binary || rec.Conversation != "" || rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required || rec.BootstrapExpectation.LaunchID != tr.LaunchID ||
+		!rec.StartedAt.Equal(tr.LaunchStartedAt) || rec.Tmux == nil || rec.Tmux.Target == "adopted" || rec.GoalBinding.Mode != "native_goal" || !rec.GoalBinding.NativeGoal ||
+		rec.GoalBinding.Source != "goal-control" || rec.GoalBinding.Command != prompt {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("lead launch identity/binding changed before resume goal send")
+	}
+	attemptPath, err := goalAttemptPath(opts.Project, opts.Profile, opts.Session, attemptID)
+	if err != nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, err
+	}
+	attempt, err := readGoalAttempt(attemptPath, attemptID)
+	if err != nil || validateResumeGoalAttempt(attempt, opts.Project, opts.Profile, opts.Session, opts.Role, opts.Member.Handle, opts.Goal, attemptID, opts.Namespace) != nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("new resume goal attempt changed before send")
+	}
+	if _, err := os.Stat(goalAttemptClaimPath(attemptPath)); err == nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("new resume goal attempt was already claimed before send")
+	} else if !os.IsNotExist(err) {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, fmt.Errorf("inspect new resume goal claim: %w", err)
+	}
+	launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(mr.AgentDir))
+	if err != nil {
+		return memberRuntime{}, resumeGoalSendSnapshot{}, err
+	}
+	return mr, resumeGoalSendSnapshot{TeamDigest: teamDigest, TeamModTime: teamMod, LaunchDigest: launchDigest, LaunchModTime: launchMod}, nil
+}
+
+func validateResumeGoalSendSnapshot(opts goalDeliveryOptions, tr *resumeGoalTransitionRecord, prompt, attemptID string, expected resumeGoalSendSnapshot) (memberRuntime, error) {
+	mr, current, err := captureResumeGoalSendSnapshot(opts, tr, prompt, attemptID)
+	if err != nil {
+		return memberRuntime{}, err
+	}
+	if current != expected {
+		return memberRuntime{}, fmt.Errorf("team or launch generation changed immediately before resume goal send")
+	}
+	return mr, nil
+}
+
+func revalidateResumeGoalAfterLaunch(t team.Team, profile, workstream string, check resumeExecLaunchCheck, plan runwizard.ResumeGoalPlan) error {
+	currentTeam, err := team.ReadProfile(t.Project, profile)
+	if err != nil {
+		return fmt.Errorf("reread team: %w", err)
+	}
+	lead := strings.TrimSpace(currentTeam.Lead)
+	if lead == "" && len(currentTeam.Members) == 1 {
+		lead = currentTeam.Members[0].Role
+	}
+	if lead != plan.LeadRole {
+		return fmt.Errorf("team lead changed from %q to %q", plan.LeadRole, lead)
+	}
+	member, ok := teamMemberByRole(currentTeam, plan.LeadRole)
+	if !ok {
+		return fmt.Errorf("lead is no longer a team member")
+	}
+	if canonicalPath(currentTeam.Project) != canonicalPath(t.Project) || member.Role != plan.LeadRole || memberHandle(member) != plan.LeadHandle {
+		return fmt.Errorf("current lead roster identity changed")
+	}
+	if pinned := strings.TrimSpace(member.Session); pinned != "" && pinned != workstream {
+		return fmt.Errorf("current lead session pin changed to %q", pinned)
+	}
+	rec, err := launch.Read(check.AgentDir)
+	if err != nil {
+		return fmt.Errorf("reread lead launch record: %w", err)
+	}
+	ns := squadnamespace.Resolve(t.Project, profile, workstream)
+	switch {
+	case rec.Role != plan.LeadRole:
+		return fmt.Errorf("lead role changed")
+	case rec.Handle != plan.LeadHandle || rec.Handle != check.Handle:
+		return fmt.Errorf("lead handle changed")
+	case rec.Session != workstream:
+		return fmt.Errorf("lead session changed")
+	case !squadnamespace.ProfilesEqual(rec.TeamProfile, profile):
+		return fmt.Errorf("lead profile changed")
+	case canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(currentTeam.Project)) || canonicalPath(rec.CWD) != canonicalPath(check.CWD):
+		return fmt.Errorf("lead cwd changed")
+	case canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) || canonicalPath(rec.Root) != canonicalPath(check.Root):
+		return fmt.Errorf("lead root changed")
+	case rec.Binary != member.Binary || rec.Binary != check.Binary:
+		return fmt.Errorf("lead binary changed")
+	case rec.Conversation != "":
+		return fmt.Errorf("lead unexpectedly reattached a conversation")
+	case rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required:
+		return fmt.Errorf("lead launch did not enable bootstrap re-orientation")
+	case strings.TrimSpace(rec.BootstrapExpectation.LaunchID) == "" || rec.StartedAt.IsZero():
+		return fmt.Errorf("lead launch has no fresh launch identity")
+	case rec.Tmux == nil || strings.TrimSpace(rec.Tmux.PaneID) == "":
+		return fmt.Errorf("lead launch has no tmux pane identity")
+	case rec.Tmux.Target == "adopted":
+		return fmt.Errorf("adopted lead pane is not a verified fresh bootstrap launch")
+	}
+	if _, alive := statusPaneInspector(rec.Tmux.PaneID); !alive {
+		return fmt.Errorf("verified lead pane %s is not live", rec.Tmux.PaneID)
+	}
+	if rec.GoalBinding == nil || digestJSON(*rec.GoalBinding) != plan.BindingDigest || digestBytes([]byte(rec.GoalBinding.Command)) != plan.BindingCommandDigest {
+		return fmt.Errorf("saved goal binding changed")
+	}
+	goal, attemptID, err := parseGeneratedGoalBinding(rec.GoalBinding.Command)
+	if err != nil || goal != plan.Goal || attemptID != plan.OriginalAttemptID {
+		return fmt.Errorf("saved goal command identity changed")
+	}
+	if expected := nativeGoalControlPrompt(goal, currentTeam, profile, workstream, plan.LeadRole, attemptID); rec.GoalBinding.Command != expected {
+		return fmt.Errorf("saved goal command no longer matches the team contract")
+	}
+	attemptPath, err := goalAttemptPath(t.Project, profile, workstream, attemptID)
+	if err != nil {
+		return err
+	}
+	attemptBytes, err := os.ReadFile(attemptPath)
+	if err != nil || digestBytes(attemptBytes) != plan.AttemptDigest {
+		return fmt.Errorf("original goal attempt changed")
+	}
+	claimBytes, err := os.ReadFile(goalAttemptClaimPath(attemptPath))
+	if err != nil || digestBytes(claimBytes) != plan.ClaimDigest {
+		return fmt.Errorf("original goal claim changed")
+	}
+	return nil
+}
+
+func resumeGoalRecoveryFromTypedError(t team.Team, profile, session, role, agentDir string, deliveryErr error) string {
+	var attemptErr *goalDeliveryAttemptError
+	var postErr *goalPostDeliveryBindingError
+	attemptID := ""
+	if errors.As(deliveryErr, &attemptErr) {
+		if attemptErr.State == goalDeliveryStateNativeQueued || attemptErr.State == goalDeliveryStateFallbackSent || attemptErr.State == goalDeliveryStatePaneDelivered {
+			return ""
+		}
+		if !attemptErr.Sent && attemptErr.AttemptPath == "" {
+			return ""
+		}
+		attemptID = attemptErr.AttemptID
+	} else if errors.As(deliveryErr, &postErr) {
+		return ""
+	} else {
+		return ""
+	}
+	current, err := team.ReadProfile(t.Project, profile)
+	if err != nil {
+		return ""
+	}
+	lead := strings.TrimSpace(current.Lead)
+	if lead == "" && len(current.Members) == 1 {
+		lead = current.Members[0].Role
+	}
+	if lead != role {
+		return ""
+	}
+	member, ok := teamMemberByRole(current, role)
+	if !ok {
+		return ""
+	}
+	path, err := goalAttemptPath(t.Project, profile, session, attemptID)
+	if err != nil {
+		return ""
+	}
+	attempt, err := readGoalAttempt(path, attemptID)
+	if err != nil || validateResumeGoalAttempt(attempt, t.Project, profile, session, role, memberHandle(member), attempt.Goal, attemptID, squadnamespace.Resolve(t.Project, profile, session)) != nil {
+		return ""
+	}
+	if _, err := os.Stat(goalAttemptClaimPath(path)); !os.IsNotExist(err) {
+		return ""
+	}
+	rec, err := launch.Read(agentDir)
+	if err != nil || rec.GoalBinding == nil {
+		return ""
+	}
+	goal, boundID, err := parseGeneratedGoalBinding(rec.GoalBinding.Command)
+	ns := squadnamespace.Resolve(t.Project, profile, session)
+	if err != nil || boundID != attemptID || goal != attempt.Goal || rec.GoalBinding.Mode != "native_goal" || !rec.GoalBinding.NativeGoal || rec.GoalBinding.Source != "goal-control" ||
+		rec.Role != role || rec.Handle != memberHandle(member) || rec.Session != session || !squadnamespace.ProfilesEqual(rec.TeamProfile, profile) ||
+		canonicalPath(rec.TeamHome) != canonicalPath(t.Project) || canonicalPath(rec.Root) != canonicalPath(ns.AMQRoot) || canonicalPath(rec.CWD) != canonicalPath(member.EffectiveCWD(current.Project)) ||
+		rec.Binary != member.Binary || rec.Conversation != "" || rec.BootstrapExpectation == nil || !rec.BootstrapExpectation.Required || rec.Tmux == nil || rec.Tmux.Target == "adopted" ||
+		rec.GoalBinding.Command != nativeGoalControlPrompt(goal, current, profile, session, role, attemptID) {
+		return ""
+	}
+	args := []string{"amq-squad", "goal", "retry-attempt", "--project", t.Project, "--profile", profile, "--session", session, "--role", role, "--attempt-id", attemptID, "--yes"}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}

--- a/internal/cli/resume_goal_test.go
+++ b/internal/cli/resume_goal_test.go
@@ -1,0 +1,1077 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/bootstrapack"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+func seededResumeGoalPlan(t *testing.T, conversation string, writeClaim bool) (team.Team, string, []resumePlan) {
+	t.Helper()
+	project := t.TempDir()
+	session := "issue-447"
+	tm := team.Team{
+		Project: project, Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: session, CWD: project}},
+	}
+	ns := squadnamespace.Resolve(project, team.DefaultProfile, session)
+	const attemptID = "attempt-original"
+	goal := "ship literal --attempt-id fake\nwith \"quotes\""
+	command := nativeGoalControlPrompt(goal, tm, team.DefaultProfile, session, "cto", attemptID)
+	created := time.Unix(100, 0).UTC()
+	attempt := goalAttemptRecord{SchemaVersion: 1, AttemptID: attemptID, Goal: goal, Project: project, Profile: team.DefaultProfile, Session: session, Namespace: ns, Role: "cto", Handle: "cto", CreatedAt: created}
+	attemptPath, err := goalAttemptPath(project, team.DefaultProfile, session, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(attemptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestJSON(t, attemptPath, attempt)
+	if writeClaim {
+		writeTestJSON(t, goalAttemptClaimPath(attemptPath), goalAttemptClaim{AttemptID: attemptID, Route: "native", ClaimedAt: created.Add(time.Second)})
+	}
+	rec := launch.Record{
+		CWD: project, Binary: "codex", Session: session, SharedWorkstream: true, Conversation: conversation,
+		Handle: "cto", Role: "cto", Root: ns.AMQRoot, TeamProfile: team.DefaultProfile,
+		BootstrapExpectation: &bootstrapack.Expectation{Required: true},
+		GoalBinding:          &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: command, Detail: "delivered"},
+	}
+	return tm, session, []resumePlan{{Role: "cto", Handle: "cto", Action: resumeRestore, HasRestoreRecord: true, RestoreRecord: &rec}}
+}
+
+func writeTestJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(payload, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustGoalAttemptPath(t *testing.T, project, profile, session, attemptID string) string {
+	t.Helper()
+	path, err := goalAttemptPath(project, profile, session, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func freshResumeTransitionFixture(t *testing.T) (team.Team, string, []resumePlan, runwizard.ResumeGoalPlan, resumeExecLaunchResult) {
+	t.Helper()
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	if err := team.WriteProfile(tm.Project, team.DefaultProfile, tm); err != nil {
+		t.Fatal(err)
+	}
+	plan := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if !plan.Eligible {
+		t.Fatalf("seed plan ineligible: %+v", plan)
+	}
+	ns := squadnamespace.Resolve(tm.Project, team.DefaultProfile, session)
+	agentDir := filepath.Join(ns.AMQRoot, "agents", "cto")
+	rec := *plans[0].RestoreRecord
+	rec.TeamHome = tm.Project
+	rec.StartedAt = time.Unix(500, 0).UTC()
+	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true, LaunchID: "fresh-launch-447"}
+	rec.Tmux = &launch.TmuxInfo{PaneID: "%447", Target: "current-window"}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(launch.ExistingPath(agentDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldInspector := statusPaneInspector
+	statusPaneInspector = func(id string) (tmuxpane.TmuxPane, bool) {
+		return tmuxpane.TmuxPane{PaneID: id, CWD: tm.Project, Command: "codex"}, id == "%447"
+	}
+	t.Cleanup(func() { statusPaneInspector = oldInspector })
+	result := resumeExecLaunchResult{
+		Check: resumeExecLaunchCheck{Role: "cto", Handle: "cto", CWD: tm.Project, AgentDir: agentDir, Workstream: session, Root: ns.AMQRoot, Binary: "codex", Profile: team.DefaultProfile},
+		State: resumeExecLaunchStateLaunched, RecordModTime: info.ModTime(), RecordStarted: rec.StartedAt,
+	}
+	return tm, session, plans, plan, result
+}
+
+func TestResumeGoalTransitionNoReplaceAndPlannerFingerprint(t *testing.T) {
+	tm, session, plans, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatalf("reserve transition: %v", err)
+	}
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate transition accepted: %v", err)
+	}
+	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if blocked.Eligible || blocked.Action != "blocked" || blocked.TransitionID != plan.TransitionID || blocked.TransitionState != "reserved" || blocked.TransitionDigest == "" || blocked.EvidenceDigest == plan.EvidenceDigest {
+		t.Fatalf("transition not included in read-only plan/fingerprint: %+v", blocked)
+	}
+}
+
+func TestResumeGoalTransitionConcurrentReservationHasOneWinner(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			errs <- reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan)
+		}()
+	}
+	close(start)
+	success, refused := 0, 0
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err == nil {
+			success++
+		} else if strings.Contains(err.Error(), "already exists") {
+			refused++
+		} else {
+			t.Fatalf("unexpected concurrent reservation result: %v", err)
+		}
+	}
+	if success != 1 || refused != 1 {
+		t.Fatalf("concurrent reservation success=%d refused=%d", success, refused)
+	}
+}
+
+func TestResumeGoalTransitionRejectsLaunchRecordABA(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	path := launch.ExistingPath(verified.Check.AgentDir)
+	original, err := launch.Read(verified.Check.AgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := original
+	mutated.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt("different", tm, team.DefaultProfile, session, "cto", "different-attempt")}
+	if err := launch.Write(verified.Check.AgentDir, mutated); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(verified.Check.AgentDir, original); err != nil {
+		t.Fatal(err)
+	}
+	future := verified.RecordModTime.Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err == nil || !strings.Contains(err.Error(), "ABA") {
+		t.Fatalf("binding replace+restore generation accepted: %v", err)
+	}
+	transitionPath, _ := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if _, err := os.Stat(transitionPath); !os.IsNotExist(err) {
+		t.Fatalf("ABA refusal published a transition: %v", err)
+	}
+}
+
+func TestResumeGoalTransitionRejectsAdoptedFreshness(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	rec, err := launch.Read(verified.Check.AgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Tmux.Target = "adopted"
+	if err := launch.Write(verified.Check.AgentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(launch.ExistingPath(verified.Check.AgentDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified.RecordModTime = info.ModTime()
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err == nil || !strings.Contains(err.Error(), "adopted") {
+		t.Fatalf("adopted launch accepted for redelivery: %v", err)
+	}
+}
+
+func TestResumeGoalPostLaunchEvidenceMutationRefusesBeforeSend(t *testing.T) {
+	for _, kind := range []string{"binding", "attempt", "claim"} {
+		t.Run(kind, func(t *testing.T) {
+			tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+			plan.Selected = true
+			switch kind {
+			case "binding":
+				rec, err := launch.Read(verified.Check.AgentDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rec.GoalBinding.Detail = "changed-after-verification"
+				if err := launch.Write(verified.Check.AgentDir, rec); err != nil {
+					t.Fatal(err)
+				}
+			case "attempt", "claim":
+				path := mustGoalAttemptPath(t, tm.Project, team.DefaultProfile, session, plan.OriginalAttemptID)
+				if kind == "claim" {
+					path = goalAttemptClaimPath(path)
+				}
+				payload, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, append(payload, ' '), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			goalCalls := 0
+			oldGoal := runStartGoalWithVersion
+			runStartGoalWithVersion = func([]string, string) error { goalCalls++; return nil }
+			t.Cleanup(func() { runStartGoalWithVersion = oldGoal })
+			err := deliverResumeGoalAfterLaunch(tm, team.DefaultProfile, session, []resumeExecLaunchResult{verified}, plan)
+			var partial *PartialError
+			if !errors.As(err, &partial) || goalCalls != 0 {
+				t.Fatalf("mutation=%s err=%v goalCalls=%d", kind, err, goalCalls)
+			}
+			transitionPath, _ := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+			if _, err := os.Stat(transitionPath); !os.IsNotExist(err) {
+				t.Fatalf("mutation=%s published transition: %v", kind, err)
+			}
+			entries, _ := os.ReadDir(goalAttemptDir(tm.Project, team.DefaultProfile, session))
+			attempts := 0
+			for _, entry := range entries {
+				if !strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+					attempts++
+				}
+			}
+			if attempts != 1 {
+				t.Fatalf("mutation=%s attempts=%d entries=%v", kind, attempts, entries)
+			}
+		})
+	}
+}
+
+func TestResumeJSONSelectedGoalPlanIsReadOnly(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	if err := team.WriteProfile(tm.Project, team.DefaultProfile, tm); err != nil {
+		t.Fatal(err)
+	}
+	ns := squadnamespace.Resolve(tm.Project, team.DefaultProfile, session)
+	agentDir := filepath.Join(ns.AMQRoot, "agents", "cto")
+	rec := *plans[0].RestoreRecord
+	rec.TeamHome = tm.Project
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	launchBefore, _ := os.ReadFile(launch.ExistingPath(agentDir))
+	entriesBefore, _ := os.ReadDir(goalAttemptDir(tm.Project, team.DefaultProfile, session))
+	oldLister := statusPaneLister
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return nil, nil }
+	t.Cleanup(func() { statusPaneLister = oldLister })
+	var out strings.Builder
+	err := executeResume(resumeExecution{
+		ProjectDir: tm.Project, RequestedSession: session, ExplicitSession: true, Profile: team.DefaultProfile, JSON: true, GoalRedelivery: true,
+		Probe: duplicateLaunchProbe{PIDAlive: func(int) bool { return false }, ProcessMatch: func(int, func(string) bool) bool { return false }, Now: time.Now},
+		Exec:  resumeExecOptions{RedeliverGoal: true, RedeliveryExplicit: true}, Out: &out,
+	})
+	if err != nil {
+		t.Fatalf("plan-only selected resume JSON: %v", err)
+	}
+	env := decodeJSONEnvelope[resumeEnvelopeData](t, out.String())
+	if env.SchemaVersion != 1 || env.Data.GoalPlan == nil || !env.Data.GoalPlan.Selected || !env.Data.GoalPlan.Eligible {
+		t.Fatalf("goal plan JSON=%s", out.String())
+	}
+	launchAfter, _ := os.ReadFile(launch.ExistingPath(agentDir))
+	entriesAfter, _ := os.ReadDir(goalAttemptDir(tm.Project, team.DefaultProfile, session))
+	if string(launchAfter) != string(launchBefore) || len(entriesAfter) != len(entriesBefore) {
+		t.Fatalf("plan-only JSON mutated launch/attempt evidence")
+	}
+	transitionPath, _ := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, env.Data.GoalPlan.TransitionID)
+	if _, err := os.Stat(transitionPath); !os.IsNotExist(err) {
+		t.Fatalf("plan-only JSON published transition: %v", err)
+	}
+}
+
+func TestResumeGoalTransitionCreatesExactlyOnePreallocatedAttempt(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	oldLister, oldSend := statusPaneLister, sendPromptToPane
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex", Title: "amq:" + session + ":cto"}}, nil
+	}
+	var prompts []string
+	sendPromptToPane = func(_ string, prompt string) error { prompts = append(prompts, prompt); return nil }
+	t.Cleanup(func() { statusPaneLister, sendPromptToPane = oldLister, oldSend })
+	opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
+	result, err := executeGoalDelivery(opts)
+	if err != nil {
+		t.Fatalf("transition delivery: %v", err)
+	}
+	if result.DeliveryReceipt == nil || len(prompts) != 1 {
+		t.Fatalf("delivery result=%+v prompts=%v", result, prompts)
+	}
+	transitionPath, _ := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	var tr resumeGoalTransitionRecord
+	payload, _ := os.ReadFile(transitionPath)
+	if err := json.Unmarshal(payload, &tr); err != nil || result.DeliveryReceipt.AttemptID != tr.NewAttemptID || !strings.Contains(prompts[0], "--attempt-id "+tr.NewAttemptID) {
+		t.Fatalf("preallocated attempt mismatch: transition=%+v receipt=%+v prompts=%v err=%v", tr, result.DeliveryReceipt, prompts, err)
+	}
+	if _, err := executeGoalDelivery(opts); err == nil || !strings.Contains(err.Error(), "already consumed") {
+		t.Fatalf("duplicate transition delivery accepted: %v", err)
+	}
+	entries, _ := os.ReadDir(goalAttemptDir(tm.Project, team.DefaultProfile, session))
+	attempts := 0
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+			attempts++
+		}
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts=%d want original+one redelivery; entries=%v", attempts, entries)
+	}
+}
+
+func TestResumeGoalTransitionCASBlocksIdentityWritersThroughBindingAndSend(t *testing.T) {
+	for _, kind := range []string{"launch", "team"} {
+		t.Run(kind, func(t *testing.T) {
+			tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+			if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+				t.Fatal(err)
+			}
+			oldBindingHook, oldSend, oldLister := goalBeforeTransitionBindingCAS, sendPromptToPane, statusPaneLister
+			writerDone := make(chan error, 1)
+			goalBeforeTransitionBindingCAS = func() {
+				started := make(chan struct{})
+				go func() {
+					close(started)
+					switch kind {
+					case "launch":
+						writerDone <- launch.WithRecordLock(verified.Check.AgentDir, func() error {
+							rec, err := launch.Read(verified.Check.AgentDir)
+							if err != nil {
+								return err
+							}
+							rec.Model = "concurrent-launch-update"
+							return launch.WriteUnderRecordLock(verified.Check.AgentDir, rec)
+						})
+					case "team":
+						writerDone <- team.WithProfileLock(tm.Project, team.DefaultProfile, func() error {
+							changed, err := team.ReadProfile(tm.Project, team.DefaultProfile)
+							if err != nil {
+								return err
+							}
+							changed.Members[0].Model = "concurrent-team-update"
+							return team.WriteProfileUnderLock(tm.Project, team.DefaultProfile, changed)
+						})
+					}
+				}()
+				<-started
+				select {
+				case err := <-writerDone:
+					t.Fatalf("%s writer completed inside transition identity lock: %v", kind, err)
+				case <-time.After(50 * time.Millisecond):
+				}
+			}
+			sends := 0
+			sendPromptToPane = func(string, string) error {
+				select {
+				case err := <-writerDone:
+					t.Fatalf("%s writer interleaved before pane send: %v", kind, err)
+				default:
+				}
+				sends++
+				return nil
+			}
+			statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+				return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex"}}, nil
+			}
+			t.Cleanup(func() {
+				goalBeforeTransitionBindingCAS, sendPromptToPane, statusPaneLister = oldBindingHook, oldSend, oldLister
+			})
+			opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
+			if _, err := executeGoalDelivery(opts); err != nil || sends != 1 {
+				t.Fatalf("kind=%s err=%v sends=%d", kind, err, sends)
+			}
+			select {
+			case err := <-writerDone:
+				if err != nil {
+					t.Fatalf("%s writer after transition: %v", kind, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s writer did not resume after transition locks released", kind)
+			}
+			if kind == "launch" {
+				rec, readErr := launch.Read(verified.Check.AgentDir)
+				boundGoal := ""
+				if rec.GoalBinding != nil {
+					boundGoal, _, _ = parseGeneratedGoalBinding(rec.GoalBinding.Command)
+				}
+				if readErr != nil || rec.GoalBinding == nil || boundGoal != plan.Goal || rec.Model != "concurrent-launch-update" {
+					t.Fatalf("serialized launch update lost binding: rec=%+v model=%q err=%v", rec.GoalBinding, rec.Model, readErr)
+				}
+			} else {
+				changed, readErr := team.ReadProfile(tm.Project, team.DefaultProfile)
+				if readErr != nil || changed.Members[0].Model != "concurrent-team-update" {
+					t.Fatalf("serialized team update missing: model=%q err=%v", changed.Members[0].Model, readErr)
+				}
+			}
+		})
+	}
+}
+
+func TestResumeGoalTransitionCASBlocksLaunchWriterAfterFinalSendValidation(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	oldSendHook, oldSend, oldLister := goalBeforeTransitionSendCAS, sendPromptToPane, statusPaneLister
+	writerDone := make(chan error, 1)
+	goalBeforeTransitionSendCAS = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- launch.WithRecordLock(verified.Check.AgentDir, func() error {
+				rec, err := launch.Read(verified.Check.AgentDir)
+				if err != nil {
+					return err
+				}
+				rec.Model = "concurrent-before-send"
+				return launch.WriteUnderRecordLock(verified.Check.AgentDir, rec)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("launch writer completed inside final send CAS: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	sends := 0
+	sendPromptToPane = func(string, string) error {
+		select {
+		case err := <-writerDone:
+			t.Fatalf("launch writer interleaved before send: %v", err)
+		default:
+		}
+		sends++
+		return nil
+	}
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex"}}, nil
+	}
+	t.Cleanup(func() {
+		goalBeforeTransitionSendCAS, sendPromptToPane, statusPaneLister = oldSendHook, oldSend, oldLister
+	})
+	opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
+	if _, err := executeGoalDelivery(opts); err != nil || sends != 1 {
+		t.Fatalf("err=%v sends=%d", err, sends)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("launch writer did not resume after send lock released")
+	}
+	rec, readErr := launch.Read(verified.Check.AgentDir)
+	boundGoal := ""
+	if rec.GoalBinding != nil {
+		boundGoal, _, _ = parseGeneratedGoalBinding(rec.GoalBinding.Command)
+	}
+	if readErr != nil || rec.Model != "concurrent-before-send" || rec.GoalBinding == nil || boundGoal != plan.Goal {
+		t.Fatalf("serialized pre-send launch update lost binding: model=%q binding=%+v err=%v", rec.Model, rec.GoalBinding, readErr)
+	}
+}
+
+func TestResumeGoalFailureGuidanceDoesNotRetrySettledDeliveryStates(t *testing.T) {
+	tests := []struct {
+		name, state string
+		post        bool
+	}{
+		{name: "native queued", state: goalDeliveryStateNativeQueued},
+		{name: "fallback sent", state: goalDeliveryStateFallbackSent},
+		{name: "pane delivered", state: goalDeliveryStatePaneDelivered, post: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+			plan.Selected = true
+			oldGoal := runStartGoalWithVersion
+			runStartGoalWithVersion = func([]string, string) error {
+				if tt.post {
+					return &goalPostDeliveryBindingError{AttemptID: "exact-attempt", Cause: errors.New("post-delivery failure")}
+				}
+				return &goalDeliveryAttemptError{AttemptID: "exact-attempt", AttemptPath: "/exact/attempt.json", Sent: true, State: tt.state, Cause: errors.New("delivery failure")}
+			}
+			t.Cleanup(func() { runStartGoalWithVersion = oldGoal })
+			err := deliverResumeGoalAfterLaunch(tm, team.DefaultProfile, session, []resumeExecLaunchResult{verified}, plan)
+			if err == nil || !strings.Contains(err.Error(), "exact-attempt") || !strings.Contains(err.Error(), "DO NOT retry") || strings.Contains(err.Error(), "retry-attempt") {
+				t.Fatalf("unsafe state guidance: %v", err)
+			}
+		})
+	}
+}
+
+func TestResumeGoalPlanEligibleUsesExactSettledEvidence(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	got := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if !got.Eligible || got.Action != "redeliver" || got.ClaimState != "claimed" || got.AttemptState != "recorded" || got.OriginalAttemptID != "attempt-original" {
+		t.Fatalf("goal plan = %+v", got)
+	}
+	if !strings.Contains(got.Goal, "literal --attempt-id fake") || got.BindingCommandDigest == "" || got.AttemptDigest == "" || got.ClaimDigest == "" || got.EvidenceDigest == "" {
+		t.Fatalf("goal plan omitted exact scalar evidence: %+v", got)
+	}
+	if again := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false); again != got {
+		t.Fatalf("read-only plan is not byte-stable:\n%+v\n%+v", got, again)
+	}
+}
+
+func TestResumeGoalAttemptIdentityIsExact(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	plan := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	path := mustGoalAttemptPath(t, tm.Project, team.DefaultProfile, session, plan.OriginalAttemptID)
+	attempt, err := readGoalAttempt(path, plan.OriginalAttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := squadnamespace.Resolve(tm.Project, team.DefaultProfile, session)
+	mutations := map[string]func(*goalAttemptRecord){
+		"role case":         func(a *goalAttemptRecord) { a.Role = "CTO" },
+		"handle case":       func(a *goalAttemptRecord) { a.Handle = "CTO" },
+		"namespace display": func(a *goalAttemptRecord) { a.Namespace.Display = "changed" },
+		"namespace path":    func(a *goalAttemptRecord) { a.Namespace.Paths.Brief = "/other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			got := attempt
+			mutate(&got)
+			if err := validateResumeGoalAttempt(got, tm.Project, team.DefaultProfile, session, "cto", "cto", plan.Goal, plan.OriginalAttemptID, ns); err == nil {
+				t.Fatalf("exact identity mutation accepted: %+v", got)
+			}
+		})
+	}
+}
+
+func TestResumeGoalPlanReattachSkipsButFingerprintsBinding(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "saved-conversation", false)
+	got := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if got.Eligible || got.Action != "skip" || !got.SavedConversation || got.BindingDigest == "" || got.BindingCommandDigest == "" || got.Goal == "" {
+		t.Fatalf("reattach plan = %+v", got)
+	}
+}
+
+func TestResumeGoalPlanUnclaimedBlocksWithoutCreatingAttempt(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", false)
+	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
+	before, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	after, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Eligible || got.Action != "blocked" || got.ClaimState != "unclaimed" || len(after) != len(before) {
+		t.Fatalf("unclaimed plan=%+v files before=%d after=%d", got, len(before), len(after))
+	}
+}
+
+func TestResumeGoalPlanRejectsNonGeneratedRawCommand(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	valid := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	mutations := []string{
+		plans[0].RestoreRecord.GoalBinding.Command + " --attempt-id duplicate",
+		plans[0].RestoreRecord.GoalBinding.Command + " --unknown value",
+		strings.Replace(plans[0].RestoreRecord.GoalBinding.Command, "--profile default", "--profile other", 1),
+	}
+	for _, command := range mutations {
+		rec := *plans[0].RestoreRecord
+		binding := *rec.GoalBinding
+		binding.Command = command
+		rec.GoalBinding = &binding
+		mutated := []resumePlan{plans[0]}
+		mutated[0].RestoreRecord = &rec
+		got := buildResumeGoalPlan(tm, team.DefaultProfile, session, mutated, false, false)
+		if got.Eligible || got.Action != "blocked" || got.BindingCommandDigest == valid.BindingCommandDigest {
+			t.Fatalf("crafted command accepted: %q\n%+v", command, got)
+		}
+	}
+}
+
+func TestParseGeneratedGoalBindingIsQuoteAware(t *testing.T) {
+	tm := team.Team{ExecutionMode: executionModeProjectLead}
+	command := nativeGoalControlPrompt("say --attempt-id fake and \"quoted\"", tm, "default", "issue-447", "cto", "real-attempt")
+	goal, attemptID, err := parseGeneratedGoalBinding(command)
+	if err != nil || attemptID != "real-attempt" || !strings.Contains(goal, "--attempt-id fake") {
+		t.Fatalf("parse = goal %q attempt %q err %v", goal, attemptID, err)
+	}
+	if _, _, err := parseGeneratedGoalBinding(command + " --attempt-id duplicate"); err == nil {
+		t.Fatal("duplicate attempt flag must fail")
+	}
+}
+
+func TestRestoreGoalBindingIsMetadataNotChildArg(t *testing.T) {
+	command := `/goal --goal "ship" --session s --profile default --mode project_lead --attempt-id a1`
+	rec := launch.Record{CWD: "/tmp/project", Binary: "codex", Role: "cto", Handle: "cto", Session: "s", Argv: []string{"--enable", "goals", command}, GoalBinding: &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: command, Detail: "reserved"}}
+	args := launchArgsFromRecord(rec)
+	var metadata string
+	dash := len(args)
+	for i, arg := range args {
+		if arg == "--restore-goal-binding" && i+1 < len(args) {
+			metadata = args[i+1]
+		}
+		if arg == "--" {
+			dash = i
+			break
+		}
+	}
+	if metadata == "" {
+		t.Fatalf("restore args omitted binding metadata: %#v", args)
+	}
+	for _, arg := range args[dash:] {
+		if arg == command {
+			t.Fatalf("saved goal leaked into child argv: %#v", args)
+		}
+	}
+	var decoded launch.GoalBinding
+	if err := json.Unmarshal([]byte(metadata), &decoded); err != nil || decoded != *rec.GoalBinding {
+		t.Fatalf("metadata round trip = %+v, %v", decoded, err)
+	}
+	if emitted := emitCommand(rec); !strings.Contains(emitted, "--restore-goal-binding") {
+		t.Fatalf("copy-paste restore omitted binding metadata: %s", emitted)
+	}
+}
+
+func TestRunLaunchRestoresGoalBindingMetadataWithoutActivation(t *testing.T) {
+	project := seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "issue-447"}}, Orchestrated: true, Lead: "cto"})
+	setupFakeAMQ(t)
+	binding := &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: `/goal --goal "ship" --session issue-447 --profile default --mode project_lead --attempt-id a1`, Detail: "reserved bytes\nunchanged"}
+	rec := launch.Record{CWD: project, Binary: "codex", Role: "cto", Handle: "cto", Session: "issue-447", SharedWorkstream: true, TeamHome: project, Argv: []string{"--enable", "goals", binding.Command}, GoalBinding: binding}
+	var observed launch.Record
+	var child []string
+	oldObserver := launchPlanObserver
+	launchPlanObserver = func(got launch.Record, args []string) { observed, child = got, append([]string(nil), args...) }
+	t.Cleanup(func() { launchPlanObserver = oldObserver })
+	args := append([]string{"--dry-run", "--project", project}, launchArgsFromRecord(rec)...)
+	if _, _, err := captureOutput(t, func() error { return runLaunch(args) }); err != nil {
+		t.Fatalf("restore launch: %v", err)
+	}
+	if observed.GoalBinding == nil || *observed.GoalBinding != *binding {
+		t.Fatalf("restored binding changed: got=%+v want=%+v", observed.GoalBinding, binding)
+	}
+	for _, arg := range child {
+		if strings.HasPrefix(strings.TrimSpace(arg), "/goal") {
+			t.Fatalf("restored binding activated through child argv: %v", child)
+		}
+	}
+	payload, err := json.Marshal(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflict := []string{"--dry-run", "--project", project, "--session", "issue-447", "--role", "cto", "--restore-goal-binding", string(payload), "codex", "--", binding.Command}
+	if _, _, err := captureOutput(t, func() error { return runLaunch(conflict) }); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("metadata/native-goal conflict accepted: %v", err)
+	}
+}
+
+func TestGoalRetryAttemptRequiresYesAndNeverCreatesAnotherAttempt(t *testing.T) {
+	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const attemptID = "reserved-recovery"
+	opts := goalDeliveryOptions{Project: dir, Profile: team.DefaultProfile, Session: "issue-96", Role: "cto", Goal: "recover safely", Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(dir, team.DefaultProfile, "issue-96"), Mode: executionModeProjectLead}
+	if _, err := createGoalAttempt(opts, attemptID, time.Unix(200, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(opts.Goal, tm, team.DefaultProfile, "issue-96", "cto", attemptID), Detail: "reserved"}
+	rec.Root = opts.Namespace.AMQRoot
+	rec.TeamHome = dir
+	rec.TeamProfile = team.DefaultProfile
+	rec.StartedAt = time.Unix(199, 0).UTC()
+	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true, LaunchID: "fresh-retry-launch"}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"retry-attempt", "--project", dir, "--session", "issue-96", "--role", "cto", "--attempt-id", attemptID}
+	if err := runGoal(args); err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("retry without gate = %v", err)
+	}
+	if len(*prompts) != 0 {
+		t.Fatalf("retry without --yes mutated pane: %v", *prompts)
+	}
+	if _, _, err := captureOutput(t, func() error { return runGoal(append(args, "--yes")) }); err != nil {
+		t.Fatalf("same-attempt retry: %v", err)
+	}
+	if len(*prompts) != 1 || *prompts == nil || !strings.Contains((*prompts)[0], "--attempt-id "+attemptID) {
+		t.Fatalf("retry prompt = %v", *prompts)
+	}
+	entries, err := os.ReadDir(goalAttemptDir(dir, team.DefaultProfile, "issue-96"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attemptRecords := 0
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+			attemptRecords++
+		}
+	}
+	if attemptRecords != 1 {
+		t.Fatalf("retry created another attempt: %v", entries)
+	}
+	if claimed, _, err := claimGoalAttempt(dir, team.DefaultProfile, "issue-96", attemptID, "native", time.Unix(201, 0).UTC()); err != nil || !claimed {
+		t.Fatalf("claim recovery attempt: claimed=%t err=%v", claimed, err)
+	}
+	if _, _, err := captureOutput(t, func() error { return runGoal(append(args, "--yes")) }); err == nil || !strings.Contains(err.Error(), "already claimed") {
+		t.Fatalf("claimed retry should refuse: %v", err)
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("claimed retry sent again: %v", *prompts)
+	}
+}
+
+func TestGoalBindingReservationFailureReportsExactUnsentAttempt(t *testing.T) {
+	dir, _, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+	oldWrite := goalLaunchWrite
+	goalLaunchWrite = func(string, launch.Record) error { return errors.New("injected binding write failure") }
+	t.Cleanup(func() { goalLaunchWrite = oldWrite })
+	_, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "durable ordering"})
+	})
+	var attemptErr *goalDeliveryAttemptError
+	if !errors.As(err, &attemptErr) || attemptErr.AttemptID == "" || attemptErr.AttemptPath == "" || attemptErr.Sent {
+		t.Fatalf("reservation failure lacks typed exact not-sent attempt: err=%v typed=%+v", err, attemptErr)
+	}
+	if _, statErr := os.Stat(attemptErr.AttemptPath); statErr != nil {
+		t.Fatalf("typed attempt was not durable: %v", statErr)
+	}
+	if len(*prompts) != 0 {
+		t.Fatalf("pane mutated after binding reservation failure: %v", *prompts)
+	}
+}
+
+func TestGoalRetryAttemptQueuedAndFallbackReuseExactAttempt(t *testing.T) {
+	tests := []struct {
+		name          string
+		sendErr       error
+		wantFallbacks int
+	}{
+		{name: "queued", sendErr: &tmuxpane.QueuedInputError{PaneID: "%7"}},
+		{name: "unconfirmed fallback", sendErr: &tmuxpane.SubmitUnconfirmedError{PaneID: "%7", Attempts: 3}, wantFallbacks: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, base, calls, prompts := setupGoalDeliveryFailureTest(t, tt.sendErr)
+			tm, err := team.ReadProfile(dir, team.DefaultProfile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const attemptID = "retry-same-attempt"
+			ns := squadnamespace.Resolve(dir, team.DefaultProfile, "issue-96")
+			opts := goalDeliveryOptions{Project: dir, Profile: team.DefaultProfile, Session: "issue-96", Role: "cto", Goal: "retry exact", Team: tm, Member: tm.Members[0], Namespace: ns, Mode: executionModeProjectLead}
+			if _, err := createGoalAttempt(opts, attemptID, time.Unix(600, 0).UTC()); err != nil {
+				t.Fatal(err)
+			}
+			agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+			rec, err := launch.Read(agentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec.Root, rec.TeamHome, rec.TeamProfile = ns.AMQRoot, dir, team.DefaultProfile
+			rec.StartedAt = time.Unix(599, 0).UTC()
+			rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true, LaunchID: "retry-queued-fallback"}
+			rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(opts.Goal, tm, team.DefaultProfile, "issue-96", "cto", attemptID), Detail: "reserved"}
+			if err := launch.Write(agentDir, rec); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := captureOutput(t, func() error {
+				return runGoal([]string{"retry-attempt", "--project", dir, "--session", "issue-96", "--role", "cto", "--attempt-id", attemptID, "--yes"})
+			}); err != nil {
+				t.Fatalf("retry path: %v", err)
+			}
+			if len(*prompts) != 1 || !strings.Contains((*prompts)[0], "--attempt-id "+attemptID) || len(*calls) != tt.wantFallbacks {
+				t.Fatalf("retry prompts=%v fallbacks=%d want=%d", *prompts, len(*calls), tt.wantFallbacks)
+			}
+			if tt.wantFallbacks == 1 && !strings.Contains(strings.Join((*calls)[0].Arg, " "), attemptID) {
+				t.Fatalf("fallback did not reuse exact attempt %s: %+v", attemptID, (*calls)[0].Arg)
+			}
+			entries, _ := os.ReadDir(goalAttemptDir(dir, team.DefaultProfile, "issue-96"))
+			attempts := 0
+			for _, entry := range entries {
+				if !strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+					attempts++
+				}
+			}
+			if attempts != 1 {
+				t.Fatalf("retry created another attempt: %v", entries)
+			}
+		})
+	}
+}
+
+func TestGoalRetryAttemptCASBlocksLaunchWriterThroughSend(t *testing.T) {
+	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const attemptID = "retry-cas-attempt"
+	ns := squadnamespace.Resolve(dir, team.DefaultProfile, "issue-96")
+	opts := goalDeliveryOptions{Project: dir, Profile: team.DefaultProfile, Session: "issue-96", Role: "cto", Goal: "retry cas", Team: tm, Member: tm.Members[0], Namespace: ns, Mode: executionModeProjectLead}
+	if _, err := createGoalAttempt(opts, attemptID, time.Unix(700, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Root, rec.TeamHome, rec.TeamProfile = ns.AMQRoot, dir, team.DefaultProfile
+	rec.StartedAt = time.Unix(699, 0).UTC()
+	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true, LaunchID: "retry-cas-launch"}
+	rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(opts.Goal, tm, team.DefaultProfile, "issue-96", "cto", attemptID), Detail: "reserved"}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	oldHook, oldSend := goalBeforeRetrySendCAS, sendPromptToPane
+	writerDone := make(chan error, 1)
+	goalBeforeRetrySendCAS = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- launch.WithRecordLock(agentDir, func() error {
+				changed, err := launch.Read(agentDir)
+				if err != nil {
+					return err
+				}
+				changed.Model = "concurrent-retry-update"
+				return launch.WriteUnderRecordLock(agentDir, changed)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("retry writer completed inside final CAS: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	sendPromptToPane = func(paneID, prompt string) error {
+		select {
+		case err := <-writerDone:
+			t.Fatalf("retry writer interleaved before send: %v", err)
+		default:
+		}
+		return oldSend(paneID, prompt)
+	}
+	t.Cleanup(func() { goalBeforeRetrySendCAS, sendPromptToPane = oldHook, oldSend })
+	_, _, err = captureOutput(t, func() error {
+		return runGoal([]string{"retry-attempt", "--project", dir, "--session", "issue-96", "--role", "cto", "--attempt-id", attemptID, "--yes"})
+	})
+	if err != nil || len(*prompts) != 1 {
+		t.Fatalf("retry CAS err=%v prompts=%v", err, *prompts)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry writer did not resume after send lock released")
+	}
+	current, readErr := launch.Read(agentDir)
+	if readErr != nil || current.Model != "concurrent-retry-update" || current.GoalBinding == nil || current.GoalBinding.Command != rec.GoalBinding.Command {
+		t.Fatalf("serialized retry update lost binding: model=%q binding=%+v err=%v", current.Model, current.GoalBinding, readErr)
+	}
+}
+
+func TestQueuedRedeliveryReservesSecondAttemptAndBlocksThird(t *testing.T) {
+	dir, base, _, _ := setupGoalDeliveryFailureTest(t, &tmuxpane.QueuedInputError{PaneID: "%7"})
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := squadnamespace.Resolve(dir, team.DefaultProfile, "issue-96")
+	original := goalDeliveryOptions{Project: dir, Profile: team.DefaultProfile, Session: "issue-96", Role: "cto", Goal: "ship safely", Team: tm, Member: tm.Members[0], Namespace: ns, Mode: executionModeProjectLead}
+	const originalID = "original-claimed"
+	if _, err := createGoalAttempt(original, originalID, time.Unix(300, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if claimed, _, err := claimGoalAttempt(dir, team.DefaultProfile, "issue-96", originalID, "native", time.Unix(301, 0).UTC()); err != nil || !claimed {
+		t.Fatalf("claim original: %t %v", claimed, err)
+	}
+	if _, _, err := captureOutput(t, func() error {
+		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", original.Goal})
+	}); err != nil {
+		t.Fatalf("queued redelivery: %v", err)
+	}
+	agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, secondID, err := parseGeneratedGoalBinding(rec.GoalBinding.Command)
+	if err != nil || secondID == "" || secondID == originalID {
+		t.Fatalf("reserved binding did not advance attempt: %q %v", secondID, err)
+	}
+	rec.Root = ns.AMQRoot
+	rec.TeamProfile = team.DefaultProfile
+	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true}
+	plan := buildResumeGoalPlan(tm, team.DefaultProfile, "issue-96", []resumePlan{{Role: "cto", Handle: "cto", Action: resumeRestore, RestoreRecord: &rec}}, false, false)
+	if plan.Eligible || plan.Action != "blocked" || plan.OriginalAttemptID != secondID || plan.ClaimState != "unclaimed" {
+		t.Fatalf("second queued attempt did not block third: %+v", plan)
+	}
+	entries, err := os.ReadDir(goalAttemptDir(dir, team.DefaultProfile, "issue-96"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempts := 0
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+			attempts++
+		}
+	}
+	if attempts != 2 {
+		t.Fatalf("attempt count=%d want exactly 2; entries=%v", attempts, entries)
+	}
+}
+
+func TestResumeExplicitRedeliveryRejectsPendingSecondAttemptBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name       string
+		sendErr    error
+		claimRoute string
+	}{
+		{name: "queued native", sendErr: &tmuxpane.QueuedInputError{PaneID: "%7"}, claimRoute: "native"},
+		{name: "durable fallback", sendErr: &tmuxpane.SubmitUnconfirmedError{PaneID: "%7", Attempts: 3}, claimRoute: "amq"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, base, calls, prompts := setupGoalDeliveryFailureTest(t, tt.sendErr)
+			if err := os.Symlink(base, filepath.Join(dir, ".agent-mail")); err != nil {
+				t.Fatal(err)
+			}
+			tm, err := team.ReadProfile(dir, team.DefaultProfile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ns := squadnamespace.Resolve(dir, team.DefaultProfile, "issue-96")
+			original := goalDeliveryOptions{Project: dir, Profile: team.DefaultProfile, Session: "issue-96", Role: "cto", Goal: "ship safely", Team: tm, Member: tm.Members[0], Namespace: ns, Mode: executionModeProjectLead}
+			const originalID = "settled-original"
+			if _, err := createGoalAttempt(original, originalID, time.Unix(400, 0).UTC()); err != nil {
+				t.Fatal(err)
+			}
+			if claimed, _, err := claimGoalAttempt(dir, team.DefaultProfile, "issue-96", originalID, tt.claimRoute, time.Unix(401, 0).UTC()); err != nil || !claimed {
+				t.Fatalf("claim original: %t %v", claimed, err)
+			}
+			agentDir := filepath.Join(base, "issue-96", "agents", "cto")
+			rec, err := launch.Read(agentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec.Root = filepath.Join(base, "issue-96")
+			rec.BaseRoot = base
+			rec.TeamHome = dir
+			rec.TeamProfile = team.DefaultProfile
+			rec.SharedWorkstream = true
+			rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true, LaunchID: "fresh-resume-redelivery"}
+			rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(original.Goal, tm, team.DefaultProfile, "issue-96", "cto", originalID), Detail: "delivered"}
+			goalPlan := buildResumeGoalPlan(tm, team.DefaultProfile, "issue-96", []resumePlan{{Role: "cto", Handle: "cto", Action: resumeRestore, HasRestoreRecord: true, RestoreRecord: &rec}}, false, false)
+			if !goalPlan.Eligible {
+				t.Fatalf("original settled plan ineligible: %+v", goalPlan)
+			}
+			goalPlan.Selected = true
+			rec.StartedAt = time.Unix(402, 0).UTC()
+			rec.Tmux = &launch.TmuxInfo{PaneID: "%7", Target: "current-window"}
+			if err := launch.Write(agentDir, rec); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(launch.ExistingPath(agentDir))
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldInspector := statusPaneInspector
+			statusPaneInspector = func(id string) (tmuxpane.TmuxPane, bool) {
+				return tmuxpane.TmuxPane{PaneID: id, CWD: dir, Command: "codex"}, id == "%7"
+			}
+			t.Cleanup(func() { statusPaneInspector = oldInspector })
+			// Assert the durable attempt and launch binding exist before either the
+			// queued-native or unconfirmed/fallback send seam runs.
+			underlyingSend := sendPromptToPane
+			sendPromptToPane = func(paneID, prompt string) error {
+				_, attemptID, parseErr := parseGeneratedGoalBinding(prompt)
+				if parseErr != nil {
+					t.Fatalf("parse outgoing redelivery: %v", parseErr)
+				}
+				if _, statErr := os.Stat(mustGoalAttemptPath(t, dir, team.DefaultProfile, "issue-96", attemptID)); statErr != nil {
+					t.Fatalf("attempt missing at send time: %v", statErr)
+				}
+				bound, readErr := launch.Read(agentDir)
+				if readErr != nil || bound.GoalBinding == nil || bound.GoalBinding.Command != prompt {
+					t.Fatalf("binding not durable at send time: rec=%+v err=%v", bound.GoalBinding, readErr)
+				}
+				return underlyingSend(paneID, prompt)
+			}
+			verified := resumeExecLaunchResult{Check: resumeExecLaunchCheck{Role: "cto", Handle: "cto", CWD: dir, AgentDir: agentDir, Workstream: "issue-96", Root: filepath.Join(base, "issue-96"), Binary: "codex", Profile: team.DefaultProfile}, State: resumeExecLaunchStateLaunched, RecordModTime: info.ModTime(), RecordStarted: rec.StartedAt}
+			if _, _, err := captureOutput(t, func() error {
+				return deliverResumeGoalAfterLaunch(tm, team.DefaultProfile, "issue-96", []resumeExecLaunchResult{verified}, goalPlan)
+			}); err != nil {
+				t.Fatalf("resume redelivery did not create pending second attempt: %v", err)
+			}
+			current, err := launch.Read(agentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, secondID, err := parseGeneratedGoalBinding(current.GoalBinding.Command)
+			if err != nil || secondID == originalID {
+				t.Fatalf("second binding = %q, %v", secondID, err)
+			}
+			// The crash/restart scenario has no surviving pane; keep the initial
+			// delivery seam above, then make resume classify the lead as restore.
+			statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return nil, nil }
+			paneCalls, goalCalls := 0, 0
+			oldTmux := runTmuxLaunchPlanForResume
+			oldGoal := runStartGoalWithVersion
+			runTmuxLaunchPlanForResume = func(tmuxLaunchPlan) error { paneCalls++; return nil }
+			runStartGoalWithVersion = func([]string, string) error { goalCalls++; return nil }
+			t.Cleanup(func() { runTmuxLaunchPlanForResume, runStartGoalWithVersion = oldTmux, oldGoal })
+			beforePrompts, beforeFallbacks := len(*prompts), len(*calls)
+			err = executeResume(resumeExecution{
+				ProjectDir: dir, RequestedSession: "issue-96", ExplicitSession: true, Mode: resumeModeDefault,
+				Profile: team.DefaultProfile, GoalRedelivery: true,
+				Probe: duplicateLaunchProbe{PIDAlive: func(int) bool { return false }, ProcessMatch: func(int, func(string) bool) bool { return false }, Now: time.Now},
+				Exec:  resumeExecOptions{Enabled: true, Terminal: "tmux", Target: "current-window", Layout: "vertical", RedeliverGoal: true, RedeliveryExplicit: true},
+			})
+			if err == nil || !strings.Contains(err.Error(), "--redeliver-goal is unavailable") || !strings.Contains(err.Error(), "claim is missing") {
+				t.Fatalf("second resume request = %v", err)
+			}
+			if paneCalls != 0 || goalCalls != 0 || len(*prompts) != beforePrompts || len(*calls) != beforeFallbacks {
+				t.Fatalf("ineligible resume mutated: pane=%d goal=%d prompts=%d/%d fallback=%d/%d", paneCalls, goalCalls, len(*prompts), beforePrompts, len(*calls), beforeFallbacks)
+			}
+			entries, err := os.ReadDir(goalAttemptDir(dir, team.DefaultProfile, "issue-96"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			attempts := 0
+			for _, entry := range entries {
+				if !strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+					attempts++
+				}
+			}
+			if attempts != 2 {
+				t.Fatalf("attempt count=%d want 2", attempts)
+			}
+			if claimed, _, err := claimGoalAttempt(dir, team.DefaultProfile, "issue-96", secondID, "native", time.Now().UTC()); err != nil || !claimed {
+				t.Fatalf("pending second attempt is not actionable: claimed=%t err=%v", claimed, err)
+			}
+		})
+	}
+}

--- a/internal/cli/resume_goal_test.go
+++ b/internal/cli/resume_goal_test.go
@@ -510,19 +510,19 @@ func TestResumeGoalTransitionReservedBindingGenerationChangeFailsClosed(t *testi
 	}
 }
 
-func TestResumeGoalTransitionCASBlocksIdentityWritersThroughBindingAndSend(t *testing.T) {
+func TestResumeGoalTransitionReleasesIdentityLocksBeforeBlockedSend(t *testing.T) {
 	for _, kind := range []string{"launch", "team"} {
 		t.Run(kind, func(t *testing.T) {
 			tm, session, _, plan, verified := freshResumeTransitionFixture(t)
 			if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
 				t.Fatal(err)
 			}
-			oldBindingHook, oldSend, oldLister := goalBeforeTransitionBindingCAS, sendPromptToPane, statusPaneLister
+			oldSend, oldLister := sendPromptToPane, statusPaneLister
 			writerDone := make(chan error, 1)
-			goalBeforeTransitionBindingCAS = func() {
-				started := make(chan struct{})
+			sends := 0
+			sendPromptToPane = func(string, string) error {
+				sends++
 				go func() {
-					close(started)
 					switch kind {
 					case "launch":
 						writerDone <- launch.WithRecordLock(verified.Check.AgentDir, func() error {
@@ -544,42 +544,31 @@ func TestResumeGoalTransitionCASBlocksIdentityWritersThroughBindingAndSend(t *te
 						})
 					}
 				}()
-				<-started
 				select {
 				case err := <-writerDone:
-					t.Fatalf("%s writer completed inside transition identity lock: %v", kind, err)
-				case <-time.After(50 * time.Millisecond):
+					if err != nil {
+						t.Fatalf("%s writer while send blocked: %v", kind, err)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("%s writer was blocked by transition external send", kind)
 				}
-			}
-			sends := 0
-			sendPromptToPane = func(string, string) error {
-				select {
-				case err := <-writerDone:
-					t.Fatalf("%s writer interleaved before pane send: %v", kind, err)
-				default:
-				}
-				sends++
 				return nil
 			}
 			statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
 				return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex"}}, nil
 			}
 			t.Cleanup(func() {
-				goalBeforeTransitionBindingCAS, sendPromptToPane, statusPaneLister = oldBindingHook, oldSend, oldLister
+				sendPromptToPane, statusPaneLister = oldSend, oldLister
 			})
 			opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
-			if _, err := executeGoalDelivery(opts); err != nil || sends != 1 {
-				t.Fatalf("kind=%s err=%v sends=%d", kind, err, sends)
-			}
-			select {
-			case err := <-writerDone:
-				if err != nil {
-					t.Fatalf("%s writer after transition: %v", kind, err)
-				}
-			case <-time.After(2 * time.Second):
-				t.Fatalf("%s writer did not resume after transition locks released", kind)
+			_, err := executeGoalDelivery(opts)
+			if sends != 1 {
+				t.Fatalf("kind=%s sends=%d", kind, sends)
 			}
 			if kind == "launch" {
+				if err != nil {
+					t.Fatalf("launch update should merge after transition send: %v", err)
+				}
 				rec, readErr := launch.Read(verified.Check.AgentDir)
 				boundGoal := ""
 				if rec.GoalBinding != nil {
@@ -589,6 +578,9 @@ func TestResumeGoalTransitionCASBlocksIdentityWritersThroughBindingAndSend(t *te
 					t.Fatalf("serialized launch update lost binding: rec=%+v model=%q err=%v", rec.GoalBinding, rec.Model, readErr)
 				}
 			} else {
+				if err == nil || !strings.Contains(err.Error(), "team generation changed after pane delivery") {
+					t.Fatalf("team update must cause explicit stale-generation refusal, got %v", err)
+				}
 				changed, readErr := team.ReadProfile(tm.Project, team.DefaultProfile)
 				if readErr != nil || changed.Members[0].Model != "concurrent-team-update" {
 					t.Fatalf("serialized team update missing: model=%q err=%v", changed.Members[0].Model, readErr)
@@ -598,17 +590,17 @@ func TestResumeGoalTransitionCASBlocksIdentityWritersThroughBindingAndSend(t *te
 	}
 }
 
-func TestResumeGoalTransitionCASBlocksLaunchWriterAfterFinalSendValidation(t *testing.T) {
+func TestResumeGoalTransitionFinalValidationReleasesLockBeforeBlockedSend(t *testing.T) {
 	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
 	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
 		t.Fatal(err)
 	}
-	oldSendHook, oldSend, oldLister := goalBeforeTransitionSendCAS, sendPromptToPane, statusPaneLister
+	oldSend, oldLister := sendPromptToPane, statusPaneLister
 	writerDone := make(chan error, 1)
-	goalBeforeTransitionSendCAS = func() {
-		started := make(chan struct{})
+	sends := 0
+	sendPromptToPane = func(string, string) error {
+		sends++
 		go func() {
-			close(started)
 			writerDone <- launch.WithRecordLock(verified.Check.AgentDir, func() error {
 				rec, err := launch.Read(verified.Check.AgentDir)
 				if err != nil {
@@ -618,40 +610,25 @@ func TestResumeGoalTransitionCASBlocksLaunchWriterAfterFinalSendValidation(t *te
 				return launch.WriteUnderRecordLock(verified.Check.AgentDir, rec)
 			})
 		}()
-		<-started
 		select {
 		case err := <-writerDone:
-			t.Fatalf("launch writer completed inside final send CAS: %v", err)
-		case <-time.After(50 * time.Millisecond):
+			if err != nil {
+				t.Fatalf("launch writer while send blocked: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("launch writer was blocked by transition external send")
 		}
-	}
-	sends := 0
-	sendPromptToPane = func(string, string) error {
-		select {
-		case err := <-writerDone:
-			t.Fatalf("launch writer interleaved before send: %v", err)
-		default:
-		}
-		sends++
 		return nil
 	}
 	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
 		return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex"}}, nil
 	}
 	t.Cleanup(func() {
-		goalBeforeTransitionSendCAS, sendPromptToPane, statusPaneLister = oldSendHook, oldSend, oldLister
+		sendPromptToPane, statusPaneLister = oldSend, oldLister
 	})
 	opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
 	if _, err := executeGoalDelivery(opts); err != nil || sends != 1 {
 		t.Fatalf("err=%v sends=%d", err, sends)
-	}
-	select {
-	case err := <-writerDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("launch writer did not resume after send lock released")
 	}
 	rec, readErr := launch.Read(verified.Check.AgentDir)
 	boundGoal := ""
@@ -1058,7 +1035,7 @@ func TestGoalRetryAttemptQueuedAndFallbackReuseExactAttempt(t *testing.T) {
 	}
 }
 
-func TestGoalRetryAttemptCASBlocksLaunchWriterThroughSend(t *testing.T) {
+func TestGoalRetryAttemptReleasesIdentityLocksBeforeBlockedSend(t *testing.T) {
 	dir, base, _, prompts := setupGoalDeliveryFailureTest(t, nil)
 	tm, err := team.ReadProfile(dir, team.DefaultProfile)
 	if err != nil {
@@ -1082,12 +1059,10 @@ func TestGoalRetryAttemptCASBlocksLaunchWriterThroughSend(t *testing.T) {
 	if err := launch.Write(agentDir, rec); err != nil {
 		t.Fatal(err)
 	}
-	oldHook, oldSend := goalBeforeRetrySendCAS, sendPromptToPane
+	oldSend := sendPromptToPane
 	writerDone := make(chan error, 1)
-	goalBeforeRetrySendCAS = func() {
-		started := make(chan struct{})
+	sendPromptToPane = func(paneID, prompt string) error {
 		go func() {
-			close(started)
 			writerDone <- launch.WithRecordLock(agentDir, func() error {
 				changed, err := launch.Read(agentDir)
 				if err != nil {
@@ -1097,35 +1072,22 @@ func TestGoalRetryAttemptCASBlocksLaunchWriterThroughSend(t *testing.T) {
 				return launch.WriteUnderRecordLock(agentDir, changed)
 			})
 		}()
-		<-started
 		select {
 		case err := <-writerDone:
-			t.Fatalf("retry writer completed inside final CAS: %v", err)
-		case <-time.After(50 * time.Millisecond):
-		}
-	}
-	sendPromptToPane = func(paneID, prompt string) error {
-		select {
-		case err := <-writerDone:
-			t.Fatalf("retry writer interleaved before send: %v", err)
-		default:
+			if err != nil {
+				t.Fatalf("retry writer while send blocked: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("retry writer was blocked by external send")
 		}
 		return oldSend(paneID, prompt)
 	}
-	t.Cleanup(func() { goalBeforeRetrySendCAS, sendPromptToPane = oldHook, oldSend })
+	t.Cleanup(func() { sendPromptToPane = oldSend })
 	_, _, err = captureOutput(t, func() error {
 		return runGoal([]string{"retry-attempt", "--project", dir, "--session", "issue-96", "--role", "cto", "--attempt-id", attemptID, "--yes"})
 	})
-	if err != nil || len(*prompts) != 1 {
-		t.Fatalf("retry CAS err=%v prompts=%v", err, *prompts)
-	}
-	select {
-	case err := <-writerDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("retry writer did not resume after send lock released")
+	if err == nil || !strings.Contains(err.Error(), "was sent but current identity/generation changed afterward") || len(*prompts) != 1 {
+		t.Fatalf("retry must explicitly refuse stale post-send identity: err=%v prompts=%v", err, *prompts)
 	}
 	current, readErr := launch.Read(agentDir)
 	if readErr != nil || current.Model != "concurrent-retry-update" || current.GoalBinding == nil || current.GoalBinding.Command != rec.GoalBinding.Command {

--- a/internal/cli/resume_goal_test.go
+++ b/internal/cli/resume_goal_test.go
@@ -44,7 +44,7 @@ func seededResumeGoalPlan(t *testing.T, conversation string, writeClaim bool) (t
 	}
 	rec := launch.Record{
 		CWD: project, Binary: "codex", Session: session, SharedWorkstream: true, Conversation: conversation,
-		Handle: "cto", Role: "cto", Root: ns.AMQRoot, TeamProfile: team.DefaultProfile,
+		Handle: "cto", Role: "cto", Root: ns.AMQRoot, TeamHome: project, TeamProfile: team.DefaultProfile,
 		BootstrapExpectation: &bootstrapack.Expectation{Required: true},
 		GoalBinding:          &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: command, Detail: "delivered"},
 	}
@@ -116,8 +116,38 @@ func TestResumeGoalTransitionNoReplaceAndPlannerFingerprint(t *testing.T) {
 		t.Fatalf("duplicate transition accepted: %v", err)
 	}
 	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
-	if blocked.Eligible || blocked.Action != "blocked" || blocked.TransitionID != plan.TransitionID || blocked.TransitionState != "reserved" || blocked.TransitionDigest == "" || blocked.EvidenceDigest == plan.EvidenceDigest {
+	if blocked.Eligible || blocked.Action != "continue" || blocked.TransitionID != plan.TransitionID || blocked.TransitionState != "reserved" || blocked.TransitionDigest == "" || blocked.RecoveryAttemptID == "" || !strings.Contains(blocked.RecoveryCommand, "--resume-transition "+plan.TransitionID) || blocked.EvidenceDigest == plan.EvidenceDigest {
 		t.Fatalf("transition not included in read-only plan/fingerprint: %+v", blocked)
+	}
+}
+
+func TestResumeGoalPlanRejectsSavedTeamHomeAndAdoptedTarget(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*launch.Record, string)
+		want   string
+	}{
+		{
+			name:   "team home mismatch",
+			mutate: func(rec *launch.Record, project string) { rec.TeamHome = filepath.Join(project, "other-team") },
+			want:   "team home",
+		},
+		{
+			name:   "adopted pane",
+			mutate: func(rec *launch.Record, _ string) { rec.Tmux = &launch.TmuxInfo{PaneID: "%old", Target: "adopted"} },
+			want:   "adopted",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tm, session, plans := seededResumeGoalPlan(t, "", true)
+			rec := *plans[0].RestoreRecord
+			tt.mutate(&rec, tm.Project)
+			plans[0].RestoreRecord = &rec
+			plan := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+			if plan.Eligible || !strings.Contains(plan.Reason, tt.want) {
+				t.Fatalf("plan accepted invalid saved identity: %+v", plan)
+			}
+		})
 	}
 }
 
@@ -329,6 +359,154 @@ func TestResumeGoalTransitionCreatesExactlyOnePreallocatedAttempt(t *testing.T) 
 	}
 	if attempts != 2 {
 		t.Fatalf("attempts=%d want original+one redelivery; entries=%v", attempts, entries)
+	}
+}
+
+func TestResumeGoalTransitionContinuationReusesReservedAttemptAfterCrash(t *testing.T) {
+	tm, session, plans, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	transitionPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tr resumeGoalTransitionRecord
+	transitionBytes, err := os.ReadFile(transitionPath)
+	if err != nil || json.Unmarshal(transitionBytes, &tr) != nil {
+		t.Fatalf("read transition: %v", err)
+	}
+	opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
+	if _, err := createGoalAttempt(opts, tr.NewAttemptID, time.Unix(501, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a process crash after it has reserved the new binding but before
+	// the durable transition completion marker. The recovery must neither reject
+	// that legitimate generation nor manufacture a third attempt.
+	rec, err := launch.Read(verified.Check.AgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(plan.Goal, tm, team.DefaultProfile, session, "cto", tr.NewAttemptID), Detail: "reserved"}
+	if err := launch.Write(verified.Check.AgentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if blocked.Eligible || blocked.Action != "continue" || blocked.RecoveryAttemptID != tr.NewAttemptID || !strings.Contains(blocked.RecoveryCommand, "--resume-transition "+plan.TransitionID) {
+		t.Fatalf("reserved crash recovery plan = %+v", blocked)
+	}
+	oldLister, oldSend := statusPaneLister, sendPromptToPane
+	var prompts []string
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{PaneID: "%447", CWD: tm.Project, Command: "codex"}}, nil
+	}
+	sendPromptToPane = func(_ string, prompt string) error { prompts = append(prompts, prompt); return nil }
+	t.Cleanup(func() { statusPaneLister, sendPromptToPane = oldLister, oldSend })
+	if _, err := executeGoalDelivery(opts); err != nil {
+		t.Fatalf("continue reserved transition: %v", err)
+	}
+	if len(prompts) != 1 || !strings.Contains(prompts[0], "--attempt-id "+tr.NewAttemptID) {
+		t.Fatalf("continuation prompt = %v", prompts)
+	}
+	if _, err := os.Stat(resumeGoalTransitionConsumedPath(transitionPath)); err != nil {
+		t.Fatalf("continuation did not mark transition consumed: %v", err)
+	}
+	entries, err := os.ReadDir(goalAttemptDir(tm.Project, team.DefaultProfile, session))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempts := 0
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".json") && !strings.HasSuffix(entry.Name(), ".claim.json") {
+			attempts++
+		}
+	}
+	if attempts != 2 {
+		t.Fatalf("continuation created a third attempt: %v", entries)
+	}
+}
+
+func TestResumeGoalTransitionConsumedRecoveryPlanUsesExactRetry(t *testing.T) {
+	tm, session, plans, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	transitionPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tr resumeGoalTransitionRecord
+	transitionBytes, err := os.ReadFile(transitionPath)
+	if err != nil || json.Unmarshal(transitionBytes, &tr) != nil {
+		t.Fatalf("read transition: %v", err)
+	}
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(transitionPath), resumeGoalTransitionConsumed{SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: tr.TransitionID, NewAttemptID: tr.NewAttemptID, ConsumedAt: time.Unix(502, 0).UTC()})
+	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if blocked.Eligible || blocked.Action != "retry" || blocked.TransitionState != "consumed" || blocked.RecoveryAttemptID != tr.NewAttemptID || !strings.Contains(blocked.RecoveryCommand, "retry-attempt") || !strings.Contains(blocked.RecoveryCommand, "--attempt-id "+tr.NewAttemptID) {
+		t.Fatalf("consumed crash recovery plan = %+v", blocked)
+	}
+}
+
+func TestResumeGoalTransitionMismatchedRecoveryFailsClosed(t *testing.T) {
+	tm, session, plans, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	transitionPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tr resumeGoalTransitionRecord
+	transitionBytes, err := os.ReadFile(transitionPath)
+	if err != nil || json.Unmarshal(transitionBytes, &tr) != nil {
+		t.Fatalf("read transition: %v", err)
+	}
+	tr.NewAttemptID = tr.OriginalAttemptID
+	writeTestJSON(t, transitionPath, tr)
+	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
+	if blocked.Eligible || blocked.TransitionState != "mismatched" || blocked.RecoveryCommand != "" {
+		t.Fatalf("mismatched transition exposed recovery: %+v", blocked)
+	}
+}
+
+func TestResumeGoalTransitionReservedBindingGenerationChangeFailsClosed(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	transitionPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tr resumeGoalTransitionRecord
+	transitionBytes, err := os.ReadFile(transitionPath)
+	if err != nil || json.Unmarshal(transitionBytes, &tr) != nil {
+		t.Fatalf("read transition: %v", err)
+	}
+	opts := goalDeliveryOptions{Project: tm.Project, Profile: team.DefaultProfile, Session: session, Role: "cto", Goal: plan.Goal, Team: tm, Member: tm.Members[0], Namespace: squadnamespace.Resolve(tm.Project, team.DefaultProfile, session), Mode: executionModeProjectLead, ResumeTransitionID: plan.TransitionID}
+	if _, err := createGoalAttempt(opts, tr.NewAttemptID, time.Unix(503, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := launch.Read(verified.Check.AgentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.GoalBinding = &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Source: "goal-control", Command: nativeGoalControlPrompt(plan.Goal, tm, team.DefaultProfile, session, "cto", tr.NewAttemptID), Detail: "reserved"}
+	if err := launch.Write(verified.Check.AgentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureResumeGoalTransitionBinding(opts, &tr, verified.Check.AgentDir); err != nil {
+		t.Fatal(err)
+	}
+	rec.Model = "mutated-after-bound-marker"
+	if err := launch.Write(verified.Check.AgentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	oldSend := sendPromptToPane
+	sendPromptToPane = func(string, string) error { t.Fatal("generation mismatch reached pane send"); return nil }
+	t.Cleanup(func() { sendPromptToPane = oldSend })
+	if _, err := executeGoalDelivery(opts); err == nil || !strings.Contains(err.Error(), "reserved launch binding generation changed") {
+		t.Fatalf("reserved generation mutation was accepted: %v", err)
 	}
 }
 
@@ -562,6 +740,68 @@ func TestResumeGoalPlanReattachSkipsButFingerprintsBinding(t *testing.T) {
 	}
 }
 
+func TestResumeSurfacesNativeGoalBlockedRecoveryWithoutReactivation(t *testing.T) {
+	tm, session, plans := seededResumeGoalPlan(t, "", true)
+	rec := *plans[0].RestoreRecord
+	binding := *rec.GoalBinding
+	binding.Mode = "native_goal_blocked"
+	binding.Detail = "Goal blocked (/goal resume)\n\x1b[31munsafe control text"
+	rec.GoalBinding = &binding
+	plans[0].RestoreRecord = &rec
+
+	recoveries := resumeNativeGoalBlockedRecoveries(plans)
+	if len(recoveries) != 1 || recoveries[0].Role != "cto" || recoveries[0].Action != string(resumeRestore) {
+		t.Fatalf("recoveries = %+v", recoveries)
+	}
+	if !strings.Contains(recoveries[0].Guidance, "/goal resume") || strings.Contains(recoveries[0].Guidance, "automatically redeliver") && !strings.Contains(recoveries[0].Guidance, "Do not automatically") {
+		t.Fatalf("unsafe recovery guidance: %q", recoveries[0].Guidance)
+	}
+
+	var plain strings.Builder
+	writeResumeNativeGoalBlockedRecoveries(&plain, recoveries)
+	if !strings.Contains(plain.String(), "Native goal recovery required") || !strings.Contains(plain.String(), "/goal resume") || strings.ContainsRune(plain.String(), '\x1b') {
+		t.Fatalf("plain recovery output is not safe/explicit: %q", plain.String())
+	}
+	if strings.Contains(plain.String(), rec.GoalBinding.Command) {
+		t.Fatalf("plain recovery output leaked saved goal command: %q", plain.String())
+	}
+
+	var jsonOut strings.Builder
+	if err := writeResumeJSONWithGoal(&jsonOut, tm, session, resumeModeDefault, team.DefaultProfile, nil, plans, runwizard.ResumeGoalPlan{}); err != nil {
+		t.Fatal(err)
+	}
+	env := decodeJSONEnvelope[resumeEnvelopeData](t, jsonOut.String())
+	if len(env.Data.NativeGoalBlockedRecovery) != 1 || env.Data.NativeGoalBlockedRecovery[0].Guidance != nativeGoalBlockedResumeGuidance {
+		t.Fatalf("native blocked recovery JSON = %s", jsonOut.String())
+	}
+}
+
+func TestResumeNativeGoalBlockedRecoveryCoversMixedRosterWithoutFalsePositives(t *testing.T) {
+	blockedLead := launch.Record{GoalBinding: &launch.GoalBinding{Mode: "native_goal_blocked", NativeGoal: true, Detail: "lead blocked"}}
+	blockedWorker := launch.Record{GoalBinding: &launch.GoalBinding{Mode: "native_goal_blocked", NativeGoal: true, Detail: "worker blocked"}}
+	nativeDelivered := launch.Record{GoalBinding: &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Detail: "delivered"}}
+	plans := []resumePlan{
+		{Role: "cto", Handle: "cto", Action: resumeRestore, RestoreRecord: &blockedLead},
+		{Role: "fullstack", Handle: "fullstack", Action: resumeRestore, RestoreRecord: &nativeDelivered},
+		{Role: "qa", Handle: "qa", Action: resumeFresh},
+		{Role: "analyst", Handle: "analyst", Action: resumeRestore, RestoreRecord: &blockedWorker},
+	}
+	recoveries := resumeNativeGoalBlockedRecoveries(plans)
+	if len(recoveries) != 2 || recoveries[0].Role != "cto" || recoveries[1].Role != "analyst" {
+		t.Fatalf("mixed roster recoveries = %+v", recoveries)
+	}
+	for _, recovery := range recoveries {
+		if recovery.Action != string(resumeRestore) || recovery.Guidance != nativeGoalBlockedResumeGuidance || strings.Contains(strings.ToLower(recovery.Detail), "delivered") {
+			t.Fatalf("invalid recovery = %+v", recovery)
+		}
+	}
+	var out strings.Builder
+	writeResumeNativeGoalBlockedRecoveries(&out, recoveries)
+	if strings.Count(out.String(), "# Recovery:") != 2 || !strings.Contains(out.String(), "cto") || !strings.Contains(out.String(), "analyst") || strings.Contains(out.String(), "fullstack") {
+		t.Fatalf("mixed roster output = %q", out.String())
+	}
+}
+
 func TestResumeGoalPlanUnclaimedBlocksWithoutCreatingAttempt(t *testing.T) {
 	tm, session, plans := seededResumeGoalPlan(t, "", false)
 	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
@@ -741,9 +981,9 @@ func TestGoalRetryAttemptRequiresYesAndNeverCreatesAnotherAttempt(t *testing.T) 
 
 func TestGoalBindingReservationFailureReportsExactUnsentAttempt(t *testing.T) {
 	dir, _, _, prompts := setupGoalDeliveryFailureTest(t, nil)
-	oldWrite := goalLaunchWrite
-	goalLaunchWrite = func(string, launch.Record) error { return errors.New("injected binding write failure") }
-	t.Cleanup(func() { goalLaunchWrite = oldWrite })
+	oldWrite := goalLaunchWriteUnderRecordLock
+	goalLaunchWriteUnderRecordLock = func(string, launch.Record) error { return errors.New("injected binding write failure") }
+	t.Cleanup(func() { goalLaunchWriteUnderRecordLock = oldWrite })
 	_, _, err := captureOutput(t, func() error {
 		return runGoal([]string{"deliver", "--project", dir, "--session", "issue-96", "--role", "cto", "--goal", "durable ordering"})
 	})
@@ -923,6 +1163,7 @@ func TestQueuedRedeliveryReservesSecondAttemptAndBlocksThird(t *testing.T) {
 		t.Fatalf("reserved binding did not advance attempt: %q %v", secondID, err)
 	}
 	rec.Root = ns.AMQRoot
+	rec.TeamHome = dir
 	rec.TeamProfile = team.DefaultProfile
 	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: true}
 	plan := buildResumeGoalPlan(tm, team.DefaultProfile, "issue-96", []resumePlan{{Role: "cto", Handle: "cto", Action: resumeRestore, RestoreRecord: &rec}}, false, false)

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -426,6 +426,91 @@ func TestRunResumeReorientsSeatWithoutConversation(t *testing.T) {
 	})
 }
 
+func TestRunResumeSurfacesNativeGoalBlockedRecovery(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream:    "issue-447",
+		Orchestrated:  true,
+		Lead:          "cto",
+		ExecutionMode: executionModeProjectLead,
+		Members:       []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-447"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeMemberLaunchRecord(t, base, "issue-447", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", StartedAt: time.Now(),
+		GoalBinding: &launch.GoalBinding{
+			Mode:       "native_goal_blocked",
+			NativeGoal: true,
+			Source:     "goal-runtime",
+			Command:    `/goal --goal "ship"`,
+			Detail:     "Goal blocked (/goal resume)",
+		},
+	})
+
+	plain, _, err := captureOutput(t, func() error { return runResume(nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plain, "Native goal recovery required") || !strings.Contains(plain, "then enter /goal resume manually") || !strings.Contains(plain, "Do not automatically redeliver") {
+		t.Fatalf("resume plan did not surface safe blocked-goal recovery:\n%s", plain)
+	}
+
+	jsonOut, _, err := captureOutput(t, func() error { return runResume([]string{"--json"}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := decodeJSONEnvelope[resumeEnvelopeData](t, jsonOut)
+	if len(env.Data.NativeGoalBlockedRecovery) != 1 || env.Data.NativeGoalBlockedRecovery[0].Role != "cto" || !strings.Contains(env.Data.NativeGoalBlockedRecovery[0].Guidance, "/goal resume") {
+		t.Fatalf("resume JSON did not surface blocked-goal recovery:\n%s", jsonOut)
+	}
+}
+
+func TestRunResumeExecSurfacesBlockedGoalRecoveryForMixedRoster(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-447", Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-447"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-447"},
+			{Role: "fullstack", Binary: "codex", Handle: "fullstack", Session: "issue-447"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range []struct {
+		role    string
+		binding *launch.GoalBinding
+	}{
+		{role: "cto", binding: &launch.GoalBinding{Mode: "native_goal_blocked", NativeGoal: true, Detail: "lead blocked"}},
+		{role: "qa", binding: &launch.GoalBinding{Mode: "native_goal_blocked", NativeGoal: true, Detail: "worker blocked"}},
+		{role: "fullstack", binding: &launch.GoalBinding{Mode: "native_goal", NativeGoal: true, Detail: "delivered"}},
+	} {
+		writeMemberLaunchRecord(t, base, "issue-447", row.role, launch.Record{CWD: dir, Binary: "codex", Role: row.role, Handle: row.role, Session: "issue-447", StartedAt: time.Now(), GoalBinding: row.binding})
+	}
+	oldRun, oldVerify := runTmuxLaunchPlanForResume, verifyResumeExecLaunchRecordsNow
+	runTmuxLaunchPlanForResume = func(tmuxLaunchPlan) error { return nil }
+	verifyResumeExecLaunchRecordsNow = func(checks []resumeExecLaunchCheck, _ map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+		out := make([]resumeExecLaunchResult, 0, len(checks))
+		for _, check := range checks {
+			out = append(out, resumeExecLaunchResult{Check: check, State: resumeExecLaunchStateLaunched})
+		}
+		return out
+	}
+	t.Cleanup(func() { runTmuxLaunchPlanForResume, verifyResumeExecLaunchRecordsNow = oldRun, oldVerify })
+	_, stderr, err := captureOutput(t, func() error { return runResume([]string{"--exec", "--stagger", "0"}) })
+	if err != nil {
+		t.Fatalf("resume --exec: %v\nstderr:\n%s", err, stderr)
+	}
+	if strings.Count(stderr, "# Recovery:") != 2 || !strings.Contains(stderr, "cto") || !strings.Contains(stderr, "qa") || strings.Contains(stderr, "fullstack") || !strings.Contains(stderr, "then enter /goal resume manually") {
+		t.Fatalf("mixed exec recovery output = %q", stderr)
+	}
+}
+
 func TestRunResumeRejectsFreshFlag(t *testing.T) {
 	dir := t.TempDir()
 	resumeChdir(t, dir)

--- a/internal/cli/run_start_discovery.go
+++ b/internal/cli/run_start_discovery.go
@@ -386,6 +386,8 @@ func discoverRunStartWizardSession(t team.Team, profile, session string, source 
 		summary.Members = append(summary.Members, row)
 		fingerprint.MemberPlans = append(fingerprint.MemberPlans, runStartWizardDiscoveryMemberPlan(plan, action))
 	}
+	summary.GoalPlan = buildResumeGoalPlan(planningTeam, profile, session, plans, false, false)
+	fingerprint.GoalPlan = summary.GoalPlan
 	if len(active) == 0 {
 		summary.Blocked = len(t.Members)
 	}

--- a/internal/cli/run_start_wizard.go
+++ b/internal/cli/run_start_wizard.go
@@ -323,7 +323,7 @@ func refreshWizardExistingSelection(spec runwizard.Spec) error {
 			if session.Fingerprint != spec.DiscoveryFingerprint {
 				return stale(fmt.Errorf("discovery fingerprint changed"))
 			}
-			if session.Classification.Backend != spec.Backend || session.Classification.State != spec.RunState || session.Classification.Executable != spec.RunExecutable || session.RecordCount != spec.RecordCount || (session.RecordCount > 0) != spec.RestoreExisting || !reflect.DeepEqual(session.Members, spec.ResumeMembers) {
+			if session.Classification.Backend != spec.Backend || session.Classification.State != spec.RunState || session.Classification.Executable != spec.RunExecutable || session.RecordCount != spec.RecordCount || (session.RecordCount > 0) != spec.RestoreExisting || !reflect.DeepEqual(session.Members, spec.ResumeMembers) || !reflect.DeepEqual(session.GoalPlan, spec.ResumeGoalPlan) {
 				return stale(fmt.Errorf("refreshed run contract changed without a fingerprint change"))
 			}
 			return nil

--- a/internal/cli/run_start_wizard_live_test.go
+++ b/internal/cli/run_start_wizard_live_test.go
@@ -347,6 +347,30 @@ func TestFinishWizardResumeFingerprintDeltaAfterYesRestartsWithoutExec(t *testin
 	assertWizardRestartCleared(t, restart.Defaults, spec)
 }
 
+func TestRefreshWizardExistingSelectionInvalidatesOnGoalEvidenceOnly(t *testing.T) {
+	withWizardExecutionSeams(t)
+	spec, current := resumeWizardFixture("placeholder")
+	currentPlan := runwizard.ResumeGoalPlan{SchemaVersion: 1, Action: "redeliver", Eligible: true, BindingDigest: "sha256:binding", AttemptDigest: "sha256:attempt", ClaimDigest: "sha256:claim-a", TransitionState: "absent"}
+	currentFP := runwizard.DiscoveryFingerprint(runwizard.DiscoveryFingerprintInput{Profile: "release", Session: "s", GoalPlan: currentPlan})
+	current.Profiles[0].Sessions[0].GoalPlan = currentPlan
+	current.Profiles[0].Sessions[0].Fingerprint = currentFP
+	spec.SelectExistingSession(current.Profiles[0].Sessions[0])
+	spec.RedeliverGoal = true
+	changed := current
+	changed.Profiles = append([]runwizard.ProfileSummary(nil), current.Profiles...)
+	changed.Profiles[0].Sessions = append([]runwizard.SessionSummary(nil), current.Profiles[0].Sessions...)
+	changedPlan := currentPlan
+	changedPlan.ClaimDigest = "sha256:claim-b"
+	changed.Profiles[0].Sessions[0].GoalPlan = changedPlan
+	changed.Profiles[0].Sessions[0].Fingerprint = runwizard.DiscoveryFingerprint(runwizard.DiscoveryFingerprintInput{Profile: "release", Session: "s", GoalPlan: changedPlan})
+	runStartWizardInspectProject = func(string) (runwizard.ProjectContext, error) { return changed, nil }
+	err := refreshWizardExistingSelection(spec)
+	var restart *wizardRestartError
+	if !errors.As(err, &restart) || restart.Defaults.RedeliverGoal || restart.Defaults.ResumeGoalPlan != (runwizard.ResumeGoalPlan{}) {
+		t.Fatalf("goal-only evidence delta did not clear stale choice: err=%v defaults=%+v", err, restart)
+	}
+}
+
 func TestRefreshWizardExistingSelectionFailsClosed(t *testing.T) {
 	tests := map[string]func(runwizard.ProjectContext) (runwizard.ProjectContext, error){
 		"inspector error": func(runwizard.ProjectContext) (runwizard.ProjectContext, error) {

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
 // tmuxRuntimeJSON is the stable tmux runtime-identity block that amq-noc (and
@@ -393,18 +394,23 @@ type resumeLivenessJSON struct {
 // classification `resume` prints, in a stable shape clients can render as
 // actions. It is a read-only preview (never executes).
 type resumeEnvelopeData struct {
-	TeamHome          string                 `json:"team_home"`
-	Workstream        string                 `json:"workstream"`
-	Profile           string                 `json:"profile,omitempty"`
-	Mode              string                 `json:"mode"`
-	NamespaceConflict *namespaceConflictData `json:"namespace_conflict,omitempty"`
-	Members           int                    `json:"members"`
-	Plan              []resumeMemberJSON     `json:"plan"`
+	TeamHome          string                    `json:"team_home"`
+	Workstream        string                    `json:"workstream"`
+	Profile           string                    `json:"profile,omitempty"`
+	Mode              string                    `json:"mode"`
+	NamespaceConflict *namespaceConflictData    `json:"namespace_conflict,omitempty"`
+	Members           int                       `json:"members"`
+	Plan              []resumeMemberJSON        `json:"plan"`
+	GoalPlan          *runwizard.ResumeGoalPlan `json:"goal_plan,omitempty"`
 }
 
 // writeResumeJSON emits the resume_plan envelope. Pane liveness is resolved once
 // across every member that carries a tmux identity.
 func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeMode, profile string, conflict *namespaceConflictData, plans []resumePlan) error {
+	return writeResumeJSONWithGoal(out, t, workstream, mode, profile, conflict, plans, runwizard.ResumeGoalPlan{})
+}
+
+func writeResumeJSONWithGoal(out io.Writer, t team.Team, workstream string, mode resumeMode, profile string, conflict *namespaceConflictData, plans []resumePlan, goalPlan runwizard.ResumeGoalPlan) error {
 	rows := make([]resumeMemberJSON, 0, len(plans))
 	var livePanes map[string]bool
 	for _, p := range plans {
@@ -441,6 +447,11 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 	if profile == team.DefaultProfile {
 		profile = ""
 	}
+	var goalPlanJSON *runwizard.ResumeGoalPlan
+	if goalPlan.SchemaVersion != 0 {
+		copy := goalPlan
+		goalPlanJSON = &copy
+	}
 	return writeJSONEnvelope(out, "resume_plan", resumeEnvelopeData{
 		TeamHome:          t.Project,
 		Workstream:        workstream,
@@ -449,6 +460,7 @@ func writeResumeJSON(out io.Writer, t team.Team, workstream string, mode resumeM
 		NamespaceConflict: conflict,
 		Members:           len(rows),
 		Plan:              rows,
+		GoalPlan:          goalPlanJSON,
 	})
 }
 

--- a/internal/cli/runtime_json.go
+++ b/internal/cli/runtime_json.go
@@ -394,14 +394,15 @@ type resumeLivenessJSON struct {
 // classification `resume` prints, in a stable shape clients can render as
 // actions. It is a read-only preview (never executes).
 type resumeEnvelopeData struct {
-	TeamHome          string                    `json:"team_home"`
-	Workstream        string                    `json:"workstream"`
-	Profile           string                    `json:"profile,omitempty"`
-	Mode              string                    `json:"mode"`
-	NamespaceConflict *namespaceConflictData    `json:"namespace_conflict,omitempty"`
-	Members           int                       `json:"members"`
-	Plan              []resumeMemberJSON        `json:"plan"`
-	GoalPlan          *runwizard.ResumeGoalPlan `json:"goal_plan,omitempty"`
+	TeamHome                  string                     `json:"team_home"`
+	Workstream                string                     `json:"workstream"`
+	Profile                   string                     `json:"profile,omitempty"`
+	Mode                      string                     `json:"mode"`
+	NamespaceConflict         *namespaceConflictData     `json:"namespace_conflict,omitempty"`
+	Members                   int                        `json:"members"`
+	Plan                      []resumeMemberJSON         `json:"plan"`
+	GoalPlan                  *runwizard.ResumeGoalPlan  `json:"goal_plan,omitempty"`
+	NativeGoalBlockedRecovery []resumeNativeGoalRecovery `json:"native_goal_blocked_recovery,omitempty"`
 }
 
 // writeResumeJSON emits the resume_plan envelope. Pane liveness is resolved once
@@ -453,14 +454,15 @@ func writeResumeJSONWithGoal(out io.Writer, t team.Team, workstream string, mode
 		goalPlanJSON = &copy
 	}
 	return writeJSONEnvelope(out, "resume_plan", resumeEnvelopeData{
-		TeamHome:          t.Project,
-		Workstream:        workstream,
-		Profile:           profile,
-		Mode:              string(mode),
-		NamespaceConflict: conflict,
-		Members:           len(rows),
-		Plan:              rows,
-		GoalPlan:          goalPlanJSON,
+		TeamHome:                  t.Project,
+		Workstream:                workstream,
+		Profile:                   profile,
+		Mode:                      string(mode),
+		NamespaceConflict:         conflict,
+		Members:                   len(rows),
+		Plan:                      rows,
+		GoalPlan:                  goalPlanJSON,
+		NativeGoalBlockedRecovery: resumeNativeGoalBlockedRecoveries(plans),
 	})
 }
 

--- a/internal/cli/runtime_json_test.go
+++ b/internal/cli/runtime_json_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
 // swapStatusPaneLister installs a fake pane lister for the duration of a test.
@@ -288,6 +289,29 @@ func TestWriteResumeJSONShapeAndPaneAlive(t *testing.T) {
 	}
 	if qa.LaunchState != "will-launch" || qa.RecordState != "missing" {
 		t.Errorf("qa state wrong: launch=%q record=%q", qa.LaunchState, qa.RecordState)
+	}
+}
+
+func TestWriteResumeJSONGoalPlanIsAdditiveAndPreservesSelection(t *testing.T) {
+	base := team.Team{Project: "/r"}
+	plans := []resumePlan{{Role: "cto", Handle: "cto", Action: resumeRestore}}
+	var legacy bytes.Buffer
+	if err := writeResumeJSON(&legacy, base, "s", resumeModeDefault, team.DefaultProfile, nil, plans); err != nil {
+		t.Fatal(err)
+	}
+	if env := decodeJSONEnvelope[resumeEnvelopeData](t, legacy.String()); env.Data.GoalPlan != nil || strings.Contains(legacy.String(), "goal_plan") {
+		t.Fatalf("legacy resume JSON changed: %s", legacy.String())
+	}
+	for _, selected := range []bool{false, true} {
+		var buf bytes.Buffer
+		plan := runwizard.ResumeGoalPlan{SchemaVersion: 1, Action: "redeliver", Eligible: true, Selected: selected, BindingDigest: "sha256:binding", EvidenceDigest: "sha256:evidence"}
+		if err := writeResumeJSONWithGoal(&buf, base, "s", resumeModeDefault, team.DefaultProfile, nil, plans, plan); err != nil {
+			t.Fatal(err)
+		}
+		env := decodeJSONEnvelope[resumeEnvelopeData](t, buf.String())
+		if env.SchemaVersion != 1 || env.Data.GoalPlan == nil || env.Data.GoalPlan.Selected != selected || env.Data.GoalPlan.BindingDigest != plan.BindingDigest {
+			t.Fatalf("selected=%t JSON=%s", selected, buf.String())
+		}
 	}
 }
 

--- a/internal/cli/team_autonomous.go
+++ b/internal/cli/team_autonomous.go
@@ -9,6 +9,11 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
+// teamAutonomousAfterRead is a deterministic test seam. It runs while the
+// profile writer lock is held, after the command has loaded the only snapshot
+// it may mutate.
+var teamAutonomousAfterRead = func() {}
+
 func runTeamAutonomous(args []string) error {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fmt.Fprint(os.Stderr, `amq-squad team autonomous - inspect or control opt-in Autonomous mode
@@ -85,26 +90,32 @@ func runTeamAutonomousMutation(args []string, action string) error {
 	if fs.NArg() != 0 {
 		return usageErrorf("team autonomous %s takes no positional arguments", action)
 	}
-	t, profile, err := readAutonomousTeam(*projectFlag, *profileFlag, fs)
+	projectDir, profile, err := resolveAutonomousProjectProfile(*projectFlag, *profileFlag, fs)
 	if err != nil {
 		return err
 	}
-	if team.EffectiveComposition(t) != team.CompositionAutonomous || t.Autonomous == nil {
-		return usageErrorf("team autonomous %s requires a profile with composition=autonomous", action)
-	}
-	switch action {
-	case "pause":
-		t.Autonomous.Paused = true
-	case "resume":
-		t.Autonomous.Paused = false
-		if t.Autonomous.Disabled {
-			return usageErrorf("team autonomous resume cannot resume a disabled policy; reconfigure the profile explicitly")
+	if err := team.WithProfileLock(projectDir, profile, func() error {
+		t, err := team.ReadProfile(projectDir, profile)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
 		}
-	case "disable":
-		t.Autonomous.Disabled = true
-	}
-	projectDir := t.Project
-	if err := team.WriteProfile(projectDir, profile, t); err != nil {
+		if team.EffectiveComposition(t) != team.CompositionAutonomous || t.Autonomous == nil {
+			return usageErrorf("team autonomous %s requires a profile with composition=autonomous", action)
+		}
+		teamAutonomousAfterRead()
+		switch action {
+		case "pause":
+			t.Autonomous.Paused = true
+		case "resume":
+			t.Autonomous.Paused = false
+			if t.Autonomous.Disabled {
+				return usageErrorf("team autonomous resume cannot resume a disabled policy; reconfigure the profile explicitly")
+			}
+		case "disable":
+			t.Autonomous.Disabled = true
+		}
+		return team.WriteProfileUnderLock(projectDir, profile, t)
+	}); err != nil {
 		return err
 	}
 	fmt.Printf("autonomous %s for profile %s\n", action, profile)
@@ -112,15 +123,7 @@ func runTeamAutonomousMutation(args []string, action string) error {
 }
 
 func readAutonomousTeam(projectFlag, profileFlag string, fs *flag.FlagSet) (team.Team, string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return team.Team{}, "", fmt.Errorf("getwd: %w", err)
-	}
-	projectDir, err := resolveProjectDirFlag(cwd, projectFlag, flagWasSet(fs, "project"))
-	if err != nil {
-		return team.Team{}, "", err
-	}
-	profile, err := resolveProfileFlag(profileFlag)
+	projectDir, profile, err := resolveAutonomousProjectProfile(projectFlag, profileFlag, fs)
 	if err != nil {
 		return team.Team{}, "", err
 	}
@@ -129,4 +132,20 @@ func readAutonomousTeam(projectFlag, profileFlag string, fs *flag.FlagSet) (team
 		return team.Team{}, "", fmt.Errorf("read team: %w", err)
 	}
 	return t, profile, nil
+}
+
+func resolveAutonomousProjectProfile(projectFlag, profileFlag string, fs *flag.FlagSet) (string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("getwd: %w", err)
+	}
+	projectDir, err := resolveProjectDirFlag(cwd, projectFlag, flagWasSet(fs, "project"))
+	if err != nil {
+		return "", "", err
+	}
+	profile, err := resolveProfileFlag(profileFlag)
+	if err != nil {
+		return "", "", err
+	}
+	return projectDir, profile, nil
 }

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -147,7 +147,7 @@ func runTeamLeadClear(args []string) error {
 		t.Orchestrated = false
 		t.Lead = ""
 		t.LeadMode = ""
-		return team.WriteProfile(projectDir, profile, t)
+		return team.WriteProfileUnderLock(projectDir, profile, t)
 	}); err != nil {
 		return err
 	}
@@ -397,11 +397,7 @@ func runLeadRegister(args []string) error {
 		},
 	}
 	rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
-	if preserveExternalGoalBinding(existingRec, existingRecErr, role, env.SessionName) {
-		gb := *existingRec.GoalBinding
-		rec.GoalBinding = &gb
-	}
-	if err := launch.Write(agentDir, rec); err != nil {
+	if err := writeExternalLeadLaunchRecord(agentDir, rec, role, env.SessionName); err != nil {
 		return fmt.Errorf("write external launch record: %w", err)
 	}
 	if err := setTeamLeadForProfile(projectDir, profile, role, "", false); err != nil {
@@ -414,6 +410,17 @@ func runLeadRegister(args []string) error {
 		fmt.Printf("wake: %s\n", wakeResult.Detail)
 	}
 	return nil
+}
+
+func writeExternalLeadLaunchRecord(agentDir string, rec launch.Record, role, session string) error {
+	return launch.WithRecordLock(agentDir, func() error {
+		current, currentErr := launch.Read(agentDir)
+		if preserveExternalGoalBinding(current, currentErr, role, session) {
+			gb := *current.GoalBinding
+			rec.GoalBinding = &gb
+		}
+		return launch.WriteUnderRecordLock(agentDir, rec)
+	})
 }
 
 func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, viaExplicit, argsExplicit bool, existing launch.Record, existingErr error, role, handle, profile, session, root, paneID string) (wakeInjectConfig, error) {
@@ -764,7 +771,7 @@ func setTeamLeadForProfile(projectDir, profile, role string, leadMode string, le
 		if leadModeSet {
 			t.LeadMode = leadModeForPersist(leadMode)
 		}
-		return team.WriteProfile(projectDir, profile, t)
+		return team.WriteProfileUnderLock(projectDir, profile, t)
 	})
 }
 

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -292,10 +291,10 @@ func runTeamMemberAdd(args []string) error {
 			return err
 		}
 		t.Members = append(t.Members, added)
-		// WriteProfile re-validates the whole team (orchestration, per-member
+		// WriteProfileUnderLock re-validates the whole team (orchestration, per-member
 		// binary-match, duplicate handles) before the atomic rename, so an
 		// invalid add never persists.
-		if err := team.WriteProfile(projectDir, profile, t); err != nil {
+		if err := team.WriteProfileUnderLock(projectDir, profile, t); err != nil {
 			return err
 		}
 		return nil
@@ -446,7 +445,7 @@ func runTeamMemberRemove(args []string) error {
 			return fmt.Errorf("role %q is not a team member", role)
 		}
 		t.Members = kept
-		if err := team.WriteProfile(projectDir, profile, t); err != nil {
+		if err := team.WriteProfileUnderLock(projectDir, profile, t); err != nil {
 			return err
 		}
 		return nil
@@ -530,7 +529,7 @@ func resolveExistingTeamProfile(projectFlag, profileFlag string, projectSet bool
 // concurrent amq-squad processes via an exclusive lock on a sidecar file, so
 // a lead and a worker mutating the roster at once cannot lose an update.
 func withProfileLock(projectDir, profile string, fn func() error) error {
-	return flock.WithLock(team.ProfilePath(projectDir, profile)+".lock", fn)
+	return team.WithProfileLock(projectDir, profile, fn)
 }
 
 // inheritedSession returns the workstream a new member should join: the

--- a/internal/cli/team_member_test.go
+++ b/internal/cli/team_member_test.go
@@ -3,9 +3,38 @@ package cli
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
+
+func TestWithProfileLockUnderLockWriteDoesNotSelfDeadlock(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-447"}},
+	})
+	done := make(chan error, 1)
+	go func() {
+		done <- withProfileLock(dir, team.DefaultProfile, func() error {
+			cfg, err := team.ReadProfile(dir, team.DefaultProfile)
+			if err != nil {
+				return err
+			}
+			cfg.Members = append(cfg.Members, team.Member{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-447"})
+			return team.WriteProfileUnderLock(dir, team.DefaultProfile, cfg)
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CLI profile mutation self-deadlocked by reacquiring the shared team lock")
+	}
+	if got := teamMembers(t, dir); len(got) != 2 || got[1].Role != "qa" {
+		t.Fatalf("serialized profile mutation was not persisted: %+v", got)
+	}
+}
 
 func teamMembers(t *testing.T, dir string) []team.Member {
 	t.Helper()

--- a/internal/cli/team_operator.go
+++ b/internal/cli/team_operator.go
@@ -179,7 +179,7 @@ func mutateOperatorProfile(projectDir, profile string, mutate func(*team.Team) e
 		if err := mutate(&cfg); err != nil {
 			return err
 		}
-		if err := team.WriteProfile(projectDir, profile, cfg); err != nil {
+		if err := team.WriteProfileUnderLock(projectDir, profile, cfg); err != nil {
 			return err
 		}
 		view := cfg.Operator.SelfOperator

--- a/internal/cli/team_overlay.go
+++ b/internal/cli/team_overlay.go
@@ -38,6 +38,11 @@ type claudeSettingsOverlay struct {
 	DisableAllHooks bool            `json:"disableAllHooks,omitempty"`
 }
 
+// teamOverlayAfterRead is a deterministic test seam. It runs while a real
+// overlay mutation holds the profile writer lock, after reading the snapshot
+// that will be validated and written.
+var teamOverlayAfterRead = func() {}
+
 func runTeamOverlay(args []string) error {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fmt.Fprint(os.Stderr, `amq-squad team overlay - per-member Claude settings overlays
@@ -106,16 +111,6 @@ func runTeamOverlayInit(args []string) error {
 	if err != nil {
 		return err
 	}
-	t, err := team.ReadProfile(projectDir, profile)
-	if err != nil {
-		return fmt.Errorf("read team: %w", err)
-	}
-
-	targets, err := overlayTargets(t, *roleFlag, *workers)
-	if err != nil {
-		return err
-	}
-
 	overlay := claudeSettingsOverlay{EnabledPlugins: map[string]bool{}}
 	for _, id := range splitCommaList(*disablePluginsRaw) {
 		overlay.EnabledPlugins[id] = false
@@ -127,61 +122,84 @@ func runTeamOverlayInit(args []string) error {
 	}
 	body = append(body, '\n')
 
-	changed := false
-	for _, idx := range targets {
-		m := &t.Members[idx]
-		path := overlayPath(t.Project, m.Role)
-		rel, err := overlayRelPath(m.EffectiveCWD(t.Project), path)
+	apply := func(t team.Team, writeProfile func(team.Team) error) error {
+		targets, err := overlayTargets(t, *roleFlag, *workers)
 		if err != nil {
-			return fmt.Errorf("member %s: %w", m.Role, err)
+			return err
 		}
+		changed := false
+		for _, idx := range targets {
+			m := &t.Members[idx]
+			path := overlayPath(t.Project, m.Role)
+			rel, err := overlayRelPath(m.EffectiveCWD(t.Project), path)
+			if err != nil {
+				return fmt.Errorf("member %s: %w", m.Role, err)
+			}
 
-		// 1. The overlay file. No-clobber: an existing (possibly user-edited)
-		// overlay is kept unless --force; wiring still proceeds either way.
-		fileAction := "write"
-		if _, statErr := os.Stat(path); statErr == nil && !*force {
-			fileAction = "keep existing"
-		}
-		// 2. The team.json wiring. Runs before the dry-run gate on purpose:
-		// a foreign --settings conflict would block any real run, so the
-		// preview should fail the same way instead of printing a plan that
-		// could never execute.
-		wireAction, newArgs, err := wireSettingsArg(m.ClaudeArgs, rel, *force)
-		if err != nil {
-			return fmt.Errorf("member %s: %w", m.Role, err)
-		}
+			// 1. The overlay file. No-clobber: an existing (possibly user-edited)
+			// overlay is kept unless --force; wiring still proceeds either way.
+			fileAction := "write"
+			if _, statErr := os.Stat(path); statErr == nil && !*force {
+				fileAction = "keep existing"
+			}
+			// 2. The team.json wiring. Runs before the dry-run gate on purpose:
+			// a foreign --settings conflict would block any real run, so the
+			// preview should fail the same way instead of printing a plan that
+			// could never execute.
+			wireAction, newArgs, err := wireSettingsArg(m.ClaudeArgs, rel, *force)
+			if err != nil {
+				return fmt.Errorf("member %s: %w", m.Role, err)
+			}
 
-		fmt.Printf("%s:\n  overlay: %s (%s)\n  claude_args: %s (%s)\n",
-			m.Role, path, fileAction, joinedAgentArgs(newArgs), wireAction)
+			fmt.Printf("%s:\n  overlay: %s (%s)\n  claude_args: %s (%s)\n",
+				m.Role, path, fileAction, joinedAgentArgs(newArgs), wireAction)
+
+			if *dryRun {
+				continue
+			}
+			if fileAction == "write" {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					return fmt.Errorf("create overlays dir: %w", err)
+				}
+				if err := os.WriteFile(path, body, 0o644); err != nil {
+					return fmt.Errorf("write overlay: %w", err)
+				}
+			}
+			if wireAction != "unchanged" {
+				m.ClaudeArgs = newArgs
+				changed = true
+			}
+		}
 
 		if *dryRun {
-			continue
+			fmt.Println("\n(dry run - nothing written)")
+			return nil
 		}
-		if fileAction == "write" {
-			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-				return fmt.Errorf("create overlays dir: %w", err)
-			}
-			if err := os.WriteFile(path, body, 0o644); err != nil {
-				return fmt.Errorf("write overlay: %w", err)
+		if changed {
+			if err := writeProfile(t); err != nil {
+				return fmt.Errorf("write team.json: %w", err)
 			}
 		}
-		if wireAction != "unchanged" {
-			m.ClaudeArgs = newArgs
-			changed = true
-		}
-	}
-
-	if *dryRun {
-		fmt.Println("\n(dry run - nothing written)")
+		fmt.Printf("\nnext: amq-squad up --dry-run   # the wired members launch with --settings\n")
 		return nil
 	}
-	if changed {
-		if err := team.WriteProfile(projectDir, profile, t); err != nil {
-			return fmt.Errorf("write team.json: %w", err)
+	if *dryRun {
+		t, err := team.ReadProfile(projectDir, profile)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
 		}
+		return apply(t, nil)
 	}
-	fmt.Printf("\nnext: amq-squad up --dry-run   # the wired members launch with --settings\n")
-	return nil
+	return team.WithProfileLock(projectDir, profile, func() error {
+		t, err := team.ReadProfile(projectDir, profile)
+		if err != nil {
+			return fmt.Errorf("read team: %w", err)
+		}
+		teamOverlayAfterRead()
+		return apply(t, func(updated team.Team) error {
+			return team.WriteProfileUnderLock(projectDir, profile, updated)
+		})
+	})
 }
 
 // overlayTargets resolves --role/--workers to member indexes. --workers means

--- a/internal/cli/team_overlay_test.go
+++ b/internal/cli/team_overlay_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
@@ -89,6 +90,52 @@ func TestOverlayInitIdempotent(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("re-running overlay init must not duplicate --settings: %v", m.ClaudeArgs)
+	}
+}
+
+func TestOverlayInitSerializesProfileReadModifyWrite(t *testing.T) {
+	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "analyst", Binary: "claude", Handle: "analyst", Session: "s"}}})
+	chdir(t, dir)
+	oldHook := teamOverlayAfterRead
+	writerDone := make(chan error, 1)
+	teamOverlayAfterRead = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- team.WithProfileLock(dir, team.DefaultProfile, func() error {
+				current, err := team.ReadProfile(dir, team.DefaultProfile)
+				if err != nil {
+					return err
+				}
+				current.Members[0].Model = "concurrent-profile-update"
+				return team.WriteProfileUnderLock(dir, team.DefaultProfile, current)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("profile writer interleaved with overlay RMW: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	t.Cleanup(func() { teamOverlayAfterRead = oldHook })
+	if _, _, err := captureOutput(t, func() error { return runTeamOverlay([]string{"init", "--role", "analyst"}) }); err != nil {
+		t.Fatalf("overlay init: %v", err)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent profile writer did not resume")
+	}
+	current, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Members[0].Model != "concurrent-profile-update" || len(current.Members[0].ClaudeArgs) != 2 {
+		t.Fatalf("lost concurrent or overlay update: %+v", current.Members[0])
 	}
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -17,6 +17,7 @@ import (
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
 // resumeAction labels what `team resume` would do for one member.
@@ -64,6 +65,10 @@ type resumePlan struct {
 	// must not reconstruct it from an arbitrary scan order.
 	SavedLaunchIdentity string
 	Saved               *resumeSavedLaunchSummary
+	// RestoreRecord is the exact record chosen by findMemberRestoreRecord.
+	// Session-level goal planning must derive from this record, never from a
+	// second scan whose ordering could select different evidence.
+	RestoreRecord *launch.Record
 }
 
 type resumeSavedLaunchSummary struct {
@@ -209,6 +214,9 @@ type resumeExecution struct {
 	// JSON emits a schema-versioned resume_plan envelope instead of the human
 	// plan. It is a read-only preview, so it is mutually exclusive with Exec.
 	JSON bool
+	// GoalRedelivery enables the top-level resume-only goal plan contract.
+	// team resume and fork share this planner but retain their existing shape.
+	GoalRedelivery bool
 	// Probe abstracts liveness/process inspection for the per-member live-signal
 	// classification (mirrors how statusExecution takes a probe). Defaults to
 	// defaultDuplicateLaunchProbe when unset; tests inject a deterministic probe.
@@ -234,12 +242,18 @@ type resumeExecution struct {
 // needs, which keeps the resume entry point free of preview-flag plumbing
 // that does not apply (no --fresh, no --json envelope).
 type resumeExecOptions struct {
-	Enabled         bool
-	Terminal        string
-	Target          string
-	Layout          string
-	TerminalSession string
-	Stagger         time.Duration
+	Enabled            bool
+	Terminal           string
+	Target             string
+	Layout             string
+	TerminalSession    string
+	Stagger            time.Duration
+	RedeliverGoal      bool
+	RedeliveryExplicit bool
+	PromptGoal         bool
+	PromptIn           io.Reader
+	PromptOut          io.Writer
+	GoalPlan           runwizard.ResumeGoalPlan
 }
 
 type resumeExecLaunchCheck struct {
@@ -261,9 +275,11 @@ type resumeExecLaunchSnapshot struct {
 }
 
 type resumeExecLaunchResult struct {
-	Check  resumeExecLaunchCheck
-	State  string
-	Detail string
+	Check         resumeExecLaunchCheck
+	State         string
+	Detail        string
+	RecordModTime time.Time
+	RecordStarted time.Time
 }
 
 const (
@@ -546,11 +562,30 @@ func executeResume(r resumeExecution) error {
 			return fmt.Errorf("--fresh --session %q: workstream root %s already exists; rerun with --force-duplicate to reuse", workstream, root)
 		}
 	}
+	goalPlan := runwizard.ResumeGoalPlan{}
+	if r.GoalRedelivery {
+		goalPlan = buildResumeGoalPlan(t, r.Profile, workstream, plans, r.Force, r.NoBootstrap)
+	}
+	if r.GoalRedelivery && r.Exec.RedeliveryExplicit && r.Exec.RedeliverGoal && !goalPlan.Eligible {
+		return usageErrorf("--redeliver-goal is unavailable: %s", goalPlan.Reason)
+	}
+	goalPlan.Selected = r.Exec.RedeliverGoal
+	if r.GoalRedelivery && r.Exec.Enabled && !r.Exec.RedeliveryExplicit && r.Exec.PromptGoal && goalPlan.Eligible {
+		approved, err := promptResumeGoalRedelivery(r.Exec.PromptIn, r.Exec.PromptOut, goalPlan)
+		if err != nil {
+			return err
+		}
+		r.Exec.RedeliverGoal = approved
+		goalPlan.Selected = approved
+	}
 
 	if r.JSON {
 		out := r.Out
 		if out == nil {
 			out = os.Stdout
+		}
+		if r.GoalRedelivery {
+			return writeResumeJSONWithGoal(out, t, workstream, r.Mode, r.Profile, namespaceConflict, plans, goalPlan)
 		}
 		return writeResumeJSON(out, t, workstream, r.Mode, r.Profile, namespaceConflict, plans)
 	}
@@ -559,6 +594,7 @@ func executeResume(r resumeExecution) error {
 		if namespaceConflict != nil {
 			return namespaceConflictError("resume --exec", namespaceConflict)
 		}
+		r.Exec.GoalPlan = goalPlan
 		return execResumePlan(t, r.Profile, workstream, plans, r.Exec, r.Force)
 	}
 
@@ -569,6 +605,9 @@ func executeResume(r resumeExecution) error {
 		out = os.Stdout
 	}
 	writeResumePlan(out, t, workstream, r.Mode, plans, r.DryRun, r.Force, style)
+	if r.GoalRedelivery {
+		writeResumeGoalPlan(out, goalPlan)
+	}
 	return nil
 }
 
@@ -719,6 +758,11 @@ func execResumePlan(t team.Team, profile, workstream string, plans []resumePlan,
 		}
 		return err
 	}
+	if exec.RedeliverGoal {
+		if err := deliverResumeGoalAfterLaunch(t, profile, workstream, results, exec.GoalPlan); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -836,17 +880,26 @@ func adoptResumeExecLaunchRecords(results []resumeExecLaunchResult) bool {
 		if !ok {
 			continue
 		}
-		rec, err := launch.Read(r.Check.AgentDir)
-		if err != nil {
-			continue
+		if err := adoptResumeExecLaunchRecord(r.Check, pane); err == nil {
+			adopted = true
 		}
-		rec.Role = r.Check.Role
-		rec.Handle = r.Check.Handle
-		rec.Session = r.Check.Workstream
-		rec.Root = r.Check.Root
-		rec.CWD = r.Check.CWD
-		rec.Binary = r.Check.Binary
-		rec.TeamProfile = r.Check.Profile
+	}
+	return adopted
+}
+
+func adoptResumeExecLaunchRecord(check resumeExecLaunchCheck, pane tmuxpane.TmuxPane) error {
+	return launch.WithRecordLock(check.AgentDir, func() error {
+		rec, err := launch.Read(check.AgentDir)
+		if err != nil {
+			return err
+		}
+		rec.Role = check.Role
+		rec.Handle = check.Handle
+		rec.Session = check.Workstream
+		rec.Root = check.Root
+		rec.CWD = check.CWD
+		rec.Binary = check.Binary
+		rec.TeamProfile = check.Profile
 		rec.StartedAt = time.Now().UTC()
 		rec.Tmux = &launch.TmuxInfo{
 			Session:    pane.Session,
@@ -856,11 +909,8 @@ func adoptResumeExecLaunchRecords(results []resumeExecLaunchResult) bool {
 			Target:     "adopted",
 		}
 		rec.Terminal = launch.TerminalInfoFromTmux(rec.Tmux)
-		if err := launch.Write(r.Check.AgentDir, rec); err == nil {
-			adopted = true
-		}
-	}
-	return adopted
+		return launch.WriteUnderRecordLock(check.AgentDir, rec)
+	})
 }
 
 func resumeExecAdoptionPane(c resumeExecLaunchCheck, panes []tmuxpane.TmuxPane) (tmuxpane.TmuxPane, bool) {
@@ -946,6 +996,10 @@ func inspectResumeExecLaunchRecords(checks []resumeExecLaunchCheck, snapshots ma
 			results = append(results, res)
 			continue
 		}
+		if info, statErr := os.Stat(launch.ExistingPath(c.AgentDir)); statErr == nil {
+			res.RecordModTime = info.ModTime()
+		}
+		res.RecordStarted = rec.StartedAt
 		results = append(results, res)
 	}
 	return results
@@ -1067,6 +1121,8 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	plan.HasRestoreRecord = recFound
 	plan.Handle = handle
 	if recFound {
+		restored := rec
+		plan.RestoreRecord = &restored
 		plan.Tmux = rec.Tmux
 		plan.SavedLaunchIdentity = resumeSavedLaunchIdentity(rec)
 		savedMember := team.Member{Binary: rec.Binary}

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -567,6 +567,9 @@ func executeResume(r resumeExecution) error {
 		goalPlan = buildResumeGoalPlan(t, r.Profile, workstream, plans, r.Force, r.NoBootstrap)
 	}
 	if r.GoalRedelivery && r.Exec.RedeliveryExplicit && r.Exec.RedeliverGoal && !goalPlan.Eligible {
+		if goalPlan.RecoveryCommand != "" {
+			return usageErrorf("--redeliver-goal is unavailable: %s\nRecover the exact attempt %s manually (the command revalidates identity before mutation):\n  %s", goalPlan.Reason, goalPlan.RecoveryAttemptID, goalPlan.RecoveryCommand)
+		}
 		return usageErrorf("--redeliver-goal is unavailable: %s", goalPlan.Reason)
 	}
 	goalPlan.Selected = r.Exec.RedeliverGoal
@@ -595,7 +598,13 @@ func executeResume(r resumeExecution) error {
 			return namespaceConflictError("resume --exec", namespaceConflict)
 		}
 		r.Exec.GoalPlan = goalPlan
-		return execResumePlan(t, r.Profile, workstream, plans, r.Exec, r.Force)
+		// Emit recovery guidance before any launch side effect so --exec retains
+		// the visibility contract even when preflight or backend launch fails.
+		writeResumeNativeGoalBlockedRecoveries(os.Stderr, resumeNativeGoalBlockedRecoveries(plans))
+		if err := execResumePlan(t, r.Profile, workstream, plans, r.Exec, r.Force); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	style := r.Style
@@ -608,6 +617,7 @@ func executeResume(r resumeExecution) error {
 	if r.GoalRedelivery {
 		writeResumeGoalPlan(out, goalPlan)
 	}
+	writeResumeNativeGoalBlockedRecoveries(out, resumeNativeGoalBlockedRecoveries(plans))
 	return nil
 }
 

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 	"github.com/omriariav/amq-squad/v2/internal/team"
@@ -1800,6 +1801,59 @@ func TestRunTeamAutonomousPauseAndDisable(t *testing.T) {
 	tm, _ = team.Read(dir)
 	if tm.Autonomous == nil || !tm.Autonomous.Disabled {
 		t.Fatalf("disable did not persist: %+v", tm.Autonomous)
+	}
+}
+
+func TestRunTeamAutonomousSerializesProfileReadModifyWrite(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if err := runTeamInit([]string{
+		"--roles", "cto,fullstack", "--orchestrated", "--lead", "cto",
+		"--composition", "autonomous", "--max-agents", "4", "--max-total-spawns", "3",
+		"--allowed-roles", "fullstack", "--budget-turns", "20",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldHook := teamAutonomousAfterRead
+	writerDone := make(chan error, 1)
+	teamAutonomousAfterRead = func() {
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			writerDone <- team.WithProfileLock(dir, team.DefaultProfile, func() error {
+				current, err := team.ReadProfile(dir, team.DefaultProfile)
+				if err != nil {
+					return err
+				}
+				current.Members[0].Model = "concurrent-profile-update"
+				return team.WriteProfileUnderLock(dir, team.DefaultProfile, current)
+			})
+		}()
+		<-started
+		select {
+		case err := <-writerDone:
+			t.Fatalf("profile writer interleaved with autonomous RMW: %v", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	t.Cleanup(func() { teamAutonomousAfterRead = oldHook })
+	if err := runTeamAutonomous([]string{"pause"}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent profile writer did not resume")
+	}
+	current, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Autonomous == nil || !current.Autonomous.Paused || current.Members[0].Model != "concurrent-profile-update" {
+		t.Fatalf("lost concurrent or autonomous update: %+v", current)
 	}
 }
 

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/bootstrapack"
+	"github.com/omriariav/amq-squad/v2/internal/flock"
 )
 
 const (
@@ -252,6 +253,24 @@ func HasRecord(agentDir string) bool {
 // The agent mailbox is expected to exist (coop exec creates it), but Write
 // also creates missing parents so the record can be written pre-exec.
 func Write(agentDir string, rec Record) error {
+	return WithRecordLock(agentDir, func() error { return WriteUnderRecordLock(agentDir, rec) })
+}
+
+// RecordLockPath is the shared writer lock for one launch record.
+func RecordLockPath(agentDir string) string { return Path(agentDir) + ".lock" }
+
+// WithRecordLock serializes launch record writers and narrow conditional
+// read/write control-plane operations.
+func WithRecordLock(agentDir string, fn func() error) error {
+	if err := os.MkdirAll(ExtensionDir(agentDir), 0o700); err != nil {
+		return fmt.Errorf("ensure extension dir: %w", err)
+	}
+	return flock.WithLock(RecordLockPath(agentDir), fn)
+}
+
+// WriteUnderRecordLock writes a record while the caller holds WithRecordLock.
+// It is exported only for compound compare-and-write sections.
+func WriteUnderRecordLock(agentDir string, rec Record) error {
 	dir := ExtensionDir(agentDir)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("ensure extension dir: %w", err)

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/operatorauth"
 )
 
@@ -790,6 +791,29 @@ func normalizeEnabledOperator(op OperatorConfig) OperatorConfig {
 // schema field is set to 4 only when permission_allowlist is used; otherwise
 // writes stay on schema 3 for compatibility.
 func WriteProfile(projectDir, profile string, t Team) error {
+	return WithProfileLock(projectDir, profile, func() error {
+		return WriteProfileUnderLock(projectDir, profile, t)
+	})
+}
+
+// ProfileLockPath is the shared writer lock for one team profile.
+func ProfileLockPath(projectDir, profile string) string {
+	return ProfilePath(projectDir, profile) + ".lock"
+}
+
+// WithProfileLock serializes team profile writers and narrow conditional
+// read/write control-plane operations.
+func WithProfileLock(projectDir, profile string, fn func() error) error {
+	path := ProfilePath(projectDir, profile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("ensure %s: %w", filepath.Dir(path), err)
+	}
+	return flock.WithLock(ProfileLockPath(projectDir, profile), fn)
+}
+
+// WriteProfileUnderLock writes a profile while the caller holds
+// WithProfileLock. It is exported only for compound compare-and-write sections.
+func WriteProfileUnderLock(projectDir, profile string, t Team) error {
 	path := ProfilePath(projectDir, profile)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("ensure %s: %w", filepath.Dir(path), err)
@@ -833,6 +857,15 @@ func DeleteProfile(projectDir, profile string) error {
 			return err
 		}
 	}
+	return WithProfileLock(projectDir, profile, func() error {
+		return DeleteProfileUnderLock(projectDir, profile)
+	})
+}
+
+// DeleteProfileUnderLock removes a profile while the caller holds
+// WithProfileLock. The adjacent lock file intentionally remains as durable
+// serialization state for later recreation of the same named profile.
+func DeleteProfileUnderLock(projectDir, profile string) error {
 	path := ProfilePath(projectDir, profile)
 	if err := os.Remove(path); err != nil {
 		return err

--- a/internal/wizard/bubbletea.go
+++ b/internal/wizard/bubbletea.go
@@ -53,6 +53,7 @@ const (
 	stageGoal
 	stageSeed
 	stageResumeBrief
+	stageResumeGoal
 	stageConfirm
 )
 
@@ -392,6 +393,8 @@ func (m BubbleModel) title() string {
 		return "Optional brief source"
 	case stageResumeBrief:
 		return "Brief preserved for resume"
+	case stageResumeGoal:
+		return "Recorded lead goal"
 	case stageConfirm:
 		return "Review answers before canonical preview"
 	default:
@@ -503,6 +506,11 @@ func (m BubbleModel) note() string {
 		return "Accepted forms: file:path · issue:393 · gh:owner/repo#393"
 	case stageResumeBrief:
 		return fmt.Sprintf("Resume keeps the existing brief unchanged. Path=%s · goal excerpt=%s · seed=%s", displayValue(m.spec.BriefPath), GoalExcerpt(m.spec.BriefGoal), displayValue(m.spec.BriefSeed))
+	case stageResumeGoal:
+		if m.spec.ResumeGoalPlan.Eligible {
+			return "Default is No. Yes creates one new claim-once attempt only after the restored lead and original binding/claim evidence are revalidated. Goal: " + GoalExcerpt(m.spec.ResumeGoalPlan.Goal)
+		}
+		return fmt.Sprintf("Redelivery is %s: %s", defaultString(m.spec.ResumeGoalPlan.Action, "unavailable"), m.spec.ResumeGoalPlan.Reason)
 	}
 	return ""
 }
@@ -560,6 +568,7 @@ func (m BubbleModel) summary() string {
 	}
 	if m.spec.Backend == BackendResume {
 		parts = append(parts, fmt.Sprintf("Records   %d · restore-existing=%t", m.spec.RecordCount, m.spec.RecordCount > 0))
+		parts = append(parts, fmt.Sprintf("Goal plan %s · eligible=%t · selected=%t", defaultString(m.spec.ResumeGoalPlan.Action, "unavailable"), m.spec.ResumeGoalPlan.Eligible, m.spec.RedeliverGoal))
 		for _, member := range m.spec.ResumeMembers {
 			value := fmt.Sprintf("  %-10s %s · model=%s · effort=%s", member.Role, member.Action, defaultString(member.Model, "automatic"), defaultString(member.Effort, "automatic"))
 			if member.Action == MemberActionRestore {
@@ -763,6 +772,11 @@ func (m BubbleModel) choices() []choice {
 		return []choice{{value: "preview", label: "Run canonical preview, then decide launch separately"}}
 	case stageResumeBrief:
 		return []choice{{value: "continue", label: "Continue with the preserved brief"}}
+	case stageResumeGoal:
+		if m.spec.ResumeGoalPlan.Eligible {
+			return []choice{{value: "no", label: "No · preserve binding only"}, {value: "yes", label: "Yes · redeliver as one new claim-once attempt"}}
+		}
+		return []choice{{value: "continue", label: fmt.Sprintf("Continue · %s", defaultString(m.spec.ResumeGoalPlan.Action, "unavailable"))}}
 	default:
 		return nil
 	}
@@ -839,6 +853,14 @@ func (m BubbleModel) defaultCursor() int {
 		want = defaultLayoutPreset(m.spec.LayoutPreset, m.spec.Visibility)
 	case stageLauncherPane:
 		want = defaultLauncherPane(m.spec.LauncherPane, m.spec.Visibility, m.spec.ExternalLead)
+	case stageResumeGoal:
+		if m.spec.RedeliverGoal {
+			want = "yes"
+		} else if m.spec.ResumeGoalPlan.Eligible {
+			want = "no"
+		} else {
+			want = "continue"
+		}
 	}
 	for i, item := range choices {
 		if item.value == want {
@@ -1226,6 +1248,14 @@ func (m BubbleModel) commitChoice() (tea.Model, tea.Cmd) {
 		m.spec.LauncherPane = selected
 		m.transition(stageGoal)
 	case stageResumeBrief:
+		if m.spec.ResumeGoalPlan.Eligible {
+			m.transition(stageResumeGoal)
+		} else {
+			m.spec.RedeliverGoal = false
+			m.transition(stageConfirm)
+		}
+	case stageResumeGoal:
+		m.spec.RedeliverGoal = m.spec.ResumeGoalPlan.Eligible && selected == "yes"
 		m.transition(stageConfirm)
 	case stageConfirm:
 		m.done = true
@@ -1419,7 +1449,7 @@ func (m BubbleModel) phaseIndex() int {
 		return 2
 	case stageTopology, stageLayoutPreset, stageOperator, stageSelfOperatorAllow, stageOperatorNotifications, stageLauncherPane:
 		return 3
-	case stageGoal, stageSeed, stageResumeBrief:
+	case stageGoal, stageSeed, stageResumeBrief, stageResumeGoal:
 		return 4
 	default:
 		return 5

--- a/internal/wizard/bubbletea_test.go
+++ b/internal/wizard/bubbletea_test.go
@@ -353,6 +353,31 @@ func TestBubbleResumeUsesAgreedSavedPlacementAndShowsPreservedReviewEvidence(t *
 	}
 }
 
+func TestBubbleResumeGoalDefaultsNoAndRendersSafeEvidence(t *testing.T) {
+	m := BubbleModel{stage: stageResumeGoal, spec: Spec{Backend: BackendResume, ResumeGoalPlan: ResumeGoalPlan{Eligible: true, Action: "redeliver", Goal: "safe\x1b[31mRED\x1b[0m\x00"}}}
+	choices := m.choices()
+	if len(choices) != 2 || choices[0].value != "no" || m.cursor != 0 {
+		t.Fatalf("resume goal default choices=%+v cursor=%d", choices, m.cursor)
+	}
+	if guidance := m.note(); strings.ContainsRune(guidance, '\x1b') || strings.ContainsRune(guidance, '\x00') || strings.Contains(guidance, "[31m") {
+		t.Fatalf("unsafe guidance: %q", guidance)
+	}
+	m = updateBubble(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.spec.RedeliverGoal || m.stage != stageConfirm {
+		t.Fatalf("default No not preserved: stage=%v spec=%+v", m.stage, m.spec)
+	}
+	yes := BubbleModel{stage: stageResumeGoal, cursor: 1, spec: Spec{Backend: BackendResume, ResumeGoalPlan: ResumeGoalPlan{Eligible: true, Action: "redeliver", Goal: "safe"}}}
+	yes = updateBubble(t, yes, tea.KeyMsg{Type: tea.KeyEnter})
+	if !yes.spec.RedeliverGoal || yes.stage != stageConfirm {
+		t.Fatalf("explicit Yes not preserved: stage=%v spec=%+v", yes.stage, yes.spec)
+	}
+	blocked := BubbleModel{stage: stageResumeBrief, spec: Spec{Backend: BackendResume, ResumeGoalPlan: ResumeGoalPlan{Eligible: false, Action: "blocked", Reason: "claim missing"}}}
+	blocked = updateBubble(t, blocked, tea.KeyMsg{Type: tea.KeyEnter})
+	if blocked.stage != stageConfirm || blocked.spec.RedeliverGoal {
+		t.Fatalf("ineligible goal did not bypass choice: stage=%v spec=%+v", blocked.stage, blocked.spec)
+	}
+}
+
 func TestBubblePhaseRailsAreScopeSpecific(t *testing.T) {
 	project := BubbleModel{spec: Spec{Scope: "project"}}
 	if got, want := strings.Join(project.phaseLabels(), "|"), "Scope|Profile & run|Team|Run controls|Brief|Review"; got != want {

--- a/internal/wizard/discovery.go
+++ b/internal/wizard/discovery.go
@@ -156,6 +156,8 @@ type ResumeGoalPlan struct {
 	TransitionID         string `json:"transition_id"`
 	TransitionState      string `json:"transition_state"`
 	TransitionDigest     string `json:"transition_digest"`
+	RecoveryAttemptID    string `json:"recovery_attempt_id,omitempty"`
+	RecoveryCommand      string `json:"recovery_command,omitempty"`
 	EvidenceDigest       string `json:"evidence_digest"`
 }
 

--- a/internal/wizard/discovery.go
+++ b/internal/wizard/discovery.go
@@ -127,6 +127,38 @@ type DiscoveryMemberPlan struct {
 	Blocker             string       `json:"blocker"`
 }
 
+// ResumeGoalPlan is the read-only, session-level evidence used to decide
+// whether a freshly re-oriented lead may receive a new claim-once goal
+// attempt. Every field is scalar and byte-stable so CLI, JSON, and both
+// wizard adapters share the same facts without reconstructing the binding.
+type ResumeGoalPlan struct {
+	SchemaVersion        int    `json:"schema_version"`
+	Action               string `json:"action"`
+	Eligible             bool   `json:"eligible"`
+	Selected             bool   `json:"selected"`
+	Reason               string `json:"reason"`
+	LeadRole             string `json:"lead_role"`
+	LeadHandle           string `json:"lead_handle"`
+	LeadResumeAction     string `json:"lead_resume_action"`
+	SavedConversation    bool   `json:"saved_conversation"`
+	Goal                 string `json:"goal"`
+	BindingMode          string `json:"binding_mode"`
+	BindingNative        bool   `json:"binding_native"`
+	BindingSource        string `json:"binding_source"`
+	BindingDigest        string `json:"binding_digest"`
+	BindingCommandDigest string `json:"binding_command_digest"`
+	OriginalAttemptID    string `json:"original_attempt_id"`
+	AttemptState         string `json:"attempt_state"`
+	AttemptDigest        string `json:"attempt_digest"`
+	ClaimState           string `json:"claim_state"`
+	ClaimRoute           string `json:"claim_route"`
+	ClaimDigest          string `json:"claim_digest"`
+	TransitionID         string `json:"transition_id"`
+	TransitionState      string `json:"transition_state"`
+	TransitionDigest     string `json:"transition_digest"`
+	EvidenceDigest       string `json:"evidence_digest"`
+}
+
 // DiscoveryNamespaceFact is one independently mutable input to namespace
 // conflict detection. Result strings alone are insufficient: adding durable
 // state or changing a profile pin must invalidate a reviewed fingerprint even
@@ -157,10 +189,13 @@ type DiscoveryFingerprintInput struct {
 	RecordIDs               []string                 `json:"record_ids"`
 	RecordCount             int                      `json:"record_count"`
 	MemberPlans             []DiscoveryMemberPlan    `json:"member_plans"`
+	GoalPlan                ResumeGoalPlan           `json:"goal_plan"`
 }
 
 func DiscoveryFingerprint(input DiscoveryFingerprintInput) string {
 	canonical := input
+	// Selected is downstream operator intent, never authoritative discovery.
+	canonical.GoalPlan.Selected = false
 	canonical.NamespaceConflicts = sortedCopy(input.NamespaceConflicts)
 	canonical.NamespaceFacts = canonicalNamespaceFacts(input.NamespaceFacts)
 	canonical.RecordIDs = sortedCopy(input.RecordIDs)

--- a/internal/wizard/numbered.go
+++ b/internal/wizard/numbered.go
@@ -378,6 +378,24 @@ func RunNumbered(in io.Reader, out io.Writer, opts NumberedOptions) (Spec, error
 		s.SeedFrom = ""
 		fmt.Fprintln(out, "This wizard pane stays open; resume only opens missing agent panes.")
 		fmt.Fprintf(out, "Brief preserved for resume: path=%s\ngoal excerpt:\n%s\nseed source=%s\n", displayValue(s.BriefPath), GoalExcerpt(s.BriefGoal), displayValue(s.BriefSeed))
+		if s.ResumeGoalPlan.Eligible {
+			fmt.Fprintf(out, "Recorded goal evidence (bounded):\n%s\n", GoalExcerpt(s.ResumeGoalPlan.Goal))
+			defaultChoice := "no"
+			if s.RedeliverGoal {
+				defaultChoice = "yes"
+			}
+			choice, choiceErr := promptChoice(r, out, "Re-deliver the recorded lead goal after verified re-orientation?", []choice{
+				{value: "no", label: "No · keep the restored binding without creating a new attempt"},
+				{value: "yes", label: "Yes · create one new claim-once attempt after launch verification"},
+			}, defaultChoice)
+			if choiceErr != nil {
+				return Spec{}, choiceErr
+			}
+			s.RedeliverGoal = choice == "yes"
+		} else {
+			s.RedeliverGoal = false
+			fmt.Fprintf(out, "Recorded goal redelivery: %s · %s\n", defaultString(s.ResumeGoalPlan.Action, "unavailable"), s.ResumeGoalPlan.Reason)
+		}
 	} else {
 		if s.LauncherPane, err = promptChoice(r, out, "Launcher pane", launcherPaneChoices(s.Visibility, s.ExternalLead), defaultLauncherPane(s.LauncherPane, s.Visibility, s.ExternalLead)); err != nil {
 			return Spec{}, err

--- a/internal/wizard/numbered_test.go
+++ b/internal/wizard/numbered_test.go
@@ -356,10 +356,10 @@ func TestRunNumberedExistingProfileWithoutCLIDiscoveryFailsClosed(t *testing.T) 
 func TestRunNumberedMultipleSessionsUseKnownRunListAndComposeResume(t *testing.T) {
 	profile := ProfileSummary{Name: "release", MemberCount: 2, Members: []MemberSummary{{Role: "cto", Binary: "codex"}, {Role: "qa", Binary: "codex"}}, Sessions: []SessionSummary{
 		{Name: "run-a", Source: SessionSourceLaunchHistory, Classification: RunClassification{State: RunStateNotStarted, Backend: BackendRunStart, Executable: true}, Fresh: 2},
-		{Name: "run-b", Source: SessionSourceLaunchHistory, Fingerprint: "run-b-fp", RecordCount: 2, BriefPath: "/repo/.amq-squad/briefs/release/run-b.md", BriefGoal: "First goal line\nSecond goal line", BriefSeed: "gh:owner/repo#431", Members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}, Classification: RunClassification{State: RunStateStopped, Backend: BackendResume, Executable: true, RestoreExisting: true}, Restore: 2},
+		{Name: "run-b", Source: SessionSourceLaunchHistory, Fingerprint: "run-b-fp", RecordCount: 2, BriefPath: "/repo/.amq-squad/briefs/release/run-b.md", BriefGoal: "First goal line\nSecond goal line", BriefSeed: "gh:owner/repo#431", GoalPlan: ResumeGoalPlan{Eligible: true, Action: "redeliver", Goal: "recorded\x1b[31m goal\x1b[0m\x00"}, Members: []SessionMemberSummary{{Role: "cto", Binary: "codex", Action: MemberActionRestore}, {Role: "qa", Binary: "codex", Action: MemberActionRestore}}, Classification: RunClassification{State: RunStateStopped, Backend: BackendResume, Executable: true, RestoreExisting: true}, Restore: 2},
 	}}
 	var out bytes.Buffer
-	got, err := RunNumbered(strings.NewReader("\n\n\n2\n\n\n"), &out, NumberedOptions{
+	got, err := RunNumbered(strings.NewReader("\n\n\n2\n\n\n\n"), &out, NumberedOptions{
 		Defaults: Spec{Project: "/repo", Profile: "release"},
 		InspectProject: func(string) (ProjectContext, error) {
 			return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
@@ -371,10 +371,34 @@ func TestRunNumberedMultipleSessionsUseKnownRunListAndComposeResume(t *testing.T
 	if got.Session != "run-b" || got.Backend != BackendResume || got.RunState != RunStateStopped || got.DiscoveryFingerprint != "run-b-fp" {
 		t.Fatalf("known-session selection = %+v", got)
 	}
-	for _, want := range []string{"Which existing run do you want?", "run-a · launch_history · not started", "run-b · launch_history · stopped", "restores saved launch", "Brief preserved for resume", "/repo/.amq-squad/briefs/release/run-b.md", "First goal line\nSecond goal line", "gh:owner/repo#431", "Preview command:", "Live command:", "--exec"} {
+	for _, want := range []string{"Which existing run do you want?", "run-a · launch_history · not started", "run-b · launch_history · stopped", "restores saved launch", "Brief preserved for resume", "/repo/.amq-squad/briefs/release/run-b.md", "First goal line\nSecond goal line", "gh:owner/repo#431", "Recorded goal evidence", "recorded goal", "--no-redeliver-goal-prompt", "Preview command:", "Live command:", "--exec"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}
+	}
+	if got.RedeliverGoal || strings.ContainsRune(out.String(), '\x1b') || strings.ContainsRune(out.String(), '\x00') || strings.Contains(out.String(), "[31m") {
+		t.Fatalf("numbered default No/control safety failed: spec=%+v output=%q", got, out.String())
+	}
+	var yesOut bytes.Buffer
+	yes, err := RunNumbered(strings.NewReader("\n\n\n2\n\n\n2\n"), &yesOut, NumberedOptions{Defaults: Spec{Project: "/repo", Profile: "release"}, InspectProject: func(string) (ProjectContext, error) {
+		return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{profile}}, nil
+	}})
+	if err != nil || !yes.RedeliverGoal {
+		t.Fatalf("numbered explicit Yes: spec=%+v err=%v output=%q", yes, err, yesOut.String())
+	}
+	args, err := yes.ResumeArgs()
+	if err != nil || strings.Count(strings.Join(args, " "), "--redeliver-goal") != 1 {
+		t.Fatalf("numbered Yes canonical args=%v err=%v", args, err)
+	}
+	blockedProfile := profile
+	blockedProfile.Sessions = append([]SessionSummary(nil), profile.Sessions...)
+	blockedProfile.Sessions[1].GoalPlan = ResumeGoalPlan{Eligible: false, Action: "blocked", Reason: "claim missing"}
+	var blockedOut bytes.Buffer
+	blocked, err := RunNumbered(strings.NewReader("\n\n\n2\n\n\n"), &blockedOut, NumberedOptions{Defaults: Spec{Project: "/repo", Profile: "release"}, InspectProject: func(string) (ProjectContext, error) {
+		return ProjectContext{Project: "/repo", Profiles: []ProfileSummary{blockedProfile}}, nil
+	}})
+	if err != nil || blocked.RedeliverGoal || strings.Contains(blockedOut.String(), "Re-deliver the recorded") || !strings.Contains(blockedOut.String(), "claim missing") {
+		t.Fatalf("numbered unavailable path: spec=%+v err=%v output=%q", blocked, err, blockedOut.String())
 	}
 }
 

--- a/internal/wizard/profile_flow.go
+++ b/internal/wizard/profile_flow.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 const maxSavedNativeArgsDisplay = 240
@@ -43,6 +45,7 @@ type SessionSummary struct {
 	Restore        int
 	Fresh          int
 	Blocked        int
+	GoalPlan       ResumeGoalPlan
 }
 
 // SessionMemberSummary is the action-scoped member plan retained by the
@@ -138,6 +141,8 @@ func (s *Spec) SelectExistingSession(session SessionSummary) {
 	s.RestoreExisting = session.RecordCount > 0
 	s.DiscoveryFingerprint = session.Fingerprint
 	s.ResumeMembers = cloneSessionMembers(session.Members)
+	s.ResumeGoalPlan = session.GoalPlan
+	s.ResumeGoalPlan.Selected = false
 	s.BriefPath = session.BriefPath
 	s.BriefGoal = session.BriefGoal
 	s.BriefSeed = session.BriefSeed
@@ -153,6 +158,8 @@ func (s *Spec) SelectExistingSession(session SessionSummary) {
 		s.RestoreExisting = session.RecordCount > 0
 		s.DiscoveryFingerprint = session.Fingerprint
 		s.ResumeMembers = cloneSessionMembers(session.Members)
+		s.ResumeGoalPlan = session.GoalPlan
+		s.ResumeGoalPlan.Selected = false
 		s.BriefPath = session.BriefPath
 		s.BriefGoal = session.BriefGoal
 		s.BriefSeed = session.BriefSeed
@@ -189,6 +196,7 @@ func (s *Spec) SelectNewSession(session string) {
 	s.RecordCount = 0
 	s.DiscoveryFingerprint = ""
 	s.ResumeMembers = nil
+	s.ResumeGoalPlan = ResumeGoalPlan{}
 	s.BriefPath = ""
 	s.BriefGoal = ""
 	s.BriefSeed = ""
@@ -240,6 +248,7 @@ func ResumeDefaultVisibility(members []SessionMemberSummary) string {
 
 // GoalExcerpt returns at most two lines and 160 runes including the ellipsis.
 func GoalExcerpt(goal string) string {
+	goal = stripGoalTerminalControls(goal)
 	goal = strings.ReplaceAll(goal, "\r\n", "\n")
 	goal = strings.ReplaceAll(goal, "\r", "\n")
 	lines := strings.Split(goal, "\n")
@@ -265,6 +274,48 @@ func GoalExcerpt(goal string) string {
 	return value
 }
 
+func stripGoalTerminalControls(value string) string {
+	var b strings.Builder
+	for i := 0; i < len(value); {
+		if value[i] == 0x1b {
+			i++
+			if i < len(value) && value[i] == '[' { // CSI
+				i++
+				for i < len(value) {
+					c := value[i]
+					i++
+					if c >= 0x40 && c <= 0x7e {
+						break
+					}
+				}
+			} else if i < len(value) && value[i] == ']' { // OSC
+				i++
+				for i < len(value) {
+					if value[i] == 0x07 {
+						i++
+						break
+					}
+					if value[i] == 0x1b && i+1 < len(value) && value[i+1] == '\\' {
+						i += 2
+						break
+					}
+					i++
+				}
+			}
+			continue
+		}
+		r, size := rune(value[i]), 1
+		if value[i] >= utf8.RuneSelf {
+			r, size = utf8.DecodeRuneInString(value[i:])
+		}
+		i += size
+		if r == '\n' || r == '\r' || r == '\t' || !unicode.IsControl(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
 func (s *Spec) clearSelectedRun() {
 	s.clearAuthoritativeRunAnswers()
 	s.clearDownstreamRunAnswers()
@@ -280,6 +331,7 @@ func (s *Spec) clearAuthoritativeRunAnswers() {
 	s.RecordCount = 0
 	s.DiscoveryFingerprint = ""
 	s.ResumeMembers = nil
+	s.ResumeGoalPlan = ResumeGoalPlan{}
 	s.BriefPath = ""
 	s.BriefGoal = ""
 	s.BriefSeed = ""
@@ -311,6 +363,7 @@ func (s *Spec) clearDownstreamRunAnswers() {
 	s.ExternalLead = false
 	s.Goal = ""
 	s.SeedFrom = ""
+	s.RedeliverGoal = false
 }
 
 // InvalidateExistingRun returns the answer model to Profile & run after an

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -218,6 +218,9 @@ func (s Spec) ResumeArgs() ([]string, error) {
 			if reason == "" {
 				reason = "eligibility evidence is missing"
 			}
+			if recovery := strings.TrimSpace(s.ResumeGoalPlan.RecoveryCommand); recovery != "" {
+				return nil, fmt.Errorf("resume goal redelivery is unavailable: %s; recover exact attempt %s manually: %s", reason, s.ResumeGoalPlan.RecoveryAttemptID, recovery)
+			}
 			return nil, fmt.Errorf("resume goal redelivery is unavailable: %s", reason)
 		}
 		args = append(args, "--redeliver-goal")

--- a/internal/wizard/spec.go
+++ b/internal/wizard/spec.go
@@ -84,6 +84,8 @@ type Spec struct {
 	RecordCount                    int
 	DiscoveryFingerprint           string
 	ResumeMembers                  []SessionMemberSummary
+	ResumeGoalPlan                 ResumeGoalPlan
+	RedeliverGoal                  bool
 	BriefPath                      string
 	BriefGoal                      string
 	BriefSeed                      string
@@ -210,6 +212,21 @@ func (s Spec) ResumeArgs() ([]string, error) {
 	}
 	appendValue("--target", target)
 	appendValue("--layout", layout)
+	if s.RedeliverGoal {
+		if !s.ResumeGoalPlan.Eligible {
+			reason := strings.TrimSpace(s.ResumeGoalPlan.Reason)
+			if reason == "" {
+				reason = "eligibility evidence is missing"
+			}
+			return nil, fmt.Errorf("resume goal redelivery is unavailable: %s", reason)
+		}
+		args = append(args, "--redeliver-goal")
+	} else if s.ResumeGoalPlan.Eligible {
+		// Preserve the wizard's explicit default-No choice when the same args are
+		// later executed in a TTY; direct resume without this internal flag keeps
+		// its normal default-No prompt.
+		args = append(args, "--no-redeliver-goal-prompt")
+	}
 	return args, nil
 }
 

--- a/internal/wizard/spec_test.go
+++ b/internal/wizard/spec_test.go
@@ -187,3 +187,76 @@ func TestResumeArgsRejectsSemanticLeakage(t *testing.T) {
 		})
 	}
 }
+
+func TestResumeArgsEmitsOnlyRedeliverGoalIntent(t *testing.T) {
+	s := Spec{
+		Backend: BackendResume, Project: "/repo", Profile: "release", ProfileBranch: ProfileBranchExisting,
+		Session: "s", RunExecutable: true, RunState: RunStateStopped, RecordCount: 1, RestoreExisting: true,
+		DiscoveryFingerprint: "fp", ResumeMembers: []SessionMemberSummary{{Role: "cto", Action: MemberActionRestore}},
+		Visibility: "sibling-tabs", LayoutPreset: "one-window-per-agent",
+		ResumeGoalPlan: ResumeGoalPlan{SchemaVersion: 1, Eligible: true, Goal: "secret goal text"}, RedeliverGoal: true,
+	}
+	args, err := s.ResumeArgs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(args, " "); !strings.Contains(got, "--redeliver-goal") || strings.Contains(got, s.ResumeGoalPlan.Goal) {
+		t.Fatalf("resume args leaked or omitted goal intent: %q", got)
+	}
+	s.ResumeGoalPlan.Eligible = false
+	s.ResumeGoalPlan.Reason = "claim missing"
+	if _, err := s.ResumeArgs(); err == nil || !strings.Contains(err.Error(), "claim missing") {
+		t.Fatalf("ineligible selected redelivery accepted: %v", err)
+	}
+}
+
+func TestResumeArgsPreservesEligibleNoWithoutGoalText(t *testing.T) {
+	s := Spec{Backend: BackendResume, Project: "/repo", Profile: "default", ProfileBranch: ProfileBranchExisting, Session: "s", RunExecutable: true, RunState: RunStateStopped, RecordCount: 1, RestoreExisting: true, DiscoveryFingerprint: "fp", ResumeMembers: []SessionMemberSummary{{Role: "cto", Action: MemberActionRestore}}, Visibility: "sibling-tabs", LayoutPreset: "one-window-per-agent", ResumeGoalPlan: ResumeGoalPlan{SchemaVersion: 1, Eligible: true, Goal: "secret\n\x1b[31mgoal"}}
+	args, err := s.ResumeArgs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--no-redeliver-goal-prompt") || strings.Contains(joined, "secret") || strings.Contains(joined, "--redeliver-goal") {
+		t.Fatalf("eligible No args=%#v", args)
+	}
+	preview, live, err := s.CommandForms()
+	if err != nil || strings.Count(preview, "--no-redeliver-goal-prompt") != 1 || strings.Count(live, "--no-redeliver-goal-prompt") != 1 || strings.Count(live, "--exec") != 1 {
+		t.Fatalf("forms preview=%q live=%q err=%v", preview, live, err)
+	}
+}
+
+func TestDiscoveryFingerprintIgnoresGoalSelectionButTracksEvidence(t *testing.T) {
+	base := DiscoveryFingerprintInput{Profile: "default", Session: "s", GoalPlan: ResumeGoalPlan{SchemaVersion: 1, Action: "redeliver", Eligible: true, BindingDigest: "sha256:a", AttemptDigest: "sha256:b", ClaimDigest: "sha256:c", TransitionState: "absent"}}
+	want := DiscoveryFingerprint(base)
+	selected := base
+	selected.GoalPlan.Selected = true
+	if got := DiscoveryFingerprint(selected); got != want {
+		t.Fatalf("downstream Selected changed discovery fingerprint: %s != %s", got, want)
+	}
+	mutated := base
+	mutated.GoalPlan.ClaimDigest = "sha256:changed"
+	if got := DiscoveryFingerprint(mutated); got == want {
+		t.Fatal("raw goal evidence mutation did not invalidate fingerprint")
+	}
+}
+
+func TestGoalExcerptStripsTerminalControlsAndBounds(t *testing.T) {
+	got := GoalExcerpt("safe\x1b[31mRED\x1b[0m\x00\nsecond\nthird" + strings.Repeat("x", 300))
+	if strings.ContainsRune(got, '\x1b') || strings.ContainsRune(got, '\x00') || strings.Contains(got, "[31m") || len([]rune(got)) > maxGoalExcerptRunes || strings.Count(got, "\n") > 1 {
+		t.Fatalf("unsafe/unbounded excerpt: %q", got)
+	}
+}
+
+func TestResumeGoalChoiceIsDownstreamAndClearedOnInvalidation(t *testing.T) {
+	s := Spec{RedeliverGoal: true}
+	s.SelectExistingSession(SessionSummary{Name: "s", Fingerprint: "fp", Classification: RunClassification{Backend: BackendResume, Executable: true}, GoalPlan: ResumeGoalPlan{Eligible: true, Selected: true, BindingDigest: "sha256:evidence"}})
+	if s.ResumeGoalPlan.Selected || s.RedeliverGoal {
+		t.Fatalf("authoritative session imported downstream intent: %+v", s)
+	}
+	s.RedeliverGoal = true
+	s.InvalidateExistingRun()
+	if s.RedeliverGoal || s.ResumeGoalPlan != (ResumeGoalPlan{}) {
+		t.Fatalf("stale goal choice survived invalidation: %+v", s)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #447.

This completes the resume-goal redelivery hardening for verified fresh resumes while keeping goal activation claim-once and fail closed.

- Exposes `native_goal_blocked` recovery guidance in resume plan, exec output, and JSON for every affected member in mixed rosters.
- Makes ordinary goal delivery reserve its binding from a fresh current identity and preserves concurrent launch-record fields during the post-send merge.
- Makes team overlay and autonomous profile mutations use a single read/modify/write profile lock.
- Adds actionable recovery for reserved and consumed redelivery transitions: continuation reuses the exact reserved new attempt; consumed transitions use one explicit retry attempt; mismatched identity, adopted targets, and changed generations refuse safely.
- Validates saved `TeamHome` and rejects adopted tmux targets in the resume planner.

## Delivery safety and locking

Profile and launch-record identity locks are intentionally narrow. They cover only fresh identity/generation validation, attempt/binding reservation or merge, final transition validation, and conditional post-send record updates. Pane discovery, tmux send/settle, AMQ fallback, receipt persistence, and output run after those locks are released.

The per-role delivery lock still serializes the durable claim-once attempt. After successful external delivery, the implementation reacquires identity locks and either merges only the expected binding detail from a fresh record or refuses explicitly when team generation, member identity, or the exact binding changed. Retry-attempt revalidates after send and reports a typed no-retry stale-identity result rather than creating another attempt.

## Validation

- Focused resume/goal/wizard coverage passes.
- Race coverage passes for ordinary delivery, transition continuation, retry attempt, and profile/launch writers.
- Deterministic blocked-send barriers prove that profile and launch writers complete while send is blocked: independent launch updates survive conditional merge, while profile-generation changes are refused without overwrite.
- `gofmt` and `git diff --check` are clean.

## Known baseline limitation

`go test ./...` and `make ci` retain the known #449 AMQ-root compatibility failures in start/launch tests. They fail because the test environment cannot determine the AMQ root (`no .amqrc found, no .agent-mail/ directory, AM_ROOT not set`). The same failure signature was reproduced in the exact `923eefcd591f15db6b3efa765e3d443cb34ccde8` baseline; no #449 implementation is included in this PR.
