### PR TITLE
feat(#534): add the check-skill-commands drift gate and wire it into ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ amq-squad-rc-*
 .amq-squad/teams/
 .amq-squad/worktrees/
 .worktrees/
+
+# Python bytecode from the scripts/ checkers and their tests (#534 drift gate
+# loads the checker via importlib, which writes __pycache__).
+__pycache__/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check vet ci install release-check release-validator-test release-smoke readme-html readme-html-check docs-html docs-html-check html skills-generate skills-check skill-routing-check dogfood-claude clean
+.PHONY: build test fmt fmt-check vet ci skill-command-check install release-check release-validator-test release-smoke readme-html readme-html-check docs-html docs-html-check html skills-generate skills-check skill-routing-check dogfood-claude clean
 
 GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -32,7 +32,18 @@ fmt-check:
 vet:
 	go vet ./...
 
-ci: fmt-check vet test readme-html-check docs-html-check skills-check skill-routing-check release-validator-test
+ci: fmt-check vet test readme-html-check docs-html-check skills-check skill-routing-check skill-command-check release-validator-test
+
+# Every CLI command and flag named in the skills must exist in the binary (#534).
+# The skills drifting from the binary has been a recurring release-note problem;
+# this makes it a build failure instead. It is also the prerequisite for #522's
+# verb-grammar rewrite, which becomes a mechanical regeneration once drift is
+# mechanically detectable. Depends on build: the gate reads the real command
+# surface from the binary's own --help rather than a second hand-maintained list.
+skill-command-check: build
+	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for skill-command-check" >&2; exit 1; }
+	@python3 scripts/check-skill-commands.py ./amq-squad
+	@python3 scripts/test_check_skill_commands.py
 
 # Regenerate plugin SKILL.md mirrors from plugins/skills-src.
 skills-generate:

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -202,8 +202,23 @@ SUB_PROBE = "__amq_squad_probe_invalid__"
 # check rather than a per-path guess. That replaces an earlier prober that returned
 # "exists" for every response except the recognized negative -- fail-open in a
 # verifier, which made `amq-squad doctor totallybogus` verify clean.
-UNKNOWN_SUB_USE = re.compile(r"unknown\s+\S+\s+subcommand[^;]*;\s*use\s+(?P<list>[^\n.]+)", re.I)
-UNKNOWN_SUB_TRY = re.compile(r"unknown\s+'[^']+'\s+subcommand[^.]*\.\s*Try\s+(?P<list>[^\n.]+)", re.I)
+# ONE rule for every unknown-subcommand format the binary emits. There are three,
+# differing in separator and verb:
+#
+#   evidence  ->  unknown evidence subcommand "X"; use run, show, list, ...
+#   team      ->  unknown 'team' subcommand: "X". Try 'init', 'resume', ...
+#   amq       ->  unknown amq subcommand "X". Use env, ops, route, who, ...
+#
+# Handling only the first two left `amq` UNOBSERVABLE, which under the fail-closed
+# posture BLOCKED the build for any skill documenting an amq subcommand -- i.e. the
+# gate blocking correct documentation of a command it is meant to protect.
+#
+# Collapsing them into one rule rather than adding a third branch also REDUCES the
+# wording coupling: one rule plus the Go printer, instead of three regexes to keep in
+# step. (Normalizing the binary's own error wording is the durable upstream fix.)
+UNKNOWN_SUBCOMMAND_LIST = re.compile(
+    r"unknown\s+'?\S+?'?\s+subcommand[^;.]*[;.]\s*(?:use|try)\s+(?P<list>[^\n]+)", re.I
+)
 NO_POSITIONALS = re.compile(r"takes no positional arguments", re.I)
 SUB_NAME = re.compile(r"[A-Za-z][A-Za-z0-9-]*")
 
@@ -244,7 +259,7 @@ def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
     # autonomous, shared-cwd-exception appear only in the error). Using the usage
     # block alone produced FALSE FAILURES for valid subcommands, so take the UNION.
     text = run_help(binary, verb, SUB_PROBE)
-    match = UNKNOWN_SUB_USE.search(text) or UNKNOWN_SUB_TRY.search(text)
+    match = UNKNOWN_SUBCOMMAND_LIST.search(text)
     listed: set[str] = set()
     if match:
         listed = {n for n in SUB_NAME.findall(match.group("list")) if n.lower() not in {"or", "and"}}

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -22,10 +22,32 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SKILLS = REPO / "plugins" / "skills-src"
 
-# A command reference must START its line. Occurrences mid-sentence are prose:
-# "This project uses amq-squad for agent team coordination" is English, and the
-# fences in these skills legitimately contain file templates as well as shell.
-COMMAND_LINE = re.compile(r"^\s*(?:\$\s+|&&\s+|\|\s+)?amq-squad\s+(?P<rest>[^\n]*)", re.M)
+# A command reference must START its line, or appear inside a Bash(...) permission
+# string. Occurrences mid-sentence are prose: "This project uses amq-squad for
+# agent team coordination" is English, and the fences in these skills legitimately
+# contain file templates as well as shell.
+#
+# MEDIUM 4: Bash(amq-squad review-worktree remove:*) is a REAL command reference --
+# it is what an operator puts in an allowlist -- and the line-start rule alone
+# ignored it, so renames could break permission strings silently.
+COMMAND_LINE = re.compile(
+    r"(?:^\s*(?:\$\s+|&&\s+|\|\s+)?|\bBash\(\s*)amq-squad\s+(?P<rest>[^\n]*)", re.M
+)
+
+# A trailing permission-string suffix: Bash(amq-squad x remove:*) -> drop ":*)".
+PERMISSION_SUFFIX = re.compile(r"[:)].*$")
+
+# Continuation joining (HIGH 2). A reference wraps in these files:
+#   `amq-squad evidence run TASK --profile PROFILE --session SESSION --me ACTOR
+#   --subject TEXT --attempt-id ID -- COMMAND [ARG...]`
+# Capturing only to the first newline SILENTLY dropped every flag after the wrap
+# (--subject, --attempt-id, and in other references --lead, --launch-shape, --go).
+# Silently dropping flags is the same class as dropping whole references: the gate
+# reports agreement about text it never read.
+# In a FENCE, only a genuine continuation is joined: a trailing backslash, or a
+# following line indented under the command. Joining unconditionally would merge
+# distinct commands that simply sit on consecutive lines.
+FENCE_CONTINUATION = re.compile(r"\\\n\s*|\n[ \t]+(?=--)")
 
 FENCE = re.compile(r"```.*?```", re.S)
 # Inline spans WRAP ACROSS LINES in these files (cli/SKILL.md names
@@ -35,7 +57,16 @@ FENCE = re.compile(r"```.*?```", re.S)
 INLINE = re.compile(r"`([^`]+)`", re.S)
 
 VERB = re.compile(r"^[a-z][a-z0-9-]*$")
-FLAG = re.compile(r"^--[a-z][a-z0-9-]*$")
+# A subcommand token may be malformed; we still check it rather than drop it.
+SUBCOMMAND_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9-]*$")
+# Sentinel key for a flag-only reference such as `amq-squad --version`.
+GLOBAL_FLAG_KEY = "<global-flags>"
+# A flag token may be MALFORMED and must still be extracted so it can be reported.
+# A lowercase-only pattern silently dropped `--launch-shapeX`, which is the
+# vanishing-reference class a third time: fixed in the verb position, found by
+# review in the subcommand position, and still live in the flag position until a
+# test caught it. Extract anything flag-shaped; let verification judge it.
+FLAG = re.compile(r"^--[A-Za-z][A-Za-z0-9-]*$")
 
 # Strings that are formatted as commands but are not commands.
 #
@@ -54,6 +85,9 @@ NOT_A_COMMAND = {
 # skills are in before they name commands.
 MIN_COMMANDS = 8
 MIN_VERBS_IN_SURFACE = 20
+# Below this many claimed flags the zero-verified floor would be noise; above it,
+# verifying none of them means flag parsing has broken.
+MIN_FLAGS_CLAIMED_FOR_FLOOR = 4
 
 
 def run_help(binary: str, *args: str) -> str:
@@ -73,6 +107,28 @@ def verb_surface(binary: str) -> set[str]:
 # A command like that accepts flags its own help never enumerates, so its flag set
 # is not observable from --help and must not be treated as exhaustive.
 DELEGATES_FLAGS = re.compile(r"\[[^\]]*\b(?:flags|options)\]")
+
+
+# The binary names its own valid subcommands when given a bad one:
+#   error: unknown 'team' subcommand: "synchronise". Try 'init', 'resume', ...
+# That is a DEFINITIVE negative, so it is the one subcommand error we interpret --
+# the same discipline as t2's single interpretable git error. Everything else stays
+# uninterpretable rather than being optimistically treated as fine.
+UNKNOWN_SUBCOMMAND = re.compile(r"unknown '([^']+)' subcommand", re.I)
+
+
+def subcommand_exists(binary: str, verb: str, sub: str) -> tuple[bool, bool]:
+    """Return (exists, definitive).
+
+    HIGH 1: the gate previously verified only the TOP-LEVEL verb, so
+    `amq-squad team syncX` passed because `team` resolves and the resulting help
+    error was filed as merely unverifiable. Subcommands are where most renames
+    happen, so that hole voided the gate's core promise.
+    """
+    text = run_help(binary, verb, sub)
+    if UNKNOWN_SUBCOMMAND.search(text):
+        return False, True
+    return True, True
 
 
 def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], bool]:
@@ -98,8 +154,24 @@ def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], boo
 
 
 def code_blobs(text: str) -> list[str]:
-    blobs = [m.group(0) for m in FENCE.finditer(text)]
-    blobs.extend(m.group(1) for m in INLINE.finditer(FENCE.sub("", text)))
+    """Return code blobs already normalized for whole-reference extraction.
+
+    HIGH 2: an inline span is ONE logical command even when the markdown wraps it
+    mid-flag-list, and the wrap in cli/SKILL.md has NO leading whitespace on the
+    continuation line:
+
+        `amq-squad evidence run TASK --profile P --session S --me ACTOR
+        --subject TEXT --attempt-id ID -- COMMAND [ARG...]`
+
+    so a continuation rule requiring indentation missed it and every flag after the
+    wrap was silently dropped. Inline spans therefore collapse ALL newlines; fences
+    join only genuine continuations, because consecutive lines in a fence are
+    usually separate commands.
+    """
+    blobs = [FENCE_CONTINUATION.sub(" ", m.group(0)) for m in FENCE.finditer(text)]
+    blobs.extend(
+        re.sub(r"\s*\n\s*", " ", m.group(1)) for m in INLINE.finditer(FENCE.sub("", text))
+    )
     return blobs
 
 
@@ -108,25 +180,32 @@ def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
     found: dict[tuple[str, str | None], set[str]] = {}
     for path in paths:
         for blob in code_blobs(path.read_text()):
+            # Join wrapped continuation lines so a reference is read whole.
             for match in COMMAND_LINE.finditer(blob):
-                tokens = match.group("rest").split()
+                rest = PERMISSION_SUFFIX.sub("", match.group("rest"))
+                tokens = rest.split()
                 if not tokens:
                     continue
-                # Skip only a leading FLAG: `amq-squad --version` is legitimate and
-                # names no verb. Anything ELSE in the verb position is a CLAIMED
-                # command and must be checked, even when it does not look like a
-                # valid verb.
-                #
-                # An earlier version skipped any token failing the lowercase VERB
-                # pattern. That meant renaming a command to `evidenceX` made the
-                # reference VANISH rather than fail: the extracted count silently
-                # dropped from 11 to 10 and the gate reported success. A drift gate
-                # that discards references it cannot parse is worse than no gate,
-                # because the discard is indistinguishable from agreement.
-                if tokens[0].startswith("-"):
-                    continue
                 verb = tokens[0]
-                sub = tokens[1] if len(tokens) > 1 and VERB.match(tokens[1]) else None
+                # MEDIUM 3: a leading-dash token must not be discarded wholesale.
+                # `amq-squad --version` is a legitimate flag-only reference; a
+                # malformed verb like `-doctor`, or a global flag that does not
+                # exist, is a CLAIM that must be checked. Blanket-skipping anything
+                # starting with "-" was the vanishing-reference class surviving in
+                # the flag branch after being fixed in the verb branch.
+                if verb.startswith("-"):
+                    if len(tokens) == 1 and verb.startswith("--"):
+                        found.setdefault((GLOBAL_FLAG_KEY, None), set()).add(verb)
+                    else:
+                        found.setdefault((verb, None), set())
+                    continue
+                sub = tokens[1] if len(tokens) > 1 and not tokens[1].startswith("-") else None
+                if sub is not None and not SUBCOMMAND_TOKEN.match(sub):
+                    # A malformed subcommand (e.g. `syncX`) must be REPORTED, not
+                    # silently folded into the bare verb: folding both loses the
+                    # rename and, when the same verb also appears with a real
+                    # subcommand, produced a None/str sort crash.
+                    sub = sub.lower() if sub.isalpha() else sub
                 flags = {t for t in tokens if FLAG.match(t)}
                 found.setdefault((verb, sub), set()).update(flags)
     return found
@@ -171,25 +250,70 @@ def main() -> int:
     failures: list[str] = []
     unverifiable: list[str] = []
     flags_checked = 0
+    flags_claimed = 0
     verified_real_verb = False
-    for (verb, sub), flags in sorted(checked.items()):
+
+    global_flags, _ = flag_surface(binary, "", None)
+
+    # Sort with a None-safe key. Sorting raw (verb, sub) tuples crashed with
+    # TypeError whenever one verb appeared both bare and with a subcommand, because
+    # None is not comparable to str. That crash surfaced while probing HIGH 1 and is
+    # its own defect: a gate that dies on a legitimate corpus shape is unusable.
+    for (verb, sub), flags in sorted(checked.items(), key=lambda kv: (kv[0][0], kv[0][1] or "")):
+        flags_claimed += len(flags)
+
+        # A flag-only reference (`amq-squad --version`): verify the flags exist.
+        if verb == GLOBAL_FLAG_KEY:
+            for flag in sorted(flags):
+                if global_flags and flag not in global_flags:
+                    failures.append(f"global flag '{flag}' is named in the skills but 'amq-squad --help' does not list it")
+                else:
+                    flags_checked += 1
+            continue
+
+        if verb.startswith("-"):
+            failures.append(f"'amq-squad {verb}' is named in the skills but is not a command or a global flag")
+            continue
+
         if verb not in surface:
             failures.append(f"verb 'amq-squad {verb}' is named in the skills but is not a command")
             continue
         verified_real_verb = True
-        known, observable = flag_surface(binary, verb, sub)
+
+        # HIGH 1: verify the FULL command path, not just the first token.
+        if sub is not None:
+            exists, definitive = subcommand_exists(binary, verb, sub)
+            if definitive and not exists:
+                failures.append(f"subcommand 'amq-squad {verb} {sub}' is named in the skills but {verb} has no such subcommand")
+                continue
+
         target = f"{verb} {sub}" if sub else verb
+        known, observable = flag_surface(binary, verb, sub)
         if not observable:
             if flags:
                 unverifiable.append(f"amq-squad {target} ({len(flags)} flag(s): {', '.join(sorted(flags))})")
             continue
-        flags_checked += len(flags)
         for flag in sorted(flags):
             if flag not in known:
                 failures.append(f"flag '{flag}' is named for 'amq-squad {target}' but that command does not accept it")
+            else:
+                flags_checked += 1
 
     if not verified_real_verb:
         print("error: no real verb was verified; the gate checked nothing", file=sys.stderr)
+        return 2
+
+    # MEDIUM 5: floor the FLAG coverage too. Verbs were floored; flags were not, so
+    # a help-format change that stopped yielding parsed flags would make everything
+    # "unverifiable" and keep the build green -- the same silent shrink, one level
+    # down.
+    if flags_claimed >= MIN_FLAGS_CLAIMED_FOR_FLOOR and flags_checked == 0:
+        print(
+            f"error: {flags_claimed} flag(s) are named in the skills but ZERO were verified. "
+            "Flag help is probably no longer parseable; this gate would otherwise pass by "
+            "verifying no flags at all.",
+            file=sys.stderr,
+        )
         return 2
 
     if failures:
@@ -199,9 +323,7 @@ def main() -> int:
         print("\nFix the skill text, or the command, so they agree.", file=sys.stderr)
         return 1
 
-    # Report coverage honestly: a gate that quietly verifies less than it claims is
-    # the failure mode this whole file exists to prevent.
-    print(f"skills name {len(checked)} command(s); all {len(checked)} verb(s) resolve, {flags_checked} flag(s) verified")
+    print(f"skills name {len(checked)} command(s); all verb/subcommand paths resolve, {flags_checked} of {flags_claimed} flag(s) verified")
     if unverifiable:
         print(f"flags NOT verifiable from --help for {len(unverifiable)} command(s) "
               "(help errors without required positionals, or delegates its flag set):")

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Fail the build when a skill names a CLI command or flag the binary does not have.
+
+#534: the skills drift from the binary between releases, and the drift is only
+found when an operator follows an instruction that no longer works. This converts
+that from a recurring release-note problem into a build failure, and it is the
+prerequisite for #522's verb-grammar rewrite: with this gate in place that rewrite
+becomes a mechanical regeneration instead of a manual audit.
+
+The command surface is read from the binary's own --help output, so there is no
+second list of verbs to keep in sync. That is deliberate: a hand-maintained mirror
+of the command surface would be the very defect this gate exists to catch.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILLS = REPO / "plugins" / "skills-src"
+
+# A command reference must START its line. Occurrences mid-sentence are prose:
+# "This project uses amq-squad for agent team coordination" is English, and the
+# fences in these skills legitimately contain file templates as well as shell.
+COMMAND_LINE = re.compile(r"^\s*(?:\$\s+|&&\s+|\|\s+)?amq-squad\s+(?P<rest>[^\n]*)", re.M)
+
+FENCE = re.compile(r"```.*?```", re.S)
+# Inline spans WRAP ACROSS LINES in these files (cli/SKILL.md names
+# `amq-squad evidence run TASK --profile ...` broken over two lines), so the span
+# body must tolerate newlines. A newline-hostile pattern misses it SILENTLY, which
+# is the dangerous kind of miss.
+INLINE = re.compile(r"`([^`]+)`", re.S)
+
+VERB = re.compile(r"^[a-z][a-z0-9-]*$")
+FLAG = re.compile(r"^--[a-z][a-z0-9-]*$")
+
+# Strings that are formatted as commands but are not commands.
+#
+# This list must stay EMPTY-able: every entry is a concession, and
+# test_check_skill_commands.py asserts each one still actually appears in the
+# skills, so a concession cannot outlive its cause silently.
+NOT_A_COMMAND = {
+    # The version-announcement preamble renders an identity string in backticks:
+    # "stating the loaded identity as `amq-squad skill v2.24.0`". #534's skill
+    # rewrite removes that preamble entirely, at which point this entry must go.
+    "skill": "version-announcement identity string, not a command; removed by #534's preamble deletion",
+}
+
+# Anti-vacuity floors. A gate that silently finds nothing is worse than no gate:
+# it reports success while checking zero things, which is exactly the state the
+# skills are in before they name commands.
+MIN_COMMANDS = 8
+MIN_VERBS_IN_SURFACE = 20
+
+
+def run_help(binary: str, *args: str) -> str:
+    proc = subprocess.run([binary, *args, "--help"], capture_output=True, text=True)
+    return proc.stdout + proc.stderr
+
+
+def verb_surface(binary: str) -> set[str]:
+    """Top-level verbs, parsed from the binary's own two-column help."""
+    text = run_help(binary)
+    return {m for m in re.findall(r"^\s{2,}([a-z][a-z0-9-]{1,30})\s{2,}\S", text, re.M)}
+
+
+# Help text that DELEGATES its flags rather than listing them, e.g.
+#   amq-squad wizard [run start prefill flags] [--scope project|global]
+#   amq-squad new profile NAME ... [team init options]
+# A command like that accepts flags its own help never enumerates, so its flag set
+# is not observable from --help and must not be treated as exhaustive.
+DELEGATES_FLAGS = re.compile(r"\[[^\]]*\b(?:flags|options)\]")
+
+
+def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], bool]:
+    """Return (flags, observable).
+
+    observable is False when the exact command's help cannot be trusted as an
+    exhaustive flag list: either it errored (some subcommands refuse --help without
+    required positionals, e.g. `evidence run`) or it delegates its flags to another
+    command's set. In those cases flags are UNVERIFIABLE, not absent.
+
+    Falling back to the PARENT's help would be worse than not checking: `evidence`
+    and `evidence run` have different flag sets, so the parent's list produced
+    confident false positives for flags that do work.
+    """
+    args = [verb] if sub is None else [verb, sub]
+    text = run_help(binary, *args)
+    if text.lstrip().startswith("error:"):
+        return set(), False
+    if DELEGATES_FLAGS.search(text):
+        return set(), False
+    flags = set(re.findall(r"(--[a-z][a-z0-9-]*)", text))
+    return flags, bool(flags)
+
+
+def code_blobs(text: str) -> list[str]:
+    blobs = [m.group(0) for m in FENCE.finditer(text)]
+    blobs.extend(m.group(1) for m in INLINE.finditer(FENCE.sub("", text)))
+    return blobs
+
+
+def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
+    """Map (verb, subcommand-or-None) -> set of flags named with it, per skills."""
+    found: dict[tuple[str, str | None], set[str]] = {}
+    for path in paths:
+        for blob in code_blobs(path.read_text()):
+            for match in COMMAND_LINE.finditer(blob):
+                tokens = match.group("rest").split()
+                if not tokens:
+                    continue
+                # Skip only a leading FLAG: `amq-squad --version` is legitimate and
+                # names no verb. Anything ELSE in the verb position is a CLAIMED
+                # command and must be checked, even when it does not look like a
+                # valid verb.
+                #
+                # An earlier version skipped any token failing the lowercase VERB
+                # pattern. That meant renaming a command to `evidenceX` made the
+                # reference VANISH rather than fail: the extracted count silently
+                # dropped from 11 to 10 and the gate reported success. A drift gate
+                # that discards references it cannot parse is worse than no gate,
+                # because the discard is indistinguishable from agreement.
+                if tokens[0].startswith("-"):
+                    continue
+                verb = tokens[0]
+                sub = tokens[1] if len(tokens) > 1 and VERB.match(tokens[1]) else None
+                flags = {t for t in tokens if FLAG.match(t)}
+                found.setdefault((verb, sub), set()).update(flags)
+    return found
+
+
+def main() -> int:
+    binary = sys.argv[1] if len(sys.argv) > 1 else str(REPO / "amq-squad")
+    # Optional second argument: the skills root. Defaults to this repo's sources.
+    # It exists so the no-skills-found branch is testable without faking the repo
+    # layout, and so the gate can be pointed at another checkout.
+    skills = Path(sys.argv[2]) if len(sys.argv) > 2 else SKILLS
+    if not Path(binary).exists():
+        print(f"error: binary not found at {binary}; run 'make build' first", file=sys.stderr)
+        return 2
+
+    surface = verb_surface(binary)
+    if len(surface) < MIN_VERBS_IN_SURFACE:
+        print(
+            f"error: only {len(surface)} verbs parsed from '{binary} --help' "
+            f"(expected >= {MIN_VERBS_IN_SURFACE}). The help format probably changed; "
+            "this gate would otherwise pass by checking against an empty surface.",
+            file=sys.stderr,
+        )
+        return 2
+
+    paths = sorted(skills.rglob("*.md"))
+    if not paths:
+        print(f"error: no skill sources found under {skills}", file=sys.stderr)
+        return 2
+
+    found = extract(paths)
+    checked = {k: v for k, v in found.items() if k[0] not in NOT_A_COMMAND}
+    if len(checked) < MIN_COMMANDS:
+        print(
+            f"error: extracted only {len(checked)} command references from the skills "
+            f"(expected >= {MIN_COMMANDS}). Either the skills stopped naming commands or the "
+            "extractor broke; both must fail rather than silently check nothing.",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures: list[str] = []
+    unverifiable: list[str] = []
+    flags_checked = 0
+    verified_real_verb = False
+    for (verb, sub), flags in sorted(checked.items()):
+        if verb not in surface:
+            failures.append(f"verb 'amq-squad {verb}' is named in the skills but is not a command")
+            continue
+        verified_real_verb = True
+        known, observable = flag_surface(binary, verb, sub)
+        target = f"{verb} {sub}" if sub else verb
+        if not observable:
+            if flags:
+                unverifiable.append(f"amq-squad {target} ({len(flags)} flag(s): {', '.join(sorted(flags))})")
+            continue
+        flags_checked += len(flags)
+        for flag in sorted(flags):
+            if flag not in known:
+                failures.append(f"flag '{flag}' is named for 'amq-squad {target}' but that command does not accept it")
+
+    if not verified_real_verb:
+        print("error: no real verb was verified; the gate checked nothing", file=sys.stderr)
+        return 2
+
+    if failures:
+        print(f"skill/command drift ({len(failures)}):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        print("\nFix the skill text, or the command, so they agree.", file=sys.stderr)
+        return 1
+
+    # Report coverage honestly: a gate that quietly verifies less than it claims is
+    # the failure mode this whole file exists to prevent.
+    print(f"skills name {len(checked)} command(s); all {len(checked)} verb(s) resolve, {flags_checked} flag(s) verified")
+    if unverifiable:
+        print(f"flags NOT verifiable from --help for {len(unverifiable)} command(s) "
+              "(help errors without required positionals, or delegates its flag set):")
+        for u in unverifiable:
+            print(f"  - {u}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -129,10 +129,23 @@ MIN_FLAGS_CLAIMED_FOR_FLOOR = 4
 # Committed coverage baseline. At the time of writing the gate verifies 15 of 23
 # claimed flags; these floors make a regression from that a BUILD failure rather
 # than a quiet shrink. Raise them when coverage genuinely improves.
-MIN_VERIFIED_FLAGS = 4
+# Floors sit AT committed coverage with one flag of headroom. Set far below it (4
+# and 5 against real coverage of 13) they permitted a 13 -> 5 collapse while exiting
+# 0, which is the silent shrink the floor exists to prevent.
+MIN_VERIFIED_FLAGS = 12
 # The VERIFIABLE set must not silently shrink either, or the ratio is vacuous.
-MIN_VERIFIABLE_FLAGS = 5
+MIN_VERIFIABLE_FLAGS = 12
 MIN_VERIFIED_FLAG_RATIO = 0.5
+
+
+def required_verified(verifiable: int) -> int:
+    """Minimum verified flags for a given verifiable count.
+
+    Production calculation, exposed so a test exercises THIS rather than Python's
+    math library: asserting math.ceil(23 * 0.5) == 12 stays green when production
+    truncates with int(), which made that test vacuous.
+    """
+    return max(MIN_VERIFIED_FLAGS, math.ceil(verifiable * MIN_VERIFIED_FLAG_RATIO))
 
 
 def run_help(binary: str, *args: str) -> str:
@@ -152,6 +165,10 @@ def verb_surface(binary: str) -> set[str]:
 # A command like that accepts flags its own help never enumerates, so its flag set
 # is not observable from --help and must not be treated as exhaustive.
 DELEGATES_FLAGS = re.compile(r"\[[^\]]*\b(?:flags|options)\]")
+
+# Section headers that introduce a FLAG LIST. Anything else (Examples:, Exit codes:,
+# Commands:, prose) is not a flag surface.
+FLAG_SECTION_HEADER = re.compile(r"\b(?:flags|options)\b", re.I)
 
 
 # The binary names its own valid subcommands when given a bad one:
@@ -284,8 +301,24 @@ def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], boo
                 continue
             usage_flags.update(re.findall(r"--([A-Za-z][A-Za-z0-9-]*)", line))
 
+    # Finding 1: scanning the WHOLE body let any indented dash-leading line become a
+    # "definition", so an indented PROSE line mentioning a flag entered the surface.
+    # Collect definitions only inside recognized FLAG SECTIONS: everything after Go's
+    # `Usage of X:` header (that whole block is the definition list), or a hand-written
+    # section whose header names flags/options. `Examples:` and prose sections are
+    # excluded by construction rather than by pattern luck.
     definitions: set[str] = set()
+    in_flag_section = False
     for line in lines:
+        if line.startswith("Usage of "):
+            in_flag_section = True
+            continue
+        # A column-0 line ending in ':' starts a new section.
+        if line and not line[0].isspace() and line.rstrip().endswith(":"):
+            in_flag_section = bool(FLAG_SECTION_HEADER.search(line))
+            continue
+        if not in_flag_section:
+            continue
         m = re.match(r"^[ \t]{2,}--?([A-Za-z][A-Za-z0-9-]*)(?:[ \t=,]|$)", line)
         if m:
             definitions.add(m.group(1))
@@ -572,7 +605,7 @@ def main() -> int:
         # The floor measures against VERIFIABLE claims, because a flag on a
         # non-exhaustive surface can only ever be confirmed, never refuted, so
         # counting it as a miss would fail every build under the honest model.
-        required = max(MIN_VERIFIED_FLAGS, math.ceil(flags_verifiable * MIN_VERIFIED_FLAG_RATIO))
+        required = required_verified(flags_verifiable)
         if flags_checked < required:
             print(
                 f"error: only {flags_checked} of {flags_claimed} named flag(s) were verified "

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -30,9 +30,21 @@ SKILLS = REPO / "plugins" / "skills-src"
 # MEDIUM 4: Bash(amq-squad review-worktree remove:*) is a REAL command reference --
 # it is what an operator puts in an allowlist -- and the line-start rule alone
 # ignored it, so renames could break permission strings silently.
+# `rest` stops at the next `amq-squad` token, so an inline span holding TWO
+# commands does not attribute the second command's verb and flags to the first.
+# M3: collapsing spans unconditionally (needed for wrapped references) made
+# `amq-squad team sync --apply` + `amq-squad doctor --json` in one span read as
+# `team sync --apply amq-squad doctor --json`, i.e. invented drift.
 COMMAND_LINE = re.compile(
-    r"(?:^\s*(?:\$\s+|&&\s+|\|\s+)?|\bBash\(\s*)amq-squad\s+(?P<rest>[^\n]*)", re.M
+    r"(?:^\s*(?:\$\s+|&&\s+|\|\s+)?|\bBash\(\s*)amq-squad\s+(?P<rest>(?:(?!amq-squad)[^\n])*)",
+    re.M,
 )
+
+# An inline shell comment is not part of the command. Without stripping it,
+# `amq-squad doctor    # AMQ version, tmux, wake` extracted `#` as doctor's
+# SUBCOMMAND, which then hit the `doctor takes no positional arguments` error and
+# (before H1) was reported as a PROVEN path.
+INLINE_COMMENT = re.compile(r"\s+#.*$")
 
 # A trailing permission-string suffix: Bash(amq-squad x remove:*) -> drop ":*)".
 PERMISSION_SUFFIX = re.compile(r"[:)].*$")
@@ -61,6 +73,9 @@ VERB = re.compile(r"^[a-z][a-z0-9-]*$")
 SUBCOMMAND_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9-]*$")
 # Sentinel key for a flag-only reference such as `amq-squad --version`.
 GLOBAL_FLAG_KEY = "<global-flags>"
+# Sentinel for flag-shaped tokens that are not valid flag syntax (e.g. --apply_bad).
+# They are REPORTED, never dropped.
+MALFORMED_FLAG_KEY = "<malformed-flags>"
 # A flag token may be MALFORMED and must still be extracted so it can be reported.
 # A lowercase-only pattern silently dropped `--launch-shapeX`, which is the
 # vanishing-reference class a third time: fixed in the verb position, found by
@@ -88,6 +103,11 @@ MIN_VERBS_IN_SURFACE = 20
 # Below this many claimed flags the zero-verified floor would be noise; above it,
 # verifying none of them means flag parsing has broken.
 MIN_FLAGS_CLAIMED_FOR_FLOOR = 4
+# Committed coverage baseline. At the time of writing the gate verifies 15 of 23
+# claimed flags; these floors make a regression from that a BUILD failure rather
+# than a quiet shrink. Raise them when coverage genuinely improves.
+MIN_VERIFIED_FLAGS = 10
+MIN_VERIFIED_FLAG_RATIO = 0.5
 
 
 def run_help(binary: str, *args: str) -> str:
@@ -117,18 +137,86 @@ DELEGATES_FLAGS = re.compile(r"\[[^\]]*\b(?:flags|options)\]")
 UNKNOWN_SUBCOMMAND = re.compile(r"unknown '([^']+)' subcommand", re.I)
 
 
-def subcommand_exists(binary: str, verb: str, sub: str) -> tuple[bool, bool]:
-    """Return (exists, definitive).
+# Tri-state subcommand observation. Returning "exists" for every response except
+# the recognized negative was FAIL-OPEN IN A VERIFIER: an I/O error, a config
+# failure, or `doctor takes no positional arguments` all PROVED the path, so
+# `amq-squad doctor totallybogus` verified clean.
+#
+# This is the probe-posture rule for the third time in one milestone (the #538 git
+# probe, the earlier version of this prober, and now here): a readiness/verification
+# probe must fail CLOSED, and "closed" for an unreadable observation means failing
+# the BUILD loudly, not failing the reference silently — a silent reference failure
+# would be an invented drift report, which is its own bad outcome.
+SUB_PROBE = "__amq_squad_probe_invalid__"
 
-    HIGH 1: the gate previously verified only the TOP-LEVEL verb, so
-    `amq-squad team syncX` passed because `team` resolves and the resulting help
-    error was filed as merely unverifiable. Subcommands are where most renames
-    happen, so that hole voided the gate's core promise.
+# The binary lists its own valid subcommands when handed a bogus one, in two
+# formats:
+#   error: unknown evidence subcommand "X"; use run, show, list, recover, or lookup
+#   error: unknown 'team' subcommand: "X". Try 'init', 'resume', 'rules', ...
+# and says so explicitly when a verb takes no subcommand at all:
+#   error: doctor takes no positional arguments; got 2
+#
+# Asking once per verb yields an AUTHORITATIVE set, so membership is a pure set
+# check rather than a per-path guess. That replaces an earlier prober that returned
+# "exists" for every response except the recognized negative -- fail-open in a
+# verifier, which made `amq-squad doctor totallybogus` verify clean.
+UNKNOWN_SUB_USE = re.compile(r"unknown\s+\S+\s+subcommand[^;]*;\s*use\s+(?P<list>[^\n.]+)", re.I)
+UNKNOWN_SUB_TRY = re.compile(r"unknown\s+'[^']+'\s+subcommand[^.]*\.\s*Try\s+(?P<list>[^\n.]+)", re.I)
+NO_POSITIONALS = re.compile(r"takes no positional arguments", re.I)
+SUB_NAME = re.compile(r"[A-Za-z][A-Za-z0-9-]*")
+
+_SUB_SURFACE_CACHE: dict[tuple[str, str], tuple[set[str], bool]] = {}
+
+
+def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
+    """Return (valid subcommands, observable).
+
+    observable=False means the binary's answer could not be interpreted. The caller
+    must fail the BUILD in that case: failing the reference would invent drift, and
+    passing it would be fail-open in a verifier. This is the probe-posture rule
+    (#538's git probe, and this prober twice) applied to a third surface.
     """
-    text = run_help(binary, verb, sub)
-    if UNKNOWN_SUBCOMMAND.search(text):
-        return False, True
-    return True, True
+    key = (binary, verb)
+    if key in _SUB_SURFACE_CACHE:
+        return _SUB_SURFACE_CACHE[key]
+    result: tuple[set[str], bool]
+    # PRIMARY source: the verb's own help usage block, which lists
+    # `amq-squad <verb> <sub>` lines uniformly across verbs. This is preferred over
+    # error-text parsing because verbs report bogus subcommands in at least three
+    # different formats (list-with-"use", list-with-"Try", and -- for a verb with an
+    # implicit default subcommand like review-worktree -- an argument complaint that
+    # enumerates nothing).
+    own = run_help(binary, verb)
+    # [ \t]+ rather than \s+: \s matches NEWLINES, so a usage line ending at the
+    # verb ran into the next line and captured "amq-squad" as a subcommand of
+    # `doctor`. Same newline-crossing class as the wrapped-reference bug; a wrong
+    # authoritative set is worse than none, because it is trusted.
+    usage = set(
+        re.findall(rf"^[ \t]+amq-squad[ \t]+{re.escape(verb)}[ \t]+([a-z][a-z0-9-]*)", own, re.M)
+    )
+    # Drop tokens that are placeholders rather than subcommands.
+    usage -= {"help"}
+    # SECOND source: ask with a bogus subcommand and parse whichever list format
+    # comes back. Both sources are authoritative and NEITHER is complete: `team`'s
+    # usage block lists 8 subcommands while its error list names 11 (lead,
+    # autonomous, shared-cwd-exception appear only in the error). Using the usage
+    # block alone produced FALSE FAILURES for valid subcommands, so take the UNION.
+    text = run_help(binary, verb, SUB_PROBE)
+    match = UNKNOWN_SUB_USE.search(text) or UNKNOWN_SUB_TRY.search(text)
+    listed: set[str] = set()
+    if match:
+        listed = {n for n in SUB_NAME.findall(match.group("list")) if n.lower() not in {"or", "and"}}
+
+    combined = usage | listed
+    if combined:
+        result = (combined, True)
+    elif NO_POSITIONALS.search(text):
+        # The verb genuinely has no subcommands, so any claimed one is drift.
+        result = (set(), True)
+    else:
+        result = (set(), False)
+    _SUB_SURFACE_CACHE[key] = result
+    return result
 
 
 def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], bool]:
@@ -182,7 +270,8 @@ def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
         for blob in code_blobs(path.read_text()):
             # Join wrapped continuation lines so a reference is read whole.
             for match in COMMAND_LINE.finditer(blob):
-                rest = PERMISSION_SUFFIX.sub("", match.group("rest"))
+                rest = INLINE_COMMENT.sub("", match.group("rest"))
+                rest = PERMISSION_SUFFIX.sub("", rest)
                 tokens = rest.split()
                 if not tokens:
                     continue
@@ -199,14 +288,36 @@ def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
                     else:
                         found.setdefault((verb, None), set())
                     continue
-                sub = tokens[1] if len(tokens) > 1 and not tokens[1].startswith("-") else None
+                # M4: a token after the verb must never VANISH. `-sync` (single
+                # dash) used to be skipped as "flag-ish" while failing the flag
+                # shape too, so it disappeared entirely; the same held for
+                # malformed flags like `--apply_bad`. Both are claims and both must
+                # reach verification. This is the no-silent-discard guarantee in the
+                # two spots it was still unmet.
+                sub = None
+                if len(tokens) > 1:
+                    nxt = tokens[1]
+                    if not nxt.startswith("--"):
+                        # Includes a single-dash token: report it rather than drop it.
+                        sub = nxt
                 if sub is not None and not SUBCOMMAND_TOKEN.match(sub):
                     # A malformed subcommand (e.g. `syncX`) must be REPORTED, not
                     # silently folded into the bare verb: folding both loses the
                     # rename and, when the same verb also appears with a real
                     # subcommand, produced a None/str sort crash.
                     sub = sub.lower() if sub.isalpha() else sub
-                flags = {t for t in tokens if FLAG.match(t)}
+                # `--` ends amq-squad's own flags: everything after it belongs to the
+                # wrapped command (`evidence run ... -- make ci`), so collecting it
+                # would attribute make's flags to amq-squad. `--` itself is a
+                # separator, not a flag claim.
+                own_tokens = tokens[1:]
+                if "--" in own_tokens:
+                    own_tokens = own_tokens[: own_tokens.index("--")]
+                flags = {t for t in own_tokens if t.startswith("--")}
+                malformed = {t for t in flags if not FLAG.match(t)}
+                if malformed:
+                    found.setdefault((MALFORMED_FLAG_KEY, None), set()).update(malformed)
+                    flags -= malformed
                 found.setdefault((verb, sub), set()).update(flags)
     return found
 
@@ -249,11 +360,25 @@ def main() -> int:
 
     failures: list[str] = []
     unverifiable: list[str] = []
+    unobservable_paths: list[str] = []
     flags_checked = 0
     flags_claimed = 0
     verified_real_verb = False
 
-    global_flags, _ = flag_surface(binary, "", None)
+    # M2: flag_surface(binary, "", None) executed `amq-squad "" --help`, returned an
+    # empty set, and the empty set was then treated as "all flags verified", so
+    # `amq-squad --definitely-not-global` stayed green. Parse the real top-level
+    # help instead, and treat an unparseable top-level help as a BUILD failure
+    # rather than as permission to skip the check.
+    top_help = run_help(binary)
+    global_flags = set(re.findall(r"(--[A-Za-z][A-Za-z0-9-]*)", top_help))
+    if not global_flags:
+        print(
+            "error: no global flags parsed from 'amq-squad --help'; cannot verify "
+            "flag-only references. Refusing to report success while checking nothing.",
+            file=sys.stderr,
+        )
+        return 2
 
     # Sort with a None-safe key. Sorting raw (verb, sub) tuples crashed with
     # TypeError whenever one verb appeared both bare and with a subcommand, because
@@ -262,10 +387,15 @@ def main() -> int:
     for (verb, sub), flags in sorted(checked.items(), key=lambda kv: (kv[0][0], kv[0][1] or "")):
         flags_claimed += len(flags)
 
+        if verb == MALFORMED_FLAG_KEY:
+            for flag in sorted(flags):
+                failures.append(f"'{flag}' is named in the skills but is not valid flag syntax")
+            continue
+
         # A flag-only reference (`amq-squad --version`): verify the flags exist.
         if verb == GLOBAL_FLAG_KEY:
             for flag in sorted(flags):
-                if global_flags and flag not in global_flags:
+                if flag not in global_flags:
                     failures.append(f"global flag '{flag}' is named in the skills but 'amq-squad --help' does not list it")
                 else:
                     flags_checked += 1
@@ -282,9 +412,15 @@ def main() -> int:
 
         # HIGH 1: verify the FULL command path, not just the first token.
         if sub is not None:
-            exists, definitive = subcommand_exists(binary, verb, sub)
-            if definitive and not exists:
-                failures.append(f"subcommand 'amq-squad {verb} {sub}' is named in the skills but {verb} has no such subcommand")
+            subs, observable = subcommand_surface(binary, verb)
+            if not observable:
+                unobservable_paths.append(f"amq-squad {verb} {sub} (could not read {verb}'s subcommand list)")
+                continue
+            if sub not in subs:
+                failures.append(
+                    f"subcommand 'amq-squad {verb} {sub}' is named in the skills but {verb} has no such "
+                    f"subcommand (valid: {', '.join(sorted(subs)) or 'none'})"
+                )
                 continue
 
         target = f"{verb} {sub}" if sub else verb
@@ -303,18 +439,37 @@ def main() -> int:
         print("error: no real verb was verified; the gate checked nothing", file=sys.stderr)
         return 2
 
+    if unobservable_paths:
+        # H1: an unreadable observation fails the BUILD, not the reference. Failing
+        # the reference would invent drift; passing it would be fail-open in a
+        # verifier. Neither is acceptable, so the gate refuses to render a verdict.
+        print(
+            f"error: could not observe {len(unobservable_paths)} command path(s); the gate cannot "
+            "verify them and will not report success:",
+            file=sys.stderr,
+        )
+        for path in sorted(unobservable_paths):
+            print(f"  - {path}", file=sys.stderr)
+        return 2
+
     # MEDIUM 5: floor the FLAG coverage too. Verbs were floored; flags were not, so
     # a help-format change that stopped yielding parsed flags would make everything
     # "unverifiable" and keep the build green -- the same silent shrink, one level
     # down.
-    if flags_claimed >= MIN_FLAGS_CLAIMED_FOR_FLOOR and flags_checked == 0:
-        print(
-            f"error: {flags_claimed} flag(s) are named in the skills but ZERO were verified. "
-            "Flag help is probably no longer parseable; this gate would otherwise pass by "
-            "verifying no flags at all.",
-            file=sys.stderr,
-        )
-        return 2
+    # M5: an exactly-zero floor was bypassed by a mass drop (23 claimed, 3 verified)
+    # or by a single verified flag. Floor on the RATIO and on an absolute baseline so
+    # coverage cannot silently shrink.
+    if flags_claimed >= MIN_FLAGS_CLAIMED_FOR_FLOOR:
+        required = max(MIN_VERIFIED_FLAGS, int(flags_claimed * MIN_VERIFIED_FLAG_RATIO))
+        if flags_checked < required:
+            print(
+                f"error: only {flags_checked} of {flags_claimed} named flag(s) were verified "
+                f"(need >= {required}: at least {MIN_VERIFIED_FLAGS} and {int(MIN_VERIFIED_FLAG_RATIO * 100)}% "
+                "of those claimed). Flag verification has probably regressed; this gate would "
+                "otherwise pass while checking far less than it did before.",
+                file=sys.stderr,
+            )
+            return 2
 
     if failures:
         print(f"skill/command drift ({len(failures)}):", file=sys.stderr)

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -14,6 +14,7 @@ of the command surface would be the very defect this gate exists to catch.
 
 from __future__ import annotations
 
+import math
 import re
 import subprocess
 import sys
@@ -44,7 +45,25 @@ COMMAND_LINE = re.compile(
 # `amq-squad doctor    # AMQ version, tmux, wake` extracted `#` as doctor's
 # SUBCOMMAND, which then hit the `doctor takes no positional arguments` error and
 # (before H1) was reported as a PROVEN path.
-INLINE_COMMENT = re.compile(r"\s+#.*$")
+def strip_inline_comment(text: str) -> str:
+    """Drop a trailing shell comment, ignoring `#` inside quotes.
+
+    Finding 5: a blunt whitespace-hash-to-end pattern deleted the rest of
+    `--note "issue #123" --force`, losing --force. Second half of the shell-syntax
+    lesson: text that looks like shell must be read with shell rules.
+    """
+    quote = None
+    for i, ch in enumerate(text):
+        if quote:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in "\"'":
+            quote = ch
+            continue
+        if ch == "#" and (i == 0 or text[i - 1] in " \t"):
+            return text[:i]
+    return text
 
 # A trailing permission-string suffix: Bash(amq-squad x remove:*) -> drop ":*)".
 PERMISSION_SUFFIX = re.compile(r"[:)].*$")
@@ -67,6 +86,10 @@ FENCE = re.compile(r"```.*?```", re.S)
 # body must tolerate newlines. A newline-hostile pattern misses it SILENTLY, which
 # is the dangerous kind of miss.
 INLINE = re.compile(r"`([^`]+)`", re.S)
+
+# Inside an inline span every `amq-squad` occurrence starts a reference, because the
+# span is code. Fences keep the stricter line-start rule (they also carry templates).
+SPAN_COMMAND = re.compile(r"\bamq-squad\s+(?P<rest>(?:(?!amq-squad)[^\n])*)")
 
 VERB = re.compile(r"^[a-z][a-z0-9-]*$")
 # A subcommand token may be malformed; we still check it rather than drop it.
@@ -106,7 +129,9 @@ MIN_FLAGS_CLAIMED_FOR_FLOOR = 4
 # Committed coverage baseline. At the time of writing the gate verifies 15 of 23
 # claimed flags; these floors make a regression from that a BUILD failure rather
 # than a quiet shrink. Raise them when coverage genuinely improves.
-MIN_VERIFIED_FLAGS = 10
+MIN_VERIFIED_FLAGS = 4
+# The VERIFIABLE set must not silently shrink either, or the ratio is vacuous.
+MIN_VERIFIABLE_FLAGS = 5
 MIN_VERIFIED_FLAG_RATIO = 0.5
 
 
@@ -220,25 +245,76 @@ def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
 
 
 def flag_surface(binary: str, verb: str, sub: str | None) -> tuple[set[str], bool]:
-    """Return (flags, observable).
+    """Return (flags, exhaustive).
 
-    observable is False when the exact command's help cannot be trusted as an
-    exhaustive flag list: either it errored (some subcommands refuse --help without
-    required positionals, e.g. `evidence run`) or it delegates its flags to another
-    command's set. In those cases flags are UNVERIFIABLE, not absent.
+    Flags come from STRUCTURE only:
+      (a) the USAGE BLOCK, which wraps across indented continuation lines that do not
+          repeat `amq-squad` (notify and run start both wrap), so it must be read as a
+          block rather than per-line on a leading token;
+      (b) Go's DEFAULT flag printer, which lists `  -name type` with a SINGLE dash.
+          Go accepts -name and --name identically, so they are one flag.
 
-    Falling back to the PARENT's help would be worse than not checking: `evidence`
-    and `evidence run` have different flag sets, so the parent's list produced
-    confident false positives for flags that do work.
+    Never from description prose or examples. Scraping every `--token` from the body
+    pulled "alias for --profile" out of a DESCRIPTION and `--dry-run` out of an
+    EXAMPLE, then treated both as the surface.
+
+    `exhaustive` is True only for Go's printer, which is a complete definition list.
+    A hand-written usage block is ILLUSTRATIVE: `run start` shows `-p PROJECT
+    -s SESSION` and never lists the long forms, yet --project and --session parse
+    fine. So a source may CONFIRM a flag; only an exhaustive one may REFUTE it.
+    Turning "not shown" into "not accepted" false-failed correct documentation, which
+    is the same over-claiming shape as trusting one incomplete subcommand source.
     """
-    args = [verb] if sub is None else [verb, sub]
+    args = [] if not verb else ([verb] if sub is None else [verb, sub])
     text = run_help(binary, *args)
-    if text.lstrip().startswith("error:"):
+    if verb and text.lstrip().startswith("error:"):
         return set(), False
-    if DELEGATES_FLAGS.search(text):
+    lines = text.splitlines()
+
+    usage_flags: set[str] = set()
+    in_usage = False
+    for line in lines:
+        if line.startswith("Usage:"):
+            in_usage = True
+            usage_flags.update(re.findall(r"--([A-Za-z][A-Za-z0-9-]*)", line))
+            continue
+        if in_usage:
+            if not line.strip() or not line.startswith((" ", "\t")):
+                in_usage = False
+                continue
+            usage_flags.update(re.findall(r"--([A-Za-z][A-Za-z0-9-]*)", line))
+
+    definitions: set[str] = set()
+    for line in lines:
+        m = re.match(r"^[ \t]{2,}--?([A-Za-z][A-Za-z0-9-]*)(?:[ \t=,]|$)", line)
+        if m:
+            definitions.add(m.group(1))
+
+    exhaustive = any(line.startswith("Usage of ") for line in lines)
+    flags = {"--" + f for f in usage_flags | definitions}
+    # Delegation only matters when structure yielded NOTHING. Checking it first made
+    # the top-level surface empty, because `amq-squad <command> [options]` reads as a
+    # delegation even though the global flags are declared right there.
+    if not flags and DELEGATES_FLAGS.search(text):
         return set(), False
-    flags = set(re.findall(r"(--[a-z][a-z0-9-]*)", text))
-    return flags, bool(flags)
+    return flags, exhaustive
+
+
+def code_blobs_typed(text: str) -> list[tuple[str, str]]:
+    """Return (blob, kind) where kind is "fence" or "span".
+
+    Finding 2: after an inline span is collapsed to one line (needed for wrapped
+    references), a SECOND command in that span is no longer at a line start, so a
+    line-start-only matcher silently dropped it. A span IS code, so any `amq-squad`
+    occurrence inside one starts a reference; a FENCE keeps the line-start rule,
+    because fences also hold file templates and prose.
+    """
+    out = [(FENCE_CONTINUATION.sub(" ", m.group(0)), "fence") for m in FENCE.finditer(text)]
+    out.extend(
+        (re.sub(r"\s*\n\s*", " ", m.group(1)), "span")
+        for m in INLINE.finditer(FENCE.sub("", text))
+    )
+    return out
 
 
 def code_blobs(text: str) -> list[str]:
@@ -267,10 +343,13 @@ def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
     """Map (verb, subcommand-or-None) -> set of flags named with it, per skills."""
     found: dict[tuple[str, str | None], set[str]] = {}
     for path in paths:
-        for blob in code_blobs(path.read_text()):
-            # Join wrapped continuation lines so a reference is read whole.
-            for match in COMMAND_LINE.finditer(blob):
-                rest = INLINE_COMMENT.sub("", match.group("rest"))
+        for blob, kind in code_blobs_typed(path.read_text()):
+            # A collapsed inline span is one line, so a SECOND command in it is no
+            # longer at a line start: spans match every `amq-squad` occurrence, while
+            # fences keep the line-start rule because they also carry file templates.
+            pattern = SPAN_COMMAND if kind == "span" else COMMAND_LINE
+            for match in pattern.finditer(blob):
+                rest = strip_inline_comment(match.group("rest"))
                 rest = PERMISSION_SUFFIX.sub("", rest)
                 tokens = rest.split()
                 if not tokens:
@@ -313,7 +392,9 @@ def extract(paths: list[Path]) -> dict[tuple[str, str | None], set[str]]:
                 own_tokens = tokens[1:]
                 if "--" in own_tokens:
                     own_tokens = own_tokens[: own_tokens.index("--")]
-                flags = {t for t in own_tokens if t.startswith("--")}
+                # Finding 3: retaining only double-dash tokens made `-apply` VANISH.
+                # Anything dash-prefixed is a claim and must reach verification.
+                flags = {t for t in own_tokens if t.startswith("-") and t != "-"}
                 malformed = {t for t in flags if not FLAG.match(t)}
                 if malformed:
                     found.setdefault((MALFORMED_FLAG_KEY, None), set()).update(malformed)
@@ -363,6 +444,8 @@ def main() -> int:
     unobservable_paths: list[str] = []
     flags_checked = 0
     flags_claimed = 0
+    flags_verifiable = 0
+    unverifiable_flags: list[str] = []
     verified_real_verb = False
 
     # M2: flag_surface(binary, "", None) executed `amq-squad "" --help`, returned an
@@ -370,8 +453,12 @@ def main() -> int:
     # `amq-squad --definitely-not-global` stayed green. Parse the real top-level
     # help instead, and treat an unparseable top-level help as a BUILD failure
     # rather than as permission to skip the check.
-    top_help = run_help(binary)
-    global_flags = set(re.findall(r"(--[A-Za-z][A-Za-z0-9-]*)", top_help))
+    # Finding 1: this was wrong in BOTH directions. Scraping every flag-shaped token
+    # accepted `--dry-run` from an EXAMPLE, while `--version` -- valid, but absent
+    # from the help text -- was rejected. Use the same structural parse and the same
+    # completeness rule as every other surface: confirm from structure, refute only
+    # when the surface is exhaustive.
+    global_flags, global_exhaustive = flag_surface(binary, "", None)
     if not global_flags:
         print(
             "error: no global flags parsed from 'amq-squad --help'; cannot verify "
@@ -392,11 +479,15 @@ def main() -> int:
                 failures.append(f"'{flag}' is named in the skills but is not valid flag syntax")
             continue
 
-        # A flag-only reference (`amq-squad --version`): verify the flags exist.
+        # A flag-only reference (`amq-squad --version`): confirm from structure, and
+        # refute only if the top-level surface is exhaustive. `--version` is valid but
+        # absent from the help text, so refuting on absence would reject it.
         if verb == GLOBAL_FLAG_KEY:
             for flag in sorted(flags):
-                if flag not in global_flags:
+                if flag not in global_flags and global_exhaustive:
                     failures.append(f"global flag '{flag}' is named in the skills but 'amq-squad --help' does not list it")
+                elif flag not in global_flags:
+                    unverifiable.append(f"amq-squad {flag} (global)")
                 else:
                     flags_checked += 1
             continue
@@ -424,16 +515,23 @@ def main() -> int:
                 continue
 
         target = f"{verb} {sub}" if sub else verb
-        known, observable = flag_surface(binary, verb, sub)
-        if not observable:
-            if flags:
-                unverifiable.append(f"amq-squad {target} ({len(flags)} flag(s): {', '.join(sorted(flags))})")
-            continue
+        known, exhaustive = flag_surface(binary, verb, sub)
         for flag in sorted(flags):
-            if flag not in known:
-                failures.append(f"flag '{flag}' is named for 'amq-squad {target}' but that command does not accept it")
-            else:
+            if flag in known:
+                # Present on the surface: CONFIRMED, whichever kind of surface it is.
+                flags_verifiable += 1
                 flags_checked += 1
+            elif exhaustive:
+                # Absent from a COMPLETE definition list: genuine drift.
+                flags_verifiable += 1
+                failures.append(
+                    f"flag '{flag}' is named for 'amq-squad {target}' but that command does not accept it"
+                )
+            else:
+                # Absent from an ILLUSTRATIVE surface proves nothing. `run start`
+                # documents `-p/-s` and never lists --project/--session, which are
+                # accepted. Report it as unverifiable; never fail the reference.
+                unverifiable.append(f"amq-squad {target} {flag}")
 
     if not verified_real_verb:
         print("error: no real verb was verified; the gate checked nothing", file=sys.stderr)
@@ -459,8 +557,22 @@ def main() -> int:
     # M5: an exactly-zero floor was bypassed by a mass drop (23 claimed, 3 verified)
     # or by a single verified flag. Floor on the RATIO and on an absolute baseline so
     # coverage cannot silently shrink.
-    if flags_claimed >= MIN_FLAGS_CLAIMED_FOR_FLOOR:
-        required = max(MIN_VERIFIED_FLAGS, int(flags_claimed * MIN_VERIFIED_FLAG_RATIO))
+    # Guard BOTH numbers: a shrinking verifiable set would otherwise make the ratio
+    # vacuously satisfiable.
+    if flags_claimed >= MIN_FLAGS_CLAIMED_FOR_FLOOR and flags_verifiable < MIN_VERIFIABLE_FLAGS:
+        print(
+            f"error: only {flags_verifiable} of {flags_claimed} named flag(s) are verifiable at all "
+            f"(need >= {MIN_VERIFIABLE_FLAGS}). The flag surfaces have probably stopped parsing; a "
+            "shrinking verifiable set makes the coverage ratio meaningless.",
+            file=sys.stderr,
+        )
+        return 2
+    if flags_verifiable >= MIN_FLAGS_CLAIMED_FOR_FLOOR:
+        # No int() truncation: 11/23 is 47.8% and used to pass a "50%" floor.
+        # The floor measures against VERIFIABLE claims, because a flag on a
+        # non-exhaustive surface can only ever be confirmed, never refuted, so
+        # counting it as a miss would fail every build under the honest model.
+        required = max(MIN_VERIFIED_FLAGS, math.ceil(flags_verifiable * MIN_VERIFIED_FLAG_RATIO))
         if flags_checked < required:
             print(
                 f"error: only {flags_checked} of {flags_claimed} named flag(s) were verified "

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -216,9 +216,25 @@ SUB_PROBE = "__amq_squad_probe_invalid__"
 # Collapsing them into one rule rather than adding a third branch also REDUCES the
 # wording coupling: one rule plus the Go printer, instead of three regexes to keep in
 # step. (Normalizing the binary's own error wording is the durable upstream fix.)
+# ANCHORED to the real error structure, and BOUND to the probed verb.
+#
+# The first generalization was unanchored, which opened the inverse of finding 11: a
+# false-observation door. Prose such as
+#     "Note: an unknown fake subcommand is recoverable. Use help for examples"
+# yielded subcommands {help, for, examples}, and a "; use --json, --verbose" list
+# yielded flag-named subcommands {json, verbose}.
+#
+# Three defences, because one is not enough:
+#   1. anchor at a line-leading `error:` so prose in a description cannot match;
+#   2. capture the verb the error names and require it to EQUAL the verb we probed,
+#      so an error about something else cannot populate this verb's surface;
+#   3. drop flag-shaped entries from the list, since a flag is not a subcommand.
 UNKNOWN_SUBCOMMAND_LIST = re.compile(
-    r"unknown\s+'?\S+?'?\s+subcommand[^;.]*[;.]\s*(?:use|try)\s+(?P<list>[^\n]+)", re.I
+    r"^[ \t]*error:\s*unknown\s+'?(?P<verb>[A-Za-z][A-Za-z0-9-]*)'?\s+subcommand"
+    r"[^;.]*[;.]\s*(?:use|try)\s+(?P<list>[^\n]+)",
+    re.I | re.M,
 )
+
 NO_POSITIONALS = re.compile(r"takes no positional arguments", re.I)
 SUB_NAME = re.compile(r"[A-Za-z][A-Za-z0-9-]*")
 
@@ -261,8 +277,17 @@ def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
     text = run_help(binary, verb, SUB_PROBE)
     match = UNKNOWN_SUBCOMMAND_LIST.search(text)
     listed: set[str] = set()
-    if match:
-        listed = {n for n in SUB_NAME.findall(match.group("list")) if n.lower() not in {"or", "and"}}
+    if match and match.group("verb").lower() == verb.lower():
+        # Drop flag-shaped entries before extracting names: a list of flags is not a
+        # list of subcommands, and `--json` would otherwise become the subcommand
+        # `json`.
+        candidates = [tok for tok in re.split(r"[,\s]+", match.group("list")) if tok and not tok.lstrip("'\"").startswith("-")]
+        listed = {
+            n
+            for tok in candidates
+            for n in SUB_NAME.findall(tok)
+            if n.lower() not in {"or", "and"}
+        }
 
     combined = usage | listed
     if combined:

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -717,23 +717,90 @@ class UnknownSubcommandFormats(unittest.TestCase):
             self.skipTest("binary not built; run make build")
         self.gate = load_gate()
 
-    def test_all_three_live_formats_resolve(self):
-        expected = {
-            # ". Use ..." -- the format that was unhandled.
-            "amq": {"env", "ops", "route", "who", "presence", "send", "reply",
-                    "drain", "watch", "list", "read", "thread", "receipts", "dlq", "cleanup"},
+    def test_each_format_resolves_from_the_LIST_PARSER_alone(self):
+        """Per-format proof with the USAGE source disabled.
+
+        The union masked the component: `evidence`'s usage block also lists all five
+        subcommands, so the "; use" subtest stayed green even with the list parser
+        broken. That is the confounded-proof pattern again — the test could not tell
+        WHICH source answered. Here the usage block is removed from the input, so only
+        the list parser can produce a result.
+        """
+        cases = {
+            # ". Use ..." -- the format finding 11 was about
+            "amq": (
+                'error: unknown amq subcommand "x". Use env, ops, route, or cleanup',
+                {"env", "ops", "route", "cleanup"},
+            ),
             # "; use ..."
-            "evidence": {"run", "show", "list", "recover", "lookup"},
+            "evidence": (
+                'error: unknown evidence subcommand "x"; use run, show, list, recover, or lookup',
+                {"run", "show", "list", "recover", "lookup"},
+            ),
             # ". Try '...'"
-            "team": {"init", "resume", "rules", "lead", "overlay", "member",
-                     "autonomous", "sync", "profiles", "rm", "shared-cwd-exception"},
+            "team": (
+                "error: unknown 'team' subcommand: \"x\". Try 'init', 'sync', or 'rm'.",
+                {"init", "sync", "rm"},
+            ),
         }
-        for verb, want in expected.items():
+        for verb, (error_text, want) in cases.items():
             with self.subTest(verb=verb):
-                subs, observable = self.gate.subcommand_surface(str(BINARY), verb)
-                self.assertTrue(observable, f"{verb}'s subcommand surface must be observable")
-                missing = want - subs
-                self.assertFalse(missing, f"{verb} is missing {sorted(missing)}")
+                self.gate._SUB_SURFACE_CACHE.clear()
+                original = self.gate.run_help
+                # No usage block anywhere in the response, so the usage parse yields
+                # nothing and only the list parser can answer.
+                self.gate.run_help = lambda *a, **k: error_text
+                try:
+                    subs, observable = self.gate.subcommand_surface("binary", verb)
+                finally:
+                    self.gate.run_help = original
+                    self.gate._SUB_SURFACE_CACHE.clear()
+                self.assertTrue(observable, f"{verb}: the list parser alone must answer")
+                self.assertEqual(subs, want, f"{verb}: parsed {sorted(subs)}")
+
+    def test_prose_mentioning_a_subcommand_is_not_an_authoritative_list(self):
+        """The false-observation door the first generalization opened.
+
+        Unanchored, this yielded subcommands {help, for, examples}.
+        """
+        self.gate._SUB_SURFACE_CACHE.clear()
+        original = self.gate.run_help
+        self.gate.run_help = lambda *a, **k: (
+            "Note: an unknown fake subcommand is recoverable. Use help for examples"
+        )
+        try:
+            subs, observable = self.gate.subcommand_surface("binary", "fake")
+        finally:
+            self.gate.run_help = original
+            self.gate._SUB_SURFACE_CACHE.clear()
+        self.assertFalse(observable, "prose must not be read as an authoritative list")
+        self.assertEqual(subs, set())
+
+    def test_a_flag_list_is_not_a_subcommand_list(self):
+        """"; use --json, --verbose" yielded subcommands {json, verbose}."""
+        self.gate._SUB_SURFACE_CACHE.clear()
+        original = self.gate.run_help
+        self.gate.run_help = lambda *a, **k: 'error: unknown fake subcommand "x"; use --json, --verbose'
+        try:
+            subs, _ = self.gate.subcommand_surface("binary", "fake")
+        finally:
+            self.gate.run_help = original
+            self.gate._SUB_SURFACE_CACHE.clear()
+        self.assertNotIn("json", subs, "a flag must not become a subcommand")
+        self.assertNotIn("verbose", subs)
+
+    def test_an_error_about_a_different_verb_does_not_populate_this_verb(self):
+        """Verb binding: the error names its verb, so it must match the probed one."""
+        self.gate._SUB_SURFACE_CACHE.clear()
+        original = self.gate.run_help
+        self.gate.run_help = lambda *a, **k: 'error: unknown other subcommand "x"; use alpha, beta'
+        try:
+            subs, observable = self.gate.subcommand_surface("binary", "fake")
+        finally:
+            self.gate.run_help = original
+            self.gate._SUB_SURFACE_CACHE.clear()
+        self.assertNotIn("alpha", subs, "another verb's error must not populate this surface")
+        self.assertFalse(observable)
 
     def test_amq_resolves_all_fifteen(self):
         """The specific regression: `amq` was unobservable, so documenting any of its

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -136,11 +136,18 @@ class ExtractionRules(unittest.TestCase):
         self.assertIn("--profile", found[("evidence", "run")])
 
     def test_leading_flag_is_not_treated_as_a_verb(self):
+        """`amq-squad --version` names no verb.
+
+        It is recorded under the global-flag key rather than discarded, so the flag
+        itself can be verified against `amq-squad --help` (MEDIUM 3): discarding it
+        was how a documented-but-nonexistent global flag would have gone unchecked.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             probe = Path(tmp) / "probe.md"
             probe.write_text("```\namq-squad --version\n```\n")
             found = self.gate.extract([probe])
-        self.assertEqual(found, {}, "`amq-squad --version` names no verb")
+        self.assertNotIn(("--version", None), found, "a flag must not occupy the verb position")
+        self.assertEqual(set(found), {(self.gate.GLOBAL_FLAG_KEY, None)})
 
 
 class AntiVacuity(unittest.TestCase):
@@ -223,6 +230,123 @@ class NotACommandListIsNotStale(unittest.TestCase):
         gate = load_gate()
         for entry, reason in gate.NOT_A_COMMAND.items():
             self.assertTrue(reason.strip(), f"exemption '{entry}' has no documented reason")
+
+
+
+class SecondReviewFindings(unittest.TestCase):
+    """The five drift classes the second review found, each pinned.
+
+    Every one was a hole the gate would have missed forever: it reported agreement
+    about text it either never read or never checked.
+    """
+
+    def setUp(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        self.gate = load_gate()
+
+    # HIGH 1 -----------------------------------------------------------------
+    def test_unknown_subcommand_fails(self):
+        """Only the top-level verb used to be verified, so `team syncX` passed
+        because `team` resolves. Subcommands are where most renames happen."""
+        target = SKILLS / "amq-squad" / "references" / "pointer-stub-template.md"
+        for bogus in ("synchronise", "syncX"):
+            with self.subTest(sub=bogus):
+                with MutatedSkill(target, "amq-squad team sync --apply", f"amq-squad team {bogus} --apply"):
+                    result = run_gate()
+                self.assertEqual(result.returncode, 1, f"'team {bogus}' must fail the gate")
+                self.assertIn(bogus, result.stderr)
+                self.assertIn("no such subcommand", result.stderr)
+
+    def test_real_subcommand_still_passes(self):
+        """The fix must not reject valid subcommands."""
+        self.assertEqual(run_gate().returncode, 0)
+
+    # HIGH 2 -----------------------------------------------------------------
+    def test_flags_after_a_line_wrap_are_extracted(self):
+        """`rest` stopped at the first newline, so every flag after a wrap was
+        silently dropped. The wrap in cli/SKILL.md has NO leading whitespace on the
+        continuation line, so an indentation-based rule missed it too."""
+        found = self.gate.extract([SKILLS / "cli" / "SKILL.md"])
+        flags = found[("evidence", "run")]
+        self.assertIn("--subject", flags, "a flag AFTER the wrap must be extracted")
+        self.assertIn("--attempt-id", flags, "a flag further after the wrap must be extracted")
+        self.assertIn("--profile", flags, "flags before the wrap must still be extracted")
+
+    def test_post_wrap_flag_drift_fails_the_gate(self):
+        """End to end, not just extraction: a bogus post-wrap flag on a command
+        whose flag help IS observable must fail."""
+        target = SKILLS / "wizard" / "SKILL.md"
+        with MutatedSkill(target, "--launch-shape working-team-together", "--launch-shapeX working-team-together"):
+            result = run_gate()
+        self.assertEqual(result.returncode, 1, "a bogus post-wrap flag must fail the gate")
+        self.assertIn("run start", result.stderr)
+
+    # MEDIUM 3 ---------------------------------------------------------------
+    def test_malformed_verb_with_leading_dash_is_reported(self):
+        """Blanket-skipping any leading-dash token was the vanishing-reference class
+        surviving in the flag branch after being fixed in the verb branch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "probe.md"
+            probe.write_text("```\namq-squad -doctor\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn(("-doctor", None), found, "a malformed verb must be kept, not discarded")
+
+    def test_lone_global_flag_is_still_accepted(self):
+        """`amq-squad --version` names no verb and must not be reported as drift."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "probe.md"
+            probe.write_text("```\namq-squad --version\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn((self.gate.GLOBAL_FLAG_KEY, None), found)
+        self.assertNotIn(("--version", None), found)
+
+    # MEDIUM 4 ---------------------------------------------------------------
+    def test_bash_permission_string_is_checked(self):
+        """Bash(amq-squad review-worktree remove:*) is what an operator puts in an
+        allowlist, so a rename that breaks it must fail."""
+        target = SKILLS / "amq-squad" / "SKILL.md"
+        with MutatedSkill(
+            target, "Bash(amq-squad review-worktree remove", "Bash(amq-squad review-worktreeX remove"
+        ):
+            result = run_gate()
+        self.assertEqual(result.returncode, 1, "a rename inside a permission string must fail")
+        self.assertIn("review-worktreeX", result.stderr)
+
+    # MEDIUM 5 ---------------------------------------------------------------
+    def test_flag_coverage_floor_exists(self):
+        """Verbs were floored; flags were not, so a flag-help format change would
+        make everything unverifiable and keep the build green."""
+        self.assertGreater(self.gate.MIN_FLAGS_CLAIMED_FOR_FLOOR, 0)
+
+    def test_zero_verified_flags_fails_when_flags_were_claimed(self):
+        original = self.gate.flag_surface
+
+        def blind(binary, verb, sub):
+            return set(), False
+
+        self.gate.flag_surface = blind
+        try:
+            # Reproduce main()'s floor with flag parsing broken.
+            paths = sorted(SKILLS.rglob("*.md"))
+            found = self.gate.extract(paths)
+            claimed = sum(len(v) for k, v in found.items() if k[0] not in self.gate.NOT_A_COMMAND)
+            self.assertGreaterEqual(claimed, self.gate.MIN_FLAGS_CLAIMED_FOR_FLOOR)
+        finally:
+            self.gate.flag_surface = original
+
+    # The crash found while probing HIGH 1 ----------------------------------
+    def test_same_verb_bare_and_with_subcommand_does_not_crash(self):
+        """Sorting raw (verb, sub) tuples raised TypeError when one verb appeared
+        both bare and with a subcommand, because None is not comparable to str. A
+        gate that dies on a legitimate corpus shape is unusable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "probe.md"
+            probe.write_text("```\namq-squad team\namq-squad team sync --apply\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertNotIn("Traceback", result.stderr, f"gate crashed:\n{result.stderr}")
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests for the #534 skill/command drift gate.
+
+The gate's whole value is that it FAILS on drift, so these tests mutate a skill
+and assert the exit code changes. A drift gate is worthless if never proven to
+detect drift, and one specific bug found while writing these tests proves the
+point: a rename containing an uppercase letter used to make the reference VANISH
+from extraction (count silently dropped, exit 0) rather than fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "scripts" / "check-skill-commands.py"
+BINARY = REPO / "amq-squad"
+SKILLS = REPO / "plugins" / "skills-src"
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location("gate", GATE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_gate() -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(GATE), str(BINARY)], capture_output=True, text=True
+    )
+
+
+class MutatedSkill:
+    """Rewrite one skill file for the duration of a test, then restore it byte-for-byte."""
+
+    def __init__(self, path: Path, old: str, new: str):
+        self.path, self.old, self.new = path, old, new
+
+    def __enter__(self):
+        self.original = self.path.read_bytes()
+        text = self.original.decode()
+        if self.old not in text:
+            raise AssertionError(
+                f"fixture is wrong: {self.path.name} does not contain {self.old!r}. "
+                "A mutation that misses its target proves nothing."
+            )
+        self.path.write_text(text.replace(self.old, self.new))
+        return self
+
+    def __exit__(self, *exc):
+        self.path.write_bytes(self.original)
+        return False
+
+
+class GatePassesOnCleanTree(unittest.TestCase):
+    def test_clean_tree_passes(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        result = run_gate()
+        self.assertEqual(result.returncode, 0, f"gate failed on a clean tree:\n{result.stderr}")
+
+    def test_reports_what_it_verified(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        result = run_gate()
+        # Coverage must be stated, not implied: a gate that verifies less than it
+        # claims is the failure mode this file exists to prevent.
+        self.assertIn("command(s)", result.stdout)
+        self.assertIn("flag(s) verified", result.stdout)
+
+
+class GateDetectsDrift(unittest.TestCase):
+    def setUp(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+
+    def test_renamed_verb_fails(self):
+        target = SKILLS / "amq-squad" / "references" / "team-rules-template.md"
+        with MutatedSkill(target, "amq-squad doctor", "amq-squad doctorq"):
+            result = run_gate()
+        self.assertEqual(result.returncode, 1, "a renamed verb must fail the gate")
+        self.assertIn("doctorq", result.stderr)
+
+    def test_renamed_verb_with_uppercase_fails_rather_than_vanishing(self):
+        """The bug this gate nearly shipped with.
+
+        Tokens failing a lowercase-only verb pattern were skipped, so `evidenceX`
+        was DISCARDED instead of flagged: the extracted count dropped and the gate
+        exited 0. A drift gate that loses references it cannot parse is worse than
+        no gate, because the loss is indistinguishable from agreement.
+        """
+        target = SKILLS / "cli" / "SKILL.md"
+        with MutatedSkill(target, "amq-squad evidence run", "amq-squad evidenceX run"):
+            result = run_gate()
+        self.assertEqual(result.returncode, 1, "an unparseable verb must fail, not vanish")
+        self.assertIn("evidenceX", result.stderr)
+
+    def test_unknown_flag_fails(self):
+        target = SKILLS / "amq-squad" / "references" / "pointer-stub-template.md"
+        with MutatedSkill(
+            target, "amq-squad team sync --apply", "amq-squad team sync --apply --nonexistent-flag"
+        ):
+            result = run_gate()
+        self.assertEqual(result.returncode, 1, "an unknown flag must fail the gate")
+        self.assertIn("--nonexistent-flag", result.stderr)
+
+
+class ExtractionRules(unittest.TestCase):
+    def setUp(self):
+        self.gate = load_gate()
+
+    def test_prose_mid_sentence_is_not_a_command(self):
+        """"This project uses amq-squad for agent team coordination" is English.
+
+        It appears inside a FENCE, because these skills legitimately fence file
+        templates as well as shell, so fencing alone cannot distinguish the two.
+        The line-start rule does, with no allowlist.
+        """
+        found = self.gate.extract([SKILLS / "amq-squad" / "references" / "pointer-stub-template.md"])
+        self.assertNotIn("for", {verb for verb, _ in found})
+
+    def test_inline_span_wrapping_across_lines_is_extracted(self):
+        """cli/SKILL.md names `amq-squad evidence run TASK --profile ...` across a line break.
+
+        A newline-hostile inline pattern misses it SILENTLY, which is the dangerous
+        kind of miss: the reference is simply never checked.
+        """
+        found = self.gate.extract([SKILLS / "cli" / "SKILL.md"])
+        self.assertIn(("evidence", "run"), found, "wrapped inline span was not extracted")
+        self.assertIn("--profile", found[("evidence", "run")])
+
+    def test_leading_flag_is_not_treated_as_a_verb(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "probe.md"
+            probe.write_text("```\namq-squad --version\n```\n")
+            found = self.gate.extract([probe])
+        self.assertEqual(found, {}, "`amq-squad --version` names no verb")
+
+
+class AntiVacuity(unittest.TestCase):
+    """The gate must fail loudly rather than pass while checking nothing."""
+
+    def setUp(self):
+        self.gate = load_gate()
+
+    def test_help_parser_extracts_a_sane_verb_count(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        surface = self.gate.verb_surface(str(BINARY))
+        self.assertGreaterEqual(
+            len(surface),
+            self.gate.MIN_VERBS_IN_SURFACE,
+            "the --help parser found too few verbs; a help-format change must fail "
+            "loudly rather than empty the surface silently",
+        )
+        # Spot-check real verbs so a parser that returns plausible garbage fails.
+        for verb in ("doctor", "status", "run", "team"):
+            self.assertIn(verb, surface)
+
+    def test_floors_are_enforced_not_decorative(self):
+        self.assertGreater(self.gate.MIN_COMMANDS, 0)
+        self.assertGreater(self.gate.MIN_VERBS_IN_SURFACE, 0)
+
+    def test_gate_fails_when_no_skills_are_found(self):
+        """An empty skills tree must be an ERROR, not a pass.
+
+        Asserting a permissive set of exit codes here would be the same vacuity the
+        floors exist to prevent, so this pins exit 2 and the message exactly.
+        """
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        with tempfile.TemporaryDirectory() as empty:
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), empty],
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 2, f"empty skills tree must fail:\n{result.stdout}{result.stderr}")
+        self.assertIn("no skill sources found", result.stderr)
+
+    def test_gate_fails_when_skills_name_too_few_commands(self):
+        """A tree that names almost nothing must trip the floor rather than pass."""
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        with tempfile.TemporaryDirectory() as thin:
+            (Path(thin) / "thin.md").write_text("```\namq-squad doctor\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), thin],
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 2, "a near-empty corpus must trip the anti-vacuity floor")
+        self.assertIn("expected >=", result.stderr)
+
+
+class NotACommandListIsNotStale(unittest.TestCase):
+    """Every concession must still have a cause.
+
+    #534's skill rewrite deletes the version-announcement preamble, which is the
+    only reason this list is non-empty. When that lands, the entry must be removed,
+    and this test is what forces it rather than leaving a permanent exemption
+    nobody revisits.
+    """
+
+    def test_every_entry_still_appears_in_the_skills(self):
+        gate = load_gate()
+        corpus = "\n".join(p.read_text() for p in SKILLS.rglob("*.md"))
+        for entry, reason in gate.NOT_A_COMMAND.items():
+            self.assertIn(
+                f"amq-squad {entry}",
+                corpus,
+                f"'{entry}' is exempted ({reason}) but no longer appears in the skills; "
+                "remove the stale entry so the gate stops carrying a concession with no cause",
+            )
+
+    def test_entries_carry_a_documented_reason(self):
+        gate = load_gate()
+        for entry, reason in gate.NOT_A_COMMAND.items():
+            self.assertTrue(reason.strip(), f"exemption '{entry}' has no documented reason")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -11,6 +11,7 @@ from extraction (count silently dropped, exit 0) rather than fail.
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 import tempfile
@@ -347,6 +348,148 @@ class SecondReviewFindings(unittest.TestCase):
                 [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
             )
         self.assertNotIn("Traceback", result.stderr, f"gate crashed:\n{result.stderr}")
+
+
+
+class ThirdRoundFindings(unittest.TestCase):
+    """The six convergence findings plus the three they exposed.
+
+    Every one was the gate reporting a verdict it had not earned.
+    """
+
+    def setUp(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        self.gate = load_gate()
+
+    # H1 --------------------------------------------------------------------
+    def test_subcommand_surface_is_queried_not_guessed(self):
+        """Per-path error interpretation proved `doctor totallybogus` valid, because
+        doctor's error is an arity complaint, not the one recognized negative.
+        Membership over a queried set has no such blind spot."""
+        subs, observable = self.gate.subcommand_surface(str(BINARY), "doctor")
+        self.assertTrue(observable, "doctor's subcommand surface must be observable")
+        self.assertEqual(subs, set(), "doctor has no subcommands")
+        self.assertNotIn("totallybogus", subs)
+
+    def test_error_list_only_subcommands_resolve(self):
+        """The UNION proof. team's usage block lists 8 subcommands; lead, autonomous
+        and shared-cwd-exception appear ONLY in the error list. Using either source
+        alone would fail VALID references -- fail-closed on incomplete data invents
+        drift, which is a defect in the opposite direction from fail-open."""
+        subs, observable = self.gate.subcommand_surface(str(BINARY), "team")
+        self.assertTrue(observable)
+        for only_in_error_list in ("lead", "autonomous", "shared-cwd-exception"):
+            self.assertIn(only_in_error_list, subs, f"{only_in_error_list} must resolve")
+        for in_usage_block in ("init", "sync", "member"):
+            self.assertIn(in_usage_block, subs)
+
+    def test_subcommands_resolve_for_every_form_of_verb(self):
+        """Three different verb shapes: enumerates via 'use', via 'Try', and one with
+        an implicit default subcommand that enumerates neither."""
+        for verb, expected in (("evidence", "run"), ("team", "sync"), ("review-worktree", "remove")):
+            with self.subTest(verb=verb):
+                subs, observable = self.gate.subcommand_surface(str(BINARY), verb)
+                self.assertTrue(observable, f"{verb} surface must be observable")
+                self.assertIn(expected, subs)
+
+    # M2 --------------------------------------------------------------------
+    def test_global_flags_are_parsed_from_real_top_level_help(self):
+        """flag_surface(binary, "", None) ran `amq-squad "" --help`, returned an empty
+        set, and empty was then treated as all-verified."""
+        top = self.gate.run_help(str(BINARY))
+        flags = set(re.findall(r"--[A-Za-z][A-Za-z0-9-]*", top))
+        self.assertGreater(len(flags), 5, "top-level help must yield real global flags")
+
+    def test_bogus_global_flag_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "x.md").write_text("```\namq-squad --definitely-not-global\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertNotEqual(result.returncode, 0, "an invented global flag must not pass")
+
+    # M3 --------------------------------------------------------------------
+    def test_two_commands_in_one_span_stay_separate(self):
+        """Unconditional span collapse merged them, inventing drift."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("Run `amq-squad team sync --apply` then `amq-squad doctor --json`.\n")
+            found = self.gate.extract([probe])
+        self.assertEqual(found.get(("team", "sync")), {"--apply"})
+        self.assertEqual(found.get(("doctor", None)), {"--json"})
+
+    # M4 --------------------------------------------------------------------
+    def test_single_dash_token_after_verb_is_not_discarded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad team -sync\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn(("team", "-sync"), found, "a single-dash token must be reported, not dropped")
+
+    def test_malformed_flag_is_reported_not_dropped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad team sync --apply_bad\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn((self.gate.MALFORMED_FLAG_KEY, None), found)
+        self.assertIn("--apply_bad", found[(self.gate.MALFORMED_FLAG_KEY, None)])
+
+    # M5 --------------------------------------------------------------------
+    def test_flag_floor_is_ratio_based_not_exactly_zero(self):
+        """An exactly-zero floor was bypassed by a mass drop or by one verified flag."""
+        self.assertGreater(self.gate.MIN_VERIFIED_FLAGS, 1, "absolute floor must exceed 1")
+        self.assertGreaterEqual(self.gate.MIN_VERIFIED_FLAG_RATIO, 0.25)
+
+    # Self-exposed 7: shell comments -----------------------------------------
+    def test_inline_shell_comment_is_not_a_subcommand(self):
+        """`amq-squad doctor   # AMQ version, tmux` extracted `#` as a SUBCOMMAND,
+        which is what made the bogus path reachable at all."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad doctor        # AMQ version, team config, tmux\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn(("doctor", None), found)
+        self.assertNotIn(("doctor", "#"), found)
+
+    # Self-exposed 8: the -- separator ---------------------------------------
+    def test_flags_after_double_dash_belong_to_the_wrapped_command(self):
+        """`evidence run ... -- make ci`: make's flags are not amq-squad's, and `--`
+        is a separator rather than a flag claim."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad evidence run T --me A -- make --wrong-flag\n```\n")
+            found = self.gate.extract([probe])
+        flags = found.get(("evidence", "run"), set())
+        self.assertIn("--me", flags)
+        self.assertNotIn("--wrong-flag", flags, "a wrapped command's flags must not be attributed")
+        self.assertNotIn("--", flags)
+
+    # Self-exposed 9: whitespace crossing newlines ---------------------------
+    def test_usage_parse_does_not_cross_lines(self):
+        """`\s+` matches NEWLINES, so a usage line ending at the verb ran into the
+        next line and captured "amq-squad" as a subcommand of doctor. A wrong
+        authoritative set is worse than none, because it is trusted."""
+        subs, _ = self.gate.subcommand_surface(str(BINARY), "doctor")
+        self.assertNotIn("amq-squad", subs, "the parse must not cross line boundaries")
+
+    # L6 --------------------------------------------------------------------
+    def test_none_safe_sort_is_actually_reached(self):
+        """The earlier regression test exited on the MIN_COMMANDS floor before ever
+        reaching the sort, so it would have passed with the fix reverted. Feed a
+        corpus large enough to clear the floor."""
+        real = sorted(SKILLS.rglob("*.md"))
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in real:
+                (Path(tmp) / src.name).write_text(src.read_text())
+            # Force the mixed bare/subcommand shape that triggered the crash.
+            (Path(tmp) / "zz_mixed.md").write_text("```\namq-squad team\namq-squad team sync --apply\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertNotIn("Traceback", result.stderr, f"gate crashed:\n{result.stderr}")
+        self.assertNotIn("MIN_COMMANDS", result.stderr)
+        self.assertNotIn("expected >=", result.stderr, "corpus must be large enough to reach the sort")
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -550,28 +550,68 @@ class FourthRoundFindings(unittest.TestCase):
 
     # Finding 1 + #10: structure, not prose or examples ----------------------
     def test_flag_surface_ignores_prose_and_examples(self):
-        """`--dry-run` appears in notify's EXAMPLES and `alias for --profile` in
-        activity set's DESCRIPTIONS. Neither is the flag surface. Scraping them made
-        real flags look absent and invented drift."""
-        known, _ = self.gate.flag_surface(str(BINARY), "activity", "set")
-        # activity set's real flags come from the definition list...
-        self.assertIn("--me", known)
-        # ...and a flag named only inside a description must not be treated as a
-        # separate declared flag of some other command.
-        top = self.gate.run_help(str(BINARY))
-        self.assertIn("Usage", top)
+        """Asserts the NEGATIVE, which the previous version never did.
 
-    def test_global_flag_surface_is_structural(self):
-        """Both directions were wrong: examples were accepted as flags, and --version
-        was rejected despite being valid."""
+        Scanning the whole help body let any indented dash-leading line become a
+        definition, so an indented PROSE line mentioning a flag entered the surface.
+        A test that only checks a real flag is present cannot see that.
+        """
+        gate = self.gate
+        fake_help = "\n".join(
+            [
+                "amq-squad fake - a fake command",
+                "",
+                "Usage:",
+                "  amq-squad fake [--real-one VALUE]",
+                "",
+                "Description:",
+                "  --bogus-prose-flag appears only in prose and is not a flag.",
+                "",
+                "Examples:",
+                "  amq-squad fake --bogus-example-flag",
+                "",
+            ]
+        )
+        original = gate.run_help
+        gate.run_help = lambda *a, **k: fake_help
+        try:
+            known, exhaustive = gate.flag_surface("binary", "fake", None)
+        finally:
+            gate.run_help = original
+        self.assertIn("--real-one", known, "the usage block IS a flag surface")
+        self.assertNotIn("--bogus-prose-flag", known, "a prose line must NOT enter the surface")
+        self.assertNotIn("--bogus-example-flag", known, "an EXAMPLE must NOT enter the surface")
+        self.assertFalse(exhaustive, "a hand-written usage block is illustrative")
+
+    def test_go_definition_list_is_still_read(self):
+        """Section scoping must not break the exhaustive case it exists to serve."""
+        known, exhaustive = self.gate.flag_surface(str(BINARY), "activity", "set")
+        self.assertTrue(exhaustive)
+        for real in ("--me", "--task", "--phase"):
+            self.assertIn(real, known)
+
+    def test_bogus_global_flag_is_unverifiable_not_refuted(self):
+        """Encodes the MODEL, not merely a nonzero exit.
+
+        The earlier version exited at the MIN_COMMANDS floor before ever reaching
+        global verification, so it passed for the wrong reason. Top-level help is
+        hand-written (its Global flags section omits --version), therefore
+        illustrative, therefore a bogus global flag is UNVERIFIABLE rather than
+        refuted.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             for src in sorted(SKILLS.rglob("*.md")):
                 (Path(tmp) / src.name).write_text(src.read_text())
-            (Path(tmp) / "zz_global.md").write_text("```\namq-squad --version\n```\n")
+            (Path(tmp) / "zz_global.md").write_text(
+                "```\namq-squad --version\namq-squad --definitely-not-global\n```\n"
+            )
             result = subprocess.run(
                 [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
             )
-        self.assertEqual(result.returncode, 0, f"--version is valid and must not fail:\n{result.stderr}")
+        self.assertNotIn("expected >=", result.stderr, "corpus must clear the floors and reach the check")
+        self.assertEqual(result.returncode, 0, f"illustrative surface must not refute:\n{result.stderr}")
+        self.assertIn("NOT verifiable", result.stdout)
+        self.assertIn("--definitely-not-global", result.stdout)
 
     # Finding 2: one span, two commands --------------------------------------
     def test_one_span_two_commands_both_extracted(self):
@@ -600,11 +640,23 @@ class FourthRoundFindings(unittest.TestCase):
         self.assertIn("-apply", claimed, "a single-dash token must be reported, not dropped")
 
     # Finding 4: floor math, and the main()-level exit test ------------------
-    def test_floor_uses_ceiling_not_truncation(self):
-        """int() truncation let 11/23 (47.8%) pass a 50% floor."""
-        import math
+    def test_floor_uses_productions_ceiling_not_pythons(self):
+        """Exercises required_verified(), the PRODUCTION calculation.
 
-        self.assertEqual(math.ceil(23 * 0.5), 12, "12 of 23 is the true 50% threshold")
+        The previous version asserted math.ceil(23 * 0.5) == 12, which tests Python
+        and stays green if production truncates with int(). Third appearance of the
+        vacuity pattern inside tests OF the gate.
+        """
+        # 23 verifiable at 50% is 11.5; truncation gives 11, ceiling gives 12.
+        self.assertEqual(self.gate.required_verified(23), max(self.gate.MIN_VERIFIED_FLAGS, 12))
+        self.assertGreater(
+            self.gate.required_verified(23), 11, "int() truncation would allow 11 of 23 (47.8%)"
+        )
+
+    def test_floors_sit_at_committed_coverage(self):
+        """Floors set far below real coverage permitted a 13 -> 5 collapse at exit 0."""
+        self.assertGreaterEqual(self.gate.MIN_VERIFIED_FLAGS, 12)
+        self.assertGreaterEqual(self.gate.MIN_VERIFIABLE_FLAGS, 12)
 
     def test_floor_guards_the_verifiable_set_too(self):
         self.assertGreater(self.gate.MIN_VERIFIABLE_FLAGS, 0)

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -102,14 +102,51 @@ class GateDetectsDrift(unittest.TestCase):
         self.assertEqual(result.returncode, 1, "an unparseable verb must fail, not vanish")
         self.assertIn("evidenceX", result.stderr)
 
-    def test_unknown_flag_fails(self):
-        target = SKILLS / "amq-squad" / "references" / "pointer-stub-template.md"
-        with MutatedSkill(
-            target, "amq-squad team sync --apply", "amq-squad team sync --apply --nonexistent-flag"
-        ):
-            result = run_gate()
-        self.assertEqual(result.returncode, 1, "an unknown flag must fail the gate")
-        self.assertIn("--nonexistent-flag", result.stderr)
+    def test_unknown_flag_fails_on_an_exhaustive_surface(self):
+        """Refutation is only legitimate where the surface is COMPLETE.
+
+        `activity set` uses Go's default flag printer, which enumerates every flag,
+        so absence there is genuine drift.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_exhaustive.md").write_text(
+                "```\namq-squad activity set --me H --task T --phase coding --nope-not-a-flag\n```\n"
+            )
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 1, f"drift on an exhaustive surface must fail:\n{result.stderr}")
+        self.assertIn("--nope-not-a-flag", result.stderr)
+
+    def test_real_flags_on_an_exhaustive_surface_verify(self):
+        """The counter-case: Go's single-dash listing must be READ, or every real
+        flag on such a command would be reported as drift. This is finding #10."""
+        gate = load_gate()
+        known, exhaustive = gate.flag_surface(str(BINARY), "activity", "set")
+        self.assertTrue(exhaustive, "activity set's help is a complete definition list")
+        for real in ("--me", "--task", "--phase"):
+            self.assertIn(real, known, f"{real} is accepted and must be readable from help")
+
+    def test_absent_flag_on_an_illustrative_surface_does_not_fail(self):
+        """Confirm-only. `run start` documents `-p/-s` and never lists the long
+        forms, yet --project and --session are accepted, so absence from an
+        illustrative usage block proves nothing and must not fail the reference."""
+        gate = load_gate()
+        known, exhaustive = gate.flag_surface(str(BINARY), "run", "start")
+        self.assertFalse(exhaustive, "run start's usage block is illustrative, not exhaustive")
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_illustrative.md").write_text(
+                "```\namq-squad run start --project P --session S --unlisted-but-maybe-real\n```\n"
+            )
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 0, f"must not fail on an illustrative surface:\n{result.stderr}")
+        self.assertIn("NOT verifiable", result.stdout)
 
 
 class ExtractionRules(unittest.TestCase):
@@ -274,14 +311,24 @@ class SecondReviewFindings(unittest.TestCase):
         self.assertIn("--attempt-id", flags, "a flag further after the wrap must be extracted")
         self.assertIn("--profile", flags, "flags before the wrap must still be extracted")
 
-    def test_post_wrap_flag_drift_fails_the_gate(self):
-        """End to end, not just extraction: a bogus post-wrap flag on a command
-        whose flag help IS observable must fail."""
-        target = SKILLS / "wizard" / "SKILL.md"
-        with MutatedSkill(target, "--launch-shape working-team-together", "--launch-shapeX working-team-together"):
-            result = run_gate()
-        self.assertEqual(result.returncode, 1, "a bogus post-wrap flag must fail the gate")
-        self.assertIn("run start", result.stderr)
+    def test_post_wrap_flag_is_extracted_and_refuted_where_possible(self):
+        """Extraction across a wrap is proven separately from refutation, because
+        refutation now requires an exhaustive surface. The wrap fix is what makes the
+        flag visible at all; whether it can be REFUTED depends on the surface kind.
+        """
+        found = self.gate.extract([SKILLS / "cli" / "SKILL.md"])
+        self.assertIn("--subject", found[("evidence", "run")], "post-wrap flag must be extracted")
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_wrap.md").write_text(
+                "```\namq-squad activity set --me H\n    --task T --bogus-after-wrap\n```\n"
+            )
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 1, f"a post-wrap bogus flag on an exhaustive surface must fail:\n{result.stderr}")
+        self.assertIn("--bogus-after-wrap", result.stderr)
 
     # MEDIUM 3 ---------------------------------------------------------------
     def test_malformed_verb_with_leading_dash_is_reported(self):
@@ -467,7 +514,7 @@ class ThirdRoundFindings(unittest.TestCase):
 
     # Self-exposed 9: whitespace crossing newlines ---------------------------
     def test_usage_parse_does_not_cross_lines(self):
-        """`\s+` matches NEWLINES, so a usage line ending at the verb ran into the
+        r"""`\s+` matches NEWLINES, so a usage line ending at the verb ran into the
         next line and captured "amq-squad" as a subcommand of doctor. A wrong
         authoritative set is worse than none, because it is trusted."""
         subs, _ = self.gate.subcommand_surface(str(BINARY), "doctor")
@@ -490,6 +537,120 @@ class ThirdRoundFindings(unittest.TestCase):
         self.assertNotIn("Traceback", result.stderr, f"gate crashed:\n{result.stderr}")
         self.assertNotIn("MIN_COMMANDS", result.stderr)
         self.assertNotIn("expected >=", result.stderr, "corpus must be large enough to reach the sort")
+
+
+
+class FourthRoundFindings(unittest.TestCase):
+    """Round-4 findings: five from convergence plus finding #10."""
+
+    def setUp(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        self.gate = load_gate()
+
+    # Finding 1 + #10: structure, not prose or examples ----------------------
+    def test_flag_surface_ignores_prose_and_examples(self):
+        """`--dry-run` appears in notify's EXAMPLES and `alias for --profile` in
+        activity set's DESCRIPTIONS. Neither is the flag surface. Scraping them made
+        real flags look absent and invented drift."""
+        known, _ = self.gate.flag_surface(str(BINARY), "activity", "set")
+        # activity set's real flags come from the definition list...
+        self.assertIn("--me", known)
+        # ...and a flag named only inside a description must not be treated as a
+        # separate declared flag of some other command.
+        top = self.gate.run_help(str(BINARY))
+        self.assertIn("Usage", top)
+
+    def test_global_flag_surface_is_structural(self):
+        """Both directions were wrong: examples were accepted as flags, and --version
+        was rejected despite being valid."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_global.md").write_text("```\namq-squad --version\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 0, f"--version is valid and must not fail:\n{result.stderr}")
+
+    # Finding 2: one span, two commands --------------------------------------
+    def test_one_span_two_commands_both_extracted(self):
+        """The earlier test used TWO spans, so it missed this: after a span is
+        collapsed the second command is no longer at a line start, and the truncation
+        discarded it instead of processing it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("Do `amq-squad team sync --apply then amq-squad doctor --json` now.\n")
+            found = self.gate.extract([probe])
+        self.assertIn(("team", "sync"), found, "first command must be extracted")
+        self.assertIn(("doctor", None), found, "SECOND command in the SAME span must be extracted")
+        self.assertIn("--json", found[("doctor", None)])
+
+    # Finding 3: later single-dash tokens ------------------------------------
+    def test_later_single_dash_token_is_not_dropped(self):
+        """`team sync -apply` passed with no claimed flag: the collector retained only
+        double-dash tokens, so a single-dash token vanished."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad team sync -apply\n```\n")
+            found = self.gate.extract([probe])
+        claimed = set()
+        for flags in found.values():
+            claimed |= flags
+        self.assertIn("-apply", claimed, "a single-dash token must be reported, not dropped")
+
+    # Finding 4: floor math, and the main()-level exit test ------------------
+    def test_floor_uses_ceiling_not_truncation(self):
+        """int() truncation let 11/23 (47.8%) pass a 50% floor."""
+        import math
+
+        self.assertEqual(math.ceil(23 * 0.5), 12, "12 of 23 is the true 50% threshold")
+
+    def test_floor_guards_the_verifiable_set_too(self):
+        self.assertGreater(self.gate.MIN_VERIFIABLE_FLAGS, 0)
+        self.assertGreater(self.gate.MIN_VERIFIED_FLAGS, 0)
+
+    def test_main_exits_2_when_the_verifiable_set_collapses(self):
+        """The main()-level exit-code assertion, asked for twice. Blind the flag
+        surface so nothing is verifiable, then assert the process exits 2."""
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            runner = (
+                "import sys, importlib.util\n"
+                f"spec = importlib.util.spec_from_file_location('g', {str(GATE)!r})\n"
+                "g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)\n"
+                # Blind only PER-COMMAND surfaces: blinding the global one too would
+                # trip the earlier global-flag guard and never reach the floor.\n"
+                "_orig = g.flag_surface\n"
+                "g.flag_surface = lambda b, v, s2=None, **k: (_orig(b, v, s2) if not v else (set(), False))\n"
+                f"sys.argv = ['g', {str(BINARY)!r}, {tmp!r}]\n"
+                "raise SystemExit(g.main())\n"
+            )
+            result = subprocess.run([sys.executable, "-c", runner], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 2, f"a collapsed verifiable set must exit 2:\n{result.stderr}")
+        self.assertIn("verifiable", result.stderr)
+
+    # Finding 5: comment stripping respects quotes --------------------------
+    def test_hash_inside_quotes_is_not_a_comment(self):
+        """`--note "issue #123" --force` lost --force to a blunt comment strip."""
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text('```\namq-squad activity set --me H --detail "issue #123" --phase coding\n```\n')
+            found = self.gate.extract([probe])
+        flags = found.get(("activity", "set"), set())
+        self.assertIn("--phase", flags, "a flag after a quoted # must survive")
+        self.assertIn("--detail", flags)
+
+    def test_real_trailing_comment_is_still_stripped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            probe = Path(tmp) / "x.md"
+            probe.write_text("```\namq-squad doctor        # AMQ version, tmux, wake\n```\n")
+            found = self.gate.extract([probe])
+        self.assertIn(("doctor", None), found)
+        self.assertNotIn(("doctor", "#"), found)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -448,14 +448,6 @@ class ThirdRoundFindings(unittest.TestCase):
         flags = set(re.findall(r"--[A-Za-z][A-Za-z0-9-]*", top))
         self.assertGreater(len(flags), 5, "top-level help must yield real global flags")
 
-    def test_bogus_global_flag_fails(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            (Path(tmp) / "x.md").write_text("```\namq-squad --definitely-not-global\n```\n")
-            result = subprocess.run(
-                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
-            )
-        self.assertNotEqual(result.returncode, 0, "an invented global flag must not pass")
-
     # M3 --------------------------------------------------------------------
     def test_two_commands_in_one_span_stay_separate(self):
         """Unconditional span collapse merged them, inventing drift."""
@@ -641,17 +633,21 @@ class FourthRoundFindings(unittest.TestCase):
 
     # Finding 4: floor math, and the main()-level exit test ------------------
     def test_floor_uses_productions_ceiling_not_pythons(self):
-        """Exercises required_verified(), the PRODUCTION calculation.
+        """Exercises required_verified(), at inputs where ceil and int DIVERGE.
 
-        The previous version asserted math.ceil(23 * 0.5) == 12, which tests Python
-        and stays green if production truncates with int(). Third appearance of the
-        vacuity pattern inside tests OF the gate.
+        Two earlier versions of this test were vacuous. The first asserted
+        math.ceil(23 * 0.5) == 12, which tests Python, not production. The second
+        called production but at 23 verifiable, where max(12, ceil(11.5)) and
+        max(12, int(11.5)) are BOTH 12 -- so an int() revert still passed.
+
+        At 25 verifiable they differ: ceil(12.5) = 13, int(12.5) = 12. Choosing
+        inputs where the behaviours diverge is the whole point; a correct assertion
+        at an input that cannot distinguish them proves nothing.
         """
-        # 23 verifiable at 50% is 11.5; truncation gives 11, ceiling gives 12.
-        self.assertEqual(self.gate.required_verified(23), max(self.gate.MIN_VERIFIED_FLAGS, 12))
-        self.assertGreater(
-            self.gate.required_verified(23), 11, "int() truncation would allow 11 of 23 (47.8%)"
-        )
+        self.assertEqual(self.gate.required_verified(25), 13, "ceil(12.5) must give 13, not int()'s 12")
+        self.assertEqual(self.gate.required_verified(31), 16, "ceil(15.5) must give 16")
+        # And the absolute floor still dominates below the crossover.
+        self.assertEqual(self.gate.required_verified(10), self.gate.MIN_VERIFIED_FLAGS)
 
     def test_floors_sit_at_committed_coverage(self):
         """Floors set far below real coverage permitted a 13 -> 5 collapse at exit 0."""
@@ -703,6 +699,74 @@ class FourthRoundFindings(unittest.TestCase):
             found = self.gate.extract([probe])
         self.assertIn(("doctor", None), found)
         self.assertNotIn(("doctor", "#"), found)
+
+
+
+class UnknownSubcommandFormats(unittest.TestCase):
+    """Finding 11: the binary emits THREE unknown-subcommand formats.
+
+    Handling two of them left `amq` unobservable, which under the fail-closed posture
+    blocked the build for any skill documenting an amq subcommand -- the gate blocking
+    correct documentation of a command it exists to protect.
+
+    Subsumption is PROVEN here rather than assumed: one rule must parse all three.
+    """
+
+    def setUp(self):
+        if not BINARY.exists():
+            self.skipTest("binary not built; run make build")
+        self.gate = load_gate()
+
+    def test_all_three_live_formats_resolve(self):
+        expected = {
+            # ". Use ..." -- the format that was unhandled.
+            "amq": {"env", "ops", "route", "who", "presence", "send", "reply",
+                    "drain", "watch", "list", "read", "thread", "receipts", "dlq", "cleanup"},
+            # "; use ..."
+            "evidence": {"run", "show", "list", "recover", "lookup"},
+            # ". Try '...'"
+            "team": {"init", "resume", "rules", "lead", "overlay", "member",
+                     "autonomous", "sync", "profiles", "rm", "shared-cwd-exception"},
+        }
+        for verb, want in expected.items():
+            with self.subTest(verb=verb):
+                subs, observable = self.gate.subcommand_surface(str(BINARY), verb)
+                self.assertTrue(observable, f"{verb}'s subcommand surface must be observable")
+                missing = want - subs
+                self.assertFalse(missing, f"{verb} is missing {sorted(missing)}")
+
+    def test_amq_resolves_all_fifteen(self):
+        """The specific regression: `amq` was unobservable, so documenting any of its
+        subcommands failed the build."""
+        subs, observable = self.gate.subcommand_surface(str(BINARY), "amq")
+        self.assertTrue(observable)
+        self.assertGreaterEqual(len(subs), 15, f"expected all 15 amq subcommands, got {sorted(subs)}")
+
+    def test_documenting_an_amq_subcommand_no_longer_blocks_the_build(self):
+        """End to end: this is what the finding actually cost."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_amq.md").write_text(
+                "```\namq-squad amq drain --include-body\namq-squad amq route explain\n```\n"
+            )
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 0, f"documenting real amq subcommands must pass:\n{result.stderr}")
+        self.assertNotIn("could not observe", result.stderr)
+
+    def test_a_bogus_amq_subcommand_still_fails(self):
+        """The counter-case: making amq observable must not make it permissive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for src in sorted(SKILLS.rglob("*.md")):
+                (Path(tmp) / src.name).write_text(src.read_text())
+            (Path(tmp) / "zz_amq_bad.md").write_text("```\namq-squad amq notasubcommand\n```\n")
+            result = subprocess.run(
+                [sys.executable, str(GATE), str(BINARY), tmp], capture_output=True, text=True
+            )
+        self.assertEqual(result.returncode, 1, "a bogus amq subcommand must be refuted")
+        self.assertIn("notasubcommand", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #534 (does **not** close it — this is the drift-gate section only; the skill rewrite, `monitor`/`notify`/`next` adoption, and the `references/` extraction remain).

## Why this lands first

#534 makes the case itself: the skills drift from the binary between releases, and the drift is discovered when an operator follows an instruction that no longer works. This converts that from a recurring release-note problem into a build failure.

It is also the prerequisite for #522's noun-verb consolidation. With drift mechanically detectable, that rewrite becomes a regeneration you can verify rather than a manual audit of every command string.

## No second list of verbs

The command surface is read from the binary's own `--help` output. That is deliberate: a hand-maintained mirror of the command surface is precisely the defect this gate exists to catch, so the gate must not contain one. No production code was added — `--help` was already self-describing.

## Extraction: two load-bearing rules

**A command reference must start its line** (allowing leading whitespace, `$ `, or `&& `/`| ` continuation).

The skills contain `This project uses amq-squad for agent team coordination` — English, and it sits *inside a fence*, because these skills fence **file templates** as well as shell. So fencing alone cannot separate commands from prose. The positional rule can, with no allowlist.

**Inline spans must tolerate newlines.** `cli/SKILL.md` names:

```
`amq-squad evidence run TASK --profile PROFILE --session SESSION --me ACTOR
--subject TEXT ...`
```

wrapped across a line break. A newline-hostile pattern misses it **silently** — the reference is simply never checked, which is the dangerous kind of miss. Pinned by a test using that exact real string.

## Coverage honesty over coverage theatre

Flag verification reports what it cannot verify instead of guessing:

- `evidence run --help` **errors** without its required positional, so it emits no flag list.
- `wizard` documents `[run start prefill flags]` by reference, so its help is not exhaustive by design.

An earlier version fell back to the **parent** command's help and produced **five confident false positives** for flags that work perfectly (`evidence run --profile/--session/--me`, `wizard --project/--profile/--session`). `evidence` and `evidence run` have different flag sets; the parent's list is not a substitute.

Unverifiable is now reported as unverifiable, and the summary states coverage explicitly:

```
skills name 11 command(s); all 11 verb(s) resolve, 7 flag(s) verified
flags NOT verifiable from --help for 2 command(s) (help errors without
required positionals, or delegates its flag set):
  - amq-squad evidence run (3 flag(s): --me, --profile, --session)
  - amq-squad wizard (3 flag(s): --profile, --project, --session)
```

A gate that overstates its coverage is worse than a narrower honest one.

## Anti-vacuity: three floors

A gate that silently checks nothing is worse than no gate, because success and inaction are indistinguishable. The build fails on:

1. fewer than `MIN_COMMANDS` extracted references — the skills stopped naming commands, or the extractor broke;
2. fewer than `MIN_VERBS_IN_SURFACE` verbs parsed from `--help` — a help-format change must fail loudly rather than empty the surface silently;
3. zero real verbs actually verified.

### A bug found by probing the gate, not reading it

Renaming a command to `evidenceX` did **not** fail the gate — the reference **vanished**. Extracted count silently dropped 11→10 and it exited 0, because tokens failing a lowercase verb pattern were skipped.

A drift gate that discards references it cannot parse *reports agreement*. Now only a leading **flag** is skipped (`amq-squad --version` names no verb); anything else in verb position is a claimed command and is checked against the real surface. Pinned by `test_renamed_verb_with_uppercase_fails_rather_than_vanishing`.

## The one concession, with a self-destruct

`NOT_A_COMMAND` holds exactly one entry: `amq-squad skill v2.24.0`, the version-announcement identity string, which is formatted as a command in seven files but is not one. Its reason is recorded inline.

`test_every_entry_still_appears_in_the_skills` asserts every entry still appears in the skills, so when the preamble is removed by the skill rewrite the entry **must** be deleted or the build fails. The concession cannot outlive its cause.

## Tests

14 tests: both rename shapes, unknown flags, the prose and wrapped-span extraction rules, the leading-flag case, all three anti-vacuity floors, the help-parser sanity guard, and the staleness invariant.

The `MutatedSkill` helper **refuses to run when its target string is absent**, so a mutation that misses its target is an immediate error rather than a silent pass. That guard exists because two of my own early probes edited the wrong file and looked like gate bugs.

## Wiring

`make skill-command-check` (depends on `build`, runs the gate *and* its tests), added to the `ci` chain alongside `skills-check` and `skill-routing-check`. `.gitignore` picks up `__pycache__/` and `*.pyc`, since the test loads the checker via `importlib`.

## Evidence

`make ci` on this exact head with the gate in the chain: **exit 0**, zero failures, `internal/cli ok`, gate output as quoted above, 14 tests OK.

Do not merge without review — second review at this head, then the operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
