### PR TITLE
docs: prepare v2.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-## v2.19.0 (development)
-
-- In an interactive TTY, zero-argument `amq-squad run start` now opens the
-  guided wizard instead of returning the historical missing-flag error.
-  Non-TTY and CI invocations remain noninteractive and retain that error.
-- The wizard executes the canonical preview first and then asks
-  `Launch now? [y/N]`; No is the default, and explicit Yes reruns the identical
-  argv with only `--go` appended. It also offers a Global/NOC scope backed by
-  canonical `amq-squad global start`.
+> **Release-note policy:** this file is retired as a release source. Its former
+> `v2.19.0 (development)` entry was incomplete and would misrepresent later
+> releases. Canonical, reviewed release notes are maintained under `docs/`:
+> [v2.19.0](docs/v2.19.0-release-notes.md),
+> [v2.19.1](docs/v2.19.1-release-notes.md), and
+> [v2.20.0](docs/v2.20.0-release-notes.md).

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2190" id="toc-whats-new-in-v2190">What's new
-in v2.19.0</a></li>
+<li><a href="#whats-new-in-v2200" id="toc-whats-new-in-v2200">What's new
+in v2.20.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2190">What's new in v2.19.0</a></li>
+<li><a href="#whats-new-in-v2200">What's new in v2.20.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,32 +342,24 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2190">What's new in v2.19.0</h2>
-<p>v2.19.0 makes squad startup guided, observable, and safer to
-supervise:</p>
+<h2 id="whats-new-in-v2200">What's new in v2.20.0</h2>
+<p>v2.20.0 makes long-running squad recovery and AMQ compatibility safer
+to ship:</p>
 <ul>
-<li><strong>Interactive <code>run start</code> wizard</strong> with
-Bubble Tea and numbered/accessibility adapters, structured preflight,
-Project and Global/NOC flows, explicit preview-to-live confirmation, and
-deterministic tmux layouts (#393).</li>
-<li><strong>Attention-only operator notifications</strong> with
-profile-scoped desktop or direct-argv sinks, delivery de-duplication,
-gate escalation, and wizard/setup configuration that never grants
-approval (#390).</li>
-<li><strong>Bounded self-operator mode</strong> for explicit,
-exact-session merge approval. Spawn, release, tag, publish,
-external-send, and destructive actions remain human-only, and the
-approving lead cannot execute its own merge (#391).</li>
-<li><strong>Bootstrap and launch hardening</strong> with identity-bound
-bootstrap completion attestation and single-pass native Claude/Codex
-argv composition (#396).</li>
-<li><strong>Wake-friendly orchestration waits</strong>: collect briefly
-for an imminent ACK or report, then park/end the turn for longer work
-and operator gates (#404).</li>
-<li><strong>Deterministic layout finalization hardening</strong> keeps
-the configured lead in the main tmux pane, verifies exact pane/window
-identity, and preserves observable warnings without tearing down
-launched agents (#393).</li>
+<li><strong>Durable resume-goal recovery.</strong> Recovery preserves
+the exact target and delivery evidence across interrupted launches, so
+an operator can resume a staged goal without silently retargeting or
+losing the durable handoff (#447, PR #466).</li>
+<li><strong>Hermetic AMQ compatibility checks.</strong> Ordinary CLI
+tests install a package-owned fake AMQ and prove that a poison host
+binary is never selected; CI also exercises the supported AMQ floor and
+current AMQ with real sessionful and exact-root tuples (#449, PR
+#468).</li>
+<li><strong>Fail-closed inherited AMQ identities.</strong> Default and
+named sessions keep their lexical namespace identity through resolution.
+Nested profile or session symlink rewrites are rejected before AMQ
+resolver I/O, while a deliberate top-level <code>.agent-mail</code>
+container symlink remains supported.</li>
 </ul>
 <h2 id="install">Install</h2>
 <p>Install the v2 module path:</p>
@@ -375,7 +367,7 @@ launched agents (#393).</li>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.1</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -786,7 +778,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#
 <p>Safety preflights:</p>
 <div class="sourceCode" id="cb12"><pre
 class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify action <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;draft v2.19.0 release&quot;</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--gate</span> release <span class="at">--action</span> github_release <span class="at">--target</span> <span class="st">&quot;publish v2.20.0 GitHub release&quot;</span></span>
 <span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify merge <span class="at">--evidence</span> merge-evidence.json</span>
 <span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> verify release <span class="at">--evidence</span> release-evidence.json</span></code></pre></div>
 <p>The action, merge, and final-release-commit contracts are documented
@@ -877,7 +869,7 @@ coordinate reviews, recover, and produce final evidence.</td>
 <p>Invoke skills in Claude Code as <code>/amq-squad:&lt;skill&gt;</code>
 and in Codex as <code>$&lt;skill&gt;</code>.</p>
 <p>Model guidance is intentionally skill-owned because it changes faster
-than the binary. For v2.19.0, use the current model family and per-role
+than the binary. For v2.20.0, use the current model family and per-role
 model/effort recommendations in the installed skills; treat cost as a
 tie-breaker after output quality for shippable work. Prefer that
 guidance over copying model examples from this README.</p>
@@ -1085,10 +1077,10 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>AMQ 0.42.1 is the first supported release for the complete injected
-identity contract. After upgrading from an older AMQ, stop and
-resume/relaunch agents so their shells receive a coherent pin; a child
-command cannot repair stale parent environment variables.
+<p>v2.20.0 requires AMQ 0.42.1+, the first supported release for the
+complete injected identity contract. After upgrading from an older AMQ,
+stop and resume/relaunch agents so their shells receive a coherent pin;
+a child command cannot repair stale parent environment variables.
 Default-profile sessions use <code>AM_ROOT</code>,
 <code>AM_BASE_ROOT</code>, non-empty <code>AM_SESSION</code>, and
 <code>AM_ME</code>. Named profiles use their exact root with

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.19.0](#whats-new-in-v2190)
+- [What's new in v2.20.0](#whats-new-in-v2200)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,26 +38,22 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.19.0
+## What's new in v2.20.0
 
-v2.19.0 makes squad startup guided, observable, and safer to supervise:
+v2.20.0 makes long-running squad recovery and AMQ compatibility safer to ship:
 
-- **Interactive `run start` wizard** with Bubble Tea and numbered/accessibility
-  adapters, structured preflight, Project and Global/NOC flows, explicit
-  preview-to-live confirmation, and deterministic tmux layouts (#393).
-- **Attention-only operator notifications** with profile-scoped desktop or
-  direct-argv sinks, delivery de-duplication, gate escalation, and wizard/setup
-  configuration that never grants approval (#390).
-- **Bounded self-operator mode** for explicit, exact-session merge approval.
-  Spawn, release, tag, publish, external-send, and destructive actions remain
-  human-only, and the approving lead cannot execute its own merge (#391).
-- **Bootstrap and launch hardening** with identity-bound bootstrap completion
-  attestation and single-pass native Claude/Codex argv composition (#396).
-- **Wake-friendly orchestration waits**: collect briefly for an imminent ACK or
-  report, then park/end the turn for longer work and operator gates (#404).
-- **Deterministic layout finalization hardening** keeps the configured lead in
-  the main tmux pane, verifies exact pane/window identity, and preserves
-  observable warnings without tearing down launched agents (#393).
+- **Durable resume-goal recovery.** Recovery preserves the exact target and
+  delivery evidence across interrupted launches, so an operator can resume a
+  staged goal without silently retargeting or losing the durable handoff (#447,
+  PR #466).
+- **Hermetic AMQ compatibility checks.** Ordinary CLI tests install a
+  package-owned fake AMQ and prove that a poison host binary is never selected;
+  CI also exercises the supported AMQ floor and current AMQ with real
+  sessionful and exact-root tuples (#449, PR #468).
+- **Fail-closed inherited AMQ identities.** Default and named sessions keep
+  their lexical namespace identity through resolution. Nested profile or session
+  symlink rewrites are rejected before AMQ resolver I/O, while a deliberate
+  top-level `.agent-mail` container symlink remains supported.
 
 ## Install
 
@@ -71,7 +67,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.19.1
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -361,7 +357,7 @@ Safety preflights:
 
 ```sh
 amq-squad verify action --project . --session issue-96 \
-  --gate release --action github_release --target "draft v2.19.0 release"
+  --gate release --action github_release --target "publish v2.20.0 GitHub release"
 amq-squad verify merge --evidence merge-evidence.json
 amq-squad verify release --evidence release-evidence.json
 ```
@@ -418,7 +414,7 @@ Invoke skills in Claude Code as `/amq-squad:<skill>` and in Codex as
 `$<skill>`.
 
 Model guidance is intentionally skill-owned because it changes faster than the
-binary. For v2.19.0, use the current model family and per-role model/effort
+binary. For v2.20.0, use the current model family and per-role model/effort
 recommendations in the installed skills; treat cost as a tie-breaker after
 output quality for shippable work. Prefer that guidance over copying model
 examples from this README.
@@ -600,8 +596,8 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-AMQ 0.42.1 is the first supported release for the complete injected identity
-contract. After upgrading from an older AMQ, stop and resume/relaunch agents so
+v2.20.0 requires AMQ 0.42.1+, the first supported release for the complete
+injected identity contract. After upgrading from an older AMQ, stop and resume/relaunch agents so
 their shells receive a coherent pin; a child command cannot repair stale parent
 environment variables. Default-profile sessions use `AM_ROOT`, `AM_BASE_ROOT`,
 non-empty `AM_SESSION`, and `AM_ME`. Named profiles use their exact root with

--- a/docs/v2.20.0-release-notes.md
+++ b/docs/v2.20.0-release-notes.md
@@ -65,10 +65,16 @@ and merged separately before this dedicated release-prep change.
 ## Validation and review evidence
 
 - The exact merged #449 main commit
-  `6ca89229abd7c4555c1516c5e0f8231f22810ffc` passed GitHub Actions run
+  [`6ca89229abd7c4555c1516c5e0f8231f22810ffc`](https://github.com/omriariav/amq-squad/commit/6ca89229abd7c4555c1516c5e0f8231f22810ffc)
+  passed GitHub Actions run
   [29289278881](https://github.com/omriariav/amq-squad/actions/runs/29289278881):
-  `make ci` job 86948952679, real AMQ `v0.42.1` job 86948952658, and real AMQ
-  latest job 86948952678 all succeeded.
+  `make ci` job
+  [86948952679](https://github.com/omriariav/amq-squad/actions/runs/29289278881/job/86948952679),
+  real AMQ `v0.42.1` job
+  [86948952658](https://github.com/omriariav/amq-squad/actions/runs/29289278881/job/86948952658),
+  and real AMQ latest job
+  [86948952678](https://github.com/omriariav/amq-squad/actions/runs/29289278881/job/86948952678)
+  all succeeded.
 - PR #468 was independently reviewed at exact head
   `85ec46cbcdd2e04d8b78d8cdf76428e3ac393f10`, then squash-merged with a
   head-match gate. The merge commit has sole parent `8d7a86c` and the same tree

--- a/docs/v2.20.0-release-notes.md
+++ b/docs/v2.20.0-release-notes.md
@@ -1,0 +1,105 @@
+# amq-squad v2.20.0
+
+## Summary
+
+v2.20.0 assembles the 14 closed issues in milestone #26 into a release with
+resilient launch recovery, safer operator workflows, and a release-tested AMQ
+compatibility contract. It includes the final recovery hardening from #447 and
+the AMQ floor/identity remediation from #449; the two changes were reviewed
+and merged separately before this dedicated release-prep change.
+
+## Highlights
+
+- **Guided, observable launch and recovery.** The release range adds the
+  wizard discovery/profile/resume flow, role-specific model and effort catalog,
+  permission overlays, isolated review worktrees, notification supervision, and
+  attributable wake cleanup. #447 completes the range with durable
+  resume-goal recovery that keeps the exact target and delivery evidence across
+  an interrupted launch.
+- **Hermetic AMQ compatibility.** Ordinary `internal/cli` tests install the
+  package-owned fake AMQ, clear inherited AMQ identity variables, and prove a
+  poison host AMQ is never used. CI additionally runs real AMQ round trips for
+  the supported `v0.42.1` floor and the current lane.
+- **Coherent AMQ identity tuples.** Default-profile work uses a sessionful
+  tuple (`AM_ROOT=AM_BASE_ROOT/AM_SESSION`, non-empty `AM_SESSION`, `AM_ME`);
+  named-profile work uses an exact-root/sessionless tuple
+  (`AM_ROOT=AM_BASE_ROOT`, `AM_ME`, no `AM_SESSION`).
+- **Fail-closed inherited namespaces.** Default and named inherited roots must
+  preserve their lexical suffix beneath the selected `.agent-mail` container.
+  Nested profile or session symlink rewrites fail before AMQ resolver I/O;
+  deliberate top-level `.agent-mail` container symlinks remain supported.
+- **Actionable AMQ upgrade guidance.** `doctor`, the skills, README, migration
+  material, and the global runbook all identify AMQ 0.42.1 as the first
+  complete injected-identity contract and require stop/resume or relaunch for
+  stale parent-shell pins.
+
+## Milestone issue, PR, and merge ledger
+
+| Milestone issue | PR | Protected-main merge SHA | Delivered result |
+| --- | --- | --- | --- |
+| #344 | PR #459 | `923eefcd591f15db6b3efa765e3d443cb34ccde8` | Named-profile teardown no longer refuses because a legacy/default AMQ root is present. |
+| #401 | PR #438, PR #440 | `c1a12ed1a12d5df6233d9d901c1580bbc20acc02`, `3ad4791b74b98647001b6f29b9bf8eebd3ca8eb2` | AMQ floor/wake-mode work and scoped per-role launch permissions. |
+| #411 | PR #441 | `25aa75e49d71a6a61c5d2b69df28fc1d1ae7ceaa` | Wake-helper cleanup race fixed and the prior flake made attributable. |
+| #415 | PR #442 | `7bbceb59e60af200026ba634a49ea6a042f15971` | Exact-SHA review worktree helper with environment sanitization and evidence manifest. |
+| #417 | PR #446 | `6778bc0b3a9d167332fac82ae00277413c2a4890` | Shell-mangled inline bodies warn instead of being silently misinterpreted. |
+| #419 | PR #458 | `8b5b0a57201484ca556c82e32fe8fb0f6f2a669e` | AMQ update notices are suppressed in machine paths; tmux test harness is isolated. |
+| #420 | PR #438 | `c1a12ed1a12d5df6233d9d901c1580bbc20acc02` | AMQ floor review work now superseded by the final 0.42.1 contract in #449. |
+| #427 | PR #436 | `d821263a4c37c2c4acfed98d12ddd1784c9a2c44` | Launch robustness: queued-input detection, durable goal fallback, and iTerm2 control-mode warning. |
+| #428 | PR #434, PR #439, PR #444, PR #448 | `a527c69e1b0fd9be624c0f3ad69b7fcde4f097bc`, `0bd154c3c6848011c1e2b31ad98a579fb343ab59`, `1726c64f3f718cfd68f2d217d7c4da3bb7f04a25`, `5094aefca15f8e6bd97d59c2812a2d46d9a30821` | Wizard design, discovery, profile/run selection, and resume flow. |
+| #431 | PR #434, PR #439, PR #444, PR #448 | `a527c69e1b0fd9be624c0f3ad69b7fcde4f097bc`, `0bd154c3c6848011c1e2b31ad98a579fb343ab59`, `1726c64f3f718cfd68f2d217d7c4da3bb7f04a25`, `5094aefca15f8e6bd97d59c2812a2d46d9a30821` | Shared wizard/profile-flow delivery. |
+| #432 | PR #450 | `27516cabd94f032284c3aa6c88419f05cf1b52bb` | Configurable per-binary model and effort catalog overlays. |
+| #435 | PR #445, PR #453 | `455723cd25a57a8b769ee850d8942f466cbe2387`, `13ecbc566d0dab04718b563d997e20ada0d18791` | Supervised notification watcher and notification observability/receipt semantics. |
+| #447 | PR #466 | `8d7a86c99cf9bd4024adce9e710aeaa1fe9ff7d8` | Hardened resume-goal redelivery recovery. |
+| #449 | PR #468 | `6ca89229abd7c4555c1516c5e0f8231f22810ffc` | Hermetic AMQ compatibility, real-AMQ CI, and fail-closed identity handling. |
+
+## Recovery and compatibility contracts
+
+- Resume-goal recovery keeps the original target, delivery status, and safe
+  retry path durable; recovery does not silently reinterpret a staged goal.
+- AMQ compatibility is asserted in hermetic unit/integration coverage and in
+  real-AMQ CI at both the 0.42.1 floor and current lane.
+- Exact-root named profiles intentionally omit `AM_SESSION`; default sessions
+  intentionally carry it. The two forms are tested separately so a child
+  process cannot blur a parent shell's namespace identity.
+
+## Validation and review evidence
+
+- The exact merged #449 main commit
+  `6ca89229abd7c4555c1516c5e0f8231f22810ffc` passed GitHub Actions run
+  [29289278881](https://github.com/omriariav/amq-squad/actions/runs/29289278881):
+  `make ci` job 86948952679, real AMQ `v0.42.1` job 86948952658, and real AMQ
+  latest job 86948952678 all succeeded.
+- PR #468 was independently reviewed at exact head
+  `85ec46cbcdd2e04d8b78d8cdf76428e3ac393f10`, then squash-merged with a
+  head-match gate. The merge commit has sole parent `8d7a86c` and the same tree
+  as the reviewed head; the feature branch remains preserved.
+- This dedicated release-prep change is validated with generated skill/README
+  checks, `make release-check VERSION=v2.20.0`, `make ci`, a version-stamped
+  `make build VERSION=v2.20.0`, and an exact `amq-squad v2.20.0` runtime check
+  before its own review and merge gate.
+
+## Compatibility
+
+- Go 1.25+ remains required.
+- amq-squad v2.20.0 requires `amq` 0.42.1+.
+- After upgrading from an older AMQ, stop and resume/relaunch agents so parent
+  shells receive a coherent identity pin; child commands cannot repair a stale
+  parent environment.
+- The Claude/Codex plugin manifests, canonical source skill, generated skill
+  mirrors, README install example, and release metadata are versioned together
+  at v2.20.0.
+
+## Known follow-ups and explicit non-claims
+
+- [#467](https://github.com/omriariav/amq-squad/issues/467), **Regression: AMQ
+  wake still leaks `[200~`/`[201~` bracketed-paste markers into Codex panes**,
+  remains open with no milestone. It is explicitly outside milestone #26 and
+  outside this release; the durable AMQ message remains authoritative, but the
+  pane-wake injector still needs an end-to-end fix.
+- This release does not claim a tag, a GitHub release, binary archives,
+  checksums, SBOMs, or release assets. Those actions require their own final
+  exact-SHA evidence and operator gates after the release-prep PR is merged.
+- Milestone #26 remains open; this release-prep change neither closes it nor
+  claims that the milestone closeout has occurred.
+- `CHANGELOG.md` is intentionally retired as a release source; these reviewed
+  release notes are the canonical v2.20.0 history.

--- a/internal/cli/review_worktree.go
+++ b/internal/cli/review_worktree.go
@@ -97,7 +97,7 @@ Options:
 Examples:
   amq-squad review-worktree HEAD
   amq-squad review-worktree exec --repo ~/Code/app abc123 -- go test ./...
-  amq-squad review-worktree shell v2.19.1
+  amq-squad review-worktree shell v2.20.0
   amq-squad review-worktree remove /tmp/amq-squad-review-123456
 `)
 }

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.19.1** — on your FIRST response of a session, print the line `amq-squad skill v2.19.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 


### PR DESCRIPTION
## v2.20.0 release preparation

- Versions the Claude and Codex plugin manifests, canonical/generated
  `amq-squad` skills, README, and generated `README.html` at v2.20.0.
- Adds canonical `docs/v2.20.0-release-notes.md` with the complete 14-issue,
  17-PR milestone ledger and direct evidence links to the exact protected-main
  #449 commit and its CI jobs.
- Documents the AMQ 0.42.1+ compatibility guidance and retires the stale
  `CHANGELOG.md` entry in favor of reviewed release notes.
- Records #467 as an open, no-milestone known follow-up; it is outside this
  release-prep scope.

## Validation and review evidence

- QA approved exact head
  `a58c096b5dc04645313b752b40481b2aae0cb4a2` after the t26 evidence-link
  remediation (AMQ approval `2026-07-13T22-40-48.170Z_pid35299_1efd2512`).
- `make skills-generate`
- `make readme-html`
- `make docs-html`
- `git diff --check 6ca89229abd7c4555c1516c5e0f8231f22810ffc..HEAD`
- `make release-check VERSION=v2.20.0`
- `GOCACHE=/private/tmp/amq-v220-go-cache make ci`
- `GOCACHE=/private/tmp/amq-v220-go-cache make build VERSION=v2.20.0`
- `./amq-squad version` reports `amq-squad v2.20.0`

## Release boundary

This PR does **not** create or push a tag, draft or publish a GitHub release,
create release assets, checksums, or an SBOM, or close milestone #26. Those
actions remain behind the final release gate.
