### PR TITLE
fix: restore native goal metadata in wizard resume (v2.20.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 > `v2.19.0 (development)` entry was incomplete and would misrepresent later
 > releases. Canonical, reviewed release notes are maintained under `docs/`:
 > [v2.19.0](docs/v2.19.0-release-notes.md),
-> [v2.19.1](docs/v2.19.1-release-notes.md), and
-> [v2.20.0](docs/v2.20.0-release-notes.md).
+> [v2.19.1](docs/v2.19.1-release-notes.md),
+> [v2.20.0](docs/v2.20.0-release-notes.md), and
+> [v2.20.1](docs/v2.20.1-release-notes.md).

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2200" id="toc-whats-new-in-v2200">What's new
-in v2.20.0</a></li>
+<li><a href="#whats-new-in-v2201" id="toc-whats-new-in-v2201">What's new
+in v2.20.1</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2200">What's new in v2.20.0</a></li>
+<li><a href="#whats-new-in-v2201">What's new in v2.20.1</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,32 +342,29 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2200">What's new in v2.20.0</h2>
-<p>v2.20.0 makes long-running squad recovery and AMQ compatibility safer
-to ship:</p>
+<h2 id="whats-new-in-v2201">What's new in v2.20.1</h2>
+<p>v2.20.1 fixes restored native-goal metadata in the interactive resume
+path:</p>
 <ul>
-<li><strong>Durable resume-goal recovery.</strong> Recovery preserves
-the exact target and delivery evidence across interrupted launches, so
-an operator can resume a staged goal without silently retargeting or
-losing the durable handoff (#447, PR #466).</li>
-<li><strong>Hermetic AMQ compatibility checks.</strong> Ordinary CLI
-tests install a package-owned fake AMQ and prove that a poison host
-binary is never selected; CI also exercises the supported AMQ floor and
-current AMQ with real sessionful and exact-root tuples (#449, PR
-#468).</li>
-<li><strong>Fail-closed inherited AMQ identities.</strong> Default and
-named sessions keep their lexical namespace identity through resolution.
-Nested profile or session symlink rewrites are rejected before AMQ
-resolver I/O, while a deliberate top-level <code>.agent-mail</code>
-container symlink remains supported.</li>
+<li><strong>Wizard resume preserves <code>--restore-goal-binding</code>
+as launcher metadata.</strong> The
+<code>agent up &lt;binary&gt; [flags]</code> translator now recognizes
+the internal restore flag, so it is parsed by amq-squad instead of being
+forwarded to Codex after a synthesized <code>--</code> child-argument
+boundary.</li>
+<li><strong>Regression coverage pins the generated command
+shape.</strong> The test exercises the post-binary JSON flag exactly
+where restored wizard commands place it.</li>
 </ul>
+<p>See <a href="docs/v2.20.1-release-notes.md">the v2.20.1 release
+notes</a> for details.</p>
 <h2 id="install">Install</h2>
 <p>Install the v2 module path:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.1</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.20.0](#whats-new-in-v2200)
+- [What's new in v2.20.1](#whats-new-in-v2201)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,22 +38,18 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.20.0
+## What's new in v2.20.1
 
-v2.20.0 makes long-running squad recovery and AMQ compatibility safer to ship:
+v2.20.1 fixes restored native-goal metadata in the interactive resume path:
 
-- **Durable resume-goal recovery.** Recovery preserves the exact target and
-  delivery evidence across interrupted launches, so an operator can resume a
-  staged goal without silently retargeting or losing the durable handoff (#447,
-  PR #466).
-- **Hermetic AMQ compatibility checks.** Ordinary CLI tests install a
-  package-owned fake AMQ and prove that a poison host binary is never selected;
-  CI also exercises the supported AMQ floor and current AMQ with real
-  sessionful and exact-root tuples (#449, PR #468).
-- **Fail-closed inherited AMQ identities.** Default and named sessions keep
-  their lexical namespace identity through resolution. Nested profile or session
-  symlink rewrites are rejected before AMQ resolver I/O, while a deliberate
-  top-level `.agent-mail` container symlink remains supported.
+- **Wizard resume preserves `--restore-goal-binding` as launcher metadata.**
+  The `agent up <binary> [flags]` translator now recognizes the internal
+  restore flag, so it is parsed by amq-squad instead of being forwarded to
+  Codex after a synthesized `--` child-argument boundary.
+- **Regression coverage pins the generated command shape.** The test exercises
+  the post-binary JSON flag exactly where restored wizard commands place it.
+
+See [the v2.20.1 release notes](docs/v2.20.1-release-notes.md) for details.
 
 ## Install
 
@@ -67,7 +63,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.20.1
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.20.1-release-notes.md
+++ b/docs/v2.20.1-release-notes.md
@@ -1,0 +1,41 @@
+# amq-squad v2.20.1
+
+## Summary
+
+v2.20.1 is a focused hotfix for the v2.20.0 wizard resume path. A stopped
+orchestrated team whose lead carried native goal-binding metadata could open
+all requested tmux panes while the lead immediately exited, because
+`--restore-goal-binding` crossed the launcher/child-argument boundary and was
+sent to Codex instead of being consumed by amq-squad.
+
+## Fix
+
+- The `agent up <binary> [flags]` translator now classifies
+  `--restore-goal-binding` as an amq-squad string flag. Restored JSON metadata
+  remains on the launcher side of the binary positional and is persisted in
+  the new launch record without replaying the settled native `/goal` command.
+- A regression test covers the wizard-generated post-binary command shape and
+  proves the JSON flag/value pair is moved ahead of `codex`, with no synthesized
+  child boundary.
+
+## Impact
+
+- `amq-squad wizard` / `amq-squad resume --exec` can restore a v2.20.0 team
+  whose lead has recorded native goal metadata.
+- No schema or public flag changes are introduced.
+- Go 1.25+ and `amq` 0.42.1+ remain required.
+
+## Validation
+
+- Targeted translator and restore-goal tests.
+- Full `make ci`.
+- `make release-check VERSION=v2.20.1` and a version-stamped build.
+- GitHub Actions on the final PR head, followed by an exact-SHA release
+  co-sign and operator release approval before tag/publication.
+
+## Known follow-up
+
+Resume currently opens the selected worker panes in the same backend launch
+plan as the lead. If the lead process exits after tmux accepts the plan, workers
+can still start and require operator intervention; lead-readiness gating is a
+separate orchestration hardening change and is not claimed by this hotfix.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -286,7 +286,7 @@ func launchKnownFlag(name string) string {
 		return "string-accepts-dash"
 	case "--role", "--session", "--me", "--root", "--project", "--profile", "--team-home", "--team-profile",
 		"--conversation", "--conversation-id", "--trust", "--model", "--launcher", "--wake-inject-via", "--wake-inject-mode",
-		"--spawn-origin", "--spawn-depth",
+		"--spawn-origin", "--spawn-depth", "--restore-goal-binding",
 		"-role", "-session", "-s", "-me", "-root", "-project", "-p", "-profile", "-P", "-team-home", "-team-profile",
 		"-conversation", "-conversation-id", "-trust", "-model", "-launcher", "-wake-inject-via", "-wake-inject-mode",
 		"-spawn-origin", "-spawn-depth":

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -202,6 +202,7 @@ func TestTranslateAgentUpArgs(t *testing.T) {
 		{"claude-args consumes dash-prefixed value", []string{"claude", "--dry-run", "--no-bootstrap", "--claude-args", "--chrome"}, []string{"--dry-run", "--no-bootstrap", "--claude-args", "--chrome", "claude"}},
 		{"trailing codex-args with no value is child", []string{"codex", "--dry-run", "--no-bootstrap", "--codex-args"}, []string{"--dry-run", "--no-bootstrap", "codex", "--", "--codex-args"}},
 		{"post-binary --no-require-wake is a launch flag", []string{"codex", "--dry-run", "--no-require-wake"}, []string{"--dry-run", "--no-require-wake", "codex"}},
+		{"restore goal binding remains a launch flag", []string{"codex", "--role", "cto", "--restore-goal-binding", `{"mode":"native_goal"}`}, []string{"--role", "cto", "--restore-goal-binding", `{"mode":"native_goal"}`, "codex"}},
 		{
 			"post-binary named profile explicit root with spawn metadata",
 			[]string{"claude", "--project", "/repo", "--team-home", "/repo", "--team-profile", "review", "--session", "issue-96", "--team-workstream", "--role", "qa", "--me", "release-reviewer", "--spawn-origin", "release-lead", "--spawn-depth", "1", "--root", "/repo/.agent-mail/review/issue-96"},

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -14,7 +14,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.1** — on your FIRST response of a session, print the line `amq-squad skill v2.20.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -10,7 +10,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.1** — on your FIRST response of a session, print the line `amq-squad skill v2.20.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 

--- a/plugins/skills-src/amq-squad/SKILL.md
+++ b/plugins/skills-src/amq-squad/SKILL.md
@@ -12,7 +12,7 @@ Launch priming is automatic. `up` / `agent up` inject the bootstrap prompt; agen
 
 This skill is named `amq-squad`; the binary is also named `amq-squad`.
 
-**Skill version: 2.20.0** — on your FIRST response of a session, print the line `amq-squad skill v2.20.0` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
+**Skill version: 2.20.1** — on your FIRST response of a session, print the line `amq-squad skill v2.20.1` before anything else, so the operator can confirm which skill build loaded. An older cached skill lacks this step and stays silent, so the *absence* of this line is itself the signal that the expected build did not load. (Pair it with `amq-squad version` for the binary: skill and binary versions should match.)
 
 ## Context model
 


### PR DESCRIPTION
## What changed

- classify `--restore-goal-binding` as an amq-squad string flag in the post-binary `agent up` translator
- add regression coverage for the exact JSON-valued wizard resume command shape
- bump Claude/Codex plugin and skill metadata to v2.20.1
- add v2.20.1 release notes and refresh README/HTML release surfaces

## Root cause and impact

The v2.20.0 restore renderer emits `agent up codex ... --restore-goal-binding <json>`. The post-binary translator did not include that internal flag in its launch-flag registry, so it treated the flag as native Codex input and synthesized a `--` child-argument boundary. Codex then rejected the command and the lead exited while other requested tmux panes could still open.

The hotfix keeps the restore metadata on the amq-squad side of the binary positional. It does not claim the separate lead-readiness gating follow-up.

## Validation

- `make ci`
- `make release-check VERSION=v2.20.1`
- `python3 scripts/check-skill-frontmatter.py`
- `make build VERSION=v2.20.1`
- `./amq-squad version` → `amq-squad v2.20.1`
- exact `agent up codex ... --restore-goal-binding=<json> --dry-run` reproduction: metadata is consumed by amq-squad and absent from Codex child argv
