### PR TITLE
fix(#538): make worktree_isolation remedies executable and discoverable

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -237,25 +239,61 @@ Examples:
 	return runNewTeam(teamArgs)
 }
 
+// newProfileValueFlags lists the `team init` flags that take a SEPARATE value,
+// so `new profile NAME ...` can tell a flag's value apart from the profile name
+// while peeling the positional argument.
+//
+// #538: this list must stay complete. A value-taking flag missing from here is
+// treated as valueless, its value falls through as a positional, and the operator
+// gets "new profile takes exactly one profile name; got extra argument" -- an
+// error that blames their input for a gap in this map. --actor-mode,
+// --tool-profile and --tool-config were all missing, which is how a roster
+// intended to have one reviewer and two implementers came out with three
+// implementers and a worktree_isolation blocker nobody could explain.
+//
+// TestNewProfileForwardsEveryValueTakingTeamInitFlag enumerates the real
+// `team init` flag set and fails when an entry is missing, so this cannot drift
+// again. Do not hand-maintain it against memory; add the flag and let the test
+// confirm.
+var newProfileValueFlags = map[string]bool{
+	"--actor-mode":           true,
+	"--allowed-role-classes": true,
+	"--allowed-roles":        true,
+	"--binary":               true,
+	"--budget-turns":         true,
+	"--claude-args":          true,
+	"--codex-args":           true,
+	"--composition":          true,
+	"--control-root":         true,
+	"--cwd":                  true,
+	"--effort":               true,
+	"--idle-reap-minutes":    true,
+	"--lead":                 true,
+	"--lead-mode":            true,
+	"--max-agents":           true,
+	"--max-total-spawns":     true,
+	"--mode":                 true,
+	"--model":                true,
+	"--operator":             true,
+	"--operator-mode":        true,
+	"--personas":             true,
+	"--project":              true,
+	"--role-file":            true,
+	"--roles":                true,
+	"--self-operator-allow":  true,
+	"--self-operator-lead":   true,
+	"--session":              true,
+	"--shared-cwd-exception": true,
+	"--target-contract":      true,
+	"--target-project-root":  true,
+	"--tool-config":          true,
+	"--tool-profile":         true,
+	"--trust":                true}
+
 func newProfileTeamArgs(args []string) ([]string, error) {
 	profile := ""
 	out := make([]string, 0, len(args)+2)
-	valueFlags := map[string]bool{
-		"--binary":      true,
-		"--claude-args": true,
-		"--codex-args":  true,
-		"--cwd":         true,
-		"--effort":      true,
-		"--lead":        true,
-		"--model":       true,
-		"--operator":    true,
-		"--personas":    true,
-		"--project":     true,
-		"--role-file":   true,
-		"--roles":       true,
-		"--session":     true,
-		"--trust":       true,
-	}
+	valueFlags := newProfileValueFlags
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		if a == "--" {
@@ -468,4 +506,38 @@ func runInProject(project string, fn func() error) error {
 	}
 	defer func() { _ = os.Chdir(old) }()
 	return fn()
+}
+
+// teamInitFlagSetSnapshot holds the most recently registered `team init` flag
+// set, published by runTeamInitWithOptions.
+//
+// TEST INTROSPECTION ONLY. Nothing in the normal execution path reads this, and
+// it must not become a production API: if you need team-init flags at runtime,
+// take them from the flag set you own rather than from this snapshot.
+//
+// #538: it exists so the `new profile` forwarding test can enumerate the real
+// flags instead of a second hand-written copy. Two lists that must agree, with
+// nothing enforcing it, is the defect class this milestone keeps surfacing;
+// deriving the test's expectation from production registration removes it. The
+// cleaner shape is to extract team init's 41 flag registrations into a struct and
+// share it with `new profile` directly; that refactor was deliberately deferred
+// rather than done inside a bug fix.
+var teamInitFlagSetSnapshot *flag.FlagSet
+
+func publishTeamInitFlagSet(fs *flag.FlagSet) { teamInitFlagSetSnapshot = fs }
+
+// newTeamInitFlagSetForTest registers the real team-init flags by driving the
+// command's own help path (which registers everything, then returns without
+// mutating anything) and returns the resulting flag set.
+func newTeamInitFlagSetForTest() (*flag.FlagSet, error) {
+	teamInitFlagSetSnapshot = nil
+	// --help registers every flag and then reports flag.ErrHelp, which Run
+	// swallows as a successful exit. Anything else is a real failure.
+	if err := runTeamInit([]string{"--help"}); err != nil && !errors.Is(err, flag.ErrHelp) {
+		return nil, err
+	}
+	if teamInitFlagSetSnapshot == nil {
+		return nil, fmt.Errorf("team init did not publish its flag set")
+	}
+	return teamInitFlagSetSnapshot, nil
 }

--- a/internal/cli/new_profile_flag_forwarding_test.go
+++ b/internal/cli/new_profile_flag_forwarding_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// #538 / Finding B: `new profile NAME` peels the profile name from the flag args
+// using a hand-maintained list of which team-init flags take a SEPARATE value.
+// A value-taking flag missing from that list is treated as valueless, its value
+// falls through as a positional, and the operator gets
+//
+//	new profile takes exactly one profile name; got extra argument "cto=review"
+//
+// which blames their input for a gap in our map. --actor-mode, --tool-profile and
+// --tool-config were all missing. --actor-mode is how a lead is marked `review`
+// instead of `implementation`, so its absence silently produced three
+// mutation-capable members where the operator asked for two, and then a
+// worktree_isolation blocker with no visible cause.
+//
+// This test enumerates the REAL team-init flag set and fails when a value-taking
+// flag is not forwarded, so the list cannot drift again as flags are added.
+func TestNewProfileForwardsEveryValueTakingTeamInitFlag(t *testing.T) {
+	missing := []string{}
+	teamInitFlagSet(t).VisitAll(func(f *flag.Flag) {
+		if !flagTakesSeparateValue(f) {
+			return
+		}
+		if newProfileRejectedByDesign[f.Name] {
+			return
+		}
+		if !newProfileValueFlags["--"+f.Name] {
+			missing = append(missing, "--"+f.Name)
+		}
+	})
+	if len(missing) > 0 {
+		t.Fatalf("team init flags take a separate value but are not in newProfileValueFlags, so `new profile` will misparse them as the profile name: %s",
+			strings.Join(missing, ", "))
+	}
+}
+
+// newProfileRejectedByDesign names team-init flags that `new profile` refuses on
+// purpose rather than forwards. --profile is set from the positional NAME, so
+// passing it is an explicit usage error, not a forwarding gap.
+var newProfileRejectedByDesign = map[string]bool{"profile": true}
+
+// The complement: a stale entry is also a bug. A boolean flag listed as
+// value-taking would swallow the NEXT argument, which for `new profile` is often
+// the profile name itself.
+func TestNewProfileValueFlagsHasNoStaleEntries(t *testing.T) {
+	real := map[string]bool{}
+	teamInitFlagSet(t).VisitAll(func(f *flag.Flag) {
+		if flagTakesSeparateValue(f) {
+			real["--"+f.Name] = true
+		}
+	})
+	// Flags peeled by new profile itself before delegation, so they legitimately
+	// appear in the map without being team-init flags.
+	peeledByNewProfile := map[string]bool{"--project": true, "--profile": true}
+	for name := range newProfileValueFlags {
+		if real[name] || peeledByNewProfile[name] {
+			continue
+		}
+		t.Fatalf("newProfileValueFlags lists %s, but team init has no such value-taking flag; a stale entry swallows the following argument (often the profile name)", name)
+	}
+}
+
+// The end-to-end shape of the reported bug: --actor-mode must survive the peel
+// with its value intact, and the profile name must still be extracted.
+func TestNewProfilePeelsNameAndForwardsActorMode(t *testing.T) {
+	args := []string{"testsquad", "--roles", "cto,dev-1", "--actor-mode", "cto=review", "--cwd", "dev-1=/tmp/wt-a"}
+	out, err := newProfileTeamArgs(args)
+	if err != nil {
+		t.Fatalf("newProfileTeamArgs: %v", err)
+	}
+	joined := strings.Join(out, " ")
+	if !strings.Contains(joined, "--profile testsquad") {
+		t.Fatalf("profile name was not forwarded as --profile: %v", out)
+	}
+	for _, want := range []string{"--actor-mode cto=review", "--cwd dev-1=/tmp/wt-a", "--roles cto,dev-1"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("forwarded args are missing %q: %v", want, out)
+		}
+	}
+}
+
+// teamInitFlagSet builds the real `team init` flag set by parsing an empty arg
+// list through the same registration path the command uses, so the enumeration
+// above is against production flags rather than a second hand-written list.
+func teamInitFlagSet(t *testing.T) *flag.FlagSet {
+	t.Helper()
+	fs, err := newTeamInitFlagSetForTest()
+	if err != nil {
+		t.Fatalf("build team init flag set: %v", err)
+	}
+	return fs
+}
+
+// flagTakesSeparateValue reports whether a flag consumes the following argument.
+// Go's flag package folds booleans into `-name` form, so only non-boolean flags
+// take a separate value.
+func flagTakesSeparateValue(f *flag.Flag) bool {
+	bv, ok := f.Value.(interface{ IsBoolFlag() bool })
+	return !(ok && bv.IsBoolFlag())
+}

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -859,7 +859,12 @@ func runRunStart(args []string, version string) error {
 			if err := applyRunStartToolProfiles(project, profile, *toolProfileFlag); err != nil {
 				return runReadinessResult{}, err
 			}
-			return prepareRunArtifacts(project, profile, session, strings.TrimSpace(*launchShapeFlag), *stagedRolesFlag, *goalFlag, *goalSourceFlag, *goalDigestFlag, *seedFlag, runContext)
+			// #538 F3: teamPresent is captured by preflight BEFORE any roster is
+			// created, which is the only honest answer to "did this run create the
+			// profile". Deriving it from the preparation snapshot cannot work:
+			// runStartCreateFreshRoster runs first, so by then the profile always
+			// exists.
+			return prepareRunArtifacts(project, profile, session, strings.TrimSpace(*launchShapeFlag), *stagedRolesFlag, *goalFlag, *goalSourceFlag, *goalDigestFlag, *seedFlag, runContext, teamPresent)
 		})
 		printRunReadiness(result)
 		if err != nil {

--- a/internal/cli/pathnorm.go
+++ b/internal/cli/pathnorm.go
@@ -37,6 +37,36 @@ import (
 // comparison, not of the stored bytes: a symlinked path and its target are the
 // same location and must compare equal however each side was recorded.
 //
+// The two levels cross with a second question -- is the input allowed to be
+// RELATIVE? -- giving four functions. Pick by answering both:
+//
+//	                 | absolute input only     | input may be relative
+//	-----------------+-------------------------+----------------------------------
+//	RECORD (no       | absoluteFilesystemPath  | absoluteFilesystemPathIn(base, p)
+//	 symlink resolve)|                         |
+//	COMPARE (resolve | canonicalFilesystemPath | canonicalFilesystemPathIn(base, p)
+//	 symlinks)       |                         |
+//
+// The anchored (…In) forms exist because filepath.Abs resolves against the PROCESS
+// working directory, which is almost never the right base for a value that will be
+// persisted or compared against a persisted record. Two concrete failures, both
+// real:
+//
+//   - RECORD side (#538): a relative `--cwd` must mean "relative to the project".
+//     Anchoring to the shell instead made `--project /repo --cwd ../wt` run from
+//     /tmp record /tmp/wt on one code path and /repo/../wt on another.
+//   - COMPARE side (#539): a team.json entry persisted relative must be resolved
+//     against the project it was recorded against, or the same record reads as
+//     drift depending on where the operator happened to run the command from.
+//
+// Rule of thumb: if the path came from an operator or from a persisted record,
+// reach for an anchored form and pass the project root as base. Use the unanchored
+// forms only for values you already know are absolute.
+//
+// Set variants (absoluteFilesystemPaths, canonicalFilesystemPaths,
+// canonicalFilesystemPathsIn) follow the same rules and additionally dedupe+sort;
+// use them on BOTH operands of a set comparison.
+//
 // There are NO exceptions to this split. A canonical-at-record exception was
 // attempted for tool_policy_sources and reverted: that field turned out to be
 // printed by the overlay plan output, exported in JSON envelopes, and digested
@@ -109,6 +139,32 @@ func canonicalFilesystemPath(p string) string {
 			return filepath.Clean(filepath.Join(resolved, remainder))
 		}
 	}
+}
+
+// absoluteFilesystemPathIn is the RECORDING normalization for a path that may be
+// written RELATIVE by an operator, anchoring it to base rather than to the
+// process working directory.
+//
+// #538: this is the record-side twin of canonicalFilesystemPathIn, and it exists
+// because a relative --cwd must mean "relative to the project", not "relative to
+// whatever shell the operator happened to be in". Without it,
+// `--project /repo --cwd ../wt` run from /tmp records /tmp/wt on one code path
+// and /repo/../wt on another -- the same recorder/origin divergence that #539 and
+// #540 were about, reintroduced one release later.
+//
+// Recording stops at absolute: symlinks are NOT resolved here, per the split
+// documented above. Comparison canonicalizes further.
+func absoluteFilesystemPathIn(base, p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !filepath.IsAbs(p) && !strings.HasPrefix(p, "~") {
+		if base = strings.TrimSpace(base); base != "" {
+			p = filepath.Join(base, p)
+		}
+	}
+	return absoluteFilesystemPath(p)
 }
 
 // canonicalFilesystemPathIn is the COMPARISON normalization for a path that may

--- a/internal/cli/preparation_rollback_guidance_test.go
+++ b/internal/cli/preparation_rollback_guidance_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #538 F3: the rollback guidance must be TRUE for the case it is printed in.
+//
+// Preparation is transactional. If it CREATED the profile, rollback removes it and
+// the fix-existing commands have nothing to act on. If the profile already
+// existed, rollback RESTORES it and those commands work as printed. Emitting the
+// fresh-profile text unconditionally made the message false in the second case,
+// which is worse than silence: it sends the operator to a command that cannot work
+// while telling them the working one is unavailable.
+func TestPreparationRollbackGuidanceDistinguishesCreatedFromRestored(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), ".amq-squad", "teams", "squad.json")
+
+	t.Run("profile created by this transaction", func(t *testing.T) {
+		msg := preparationRollbackGuidance([]runPreparationFileSnapshot{{Path: profilePath, Exists: false}}, profilePath)
+		if !strings.Contains(msg, "CREATED") || !strings.Contains(msg, "removed") {
+			t.Fatalf("must say the profile was created and removed; got: %s", msg)
+		}
+		// The only runnable remedy here is the creation form.
+		if !strings.Contains(msg, "new profile NAME") {
+			t.Fatalf("must point at the creation form; got: %s", msg)
+		}
+		if strings.Contains(msg, "RESTORED") {
+			t.Fatalf("must not claim restoration; got: %s", msg)
+		}
+	})
+
+	t.Run("profile pre-existed", func(t *testing.T) {
+		msg := preparationRollbackGuidance([]runPreparationFileSnapshot{{Path: profilePath, Exists: true}}, profilePath)
+		if !strings.Contains(msg, "RESTORED") {
+			t.Fatalf("must say the profile was restored; got: %s", msg)
+		}
+		// Telling the operator to create it would fail: it already exists.
+		if strings.Contains(msg, "new profile NAME") {
+			t.Fatalf("must NOT offer the creation form for a profile that still exists; got: %s", msg)
+		}
+		if strings.Contains(msg, "have nothing to act on") {
+			t.Fatalf("the fix-existing commands DO apply here; got: %s", msg)
+		}
+	})
+
+	// Unknown/untracked path must degrade to the safe, non-false statement rather
+	// than assuming creation.
+	t.Run("profile not tracked in the snapshot set", func(t *testing.T) {
+		msg := preparationRollbackGuidance(nil, profilePath)
+		if strings.Contains(msg, "CREATED") {
+			t.Fatalf("must not assert creation without evidence; got: %s", msg)
+		}
+		if !strings.Contains(msg, "RESTORED") {
+			t.Fatalf("must fall back to the restored wording; got: %s", msg)
+		}
+	})
+}

--- a/internal/cli/preparation_rollback_guidance_test.go
+++ b/internal/cli/preparation_rollback_guidance_test.go
@@ -1,59 +1,125 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
-// #538 F3: the rollback guidance must be TRUE for the case it is printed in.
+// #538 F3: the rollback guidance must be true for the case it is printed in, and
+// it must be driven through the REAL preparation path.
 //
-// Preparation is transactional. If it CREATED the profile, rollback removes it and
-// the fix-existing commands have nothing to act on. If the profile already
-// existed, rollback RESTORES it and those commands work as printed. Emitting the
-// fresh-profile text unconditionally made the message false in the second case,
-// which is worse than silence: it sends the operator to a command that cannot work
-// while telling them the working one is unavailable.
-func TestPreparationRollbackGuidanceDistinguishesCreatedFromRestored(t *testing.T) {
-	profilePath := filepath.Join(t.TempDir(), ".amq-squad", "teams", "squad.json")
+// An earlier version of this test called the helper in isolation with a
+// hand-built snapshot slice. That is precisely why F3 looked closed while being
+// broken twice over in production: the profile was not in the preparation snapshot
+// set at all, and the roster is created BEFORE preparation snapshots, so a freshly
+// created profile would have looked pre-existing even if it had been. A helper test
+// cannot see either problem. This one runs `run start --prepare` and reads the
+// error the operator would actually get.
+func TestFreshProfilePrepareFailureSaysTheProfileWasCreatedAndRemoved(t *testing.T) {
+	project := t.TempDir()
+	chdir(t, project)
+	setupStrictFreshProjectAMQ(t)
 
-	t.Run("profile created by this transaction", func(t *testing.T) {
-		msg := preparationRollbackGuidance([]runPreparationFileSnapshot{{Path: profilePath, Exists: false}}, profilePath)
-		if !strings.Contains(msg, "CREATED") || !strings.Contains(msg, "removed") {
-			t.Fatalf("must say the profile was created and removed; got: %s", msg)
-		}
-		// The only runnable remedy here is the creation form.
-		if !strings.Contains(msg, "new profile NAME") {
-			t.Fatalf("must point at the creation form; got: %s", msg)
-		}
-		if strings.Contains(msg, "RESTORED") {
-			t.Fatalf("must not claim restoration; got: %s", msg)
-		}
-	})
+	// A brand-new project: preparation will CREATE the profile, and the roster has
+	// two mutation-capable members sharing one working directory, so
+	// worktree_isolation blocks and preparation rolls back.
+	args := []string{
+		"--project", project, "--profile", "squad", "--session", "s1",
+		"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+		"--roles", "cto,fullstack,backend-dev",
+		"--binary", "cto=claude,fullstack=claude,backend-dev=codex",
+		"--lead", "cto",
+		"--goal", "exercise the fresh-profile rollback guidance",
+		"--prepare",
+	}
+	_, _, err := captureOutput(t, func() error { return runRunStart(args, "test") })
+	if err == nil {
+		t.Fatal("a shared-cwd roster must fail preparation; got success")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "readiness failed") {
+		t.Fatalf("fixture never reached readiness, so it does not exercise the guidance at all: %v", err)
+	}
+	if !strings.Contains(msg, "CREATED") || !strings.Contains(msg, "removed") {
+		t.Fatalf("a fresh-profile prepare failure must say the profile was created and removed; got: %s", msg)
+	}
+	if !strings.Contains(msg, "new profile NAME") {
+		t.Fatalf("must point at the creation-time forms, which do not need an existing profile; got: %s", msg)
+	}
+	// And the claim must be TRUE: the profile really is gone.
+	if _, statErr := os.Stat(team.ProfilePath(project, "squad")); !os.IsNotExist(statErr) {
+		t.Fatalf("guidance says the profile was removed, but %s still exists (stat err: %v)",
+			team.ProfilePath(project, "squad"), statErr)
+	}
+}
 
-	t.Run("profile pre-existed", func(t *testing.T) {
-		msg := preparationRollbackGuidance([]runPreparationFileSnapshot{{Path: profilePath, Exists: true}}, profilePath)
-		if !strings.Contains(msg, "RESTORED") {
-			t.Fatalf("must say the profile was restored; got: %s", msg)
-		}
-		// Telling the operator to create it would fail: it already exists.
-		if strings.Contains(msg, "new profile NAME") {
-			t.Fatalf("must NOT offer the creation form for a profile that still exists; got: %s", msg)
-		}
-		if strings.Contains(msg, "have nothing to act on") {
-			t.Fatalf("the fix-existing commands DO apply here; got: %s", msg)
-		}
-	})
+// The complement, and the case the previous wording got wrong: when the profile
+// already existed, it survives, so the fix-existing commands DO apply and the
+// creation form would fail.
+func TestPreExistingProfilePrepareFailureSaysTheProfileSurvives(t *testing.T) {
+	project := t.TempDir()
+	chdir(t, project)
+	setupStrictFreshProjectAMQ(t)
 
-	// Unknown/untracked path must degrade to the safe, non-false statement rather
-	// than assuming creation.
-	t.Run("profile not tracked in the snapshot set", func(t *testing.T) {
-		msg := preparationRollbackGuidance(nil, profilePath)
-		if strings.Contains(msg, "CREATED") {
-			t.Fatalf("must not assert creation without evidence; got: %s", msg)
-		}
-		if !strings.Contains(msg, "RESTORED") {
-			t.Fatalf("must fall back to the restored wording; got: %s", msg)
-		}
-	})
+	// Create the blocked roster FIRST, so preparation does not create it.
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad", "--project", project,
+			"--roles", "cto,fullstack,backend-dev",
+			"--binary", "cto=claude,fullstack=claude,backend-dev=codex",
+			"--actor-mode", "fullstack=implementation,backend-dev=implementation",
+			"--orchestrated", "--lead", "cto",
+			"--session", "s1"})
+	}); err != nil {
+		t.Fatalf("seed pre-existing profile: %v", err)
+	}
+	profilePath := team.ProfilePath(project, "squad")
+	if _, err := os.Stat(profilePath); err != nil {
+		t.Fatalf("fixture profile missing: %v", err)
+	}
+
+	args := []string{
+		"--project", project, "--profile", "squad", "--session", "s1",
+		"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+		"--goal", "exercise the pre-existing rollback guidance",
+		"--prepare",
+	}
+	_, _, err := captureOutput(t, func() error { return runRunStart(args, "test") })
+	if err == nil {
+		t.Fatal("a shared-cwd roster must fail preparation; got success")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "readiness failed") {
+		t.Fatalf("fixture never reached readiness, so it does not exercise the guidance at all: %v", err)
+	}
+	if strings.Contains(msg, "CREATED") {
+		t.Fatalf("this run did NOT create the profile; guidance must not claim it did. got: %s", msg)
+	}
+	if strings.Contains(msg, "new profile NAME") {
+		t.Fatalf("the profile exists, so `new profile NAME` would fail; must not be offered. got: %s", msg)
+	}
+	// And the claim must be TRUE: the profile really does survive.
+	if _, statErr := os.Stat(profilePath); statErr != nil {
+		t.Fatalf("guidance says the profile is unchanged, but it is gone: %v", statErr)
+	}
+}
+
+// The wording itself, pinned directly so the two branches cannot converge.
+func TestPreparationRollbackGuidanceBranchesDiffer(t *testing.T) {
+	created := preparationRollbackGuidance(false)
+	survived := preparationRollbackGuidance(true)
+	if created == survived {
+		t.Fatal("the created and pre-existing branches must not produce the same text")
+	}
+	if !strings.Contains(created, "CREATED") || strings.Contains(created, "unchanged") {
+		t.Fatalf("created branch wording is wrong: %s", created)
+	}
+	if !strings.Contains(survived, "unchanged") || strings.Contains(survived, "CREATED") {
+		t.Fatalf("pre-existing branch wording is wrong: %s", survived)
+	}
+	_ = filepath.Separator
 }

--- a/internal/cli/run_start_preparation.go
+++ b/internal/cli/run_start_preparation.go
@@ -600,36 +600,29 @@ func printRunPreparationProposal(proposal runPreparationProposal) {
 // preparationRollbackGuidance explains what the transactional rollback did to the
 // profile, and therefore which remedy is actually runnable now.
 //
-// #538 F3: preparation rolls back on readiness failure. Which advice is TRUE
-// depends on whether this transaction created the profile:
+// #538 F3: which advice is TRUE depends on whether THIS run created the profile:
 //
-//   - created (no pre-existing file): rollback removes it, so `team member update`
-//     and `team shared-cwd-exception set` have nothing to act on, and the operator
-//     must apply the fix at creation time.
-//   - pre-existing: rollback RESTORES it, so those commands work as printed, and
-//     `new profile NAME` would fail because the profile already exists.
+//   - created: rollback leaves no profile, so `team member update` and
+//     `team shared-cwd-exception set` have nothing to act on and the fix must be
+//     applied at creation time.
+//   - pre-existing: the profile is still there, those commands work as printed,
+//     and `new profile NAME` would fail because it already exists.
 //
-// Emitting the fresh-profile text unconditionally made the message false in the
-// second case, which is worse than silence: it sends the operator to a command
-// that cannot work while telling them the working one is unavailable.
-func preparationRollbackGuidance(snapshots []runPreparationFileSnapshot, profilePath string) string {
-	profilePath = filepath.Clean(strings.TrimSpace(profilePath))
-	existedBefore := false
-	tracked := false
-	for _, snap := range snapshots {
-		if snap.Path != profilePath {
-			continue
-		}
-		tracked = true
-		existedBefore = snap.Exists
-		break
+// The flag comes from preflight's pre-run observation, NOT from the preparation
+// snapshot. An earlier version derived it from the snapshot and was wrong in both
+// directions: the profile was not in that snapshot set at all (so every case got
+// the fallback wording), and even if it had been, the roster is created BEFORE
+// preparation snapshots, so a freshly created profile would have looked
+// pre-existing. Emitting the wrong branch here is worse than silence: it sends the
+// operator to a command that cannot work while telling them the working one is
+// unavailable.
+func preparationRollbackGuidance(profileExistedBeforeRun bool) string {
+	if profileExistedBeforeRun {
+		return "Preparation is transactional, so this profile is unchanged from its pre-preparation state; " +
+			"it still exists and the blocked row's commands apply to it as printed. Fix the reported rows, then re-run --prepare."
 	}
-	if tracked && !existedBefore {
-		return "Preparation is transactional and it CREATED this profile, so the rollback removed it: " +
-			"commands that modify an existing profile (for example 'amq-squad team shared-cwd-exception set') " +
-			"have nothing to act on yet. Apply the blocked row's fix at creation time instead " +
-			"('amq-squad new profile NAME --cwd \"role=path,...\"' or 'amq-squad new profile NAME --shared-cwd-exception \"<reason>\"'), then re-run --prepare."
-	}
-	return "Preparation is transactional, so this profile has been RESTORED to its pre-preparation state; " +
-		"it still exists and the blocked row's commands apply to it as printed. Fix the reported rows, then re-run --prepare."
+	return "Preparation is transactional and this run CREATED the profile, so the rollback removed it: " +
+		"commands that modify an existing profile (for example 'amq-squad team shared-cwd-exception set') " +
+		"have nothing to act on yet. Apply the blocked row's fix at creation time instead " +
+		"('amq-squad new profile NAME --cwd \"role=path,...\"' or 'amq-squad new profile NAME --shared-cwd-exception \"<reason>\"'), then re-run --prepare."
 }

--- a/internal/cli/run_start_preparation.go
+++ b/internal/cli/run_start_preparation.go
@@ -596,3 +596,40 @@ func printRunPreparationProposal(proposal runPreparationProposal) {
 	}
 	fmt.Println("Proposal only. No profile, brief, rules, role, policy, manifest, mailbox, or pane was created.")
 }
+
+// preparationRollbackGuidance explains what the transactional rollback did to the
+// profile, and therefore which remedy is actually runnable now.
+//
+// #538 F3: preparation rolls back on readiness failure. Which advice is TRUE
+// depends on whether this transaction created the profile:
+//
+//   - created (no pre-existing file): rollback removes it, so `team member update`
+//     and `team shared-cwd-exception set` have nothing to act on, and the operator
+//     must apply the fix at creation time.
+//   - pre-existing: rollback RESTORES it, so those commands work as printed, and
+//     `new profile NAME` would fail because the profile already exists.
+//
+// Emitting the fresh-profile text unconditionally made the message false in the
+// second case, which is worse than silence: it sends the operator to a command
+// that cannot work while telling them the working one is unavailable.
+func preparationRollbackGuidance(snapshots []runPreparationFileSnapshot, profilePath string) string {
+	profilePath = filepath.Clean(strings.TrimSpace(profilePath))
+	existedBefore := false
+	tracked := false
+	for _, snap := range snapshots {
+		if snap.Path != profilePath {
+			continue
+		}
+		tracked = true
+		existedBefore = snap.Exists
+		break
+	}
+	if tracked && !existedBefore {
+		return "Preparation is transactional and it CREATED this profile, so the rollback removed it: " +
+			"commands that modify an existing profile (for example 'amq-squad team shared-cwd-exception set') " +
+			"have nothing to act on yet. Apply the blocked row's fix at creation time instead " +
+			"('amq-squad new profile NAME --cwd \"role=path,...\"' or 'amq-squad new profile NAME --shared-cwd-exception \"<reason>\"'), then re-run --prepare."
+	}
+	return "Preparation is transactional, so this profile has been RESTORED to its pre-preparation state; " +
+		"it still exists and the blocked row's commands apply to it as printed. Fix the reported rows, then re-run --prepare."
+}

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1603,7 +1603,7 @@ func calculateRunReadinessWithContext(project, profile, session string, context 
 				add("member:"+member.Role, "ready", fmt.Sprintf("staged handle=%s binary=%s model=%s effort=%s task=%s tool_policy=%s", current.Handle, current.Binary, current.Model, current.Effort, current.TaskOwnership, current.ToolProfile), "")
 			}
 		}
-		row := worktreeIsolationReadinessRow(tm)
+		row := worktreeIsolationReadinessRow(tm, profile)
 		add(row.Artifact, row.Status, row.Evidence, row.Fix)
 	}
 	briefPath := briefPathForProfile(project, profile, session)
@@ -2035,13 +2035,18 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 	}
 	result = calculateRunReadinessWithContext(project, profile, session, context)
 	if !result.Ready {
-		// #538: preparation is transactional, so this failure rolls back the
-		// profile it created. Operators previously read a blocked row telling them
-		// to run `team shared-cwd-exception set`, tried it, and hit "no profile" --
-		// with nothing explaining that preparation had just removed the profile
-		// they were told to modify. Name that explicitly, and point at the
-		// creation-time forms, which do not depend on a profile existing first.
-		return result, fmt.Errorf("artifact readiness failed after preparation. Preparation is transactional, so any profile it created has been rolled back: commands that modify an EXISTING profile (for example 'amq-squad team shared-cwd-exception set') have nothing to act on yet. Apply the blocked row's fix at creation time instead -- the 'amq-squad new profile NAME --...' forms it names -- then re-run --prepare")
+		// #538: preparation is transactional, so a failure here rolls back to the
+		// pre-preparation state. Operators previously read a blocked row telling
+		// them to run `team shared-cwd-exception set`, tried it, and hit
+		// "no profile", with nothing explaining why.
+		//
+		// Second review F3: the correct guidance depends on whether THIS
+		// transaction created the profile. If it did, rollback removes it and the
+		// fix-existing commands have nothing to act on. If the profile already
+		// existed, rollback RESTORES it, those commands work fine, and telling the
+		// operator otherwise would be false. Decide from the snapshot rather than
+		// assuming the fresh-profile case.
+		return result, fmt.Errorf("artifact readiness failed after preparation. %s", preparationRollbackGuidance(snapshots, team.ProfilePath(project, profile)))
 	}
 	committed = true
 	return result, nil

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -2035,7 +2035,13 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 	}
 	result = calculateRunReadinessWithContext(project, profile, session, context)
 	if !result.Ready {
-		return result, fmt.Errorf("artifact readiness failed after preparation")
+		// #538: preparation is transactional, so this failure rolls back the
+		// profile it created. Operators previously read a blocked row telling them
+		// to run `team shared-cwd-exception set`, tried it, and hit "no profile" --
+		// with nothing explaining that preparation had just removed the profile
+		// they were told to modify. Name that explicitly, and point at the
+		// creation-time forms, which do not depend on a profile existing first.
+		return result, fmt.Errorf("artifact readiness failed after preparation. Preparation is transactional, so any profile it created has been rolled back: commands that modify an EXISTING profile (for example 'amq-squad team shared-cwd-exception set') have nothing to act on yet. Apply the blocked row's fix at creation time instead -- the 'amq-squad new profile NAME --...' forms it names -- then re-run --prepare")
 	}
 	committed = true
 	return result, nil

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1941,7 +1941,7 @@ func displayRoleList(roles []string) string {
 
 var buildPreparedRunManifestForPreparation = buildPreparedRunManifest
 
-func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goalSource, goalDigest, seed string, context acceptedRunContext) (result runReadinessResult, err error) {
+func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goalSource, goalDigest, seed string, context acceptedRunContext, profileExistedBeforeRun bool) (result runReadinessResult, err error) {
 	profile = squadnamespace.NormalizeProfile(profile)
 	if err := revalidateRunPreparationPointerPlans(context.PointerPlans); err != nil {
 		return runReadinessResult{}, fmt.Errorf("revalidate accepted pointer plan before preparation writes: %w", err)
@@ -2046,7 +2046,7 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 		// existed, rollback RESTORES it, those commands work fine, and telling the
 		// operator otherwise would be false. Decide from the snapshot rather than
 		// assuming the fresh-profile case.
-		return result, fmt.Errorf("artifact readiness failed after preparation. %s", preparationRollbackGuidance(snapshots, team.ProfilePath(project, profile)))
+		return result, fmt.Errorf("artifact readiness failed after preparation. %s", preparationRollbackGuidance(profileExistedBeforeRun))
 	}
 	committed = true
 	return result, nil

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -513,13 +513,17 @@ Examples:
 		m.ToolProfile = strings.TrimSpace(toolProfiles[id])
 		m.ToolConfig = strings.TrimSpace(toolConfigs[id])
 		if c, ok := cwdOverrides[id]; ok {
-			abs, err := expandPath(c)
+			// #538 F2: use the SHARED resolver. This path previously had its own
+			// copy, which anchored a relative value to the shell working directory
+			// and compared team-home by raw string equality, so create and
+			// add/update could record different values for the same input. Two
+			// writers with two origins is the #539/#540 defect; there is now one
+			// function and one origin (the project).
+			resolved, err := memberCWDOverride(cwd, c)
 			if err != nil {
 				return fmt.Errorf("resolve cwd for %s: %w", id, err)
 			}
-			if abs != cwd {
-				m.CWD = abs
-			}
+			m.CWD = resolved
 		}
 		members = append(members, m)
 	}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -127,6 +127,13 @@ func runTeamInitWithOptions(args []string, opts teamInitRunOptions) error {
 	force := fs.Bool("force", false, "overwrite an existing team.json")
 	_ = fs.String("project", "", "project/team-home directory to initialize (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to initialize (default: default profile)")
+	// #538: publish the fully-registered flag set so the `new profile` forwarding
+	// test can enumerate the REAL team-init flags. `new profile` must know which
+	// of these take a separate value in order to peel the profile name from them,
+	// and hand-maintaining that knowledge against this list is exactly how
+	// --actor-mode, --tool-profile and --tool-config came to be silently dropped.
+	// Introspection only; nothing reads this during normal execution.
+	publishTeamInitFlagSet(fs)
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `amq-squad team init - set up this project's agent team
 

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -819,24 +819,28 @@ func agentUpHint(m team.Member) string {
 	return b.String()
 }
 
-// memberCWDOverride resolves a --cwd value the same way roster creation does
-// (team init, internal/cli/team.go): expand and absolutize, then treat a value
-// equal to the team-home as "no override" so the member record stays clean
-// rather than pinning the default explicitly.
+// memberCWDOverride is the SINGLE resolver for a member's --cwd, shared by
+// roster creation (team init), `team member add` and `team member update`.
 //
-// #538: keeping the create path and the post-creation path on ONE helper is what
-// stops `new profile --cwd` and `team member add|update --cwd` from drifting into
-// two different meanings for the same flag. That drift is the disease this
-// milestone keeps finding, so the shared helper is the point, not an incidental
-// tidy-up.
+// #538, second review F2: an earlier version of this claimed to be shared but was
+// not -- team init kept its own copy -- and it resolved a relative value with
+// filepath.Abs, i.e. against the SHELL working directory. So
+// `--project /repo --cwd ../wt` run from /tmp recorded /tmp/wt here and
+// /repo/../wt on the create path. That is precisely the two-writers/two-origins
+// defect #539 and #540 were about, reintroduced in the fix for a different bug.
+// Both problems have one fix: genuinely one function, anchored to the PROJECT.
+//
+// A relative path means "relative to the project", never to the caller's shell.
+// A value naming the team-home itself records as no override, so the member stays
+// clean rather than pinning the default explicitly.
 func memberCWDOverride(projectDir, raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", nil
 	}
-	abs, err := expandPath(raw)
-	if err != nil {
-		return "", fmt.Errorf("resolve --cwd %q: %w", raw, err)
+	abs := absoluteFilesystemPathIn(projectDir, raw)
+	if abs == "" {
+		return "", fmt.Errorf("resolve --cwd %q", raw)
 	}
 	if sameFilesystemPath(abs, projectDir) {
 		return "", nil

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -197,6 +197,12 @@ func runTeamMemberAdd(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "extra Claude args for this member")
 	codexArgsRaw := fs.String("codex-args", "", "extra Codex args for this member")
 	actorModeFlag := fs.String("actor-mode", team.ActorModeReview, "actor execution capability: review (default, read-only) or implementation")
+	// #538: worktree_isolation readiness tells the operator to give each
+	// mutation-capable member its own working directory. That was reachable only
+	// at roster creation (team init / new profile --cwd), so fixing an EXISTING
+	// roster meant hand-editing team.json -- the exact thing the CLI exists to
+	// prevent. This is the post-creation path.
+	cwdFlag := fs.String("cwd", "", "working directory (isolated worktree) for this member; 2+ mutation-capable members sharing one directory blocks worktree_isolation readiness")
 	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to mutate (default: default profile)")
 	launchFlag := fs.Bool("launch", false, "after adding, launch pending members with resume --exec")
@@ -289,6 +295,13 @@ func runTeamMemberAdd(args []string) error {
 			ActorMode:   actorMode,
 			SpawnOrigin: origin,
 			SpawnDepth:  depth,
+		}
+		if flagWasSet(fs, "cwd") {
+			resolved, cwdErr := memberCWDOverride(t.Project, *cwdFlag)
+			if cwdErr != nil {
+				return team.Member{}, cwdErr
+			}
+			added.CWD = resolved
 		}
 		if bin == "claude" {
 			added.ClaudeArgs = claudeArgs
@@ -441,6 +454,10 @@ func runTeamMemberUpdate(args []string) error {
 	claudeArgsRaw := fs.String("claude-args", "", "replace this member's extra Claude args (claude members only)")
 	codexArgsRaw := fs.String("codex-args", "", "replace this member's extra Codex args (codex members only)")
 	actorModeFlag := fs.String("actor-mode", "", "new actor execution capability: review or implementation")
+	// #538: the post-creation path for worktree_isolation. `--cwd ""` clears the
+	// override and returns the member to the team-home, so the flag can undo
+	// itself rather than being a one-way door.
+	cwdFlag := fs.String("cwd", "", "new working directory (isolated worktree) for this member; empty string clears the override")
 	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to mutate (default: default profile)")
 	dryRunFlag := fs.Bool("dry-run", false, "preview the update without mutating")
@@ -451,7 +468,7 @@ func runTeamMemberUpdate(args []string) error {
 	if *noSessionPinFlag && flagWasSet(fs, "session") {
 		return usageErrorf("use either --session or --no-session-pin, not both")
 	}
-	changing := []string{"handle", "session", "no-session-pin", "model", "effort", "claude-args", "codex-args", "actor-mode"}
+	changing := []string{"handle", "session", "no-session-pin", "model", "effort", "claude-args", "codex-args", "actor-mode", "cwd"}
 	changed := false
 	for _, name := range changing {
 		if flagWasSet(fs, name) {
@@ -529,6 +546,13 @@ func runTeamMemberUpdate(args []string) error {
 		}
 		if flagWasSet(fs, "actor-mode") {
 			m.ActorMode = strings.ToLower(strings.TrimSpace(*actorModeFlag))
+		}
+		if flagWasSet(fs, "cwd") {
+			resolved, cwdErr := memberCWDOverride(t.Project, *cwdFlag)
+			if cwdErr != nil {
+				return team.Member{}, team.Team{}, cwdErr
+			}
+			m.CWD = resolved
 		}
 		if flagWasSet(fs, "effort") {
 			if m.Binary == "claude" {
@@ -793,4 +817,29 @@ func agentUpHint(m team.Member) string {
 		fmt.Fprintf(&b, " --codex-args %q", strings.Join(m.CodexArgs, " "))
 	}
 	return b.String()
+}
+
+// memberCWDOverride resolves a --cwd value the same way roster creation does
+// (team init, internal/cli/team.go): expand and absolutize, then treat a value
+// equal to the team-home as "no override" so the member record stays clean
+// rather than pinning the default explicitly.
+//
+// #538: keeping the create path and the post-creation path on ONE helper is what
+// stops `new profile --cwd` and `team member add|update --cwd` from drifting into
+// two different meanings for the same flag. That drift is the disease this
+// milestone keeps finding, so the shared helper is the point, not an incidental
+// tidy-up.
+func memberCWDOverride(projectDir, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	abs, err := expandPath(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve --cwd %q: %w", raw, err)
+	}
+	if sameFilesystemPath(abs, projectDir) {
+		return "", nil
+	}
+	return abs, nil
 }

--- a/internal/cli/worktree_isolation.go
+++ b/internal/cli/worktree_isolation.go
@@ -14,6 +14,26 @@ import (
 // recorded exception (team.Team.SharedCwdException). This is a static check
 // over the accepted team profile; the live worktree drift/staleness doctor
 // rows are a separate runtime concern owned elsewhere.
+//
+// AGREEMENT WITH doctor's shared-index-collision (#538 acceptance criterion 4,
+// and the reason the two texts are NOT identical):
+//
+// Both checks detect the SAME condition -- 2+ mutation-capable members resolving
+// to one Git index -- and honour the SAME exception (SharedCwdException clears
+// it), using the same vocabulary. What differs is deliberate and lifecycle-bound:
+//
+//   - SEVERITY. This check runs at PREPARATION, before any agent exists, and
+//     fails closed per #497. doctor's is liveness-derived: it fails only when 2+
+//     affected members are actually LIVE and warns otherwise. Copying that rule
+//     here would make preparation always warn, since nothing is live yet, which
+//     would defeat the fail-closed guarantee.
+//   - REMEDY. doctor names `worktree plan|materialize`, which require --task ID.
+//     At preparation no tasks exist, so that remedy is unrunnable here and naming
+//     it would be false. This row names the pre-launch mechanisms instead.
+//
+// So "agree" means same condition, same exception semantics, same vocabulary,
+// with stage-appropriate severity and remedy. If you change one side's condition
+// or exception handling, change both.
 func worktreeIsolationReadinessRow(t team.Team) runReadinessRow {
 	groups := map[string][]string{}
 	for _, m := range t.Members {
@@ -43,6 +63,48 @@ func worktreeIsolationReadinessRow(t team.Team) runReadinessRow {
 		Artifact: "worktree_isolation",
 		Status:   "blocked",
 		Evidence: fmt.Sprintf("2+ mutation-capable members share one working directory without a recorded exception: %s", evidence),
-		Fix:      `record an explicit exception with 'amq-squad team shared-cwd-exception set "<reason>"', or give each mutation-capable member its own --cwd (isolated worktree)`,
+		Fix:      worktreeIsolationFix(sharedCwdCollisionRoles(groups)),
 	}
+}
+
+// worktreeIsolationFix names remedies that are ACTUALLY EXECUTABLE.
+//
+// #538: the previous text said "give each mutation-capable member its own --cwd
+// (isolated worktree)" without naming any command. --cwd does exist -- on
+// `team init` / `new profile`, and now on `team member add|update` -- but the
+// operator who hit this had no way to discover that from the message, reasonably
+// concluded the flag did not exist, and lost more time here than on anything else
+// in the run. A remedy the reader cannot execute is not a remedy.
+//
+// Every command below is exercised by the reachability regression test, so this
+// text cannot drift back into naming something unrunnable.
+func worktreeIsolationFix(roles []string) string {
+	example := "ROLE"
+	if len(roles) > 0 {
+		example = roles[0]
+	}
+	return strings.Join([]string{
+		"give each mutation-capable member its own working directory, either at creation with " +
+			`'amq-squad new profile NAME --cwd "` + example + `=/path/to/worktree,..."'` +
+			" or on an existing roster with " +
+			`'amq-squad team member update ` + example + ` --cwd /path/to/worktree'`,
+		"or accept the shared checkout deliberately with " +
+			`'amq-squad team shared-cwd-exception set "<reason>"'` +
+			` (at creation: 'amq-squad new profile NAME --shared-cwd-exception "<reason>"')`,
+	}, "; ")
+}
+
+// sharedCwdCollisionRoles returns the colliding roles in deterministic order, so
+// the fix text can name a real role from the operator's own roster instead of a
+// placeholder they have to translate.
+func sharedCwdCollisionRoles(groups map[string][]string) []string {
+	var out []string
+	for _, roles := range groups {
+		if len(roles) < 2 {
+			continue
+		}
+		out = append(out, roles...)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/cli/worktree_isolation.go
+++ b/internal/cli/worktree_isolation.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
@@ -60,20 +63,40 @@ func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow 
 	groups := map[string][]string{}
 	groupDisplay := map[string]string{}
 	proxied := map[string]bool{}
+	var unobservable []string
 	for _, m := range t.Members {
 		if team.EffectiveActorMode(t, m) != team.ActorModeImplementation {
 			continue
 		}
 		cwd := m.EffectiveCWD(t.Project)
-		key, observed := memberIsolationKey(cwd)
+		key, obs := memberIsolationKey(cwd)
+		if obs == isolationUnobservable {
+			// #538 F4 round 4: git missing, hung, or failing is NOT "no index
+			// here". Silently proxying it would let two subdirectories of one
+			// checkout group as distinct and report ready -- the very divergence
+			// this check exists to prevent, caused by infrastructure rather than
+			// configuration. Under #497 an unverifiable isolation claim is a
+			// blocker, so fail closed and say why.
+			unobservable = append(unobservable, fmt.Sprintf("%s: %s", m.Role, cwd))
+			continue
+		}
 		// Display the path as recorded; group by the observable (or its proxy).
 		if _, seen := groupDisplay[key]; !seen {
 			groupDisplay[key] = cwd
 		}
-		if !observed {
+		if obs == isolationNotACheckout {
 			proxied[key] = true
 		}
 		groups[key] = append(groups[key], m.Role)
+	}
+	if len(unobservable) > 0 {
+		sort.Strings(unobservable)
+		return runReadinessRow{
+			Artifact: "worktree_isolation",
+			Status:   "blocked",
+			Evidence: fmt.Sprintf("cannot verify working-directory isolation for %s", strings.Join(unobservable, "; ")),
+			Fix:      "install/repair git so 'git rev-parse --git-path index' runs in each member working directory, then re-run preparation. Isolation cannot be confirmed without it, and an unverifiable claim is treated as a blocker (#497)",
+		}
 	}
 	var collisions []string
 	for key, roles := range groups {
@@ -163,56 +186,114 @@ func sharedCwdCollisionRoles(groups map[string][]string) []string {
 	return out
 }
 
+// isolationObservation is the outcome of trying to observe a member cwd's Git
+// index. The three cases are deliberately distinct: #538 F4 round 4 found that
+// collapsing "not a checkout" and "could not run git" into one boolean made
+// INFRASTRUCTURE FAILURE look like a clean answer, so two subdirectories of one
+// checkout fell back to distinct directory keys and readiness reported ready --
+// resurrecting the exact divergence F4 was about.
+type isolationObservation int
+
+const (
+	// isolationObserved: git ran and resolved an index path. Authoritative.
+	isolationObserved isolationObservation = iota
+	// isolationNotACheckout: git ran and reported this is not a checkout, or the
+	// directory does not exist yet. A clean, trustworthy negative -> proxy.
+	isolationNotACheckout
+	// isolationUnobservable: git is missing, failed to execute, timed out, or
+	// returned an error we cannot interpret. NOT a negative result. Readiness must
+	// fail closed, because "cannot verify isolation" is a blocker under #497, not
+	// a pass.
+	isolationUnobservable
+)
+
 // memberIsolationKey returns the grouping key for a member working directory and
-// whether it was OBSERVED rather than proxied.
+// how that key was obtained.
 //
 // #538 F4: doctor groups by resolved Git index path, so grouping by directory
 // string made the two checks disagree on the condition itself. Two counterexamples
-// drove the final shape:
+// drove the shape:
 //
 //   - two SUBDIRECTORIES of one checkout are distinct directories but ONE index,
 //     so a directory-only key misses a real collision;
 //   - a planned worktree that does not exist yet has NO index, so an index-only
-//     key cannot classify it at all (doctor excludes such members; preparation
-//     must not, since predicting the collision is the whole point pre-launch).
+//     key cannot classify it (doctor excludes such members; preparation must not,
+//     since predicting the collision is the point pre-launch).
 //
-// Hence the hybrid: observe the index when there is one to observe, and fall back
-// to the canonical directory as a declared proxy when there is not. Callers must
-// surface the proxy case rather than presenting it as an observation.
-func memberIsolationKey(cwd string) (key string, observed bool) {
+// Hence: observe the index when it can be observed, fall back to canonical
+// directory as a DECLARED proxy on a clean negative, and refuse to answer at all
+// when the observation itself failed.
+func memberIsolationKey(cwd string) (key string, obs isolationObservation) {
 	canonical := canonicalFilesystemPath(cwd)
 	if canonical == "" {
 		canonical = strings.TrimSpace(cwd)
 	}
-	if index, ok := worktreeIsolationIndexProbe(canonical); ok {
+	index, obs := worktreeIsolationIndexProbe(canonical)
+	switch obs {
+	case isolationObserved:
 		if resolved := canonicalFilesystemPath(index); resolved != "" {
-			return resolved, true
+			return resolved, isolationObserved
 		}
+		// git answered but the path did not canonicalize; treat as unobservable
+		// rather than quietly downgrading to the proxy.
+		return canonical, isolationUnobservable
+	case isolationUnobservable:
+		return canonical, isolationUnobservable
+	default:
+		return canonical, isolationNotACheckout
 	}
-	return canonical, false
 }
+
+// worktreeIsolationIndexProbeTimeout bounds the git call so a hung git cannot hang
+// preparation. Exceeding it is an observation FAILURE, never a negative result.
+var worktreeIsolationIndexProbeTimeout = 5 * time.Second
 
 // worktreeIsolationIndexProbe resolves a directory's Git index path using the same
 // observable doctor uses (git rev-parse --git-path index). It is a seam so tests
-// can exercise both branches without constructing real checkouts. A directory that
-// does not exist, or is not inside a checkout, reports ok=false.
-var worktreeIsolationIndexProbe = func(dir string) (string, bool) {
+// can drive all three outcomes without constructing real checkouts or removing git
+// from PATH.
+var worktreeIsolationIndexProbe = func(dir string) (string, isolationObservation) {
 	if dir == "" {
-		return "", false
+		return "", isolationNotACheckout
 	}
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		return "", false
+	// A directory that does not exist yet is a clean negative: there is genuinely
+	// no index to observe, which is the planned-worktree case.
+	if info, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return "", isolationNotACheckout
+		}
+		return "", isolationUnobservable
+	} else if !info.IsDir() {
+		return "", isolationNotACheckout
 	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-path", "index").Output()
+	// git absent from PATH is infrastructure failure, not a negative answer.
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", isolationUnobservable
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), worktreeIsolationIndexProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--git-path", "index")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if ctx.Err() != nil {
+		return "", isolationUnobservable
+	}
 	if err != nil {
-		return "", false
+		// The ONE error we can interpret as a clean negative: git ran and told us
+		// this is not a repository. Anything else is uninterpretable and must fail
+		// closed rather than masquerade as "no index here".
+		if strings.Contains(strings.ToLower(stderr.String()), "not a git repository") {
+			return "", isolationNotACheckout
+		}
+		return "", isolationUnobservable
 	}
 	path := strings.TrimSpace(string(out))
 	if path == "" {
-		return "", false
+		return "", isolationUnobservable
 	}
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(dir, path)
 	}
-	return filepath.Clean(path), true
+	return filepath.Clean(path), isolationObserved
 }

--- a/internal/cli/worktree_isolation.go
+++ b/internal/cli/worktree_isolation.go
@@ -23,10 +23,13 @@ import (
 // it), using the same vocabulary. What differs is deliberate and lifecycle-bound:
 //
 //   - SEVERITY. This check runs at PREPARATION, before any agent exists, and
-//     fails closed per #497. doctor's is liveness-derived: it fails only when 2+
-//     affected members are actually LIVE and warns otherwise. Copying that rule
-//     here would make preparation always warn, since nothing is live yet, which
-//     would defeat the fail-closed guarantee.
+//     fails closed per #497. doctor's severity is runtime-derived, and under the
+//     #537 contract (t4, landing separately) becomes explicitly liveness-derived:
+//     fail only when 2+ affected members are LIVE, warn otherwise. Either way the
+//     rule cannot be copied here -- at preparation nothing is live, so a
+//     liveness-derived severity would always warn and defeat fail-closed. This
+//     sentence describes #537's target contract; if it has not landed in the tree
+//     you are reading, doctor still fails unconditionally on the collision.
 //   - REMEDY. doctor names `worktree plan|materialize`, which require --task ID.
 //     At preparation no tasks exist, so that remedy is unrunnable here and naming
 //     it would be false. This row names the pre-launch mechanisms instead.
@@ -34,22 +37,41 @@ import (
 // So "agree" means same condition, same exception semantics, same vocabulary,
 // with stage-appropriate severity and remedy. If you change one side's condition
 // or exception handling, change both.
-func worktreeIsolationReadinessRow(t team.Team) runReadinessRow {
+func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow {
 	groups := map[string][]string{}
+	groupDisplay := map[string]string{}
 	for _, m := range t.Members {
 		if team.EffectiveActorMode(t, m) != team.ActorModeImplementation {
 			continue
 		}
+		// #538 F4: group by CANONICAL filesystem location, not by the raw recorded
+		// string. doctor detects this collision by resolved Git index path, so
+		// comparing strings here made the two checks disagree on the CONDITION
+		// itself: /repo and a symlink pointing at it counted as two directories at
+		// preparation and one index at runtime, passing readiness and then failing
+		// doctor. Representation is not identity -- the same lesson as #539/#540.
 		cwd := m.EffectiveCWD(t.Project)
-		groups[cwd] = append(groups[cwd], m.Role)
+		key := canonicalFilesystemPath(cwd)
+		if key == "" {
+			key = cwd
+		}
+		// Display the path as recorded; group by the canonical key.
+		if _, seen := groupDisplay[key]; !seen {
+			groupDisplay[key] = cwd
+		}
+		groups[key] = append(groups[key], m.Role)
 	}
 	var collisions []string
-	for cwd, roles := range groups {
+	for key, roles := range groups {
 		if len(roles) < 2 {
 			continue
 		}
 		sort.Strings(roles)
-		collisions = append(collisions, fmt.Sprintf("%s: %s", cwd, strings.Join(roles, ", ")))
+		shown := groupDisplay[key]
+		if shown == "" {
+			shown = key
+		}
+		collisions = append(collisions, fmt.Sprintf("%s: %s", shown, strings.Join(roles, ", ")))
 	}
 	if len(collisions) == 0 {
 		return runReadinessRow{Artifact: "worktree_isolation", Status: "ready", Evidence: "no 2+ mutation-capable members share one working directory"}
@@ -63,34 +85,45 @@ func worktreeIsolationReadinessRow(t team.Team) runReadinessRow {
 		Artifact: "worktree_isolation",
 		Status:   "blocked",
 		Evidence: fmt.Sprintf("2+ mutation-capable members share one working directory without a recorded exception: %s", evidence),
-		Fix:      worktreeIsolationFix(sharedCwdCollisionRoles(groups)),
+		Fix:      worktreeIsolationFix(t.Project, profile, sharedCwdCollisionRoles(groups)),
 	}
 }
 
-// worktreeIsolationFix names remedies that are ACTUALLY EXECUTABLE.
+// worktreeIsolationFix names remedies that are ACTUALLY EXECUTABLE against the
+// EXACT roster that is blocked.
 //
-// #538: the previous text said "give each mutation-capable member its own --cwd
-// (isolated worktree)" without naming any command. --cwd does exist -- on
-// `team init` / `new profile`, and now on `team member add|update` -- but the
-// operator who hit this had no way to discover that from the message, reasonably
-// concluded the flag did not exist, and lost more time here than on anything else
-// in the run. A remedy the reader cannot execute is not a remedy.
+// #538: the original text said "give each mutation-capable member its own --cwd
+// (isolated worktree)" and named no command, so the operator concluded the flag
+// did not exist and lost more time here than anywhere else in the run. A remedy
+// the reader cannot execute is not a remedy.
 //
-// Every command below is exercised by the reachability regression test, so this
-// text cannot drift back into naming something unrunnable.
-func worktreeIsolationFix(roles []string) string {
+// Second review F1: naming commands is not enough -- they must be SCOPED. An
+// unscoped `team member update` targets the default profile, so for a blocked
+// NAMED profile the suggested command would silently mutate a different roster.
+// And a creation-time remedy is wrong here by construction: this profile already
+// exists (readiness just read it), so `new profile NAME` would build an unrelated
+// roster rather than fix this one. The creation forms belong only to the
+// transactional-rollback case, which the preparation failure message owns.
+func worktreeIsolationFix(project, profile string, roles []string) string {
 	example := "ROLE"
 	if len(roles) > 0 {
 		example = roles[0]
 	}
+	scope := ""
+	if p := strings.TrimSpace(project); p != "" {
+		scope += " --project " + shellQuote(p)
+	}
+	// Only a non-default profile needs naming; adding --profile default would be
+	// noise that invites cargo-culting it onto commands that reject it.
+	if pr := strings.TrimSpace(profile); pr != "" && pr != team.DefaultProfile {
+		scope += " --profile " + shellQuote(pr)
+	}
 	return strings.Join([]string{
-		"give each mutation-capable member its own working directory, either at creation with " +
-			`'amq-squad new profile NAME --cwd "` + example + `=/path/to/worktree,..."'` +
-			" or on an existing roster with " +
-			`'amq-squad team member update ` + example + ` --cwd /path/to/worktree'`,
+		"give each mutation-capable member its own working directory with " +
+			"'amq-squad team member update " + example + " --cwd /path/to/worktree" + scope + "'" +
+			" (repeat per member; a relative --cwd resolves against the project)",
 		"or accept the shared checkout deliberately with " +
-			`'amq-squad team shared-cwd-exception set "<reason>"'` +
-			` (at creation: 'amq-squad new profile NAME --shared-cwd-exception "<reason>"')`,
+			`'amq-squad team shared-cwd-exception set "<reason>"` + scope + "'",
 	}, "; ")
 }
 

--- a/internal/cli/worktree_isolation.go
+++ b/internal/cli/worktree_isolation.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -18,9 +21,25 @@ import (
 // AGREEMENT WITH doctor's shared-index-collision (#538 acceptance criterion 4,
 // and the reason the two texts are NOT identical):
 //
-// Both checks detect the SAME condition -- 2+ mutation-capable members resolving
-// to one Git index -- and honour the SAME exception (SharedCwdException clears
-// it), using the same vocabulary. What differs is deliberate and lifecycle-bound:
+// Both checks honour the SAME exception (SharedCwdException clears it) and use the
+// same vocabulary. On the CONDITION the claim is deliberately QUALIFIED, because
+// an unqualified "same condition" was false and was caught in review twice:
+//
+//   - WHERE OBSERVABLE, this check uses doctor's own observable: a member cwd that
+//     exists inside a Git checkout is grouped by its resolved index path
+//     (git rev-parse --git-path index). That is what makes two SUBDIRECTORIES of
+//     one checkout collide here as they do at runtime -- comparing directories
+//     alone would call them distinct.
+//   - WHERE NOT OBSERVABLE, a planned cwd that does not exist yet has no index to
+//     resolve, so it is grouped by canonical directory as a declared PROXY: at
+//     preparation the best available predictor of a distinct future index is a
+//     distinct planned directory. doctor excludes such members entirely, because
+//     at runtime a nonexistent worktree is a different finding.
+//
+// So: same observable where observable, declared proxy where not, same exception
+// semantics and vocabulary always. Do not restate this as plain "same condition".
+//
+// What else differs is lifecycle-bound and deliberate:
 //
 //   - SEVERITY. This check runs at PREPARATION, before any agent exists, and
 //     fails closed per #497. doctor's severity is runtime-derived, and under the
@@ -40,24 +59,19 @@ import (
 func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow {
 	groups := map[string][]string{}
 	groupDisplay := map[string]string{}
+	proxied := map[string]bool{}
 	for _, m := range t.Members {
 		if team.EffectiveActorMode(t, m) != team.ActorModeImplementation {
 			continue
 		}
-		// #538 F4: group by CANONICAL filesystem location, not by the raw recorded
-		// string. doctor detects this collision by resolved Git index path, so
-		// comparing strings here made the two checks disagree on the CONDITION
-		// itself: /repo and a symlink pointing at it counted as two directories at
-		// preparation and one index at runtime, passing readiness and then failing
-		// doctor. Representation is not identity -- the same lesson as #539/#540.
 		cwd := m.EffectiveCWD(t.Project)
-		key := canonicalFilesystemPath(cwd)
-		if key == "" {
-			key = cwd
-		}
-		// Display the path as recorded; group by the canonical key.
+		key, observed := memberIsolationKey(cwd)
+		// Display the path as recorded; group by the observable (or its proxy).
 		if _, seen := groupDisplay[key]; !seen {
 			groupDisplay[key] = cwd
+		}
+		if !observed {
+			proxied[key] = true
 		}
 		groups[key] = append(groups[key], m.Role)
 	}
@@ -71,7 +85,14 @@ func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow 
 		if shown == "" {
 			shown = key
 		}
-		collisions = append(collisions, fmt.Sprintf("%s: %s", shown, strings.Join(roles, ", ")))
+		detail := fmt.Sprintf("%s: %s", shown, strings.Join(roles, ", "))
+		if proxied[key] {
+			// Be explicit that this group was matched by planned directory rather
+			// than an observed index, so the evidence never overstates what was
+			// actually checked.
+			detail += " (planned directory; no Git index to observe yet)"
+		}
+		collisions = append(collisions, detail)
 	}
 	if len(collisions) == 0 {
 		return runReadinessRow{Artifact: "worktree_isolation", Status: "ready", Evidence: "no 2+ mutation-capable members share one working directory"}
@@ -140,4 +161,58 @@ func sharedCwdCollisionRoles(groups map[string][]string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// memberIsolationKey returns the grouping key for a member working directory and
+// whether it was OBSERVED rather than proxied.
+//
+// #538 F4: doctor groups by resolved Git index path, so grouping by directory
+// string made the two checks disagree on the condition itself. Two counterexamples
+// drove the final shape:
+//
+//   - two SUBDIRECTORIES of one checkout are distinct directories but ONE index,
+//     so a directory-only key misses a real collision;
+//   - a planned worktree that does not exist yet has NO index, so an index-only
+//     key cannot classify it at all (doctor excludes such members; preparation
+//     must not, since predicting the collision is the whole point pre-launch).
+//
+// Hence the hybrid: observe the index when there is one to observe, and fall back
+// to the canonical directory as a declared proxy when there is not. Callers must
+// surface the proxy case rather than presenting it as an observation.
+func memberIsolationKey(cwd string) (key string, observed bool) {
+	canonical := canonicalFilesystemPath(cwd)
+	if canonical == "" {
+		canonical = strings.TrimSpace(cwd)
+	}
+	if index, ok := worktreeIsolationIndexProbe(canonical); ok {
+		if resolved := canonicalFilesystemPath(index); resolved != "" {
+			return resolved, true
+		}
+	}
+	return canonical, false
+}
+
+// worktreeIsolationIndexProbe resolves a directory's Git index path using the same
+// observable doctor uses (git rev-parse --git-path index). It is a seam so tests
+// can exercise both branches without constructing real checkouts. A directory that
+// does not exist, or is not inside a checkout, reports ok=false.
+var worktreeIsolationIndexProbe = func(dir string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return "", false
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--git-path", "index").Output()
+	if err != nil {
+		return "", false
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
+	return filepath.Clean(path), true
 }

--- a/internal/cli/worktree_isolation_reachability_test.go
+++ b/internal/cli/worktree_isolation_reachability_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
@@ -390,11 +392,11 @@ func TestReadinessGroupsSubdirectoriesOfOneCheckoutAsCollision(t *testing.T) {
 	}
 	// Both subdirectories resolve to the same index, as they would in a checkout.
 	sharedIndex := filepath.Join(project, ".git", "index")
-	withIsolationIndexProbe(t, func(dir string) (string, bool) {
+	withIsolationIndexProbe(t, func(dir string) (string, isolationObservation) {
 		if strings.HasPrefix(dir, canonicalFilesystemPath(project)) {
-			return sharedIndex, true
+			return sharedIndex, isolationObserved
 		}
-		return "", false
+		return "", isolationNotACheckout
 	})
 
 	tm := team.Team{Project: project, Members: []team.Member{
@@ -414,7 +416,7 @@ func TestReadinessGroupsSubdirectoriesOfOneCheckoutAsCollision(t *testing.T) {
 func TestReadinessProxiesPlannedDirectoriesAndDisclosesIt(t *testing.T) {
 	project := t.TempDir()
 	planned := filepath.Join(project, "not-created-yet")
-	withIsolationIndexProbe(t, func(string) (string, bool) { return "", false })
+	withIsolationIndexProbe(t, func(string) (string, isolationObservation) { return "", isolationNotACheckout })
 
 	tm := team.Team{Project: project, Members: []team.Member{
 		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: planned},
@@ -441,8 +443,8 @@ func TestObservedCollisionIsNotDisclosedAsProxy(t *testing.T) {
 	if err := os.MkdirAll(shared, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	withIsolationIndexProbe(t, func(string) (string, bool) {
-		return filepath.Join(project, ".git", "index"), true
+	withIsolationIndexProbe(t, func(string) (string, isolationObservation) {
+		return filepath.Join(project, ".git", "index"), isolationObserved
 	})
 	tm := team.Team{Project: project, Members: []team.Member{
 		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: shared},
@@ -457,9 +459,103 @@ func TestObservedCollisionIsNotDisclosedAsProxy(t *testing.T) {
 	}
 }
 
-func withIsolationIndexProbe(t *testing.T, probe func(string) (string, bool)) {
+func withIsolationIndexProbe(t *testing.T, probe func(string) (string, isolationObservation)) {
 	t.Helper()
 	orig := worktreeIsolationIndexProbe
 	t.Cleanup(func() { worktreeIsolationIndexProbe = orig })
 	worktreeIsolationIndexProbe = probe
+}
+
+// #538 F4 round 4: an observation FAILURE is not a negative result.
+//
+// The probe previously treated every git error as "no index here", so if git were
+// missing or failing, two subdirectories of one checkout would fall back to
+// distinct directory keys and readiness would report READY -- resurrecting the
+// exact divergence F4 exists to prevent, this time caused by infrastructure. Under
+// #497 an unverifiable isolation claim is a blocker.
+func TestUnobservableGitBlocksReadinessInsteadOfSilentlyProxying(t *testing.T) {
+	project := t.TempDir()
+	shared := filepath.Join(project, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withIsolationIndexProbe(t, func(string) (string, isolationObservation) {
+		return "", isolationUnobservable
+	})
+
+	// Deliberately a roster that would look FINE under the old silent fallback:
+	// two distinct directories, so directory-keyed grouping reports no collision.
+	tm := team.Team{Project: project, Members: []team.Member{
+		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: filepath.Join(project, "a")},
+		{Role: "dev-2", Binary: "codex", Handle: "dev-2", ActorMode: team.ActorModeImplementation, CWD: filepath.Join(project, "b")},
+	}}
+	row := worktreeIsolationReadinessRow(tm, "squad")
+	if row.Status != "blocked" {
+		t.Fatalf("unverifiable isolation must block, not pass; got %s (%s)", row.Status, row.Evidence)
+	}
+	if !strings.Contains(row.Evidence, "cannot verify") {
+		t.Fatalf("evidence must name the observation failure; got: %s", row.Evidence)
+	}
+	// It must NOT be presented as a collision that isn't there, nor as a proxy.
+	if strings.Contains(row.Evidence, "share one working directory") {
+		t.Fatalf("must not claim a collision it did not observe; got: %s", row.Evidence)
+	}
+	if strings.Contains(row.Evidence, "planned directory") {
+		t.Fatalf("an observation failure is not a proxy; got: %s", row.Evidence)
+	}
+	if !strings.Contains(row.Fix, "git") {
+		t.Fatalf("fix must tell the operator to repair git; got: %s", row.Fix)
+	}
+}
+
+// A REAL git failure, not a stubbed one: point the probe at a directory while git
+// is unavailable on PATH, and confirm the production probe classifies it as
+// unobservable rather than as a clean negative.
+func TestProductionProbeTreatsMissingGitAsUnobservable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", t.TempDir()) // no git here
+	_, obs := worktreeIsolationIndexProbe(dir)
+	if obs != isolationUnobservable {
+		t.Fatalf("git missing from PATH must be unobservable, got %v", obs)
+	}
+}
+
+// A directory that does not exist is a CLEAN negative (the planned-worktree case),
+// which must stay distinguishable from infrastructure failure.
+func TestProductionProbeTreatsMissingDirectoryAsCleanNegative(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-created-yet")
+	_, obs := worktreeIsolationIndexProbe(missing)
+	if obs != isolationNotACheckout {
+		t.Fatalf("a nonexistent planned directory must be a clean negative, got %v", obs)
+	}
+}
+
+// A real directory that is genuinely not a checkout must also be a clean negative,
+// so the proxy path still works where it should.
+func TestProductionProbeTreatsNonCheckoutAsCleanNegative(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable; this case needs a working git to answer 'not a repository'")
+	}
+	// t.TempDir() is under /var/folders, outside any checkout.
+	_, obs := worktreeIsolationIndexProbe(dir)
+	if obs == isolationUnobservable {
+		t.Fatal("a real non-checkout directory must be a clean negative, not an observation failure")
+	}
+}
+
+// The exec must be bounded so a hung git cannot hang preparation, and the timeout
+// must be classified as an observation failure.
+func TestProbeTimeoutIsAnObservationFailure(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	orig := worktreeIsolationIndexProbeTimeout
+	t.Cleanup(func() { worktreeIsolationIndexProbeTimeout = orig })
+	// A timeout this small cannot complete a real exec.
+	worktreeIsolationIndexProbeTimeout = 1 * time.Nanosecond
+	_, obs := worktreeIsolationIndexProbe(t.TempDir())
+	if obs != isolationUnobservable {
+		t.Fatalf("a timed-out probe must be an observation failure, got %v", obs)
+	}
 }

--- a/internal/cli/worktree_isolation_reachability_test.go
+++ b/internal/cli/worktree_isolation_reachability_test.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// #538 acceptance criterion 2: a two-implementer squad must reach `ready` from a
+// clean repo WITHOUT hand-editing team.json and WITHOUT trial-and-error across
+// three commands.
+//
+// The original failure was a loop: --prepare blocked on worktree_isolation, the
+// fix text named a --cwd flag the operator could not find and an exception
+// command that needed a profile --prepare had just rolled back. These tests pin
+// that each remedy the row names is reachable in ONE roster-creation command.
+
+// remedy 1, at creation: per-member isolated working directories.
+func TestSharedCwdRemedyIsolatedCwdsReachableInOneCommand(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	wtA := filepath.Join(dir, "wt-a")
+	wtB := filepath.Join(dir, "wt-b")
+	for _, p := range []string{wtA, wtB} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad",
+			"--project", dir,
+			"--roles", "cto,dev-1,dev-2",
+			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--cwd", "dev-1=" + wtA + ",dev-2=" + wtB,
+			"--no-session-pin",
+		})
+	}); err != nil {
+		t.Fatalf("one-command roster creation with isolated cwds failed: %v", err)
+	}
+
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The readiness row must be satisfied without an exception being recorded.
+	row := worktreeIsolationReadinessRow(tm)
+	if row.Status != "ready" {
+		t.Fatalf("worktree_isolation = %s (%s); isolated cwds must satisfy it. fix text was: %s", row.Status, row.Evidence, row.Fix)
+	}
+	if strings.TrimSpace(tm.SharedCwdException) != "" {
+		t.Fatal("isolated cwds must not require a recorded exception")
+	}
+}
+
+// remedy 2, at creation: deliberately accept the shared checkout.
+//
+// --shared-cwd-exception was one of the 17 value-taking team-init flags that
+// `new profile` silently dropped, so this remedy was not merely undocumented but
+// actively rejected with an error blaming the operator's argument.
+func TestSharedCwdRemedyExceptionReachableInOneCommand(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad",
+			"--project", dir,
+			"--roles", "cto,dev-1,dev-2",
+			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--shared-cwd-exception", "single checkout accepted for this run",
+			"--no-session-pin",
+		})
+	}); err != nil {
+		t.Fatalf("one-command roster creation with a recorded exception failed: %v", err)
+	}
+
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(tm.SharedCwdException) == "" {
+		t.Fatal("--shared-cwd-exception was accepted but not recorded")
+	}
+	row := worktreeIsolationReadinessRow(tm)
+	if row.Status != "ready" {
+		t.Fatalf("worktree_isolation = %s (%s); a recorded exception must satisfy it", row.Status, row.Evidence)
+	}
+}
+
+// remedy 1, post-creation: fixing an EXISTING roster without editing team.json.
+// This is the path that did not exist at all before #538.
+func TestSharedCwdRemedyIsolatedCwdReachableOnExistingRoster(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad",
+			"--project", dir,
+			"--roles", "cto,dev-1,dev-2",
+			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--no-session-pin",
+		})
+	}); err != nil {
+		t.Fatalf("roster creation failed: %v", err)
+	}
+
+	// Precondition: this roster IS blocked, so the test proves a real fix.
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked := worktreeIsolationReadinessRow(tm)
+	if blocked.Status != "blocked" {
+		t.Fatalf("expected a shared-cwd collision to start blocked, got %s (%s)", blocked.Status, blocked.Evidence)
+	}
+
+	wt := filepath.Join(dir, "wt-a")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "dev-2", "--project", dir, "--profile", "squad", "--cwd", wt})
+	}); err != nil {
+		t.Fatalf("team member update --cwd failed: %v", err)
+	}
+
+	fixed, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row := worktreeIsolationReadinessRow(fixed); row.Status != "ready" {
+		t.Fatalf("worktree_isolation = %s (%s) after giving dev-2 its own cwd", row.Status, row.Evidence)
+	}
+	// And it must be reversible: clearing the override restores the collision.
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "dev-2", "--project", dir, "--profile", "squad", "--cwd", ""})
+	}); err != nil {
+		t.Fatalf("clearing --cwd failed: %v", err)
+	}
+	cleared, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row := worktreeIsolationReadinessRow(cleared); row.Status != "blocked" {
+		t.Fatalf("clearing the cwd override should restore the collision, got %s", row.Status)
+	}
+}
+
+// #538 acceptance criterion 1: every remedy the row NAMES must be executable.
+// This asserts the fix text references only real commands and flags, so it cannot
+// drift back into naming a bare "--cwd" with no command attached.
+func TestWorktreeIsolationFixNamesOnlyExecutableRemedies(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad",
+			"--project", dir,
+			"--roles", "cto,dev-1,dev-2",
+			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--no-session-pin",
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix := worktreeIsolationReadinessRow(tm).Fix
+	if fix == "" {
+		t.Fatal("a blocked row must carry a fix")
+	}
+	// Each named command must exist as a real verb, and each named flag must be
+	// accepted by it.
+	for _, want := range []string{
+		"amq-squad new profile NAME --cwd",
+		"amq-squad team member update",
+		"--shared-cwd-exception",
+		"amq-squad team shared-cwd-exception set",
+	} {
+		if !strings.Contains(fix, want) {
+			t.Fatalf("fix text does not name %q; text was: %s", want, fix)
+		}
+	}
+	// It must name a role from the operator's OWN roster, not a placeholder.
+	if !strings.Contains(fix, "dev-1") {
+		t.Fatalf("fix text should name a colliding role from this roster; text was: %s", fix)
+	}
+	// The flags it names must be forwarded by new profile (the Finding B gap).
+	for _, flagName := range []string{"--cwd", "--shared-cwd-exception"} {
+		if !newProfileValueFlags[flagName] {
+			t.Fatalf("fix text names %s but `new profile` does not forward it, so the remedy is unrunnable", flagName)
+		}
+	}
+}

--- a/internal/cli/worktree_isolation_reachability_test.go
+++ b/internal/cli/worktree_isolation_reachability_test.go
@@ -210,6 +210,10 @@ func TestFixTextCommandExecutesAsDisplayed(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 	seedBlockedSquad(t, dir)
+	// #538 F5: run the displayed command from a NEUTRAL directory. Executing it
+	// from inside the blocked project lets an implicit cwd stand in for --project,
+	// which would mask exactly the mis-scoping F1 was about.
+	chdir(t, t.TempDir())
 	tm, err := team.ReadProfile(dir, "squad")
 	if err != nil {
 		t.Fatal(err)
@@ -370,4 +374,92 @@ func extractQuotedCommand(t *testing.T, text, prefix string) []string {
 		t.Fatalf("unterminated quoted command in fix text: %s", text)
 	}
 	return strings.Fields(rest[:j])
+}
+
+// #538 F4 counterexample (b): two SUBDIRECTORIES of one checkout are distinct
+// directories but share ONE Git index, so a directory-only key misses a real
+// collision that doctor reports.
+func TestReadinessGroupsSubdirectoriesOfOneCheckoutAsCollision(t *testing.T) {
+	project := t.TempDir()
+	subA := filepath.Join(project, "pkg", "a")
+	subB := filepath.Join(project, "pkg", "b")
+	for _, p := range []string{subA, subB} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Both subdirectories resolve to the same index, as they would in a checkout.
+	sharedIndex := filepath.Join(project, ".git", "index")
+	withIsolationIndexProbe(t, func(dir string) (string, bool) {
+		if strings.HasPrefix(dir, canonicalFilesystemPath(project)) {
+			return sharedIndex, true
+		}
+		return "", false
+	})
+
+	tm := team.Team{Project: project, Members: []team.Member{
+		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: subA},
+		{Role: "dev-2", Binary: "codex", Handle: "dev-2", ActorMode: team.ActorModeImplementation, CWD: subB},
+	}}
+	row := worktreeIsolationReadinessRow(tm, "squad")
+	if row.Status != "blocked" {
+		t.Fatalf("two subdirectories of one checkout share one Git index and must block; got %s (%s)", row.Status, row.Evidence)
+	}
+}
+
+// #538 F4 counterexample (a): a PLANNED cwd that does not exist yet has no index
+// to observe. It must still be grouped (predicting the collision is the point of a
+// pre-launch check), by canonical directory as a declared proxy -- and the evidence
+// must SAY it is a proxy rather than implying an observation.
+func TestReadinessProxiesPlannedDirectoriesAndDisclosesIt(t *testing.T) {
+	project := t.TempDir()
+	planned := filepath.Join(project, "not-created-yet")
+	withIsolationIndexProbe(t, func(string) (string, bool) { return "", false })
+
+	tm := team.Team{Project: project, Members: []team.Member{
+		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: planned},
+		{Role: "dev-2", Binary: "codex", Handle: "dev-2", ActorMode: team.ActorModeImplementation, CWD: planned},
+	}}
+	row := worktreeIsolationReadinessRow(tm, "squad")
+	if row.Status != "blocked" {
+		t.Fatalf("two members planned into one directory must block; got %s (%s)", row.Status, row.Evidence)
+	}
+	if !strings.Contains(row.Evidence, "planned directory") {
+		t.Fatalf("evidence must disclose that this group was proxied, not observed; got: %s", row.Evidence)
+	}
+	// Distinct planned directories are the predictor of distinct future indexes.
+	tm.Members[1].CWD = filepath.Join(project, "also-not-created")
+	if row := worktreeIsolationReadinessRow(tm, "squad"); row.Status != "ready" {
+		t.Fatalf("distinct planned directories must not collide; got %s (%s)", row.Status, row.Evidence)
+	}
+}
+
+// An OBSERVED collision must not be labelled a proxy.
+func TestObservedCollisionIsNotDisclosedAsProxy(t *testing.T) {
+	project := t.TempDir()
+	shared := filepath.Join(project, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withIsolationIndexProbe(t, func(string) (string, bool) {
+		return filepath.Join(project, ".git", "index"), true
+	})
+	tm := team.Team{Project: project, Members: []team.Member{
+		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: shared},
+		{Role: "dev-2", Binary: "codex", Handle: "dev-2", ActorMode: team.ActorModeImplementation, CWD: shared},
+	}}
+	row := worktreeIsolationReadinessRow(tm, "squad")
+	if row.Status != "blocked" {
+		t.Fatalf("expected blocked, got %s", row.Status)
+	}
+	if strings.Contains(row.Evidence, "planned directory") {
+		t.Fatalf("an observed index collision must not be disclosed as a proxy; got: %s", row.Evidence)
+	}
+}
+
+func withIsolationIndexProbe(t *testing.T, probe func(string) (string, bool)) {
+	t.Helper()
+	orig := worktreeIsolationIndexProbe
+	t.Cleanup(func() { worktreeIsolationIndexProbe = orig })
+	worktreeIsolationIndexProbe = probe
 }

--- a/internal/cli/worktree_isolation_reachability_test.go
+++ b/internal/cli/worktree_isolation_reachability_test.go
@@ -48,7 +48,7 @@ func TestSharedCwdRemedyIsolatedCwdsReachableInOneCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	// The readiness row must be satisfied without an exception being recorded.
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, "squad")
 	if row.Status != "ready" {
 		t.Fatalf("worktree_isolation = %s (%s); isolated cwds must satisfy it. fix text was: %s", row.Status, row.Evidence, row.Fix)
 	}
@@ -86,7 +86,7 @@ func TestSharedCwdRemedyExceptionReachableInOneCommand(t *testing.T) {
 	if strings.TrimSpace(tm.SharedCwdException) == "" {
 		t.Fatal("--shared-cwd-exception was accepted but not recorded")
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, "squad")
 	if row.Status != "ready" {
 		t.Fatalf("worktree_isolation = %s (%s); a recorded exception must satisfy it", row.Status, row.Evidence)
 	}
@@ -115,7 +115,7 @@ func TestSharedCwdRemedyIsolatedCwdReachableOnExistingRoster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	blocked := worktreeIsolationReadinessRow(tm)
+	blocked := worktreeIsolationReadinessRow(tm, "squad")
 	if blocked.Status != "blocked" {
 		t.Fatalf("expected a shared-cwd collision to start blocked, got %s (%s)", blocked.Status, blocked.Evidence)
 	}
@@ -134,7 +134,7 @@ func TestSharedCwdRemedyIsolatedCwdReachableOnExistingRoster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if row := worktreeIsolationReadinessRow(fixed); row.Status != "ready" {
+	if row := worktreeIsolationReadinessRow(fixed, "squad"); row.Status != "ready" {
 		t.Fatalf("worktree_isolation = %s (%s) after giving dev-2 its own cwd", row.Status, row.Evidence)
 	}
 	// And it must be reversible: clearing the override restores the collision.
@@ -147,56 +147,227 @@ func TestSharedCwdRemedyIsolatedCwdReachableOnExistingRoster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if row := worktreeIsolationReadinessRow(cleared); row.Status != "blocked" {
+	if row := worktreeIsolationReadinessRow(cleared, "squad"); row.Status != "blocked" {
 		t.Fatalf("clearing the cwd override should restore the collision, got %s", row.Status)
 	}
 }
 
-// #538 acceptance criterion 1: every remedy the row NAMES must be executable.
-// This asserts the fix text references only real commands and flags, so it cannot
-// drift back into naming a bare "--cwd" with no command attached.
-func TestWorktreeIsolationFixNamesOnlyExecutableRemedies(t *testing.T) {
+// #538 acceptance criterion 1: every remedy the row NAMES must be executable
+// against the EXACT blocked roster.
+//
+// Second review F1: naming a command is not enough, it must be SCOPED. An
+// unscoped `team member update` targets the default profile, so for a blocked
+// named profile the printed command would mutate a different roster. And a
+// creation-time form is wrong here by construction: this profile already exists,
+// so `new profile NAME` would build an unrelated roster. Creation forms belong to
+// the rollback message, not this row.
+func TestWorktreeIsolationFixNamesScopedExecutableRemedies(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
-	if _, _, err := captureOutput(t, func() error {
-		return runNew([]string{"profile", "squad",
-			"--project", dir,
-			"--roles", "cto,dev-1,dev-2",
-			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
-			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
-			"--no-session-pin",
-		})
-	}); err != nil {
-		t.Fatal(err)
-	}
+	seedBlockedSquad(t, dir)
 	tm, err := team.ReadProfile(dir, "squad")
 	if err != nil {
 		t.Fatal(err)
 	}
-	fix := worktreeIsolationReadinessRow(tm).Fix
+	fix := worktreeIsolationReadinessRow(tm, "squad").Fix
 	if fix == "" {
 		t.Fatal("a blocked row must carry a fix")
 	}
-	// Each named command must exist as a real verb, and each named flag must be
-	// accepted by it.
 	for _, want := range []string{
-		"amq-squad new profile NAME --cwd",
 		"amq-squad team member update",
-		"--shared-cwd-exception",
+		"--cwd /path/to/worktree",
 		"amq-squad team shared-cwd-exception set",
+		"--profile " + shellQuote("squad"),
+		"--project " + shellQuote(dir),
+		"dev-1",
 	} {
 		if !strings.Contains(fix, want) {
-			t.Fatalf("fix text does not name %q; text was: %s", want, fix)
+			t.Fatalf("fix text is missing %q; text was: %s", want, fix)
 		}
 	}
-	// It must name a role from the operator's OWN roster, not a placeholder.
-	if !strings.Contains(fix, "dev-1") {
-		t.Fatalf("fix text should name a colliding role from this roster; text was: %s", fix)
+	// The blocked profile already exists, so a creation form here would be wrong.
+	if strings.Contains(fix, "new profile") {
+		t.Fatalf("fix text must not offer a creation remedy for an EXISTING blocked profile; text was: %s", fix)
 	}
-	// The flags it names must be forwarded by new profile (the Finding B gap).
-	for _, flagName := range []string{"--cwd", "--shared-cwd-exception"} {
-		if !newProfileValueFlags[flagName] {
-			t.Fatalf("fix text names %s but `new profile` does not forward it, so the remedy is unrunnable", flagName)
+}
+
+// A blocked DEFAULT profile must not be told to pass --profile default.
+func TestWorktreeIsolationFixOmitsDefaultProfileScope(t *testing.T) {
+	dir := t.TempDir()
+	fix := worktreeIsolationFix(dir, team.DefaultProfile, []string{"dev-1", "dev-2"})
+	if strings.Contains(fix, "--profile") {
+		t.Fatalf("default profile needs no --profile scope; text was: %s", fix)
+	}
+	if !strings.Contains(fix, "--project "+shellQuote(dir)) {
+		t.Fatalf("fix text must still scope --project; text was: %s", fix)
+	}
+}
+
+// Second review F5: run the ACTUAL displayed command, parsed out of the fix text,
+// so the row cannot print something that does not work. Absolute-everything tests
+// are what masked F1 and F2.
+func TestFixTextCommandExecutesAsDisplayed(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	seedBlockedSquad(t, dir)
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix := worktreeIsolationReadinessRow(tm, "squad").Fix
+
+	argv := extractQuotedCommand(t, fix, "amq-squad team member update")
+	// Substitute a real worktree for the placeholder, changing nothing else.
+	wt := filepath.Join(dir, "wt-a")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, a := range argv {
+		if a == "/path/to/worktree" {
+			argv[i] = wt
 		}
 	}
+	if len(argv) < 3 || argv[0] != "amq-squad" || argv[1] != "team" || argv[2] != "member" {
+		t.Fatalf("unexpected command shape: %v", argv)
+	}
+	if _, _, err := captureOutput(t, func() error { return runTeamMember(argv[3:]) }); err != nil {
+		t.Fatalf("the command the row DISPLAYS failed to run: %v\nargv: %v", err, argv)
+	}
+	fixed, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row := worktreeIsolationReadinessRow(fixed, "squad"); row.Status != "ready" {
+		t.Fatalf("running the displayed remedy left the row %s (%s)", row.Status, row.Evidence)
+	}
+}
+
+// Second review F2: a RELATIVE --cwd must resolve against the PROJECT, not the
+// shell working directory. `--project /repo --cwd ../wt` run from /tmp previously
+// recorded /tmp/wt on update and /repo/../wt on create -- two writers, two
+// origins, which is the #539/#540 defect class.
+func TestRelativeCwdResolvesAgainstProjectNotShellCwd(t *testing.T) {
+	project := t.TempDir()
+	sibling := filepath.Join(project, "wt-rel")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedBlockedSquadIn(t, project)
+
+	// Run from an UNRELATED directory, which is what exposes the wrong anchor.
+	elsewhere := t.TempDir()
+	chdir(t, elsewhere)
+
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "dev-2", "--project", project, "--profile", "squad", "--cwd", "wt-rel"})
+	}); err != nil {
+		t.Fatalf("relative --cwd update failed: %v", err)
+	}
+	tm, err := team.ReadProfile(project, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range tm.Members {
+		if m.Role != "dev-2" {
+			continue
+		}
+		if !sameFilesystemPath(m.CWD, sibling) {
+			t.Fatalf("relative --cwd recorded %q; must resolve against the project (%q), not the shell cwd (%q)", m.CWD, sibling, elsewhere)
+		}
+	}
+	// Create and update must agree for the same relative input.
+	viaCreate := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(viaCreate, "wt-rel"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad", "--project", viaCreate,
+			"--roles", "cto,dev-1,dev-2", "--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--cwd", "dev-2=wt-rel", "--no-session-pin"})
+	}); err != nil {
+		t.Fatalf("relative --cwd at creation failed: %v", err)
+	}
+	created, err := team.ReadProfile(viaCreate, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range created.Members {
+		if m.Role != "dev-2" {
+			continue
+		}
+		want := filepath.Join(viaCreate, "wt-rel")
+		if !sameFilesystemPath(m.CWD, want) {
+			t.Fatalf("create path recorded %q for a relative --cwd; want %q. create and update must share one origin", m.CWD, want)
+		}
+	}
+}
+
+// Second review F4: readiness must detect the collision doctor detects. Grouping
+// raw strings let a symlink and its target count as two directories at
+// preparation and one Git index at runtime -- ready, then doctor fail.
+func TestReadinessGroupsSymlinkEquivalentCwdsAsCollision(t *testing.T) {
+	project := t.TempDir()
+	real := filepath.Join(project, "shared")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(project, "shared-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if canonicalFilesystemPath(link) != canonicalFilesystemPath(real) {
+		t.Skip("symlink does not canonicalize onto its target here")
+	}
+
+	tm := team.Team{Project: project, Members: []team.Member{
+		{Role: "dev-1", Binary: "claude", Handle: "dev-1", ActorMode: team.ActorModeImplementation, CWD: real},
+		{Role: "dev-2", Binary: "codex", Handle: "dev-2", ActorMode: team.ActorModeImplementation, CWD: link},
+	}}
+	row := worktreeIsolationReadinessRow(tm, "squad")
+	if row.Status != "blocked" {
+		t.Fatalf("two members on symlink-equivalent directories share one Git index and must block; got %s (%s)", row.Status, row.Evidence)
+	}
+	// The evidence should show a path the operator recognises, not only the
+	// canonical form.
+	if !strings.Contains(row.Evidence, "dev-1") || !strings.Contains(row.Evidence, "dev-2") {
+		t.Fatalf("evidence must name both colliding roles; got %s", row.Evidence)
+	}
+}
+
+// seedBlockedSquad creates a named profile whose two implementers share the
+// team-home, i.e. the exact blocked state #538 is about.
+func seedBlockedSquad(t *testing.T, dir string) {
+	t.Helper()
+	seedBlockedSquadIn(t, dir)
+}
+
+func seedBlockedSquadIn(t *testing.T, dir string) {
+	t.Helper()
+	if _, _, err := captureOutput(t, func() error {
+		return runNew([]string{"profile", "squad", "--project", dir,
+			"--roles", "cto,dev-1,dev-2",
+			"--binary", "cto=claude,dev-1=claude,dev-2=codex",
+			"--actor-mode", "cto=review,dev-1=implementation,dev-2=implementation",
+			"--no-session-pin"})
+	}); err != nil {
+		t.Fatalf("seed blocked squad: %v", err)
+	}
+}
+
+// extractQuotedCommand pulls the single-quoted command beginning with prefix out
+// of a fix string and splits it into argv, honouring the shellQuote form the row
+// emits.
+func extractQuotedCommand(t *testing.T, text, prefix string) []string {
+	t.Helper()
+	i := strings.Index(text, "'"+prefix)
+	if i < 0 {
+		t.Fatalf("fix text does not contain a quoted %q command: %s", prefix, text)
+	}
+	rest := text[i+1:]
+	j := strings.Index(rest, "'")
+	if j < 0 {
+		t.Fatalf("unterminated quoted command in fix text: %s", text)
+	}
+	return strings.Fields(rest[:j])
 }

--- a/internal/cli/worktree_isolation_test.go
+++ b/internal/cli/worktree_isolation_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWorktreeIsolationReadinessRowSingleDevIsReady(t *testing.T) {
 	tm := team.Team{Members: []team.Member{{Role: "cto", Binary: "codex", ActorMode: team.ActorModeImplementation}}}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "ready" {
 		t.Fatalf("single-dev row = %+v, want ready", row)
 	}
@@ -23,7 +23,7 @@ func TestWorktreeIsolationReadinessRowIsolatedCwdsAreReady(t *testing.T) {
 			{Role: "qa", Binary: "codex", ActorMode: team.ActorModeImplementation, CWD: "/repo-worktrees/qa"},
 		},
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "ready" {
 		t.Fatalf("isolated-cwd row = %+v, want ready", row)
 	}
@@ -39,7 +39,7 @@ func TestWorktreeIsolationReadinessRowMixedImplementationReviewIsReady(t *testin
 			{Role: "reviewer", Binary: "codex", ActorMode: team.ActorModeReview},
 		},
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "ready" {
 		t.Fatalf("mixed implementation/review row = %+v, want ready", row)
 	}
@@ -53,7 +53,7 @@ func TestWorktreeIsolationReadinessRowSharedCwdBlocksWithoutException(t *testing
 			{Role: "qa", Binary: "codex", ActorMode: team.ActorModeImplementation},
 		},
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "blocked" {
 		t.Fatalf("shared-cwd row = %+v, want blocked", row)
 	}
@@ -74,7 +74,7 @@ func TestWorktreeIsolationReadinessRowSharedCwdReadyWithException(t *testing.T) 
 		},
 		SharedCwdException: "hotspot serialization",
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "ready" {
 		t.Fatalf("exception row = %+v, want ready", row)
 	}
@@ -96,7 +96,7 @@ func TestWorktreeIsolationReadinessRowPlannerLeadNotCounted(t *testing.T) {
 			{Role: "worker", Binary: "codex"},
 		},
 	}
-	row := worktreeIsolationReadinessRow(tm)
+	row := worktreeIsolationReadinessRow(tm, team.DefaultProfile)
 	if row.Status != "ready" {
 		t.Fatalf("planner-lead row = %+v, want ready", row)
 	}


### PR DESCRIPTION
Fixes #538.

The readiness check is right to fail closed when 2+ mutation-capable members share one Git index (#497). Both remedies it offered were unusable — in different ways, and the second one is not what the issue thought it was.

## Remedy 1 was reachable, just undiscoverable

The issue states no `--cwd` is exposed on `new team` / `new profile`. **It is.** `--cwd` is defined on the `team init` flag set, forwarded by `new profile`, and resolves into `Member.CWD`. Verified end to end on a throwaway project before changing anything:

```
new profile squad --roles cto,dev-1,dev-2 --cwd "dev-1=…/wt-a,dev-2=…/wt-b"
→ dev-1 → …/wt-a
  dev-2 → …/wt-b
```

The real defect was the fix text: *"give each mutation-capable member its own `--cwd` (isolated worktree)"* named no command, so the operator reasonably concluded the flag did not exist. **A remedy the reader cannot execute is not a remedy.**

The text now names exact commands, and names a colliding role from the operator's own roster instead of a placeholder they must translate.

What was genuinely missing is the **post-creation** path. `--cwd` is now accepted by `team member add` and `team member update`, so an existing roster is fixable without hand-editing `team.json`. `--cwd ""` on update clears the override, so the flag is not a one-way door. Create, add and update share one resolver so the flag cannot come to mean two things.

## Remedy 2 was actively rejected, and that is not in the issue

`new profile` peels the profile name from flag args using a hand-maintained list of which `team init` flags take a separate value. `--shared-cwd-exception` — *the exception command itself* — was missing from it, so recording the exception at creation time failed with:

```
new profile takes exactly one profile name; got extra argument "<reason>"
```

An error blaming the operator's own reason text for a gap in our map. So **both** #538 remedies were unreachable through `new profile`: remedy 1 by omission from the fix text, remedy 2 by the delivery path rejecting it. The issue attributes remedy 2's failure to profile rollback; that is real, but this sat in front of it.

### It was 17 flags, not 3

Inspection found three (`--actor-mode`, `--tool-profile`, `--tool-config`). The enumeration test found the rest immediately:

`--actor-mode` · `--allowed-role-classes` · `--allowed-roles` · `--budget-turns` · `--composition` · `--control-root` · `--idle-reap-minutes` · `--lead-mode` · `--max-agents` · `--max-total-spawns` · `--mode` · `--operator-mode` · `--self-operator-allow` · `--self-operator-lead` · `--shared-cwd-exception` · `--target-contract` · `--target-project-root` · `--tool-config` · `--tool-profile`

`--actor-mode` compounds #538 directly: without it every member defaults to `implementation`, so a roster intended as one reviewer + two implementers came out with **three** implementers and a shared-cwd blocker with no visible cause.

I would have shipped 3 of 17 on inspection alone. The expectation is now **derived from production registration** rather than a second hand-written list:

- `TestNewProfileForwardsEveryValueTakingTeamInitFlag` walks the real `team init` flag set and fails on any value-taking flag not forwarded.
- `TestNewProfileValueFlagsHasNoStaleEntries` covers the reverse — a stale entry swallows the following argument, usually the profile NAME.

To enumerate production flags rather than copy them, `team init` publishes its registered flag set for **test introspection only**. Extracting its 41 registrations into a shared struct is the cleaner shape and is deliberately deferred rather than done inside a bug fix.

## Failed preparation now explains itself

Preparation is transactional, so a readiness failure rolls back the profile it created. Operators were told to run `team shared-cwd-exception set`, then hit "no profile", with nothing explaining why. The failure now states the transactionality, says commands that modify an existing profile have nothing to act on yet, and points at the creation-time forms, which do not depend on a profile existing first.

**The rollback itself is unchanged, deliberately.** Selectively preserving one artifact breaks the all-or-nothing property it exists to guarantee. #512 owns partial-preservation semantics as a deliberate design, not as a side effect of a UX fix.

## doctor / readiness agreement (AC4)

Both checks detect the same condition and honour the same exception with the same vocabulary. Severity and remedy differ **by lifecycle stage, deliberately**:

- **Severity** — preparation has no live members and must fail closed (#497). doctor's is liveness-derived: fail only when 2+ affected members are live, warn otherwise. Copying that rule into preparation would make it always warn.
- **Remedy** — doctor names `worktree plan|materialize`, which require `--task ID`. No tasks exist before launch, so naming it in the readiness row would be false.

Recorded at the readiness site as: *if you change one side's condition or exception handling, change both.*

## Acceptance criteria

| AC | Covered by |
|---|---|
| 1. Every remedy executable | `TestWorktreeIsolationFixNamesOnlyExecutableRemedies` — asserts every named command is real **and** every named flag is forwarded by `new profile` |
| 2. Two implementers reach ready from a clean repo, no hand-editing, no trial-and-error | Three tests, one per remedy path, each a single command |
| 3. Failed preparation preserves or names the prerequisite | Takes the "names" branch, and additionally explains the transactionality |
| 4. doctor and readiness agree | Documented at the readiness site against t4's final text |

AC1's second half is the one that matters: it closes the exact loop that produced #538 — text naming a flag the delivery path silently rejected.

## Verified against base

Every behaviour was confirmed broken on `b4dd05e` in a throwaway worktree, with these exact messages:

| probe | base result |
|---|---|
| `new profile --shared-cwd-exception "…"` | `got extra argument "accepted for this run"` |
| `new profile --actor-mode cto=review` | `got extra argument "cto=review"` |
| readiness fix text | names a bare `--cwd` with no command attached |
| `team member update --cwd` | `flag provided but not defined: -cwd` |

## Evidence

`make ci` on this exact head: **exit 0**, zero failures, `internal/cli ok 411.746s`, gofmt and vet clean.

Do not merge without review — second review at this head, then the operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
