### PR TITLE
test: cover AMQ v0.47 and v0.48 compatibility (#533)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.42.1, v0.43.1, v0.45.0, latest]
+        amq-version: [v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.42.1, v0.43.1, v0.45.0]
+        amq-version: [v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/README.html
+++ b/README.html
@@ -1285,9 +1285,31 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>The minimum 0.42.1 compatibility floor is unchanged. This release is
-explicitly validated against pinned 0.45.0; latest remains a
-forward-compatibility canary.</p>
+<p>The minimum 0.42.1 compatibility floor is unchanged. General
+compatibility is explicitly validated against 0.42.1, 0.43.1, 0.45.0,
+0.47.2, and 0.48.0; <code>latest</code> remains a moving
+forward-compatibility canary. The required macOS real-PTY wake matrix
+pins the same releases except for <code>latest</code>.</p>
+<p>AMQ 0.47.1 changed supervised <code>coop exec</code> wake input
+deliberately: instead of injecting message headers or subjects, it
+submits the fixed, shell-inert doorbell
+<code>: AMQ doorbell run amq drain --include-body then act on it</code>.
+Agents must drain the durable mailbox to discover the sender, subject,
+and body. AMQ 0.47.2 is the pinned 0.47 representative because it also
+keeps terminal authority stable during TTY activity.</p>
+<p>On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the
+kernel disables it, wake degrades to a non-input notifier and records
+<code>injector_unsupported</code> diagnostics instead of pretending
+synthetic input was delivered. The macOS real-PTY lane proves native
+injection where TIOCSTI is available; AMQ's upstream tests own the
+Linux-only <code>/proc/sys/dev/tty/legacy_tiocsti=0</code> fallback.</p>
+<p>AMQ 0.48.0 can also inspect malformed configured mailbox layouts with
+<code>amq doctor --json</code> and create only missing safe directories
+with <code>amq doctor --fix-mailboxes --json</code>. Repair is explicit
+and fail-closed: existing messages are not moved, overwritten, or
+deleted, discovered-only mailboxes are not repair eligible, and unsafe
+filesystem state is refused. amq-squad never runs this mutating repair
+automatically.</p>
 <p>v2.20.0 requires AMQ 0.42.1+, the first supported release for the
 complete injected identity contract. After upgrading AMQ, stop and
 resume/relaunch agents so their parent shells refresh the complete

--- a/README.md
+++ b/README.md
@@ -787,9 +787,31 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-The minimum 0.42.1 compatibility floor is unchanged. This release is
-explicitly validated against pinned 0.45.0; latest remains a
-forward-compatibility canary.
+The minimum 0.42.1 compatibility floor is unchanged. General compatibility is
+explicitly validated against 0.42.1, 0.43.1, 0.45.0, 0.47.2, and 0.48.0;
+`latest` remains a moving forward-compatibility canary. The required macOS
+real-PTY wake matrix pins the same releases except for `latest`.
+
+AMQ 0.47.1 changed supervised `coop exec` wake input deliberately: instead of
+injecting message headers or subjects, it submits the fixed, shell-inert
+doorbell `: AMQ doorbell run amq drain --include-body then act on it`. Agents
+must drain the durable mailbox to discover the sender, subject, and body.
+AMQ 0.47.2 is the pinned 0.47 representative because it also keeps terminal
+authority stable during TTY activity.
+
+On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the kernel
+disables it, wake degrades to a non-input notifier and records
+`injector_unsupported` diagnostics instead of pretending synthetic input was
+delivered. The macOS real-PTY lane proves native injection where TIOCSTI is
+available; AMQ's upstream tests own the Linux-only
+`/proc/sys/dev/tty/legacy_tiocsti=0` fallback.
+
+AMQ 0.48.0 can also inspect malformed configured mailbox layouts with
+`amq doctor --json` and create only missing safe directories with
+`amq doctor --fix-mailboxes --json`. Repair is explicit and fail-closed:
+existing messages are not moved, overwritten, or deleted, discovered-only
+mailboxes are not repair eligible, and unsafe filesystem state is refused.
+amq-squad never runs this mutating repair automatically.
 
 v2.20.0 requires AMQ 0.42.1+, the first supported release for the complete
 injected identity contract. After upgrading AMQ, stop and resume/relaunch agents

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -165,6 +165,11 @@ func TestRealAMQCompatibility(t *testing.T) {
 			realAMQExternalWakeBaselineContract(t, binary)
 		})
 	}
+	if semverMeetsStableFloor(version, "0.48.0") {
+		t.Run("doctor repairs malformed configured mailbox", func(t *testing.T) {
+			realAMQDoctorMailboxRepairContract(t, binary)
+		})
+	}
 
 	t.Run("post-coop child identity", func(t *testing.T) {
 		project := t.TempDir()
@@ -282,6 +287,110 @@ func TestRealAMQCompatibility(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type realAMQDoctorReport struct {
+	Mailboxes []struct {
+		Handle         string   `json:"handle"`
+		Status         string   `json:"status"`
+		Issues         []string `json:"issues"`
+		RepairEligible bool     `json:"repair_eligible"`
+		CreatedPaths   []string `json:"created_paths"`
+	} `json:"mailboxes"`
+	MailboxRepair *struct {
+		Status       string   `json:"status"`
+		CreatedPaths []string `json:"created_paths"`
+	} `json:"mailbox_repair"`
+	Summary struct {
+		Error int `json:"error"`
+	} `json:"summary"`
+}
+
+func realAMQDoctorMailboxRepairContract(t *testing.T, binary string) {
+	t.Helper()
+	project := t.TempDir()
+	root := filepath.Join(project, ".agent-mail", "doctor-mailbox-repair")
+	realAMQInitAgents(t, binary, project, root, "alpha")
+
+	sentinelPath := filepath.Join(root, "agents", "alpha", "inbox", "new", "sentinel.md")
+	if err := os.WriteFile(sentinelPath, []byte("do not touch"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	sentinelBefore, err := os.Stat(sentinelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingPath := filepath.Join(root, "agents", "alpha", "inbox", "cur")
+	if err := os.Remove(missingPath); err != nil {
+		t.Fatal(err)
+	}
+
+	env := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(os.Environ()))
+	env = append(env, "AM_ROOT="+root, "AM_ME=alpha")
+	runDoctor := func(args ...string) realAMQDoctorReport {
+		t.Helper()
+		out := realAMQCommand(t, binary, project, env, append([]string{"doctor"}, args...)...)
+		var report realAMQDoctorReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatalf("parse real AMQ doctor JSON: %v\n%s", err, out)
+		}
+		return report
+	}
+	findAlpha := func(report realAMQDoctorReport) (status string, issues, created []string, eligible bool) {
+		t.Helper()
+		for _, mailbox := range report.Mailboxes {
+			if mailbox.Handle == "alpha" {
+				return mailbox.Status, mailbox.Issues, mailbox.CreatedPaths, mailbox.RepairEligible
+			}
+		}
+		t.Fatalf("doctor omitted configured alpha mailbox: %+v", report.Mailboxes)
+		return "", nil, nil, false
+	}
+
+	inspection := runDoctor("--json")
+	status, issues, _, eligible := findAlpha(inspection)
+	if status != "error" || len(issues) != 1 || issues[0] != "missing:inbox/cur" || !eligible || inspection.Summary.Error != 1 || inspection.MailboxRepair != nil {
+		t.Fatalf("malformed mailbox inspection = status:%q issues:%v eligible:%t errors:%d repair:%+v", status, issues, eligible, inspection.Summary.Error, inspection.MailboxRepair)
+	}
+
+	repaired := runDoctor("--fix-mailboxes", "--json")
+	status, issues, created, eligible := findAlpha(repaired)
+	if status != "ok" || len(issues) != 0 || eligible || len(created) != 1 || created[0] != "inbox/cur" ||
+		repaired.Summary.Error != 0 || repaired.MailboxRepair == nil || repaired.MailboxRepair.Status != "repaired" ||
+		len(repaired.MailboxRepair.CreatedPaths) != 1 || repaired.MailboxRepair.CreatedPaths[0] != "agents/alpha/inbox/cur" {
+		t.Fatalf("mailbox repair = status:%q issues:%v created:%v eligible:%t errors:%d repair:%+v", status, issues, created, eligible, repaired.Summary.Error, repaired.MailboxRepair)
+	}
+	if info, err := os.Stat(missingPath); err != nil || !info.IsDir() {
+		t.Fatalf("repaired mailbox directory = %v, info=%v", err, info)
+	}
+	assertRealAMQDoctorSentinelUnchanged(t, sentinelPath, sentinelBefore)
+
+	idempotent := runDoctor("--fix-mailboxes", "--json")
+	status, issues, created, eligible = findAlpha(idempotent)
+	if status != "ok" || len(issues) != 0 || len(created) != 0 || eligible ||
+		idempotent.Summary.Error != 0 || idempotent.MailboxRepair == nil ||
+		idempotent.MailboxRepair.Status != "repaired" || len(idempotent.MailboxRepair.CreatedPaths) != 0 {
+		t.Fatalf("idempotent mailbox repair = status:%q issues:%v created:%v eligible:%t errors:%d repair:%+v", status, issues, created, eligible, idempotent.Summary.Error, idempotent.MailboxRepair)
+	}
+	assertRealAMQDoctorSentinelUnchanged(t, sentinelPath, sentinelBefore)
+}
+
+func assertRealAMQDoctorSentinelUnchanged(t *testing.T, path string, before os.FileInfo) {
+	t.Helper()
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(before, after) || before.Mode() != after.Mode() {
+		t.Fatalf("doctor changed sentinel identity or mode: before=%v after=%v", before, after)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "do not touch" {
+		t.Fatalf("doctor changed sentinel content: %q", data)
 	}
 }
 

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -19,11 +19,15 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
+const realAMQCoopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
+
 // TestRealAMQWakeCompatibility is the required macOS floor/current contract,
 // with latest rerun as a forward-compatibility canary. Unlike the Linux queue
 // compatibility test, every case here uses a disposable real tmux PTY and
 // fails (rather than skips) when tmux or native wake injection is unavailable
-// after the lane opts in.
+// after the lane opts in. AMQ v0.48.0's Linux-only
+// /proc/sys/dev/tty/legacy_tiocsti=0 degradation cannot be exercised by this
+// macOS lane; upstream AMQ unit tests own that non-input-notifier path.
 func TestRealAMQWakeCompatibility(t *testing.T) {
 	amq := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ"))
 	if amq == "" {
@@ -62,10 +66,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 				h.start([]string{amq, "coop", "exec", "--root", h.root, "--me", "codex", "--require-wake", "--wake-inject-mode", mode, h.recorder})
 				h.send("sender", "codex", "native-"+mode, "native wake canary")
 				line := h.oneSubmittedLine()
-				assertMarkerFreeWake(t, line)
-				if !strings.Contains(line, "native-"+mode) {
-					t.Fatalf("submitted wake = %q, want subject native-%s", line, mode)
-				}
+				assertRealAMQCoopWakePayload(t, version, line, "native-"+mode)
 			})
 		}
 	})
@@ -89,10 +90,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		}
 		h.send("cto", "qa", "managed-raw", "managed wake canary")
 		line := h.oneSubmittedLine()
-		assertMarkerFreeWake(t, line)
-		if !strings.Contains(line, "managed-raw") {
-			t.Fatalf("submitted managed wake = %q", line)
-		}
+		assertRealAMQCoopWakePayload(t, version, line, "managed-raw")
 	})
 
 	t.Run("managed stop resume and cleanup", func(t *testing.T) {
@@ -171,10 +169,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		assertRealWakeProcessIdentity(t, resumed)
 		h.send("cto", "qa", "managed-resume", "managed resume wake canary")
 		line := h.oneSubmittedLine()
-		assertMarkerFreeWake(t, line)
-		if !strings.Contains(line, "managed-resume") {
-			t.Fatalf("submitted resumed wake = %q", line)
-		}
+		assertRealAMQCoopWakePayload(t, version, line, "managed-resume")
 
 		realWakeCommand(t, h.project, h.env(), squad,
 			"stop", "--project", h.project, "--profile", team.DefaultProfile, "--session", h.session, "--role", "cto")
@@ -524,6 +519,20 @@ func assertMarkerFreeWake(t *testing.T, got string) {
 		if strings.Contains(got, marker) {
 			t.Fatalf("submitted terminal input contains bracketed-paste marker %q: %q", marker, got)
 		}
+	}
+}
+
+func assertRealAMQCoopWakePayload(t *testing.T, version, got, legacySubject string) {
+	t.Helper()
+	assertMarkerFreeWake(t, got)
+	if semverMeetsStableFloor(version, "0.47.1") {
+		if got != realAMQCoopWakeDoorbell {
+			t.Fatalf("submitted coop wake = %q, want fixed doorbell %q for AMQ %s", got, realAMQCoopWakeDoorbell, version)
+		}
+		return
+	}
+	if !strings.Contains(got, legacySubject) {
+		t.Fatalf("submitted legacy coop wake = %q, want subject %q for AMQ %s", got, legacySubject, version)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expand the general real-AMQ compatibility matrix through v0.47.2 and v0.48.0 while retaining the v0.42.1 floor and latest
- expand managed wake coverage through v0.48.0 and assert the fixed subject-free doorbell from v0.47.1 onward
- add a v0.48-gated disposable doctor contract for malformed configured mailbox inspection, explicit repair, preservation, and idempotence
- document the release boundaries, Linux TIOCSTI tradeoff, and explicit-only repair posture

## Release findings

- v0.47.0 introduces owner-bound lifecycle behavior and remains compatible with the legacy dynamic wake subject.
- v0.47.1 introduces the fixed shell-inert subject-free doorbell and fail-closed repair continuity.
- v0.47.2 stabilizes terminal authority during TTY activity and is the selected v0.47 matrix pin.
- v0.47.3 hardens descriptor closure, lock admission, interrupt opt-in, stray argument rejection, and checksum failure behavior; the selected pin remains v0.47.2 to cover the terminal-authority fix directly.
- v0.48.0 adds the Linux TIOCSTI capability probe with non-input notifier degradation and doctor repair for malformed mailbox directories.

## Decision record

- general matrix: v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0, latest
- wake matrix: v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0
- minimum supported AMQ remains v0.42.1
- wake assertions use the v0.47.1 semantic boundary at all three capture sites
- malformed mailbox repair is explicit via AMQ doctor only; amq-squad does not auto-repair
- macOS cannot exercise the Linux /proc/sys/dev/tty/legacy_tiocsti=0 branch, so CI documents that platform boundary

## Evidence

- t6-go-suite-head-003: full Go suite succeeded and finalized at 7fb74b9; summary sha256:2f5c1c7394e4d5215a7caae8df471341a0ad1db4edf97244a0c67689bdb64867
- t6-make-ci-head-001: make ci succeeded and finalized at 7fb74b9; summary sha256:c72a3ea672d0e8f85711c57ab18764efb1b33ad165e78c3015d7669e59576089
- direct real-AMQ checks passed for v0.48 full compatibility including doctor repair, v0.47.0 and v0.47.2 native wake boundaries, and v0.47.2 managed initial launch

The immediate branch update will incorporate the merged #551 pane-stamp fix required by the new v0.47.2 and v0.48.0 managed-resume lanes.

Fixes #533
