### PR TITLE
fix: make AMQ compatibility checks hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,40 @@ jobs:
 
       - name: Run make ci
         run: make ci
+
+  real-amq-compatibility:
+    name: real AMQ compatibility (${{ matrix.amq-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        amq-version: [v0.42.1, latest]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install requested AMQ
+        shell: bash
+        run: |
+          set -euo pipefail
+          export GOBIN="$RUNNER_TEMP/amq-bin"
+          mkdir -p "$GOBIN"
+          go install github.com/avivsinai/agent-message-queue/cmd/amq@${{ matrix.amq-version }}
+          "$GOBIN/amq" version
+
+      - name: Run focused real-AMQ compatibility lane
+        shell: bash
+        env:
+          AMQ_SQUAD_REAL_AMQ: ${{ runner.temp }}/amq-bin/amq
+          AMQ_SQUAD_REAL_AMQ_VERSION: ${{ matrix.amq-version }}
+          AMQ_NO_UPDATE_CHECK: "1"
+        run: |
+          set -euo pipefail
+          "$AMQ_SQUAD_REAL_AMQ" version
+          go test ./internal/cli -run '^TestRealAMQCompatibility$' -count=1 -v -timeout=10m

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,24 @@ session state does **not** need to be migrated.
 
 This guide covers everything you have to change.
 
+## What's new in 2.20.0: AMQ 0.42.1 identity pins
+
+amq-squad 2.20.0 requires **amq 0.42.1+**. This is the first supported AMQ
+release for the complete injected identity contract. Upgrade AMQ, then stop
+and resume/relaunch every agent so its parent shell is rebuilt; a child command
+cannot repair stale inherited variables.
+
+- Default-profile sessions use `AM_ROOT=AM_BASE_ROOT/AM_SESSION`, a non-empty
+  `AM_SESSION`, and `AM_ME`.
+- Named-profile sessions use their exact root with `AM_ROOT=AM_BASE_ROOT` and
+  omit `AM_SESSION` entirely.
+
+Run `amq-squad doctor` before `resume --exec` or `agent resume`. If it reports
+a legacy or inconsistent AMQ identity pin, stop and relaunch instead of relying
+on a bare child command. Until then, use the explicitly scoped
+`amq-squad amq ... --project ... --profile ... --session ...` wrapper for
+control-plane operations.
+
 ## What's new in 2.1.0 (additive; nothing to migrate)
 
 2.1.0 ("orchestrator dogfood hardening") only adds commands and fixes — it

--- a/README.html
+++ b/README.html
@@ -1075,7 +1075,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.42.0+ on <code>PATH</code></li>
+<li><code>amq</code> 0.42.1+ on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>
@@ -1085,5 +1085,15 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
+<p>AMQ 0.42.1 is the first supported release for the complete injected
+identity contract. After upgrading from an older AMQ, stop and
+resume/relaunch agents so their shells receive a coherent pin; a child
+command cannot repair stale parent environment variables.
+Default-profile sessions use <code>AM_ROOT</code>,
+<code>AM_BASE_ROOT</code>, non-empty <code>AM_SESSION</code>, and
+<code>AM_ME</code>. Named profiles use their exact root with
+<code>AM_ROOT=AM_BASE_ROOT</code> and no <code>AM_SESSION</code>. Run
+<code>amq-squad doctor</code> before resuming if it reports a legacy or
+inconsistent pin.</p>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.42.0+ on `PATH`
+- `amq` 0.42.1+ on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend
@@ -599,3 +599,11 @@ amq-squad completion fish
 amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
+
+AMQ 0.42.1 is the first supported release for the complete injected identity
+contract. After upgrading from an older AMQ, stop and resume/relaunch agents so
+their shells receive a coherent pin; a child command cannot repair stale parent
+environment variables. Default-profile sessions use `AM_ROOT`, `AM_BASE_ROOT`,
+non-empty `AM_SESSION`, and `AM_ME`. Named profiles use their exact root with
+`AM_ROOT=AM_BASE_ROOT` and no `AM_SESSION`. Run `amq-squad doctor` before
+resuming if it reports a legacy or inconsistent pin.

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -19,8 +19,11 @@ verbs are the source of truth.
   with the default `--visibility sibling-tabs` or `--visibility current`).
   Hidden spawns (`run start --visibility detached --go`) do not require a
   visible pane.
-- `amq-squad` + `amq` on `PATH`; AMQ floor is **0.42.0**. `amq-squad doctor`
-  warns on version skew (children inherit the `amq-squad` on `PATH`).
+- `amq-squad` + `amq` on `PATH`; AMQ floor is **0.42.1**. After upgrading,
+  stop and resume/relaunch agents so the parent shell receives a complete AMQ
+  identity pin; a child command cannot repair stale injected environment.
+  `amq-squad doctor` reports legacy/inconsistent pins and version skew
+  (children inherit the `amq-squad` on `PATH`).
 - In the orchestrator conversation, invoke the **`amq-squad-orchestrator`** skill.
 
 Being inside tmux is **necessary but not sufficient**: a manually started

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -658,8 +658,16 @@ only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
 <code>--settings</code> file is missing. AMQ floor (v2.20.0+): amq-squad
-requires amq 0.42.0+. Launches pass <code>--require-wake</code> so a
-launch fails immediately when the wake sidecar cannot acquire its lock
+requires amq 0.42.1+. AMQ 0.42.1 is the first supported complete
+identity-pin contract: after upgrading, stop and resume/relaunch agents
+so their parent shells receive a coherent tuple; a child command cannot
+repair stale injected environment. Default profiles use
+<code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty
+<code>AM_SESSION</code>; named profiles use an exact root with
+<code>AM_ROOT=AM_BASE_ROOT</code> and omit <code>AM_SESSION</code>. Run
+<code>amq-squad doctor</code> before resume if it reports a legacy or
+inconsistent pin. Launches pass <code>--require-wake</code> so a launch
+fails immediately when the wake sidecar cannot acquire its lock
 (<code>--no-require-wake</code> opts out and persists into resume). Use
 <code>--wake-inject-mode none</code> for permission-prompt workflows
 that require AMQ wake notices with zero synthetic terminal input; normal

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -217,7 +217,14 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ floor (v2.20.0+): amq-squad requires amq 0.42.0+. Launches pass
+missing. AMQ floor (v2.20.0+): amq-squad requires amq 0.42.1+. AMQ 0.42.1 is
+the first supported complete identity-pin contract: after upgrading, stop and
+resume/relaunch agents so their parent shells receive a coherent tuple; a child
+command cannot repair stale injected environment. Default profiles use
+`AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty `AM_SESSION`; named profiles
+use an exact root with `AM_ROOT=AM_BASE_ROOT` and omit `AM_SESSION`. Run
+`amq-squad doctor` before resume if it reports a legacy or inconsistent pin.
+Launches pass
 `--require-wake` so a launch fails immediately when the wake sidecar cannot
 acquire its lock (`--no-require-wake` opts out and persists into resume).
 Use `--wake-inject-mode none` for permission-prompt workflows that require AMQ

--- a/internal/act/act.go
+++ b/internal/act/act.go
@@ -153,10 +153,10 @@ func Preview(m OpMessage) string {
 // Send shells `amq send ...` via the injectable seam, writing the message to the
 // bus. It is the ONLY executing path in this package.
 //
-// Identity safety: Send strips AM_ROOT/AM_BASE_ROOT/AM_ME from the child
-// environment (mirroring cli.envWithoutAMQIdentity) so a stale shell identity
-// cannot redirect the write — the explicit --root/--me on the argv are the sole
-// source of truth.
+// Identity safety: Send strips AM_ROOT/AM_BASE_ROOT/AM_SESSION/AM_ME and
+// AMQ_GLOBAL_ROOT from the child environment (mirroring
+// cli.envWithoutAMQIdentity) so a stale shell identity cannot redirect the
+// write — the explicit --root/--me on the argv are the sole source of truth.
 //
 // Send validates that --to is non-empty before invoking the seam: a write with
 // no recipient is a no-op on the bus and almost certainly an operator mistake,
@@ -169,16 +169,19 @@ func Send(m OpMessage) error {
 	return sendExec("amq", m.argv(), env)
 }
 
-// envWithoutAMQIdentity returns env with the AMQ identity variables removed, so
-// a stale AM_ROOT/AM_BASE_ROOT/AM_ME from a previous shell session cannot
-// override the explicit --root/--me the operator put on the wire. It mirrors
-// cli.envWithoutAMQIdentity (that one is unexported in another package); the
-// behavior is identical and intentionally kept in lockstep.
+// envWithoutAMQIdentity returns env with the AMQ identity/config variables
+// removed, so a stale AM_ROOT/AM_BASE_ROOT/AM_SESSION/AM_ME/AMQ_GLOBAL_ROOT
+// from a previous shell session cannot override the explicit --root/--me the
+// operator put on the wire. It mirrors cli.envWithoutAMQIdentity (that one is
+// unexported in another package); the behavior is identical and intentionally
+// kept in lockstep.
 func envWithoutAMQIdentity(env []string) []string {
 	remove := map[string]bool{
-		"AM_ROOT":      true,
-		"AM_BASE_ROOT": true,
-		"AM_ME":        true,
+		"AM_ROOT":         true,
+		"AM_BASE_ROOT":    true,
+		"AM_SESSION":      true,
+		"AM_ME":           true,
+		"AMQ_GLOBAL_ROOT": true,
 	}
 	out := make([]string, 0, len(env))
 	for _, entry := range env {

--- a/internal/act/act_test.go
+++ b/internal/act/act_test.go
@@ -113,6 +113,28 @@ func TestDenyArgvBareWhenNoReason(t *testing.T) {
 	}
 }
 
+func TestSendSanitizesCompleteAMQIdentityTuple(t *testing.T) {
+	t.Setenv("AM_ROOT", "/stale/root")
+	t.Setenv("AM_BASE_ROOT", "/stale/base")
+	t.Setenv("AM_SESSION", "")
+	t.Setenv("AM_ME", "stale")
+	t.Setenv("AMQ_GLOBAL_ROOT", "/stale/global")
+	rec := withFakeSeam(t)
+	if err := Send(OpMessage{Root: testRoot, Me: "user", To: "cto", Subject: "status", Body: "ok", Thread: "t", Kind: string(state.KindAnswer)}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if !rec.called {
+		t.Fatal("send seam was not called")
+	}
+	for _, key := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AM_ME", "AMQ_GLOBAL_ROOT"} {
+		for _, entry := range rec.env {
+			if strings.HasPrefix(entry, key+"=") {
+				t.Fatalf("stale %s leaked to child: %#v", key, rec.env)
+			}
+		}
+	}
+}
+
 func TestBroadcastArgv(t *testing.T) {
 	// Operator handle and a duplicate are filtered; result is sorted+deduped.
 	m := Broadcast(testRoot, testSession,

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -217,26 +217,37 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 	if strings.TrimSpace(session) == "" {
 		return "", false, nil
 	}
-	base, root, err := canonicalInheritedAMQInferencePaths(projectDir, root)
+	lexicalBase, lexicalRoot := lexicalInheritedAMQInferencePaths(projectDir, root)
+	rel, err := filepath.Rel(lexicalBase, lexicalRoot)
 	if err != nil {
 		return "", false, err
 	}
-	rel, err := filepath.Rel(base, root)
-	if err != nil || rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", false, usageErrorf("inherited AM_ROOT %q resolves outside selected .agent-mail base %q; pass an explicit --profile/--project or relaunch the agent shell", root, base)
+	if rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false, usageErrorf("inherited AM_ROOT %q is outside the selected project .agent-mail root; pass an explicit --profile/--project or relaunch the agent shell", lexicalRoot)
 	}
 	parts := strings.Split(filepath.Clean(rel), string(os.PathSeparator))
+
+	base, resolvedRoot, err := canonicalInheritedAMQInferencePaths(lexicalBase, lexicalRoot)
+	if err != nil {
+		return "", false, err
+	}
+	canonicalRel, err := filepath.Rel(base, resolvedRoot)
+	if err != nil || canonicalRel == "." || canonicalRel == "" || canonicalRel == ".." || strings.HasPrefix(canonicalRel, ".."+string(os.PathSeparator)) {
+		return "", false, usageErrorf("inherited AM_ROOT %q resolves outside selected .agent-mail base %q; pass an explicit --profile/--project or relaunch the agent shell", lexicalRoot, base)
+	}
 	if len(parts) == 1 {
 		if parts[0] != session {
 			return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[0], session)
 		}
+		// This is the ordinary default namespace. It is valid but does not
+		// infer a named profile or alter default-profile resolution.
 		return "", false, nil
 	}
 	if len(parts) != 2 {
 		return "", false, usageErrorf("inherited AM_ROOT %q is not an exact profile/session mailbox root", root)
 	}
 	if parts[0] == team.DefaultProfile {
-		return "", false, usageErrorf("inherited AM_ROOT %q uses reserved profile segment %q; it collides with the default session namespace", root, team.DefaultProfile)
+		return "", false, usageErrorf("inherited AM_ROOT %q uses reserved profile segment %q; it collides with the default session namespace", lexicalRoot, team.DefaultProfile)
 	}
 	profile := squadnamespace.NormalizeProfile(parts[0])
 	if err := team.ValidateProfileName(profile); err != nil {
@@ -245,19 +256,26 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 	if parts[1] != session {
 		return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[1], session)
 	}
+	expectedRoot := filepath.Clean(filepath.Join(base, rel))
+	if filepath.Clean(resolvedRoot) != expectedRoot {
+		return "", false, usageErrorf("inherited AM_ROOT %q does not preserve selected .agent-mail identity %q after resolution (got %q); nested namespace symlinks are not allowed", lexicalRoot, expectedRoot, resolvedRoot)
+	}
 	return profile, true, nil
 }
 
-// canonicalInheritedAMQInferencePaths resolves the only two filesystem paths
-// that implicit named-profile inference trusts. The selected .agent-mail
-// container may itself be a deliberate symlink (for example, to a managed
-// mailbox volume), so containment is against that resolved container. A
-// symlink below the container must still resolve beneath it; otherwise a
-// lexical .agent-mail/<profile>/<session> path could escape the selected
-// project namespace.
-func canonicalInheritedAMQInferencePaths(projectDir, inheritedRoot string) (string, string, error) {
-	lexicalBase := absoluteAMQRoot("", filepath.Join(filepath.Clean(projectDir), ".agent-mail"))
-	lexicalRoot := absoluteAMQRoot(projectDir, inheritedRoot)
+// lexicalInheritedAMQInferencePaths preserves the caller's namespace
+// segments. Only the selected top-level .agent-mail base may be a symlink;
+// profile/session components below it are identity and must not be rewritten by
+// symlink resolution.
+func lexicalInheritedAMQInferencePaths(projectDir, inheritedRoot string) (string, string) {
+	return absoluteAMQRoot("", filepath.Join(filepath.Clean(projectDir), ".agent-mail")), absoluteAMQRoot(projectDir, inheritedRoot)
+}
+
+// canonicalInheritedAMQInferencePaths resolves the selected top-level
+// .agent-mail container and inherited root. Callers compare the result against
+// the lexical namespace suffix separately so a nested symlink cannot silently
+// rewrite a profile/session identity.
+func canonicalInheritedAMQInferencePaths(lexicalBase, lexicalRoot string) (string, string, error) {
 	base, err := filepath.EvalSymlinks(lexicalBase)
 	if err != nil {
 		return "", "", usageErrorf("cannot resolve selected .agent-mail base %q while validating inherited AM_ROOT %q: %v", lexicalBase, lexicalRoot, err)

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -235,6 +235,10 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 	if err != nil || canonicalRel == "." || canonicalRel == "" || canonicalRel == ".." || strings.HasPrefix(canonicalRel, ".."+string(os.PathSeparator)) {
 		return "", false, usageErrorf("inherited AM_ROOT %q resolves outside selected .agent-mail base %q; pass an explicit --profile/--project or relaunch the agent shell", lexicalRoot, base)
 	}
+	expectedRoot := filepath.Clean(filepath.Join(base, rel))
+	if filepath.Clean(resolvedRoot) != expectedRoot {
+		return "", false, usageErrorf("inherited AM_ROOT %q does not preserve selected .agent-mail identity %q after resolution (got %q); nested namespace symlinks are not allowed", lexicalRoot, expectedRoot, resolvedRoot)
+	}
 	if len(parts) == 1 {
 		if parts[0] != session {
 			return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[0], session)
@@ -255,10 +259,6 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 	}
 	if parts[1] != session {
 		return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[1], session)
-	}
-	expectedRoot := filepath.Clean(filepath.Join(base, rel))
-	if filepath.Clean(resolvedRoot) != expectedRoot {
-		return "", false, usageErrorf("inherited AM_ROOT %q does not preserve selected .agent-mail identity %q after resolution (got %q); nested namespace symlinks are not allowed", lexicalRoot, expectedRoot, resolvedRoot)
 	}
 	return profile, true, nil
 }

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -71,7 +71,19 @@ type amqContext struct {
 	Env        amqEnv
 	Root       string
 	Me         string
+	Session    string
+	PinMode    amqPinMode
 }
+
+// amqPinMode is deliberately independent of amqEnv.SessionName. AMQ returns a
+// display session for an explicit named-profile root, but that root must still
+// be launched with an exact-root/sessionless identity tuple.
+type amqPinMode uint8
+
+const (
+	amqPinExactRoot amqPinMode = iota
+	amqPinSessionful
+)
 
 func runAMQ(args []string) error {
 	if len(args) == 0 {
@@ -122,11 +134,21 @@ func resolveAMQContext(projectFlag, profileFlag, session, me string, projectSet 
 	if err != nil {
 		return amqContext{}, err
 	}
+	profileExplicit := strings.TrimSpace(profileFlag) != ""
+	if !profileExplicit {
+		inferred, ok, err := namedProfileFromInheritedAMQRoot(projectDir, session)
+		if err != nil {
+			return amqContext{}, err
+		}
+		if ok {
+			profile = inferred
+		}
+	}
 	ctx, err := resolveAMQContextForNamespace(projectDir, profile, session, me)
 	if err != nil {
 		return amqContext{}, err
 	}
-	return inferAMQContextProfileFromRoot(ctx, strings.TrimSpace(profileFlag) != ""), nil
+	return inferAMQContextProfileFromRoot(ctx, profileExplicit), nil
 }
 
 func resolveAMQContextForProject(projectDir, session, me string) (amqContext, error) {
@@ -138,13 +160,19 @@ func resolveAMQContextForProject(projectDir, session, me string) (amqContext, er
 	if handle == "" {
 		handle = strings.TrimSpace(me)
 	}
-	return amqContext{
+	ctx := amqContext{
 		ProjectDir: projectDir,
 		Profile:    team.DefaultProfile,
 		Env:        env,
 		Root:       absoluteAMQRoot(projectDir, env.Root),
 		Me:         handle,
-	}, nil
+		Session:    strings.TrimSpace(session),
+		PinMode:    amqPinExactRoot,
+	}
+	if ctx.Session != "" {
+		ctx.PinMode = amqPinSessionful
+	}
+	return ctx, nil
 }
 
 func resolveAMQContextForNamespace(projectDir, profile, session, me string) (amqContext, error) {
@@ -169,7 +197,53 @@ func resolveAMQContextForNamespace(projectDir, profile, session, me string) (amq
 		Env:        env,
 		Root:       absoluteAMQRoot(projectDir, env.Root),
 		Me:         handle,
+		Session:    strings.TrimSpace(session),
+		PinMode:    amqPinExactRoot,
 	}, nil
+}
+
+// namedProfileFromInheritedAMQRoot recognizes only an exact live named-profile
+// root. A bare --session would reinterpret that namespace below .agent-mail
+// and lose the profile segment, so callers must resolve named roots explicitly.
+// Any supplied root that is outside the requested project, malformed, or names
+// a different session is rejected rather than silently falling back to the
+// default profile.
+func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool, error) {
+	root, present := os.LookupEnv("AM_ROOT")
+	root = strings.TrimSpace(root)
+	if !present || root == "" {
+		return "", false, nil
+	}
+	if strings.TrimSpace(session) == "" {
+		return "", false, nil
+	}
+	root = absoluteAMQRoot(projectDir, root)
+	base := filepath.Join(filepath.Clean(projectDir), ".agent-mail")
+	rel, err := filepath.Rel(base, root)
+	if err != nil || rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false, usageErrorf("inherited AM_ROOT %q is outside the selected project .agent-mail root; pass an explicit --profile/--project or relaunch the agent shell", root)
+	}
+	parts := strings.Split(filepath.Clean(rel), string(os.PathSeparator))
+	if len(parts) == 1 {
+		if parts[0] != session {
+			return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[0], session)
+		}
+		return "", false, nil
+	}
+	if len(parts) != 2 {
+		return "", false, usageErrorf("inherited AM_ROOT %q is not an exact profile/session mailbox root", root)
+	}
+	if parts[0] == team.DefaultProfile {
+		return "", false, usageErrorf("inherited AM_ROOT %q uses reserved profile segment %q; it collides with the default session namespace", root, team.DefaultProfile)
+	}
+	profile := squadnamespace.NormalizeProfile(parts[0])
+	if err := team.ValidateProfileName(profile); err != nil {
+		return "", false, usageErrorf("inherited AM_ROOT has invalid profile segment %q: %v", parts[0], err)
+	}
+	if parts[1] != session {
+		return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[1], session)
+	}
+	return profile, true, nil
 }
 
 func inferAMQContextProfileFromRoot(ctx amqContext, profileExplicit bool) amqContext {
@@ -219,11 +293,22 @@ func resolveAMQBaseRootForProject(projectDir, session, me string) (string, error
 
 func amqCommandEnv(ctx amqContext) []string {
 	env := envWithoutAMQIdentity(os.Environ())
-	if ctx.Root != "" {
-		env = append(env, "AM_ROOT="+ctx.Root)
+	root := absoluteAMQRoot(ctx.ProjectDir, ctx.Root)
+	if root == "" {
+		return env
 	}
-	if root := absoluteAMQRoot(ctx.ProjectDir, ctx.Env.BaseRoot); root != "" {
-		env = append(env, "AM_BASE_ROOT="+root)
+	baseRoot := root
+	session := ""
+	if ctx.PinMode == amqPinSessionful && strings.TrimSpace(ctx.Session) != "" {
+		baseRoot = absoluteAMQRoot(ctx.ProjectDir, ctx.Env.BaseRoot)
+		if baseRoot == "" {
+			baseRoot = filepath.Dir(root)
+		}
+		session = strings.TrimSpace(ctx.Session)
+	}
+	env = append(env, "AM_ROOT="+root, "AM_BASE_ROOT="+baseRoot)
+	if session != "" {
+		env = append(env, "AM_SESSION="+session)
 	}
 	if ctx.Me != "" {
 		env = append(env, "AM_ME="+ctx.Me)
@@ -397,8 +482,8 @@ func defaultRunAMQStreaming(ctx amqContext, cmd []string) error {
 //
 // It consumes ONLY --project/--session/--me (to resolve the queue root + acting
 // handle, exactly like every other `amq-squad amq` subcommand), injects them as
-// AM_ROOT/AM_BASE_ROOT/AM_ME plus an explicit --root, and forwards every other
-// argument to `amq` verbatim. For send, actor/audit guard flags (--me/--from,
+// a complete AMQ identity tuple plus an explicit --root, and forwards every
+// other argument to `amq` verbatim. For send, actor/audit guard flags (--me/--from,
 // --unsafe-send-as, --reason) are also extracted from the forwarded tail before
 // context resolution so they cannot bypass amq-squad's authority checks. It
 // deliberately does NOT reimplement amq's flag surface; unknown flags flow

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -217,11 +217,13 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 	if strings.TrimSpace(session) == "" {
 		return "", false, nil
 	}
-	root = absoluteAMQRoot(projectDir, root)
-	base := filepath.Join(filepath.Clean(projectDir), ".agent-mail")
+	base, root, err := canonicalInheritedAMQInferencePaths(projectDir, root)
+	if err != nil {
+		return "", false, err
+	}
 	rel, err := filepath.Rel(base, root)
 	if err != nil || rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return "", false, usageErrorf("inherited AM_ROOT %q is outside the selected project .agent-mail root; pass an explicit --profile/--project or relaunch the agent shell", root)
+		return "", false, usageErrorf("inherited AM_ROOT %q resolves outside selected .agent-mail base %q; pass an explicit --profile/--project or relaunch the agent shell", root, base)
 	}
 	parts := strings.Split(filepath.Clean(rel), string(os.PathSeparator))
 	if len(parts) == 1 {
@@ -244,6 +246,27 @@ func namedProfileFromInheritedAMQRoot(projectDir, session string) (string, bool,
 		return "", false, usageErrorf("inherited AM_ROOT session %q does not match requested --session %q; relaunch the agent shell or pass the exact namespace", parts[1], session)
 	}
 	return profile, true, nil
+}
+
+// canonicalInheritedAMQInferencePaths resolves the only two filesystem paths
+// that implicit named-profile inference trusts. The selected .agent-mail
+// container may itself be a deliberate symlink (for example, to a managed
+// mailbox volume), so containment is against that resolved container. A
+// symlink below the container must still resolve beneath it; otherwise a
+// lexical .agent-mail/<profile>/<session> path could escape the selected
+// project namespace.
+func canonicalInheritedAMQInferencePaths(projectDir, inheritedRoot string) (string, string, error) {
+	lexicalBase := absoluteAMQRoot("", filepath.Join(filepath.Clean(projectDir), ".agent-mail"))
+	lexicalRoot := absoluteAMQRoot(projectDir, inheritedRoot)
+	base, err := filepath.EvalSymlinks(lexicalBase)
+	if err != nil {
+		return "", "", usageErrorf("cannot resolve selected .agent-mail base %q while validating inherited AM_ROOT %q: %v", lexicalBase, lexicalRoot, err)
+	}
+	root, err := filepath.EvalSymlinks(lexicalRoot)
+	if err != nil {
+		return "", "", usageErrorf("cannot resolve inherited AM_ROOT %q while validating selected .agent-mail base %q: %v", lexicalRoot, base, err)
+	}
+	return filepath.Clean(base), filepath.Clean(root), nil
 }
 
 func inferAMQContextProfileFromRoot(ctx amqContext, profileExplicit bool) amqContext {

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -43,6 +43,9 @@ func resolveAMQEnvForTeamProfile(cwd, profile, session, handle string) (amqEnv, 
 // --require-wake (refuse to launch unless the wake sidecar acquires its lock).
 const minRequireWakeAMQVersion = "0.34.1"
 const minWakeInjectAMQVersion = "0.37.0"
+
+// minWakeInjectModeAMQVersion is a feature-specific capability boundary, not
+// amq-squad's supported AMQ floor; see doctorMinAMQVersion.
 const minWakeInjectModeAMQVersion = "0.42.0"
 const minNoGitignoreAMQVersion = "0.40.0"
 
@@ -169,9 +172,11 @@ func absoluteAMQRoot(cwd, root string) string {
 
 func envWithoutAMQIdentity(env []string) []string {
 	remove := map[string]bool{
-		"AM_ROOT":      true,
-		"AM_BASE_ROOT": true,
-		"AM_ME":        true,
+		"AM_ROOT":         true,
+		"AM_BASE_ROOT":    true,
+		"AM_SESSION":      true,
+		"AM_ME":           true,
+		"AMQ_GLOBAL_ROOT": true,
 	}
 	out := make([]string, 0, len(env))
 	for _, entry := range env {

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -44,7 +44,7 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 		"    echo \"unexpected cwd: $actual_cwd\" >&2\n" +
 		"    exit 2\n" +
 		"  fi\n" +
-		"  if [ -n \"$AM_ROOT$AM_BASE_ROOT$AM_ME\" ]; then\n" +
+		"  if [ -n \"$AM_ROOT$AM_BASE_ROOT$AM_ME$AMQ_GLOBAL_ROOT\" ] || env | grep -q '^AM_SESSION='; then\n" +
 		"    printf '%s\\n' '{\"root\":\"/live/session\",\"base_root\":\"/live\",\"me\":\"cto\",\"project\":\"live-project\"}'\n" +
 		"    exit 0\n" +
 		"  fi\n" +
@@ -62,7 +62,9 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 	t.Setenv("AMQ_EXPECT_CWD", expectedCWD)
 	t.Setenv("AM_ROOT", "/live/session")
 	t.Setenv("AM_BASE_ROOT", "/live")
+	t.Setenv("AM_SESSION", "")
 	t.Setenv("AM_ME", "cto")
+	t.Setenv("AMQ_GLOBAL_ROOT", "/global/mail")
 
 	got, err := resolveAMQEnvInDir(projectDir, "", "", "amq-squad")
 	if err != nil {
@@ -71,6 +73,21 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 	if got.Root != "/target/session" || got.BaseRoot != "/target" ||
 		got.Me != "amq-squad" || got.Project != "target-project" {
 		t.Fatalf("resolveAMQEnvInDir = %+v", got)
+	}
+}
+
+func TestEnvWithoutAMQIdentityRemovesCompleteTuple(t *testing.T) {
+	got := envWithoutAMQIdentity([]string{
+		"KEEP=value",
+		"AM_ROOT=/root",
+		"AM_BASE_ROOT=/base",
+		"AM_SESSION=",
+		"AM_ME=cto",
+		"AMQ_GLOBAL_ROOT=/global",
+		"AMQ_SQUAD_TERMINAL_TITLE=test",
+	})
+	if len(got) != 1 || got[0] != "KEEP=value" {
+		t.Fatalf("sanitized env = %#v, want only KEEP=value", got)
 	}
 }
 

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -148,6 +148,102 @@ func TestResolveAMQContextNormalizesRelativeRootsToAbsoluteEnv(t *testing.T) {
 	}
 }
 
+func TestAMQCommandEnvBuildsCompleteIdentityTuples(t *testing.T) {
+	t.Setenv("AM_ROOT", "/stale/root")
+	t.Setenv("AM_BASE_ROOT", "/stale/base")
+	t.Setenv("AM_SESSION", "stale")
+	t.Setenv("AM_ME", "stale")
+	t.Setenv("AMQ_GLOBAL_ROOT", "/stale/global")
+
+	t.Run("sessionful default profile", func(t *testing.T) {
+		ctx := amqContext{
+			ProjectDir: "/project",
+			Profile:    team.DefaultProfile,
+			Env:        amqEnv{BaseRoot: "/project/.agent-mail"},
+			Root:       "/project/.agent-mail/issue-96",
+			Me:         "cto",
+			Session:    "issue-96",
+			PinMode:    amqPinSessionful,
+		}
+		env := amqCommandEnv(ctx)
+		for key, want := range map[string]string{
+			"AM_ROOT": "/project/.agent-mail/issue-96", "AM_BASE_ROOT": "/project/.agent-mail", "AM_SESSION": "issue-96", "AM_ME": "cto",
+		} {
+			if !envHas(env, key, want) {
+				t.Fatalf("missing %s=%q in %#v", key, want, env)
+			}
+		}
+		if envHasPrefix(env, "AMQ_GLOBAL_ROOT", "") {
+			t.Fatalf("stale AMQ_GLOBAL_ROOT leaked: %#v", env)
+		}
+	})
+
+	t.Run("exact root named profile", func(t *testing.T) {
+		root := "/project/.agent-mail/review/issue-96"
+		ctx := amqContext{ProjectDir: "/project", Profile: "review", Root: root, Me: "cto", Session: "issue-96", PinMode: amqPinExactRoot}
+		env := amqCommandEnv(ctx)
+		for key, want := range map[string]string{"AM_ROOT": root, "AM_BASE_ROOT": root, "AM_ME": "cto"} {
+			if !envHas(env, key, want) {
+				t.Fatalf("missing %s=%q in %#v", key, want, env)
+			}
+		}
+		if envHasPrefix(env, "AM_SESSION", "") {
+			t.Fatalf("exact-root tuple must omit AM_SESSION: %#v", env)
+		}
+	})
+}
+
+func TestResolveAMQContextInfersNamedProfileBeforeAMQResolution(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, ".agent-mail", "review", "issue-96")
+	writeAMQBoundaryTeamProfile(t, dir, "review")
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_BASE_ROOT", root)
+	t.Setenv("AM_SESSION", "")
+
+	previous := resolveAMQEnvForAMQCommand
+	resolveAMQEnvForAMQCommand = func(cwd, rootFlag, session, handle string) (amqEnv, error) {
+		if cwd != dir || rootFlag != root || session != "" {
+			t.Fatalf("named root resolver args = cwd=%q root=%q session=%q, want exact root without --session", cwd, rootFlag, session)
+		}
+		return amqEnv{Root: root, BaseRoot: root, Me: handle, AMQVersion: "0.43.0"}, nil
+	}
+	t.Cleanup(func() { resolveAMQEnvForAMQCommand = previous })
+
+	ctx, err := resolveAMQContext(dir, "", "issue-96", "cto", true)
+	if err != nil {
+		t.Fatalf("resolveAMQContext: %v", err)
+	}
+	if ctx.Profile != "review" || ctx.PinMode != amqPinExactRoot {
+		t.Fatalf("context = %+v, want named exact-root context", ctx)
+	}
+	if env := amqCommandEnv(ctx); envHasPrefix(env, "AM_SESSION", "") || !envHas(env, "AM_BASE_ROOT", root) {
+		t.Fatalf("named exact-root tuple = %#v", env)
+	}
+}
+
+func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("outside project", func(t *testing.T) {
+		t.Setenv("AM_ROOT", filepath.Join(t.TempDir(), ".agent-mail", "review", "issue-96"))
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
+			t.Fatal("outside inherited root accepted")
+		}
+	})
+	t.Run("session mismatch", func(t *testing.T) {
+		t.Setenv("AM_ROOT", filepath.Join(dir, ".agent-mail", "review", "other"))
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
+			t.Fatal("mismatched inherited session accepted")
+		}
+	})
+	t.Run("default profile path collision", func(t *testing.T) {
+		t.Setenv("AM_ROOT", filepath.Join(dir, ".agent-mail", team.DefaultProfile, "issue-96"))
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
+			t.Fatal("colliding default-profile path accepted")
+		}
+	})
+}
+
 func TestAMQRouteAddsJSONByDefault(t *testing.T) {
 	chdir(t, t.TempDir())
 	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, `{"routable":true}`+"\n")

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -242,6 +242,19 @@ func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
 			t.Fatalf("default-session inference = profile %q, ok %t, err %v; want non-inference", profile, ok, err)
 		}
 	})
+	t.Run("symlinked default session rewrites identity inside selected base", func(t *testing.T) {
+		actual := filepath.Join(base, "actual-default-session")
+		if err := os.MkdirAll(actual, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(actual, filepath.Join(base, "issue-default-alias")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Setenv("AM_ROOT", filepath.Join(base, "issue-default-alias"))
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-default-alias"); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
+			t.Fatalf("rewritten default inherited root error = %v, want identity-preservation failure", err)
+		}
+	})
 	t.Run("outside project", func(t *testing.T) {
 		root := filepath.Join(t.TempDir(), ".agent-mail", "review", "issue-96")
 		if err := os.MkdirAll(root, 0o755); err != nil {
@@ -304,6 +317,20 @@ func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
 		t.Setenv("AM_ROOT", root)
 		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
 			t.Fatalf("rewritten inherited root error = %v, want identity-preservation failure", err)
+		}
+	})
+	t.Run("symlinked named session rewrites identity inside selected base", func(t *testing.T) {
+		actual := filepath.Join(base, "review-session", "actual")
+		if err := os.MkdirAll(actual, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(actual, filepath.Join(base, "review-session", "issue-96")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		root := filepath.Join(base, "review-session", "issue-96")
+		t.Setenv("AM_ROOT", root)
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
+			t.Fatalf("rewritten named-session root error = %v, want identity-preservation failure", err)
 		}
 	})
 	t.Run("selected base symlink is canonical namespace", func(t *testing.T) {
@@ -372,6 +399,32 @@ func TestResolveAMQContextRefusesInheritedNamedProfileSymlinkIdentityRewrite(t *
 
 	if _, err := resolveAMQContext(dir, "", "issue-96", "qa", true); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
 		t.Fatalf("resolveAMQContext symlink identity rewrite error = %v, want identity-preservation failure", err)
+	}
+}
+
+func TestResolveAMQContextRefusesInheritedDefaultSessionSymlinkIdentityRewrite(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, ".agent-mail")
+	actual := filepath.Join(base, "actual")
+	if err := os.MkdirAll(actual, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(actual, filepath.Join(base, "issue-96")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("AM_ROOT", filepath.Join(base, "issue-96"))
+	t.Setenv("AM_BASE_ROOT", base)
+	t.Setenv("AM_SESSION", "issue-96")
+
+	previous := resolveAMQEnvForAMQCommand
+	resolveAMQEnvForAMQCommand = func(string, string, string, string) (amqEnv, error) {
+		t.Fatal("AMQ resolver must not run after inherited default session rewrites namespace identity")
+		return amqEnv{}, nil
+	}
+	t.Cleanup(func() { resolveAMQEnvForAMQCommand = previous })
+
+	if _, err := resolveAMQContext(dir, "", "issue-96", "qa", true); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
+		t.Fatalf("resolveAMQContext default-session symlink identity rewrite error = %v, want identity-preservation failure", err)
 	}
 }
 

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -196,6 +196,9 @@ func TestAMQCommandEnvBuildsCompleteIdentityTuples(t *testing.T) {
 func TestResolveAMQContextInfersNamedProfileBeforeAMQResolution(t *testing.T) {
 	dir := t.TempDir()
 	root := filepath.Join(dir, ".agent-mail", "review", "issue-96")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	writeAMQBoundaryTeamProfile(t, dir, "review")
 	t.Setenv("AM_ROOT", root)
 	t.Setenv("AM_BASE_ROOT", root)
@@ -224,24 +227,103 @@ func TestResolveAMQContextInfersNamedProfileBeforeAMQResolution(t *testing.T) {
 
 func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
 	dir := t.TempDir()
+	base := filepath.Join(dir, ".agent-mail")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("outside project", func(t *testing.T) {
-		t.Setenv("AM_ROOT", filepath.Join(t.TempDir(), ".agent-mail", "review", "issue-96"))
+		root := filepath.Join(t.TempDir(), ".agent-mail", "review", "issue-96")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AM_ROOT", root)
 		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
 			t.Fatal("outside inherited root accepted")
 		}
 	})
 	t.Run("session mismatch", func(t *testing.T) {
-		t.Setenv("AM_ROOT", filepath.Join(dir, ".agent-mail", "review", "other"))
+		root := filepath.Join(base, "review", "other")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AM_ROOT", root)
 		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
 			t.Fatal("mismatched inherited session accepted")
 		}
 	})
 	t.Run("default profile path collision", func(t *testing.T) {
-		t.Setenv("AM_ROOT", filepath.Join(dir, ".agent-mail", team.DefaultProfile, "issue-96"))
+		root := filepath.Join(base, team.DefaultProfile, "issue-96")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AM_ROOT", root)
 		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil {
 			t.Fatal("colliding default-profile path accepted")
 		}
 	})
+	t.Run("unresolvable inherited root", func(t *testing.T) {
+		t.Setenv("AM_ROOT", filepath.Join(base, "review", "missing"))
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil || !strings.Contains(err.Error(), "cannot resolve inherited AM_ROOT") {
+			t.Fatalf("missing inherited root error = %v, want resolution failure", err)
+		}
+	})
+	t.Run("symlinked profile escapes selected base", func(t *testing.T) {
+		outside := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(outside, "issue-96"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(base, "review-escape")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		root := filepath.Join(base, "review-escape", "issue-96")
+		t.Setenv("AM_ROOT", root)
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil || !strings.Contains(err.Error(), "resolves outside selected .agent-mail base") {
+			t.Fatalf("escaped inherited root error = %v, want containment failure", err)
+		}
+	})
+	t.Run("selected base symlink is canonical namespace", func(t *testing.T) {
+		project := t.TempDir()
+		resolvedBase := t.TempDir()
+		root := filepath.Join(resolvedBase, "review", "issue-96")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(resolvedBase, filepath.Join(project, ".agent-mail")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Setenv("AM_ROOT", filepath.Join(project, ".agent-mail", "review", "issue-96"))
+		profile, ok, err := namedProfileFromInheritedAMQRoot(project, "issue-96")
+		if err != nil || !ok || profile != "review" {
+			t.Fatalf("base symlink inference = profile %q, ok %t, err %v", profile, ok, err)
+		}
+	})
+}
+
+func TestResolveAMQContextRefusesInheritedNamedProfileSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, ".agent-mail")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(outside, "issue-96"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(base, "review")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("AM_ROOT", filepath.Join(base, "review", "issue-96"))
+
+	previous := resolveAMQEnvForAMQCommand
+	resolveAMQEnvForAMQCommand = func(string, string, string, string) (amqEnv, error) {
+		t.Fatal("AMQ resolver must not run after inherited root escapes selected base")
+		return amqEnv{}, nil
+	}
+	t.Cleanup(func() { resolveAMQEnvForAMQCommand = previous })
+
+	if _, err := resolveAMQContext(dir, "", "issue-96", "qa", true); err == nil || !strings.Contains(err.Error(), "resolves outside selected .agent-mail base") {
+		t.Fatalf("resolveAMQContext symlink escape error = %v, want containment failure", err)
+	}
 }
 
 func TestAMQRouteAddsJSONByDefault(t *testing.T) {

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -231,6 +231,17 @@ func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Run("matching default session remains non-inference", func(t *testing.T) {
+		root := filepath.Join(base, "issue-96")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("AM_ROOT", root)
+		profile, ok, err := namedProfileFromInheritedAMQRoot(dir, "issue-96")
+		if err != nil || ok || profile != "" {
+			t.Fatalf("default-session inference = profile %q, ok %t, err %v; want non-inference", profile, ok, err)
+		}
+	})
 	t.Run("outside project", func(t *testing.T) {
 		root := filepath.Join(t.TempDir(), ".agent-mail", "review", "issue-96")
 		if err := os.MkdirAll(root, 0o755); err != nil {
@@ -281,6 +292,20 @@ func TestNamedProfileFromInheritedAMQRootFailsClosed(t *testing.T) {
 			t.Fatalf("escaped inherited root error = %v, want containment failure", err)
 		}
 	})
+	t.Run("symlinked profile rewrites identity inside selected base", func(t *testing.T) {
+		actual := filepath.Join(base, "actual", "issue-96")
+		if err := os.MkdirAll(actual, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(base, "actual"), filepath.Join(base, "review-alias")); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		root := filepath.Join(base, "review-alias", "issue-96")
+		t.Setenv("AM_ROOT", root)
+		if _, _, err := namedProfileFromInheritedAMQRoot(dir, "issue-96"); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
+			t.Fatalf("rewritten inherited root error = %v, want identity-preservation failure", err)
+		}
+	})
 	t.Run("selected base symlink is canonical namespace", func(t *testing.T) {
 		project := t.TempDir()
 		resolvedBase := t.TempDir()
@@ -323,6 +348,30 @@ func TestResolveAMQContextRefusesInheritedNamedProfileSymlinkEscape(t *testing.T
 
 	if _, err := resolveAMQContext(dir, "", "issue-96", "qa", true); err == nil || !strings.Contains(err.Error(), "resolves outside selected .agent-mail base") {
 		t.Fatalf("resolveAMQContext symlink escape error = %v, want containment failure", err)
+	}
+}
+
+func TestResolveAMQContextRefusesInheritedNamedProfileSymlinkIdentityRewrite(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, ".agent-mail")
+	actual := filepath.Join(base, "actual", "issue-96")
+	if err := os.MkdirAll(actual, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(base, "actual"), filepath.Join(base, "review")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("AM_ROOT", filepath.Join(base, "review", "issue-96"))
+
+	previous := resolveAMQEnvForAMQCommand
+	resolveAMQEnvForAMQCommand = func(string, string, string, string) (amqEnv, error) {
+		t.Fatal("AMQ resolver must not run after inherited root rewrites namespace identity")
+		return amqEnv{}, nil
+	}
+	t.Cleanup(func() { resolveAMQEnvForAMQCommand = previous })
+
+	if _, err := resolveAMQContext(dir, "", "issue-96", "qa", true); err == nil || !strings.Contains(err.Error(), "does not preserve selected .agent-mail identity") {
+		t.Fatalf("resolveAMQContext symlink identity rewrite error = %v, want identity-preservation failure", err)
 	}
 }
 

--- a/internal/cli/bootstrap.md
+++ b/internal/cli/bootstrap.md
@@ -104,7 +104,7 @@ Startup warnings:
 First steps:
 1. Read the startup files that exist.
 2. Use the current team routing above for live messages and handoffs.
-3. Run `amq drain --include-body` before acting on inbox state. Use bare `amq` commands in this shell; amq-squad already injected AM_ROOT, AM_BASE_ROOT, and AM_ME.
+3. Run `amq drain --include-body` before acting on inbox state. Use bare `amq` commands in this shell; amq-squad injected a complete AMQ identity tuple (sessionful default roots include AM_SESSION, exact named roots omit it).
 4. Inspect prior AMQ history in this workstream relevant to your role using `amq-squad status`, `amq-squad history`, `amq list`, `amq read`, and `amq thread --include-body` as needed.
 5. If routing is ambiguous, use `amq route explain` or the printed `amq-squad amq route --to <handle>` diagnostics before sending.
 6. For important review requests or queued handoffs, send with `--wait-for drained --wait-timeout 60s` and keep the message id.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -25,7 +25,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.42.0"
+const doctorMinAMQVersion = "0.42.1"
 
 type doctorStatus string
 
@@ -81,6 +81,10 @@ type doctorExecution struct {
 	// Getenv reads process environment (injectable so the tmux extended-keys
 	// check can be driven deterministically in tests). Defaults to os.Getenv.
 	Getenv func(name string) string
+	// LookupEnv preserves the distinction between an absent value and an
+	// explicitly empty AM_SESSION. AMQ 0.42.1+ treats that difference as part of
+	// the injected identity contract.
+	LookupEnv func(name string) (string, bool)
 	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
 	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
 	// false when the option is unset or tmux is unavailable. Injectable so the
@@ -123,6 +127,7 @@ func defaultDoctorExecution(projectDir string) doctorExecution {
 		LookPath:             exec.LookPath,
 		Probe:                defaultDuplicateLaunchProbe,
 		Getenv:               os.Getenv,
+		LookupEnv:            os.LookupEnv,
 		TmuxShowOptions:      defaultTmuxShowServerOption,
 		PathBinaryVersion:    defaultPathBinaryVersion,
 		CodexSkillCacheRoot:  defaultCodexSkillCacheRoot,
@@ -587,6 +592,7 @@ func countNonOK(checks []doctorCheck) int {
 func runDoctorChecks(d doctorExecution) ([]doctorCheck, string) {
 	checks := []doctorCheck{}
 	checks = append(checks, doctorCheckAMQVersion(d))
+	checks = append(checks, doctorCheckAMQIdentityPin(d))
 	checks = append(checks, doctorCheckAMQOps(d))
 	checks = append(checks, doctorCheckVersionSkew(d))
 	checks = append(checks, doctorCheckCodexSkillCache(d))
@@ -737,6 +743,54 @@ func doctorCheckAMQVersion(d doctorExecution) doctorCheck {
 		Name:   "amq version",
 		Status: doctorOK,
 		Detail: fmt.Sprintf("amq %s (min %s)", got, doctorMinAMQVersion),
+	}
+}
+
+func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
+	lookup := d.LookupEnv
+	if lookup == nil {
+		lookup = func(name string) (string, bool) {
+			if d.Getenv == nil {
+				return "", false
+			}
+			value := d.Getenv(name)
+			return value, value != ""
+		}
+	}
+	root, rootOK := lookup("AM_ROOT")
+	base, baseOK := lookup("AM_BASE_ROOT")
+	session, sessionOK := lookup("AM_SESSION")
+	me, meOK := lookup("AM_ME")
+	if !rootOK && !baseOK && !sessionOK && !meOK {
+		return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "no injected AMQ agent-shell identity"}
+	}
+	root = strings.TrimSpace(root)
+	base = strings.TrimSpace(base)
+	session = strings.TrimSpace(session)
+	me = strings.TrimSpace(me)
+	if rootOK && baseOK && meOK && root != "" && base != "" && me != "" {
+		if !sessionOK && sameResolvedDir(root, base) {
+			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy exact-root/sessionless pin (AM_ROOT=AM_BASE_ROOT; AM_SESSION omitted; AM_ME set)"}
+		}
+		if sessionOK && session == "" {
+			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.42.1+; a child command cannot repair its parent shell"}
+		}
+		if session != "" && sameResolvedDir(root, filepath.Join(base, session)) {
+			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy sessionful pin (AM_ROOT=AM_BASE_ROOT/AM_SESSION; AM_ME set)"}
+		}
+	}
+	sessionState := "absent"
+	if sessionOK {
+		sessionState = "empty"
+		if session != "" {
+			sessionState = "set"
+		}
+	}
+	shape := fmt.Sprintf("AM_ROOT=%t AM_BASE_ROOT=%t AM_SESSION=%s AM_ME=%t", rootOK, baseOK, sessionState, meOK)
+	return doctorCheck{
+		Name:   "amq identity pin",
+		Status: doctorWarn,
+		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.42.1+; a child command cannot repair its parent shell",
 	}
 }
 
@@ -1265,8 +1319,8 @@ func parseSemverParts(s string) ([3]int, bool) {
 
 // semverMeetsStableFloor compares a possibly-prerelease version against a
 // stable minimum. A prerelease with the same core is older than the stable
-// release (0.42.0-rc1 < 0.42.0), while a prerelease with a higher core remains
-// newer (0.42.1-rc1 > 0.42.0).
+// release (0.42.1-rc1 < 0.42.1), while a prerelease with a higher core remains
+// newer (0.42.2-rc1 > 0.42.1).
 func semverMeetsStableFloor(version, minimum string) bool {
 	got, ok := parseSemverParts(strings.TrimSpace(version))
 	if !ok {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -37,7 +37,7 @@ func newDoctorExec(t *testing.T, dir string) doctorExecution {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.42.0", Root: filepath.Join(dir, ".agent-mail")}, nil
+			return amqEnv{AMQVersion: "0.42.1", Root: filepath.Join(dir, ".agent-mail")}, nil
 		},
 		RunAMQOps: func(string, amqEnv) ([]byte, error) {
 			return []byte(`{"status":"ok"}`), nil
@@ -193,7 +193,7 @@ func TestExecuteDoctorAMQVersionTooOld(t *testing.T) {
 	if got == nil || got.Status != doctorFail {
 		t.Fatalf("amq version check = %+v, want fail", got)
 	}
-	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, "0.42.0") {
+	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, "0.42.1") {
 		t.Errorf("detail should name the bad version: %q", got.Detail)
 	}
 	if !strings.Contains(got.Detail, "amq upgrade") {
@@ -208,13 +208,13 @@ if [ "$AMQ_NO_UPDATE_CHECK" != "1" ]; then
   echo "update available" >&2
   exit 91
 fi
-printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.42.0"}'
+printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.42.1"}'
 `)
 
 	d := defaultDoctorExecution(t.TempDir())
 	check := doctorCheckAMQVersion(d)
-	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.42.0") {
-		t.Fatalf("doctor amq version check = %+v, want ok 0.42.0", check)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.42.1") {
+		t.Fatalf("doctor amq version check = %+v, want ok 0.42.1", check)
 	}
 	if got := os.Getenv("AMQ_NO_UPDATE_CHECK"); got != "0" {
 		t.Fatalf("parent AMQ_NO_UPDATE_CHECK = %q, want unchanged 0", got)
@@ -270,9 +270,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts042x(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0421AndNewer(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.42.0", "v0.42.1-rc1", "1.0.0+build42"} {
+	for _, v := range []string{"0.42.1", "v0.42.2-rc1", "1.0.0+build42"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -290,8 +290,8 @@ func TestExecuteDoctorAMQVersionAccepts042x(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionRejectsOlderThan042(t *testing.T) {
-	for _, version := range []string{"0.41.9", "0.42.0-rc1"} {
+func TestExecuteDoctorAMQVersionRejectsOlderThan0421(t *testing.T) {
+	for _, version := range []string{"0.41.9", "0.42.0", "0.42.1-rc1"} {
 		t.Run(version, func(t *testing.T) {
 			dir := t.TempDir()
 			d := newDoctorExec(t, dir)
@@ -301,14 +301,45 @@ func TestExecuteDoctorAMQVersionRejectsOlderThan042(t *testing.T) {
 			var buf bytes.Buffer
 			d.Out = &buf
 			if err := executeDoctor(d); err == nil {
-				t.Fatalf("doctor should fail when amq %s is below the 0.42.0 floor", version)
+				t.Fatalf("doctor should fail when amq %s is below the 0.42.1 floor", version)
 			}
 			amqLine := firstLineWith(buf.String(), "amq version")
-			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.42.0") {
+			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.42.1") {
 				t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 			}
 			if !strings.Contains(amqLine, "amq upgrade") {
 				t.Fatalf("amq version line should point at amq upgrade: %q", amqLine)
+			}
+		})
+	}
+}
+
+func TestDoctorAMQIdentityPinHealth(t *testing.T) {
+	check := func(values map[string]string) doctorCheck {
+		return doctorCheckAMQIdentityPin(doctorExecution{
+			LookupEnv: func(key string) (string, bool) {
+				value, ok := values[key]
+				return value, ok
+			},
+		})
+	}
+	tests := []struct {
+		name   string
+		values map[string]string
+		status doctorStatus
+		want   string
+	}{
+		{name: "no injected pin", values: map[string]string{}, status: doctorOK, want: "no injected"},
+		{name: "sessionful", values: map[string]string{"AM_ROOT": "/mail/issue-96", "AM_BASE_ROOT": "/mail", "AM_SESSION": "issue-96", "AM_ME": "cto"}, status: doctorOK, want: "healthy sessionful"},
+		{name: "exact root sessionless", values: map[string]string{"AM_ROOT": "/mail/review/issue-96", "AM_BASE_ROOT": "/mail/review/issue-96", "AM_ME": "cto"}, status: doctorOK, want: "healthy exact-root/sessionless"},
+		{name: "legacy partial", values: map[string]string{"AM_ROOT": "/mail/issue-96", "AM_BASE_ROOT": "/mail", "AM_ME": "cto"}, status: doctorWarn, want: "stop and resume/relaunch"},
+		{name: "inconsistent empty session", values: map[string]string{"AM_ROOT": "/mail/issue-96", "AM_BASE_ROOT": "/mail", "AM_SESSION": "", "AM_ME": "cto"}, status: doctorWarn, want: "legacy or inconsistent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := check(tt.values)
+			if got.Status != tt.status || !strings.Contains(got.Detail, tt.want) {
+				t.Fatalf("doctor pin check = %+v, want status %s and %q", got, tt.status, tt.want)
 			}
 		})
 	}
@@ -779,7 +810,7 @@ func TestExecuteDoctorWakeReuseClassifyMemberStatus(t *testing.T) {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.42.0", Root: filepath.Join(base, "issue-96")}, nil
+			return amqEnv{AMQVersion: "0.42.1", Root: filepath.Join(base, "issue-96")}, nil
 		},
 		LookPath: func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe: duplicateLaunchProbe{
@@ -822,7 +853,7 @@ func TestExecuteDoctorWakeHandlesAMQEnvErrorPerMember(t *testing.T) {
 	d := doctorExecution{
 		ProjectDir:    dir,
 		Out:           &bytes.Buffer{},
-		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.42.0"}, nil },
+		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.42.1"}, nil },
 		LookPath:      func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe:         defaultDuplicateLaunchProbe,
 	}

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -898,6 +898,8 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle, wakeInjectMode s
 	}
 	wakeResult, err := leadWakeStarter(leadWakeOptions{
 		ProjectDir:     cwd,
+		Profile:        opts.Profile,
+		Session:        env.SessionName,
 		Root:           root,
 		Handle:         handle,
 		Require:        true,

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1024,7 +1024,9 @@ func TestExecAMQCoopDisablesUpdateCheckWithoutLeakingIdentity(t *testing.T) {
 	t.Setenv("AMQ_NO_UPDATE_CHECK", "0")
 	t.Setenv("AM_ROOT", "/stale/root")
 	t.Setenv("AM_BASE_ROOT", "/stale/base")
+	t.Setenv("AM_SESSION", "")
 	t.Setenv("AM_ME", "stale")
+	t.Setenv("AMQ_GLOBAL_ROOT", "/stale/global")
 	previous := amqSyscallExec
 	var gotPath string
 	var gotArgv, gotEnv []string
@@ -1045,7 +1047,7 @@ func TestExecAMQCoopDisablesUpdateCheckWithoutLeakingIdentity(t *testing.T) {
 	if !envHas(gotEnv, "AMQ_NO_UPDATE_CHECK", "1") {
 		t.Fatalf("exec environment missing suppression: %#v", gotEnv)
 	}
-	for _, key := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_ME"} {
+	for _, key := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AM_ME", "AMQ_GLOBAL_ROOT"} {
 		if envHasPrefix(gotEnv, key, "") {
 			t.Fatalf("exec environment leaked %s: %#v", key, gotEnv)
 		}

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/amqexec"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// TestRealAMQCompatibility is intentionally opt-in. Ordinary internal/cli
+// tests must never discover or invoke a host AMQ binary; CI supplies this
+// exact binary via AMQ_SQUAD_REAL_AMQ for the focused floor/latest lane only.
+func TestRealAMQCompatibility(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ"))
+	if binary == "" {
+		t.Skip("set AMQ_SQUAD_REAL_AMQ to run disposable real-AMQ compatibility checks")
+	}
+	info, err := os.Stat(binary)
+	if err != nil {
+		t.Fatalf("stat AMQ_SQUAD_REAL_AMQ %q: %v", binary, err)
+	}
+	if info.IsDir() || info.Mode()&0o111 == 0 {
+		t.Fatalf("AMQ_SQUAD_REAL_AMQ %q is not an executable file", binary)
+	}
+	version := strings.TrimSpace(realAMQCommand(t, binary, t.TempDir(), nil, "version"))
+	if !semverMeetsStableFloor(version, doctorMinAMQVersion) {
+		t.Fatalf("real AMQ %q is below supported floor %s", version, doctorMinAMQVersion)
+	}
+	if expected := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ_VERSION")); expected != "" && expected != "latest" && strings.TrimPrefix(version, "v") != strings.TrimPrefix(expected, "v") {
+		t.Fatalf("real AMQ version = %q, expected requested %q", version, expected)
+	}
+	t.Logf("real AMQ binary=%s version=%s requested=%s", binary, version, os.Getenv("AMQ_SQUAD_REAL_AMQ_VERSION"))
+
+	t.Run("sessionful default profile", func(t *testing.T) {
+		project := t.TempDir()
+		root := filepath.Join(project, ".agent-mail", "issue-449")
+		realAMQInit(t, binary, project, root)
+		ctx := amqContext{
+			ProjectDir: project,
+			Profile:    team.DefaultProfile,
+			Env:        amqEnv{BaseRoot: filepath.Dir(root)},
+			Root:       root,
+			Me:         "lead",
+			Session:    "issue-449",
+			PinMode:    amqPinSessionful,
+		}
+		realAMQRoundTrip(t, binary, ctx, root, "sessionful")
+	})
+
+	t.Run("exact root named profile", func(t *testing.T) {
+		project := t.TempDir()
+		root := filepath.Join(project, "root with spaces", ".agent-mail", "review", "issue-449")
+		realAMQInit(t, binary, project, root)
+		ctx := amqContext{
+			ProjectDir: project,
+			Profile:    "review",
+			Root:       root,
+			Me:         "lead",
+			Session:    "issue-449",
+			PinMode:    amqPinExactRoot,
+		}
+		realAMQRoundTrip(t, binary, ctx, root, "exact-root")
+	})
+}
+
+func realAMQInit(t *testing.T, binary, project, root string) {
+	t.Helper()
+	realAMQCommand(t, binary, project, amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(os.Environ())), "init", "--root", root, "--agents", "lead,worker")
+}
+
+func realAMQRoundTrip(t *testing.T, binary string, lead amqContext, root, label string) {
+	t.Helper()
+	outside := filepath.Join(t.TempDir(), "must-not-be-used")
+	t.Setenv("AMQ_GLOBAL_ROOT", outside)
+	leadEnv := amqCommandEnv(lead)
+	if lead.PinMode == amqPinExactRoot && envHasPrefix(leadEnv, "AM_SESSION", "") {
+		t.Fatalf("%s exact-root tuple leaked AM_SESSION: %#v", label, leadEnv)
+	}
+	if lead.PinMode == amqPinSessionful && !envHas(leadEnv, "AM_SESSION", lead.Session) {
+		t.Fatalf("%s sessionful tuple omitted AM_SESSION=%q: %#v", label, lead.Session, leadEnv)
+	}
+	if envHasPrefix(leadEnv, "AMQ_GLOBAL_ROOT", "") {
+		t.Fatalf("%s tuple leaked stale AMQ_GLOBAL_ROOT: %#v", label, leadEnv)
+	}
+
+	var got amqEnv
+	if err := json.Unmarshal([]byte(realAMQCommand(t, binary, lead.ProjectDir, leadEnv, "env", "--json")), &got); err != nil {
+		t.Fatalf("%s bare amq env JSON: %v", label, err)
+	}
+	if !sameResolvedDir(got.Root, root) {
+		t.Fatalf("%s bare amq env root = %q, want %q", label, got.Root, root)
+	}
+
+	body := "real AMQ " + label + " round trip"
+	realAMQCommand(t, binary, lead.ProjectDir, leadEnv, "send", "--to", "worker", "--subject", "compatibility", "--body", body, "--kind", "todo")
+	worker := lead
+	worker.Me = "worker"
+	drained := realAMQCommand(t, binary, worker.ProjectDir, amqCommandEnv(worker), "drain", "--include-body")
+	if !strings.Contains(drained, body) {
+		t.Fatalf("%s bare amq drain did not contain delivered body:\n%s", label, drained)
+	}
+	if again := strings.TrimSpace(realAMQCommand(t, binary, worker.ProjectDir, amqCommandEnv(worker), "drain", "--include-body")); again != "" {
+		t.Fatalf("%s second bare amq drain = %q, want empty", label, again)
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Fatalf("%s command touched stale global root %q: %v", label, outside, err)
+	}
+}
+
+func realAMQCommand(t *testing.T, binary, dir string, env []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = dir
+	if env == nil {
+		env = amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(os.Environ()))
+	}
+	cmd.Env = amqexec.NoUpdateCheckEnv(env)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("real amq %s: %v\nstderr:\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	return string(out)
+}

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/amqexec"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
@@ -21,6 +22,8 @@ var currentPaneIdentity = tmuxpane.CurrentPaneIdentity
 
 type leadWakeOptions struct {
 	ProjectDir     string
+	Profile        string
+	Session        string
 	Root           string
 	Handle         string
 	Require        bool
@@ -347,6 +350,8 @@ func runLeadRegister(args []string) error {
 	if !*noWake {
 		wakeResult, err = leadWakeStarter(leadWakeOptions{
 			ProjectDir:     cwd,
+			Profile:        profile,
+			Session:        env.SessionName,
 			Root:           root,
 			Handle:         handle,
 			Require:        !*noRequireWake,
@@ -580,7 +585,19 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 	}
 	cmd := externalLeadWakeCommand("amq", args...)
 	cmd.Dir = opts.ProjectDir
-	cmd.Env = amqexec.NoUpdateCheckEnv(append(envWithoutAMQIdentity(os.Environ()), "AM_ROOT="+opts.Root, "AM_ME="+opts.Handle))
+	ctx := amqContext{
+		ProjectDir: opts.ProjectDir,
+		Profile:    squadnamespace.NormalizeProfile(opts.Profile),
+		Root:       absoluteAMQRoot(opts.ProjectDir, opts.Root),
+		Me:         opts.Handle,
+		Session:    strings.TrimSpace(opts.Session),
+		PinMode:    amqPinExactRoot,
+	}
+	if ctx.Profile == team.DefaultProfile && ctx.Session != "" {
+		ctx.PinMode = amqPinSessionful
+		ctx.Env.BaseRoot = filepath.Dir(ctx.Root)
+	}
+	cmd.Env = amqexec.NoUpdateCheckEnv(amqCommandEnv(ctx))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -743,6 +743,38 @@ func TestStartExternalLeadWakeDisablesChildUpdateCheck(t *testing.T) {
 	}
 }
 
+func TestStartExternalLeadWakeUsesCompleteExactRootTuple(t *testing.T) {
+	previous := externalLeadWakeCommand
+	var captured *exec.Cmd
+	externalLeadWakeCommand = func(_ string, _ ...string) *exec.Cmd {
+		captured = exec.Command("/bin/sh", "-c", "exit 0")
+		return captured
+	}
+	t.Cleanup(func() { externalLeadWakeCommand = previous })
+	root := filepath.Join(t.TempDir(), "with space", ".agent-mail", "review", "issue-96")
+	if _, err := startExternalLeadWake(leadWakeOptions{
+		ProjectDir: t.TempDir(),
+		Profile:    "review",
+		Session:    "issue-96",
+		Root:       root,
+		Handle:     "cto",
+		Require:    false,
+	}); err != nil {
+		t.Fatalf("startExternalLeadWake: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("wake command was not captured")
+	}
+	for key, want := range map[string]string{"AM_ROOT": root, "AM_BASE_ROOT": root, "AM_ME": "cto"} {
+		if !envHas(captured.Env, key, want) {
+			t.Fatalf("wake environment missing %s=%q: %#v", key, want, captured.Env)
+		}
+	}
+	if envHasPrefix(captured.Env, "AM_SESSION", "") {
+		t.Fatalf("exact-root wake environment must omit AM_SESSION: %#v", captured.Env)
+	}
+}
+
 func TestStartExternalLeadWakeNonRequiredTimeoutStopsSpawnedProcessAndReportsNoPID(t *testing.T) {
 	harness := installLeadWakeHelper(t, "spawn-child-late-ready")
 

--- a/internal/cli/team_rules.go
+++ b/internal/cli/team_rules.go
@@ -73,7 +73,7 @@ func renderTeamRulesWithTemplate(t team.Team, template string) (string, error) {
 
 	b.WriteString("## Communication\n\n")
 	b.WriteString("- Use focused AMQ threads. At startup and between phases, run `amq drain --include-body` before assuming the current inbox state.\n")
-	b.WriteString("- Inside an amq-squad-launched shell, use bare `amq` commands. amq-squad already injects AM_ROOT, AM_BASE_ROOT, and AM_ME; override them only when intentionally inspecting another project or handle.\n")
+	b.WriteString("- Inside an amq-squad-launched shell, use bare `amq` commands. amq-squad injects a complete AMQ identity tuple: sessionful default roots include AM_SESSION, while exact named roots omit it; override only when intentionally inspecting another project or handle.\n")
 	b.WriteString("- AMQ is the durable coordination record for tasks, reports, reviews, decisions, and gates. Prefer `amq-squad dispatch` or `amq send --kind todo` for assigned work; pane prompts are wake/fallback delivery only and are not the authoritative task body when a durable AMQ task exists.\n")
 	b.WriteString("- Use p2p threads for role-to-role handoffs; send them as `--kind review_request` (or `--kind todo` for a queued task). There is no `handoff` message kind.\n")
 	b.WriteString("- For durable AMQ tasks, reply to the task's `From` field on the same thread. Push ACK/start, progress, blockers, ready-for-review, and DONE reports proactively over AMQ instead of waiting to be polled.\n")

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -21,11 +22,14 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("AMQ_SQUAD_CONFIG", filepath.Join(modelDir, "missing.json")); err != nil {
 		panic(err)
 	}
-	if _, err := exec.LookPath("amq"); err != nil {
-		var setupErr error
-		tempDir, setupErr = installPackageTestAMQ()
-		if setupErr != nil {
-			panic(setupErr)
+	var setupErr error
+	tempDir, setupErr = installPackageTestAMQ()
+	if setupErr != nil {
+		panic(setupErr)
+	}
+	for _, key := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AM_ME", "AMQ_GLOBAL_ROOT"} {
+		if err := os.Unsetenv(key); err != nil {
+			panic(err)
 		}
 	}
 	code := m.Run()
@@ -96,7 +100,7 @@ if [ "$1" = "env" ]; then
   if [ -n "$session" ]; then
     base_root=$(dirname "$root")
   fi
-  printf '{"schema_version":1,"amq_version":"0.38.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
+  printf '{"schema_version":1,"amq_version":"0.43.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
   exit 0
 fi
 if [ "$1" = "route" ] && [ "$2" = "explain" ]; then
@@ -146,7 +150,7 @@ if [ "$1" = "ops" ]; then
   exit 0
 fi
 if [ "$1" = "version" ]; then
-  printf '0.38.0\n'
+  printf '0.43.0\n'
   exit 0
 fi
 echo "fake amq: unsupported command: $*" >&2
@@ -164,4 +168,50 @@ exit 2
 		os.Setenv("PATH", dir+string(os.PathListSeparator)+oldPath)
 	}
 	return dir, nil
+}
+
+// TestPackageOwnedAMQShadowsPoisonHost proves ordinary CLI tests never select
+// the developer/runner amq binary. The child starts with a poison amq first on
+// PATH; TestMain must prepend the package fake before this test resolves amq.
+func TestPackageOwnedAMQShadowsPoisonHost(t *testing.T) {
+	const child = "AMQ_SQUAD_TEST_POISON_CHILD"
+	const calls = "AMQ_SQUAD_TEST_POISON_CALLS"
+	if os.Getenv(child) == "1" {
+		for _, key := range []string{"AM_ROOT", "AM_BASE_ROOT", "AM_SESSION", "AM_ME", "AMQ_GLOBAL_ROOT"} {
+			if _, ok := os.LookupEnv(key); ok {
+				t.Fatalf("TestMain leaked %s into ordinary test process", key)
+			}
+		}
+		if _, err := resolveAMQEnvInDir(t.TempDir(), "", "issue-96", "cto"); err != nil {
+			t.Fatalf("package fake did not resolve amq env: %v", err)
+		}
+		return
+	}
+
+	poisonDir := t.TempDir()
+	callPath := filepath.Join(t.TempDir(), "poison-calls")
+	poisonPath := filepath.Join(poisonDir, "amq")
+	poison := "#!/bin/sh\nprintf 'poison amq invoked\\n' >> \"$" + calls + "\"\nexit 97\n"
+	if err := os.WriteFile(poisonPath, []byte(poison), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestPackageOwnedAMQShadowsPoisonHost$", "-test.count=1")
+	cmd.Env = append(os.Environ(),
+		child+"=1",
+		calls+"="+callPath,
+		"PATH="+poisonDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AM_ROOT=/poison/root",
+		"AM_BASE_ROOT=/poison/base",
+		"AM_SESSION=",
+		"AM_ME=poison",
+		"AMQ_GLOBAL_ROOT=/poison/global",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("poison subprocess failed: %v\n%s", err, out)
+	}
+	if data, err := os.ReadFile(callPath); err == nil && strings.TrimSpace(string(data)) != "" {
+		t.Fatalf("poison host amq was invoked:\n%s", data)
+	} else if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
 }

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -298,7 +298,14 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.20.0+): amq-squad requires amq 0.42.0+. The launch wake
+AMQ floor (v2.20.0+): amq-squad requires amq 0.42.1+. AMQ 0.42.1 is the
+first supported complete identity-pin contract: after upgrading, stop and
+resume/relaunch agents so their parent shells receive a coherent tuple; a child
+command cannot repair stale injected environment. Default profiles use
+`AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty `AM_SESSION`; named profiles
+use an exact root with `AM_ROOT=AM_BASE_ROOT` and omit `AM_SESSION`. Run
+`amq-squad doctor` before resume if it reports a legacy or inconsistent pin.
+The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -294,7 +294,14 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.20.0+): amq-squad requires amq 0.42.0+. The launch wake
+AMQ floor (v2.20.0+): amq-squad requires amq 0.42.1+. AMQ 0.42.1 is the
+first supported complete identity-pin contract: after upgrading, stop and
+resume/relaunch agents so their parent shells receive a coherent tuple; a child
+command cannot repair stale injected environment. Default profiles use
+`AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty `AM_SESSION`; named profiles
+use an exact root with `AM_ROOT=AM_BASE_ROOT` and omit `AM_SESSION`. Run
+`amq-squad doctor` before resume if it reports a legacy or inconsistent pin.
+The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -296,7 +296,14 @@ Plan emission fails fast when a referenced `--settings` file is missing;
 `up --dry-run` shows the args on each member's command. Codex members use a `$CODEX_HOME/<name>.config.toml` profile wired
 via `codex_args: ["--profile", "<name>"]` instead.
 
-AMQ floor (v2.20.0+): amq-squad requires amq 0.42.0+. The launch wake
+AMQ floor (v2.20.0+): amq-squad requires amq 0.42.1+. AMQ 0.42.1 is the
+first supported complete identity-pin contract: after upgrading, stop and
+resume/relaunch agents so their parent shells receive a coherent tuple; a child
+command cannot repair stale injected environment. Default profiles use
+`AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty `AM_SESSION`; named profiles
+use an exact root with `AM_ROOT=AM_BASE_ROOT` and omit `AM_SESSION`. Run
+`amq-squad doctor` before resume if it reports a legacy or inconsistent pin.
+The launch wake
 gate introduced in v2.5.0 passes `--require-wake` to `amq coop exec`, so a
 launch fails at the door when the AMQ wake sidecar cannot start and acquire its
 lock (instead of surfacing later as a stale wake). `--no-require-wake` opts out

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -11,7 +11,7 @@ import sys
 
 VERSION_RE = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
 SKILL_MARKER_RE = re.compile(r"Skill version:\s*([0-9]+\.[0-9]+\.[0-9]+)")
-AMQ_MIN_VERSION = "0.42.0"
+AMQ_MIN_VERSION = "0.42.1"
 
 
 def read(path: str) -> str:


### PR DESCRIPTION
Fixes #449

## Summary

- Make ordinary `internal/cli` tests hermetic by installing the package-owned
  fake `amq`, sanitizing inherited AMQ identity variables, and proving a poison
  host AMQ cannot be selected.
- Keep AMQ invocation tuples coherent:
  - default-profile work uses a sessionful tuple with
    `AM_ROOT=AM_BASE_ROOT/AM_SESSION`, a non-empty `AM_SESSION`, and `AM_ME`;
  - named-profile work uses an exact-root, sessionless tuple with
    `AM_ROOT=AM_BASE_ROOT`, `AM_ME`, and no `AM_SESSION` environment entry.
- Add disposable real-AMQ compatibility lanes for the supported `v0.42.1`
  floor and the current lane, exercising bare `env --json`, `send`, and
  `drain` under both tuple forms.
- Enforce and document the 0.42.1 floor through `doctor`, README/migration/
  runbook guidance, and CI. `doctor` identifies stale or incomplete identity
  pins and requires a stop/relaunch instead of trying to repair a parent shell.
- Fail closed before AMQ resolver I/O when inherited roots cross a nested
  namespace symlink boundary. This preserves deliberate top-level
  `.agent-mail` base symlinks but rejects profile or session identity rewrites,
  including default-session aliases and named roots inside or outside the
  selected container.

## Validation

- Focused direct and resolver-before-I/O namespace regressions, including
  default, named profile, named session, outside-escape, and top-level-base
  symlink cases
- Focused `-race` coverage and `TestPackageOwnedAMQShadowsPoisonHost`
- Full `go test ./internal/cli -count=1` and `go test ./...`
- Real AMQ tuple lanes for `v0.42.1` and `0.43.0`
- `make ci`, including `go vet` plus generated README/docs/skills checks
- `python3 scripts/check-release-version.py 2.19.1` and `git diff --check`
- Independent exact-head QA and CTO review of
  `85ec46cbcdd2e04d8b78d8cdf76428e3ac393f10`

## Out of scope

The v2.20.0 version bump, release-preparation changes, tags, and release work
are explicitly excluded from this PR and remain owned by dedicated task `t11`
after #449 is accepted.
