### PR TITLE
Require AMQ 0.49.0 as the sole supported release (#557)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0, latest]
+        amq-version: [v0.49.0, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.42.1, v0.43.1, v0.45.0, v0.47.2, v0.48.0]
+        amq-version: [v0.49.0, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.49.0, latest]
+        amq-version: [v0.49.0, v0.49.1, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.49.0, latest]
+        amq-version: [v0.49.0, v0.49.1, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/README.html
+++ b/README.html
@@ -1314,7 +1314,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.42.1+ on <code>PATH</code></li>
+<li><code>amq</code> 0.49.0 on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>
@@ -1324,34 +1324,64 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>The minimum 0.42.1 compatibility floor is unchanged. General
-compatibility is explicitly validated against 0.42.1, 0.43.1, 0.45.0,
-0.47.2, and 0.48.0; <code>latest</code> remains a moving
-forward-compatibility canary. The required macOS real-PTY wake matrix
-pins the same releases except for <code>latest</code>.</p>
-<p>AMQ 0.47.1 changed supervised <code>coop exec</code> wake input
-deliberately: instead of injecting message headers or subjects, it
-submits the fixed, shell-inert doorbell
+<p>AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices
+validate pinned v0.49.0 and latest; latest remains only a canary for any
+unexpected post-final release. Older AMQ versions are rejected
+fail-closed.</p>
+<table>
+<thead>
+<tr>
+<th>Real-AMQ lane</th>
+<th>Runner</th>
+<th>Versions</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Queue, routing, receipts, doctor, lifecycle</td>
+<td>Ubuntu</td>
+<td><code>v0.49.0</code>, <code>latest</code></td>
+</tr>
+<tr>
+<td>Native real-PTY wake and teardown</td>
+<td>macOS</td>
+<td><code>v0.49.0</code>, <code>latest</code></td>
+</tr>
+</tbody>
+</table>
+<p>AMQ 0.47.1 introduced the supervised <code>coop exec</code> wake
+contract now required by the 0.49.0 floor: instead of injecting message
+headers or subjects, it submits the fixed, shell-inert doorbell
 <code>: AMQ doorbell run amq drain --include-body then act on it</code>.
 Agents must drain the durable mailbox to discover the sender, subject,
-and body. AMQ 0.47.2 is the pinned 0.47 representative because it also
-keeps terminal authority stable during TTY activity.</p>
+and body. No legacy subject-injection branch remains.</p>
 <p>On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the
 kernel disables it, wake degrades to a non-input notifier and records
 <code>injector_unsupported</code> diagnostics instead of pretending
 synthetic input was delivered. The macOS real-PTY lane proves native
 injection where TIOCSTI is available; AMQ's upstream tests own the
 Linux-only <code>/proc/sys/dev/tty/legacy_tiocsti=0</code> fallback.</p>
-<p>AMQ 0.48.0 can also inspect malformed configured mailbox layouts with
+<p>AMQ can inspect malformed configured mailbox layouts with
 <code>amq doctor --json</code> and create only missing safe directories
 with <code>amq doctor --fix-mailboxes --json</code>. Repair is explicit
 and fail-closed: existing messages are not moved, overwritten, or
 deleted, discovered-only mailboxes are not repair eligible, and unsafe
-filesystem state is refused. amq-squad never runs this mutating repair
-automatically.</p>
-<p>v2.20.0 requires AMQ 0.42.1+, the first supported release for the
-complete injected identity contract. After upgrading AMQ, stop and
-resume/relaunch agents so their parent shells refresh the complete
+filesystem state is refused. AMQ 0.49.0 adds actionable remedies for
+discovered-only mailboxes. <code>amq-squad doctor</code> keeps its
+read-only ops check and never runs mutating repair automatically; use
+upstream <code>amq doctor --json</code> for the canonical remedy
+text.</p>
+<p>AMQ 0.49.0 also adds read-only
+<code>amq trace &lt;message-id&gt; --root &lt;path&gt; --json</code>,
+which joins current message, route, delivery, DLQ, receipt, and thread
+evidence. It is useful for diagnostics, but it does not prove historical
+directory-sync or notification success and therefore is not retry or
+authorization authority for amq-squad evidence/receipt flows. See the <a
+href="docs/amq-0.49.0-assessment.md">v0.49.0 leverage
+assessment</a>.</p>
+<p>AMQ 0.42.1 historically introduced the complete injected identity
+contract; 0.49.0 is now the supported floor. After upgrading AMQ, stop
+and resume/relaunch agents so their parent shells refresh the complete
 identity tuple; a child command cannot repair stale parent environment
 variables. Default-profile sessions use <code>AM_ROOT</code>,
 <code>AM_BASE_ROOT</code>, non-empty <code>AM_SESSION</code>, and

--- a/README.html
+++ b/README.html
@@ -1324,10 +1324,11 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices
-validate pinned v0.49.0 and latest; latest remains only a canary for any
-unexpected post-final release. Older AMQ versions are rejected
-fail-closed.</p>
+<p>AMQ 0.49.x is the supported series, with 0.49.0 as the minimum
+supported release and compatibility tested through 0.49.1. Both real-AMQ
+matrices validate pinned v0.49.0, pinned v0.49.1, and
+<code>latest</code>; <code>latest</code> remains a forward-compatibility
+canary. Releases older than 0.49.0 are rejected fail-closed.</p>
 <table>
 <thead>
 <tr>
@@ -1340,21 +1341,33 @@ fail-closed.</p>
 <tr>
 <td>Queue, routing, receipts, doctor, lifecycle</td>
 <td>Ubuntu</td>
-<td><code>v0.49.0</code>, <code>latest</code></td>
+<td><code>v0.49.0</code>, <code>v0.49.1</code>, <code>latest</code></td>
 </tr>
 <tr>
 <td>Native real-PTY wake and teardown</td>
 <td>macOS</td>
-<td><code>v0.49.0</code>, <code>latest</code></td>
+<td><code>v0.49.0</code>, <code>v0.49.1</code>, <code>latest</code></td>
 </tr>
 </tbody>
 </table>
 <p>AMQ 0.47.1 introduced the supervised <code>coop exec</code> wake
-contract now required by the 0.49.0 floor: instead of injecting message
-headers or subjects, it submits the fixed, shell-inert doorbell
+contract used by every supported release: instead of injecting message
+headers or subjects, managed coop wakes submit the fixed, shell-inert
+doorbell
 <code>: AMQ doorbell run amq drain --include-body then act on it</code>.
-Agents must drain the durable mailbox to discover the sender, subject,
-and body. No legacy subject-injection branch remains.</p>
+AMQ 0.49.1 extended that fixed doorbell to standalone/default wake
+injection; 0.49.0 standalone wakes still emit the post-baseline subject.
+The compatibility lane pins that historical boundary while all managed
+coop lanes require the fixed doorbell. Agents must drain the durable
+mailbox to discover the sender, subject, and body.</p>
+<p>AMQ 0.49.1 also hardens wake delivery without changing amq-squad
+production branches: transient foreground-process-group handoffs retry
+pending notices, active input through max hold demotes to out-of-band
+output, quiet detection requires consecutive samples, and periodic
+capability checks report only what they can prove. Its optional Claude
+Stop hook guards by fresh message content and recovers incomplete
+session context; amq-squad does not install or invoke that upstream
+hook.</p>
 <p>On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the
 kernel disables it, wake degrades to a non-input notifier and records
 <code>injector_unsupported</code> diagnostics instead of pretending
@@ -1377,17 +1390,17 @@ which joins current message, route, delivery, DLQ, receipt, and thread
 evidence. It is useful for diagnostics, but it does not prove historical
 directory-sync or notification success and therefore is not retry or
 authorization authority for amq-squad evidence/receipt flows. See the <a
-href="docs/amq-0.49.0-assessment.md">v0.49.0 leverage
+href="docs/amq-0.49.x-assessment.md">AMQ 0.49.x support
 assessment</a>.</p>
 <p>AMQ 0.42.1 historically introduced the complete injected identity
-contract; 0.49.0 is now the supported floor. After upgrading AMQ, stop
-and resume/relaunch agents so their parent shells refresh the complete
-identity tuple; a child command cannot repair stale parent environment
-variables. Default-profile sessions use <code>AM_ROOT</code>,
-<code>AM_BASE_ROOT</code>, non-empty <code>AM_SESSION</code>, and
-<code>AM_ME</code>. Named profiles use their exact root with
-<code>AM_ROOT=AM_BASE_ROOT</code> and no <code>AM_SESSION</code>. Run
-<code>amq-squad doctor</code> before resuming if it reports a legacy or
-inconsistent pin.</p>
+contract; 0.49.0 is the supported floor for the 0.49.x series. After
+upgrading AMQ, stop and resume/relaunch agents so their parent shells
+refresh the complete identity tuple; a child command cannot repair stale
+parent environment variables. Default-profile sessions use
+<code>AM_ROOT</code>, <code>AM_BASE_ROOT</code>, non-empty
+<code>AM_SESSION</code>, and <code>AM_ME</code>. Named profiles use
+their exact root with <code>AM_ROOT=AM_BASE_ROOT</code> and no
+<code>AM_SESSION</code>. Run <code>amq-squad doctor</code> before
+resuming if it reports a legacy or inconsistent pin.</p>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -821,21 +821,34 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices validate pinned
-v0.49.0 and latest; latest remains only a canary for any unexpected post-final
-release. Older AMQ versions are rejected fail-closed.
+AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported release
+and compatibility tested through 0.49.1. Both real-AMQ matrices validate pinned
+v0.49.0, pinned v0.49.1, and `latest`; `latest` remains a
+forward-compatibility canary. Releases older than 0.49.0 are rejected
+fail-closed.
 
 | Real-AMQ lane | Runner | Versions |
 | --- | --- | --- |
-| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.49.0`, `latest` |
-| Native real-PTY wake and teardown | macOS | `v0.49.0`, `latest` |
+| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.49.0`, `v0.49.1`, `latest` |
+| Native real-PTY wake and teardown | macOS | `v0.49.0`, `v0.49.1`, `latest` |
 
-AMQ 0.47.1 introduced the supervised `coop exec` wake contract now required by
-the 0.49.0 floor: instead of
-injecting message headers or subjects, it submits the fixed, shell-inert
-doorbell `: AMQ doorbell run amq drain --include-body then act on it`. Agents
-must drain the durable mailbox to discover the sender, subject, and body. No
-legacy subject-injection branch remains.
+AMQ 0.47.1 introduced the supervised `coop exec` wake contract used by every
+supported release: instead of injecting message headers or subjects, managed
+coop wakes submit the fixed, shell-inert doorbell
+`: AMQ doorbell run amq drain --include-body then act on it`. AMQ 0.49.1
+extended that fixed doorbell to standalone/default wake injection; 0.49.0
+standalone wakes still emit the post-baseline subject. The compatibility lane
+pins that historical boundary while all managed coop lanes require the fixed
+doorbell. Agents must drain the durable mailbox to discover the sender,
+subject, and body.
+
+AMQ 0.49.1 also hardens wake delivery without changing amq-squad production
+branches: transient foreground-process-group handoffs retry pending notices,
+active input through max hold demotes to out-of-band output, quiet detection
+requires consecutive samples, and periodic capability checks report only what
+they can prove. Its optional Claude Stop hook guards by fresh message content
+and recovers incomplete session context; amq-squad does not install or invoke
+that upstream hook.
 
 On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the kernel
 disables it, wake degrades to a non-input notifier and records
@@ -858,10 +871,10 @@ which joins current message, route, delivery, DLQ, receipt, and thread evidence.
 It is useful for diagnostics, but it does not prove historical directory-sync
 or notification success and therefore is not retry or authorization authority
 for amq-squad evidence/receipt flows. See the
-[v0.49.0 leverage assessment](docs/amq-0.49.0-assessment.md).
+[AMQ 0.49.x support assessment](docs/amq-0.49.x-assessment.md).
 
 AMQ 0.42.1 historically introduced the complete injected identity contract;
-0.49.0 is now the supported floor. After upgrading AMQ, stop and
+0.49.0 is the supported floor for the 0.49.x series. After upgrading AMQ, stop and
 resume/relaunch agents so their parent shells refresh the complete identity
 tuple; a child command cannot repair stale parent environment variables.
 Default-profile sessions use

--- a/README.md
+++ b/README.md
@@ -811,7 +811,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.42.1+ on `PATH`
+- `amq` 0.49.0 on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend
@@ -821,17 +821,21 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-The minimum 0.42.1 compatibility floor is unchanged. General compatibility is
-explicitly validated against 0.42.1, 0.43.1, 0.45.0, 0.47.2, and 0.48.0;
-`latest` remains a moving forward-compatibility canary. The required macOS
-real-PTY wake matrix pins the same releases except for `latest`.
+AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices validate pinned
+v0.49.0 and latest; latest remains only a canary for any unexpected post-final
+release. Older AMQ versions are rejected fail-closed.
 
-AMQ 0.47.1 changed supervised `coop exec` wake input deliberately: instead of
+| Real-AMQ lane | Runner | Versions |
+| --- | --- | --- |
+| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.49.0`, `latest` |
+| Native real-PTY wake and teardown | macOS | `v0.49.0`, `latest` |
+
+AMQ 0.47.1 introduced the supervised `coop exec` wake contract now required by
+the 0.49.0 floor: instead of
 injecting message headers or subjects, it submits the fixed, shell-inert
 doorbell `: AMQ doorbell run amq drain --include-body then act on it`. Agents
-must drain the durable mailbox to discover the sender, subject, and body.
-AMQ 0.47.2 is the pinned 0.47 representative because it also keeps terminal
-authority stable during TTY activity.
+must drain the durable mailbox to discover the sender, subject, and body. No
+legacy subject-injection branch remains.
 
 On Linux, AMQ 0.48.0 probes the legacy TIOCSTI capability. When the kernel
 disables it, wake degrades to a non-input notifier and records
@@ -840,17 +844,27 @@ delivered. The macOS real-PTY lane proves native injection where TIOCSTI is
 available; AMQ's upstream tests own the Linux-only
 `/proc/sys/dev/tty/legacy_tiocsti=0` fallback.
 
-AMQ 0.48.0 can also inspect malformed configured mailbox layouts with
+AMQ can inspect malformed configured mailbox layouts with
 `amq doctor --json` and create only missing safe directories with
 `amq doctor --fix-mailboxes --json`. Repair is explicit and fail-closed:
 existing messages are not moved, overwritten, or deleted, discovered-only
-mailboxes are not repair eligible, and unsafe filesystem state is refused.
-amq-squad never runs this mutating repair automatically.
+mailboxes are not repair eligible, and unsafe filesystem state is refused. AMQ
+0.49.0 adds actionable remedies for discovered-only mailboxes. `amq-squad
+doctor` keeps its read-only ops check and never runs mutating repair
+automatically; use upstream `amq doctor --json` for the canonical remedy text.
 
-v2.20.0 requires AMQ 0.42.1+, the first supported release for the complete
-injected identity contract. After upgrading AMQ, stop and resume/relaunch agents
-so their parent shells refresh the complete identity tuple; a child command
-cannot repair stale parent environment variables. Default-profile sessions use
+AMQ 0.49.0 also adds read-only `amq trace <message-id> --root <path> --json`,
+which joins current message, route, delivery, DLQ, receipt, and thread evidence.
+It is useful for diagnostics, but it does not prove historical directory-sync
+or notification success and therefore is not retry or authorization authority
+for amq-squad evidence/receipt flows. See the
+[v0.49.0 leverage assessment](docs/amq-0.49.0-assessment.md).
+
+AMQ 0.42.1 historically introduced the complete injected identity contract;
+0.49.0 is now the supported floor. After upgrading AMQ, stop and
+resume/relaunch agents so their parent shells refresh the complete identity
+tuple; a child command cannot repair stale parent environment variables.
+Default-profile sessions use
 `AM_ROOT`, `AM_BASE_ROOT`, non-empty `AM_SESSION`, and `AM_ME`. Named profiles
 use their exact root with `AM_ROOT=AM_BASE_ROOT` and no `AM_SESSION`. Run
 `amq-squad doctor` before

--- a/docs/amq-0.49.0-assessment.md
+++ b/docs/amq-0.49.0-assessment.md
@@ -1,0 +1,75 @@
+# AMQ 0.49.0 sole-support and leverage assessment
+
+AMQ 0.49.0 is the sole supported release for amq-squad. Both real-AMQ CI
+matrices run pinned `v0.49.0` plus `latest`; `latest` is only a canary for an
+unexpected post-final release. Older AMQ versions fail the doctor and
+compatibility admission checks.
+
+Historical capability boundaries remain named in code for archaeology:
+
+| Capability | First AMQ release |
+| --- | --- |
+| Complete injected identity tuple | 0.42.1 |
+| Reply refs | 0.43.1 |
+| Exact wake retirement | 0.45.0 |
+| Owner-bound coop wake lifecycle | 0.47.0 |
+| Fixed shell-inert `coop exec` doorbell | 0.47.1 |
+| Configured-mailbox repair | 0.48.0 |
+
+They are not compatibility lanes or reasons to preserve below-floor branches.
+
+## Message trace
+
+AMQ 0.49.0 adds `amq trace <message-id> --root <path> --json`, a read-only join
+over evidence already present in one queue root. It can correlate current
+message copies, persisted addressing, DLQ entries, receipts, and thread refs.
+
+Decision: use trace as an operator diagnostic, but do not consume it as
+authoritative input to amq-squad's immutable command-evidence, delivery-receipt,
+claim-once, retry, or gate decisions.
+
+The upstream `amq/trace/v1` contract explicitly does not prove the original
+directory-sync result from current file presence and reports notification
+history as `no_evidence` until a durable notification-attempt ledger exists.
+Those limits match amq-squad's committed-indeterminate and do-not-resend
+boundaries. Treating trace as stronger authority would weaken them.
+
+No local follow-up is filed for Phase A. Re-evaluate integration only when
+upstream trace gains durable notification-attempt evidence or another new
+artifact that can strengthen, rather than project, amq-squad's existing
+receipts.
+
+## Doctor discovered-mailbox remedies
+
+AMQ 0.49.0 adds actionable remedy text for discovered-only malformed mailboxes:
+register a valid handle and run explicit repair, or preserve messages and remove
+an abandoned mailbox. Invalid entries receive a preserve-then-rename/remove
+remedy.
+
+Decision: keep ownership in upstream AMQ. `amq-squad doctor` continues to run
+the read-only `amq doctor --ops --json` health check and does not duplicate
+mailbox-inventory parsing or invoke `--fix-mailboxes`. Operators use `amq doctor
+--json` for canonical remedy text and opt into `amq doctor --fix-mailboxes
+--json` themselves. This preserves the v0.48 contract that repair is explicit,
+non-destructive, and fail-closed.
+
+No follow-up is required: the missing operator guidance was fixed upstream and
+the amq-squad README now routes directly to it.
+
+## Wake retirement
+
+The pre-0.47 fixture workaround that ignored `wake retire` refusal is removed.
+AMQ 0.49.0's `coop exec --wake-inject-via` helper is owner-bound: the coop
+member now releases that exact wake through `wake recover-owner`, authenticated
+by the inherited `AMQ_WAKE_OWNER` token and matching OS session. The fixture
+asserts prompt exit and absence of the claim. The ownerless `wake retire` path
+correctly refuses this owner-bound state; when the owner is already dead,
+`recover-owner` remains the explicit fail-closed recovery path and does not
+require a live-owner token.
+
+For amq-squad-managed ownerless inject-via wakes, exact `wake retire` remains
+the required shutdown contract whenever a launch record has persisted injector
+identity. Refusal fails closed and never falls back to generic process
+signaling. Raw wakes or historical records without inject-via identity retain
+the bounded exact-PID signal path because AMQ cannot address those wakes by
+injector identity.

--- a/docs/amq-0.49.x-assessment.md
+++ b/docs/amq-0.49.x-assessment.md
@@ -1,9 +1,10 @@
-# AMQ 0.49.0 sole-support and leverage assessment
+# AMQ 0.49.x support and leverage assessment
 
-AMQ 0.49.0 is the sole supported release for amq-squad. Both real-AMQ CI
-matrices run pinned `v0.49.0` plus `latest`; `latest` is only a canary for an
-unexpected post-final release. Older AMQ versions fail the doctor and
-compatibility admission checks.
+AMQ 0.49.x is the supported series for amq-squad. The minimum supported release
+is 0.49.0 and compatibility is tested through 0.49.1. Both real-AMQ CI matrices
+run pinned `v0.49.0`, pinned `v0.49.1`, and `latest`; `latest` remains a
+forward-compatibility canary. Older AMQ versions fail both doctor diagnostics
+and launch admission before launch-record or process side effects.
 
 Historical capability boundaries remain named in code for archaeology:
 
@@ -15,6 +16,7 @@ Historical capability boundaries remain named in code for archaeology:
 | Owner-bound coop wake lifecycle | 0.47.0 |
 | Fixed shell-inert `coop exec` doorbell | 0.47.1 |
 | Configured-mailbox repair | 0.48.0 |
+| Fixed shell-inert standalone/default wake doorbell | 0.49.1 |
 
 They are not compatibility lanes or reasons to preserve below-floor branches.
 
@@ -56,10 +58,10 @@ non-destructive, and fail-closed.
 No follow-up is required: the missing operator guidance was fixed upstream and
 the amq-squad README now routes directly to it.
 
-## Wake retirement
+## Wake delivery and retirement
 
 The pre-0.47 fixture workaround that ignored `wake retire` refusal is removed.
-AMQ 0.49.0's `coop exec --wake-inject-via` helper is owner-bound: the coop
+Supported AMQ `coop exec --wake-inject-via` helpers are owner-bound: the coop
 member now releases that exact wake through `wake recover-owner`, authenticated
 by the inherited `AMQ_WAKE_OWNER` token and matching OS session. The fixture
 asserts prompt exit and absence of the claim. The ownerless `wake retire` path
@@ -67,9 +69,36 @@ correctly refuses this owner-bound state; when the owner is already dead,
 `recover-owner` remains the explicit fail-closed recovery path and does not
 require a live-owner token.
 
-For amq-squad-managed ownerless inject-via wakes, exact `wake retire` remains
-the required shutdown contract whenever a launch record has persisted injector
-identity. Refusal fails closed and never falls back to generic process
-signaling. Raw wakes or historical records without inject-via identity retain
-the bounded exact-PID signal path because AMQ cannot address those wakes by
-injector identity.
+Production cleanup applies the same three-way boundary. A persisted inject-via
+wake first receives structured `wake recover-owner --json` handling:
+owner-bound claims recover exactly after the signaled owner exits, while the
+exact structured ownerless refusal routes to `wake retire`. Unknown, corrupt,
+or mismatched results fail closed and preserve evidence. Raw wakes or
+historical records without inject-via identity retain the bounded exact-PID
+signal path because AMQ cannot address those wakes by injector identity.
+
+The fixed doorbell has two historical boundaries inside the supported series.
+Managed `coop exec` wakes use it in both 0.49.0 and 0.49.1 because that contract
+started in 0.47.1. Standalone/default wakes carry subject text in 0.49.0 and
+switch to the fixed shell-inert doorbell in 0.49.1. The version-aware
+compatibility fixture proves zero injection before the post-baseline resend and
+exactly one version-correct injection afterward; the final drain proves both
+messages remained durable.
+
+AMQ 0.49.1 adds transparent hardening around that contract: held notifications
+retry after transient foreground-process-group handoff, max-hold delivery
+demotes to out-of-band output, quiet detection requires consecutive samples,
+and periodic capability checks report only verified preconditions. None
+requires an amq-squad production version branch.
+
+## Optional Stop-hook hardening
+
+AMQ 0.49.1's optional Claude Stop hook blocks once per fresh message content,
+persists a bounded atomic 0600 guard without draining mail, resolves root and
+session through `amq env`, and recovers an incomplete ambient session pin.
+Configured-context and mailbox failures emit a visible `systemMessage`.
+
+amq-squad does not install or invoke this upstream hook; its `stop` and `resume`
+verbs manage agent processes and launch records directly. The upstream change
+is additive hardening for operators who separately enable the Claude hook and
+does not add an amq-squad production branch.

--- a/docs/amq-0.49.x-assessment.md
+++ b/docs/amq-0.49.x-assessment.md
@@ -3,8 +3,11 @@
 AMQ 0.49.x is the supported series for amq-squad. The minimum supported release
 is 0.49.0 and compatibility is tested through 0.49.1. Both real-AMQ CI matrices
 run pinned `v0.49.0`, pinned `v0.49.1`, and `latest`; `latest` remains a
-forward-compatibility canary. Older AMQ versions fail both doctor diagnostics
-and launch admission before launch-record or process side effects.
+forward-compatibility canary. Older AMQ versions fail doctor diagnostics and
+the child `agent up` gate before launch-record or process side effects. Parent
+team launch, `resume --exec`, and `up --reset` also validate every selected
+member's resolved AMQ version before creating roots, briefs, watchers, or
+panes, and before deleting an existing session.
 
 Historical capability boundaries remain named in code for archaeology:
 
@@ -90,6 +93,15 @@ retry after transient foreground-process-group handoff, max-hold delivery
 demotes to out-of-band output, quiet detection requires consecutive samples,
 and periodic capability checks report only verified preconditions. None
 requires an amq-squad production version branch.
+
+The `latest` lanes in CI run `30248307062` resolved AMQ `v0.49.2` and passed
+both the queue-compatibility and wake-compatibility suites, including exact
+inject-via retirement and structured owner-bound cleanup. Upstream `v0.49.2`
+changes `coop exec -y` startup reclamation and unverified/live raw-orphan
+handling, not the structured `recover-owner` contract consumed here; the
+`wake_owner_recover_unix.go` blob is identical to `v0.49.1`
+(`fe6444fafa8a4e7ac3bec2962483923a7d7075e0`). This is forward-canary evidence,
+not an expansion of the compatibility-tested-through boundary.
 
 ## Optional Stop-hook hardening
 

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -19,12 +19,12 @@ verbs are the source of truth.
   with the default `--visibility sibling-tabs` or `--visibility current`).
   Hidden spawns (`run start --visibility detached --go`) do not require a
   visible pane.
-- `amq-squad` + `amq` on `PATH`; AMQ floor is **0.42.1**. The minimum 0.42.1
-  compatibility floor is unchanged. This release is explicitly validated
-  against pinned 0.45.0; latest remains a forward-compatibility canary. After
-  upgrading AMQ, stop and resume/relaunch agents so the parent shell refreshes
-  the complete AMQ identity tuple; a child command cannot repair stale injected
-  environment.
+- `amq-squad` + `amq` on `PATH`; AMQ **0.49.0 is the sole supported release**.
+  Both real-AMQ matrices validate pinned v0.49.0 and latest; latest remains only
+  a canary for any unexpected post-final release. Older AMQ versions are
+  rejected fail-closed; upgrade to v0.49.0 and stop/resume agents so the parent
+  shell refreshes the complete AMQ identity tuple. A child command cannot repair
+  stale injected environment.
   `amq-squad doctor` reports legacy/inconsistent pins and version skew
   (children inherit the `amq-squad` on `PATH`).
 - In the verified live-lead conversation, invoke **`amq-squad:orchestrator`**. The old `amq-squad-orchestrator` name is a compatibility redirect only.

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -19,12 +19,13 @@ verbs are the source of truth.
   with the default `--visibility sibling-tabs` or `--visibility current`).
   Hidden spawns (`run start --visibility detached --go`) do not require a
   visible pane.
-- `amq-squad` + `amq` on `PATH`; AMQ **0.49.0 is the sole supported release**.
-  Both real-AMQ matrices validate pinned v0.49.0 and latest; latest remains only
-  a canary for any unexpected post-final release. Older AMQ versions are
-  rejected fail-closed; upgrade to v0.49.0 and stop/resume agents so the parent
-  shell refreshes the complete AMQ identity tuple. A child command cannot repair
-  stale injected environment.
+- `amq-squad` + `amq` on `PATH`; AMQ **0.49.x is the supported series**, with
+  0.49.0 as the minimum supported release and compatibility tested through
+  0.49.1. Both real-AMQ matrices validate pinned v0.49.0, pinned v0.49.1, and
+  `latest`; `latest` remains a forward-compatibility canary. Releases older
+  than 0.49.0 are rejected fail-closed; upgrade to v0.49.0 or newer and
+  stop/resume agents so the parent shell refreshes the complete AMQ identity
+  tuple. A child command cannot repair stale injected environment.
   `amq-squad doctor` reports legacy/inconsistent pins and version skew
   (children inherit the `amq-squad` on `PATH`).
 - In the verified live-lead conversation, invoke **`amq-squad:orchestrator`**. The old `amq-squad-orchestrator` name is a compatibility redirect only.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -728,13 +728,12 @@ version skew.</p>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. AMQ floor (v2.20.0+): amq-squad
-requires amq 0.42.1+. AMQ 0.42.1 is the first supported complete
-identity-pin contract. The minimum 0.42.1 compatibility floor is
-unchanged. This release is explicitly validated against pinned 0.45.0;
-latest remains a forward-compatibility canary. After upgrading AMQ, stop
-and resume/relaunch agents so their parent shells refresh the complete
-identity tuple; a child command cannot repair stale injected
+<code>--settings</code> file is missing. AMQ 0.49.0 is the sole
+supported release. Both real-AMQ matrices validate pinned v0.49.0 and
+latest; latest remains only a canary for any unexpected post-final
+release. Older AMQ versions are rejected fail-closed; upgrade to v0.49.0
+and stop/resume agents so their parent shells refresh the complete
+identity tuple. A child command cannot repair stale injected
 environment. Default profiles use
 <code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty
 <code>AM_SESSION</code>; named profiles use an exact root with

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -728,13 +728,14 @@ version skew.</p>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. AMQ 0.49.0 is the sole
-supported release. Both real-AMQ matrices validate pinned v0.49.0 and
-latest; latest remains only a canary for any unexpected post-final
-release. Older AMQ versions are rejected fail-closed; upgrade to v0.49.0
-and stop/resume agents so their parent shells refresh the complete
-identity tuple. A child command cannot repair stale injected
-environment. Default profiles use
+<code>--settings</code> file is missing. AMQ 0.49.x is the supported
+series, with 0.49.0 as the minimum supported release and compatibility
+tested through 0.49.1. Both real-AMQ matrices validate pinned v0.49.0,
+pinned v0.49.1, and <code>latest</code>; <code>latest</code> remains a
+forward-compatibility canary. Releases older than 0.49.0 are rejected
+fail-closed; upgrade to v0.49.0 or newer and stop/resume agents so their
+parent shells refresh the complete identity tuple. A child command
+cannot repair stale injected environment. Default profiles use
 <code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty
 <code>AM_SESSION</code>; named profiles use an exact root with
 <code>AM_ROOT=AM_BASE_ROOT</code> and omit <code>AM_SESSION</code>. Run

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -267,12 +267,12 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ floor (v2.20.0+): amq-squad requires amq 0.42.1+. AMQ 0.42.1 is
-the first supported complete identity-pin contract. The minimum 0.42.1
-compatibility floor is unchanged. This release is explicitly validated against
-pinned 0.45.0; latest remains a forward-compatibility canary. After upgrading
-AMQ, stop and resume/relaunch agents so their parent shells refresh the complete
-identity tuple; a child command cannot repair stale injected environment.
+missing. AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices
+validate pinned v0.49.0 and latest; latest remains only a canary for any
+unexpected post-final release. Older AMQ versions are rejected fail-closed;
+upgrade to v0.49.0 and stop/resume agents so their parent shells refresh the
+complete identity tuple. A child command cannot repair stale injected
+environment.
 Default profiles use `AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty
 `AM_SESSION`; named profiles use an exact root with `AM_ROOT=AM_BASE_ROOT` and
 omit `AM_SESSION`. Run

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -267,12 +267,13 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ 0.49.0 is the sole supported release. Both real-AMQ matrices
-validate pinned v0.49.0 and latest; latest remains only a canary for any
-unexpected post-final release. Older AMQ versions are rejected fail-closed;
-upgrade to v0.49.0 and stop/resume agents so their parent shells refresh the
-complete identity tuple. A child command cannot repair stale injected
-environment.
+missing. AMQ 0.49.x is the supported series, with 0.49.0 as the minimum
+supported release and compatibility tested through 0.49.1. Both real-AMQ
+matrices validate pinned v0.49.0, pinned v0.49.1, and `latest`; `latest`
+remains a forward-compatibility canary. Releases older than 0.49.0 are rejected
+fail-closed; upgrade to v0.49.0 or newer and stop/resume agents so their parent
+shells refresh the complete identity tuple. A child command cannot repair stale
+injected environment.
 Default profiles use `AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty
 `AM_SESSION`; named profiles use an exact root with `AM_ROOT=AM_BASE_ROOT` and
 omit `AM_SESSION`. Run

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -118,12 +118,13 @@ const minBaselineExistingAMQVersion = "0.46.0"
 // They document when persisted contracts first became available without
 // preserving pre-floor compatibility code.
 const (
-	historicalCompleteIdentityAMQVersion    = "0.42.1"
-	historicalReplyRefsAMQVersion           = "0.43.1"
-	historicalWakeRetireAMQVersion          = "0.45.0"
-	historicalOwnerBoundWakeAMQVersion      = "0.47.0"
-	historicalCoopWakeDoorbellAMQVersion    = "0.47.1"
-	historicalDoctorMailboxRepairAMQVersion = "0.48.0"
+	historicalCompleteIdentityAMQVersion       = "0.42.1"
+	historicalReplyRefsAMQVersion              = "0.43.1"
+	historicalWakeRetireAMQVersion             = "0.45.0"
+	historicalOwnerBoundWakeAMQVersion         = "0.47.0"
+	historicalCoopWakeDoorbellAMQVersion       = "0.47.1"
+	historicalDoctorMailboxRepairAMQVersion    = "0.48.0"
+	historicalStandaloneWakeDoorbellAMQVersion = "0.49.1"
 )
 
 // amqSupportsRequireWake reports whether the amq version string from `amq env`

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -113,6 +113,19 @@ const minNoGitignoreAMQVersion = "0.40.0"
 // register-orchestrator invoke wake directly and must opt in.
 const minBaselineExistingAMQVersion = "0.46.0"
 
+// Historical AMQ capability boundaries remain named for archaeology even
+// though the supported 0.49.0 floor makes their below-boundary branches dead.
+// They document when persisted contracts first became available without
+// preserving pre-floor compatibility code.
+const (
+	historicalCompleteIdentityAMQVersion    = "0.42.1"
+	historicalReplyRefsAMQVersion           = "0.43.1"
+	historicalWakeRetireAMQVersion          = "0.45.0"
+	historicalOwnerBoundWakeAMQVersion      = "0.47.0"
+	historicalCoopWakeDoorbellAMQVersion    = "0.47.1"
+	historicalDoctorMailboxRepairAMQVersion = "0.48.0"
+)
+
 // amqSupportsRequireWake reports whether the amq version string from `amq env`
 // is new enough for `coop exec --require-wake`. Empty or unparseable versions
 // return false: passing an unknown flag to an old amq would fail every

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -68,12 +68,21 @@ func resolveAMQEnvForTeamLaunchProfile(cwd, profile, session, handle string) (am
 		return amqEnv{}, err
 	}
 	root := squadnamespace.AMQRoot(cwd, team.DefaultProfile, session)
+	// The fallback root is deterministic, but the failed sessionful lookup did
+	// not yield the AMQ version needed by parent-side launch admission. Probe
+	// the exact root without a session selector: `amq env` remains read-only,
+	// while every live launch path can fail closed before creating the root.
+	versionEnv, versionErr := resolveAMQEnvInDir(cwd, root, "", handle)
+	if versionErr != nil {
+		return amqEnv{}, fmt.Errorf("resolve amq version for fresh project root: %w", versionErr)
+	}
 	return amqEnv{
 		Root:        root,
 		BaseRoot:    filepath.Dir(root),
 		SessionName: strings.TrimSpace(session),
 		Me:          strings.TrimSpace(handle),
 		RootSource:  "fresh_project_default",
+		AMQVersion:  versionEnv.AMQVersion,
 	}, nil
 }
 

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -96,7 +96,7 @@ if [ "$1" = "env" ]; then
     echo "unexpected cwd: $actual" >&2
     exit 17
   fi
-  printf '{"root":"%s","amq_version":"0.42.1"}\n' "$AMQ_FAKE_ROOT"
+  printf '{"root":"%s","amq_version":"0.49.0"}\n' "$AMQ_FAKE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2
@@ -262,7 +262,7 @@ if [ "$1" = "env" ]; then
     echo "session should not be passed to amq env when named-profile root is explicit: $saw_session" >&2
     exit 18
   fi
-  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.38.0"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
+  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.49.0"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -27,7 +27,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.42.1"
+const doctorMinAMQVersion = "0.49.0"
 
 type doctorStatus string
 
@@ -86,8 +86,8 @@ type doctorExecution struct {
 	// check can be driven deterministically in tests). Defaults to os.Getenv.
 	Getenv func(name string) string
 	// LookupEnv preserves the distinction between an absent value and an
-	// explicitly empty AM_SESSION. AMQ 0.42.1+ treats that difference as part of
-	// the injected identity contract.
+	// explicitly empty AM_SESSION. AMQ 0.42.1 introduced that distinction as
+	// part of the injected identity contract; 0.49.0 is the supported floor.
 	LookupEnv func(name string) (string, bool)
 	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
 	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
@@ -1052,7 +1052,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy exact-root/sessionless pin (AM_ROOT=AM_BASE_ROOT; AM_SESSION omitted; AM_ME set)"}
 		}
 		if sessionOK && session == "" {
-			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.42.1+; a child command cannot repair its parent shell"}
+			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.49.0; a child command cannot repair its parent shell"}
 		}
 		if session != "" && sameResolvedDir(root, filepath.Join(base, session)) {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy sessionful pin (AM_ROOT=AM_BASE_ROOT/AM_SESSION; AM_ME set)"}
@@ -1069,7 +1069,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 	return doctorCheck{
 		Name:   "amq identity pin",
 		Status: doctorWarn,
-		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.42.1+; a child command cannot repair its parent shell",
+		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.49.0; a child command cannot repair its parent shell",
 	}
 }
 
@@ -1598,8 +1598,8 @@ func parseSemverParts(s string) ([3]int, bool) {
 
 // semverMeetsStableFloor compares a possibly-prerelease version against a
 // stable minimum. A prerelease with the same core is older than the stable
-// release (0.42.1-rc1 < 0.42.1), while a prerelease with a higher core remains
-// newer (0.42.2-rc1 > 0.42.1).
+// release (0.49.0-rc1 < 0.49.0), while a prerelease with a higher core remains
+// newer (0.49.1-rc1 > 0.49.0).
 func semverMeetsStableFloor(version, minimum string) bool {
 	got, ok := parseSemverParts(strings.TrimSpace(version))
 	if !ok {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -270,7 +270,7 @@ func newDoctorExec(t *testing.T, dir string) doctorExecution {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.42.1", Root: filepath.Join(dir, ".agent-mail")}, nil
+			return amqEnv{AMQVersion: doctorMinAMQVersion, Root: filepath.Join(dir, ".agent-mail")}, nil
 		},
 		RunAMQOps: func(string, amqEnv) ([]byte, error) {
 			return []byte(`{"status":"ok"}`), nil
@@ -426,7 +426,7 @@ func TestExecuteDoctorAMQVersionTooOld(t *testing.T) {
 	if got == nil || got.Status != doctorFail {
 		t.Fatalf("amq version check = %+v, want fail", got)
 	}
-	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, "0.42.1") {
+	if !strings.Contains(got.Detail, "0.38.0") || !strings.Contains(got.Detail, doctorMinAMQVersion) {
 		t.Errorf("detail should name the bad version: %q", got.Detail)
 	}
 	if !strings.Contains(got.Detail, "amq upgrade") {
@@ -447,13 +447,13 @@ if [ -n "$AM_ROOT_ID$AM_BASE_ROOT_ID" ]; then
   echo "inherited AMQ root identity metadata leaked" >&2
   exit 92
 fi
-printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.42.1"}'
+printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.49.0"}'
 `)
 
 	d := defaultDoctorExecution(t.TempDir())
 	check := doctorCheckAMQVersion(d)
-	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.42.1") {
-		t.Fatalf("doctor amq version check = %+v, want ok 0.42.1", check)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.49.0") {
+		t.Fatalf("doctor amq version check = %+v, want ok 0.49.0", check)
 	}
 	if got := os.Getenv("AMQ_NO_UPDATE_CHECK"); got != "0" {
 		t.Fatalf("parent AMQ_NO_UPDATE_CHECK = %q, want unchanged 0", got)
@@ -509,9 +509,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts0421AndNewer(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0490AndNewerCanary(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.42.1", "v0.42.2-rc1", "0.43.1", "1.0.0+build42"} {
+	for _, v := range []string{"0.49.0", "v0.49.1-rc1", "0.50.0", "1.0.0+build49"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -529,8 +529,8 @@ func TestExecuteDoctorAMQVersionAccepts0421AndNewer(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionRejectsOlderThan0421(t *testing.T) {
-	for _, version := range []string{"0.41.9", "0.42.0", "0.42.1-rc1"} {
+func TestExecuteDoctorAMQVersionRejectsOlderThan0490(t *testing.T) {
+	for _, version := range []string{"0.42.1", "0.47.2", "0.48.0", "0.49.0-rc1"} {
 		t.Run(version, func(t *testing.T) {
 			dir := t.TempDir()
 			d := newDoctorExec(t, dir)
@@ -540,10 +540,10 @@ func TestExecuteDoctorAMQVersionRejectsOlderThan0421(t *testing.T) {
 			var buf bytes.Buffer
 			d.Out = &buf
 			if err := executeDoctor(d); err == nil {
-				t.Fatalf("doctor should fail when amq %s is below the 0.42.1 floor", version)
+				t.Fatalf("doctor should fail when amq %s is below the 0.49.0 floor", version)
 			}
 			amqLine := firstLineWith(buf.String(), "amq version")
-			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.42.1") {
+			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.49.0") {
 				t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 			}
 			if !strings.Contains(amqLine, "amq upgrade") {
@@ -1049,7 +1049,7 @@ func TestExecuteDoctorWakeReuseClassifyMemberStatus(t *testing.T) {
 		ProjectDir: dir,
 		Out:        &bytes.Buffer{},
 		ResolveAMQEnv: func(string) (amqEnv, error) {
-			return amqEnv{AMQVersion: "0.42.1", Root: filepath.Join(base, "issue-96")}, nil
+			return amqEnv{AMQVersion: doctorMinAMQVersion, Root: filepath.Join(base, "issue-96")}, nil
 		},
 		LookPath: func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe: duplicateLaunchProbe{
@@ -1092,7 +1092,7 @@ func TestExecuteDoctorWakeHandlesAMQEnvErrorPerMember(t *testing.T) {
 	d := doctorExecution{
 		ProjectDir:    dir,
 		Out:           &bytes.Buffer{},
-		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: "0.42.1"}, nil },
+		ResolveAMQEnv: func(string) (amqEnv, error) { return amqEnv{AMQVersion: doctorMinAMQVersion}, nil },
 		LookPath:      func(string) (string, error) { return "/usr/bin/tmux", nil },
 		Probe:         defaultDuplicateLaunchProbe,
 	}

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -670,7 +670,7 @@ func (r reapResult) any() bool {
 }
 
 func (r reapResult) failed() bool {
-	return r.WakeSignalFailed > 0 || r.WakeRetirement == "amq_0_45_exact_refused" || r.WakeRetirement == "amq_0_45_exact_lock_remaining"
+	return r.WakeSignalFailed > 0 || r.WakeRetirement == "amq_exact_refused" || r.WakeRetirement == "amq_exact_lock_remaining"
 }
 
 func (r reapResult) summary() string {
@@ -715,10 +715,10 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 	lockPath := wakeLockPath(agentDir)
 	lockData, lockErr := os.ReadFile(lockPath)
 	exactRetired := false
-	if lockErr == nil && semverMeetsStableFloor(rec.AMQVersion, "0.45.0") && strings.TrimSpace(rec.WakeInjectVia) != "" {
-		retired, retireErr := retireWakeWithAMQ045(rec, root, handle)
+	if lockErr == nil && strings.TrimSpace(rec.WakeInjectVia) != "" {
+		retired, retireErr := retireWakeWithAMQ(rec, root, handle)
 		if retireErr != nil {
-			// AMQ >=0.45 can race a gracefully SIGTERMed wake that removes
+			// AMQ can race a gracefully SIGTERMed wake that removes
 			// its own lock before the retirer re-checks. Recognize that exact
 			// terminal state instead of reporting a spurious refusal.
 			if rec.WakePID > 0 && wakeSelfCleanedAfterRetire(lockPath, rec.WakePID, probe) {
@@ -734,14 +734,14 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 					result.WakeSignalFailed = rec.WakePID
 				}
 				result.WakeSignalError = retireErr.Error()
-				result.WakeRetirement = "amq_0_45_exact_refused"
+				result.WakeRetirement = "amq_exact_refused"
 				result.RetirementDetail = retireErr.Error()
 				return result
 			}
 		} else {
 			result.WakeKilled = retired.PID
 			result.WakeSignalName = "amq wake retire"
-			result.WakeRetirement = "amq_0_45_exact"
+			result.WakeRetirement = "amq_exact"
 			result.RetirementDetail = retired.Reason
 			exactRetired = true
 			if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
@@ -749,18 +749,13 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 			} else {
 				result.WakeSignalFailed = retired.PID
 				result.WakeSignalError = "native retirement returned success but the wake lock is still present; legacy signaling suppressed"
-				result.WakeRetirement = "amq_0_45_exact_lock_remaining"
+				result.WakeRetirement = "amq_exact_lock_remaining"
 				result.RetirementDetail = result.WakeSignalError
 			}
 		}
 	} else if lockErr == nil {
-		result.WakeRetirement = "legacy_signal_fallback"
-		switch {
-		case strings.TrimSpace(rec.WakeInjectVia) == "":
-			result.RetirementDetail = "wake is raw or has no persisted inject-via identity"
-		default:
-			result.RetirementDetail = "recorded AMQ " + versionOrUnknown(rec.AMQVersion) + " predates wake retire"
-		}
+		result.WakeRetirement = "raw_signal_fallback"
+		result.RetirementDetail = "wake is raw or has no persisted inject-via identity"
 	}
 	// canRemoveLock tracks whether we've confirmed the lock is safe to
 	// remove: confirmed stale (dead PID / PID-reused / corrupt), or we
@@ -856,9 +851,9 @@ type nativeWakeRetireResult struct {
 	Reason string `json:"reason"`
 }
 
-const nativeWakeRetireSelfCleaned = "amq_0_45_exact_self_cleaned"
+const nativeWakeRetireSelfCleaned = "amq_exact_self_cleaned"
 
-func retireWakeWithAMQ045(rec launch.Record, root, handle string) (nativeWakeRetireResult, error) {
+func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetireResult, error) {
 	args := []string{"wake", "retire", "--root", root, "--me", handle, "--inject-via", rec.WakeInjectVia}
 	for _, arg := range rec.WakeInjectArgs {
 		args = append(args, "--inject-arg", arg)
@@ -868,18 +863,18 @@ func retireWakeWithAMQ045(rec launch.Record, root, handle string) (nativeWakeRet
 	var result nativeWakeRetireResult
 	if jsonErr := json.Unmarshal(out, &result); jsonErr != nil {
 		if err != nil {
-			return result, fmt.Errorf("amq 0.45 exact wake retirement: %w", err)
+			return result, fmt.Errorf("amq exact wake retirement: %w", err)
 		}
-		return result, fmt.Errorf("amq 0.45 exact wake retirement returned invalid JSON: %w", jsonErr)
+		return result, fmt.Errorf("amq exact wake retirement returned invalid JSON: %w", jsonErr)
 	}
 	if err != nil {
-		return result, fmt.Errorf("amq 0.45 exact wake retirement status %s: %w", result.Status, err)
+		return result, fmt.Errorf("amq exact wake retirement status %s: %w", result.Status, err)
 	}
 	if result.Status != "retired" || result.Agent != handle || !rootsMatch(result.Root, root) {
-		return result, fmt.Errorf("amq 0.45 exact wake retirement returned mismatched result status=%s agent=%s root=%s", result.Status, result.Agent, result.Root)
+		return result, fmt.Errorf("amq exact wake retirement returned mismatched result status=%s agent=%s root=%s", result.Status, result.Agent, result.Root)
 	}
 	if rec.WakePID <= 0 || result.PID != rec.WakePID {
-		return result, fmt.Errorf("amq 0.45 exact wake retirement returned mismatched pid=%d, want persisted wake pid=%d", result.PID, rec.WakePID)
+		return result, fmt.Errorf("amq exact wake retirement returned mismatched pid=%d, want persisted wake pid=%d", result.PID, rec.WakePID)
 	}
 	return result, nil
 }

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -676,7 +676,15 @@ func (r reapResult) any() bool {
 }
 
 func (r reapResult) failed() bool {
-	return r.WakeSignalFailed > 0 || r.WakeRetirement == "amq_exact_refused" || r.WakeRetirement == "amq_exact_lock_remaining"
+	switch r.WakeRetirement {
+	case "amq_exact_refused",
+		"amq_exact_lock_remaining",
+		"amq_owner_recovery_refused",
+		"amq_owner_recovery_lock_remaining":
+		return true
+	default:
+		return r.WakeSignalFailed > 0
+	}
 }
 
 func (r reapResult) summary() string {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -67,7 +68,12 @@ type signalTerminator struct {
 
 type stopTerminatorFactory func(force bool) processTerminator
 
-var runExactWakeRetire = runAMQCommand
+var (
+	runExactWakeRetire       = runAMQCommand
+	runExactWakeRecoverOwner = runAMQCommand
+	wakeOwnerRecoveryTimeout = 2 * time.Second
+	wakeOwnerRecoveryPoll    = 50 * time.Millisecond
+)
 
 // newSignalTerminator returns a terminator that sends SIGTERM by default, or
 // SIGKILL when force is set. `stop` genuinely terminates the agent: SIGTERM
@@ -716,41 +722,72 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 	lockData, lockErr := os.ReadFile(lockPath)
 	exactRetired := false
 	if lockErr == nil && strings.TrimSpace(rec.WakeInjectVia) != "" {
-		retired, retireErr := retireWakeWithAMQ(rec, root, handle)
-		if retireErr != nil {
-			// AMQ can race a gracefully SIGTERMed wake that removes
-			// its own lock before the retirer re-checks. Recognize that exact
-			// terminal state instead of reporting a spurious refusal.
-			if rec.WakePID > 0 && wakeSelfCleanedAfterRetire(lockPath, rec.WakePID, probe) {
-				result.WakeKilled = rec.WakePID
-				result.WakeSignalName = "amq wake retire"
-				result.WakeRetirement = nativeWakeRetireSelfCleaned
-				result.RetirementDetail = "wake removed its own lock after graceful termination; end state verified: pid dead, lock absent"
-				result.LockRemoved = true
-				exactRetired = true
-			} else {
-				result.WakeSignalFailed = retired.PID
-				if result.WakeSignalFailed <= 0 {
-					result.WakeSignalFailed = rec.WakePID
-				}
-				result.WakeSignalError = retireErr.Error()
-				result.WakeRetirement = "amq_exact_refused"
-				result.RetirementDetail = retireErr.Error()
-				return result
+		recovered, ownerless, recoverErr := recoverManagedWakeWithAMQ(rec, root, handle)
+		if recoverErr != nil {
+			result.WakeSignalFailed = recovered.PID
+			if result.WakeSignalFailed <= 0 {
+				result.WakeSignalFailed = rec.WakePID
 			}
-		} else {
-			result.WakeKilled = retired.PID
-			result.WakeSignalName = "amq wake retire"
-			result.WakeRetirement = "amq_exact"
-			result.RetirementDetail = retired.Reason
+			result.WakeSignalError = recoverErr.Error()
+			result.WakeRetirement = "amq_owner_recovery_refused"
+			result.RetirementDetail = recoverErr.Error()
+			return result
+		}
+		if !ownerless {
+			result.WakeKilled = rec.WakePID
+			if result.WakeKilled <= 0 {
+				result.WakeKilled = recovered.PID
+			}
+			result.WakeSignalName = "amq wake recover-owner"
+			result.WakeRetirement = "amq_owner_recovered"
+			result.RetirementDetail = recovered.Reason
 			exactRetired = true
 			if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
 				result.LockRemoved = true
 			} else {
-				result.WakeSignalFailed = retired.PID
-				result.WakeSignalError = "native retirement returned success but the wake lock is still present; legacy signaling suppressed"
-				result.WakeRetirement = "amq_exact_lock_remaining"
+				result.WakeSignalFailed = result.WakeKilled
+				result.WakeSignalError = "owner recovery returned success but the wake lock is still present; ownerless retirement and legacy signaling suppressed"
+				result.WakeRetirement = "amq_owner_recovery_lock_remaining"
 				result.RetirementDetail = result.WakeSignalError
+			}
+		}
+		if ownerless {
+			retired, retireErr := retireWakeWithAMQ(rec, root, handle)
+			if retireErr != nil {
+				// AMQ can race a gracefully SIGTERMed wake that removes
+				// its own lock before the retirer re-checks. Recognize that exact
+				// terminal state instead of reporting a spurious refusal.
+				if rec.WakePID > 0 && wakeSelfCleanedAfterRetire(lockPath, rec.WakePID, probe) {
+					result.WakeKilled = rec.WakePID
+					result.WakeSignalName = "amq wake retire"
+					result.WakeRetirement = nativeWakeRetireSelfCleaned
+					result.RetirementDetail = "wake removed its own lock after graceful termination; end state verified: pid dead, lock absent"
+					result.LockRemoved = true
+					exactRetired = true
+				} else {
+					result.WakeSignalFailed = retired.PID
+					if result.WakeSignalFailed <= 0 {
+						result.WakeSignalFailed = rec.WakePID
+					}
+					result.WakeSignalError = retireErr.Error()
+					result.WakeRetirement = "amq_exact_refused"
+					result.RetirementDetail = retireErr.Error()
+					return result
+				}
+			} else {
+				result.WakeKilled = retired.PID
+				result.WakeSignalName = "amq wake retire"
+				result.WakeRetirement = "amq_exact"
+				result.RetirementDetail = retired.Reason
+				exactRetired = true
+				if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
+					result.LockRemoved = true
+				} else {
+					result.WakeSignalFailed = retired.PID
+					result.WakeSignalError = "native retirement returned success but the wake lock is still present; legacy signaling suppressed"
+					result.WakeRetirement = "amq_exact_lock_remaining"
+					result.RetirementDetail = result.WakeSignalError
+				}
 			}
 		}
 	} else if lockErr == nil {
@@ -852,6 +889,90 @@ type nativeWakeRetireResult struct {
 }
 
 const nativeWakeRetireSelfCleaned = "amq_exact_self_cleaned"
+
+type nativeWakeRecoverOwnerResult struct {
+	Status       string `json:"status"`
+	Agent        string `json:"agent"`
+	Root         string `json:"root"`
+	PID          int    `json:"pid"`
+	OwnerPID     int    `json:"owner_pid"`
+	OwnerSession int    `json:"owner_session"`
+	Reason       string `json:"reason"`
+	NextAction   string `json:"next_action"`
+}
+
+const (
+	ownerlessWakeRecoveryReason = "wake lock is ownerless; recover-owner cannot mutate it"
+	ownerlessWakeRecoveryAction = "use wake repair or wake retire"
+)
+
+func recoverManagedWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRecoverOwnerResult, bool, error) {
+	deadline := time.Now().Add(wakeOwnerRecoveryTimeout)
+	for {
+		result, err := recoverOwnerWakeWithAMQ(rec, root, handle)
+		switch {
+		case err == nil && result.Status == "recovered":
+			return result, false, nil
+		case result.Status == "refused" &&
+			result.OwnerPID == 0 &&
+			result.Reason == ownerlessWakeRecoveryReason &&
+			result.NextAction == ownerlessWakeRecoveryAction:
+			return result, true, nil
+		case result.Status == "refused" && result.OwnerPID > 0:
+			if rec.AgentPID <= 0 || result.OwnerPID != rec.AgentPID {
+				return result, false, fmt.Errorf(
+					"amq owner wake recovery returned owner pid=%d, want persisted agent pid=%d",
+					result.OwnerPID,
+					rec.AgentPID,
+				)
+			}
+			if time.Now().After(deadline) {
+				return result, false, fmt.Errorf(
+					"amq owner wake recovery timed out waiting for owner pid %d to exit: %w",
+					result.OwnerPID,
+					err,
+				)
+			}
+			time.Sleep(wakeOwnerRecoveryPoll)
+		default:
+			if err == nil {
+				err = fmt.Errorf("unexpected recover-owner status %q", result.Status)
+			}
+			return result, false, err
+		}
+	}
+}
+
+func recoverOwnerWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRecoverOwnerResult, error) {
+	args := []string{"wake", "recover-owner", "--root", root, "--me", handle, "--json"}
+	out, err := runExactWakeRecoverOwner(amqCommandRequest{Dir: rec.CWD, Env: os.Environ(), Arg: args})
+	var result nativeWakeRecoverOwnerResult
+	if jsonErr := json.NewDecoder(bytes.NewReader(out)).Decode(&result); jsonErr != nil {
+		if err != nil {
+			return result, fmt.Errorf("amq owner wake recovery: %w", err)
+		}
+		return result, fmt.Errorf("amq owner wake recovery returned invalid JSON: %w", jsonErr)
+	}
+	if result.Agent != handle || !rootsMatch(result.Root, root) {
+		return result, fmt.Errorf(
+			"amq owner wake recovery returned mismatched result status=%s agent=%s root=%s",
+			result.Status,
+			result.Agent,
+			result.Root,
+		)
+	}
+	if result.PID > 0 && (rec.WakePID <= 0 || result.PID != rec.WakePID) {
+		return result, fmt.Errorf(
+			"amq owner wake recovery returned mismatched pid=%d, want persisted wake pid=%d",
+			result.PID,
+			rec.WakePID,
+		)
+	}
+	if err != nil {
+		return result, fmt.Errorf("amq owner wake recovery status %s: %w", result.Status, err)
+	}
+	return result, nil
+}
 
 func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetireResult, error) {
 	args := []string{"wake", "retire", "--root", root, "--me", handle, "--inject-via", rec.WakeInjectVia}

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -260,6 +260,55 @@ func TestReapOwnerRecoveryRejectsMismatchedOwnerWithoutFallback(t *testing.T) {
 	}
 }
 
+func TestReapCorruptOwnerBoundWakeWithNoPersistedWakePIDStillFails(t *testing.T) {
+	previousRecover := runExactWakeRecoverOwner
+	previousRetire := runExactWakeRetire
+	t.Cleanup(func() {
+		runExactWakeRecoverOwner = previousRecover
+		runExactWakeRetire = previousRetire
+	})
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	if err := os.WriteFile(wakeLockPath(agentDir), []byte("{corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runExactWakeRecoverOwner = func(amqCommandRequest) ([]byte, error) {
+		return []byte(fmt.Sprintf(
+			`{"status":"refused","agent":"qa","root":%q,"reason":"wake lock is corrupt","next_action":"use wake repair"}`,
+			root,
+		)), errors.New("exit status 1")
+	}
+	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
+		t.Fatal("corrupt owner-bound recovery must not fall back to ownerless retire")
+		return nil, nil
+	}
+
+	result := reapStaleArtifacts(
+		agentDir,
+		"qa",
+		root,
+		false,
+		launch.Record{AgentPID: 5151, WakePID: 0, WakeInjectVia: "/usr/bin/tmux"},
+		&recordingTerminator{},
+		downFakeProbe(nil, nil),
+	)
+	if result.WakeSignalFailed != 0 || result.WakeRetirement != "amq_owner_recovery_refused" ||
+		!result.failed() || result.any() || !strings.Contains(result.RetirementDetail, "status refused") {
+		t.Fatalf("pid-zero corrupt owner recovery result=%+v", result)
+	}
+}
+
+func TestReapResultOwnerRecoveryStatusesFailWithoutPID(t *testing.T) {
+	for _, status := range []string{"amq_owner_recovery_refused", "amq_owner_recovery_lock_remaining"} {
+		t.Run(status, func(t *testing.T) {
+			result := reapResult{WakeRetirement: status}
+			if !result.failed() {
+				t.Fatalf("status %q with pid zero must fail", status)
+			}
+		})
+	}
+}
+
 // downFakeProbe implements duplicateLaunchProbe with explicit per-PID liveness and
 // binary-match decisions so tests never shell out to ps or send real signals.
 func downFakeProbe(alive map[int]bool, match map[int]bool) duplicateLaunchProbe {

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -61,6 +61,26 @@ func TestRetireWakeWithAMQUsesExactPersistedInjectorIdentity(t *testing.T) {
 	}
 }
 
+func stubOwnerlessWakeRecovery(t *testing.T, root, handle string, pid int) {
+	t.Helper()
+	previous := runExactWakeRecoverOwner
+	t.Cleanup(func() { runExactWakeRecoverOwner = previous })
+	runExactWakeRecoverOwner = func(req amqCommandRequest) ([]byte, error) {
+		want := []string{"wake", "recover-owner", "--root", root, "--me", handle, "--json"}
+		if !reflect.DeepEqual(req.Arg, want) {
+			t.Fatalf("wake recover-owner args=%q want=%q", req.Arg, want)
+		}
+		return []byte(fmt.Sprintf(
+			`{"status":"refused","agent":%q,"root":%q,"pid":%d,"reason":%q,"next_action":%q}`,
+			handle,
+			root,
+			pid,
+			ownerlessWakeRecoveryReason,
+			ownerlessWakeRecoveryAction,
+		)), errors.New("exit status 1")
+	}
+}
+
 func TestReapRawWakeRetirementFallbackIsReported(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
@@ -81,6 +101,7 @@ func TestReapExactWakeRetirementRecognizesSelfCleanup(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "qa", 4242)
 	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
 		if err := os.Remove(wakeLockPath(agentDir)); err != nil {
 			t.Fatal(err)
@@ -99,6 +120,7 @@ func TestReapExactWakeRetirementRefusalNeverFallsBackToSignal(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "qa", 4242)
 	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
 		return []byte(fmt.Sprintf(`{"status":"refused","agent":"qa","root":%q,"pid":4242,"reason":"target mismatch"}`, root)), errors.New("exit status 1")
 	}
@@ -115,6 +137,7 @@ func TestReapExactWakeRetirementSuccessNeverFallsBackToSignal(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "qa", 4242)
 	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
 		// Deliberately leave the lock in place to prove native success can never
 		// fall through to the legacy signal path.
@@ -133,6 +156,7 @@ func TestReapExactWakeRetirementRejectsMismatchedPIDWithoutFallback(t *testing.T
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "qa", 4242)
 	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":5252,"reason":"exact target retired"}`, root)), nil
 	}
@@ -140,6 +164,99 @@ func TestReapExactWakeRetirementRejectsMismatchedPIDWithoutFallback(t *testing.T
 	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true, 5252: true}, map[int]bool{4242: true, 5252: true}))
 	if result.WakeRetirement != "amq_exact_refused" || !result.failed() || !strings.Contains(result.RetirementDetail, "mismatched pid=5252") || len(term.calls) != 0 {
 		t.Fatalf("mismatched pid result=%+v fallback calls=%v", result, term.calls)
+	}
+}
+
+func TestReapOwnerBoundWakeUsesRecoverOwnerWithoutOwnerlessRetire(t *testing.T) {
+	previousRecover := runExactWakeRecoverOwner
+	previousRetire := runExactWakeRetire
+	t.Cleanup(func() {
+		runExactWakeRecoverOwner = previousRecover
+		runExactWakeRetire = previousRetire
+	})
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	recoverCalls := 0
+	runExactWakeRecoverOwner = func(req amqCommandRequest) ([]byte, error) {
+		recoverCalls++
+		if recoverCalls == 1 {
+			return []byte(fmt.Sprintf(
+				`{"status":"refused","agent":"qa","root":%q,"pid":4242,"owner_pid":5151,"owner_session":99,"reason":"handle qa is owned by live process","next_action":"exit owner"}`,
+				root,
+			)), errors.New("exit status 1")
+		}
+		if err := os.Remove(wakeLockPath(agentDir)); err != nil {
+			t.Fatal(err)
+		}
+		return []byte(fmt.Sprintf(
+			`{"status":"recovered","agent":"qa","root":%q,"pid":4242,"owner_pid":5151,"owner_session":99,"reason":"exact owner claim released"}`,
+			root,
+		)), nil
+	}
+	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
+		t.Fatal("owner-bound recovery must not call ownerless wake retire")
+		return nil, nil
+	}
+	previousTimeout := wakeOwnerRecoveryTimeout
+	previousPoll := wakeOwnerRecoveryPoll
+	wakeOwnerRecoveryTimeout = time.Second
+	wakeOwnerRecoveryPoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeOwnerRecoveryTimeout = previousTimeout
+		wakeOwnerRecoveryPoll = previousPoll
+	})
+	result := reapStaleArtifacts(
+		agentDir,
+		"qa",
+		root,
+		false,
+		launch.Record{CWD: t.TempDir(), AgentPID: 5151, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"},
+		&recordingTerminator{},
+		downFakeProbe(map[int]bool{4242: false}, nil),
+	)
+	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved || recoverCalls != 2 {
+		t.Fatalf("owner-bound recovery result=%+v calls=%d", result, recoverCalls)
+	}
+}
+
+func TestReapOwnerRecoveryRejectsMismatchedOwnerWithoutFallback(t *testing.T) {
+	previousRecover := runExactWakeRecoverOwner
+	previousRetire := runExactWakeRetire
+	t.Cleanup(func() {
+		runExactWakeRecoverOwner = previousRecover
+		runExactWakeRetire = previousRetire
+	})
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	runExactWakeRecoverOwner = func(amqCommandRequest) ([]byte, error) {
+		return []byte(fmt.Sprintf(
+			`{"status":"refused","agent":"qa","root":%q,"pid":4242,"owner_pid":6161,"reason":"live owner"}`,
+			root,
+		)), errors.New("exit status 1")
+	}
+	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
+		t.Fatal("mismatched owner must not fall back to ownerless retire")
+		return nil, nil
+	}
+	term := &recordingTerminator{}
+	result := reapStaleArtifacts(
+		agentDir,
+		"qa",
+		root,
+		false,
+		launch.Record{AgentPID: 5151, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"},
+		term,
+		downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}),
+	)
+	if !result.failed() || result.WakeRetirement != "amq_owner_recovery_refused" ||
+		!strings.Contains(result.RetirementDetail, "owner pid=6161, want persisted agent pid=5151") ||
+		len(term.calls) != 0 {
+		t.Fatalf("mismatched owner result=%+v fallback calls=%v", result, term.calls)
 	}
 }
 
@@ -424,6 +541,7 @@ func TestExecuteDownDeadPreparedAgentAllowsExactStaleWakeCleanup(t *testing.T) {
 		WakeInjectVia: "/usr/bin/tmux", PreparedRunGeneration: "g", PreparedRunDigest: "d", PreparedRunLaunchAttempt: "a",
 	})
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "cto", 4242)
 	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
 		if err := os.Remove(wakeLockPath(agentDir)); err != nil {
 			t.Fatal(err)

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -41,7 +41,7 @@ func (r *recordingTerminator) SignalName() string {
 	return r.name
 }
 
-func TestRetireWakeWithAMQ045UsesExactPersistedInjectorIdentity(t *testing.T) {
+func TestRetireWakeWithAMQUsesExactPersistedInjectorIdentity(t *testing.T) {
 	previous := runExactWakeRetire
 	t.Cleanup(func() { runExactWakeRetire = previous })
 	root := filepath.Join(t.TempDir(), ".agent-mail", "s")
@@ -50,8 +50,8 @@ func TestRetireWakeWithAMQ045UsesExactPersistedInjectorIdentity(t *testing.T) {
 		got = req
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":4242,"reason":"exact target retired"}`, root)), nil
 	}
-	rec := launch.Record{CWD: t.TempDir(), AMQVersion: "0.45.0", WakePID: 4242, WakeInjectVia: "/usr/bin/tmux", WakeInjectArgs: []string{"load-buffer", "-"}}
-	result, err := retireWakeWithAMQ045(rec, root, "qa")
+	rec := launch.Record{CWD: t.TempDir(), AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux", WakeInjectArgs: []string{"load-buffer", "-"}}
+	result, err := retireWakeWithAMQ(rec, root, "qa")
 	if err != nil || result.PID != 4242 {
 		t.Fatalf("retire result=%+v err=%v", result, err)
 	}
@@ -61,14 +61,14 @@ func TestRetireWakeWithAMQ045UsesExactPersistedInjectorIdentity(t *testing.T) {
 	}
 }
 
-func TestReapWakeRetirementFallbackIsReported(t *testing.T) {
+func TestReapRawWakeRetirementFallbackIsReported(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: "0.43.1", WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
-	if result.WakeRetirement != "legacy_signal_fallback" || !strings.Contains(result.summary(), "predates wake retire") || len(term.calls) != 1 || term.calls[0] != 4242 {
-		t.Fatalf("legacy retirement result=%+v calls=%v", result, term.calls)
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	if result.WakeRetirement != "raw_signal_fallback" || !strings.Contains(result.summary(), "raw or has no persisted inject-via identity") || len(term.calls) != 1 || term.calls[0] != 4242 {
+		t.Fatalf("raw retirement result=%+v calls=%v", result, term.calls)
 	}
 }
 
@@ -87,7 +87,7 @@ func TestReapExactWakeRetirementRecognizesSelfCleanup(t *testing.T) {
 		}
 		return []byte(fmt.Sprintf(`{"status":"refused","agent":"qa","root":%q,"pid":4242,"reason":"wake self-cleaned"}`, root)), errors.New("exit status 1")
 	}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: "0.45.0", WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
 	if result.WakeRetirement != nativeWakeRetireSelfCleaned || result.failed() || !result.LockRemoved || result.WakeKilled != 4242 {
 		t.Fatalf("self-cleaned retirement result=%+v", result)
 	}
@@ -103,8 +103,8 @@ func TestReapExactWakeRetirementRefusalNeverFallsBackToSignal(t *testing.T) {
 		return []byte(fmt.Sprintf(`{"status":"refused","agent":"qa","root":%q,"pid":4242,"reason":"target mismatch"}`, root)), errors.New("exit status 1")
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: "0.45.0", WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
-	if result.WakeRetirement != "amq_0_45_exact_refused" || !result.failed() || len(term.calls) != 0 {
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	if result.WakeRetirement != "amq_exact_refused" || !result.failed() || len(term.calls) != 0 {
 		t.Fatalf("exact refusal result=%+v fallback calls=%v", result, term.calls)
 	}
 }
@@ -121,8 +121,8 @@ func TestReapExactWakeRetirementSuccessNeverFallsBackToSignal(t *testing.T) {
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":4242,"reason":"exact target retired"}`, root)), nil
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: "0.45.0", WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
-	if result.WakeRetirement != "amq_0_45_exact_lock_remaining" || !result.failed() || len(term.calls) != 0 {
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	if result.WakeRetirement != "amq_exact_lock_remaining" || !result.failed() || len(term.calls) != 0 {
 		t.Fatalf("exact success result=%+v fallback calls=%v", result, term.calls)
 	}
 }
@@ -137,8 +137,8 @@ func TestReapExactWakeRetirementRejectsMismatchedPIDWithoutFallback(t *testing.T
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":5252,"reason":"exact target retired"}`, root)), nil
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: "0.45.0", WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true, 5252: true}, map[int]bool{4242: true, 5252: true}))
-	if result.WakeRetirement != "amq_0_45_exact_refused" || !result.failed() || !strings.Contains(result.RetirementDetail, "mismatched pid=5252") || len(term.calls) != 0 {
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true, 5252: true}, map[int]bool{4242: true, 5252: true}))
+	if result.WakeRetirement != "amq_exact_refused" || !result.failed() || !strings.Contains(result.RetirementDetail, "mismatched pid=5252") || len(term.calls) != 0 {
 		t.Fatalf("mismatched pid result=%+v fallback calls=%v", result, term.calls)
 	}
 }
@@ -420,7 +420,7 @@ func TestExecuteDownDeadPreparedAgentAllowsExactStaleWakeCleanup(t *testing.T) {
 	dir := seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"}}})
 	root := filepath.Join(base, "issue-96")
 	agentDir := seedAgentRecord(t, base, "issue-96", "cto", launch.Record{
-		Binary: "codex", Handle: "cto", AgentPID: 1234, Root: root, AMQVersion: "0.45.0", WakePID: 4242,
+		Binary: "codex", Handle: "cto", AgentPID: 1234, Root: root, AMQVersion: doctorMinAMQVersion, WakePID: 4242,
 		WakeInjectVia: "/usr/bin/tmux", PreparedRunGeneration: "g", PreparedRunDigest: "d", PreparedRunLaunchAttempt: "a",
 	})
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
@@ -433,7 +433,7 @@ func TestExecuteDownDeadPreparedAgentAllowsExactStaleWakeCleanup(t *testing.T) {
 	term := &recordingTerminator{}
 	out, err := runDownExec(t, downExecution{ProjectDir: dir, RequestedSession: "issue-96", ExplicitSession: true, Role: "cto", Terminator: term,
 		Probe: downFakeProbe(map[int]bool{1234: false}, map[int]bool{})})
-	if err != nil || len(term.calls) != 0 || !strings.Contains(out, "amq_0_45_exact") {
+	if err != nil || len(term.calls) != 0 || !strings.Contains(out, "amq_exact") {
 		t.Fatalf("out=%s err=%v signal calls=%v", out, err, term.calls)
 	}
 }

--- a/internal/cli/fresh_amq_bootstrap_test.go
+++ b/internal/cli/fresh_amq_bootstrap_test.go
@@ -86,7 +86,7 @@ else
   root="$base"
   if [ -n "$session" ]; then root="$base/$session"; fi
 fi
-printf '{"schema_version":1,"amq_version":"0.43.1","root":"%s","base_root":"%s","session_name":"%s","me":"%s","root_source":"%s"}\n' "$root" "$base" "$session" "$me" "$source"
+printf '{"schema_version":1,"amq_version":"0.49.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","root_source":"%s"}\n' "$root" "$base" "$session" "$me" "$source"
 `
 	path := filepath.Join(binDir, "amq")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -371,6 +371,9 @@ Examples:
 	if err != nil {
 		return fmt.Errorf("resolve amq env: %w", err)
 	}
+	if err := validateLaunchAMQVersion(env.AMQVersion); err != nil {
+		return err
+	}
 	root := env.Root
 	if env.Me != "" {
 		handle = env.Me
@@ -1133,6 +1136,24 @@ func resolveAMQEnvForLaunch(cwd, rootFlag, session, profile, handle string) (amq
 		return env, nil
 	}
 	return resolveAMQEnvInDir(cwd, rootFlag, session, handle)
+}
+
+func validateLaunchAMQVersion(version string) error {
+	got := strings.TrimSpace(version)
+	if got == "" {
+		return fmt.Errorf("agent up refused: amq env returned no version (compatibility unknown)")
+	}
+	if _, ok := parseSemverParts(got); !ok {
+		return fmt.Errorf("agent up refused: amq returned unparseable version %q", got)
+	}
+	if !semverMeetsStableFloor(got, doctorMinAMQVersion) {
+		return fmt.Errorf(
+			"agent up refused: amq %s is older than required %s; run `amq upgrade` to update",
+			got,
+			doctorMinAMQVersion,
+		)
+	}
+	return nil
 }
 
 func launchUsesExplicitRoot(rootFlag, session, profile string) bool {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -695,7 +695,7 @@ func TestAMQSupportsBaselineExisting(t *testing.T) {
 func TestRunLaunchDryRunRequireWakeVersionGate(t *testing.T) {
 	// amq 0.34.1+ launches fail at the door when the wake sidecar cannot
 	// acquire its lock (#30): coop exec gains --require-wake by default.
-	setupFakeAMQWithVersion(t, "0.34.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "sandboxed", "custom-agent", "test-prompt"})
 	})
@@ -703,14 +703,14 @@ func TestRunLaunchDryRunRequireWakeVersionGate(t *testing.T) {
 		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
 	}
 	if !strings.Contains(stdout, "amq coop exec --require-wake custom-agent -- test-prompt") {
-		t.Fatalf("amq 0.34.1 launch should pass --require-wake:\n%s", stdout)
+		t.Fatalf("supported AMQ launch should pass --require-wake:\n%s", stdout)
 	}
 }
 
 func TestRunLaunchDryRunRequireWakeWithSessionShape(t *testing.T) {
 	// Pin the full production argv shape: --session before --require-wake,
 	// both before the binary positional (amq rejects misplaced flags).
-	setupFakeAMQWithVersion(t, "0.34.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--session", "issue-96", "--trust", "sandboxed", "custom-agent", "test-prompt"})
 	})
@@ -723,7 +723,7 @@ func TestRunLaunchDryRunRequireWakeWithSessionShape(t *testing.T) {
 }
 
 func TestRunLaunchNamedProfileDerivesProfileRoot(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.34.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	dir := t.TempDir()
 	old, err := os.Getwd()
 	if err != nil {
@@ -773,7 +773,7 @@ func TestExactRootChildCommandUnsetsSessionBeforeRealTarget(t *testing.T) {
 }
 
 func TestRunLaunchDefaultProfileKeepsSessionfulChildShape(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.43.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--session", "issue-96", "custom-agent"})
 	})
@@ -789,7 +789,7 @@ func TestRunLaunchDefaultProfileKeepsSessionfulChildShape(t *testing.T) {
 }
 
 func TestRunLaunchNamedProfileResumeAndDynamicPathsUseExactRootChildShim(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.43.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	project := t.TempDir()
 	chdir(t, project)
 	project, _ = os.Getwd()
@@ -839,7 +839,7 @@ func TestRunLaunchNamedProfileResumeAndDynamicPathsUseExactRootChildShim(t *test
 }
 
 func TestRunLaunchDryRunWakeInjectVersionGate(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.37.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{
 			"--dry-run", "--no-bootstrap",
@@ -868,13 +868,13 @@ func TestRunLaunchDryRunWakeInjectRejectsOldAMQ(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-via", "/opt/amq-inject", "custom-agent"})
 	})
-	if err == nil || !strings.Contains(err.Error(), "requires amq 0.37.0 or newer") {
+	if err == nil || !strings.Contains(err.Error(), "older than required "+doctorMinAMQVersion) {
 		t.Fatalf("wake-inject old amq error = %v", err)
 	}
 }
 
 func TestRunLaunchWakeInjectValidatesShape(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.37.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	if _, _, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-arg=x", "codex"})
 	}); err == nil || !strings.Contains(err.Error(), "requires --wake-inject-via") {
@@ -888,7 +888,7 @@ func TestRunLaunchWakeInjectValidatesShape(t *testing.T) {
 }
 
 func TestRunLaunchDryRunWakeInjectModeNone(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.42.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-mode", "none", "codex"})
 	})
@@ -918,7 +918,7 @@ func TestRunLaunchDefaultsManagedBinaryWakeModeToRaw(t *testing.T) {
 		{name: "claude-custom-launcher", binary: "claude", launcher: "/opt/custom-launcher"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			setupFakeAMQWithVersion(t, "0.42.0")
+			setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 			var observed launch.Record
 			oldObserver := launchPlanObserver
 			launchPlanObserver = func(rec launch.Record, _ []string) { observed = rec }
@@ -940,7 +940,7 @@ func TestRunLaunchDefaultsManagedBinaryWakeModeToRaw(t *testing.T) {
 }
 
 func TestRunLaunchWritesManagedRawWakeModeRecord(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.42.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	t.Setenv(envTmuxTarget, "")
 	previousExec := amqSyscallExec
 	amqSyscallExec = func(string, []string, []string) error { return nil }
@@ -961,7 +961,7 @@ func TestRunLaunchWritesManagedRawWakeModeRecord(t *testing.T) {
 }
 
 func TestRunLaunchStampsCapturedPaneBeforeRecordAndExec(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.42.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	project := t.TempDir()
 	agentDir := filepath.Join(os.Getenv("AMQ_FAKE_ROOT"), "agents", "cto")
 	t.Setenv(envTmuxTarget, "")
@@ -1030,7 +1030,7 @@ func TestRunLaunchStampsCapturedPaneBeforeRecordAndExec(t *testing.T) {
 }
 
 func TestRunLaunchStampFailureLeavesNoRecordAndPreventsExec(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.42.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	project := t.TempDir()
 	agentDir := filepath.Join(os.Getenv("AMQ_FAKE_ROOT"), "agents", "cto")
 	t.Setenv(envTmuxTarget, "")
@@ -1078,7 +1078,7 @@ func TestRunLaunchStampFailureLeavesNoRecordAndPreventsExec(t *testing.T) {
 }
 
 func TestRunLaunchUnknownBinaryRetainsAutoWakeMode(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.42.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-mode", "auto", "custom-agent"})
 	})
@@ -1094,7 +1094,7 @@ func TestRunLaunchWakeInjectModeRequiresAMQ042(t *testing.T) {
 	setupFakeAMQWithVersion(t, "0.41.9")
 	if _, _, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--wake-inject-mode", "none", "codex"})
-	}); err == nil || !strings.Contains(err.Error(), "requires amq 0.42.0 or newer") {
+	}); err == nil || !strings.Contains(err.Error(), "older than required "+doctorMinAMQVersion) {
 		t.Fatalf("wake inject mode floor error = %v", err)
 	}
 }
@@ -1154,7 +1154,7 @@ func TestLaunchArgsFromRecordReplaysNoPreauthorizeInScope(t *testing.T) {
 }
 
 func TestRunLaunchDryRunNoRequireWakeOptOut(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.34.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-require-wake", "custom-agent", "test-prompt"})
 	})
@@ -1167,7 +1167,7 @@ func TestRunLaunchDryRunNoRequireWakeOptOut(t *testing.T) {
 }
 
 func TestRunLaunchDryRunNoGitignore(t *testing.T) {
-	setupFakeAMQWithVersion(t, "0.40.0")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 	stdout, stderr, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-gitignore", "custom-agent", "test-prompt"})
 	})
@@ -1185,22 +1185,26 @@ func TestRunLaunchNoGitignoreRejectsOldAMQ(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
 		return runLaunch([]string{"--dry-run", "--no-bootstrap", "--no-gitignore", "custom-agent"})
 	})
-	if err == nil || !strings.Contains(err.Error(), "requires amq 0.40.0 or newer") {
+	if err == nil || !strings.Contains(err.Error(), "older than required "+doctorMinAMQVersion) {
 		t.Fatalf("no-gitignore old amq error = %v", err)
 	}
 }
 
-func TestRunLaunchDryRunOldAMQOmitsRequireWake(t *testing.T) {
-	// 0.34.0 predates the flag; passing it would fail every launch.
-	setupFakeAMQWithVersion(t, "0.34.0")
+func TestRunLaunchRejectsAMQBelowSupportedFloorBeforeSideEffects(t *testing.T) {
+	setupFakeAMQWithVersion(t, "0.48.0")
+	root := os.Getenv("AMQ_FAKE_ROOT")
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runLaunch([]string{"--dry-run", "--no-bootstrap", "custom-agent", "test-prompt"})
+		return runLaunch([]string{"--no-bootstrap", "--role", "qa", "--me", "qa", "custom-agent", "test-prompt"})
 	})
-	if err != nil {
-		t.Fatalf("runLaunch: %v\nstderr:\n%s", err, stderr)
+	if err == nil || !strings.Contains(err.Error(), "agent up refused: amq 0.48.0 is older than required "+doctorMinAMQVersion) ||
+		!strings.Contains(err.Error(), "amq upgrade") {
+		t.Fatalf("launch floor error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
-	if strings.Contains(stdout, "--require-wake") {
-		t.Fatalf("amq 0.34.0 must not receive --require-wake:\n%s", stdout)
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("launch floor rejection emitted a launch command:\n%s", stdout)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "agents", "qa", launch.FileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("launch floor rejection wrote launch state: %v", statErr)
 	}
 }
 
@@ -1635,7 +1639,7 @@ func TestApplyConversationRestoreArgsRejectsConflicts(t *testing.T) {
 
 func setupFakeAMQ(t *testing.T) {
 	t.Helper()
-	setupFakeAMQWithVersion(t, "0.42.1")
+	setupFakeAMQWithVersion(t, doctorMinAMQVersion)
 }
 
 // setupFakeAMQWithVersion installs a fake amq whose `env --json` reports the

--- a/internal/cli/parent_amq_floor_test.go
+++ b/internal/cli/parent_amq_floor_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func TestTeamLaunchRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-team"}},
+	})
+	backend := useFakeBackend(t)
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	err := executeTeamLaunch(teamLaunchOptions{
+		Terminal: "fake", Workstream: "floor-team", Profile: team.DefaultProfile,
+		Trust: trustModeApproveForMe, SquadBin: "amq-squad", NoBootstrap: true,
+	}, true, true)
+	if err == nil || !strings.Contains(err.Error(), "cto: agent up refused: amq 0.48.0 is older than required "+doctorMinAMQVersion) {
+		t.Fatalf("team launch floor error=%v", err)
+	}
+	if len(backend.launches) != 0 {
+		t.Fatalf("pre-floor team launch opened %d backend launch(es)", len(backend.launches))
+	}
+	for _, path := range []string{
+		filepath.Join(base, "floor-team"),
+		briefPathForProfile(dir, team.DefaultProfile, "floor-team"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-team"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor team launch mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestUpResetRejectsPreFloorAMQBeforeDeletingSession(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-reset"}},
+	})
+	backend := useFakeBackend(t)
+	root := filepath.Join(base, "floor-reset")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "must-survive")
+	if err := os.WriteFile(sentinel, []byte("unchanged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	_, _, err := captureOutput(t, func() error {
+		return runUp([]string{"floor-reset", "--reset", "--yes", "--terminal", "fake"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "cto: agent up refused: amq 0.48.0 is older than required "+doctorMinAMQVersion) {
+		t.Fatalf("up --reset floor error=%v", err)
+	}
+	if got, readErr := os.ReadFile(sentinel); readErr != nil || string(got) != "unchanged\n" {
+		t.Fatalf("pre-floor reset changed sentinel: body=%q err=%v", got, readErr)
+	}
+	if len(backend.launches) != 0 {
+		t.Fatalf("pre-floor reset opened %d backend launch(es)", len(backend.launches))
+	}
+	for _, path := range []string{
+		briefPathForProfile(dir, team.DefaultProfile, "floor-reset"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-reset"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor reset mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestResumeExecRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-resume"}},
+	})
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	err := executeResume(resumeExecution{
+		ProjectDir: dir, RequestedSession: "floor-resume", ExplicitSession: true,
+		Profile: team.DefaultProfile,
+		Exec:    resumeExecOptions{Enabled: true, Terminal: "tmux", Target: "current-window", Layout: "vertical"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cto: agent up refused: amq 0.48.0 is older than required "+doctorMinAMQVersion) {
+		t.Fatalf("resume --exec floor error=%v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(base, "floor-resume"),
+		briefPathForProfile(dir, team.DefaultProfile, "floor-resume"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-resume"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor resume mutated %s: %v", path, statErr)
+		}
+	}
+}

--- a/internal/cli/parent_amq_floor_test.go
+++ b/internal/cli/parent_amq_floor_test.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 func TestTeamLaunchRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
@@ -35,6 +39,111 @@ func TestTeamLaunchRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
 		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 			t.Fatalf("pre-floor team launch mutated %s: %v", path, statErr)
 		}
+	}
+}
+
+func TestTeamLaunchDryRunReportsPreFloorAMQAndRendersPreviewWithoutMutations(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-dry-run"}},
+	})
+	backend := useFakeBackend(t)
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	stdout, _, err := captureOutput(t, func() error {
+		return executeTeamLaunch(teamLaunchOptions{
+			Terminal: "fake", Workstream: "floor-dry-run", Profile: team.DefaultProfile,
+			Trust: trustModeApproveForMe, SquadBin: "amq-squad", NoBootstrap: true, DryRun: true,
+		}, true, true)
+	})
+	if err != nil {
+		t.Fatalf("team launch dry-run: %v", err)
+	}
+	for _, want := range []string{
+		"AMQ FLOOR VIOLATIONS", "role=cto", "observed=0.48.0",
+		"required_min=" + doctorMinAMQVersion, "live=refused",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("pre-floor dry-run report missing %q:\n%s", want, stdout)
+		}
+	}
+	if len(backend.dryRuns) != 1 {
+		t.Fatalf("pre-floor dry-run rendered %d backend preview(s), want 1", len(backend.dryRuns))
+	}
+	if len(backend.launches) != 0 {
+		t.Fatalf("pre-floor dry-run opened %d backend launch(es)", len(backend.launches))
+	}
+	for _, path := range []string{
+		filepath.Join(base, "floor-dry-run"),
+		briefPathForProfile(dir, team.DefaultProfile, "floor-dry-run"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-dry-run"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor dry-run mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestUpDryRunReportsPreFloorAMQAndRendersCommandsWithoutMutations(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-up-dry-run"}},
+	})
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"floor-up-dry-run", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("up dry-run: %v", err)
+	}
+	for _, want := range []string{
+		"AMQ FLOOR VIOLATIONS", "role=cto", "observed=0.48.0",
+		"required_min=" + doctorMinAMQVersion, "live=refused", "agent up",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("up dry-run report/preview missing %q:\n%s", want, stdout)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(base, "floor-up-dry-run"),
+		briefPathForProfile(dir, team.DefaultProfile, "floor-up-dry-run"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-up-dry-run"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor up dry-run mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestUpDryRunJSONReportsPreFloorAMQAndRetainsFullPlan(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-up-dry-json"}},
+	})
+	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"floor-up-dry-json", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("up dry-run json: %v", err)
+	}
+	env := decodeJSONEnvelope[teamPlan](t, stdout)
+	if env.Kind != "team_plan" || len(env.Data.Plan) != 1 {
+		t.Fatalf("dry-run json lost launch plan: kind=%q plan=%+v", env.Kind, env.Data.Plan)
+	}
+	if len(env.Data.AMQFloorViolations) != 1 {
+		t.Fatalf("dry-run json floor violations=%+v, want one", env.Data.AMQFloorViolations)
+	}
+	violation := env.Data.AMQFloorViolations[0]
+	if violation.Role != "cto" || violation.Handle != "cto" ||
+		violation.AMQVersion != "0.48.0" || violation.RequiredMin != doctorMinAMQVersion ||
+		violation.LiveOutcome != "refused" || !strings.Contains(violation.Detail, "older than required") {
+		t.Fatalf("dry-run json floor violation=%+v", violation)
+	}
+	if !strings.Contains(env.Data.Plan[0].Command, "agent up") {
+		t.Fatalf("dry-run json omitted live command: %+v", env.Data.Plan[0])
 	}
 }
 
@@ -76,6 +185,128 @@ func TestUpResetRejectsPreFloorAMQBeforeDeletingSession(t *testing.T) {
 	}
 }
 
+func TestUpResetRejectsNewlyPreFloorResolutionBeforeByteIdenticalSessionDeletion(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-reset-late"}},
+	})
+	_ = useFakeBackend(t)
+	root := filepath.Join(base, "floor-reset-late")
+	if err := os.MkdirAll(filepath.Join(root, "nested"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "nested", "must-survive"), []byte{0, 1, 2, '\n'}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotTestTree(t, root)
+
+	originalResolver := resolveTeamLaunchAMQEnv
+	resolution := 0
+	resolveTeamLaunchAMQEnv = func(cwd, profile, session, handle string) (amqEnv, error) {
+		env, err := originalResolver(cwd, profile, session, handle)
+		resolution++
+		// The initial and under-admission checks pass. The complete pinned
+		// preflight then observes a newly pre-floor version; this used to occur
+		// only inside executeTeamLaunch after --reset deleted the old session.
+		if err == nil && resolution == 3 {
+			env.AMQVersion = "0.48.0"
+		}
+		return env, err
+	}
+	t.Cleanup(func() { resolveTeamLaunchAMQEnv = originalResolver })
+
+	_, _, err := captureOutput(t, func() error {
+		return runUp([]string{"floor-reset-late", "--reset", "--yes", "--terminal", "fake"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "older than required "+doctorMinAMQVersion) {
+		t.Fatalf("late up --reset floor error=%v (resolution calls=%d)", err, resolution)
+	}
+	if resolution != 3 {
+		t.Fatalf("resolution calls=%d, want refusal at pinned preflight call 3", resolution)
+	}
+	after := snapshotTestTree(t, root)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("pre-floor reset changed existing session tree:\nbefore=%#v\nafter=%#v", before, after)
+	}
+	if _, err := os.Stat(briefPathForProfile(dir, team.DefaultProfile, "floor-reset-late")); !os.IsNotExist(err) {
+		t.Fatalf("pre-floor reset wrote brief: %v", err)
+	}
+}
+
+func TestExternalLeadLateMemberPreflightRejectsBeforePaneStampOrLaunchRecord(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-external"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "floor-external"},
+		},
+	})
+	backend := useFakeBackend(t)
+	originalPane := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{
+			Session: "tmux-main", WindowID: "@7", WindowName: "shell", PaneID: "%5",
+		}, nil
+	}
+	t.Cleanup(func() { currentPaneIdentity = originalPane })
+	t.Setenv("AM_ME", "cto")
+	t.Setenv("AM_ROOT", filepath.Join(base, "floor-external"))
+
+	originalResolver := resolveTeamLaunchAMQEnv
+	resolution := 0
+	resolveTeamLaunchAMQEnv = func(cwd, profile, session, handle string) (amqEnv, error) {
+		env, err := originalResolver(cwd, profile, session, handle)
+		resolution++
+		// Two full floor passes consume calls 1-4. Call 6 is the worker in the
+		// complete member-env preflight. Before this ordering fix, the external
+		// lead pane and launch.json were already stamped/written at call 5.
+		if err == nil && resolution == 6 {
+			env.AMQVersion = "0.48.0"
+		}
+		return env, err
+	}
+	t.Cleanup(func() { resolveTeamLaunchAMQEnv = originalResolver })
+
+	originalStamp := stampCapturedLaunchPane
+	stampCalls := 0
+	stampCapturedLaunchPane = func(string, string, string) error {
+		stampCalls++
+		return nil
+	}
+	t.Cleanup(func() { stampCapturedLaunchPane = originalStamp })
+
+	err := executeTeamLaunch(teamLaunchOptions{
+		Terminal: "fake", Workstream: "floor-external", Profile: team.DefaultProfile,
+		Trust: trustModeApproveForMe, SquadBin: "amq-squad", NoBootstrap: true,
+	}, true, true)
+	if err == nil || !strings.Contains(err.Error(), "older than required "+doctorMinAMQVersion) {
+		t.Fatalf("external-lead late floor error=%v (resolution calls=%d)", err, resolution)
+	}
+	if resolution != 6 {
+		t.Fatalf("resolution calls=%d, want refusal at complete preflight call 6", resolution)
+	}
+	if stampCalls != 0 {
+		t.Fatalf("pre-floor external-lead path stamped pane %d time(s)", stampCalls)
+	}
+	if len(backend.launches) != 0 {
+		t.Fatalf("pre-floor external-lead path opened %d backend launch(es)", len(backend.launches))
+	}
+	agentDir := filepath.Join(base, "floor-external", "agents", "cto")
+	if _, err := launch.Read(agentDir); !os.IsNotExist(err) {
+		t.Fatalf("pre-floor external-lead path wrote launch record: %v", err)
+	}
+	for _, path := range []string{
+		briefPathForProfile(dir, team.DefaultProfile, "floor-external"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-external"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("pre-floor external-lead path mutated %s: %v", path, err)
+		}
+	}
+}
+
 func TestResumeExecRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := seedTeam(t, team.Team{
@@ -100,4 +331,43 @@ func TestResumeExecRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
 			t.Fatalf("pre-floor resume mutated %s: %v", path, statErr)
 		}
 	}
+}
+
+func snapshotTestTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		value := info.Mode().String()
+		switch {
+		case info.Mode().IsRegular():
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			value += "\x00" + string(body)
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			value += "\x00" + target
+		}
+		out[rel] = value
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot tree %s: %v", root, err)
+	}
+	return out
 }

--- a/internal/cli/parent_amq_floor_test.go
+++ b/internal/cli/parent_amq_floor_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,6 +13,39 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
+
+type floorRenderingBackend struct {
+	fakeBackend
+}
+
+func (*floorRenderingBackend) Name() string { return "floor-rendering" }
+
+func (b *floorRenderingBackend) DryRun(t team.Team, opts teamLaunchOptions) error {
+	if err := b.fakeBackend.DryRun(t, opts); err != nil {
+		return err
+	}
+	for _, pane := range buildTeamLaunchPanes(t, opts) {
+		if _, err := fmt.Fprintln(os.Stdout, pane.Command); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func useFloorRenderingBackend(t *testing.T) *floorRenderingBackend {
+	t.Helper()
+	backend := &floorRenderingBackend{}
+	prev, hadPrev := teamLaunchBackends[backend.Name()]
+	teamLaunchBackends[backend.Name()] = backend
+	t.Cleanup(func() {
+		if hadPrev {
+			teamLaunchBackends[backend.Name()] = prev
+			return
+		}
+		delete(teamLaunchBackends, backend.Name())
+	})
+	return backend
+}
 
 func TestTeamLaunchRejectsPreFloorAMQBeforeParentMutations(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
@@ -47,12 +81,12 @@ func TestTeamLaunchDryRunReportsPreFloorAMQAndRendersPreviewWithoutMutations(t *
 	dir := seedTeam(t, team.Team{
 		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-dry-run"}},
 	})
-	backend := useFakeBackend(t)
+	backend := useFloorRenderingBackend(t)
 	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
 
 	stdout, _, err := captureOutput(t, func() error {
 		return executeTeamLaunch(teamLaunchOptions{
-			Terminal: "fake", Workstream: "floor-dry-run", Profile: team.DefaultProfile,
+			Terminal: backend.Name(), Workstream: "floor-dry-run", Profile: team.DefaultProfile,
 			Trust: trustModeApproveForMe, SquadBin: "amq-squad", NoBootstrap: true, DryRun: true,
 		}, true, true)
 	})
@@ -62,6 +96,7 @@ func TestTeamLaunchDryRunReportsPreFloorAMQAndRendersPreviewWithoutMutations(t *
 	for _, want := range []string{
 		"AMQ FLOOR VIOLATIONS", "role=cto", "observed=0.48.0",
 		"required_min=" + doctorMinAMQVersion, "live=refused",
+		"agent up codex", "--role cto", "--session floor-dry-run",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("pre-floor dry-run report missing %q:\n%s", want, stdout)
@@ -117,8 +152,8 @@ func TestUpDryRunReportsPreFloorAMQAndRendersCommandsWithoutMutations(t *testing
 }
 
 func TestUpDryRunJSONReportsPreFloorAMQAndRetainsFullPlan(t *testing.T) {
-	setupFakeAMQSessionRoots(t)
-	seedTeam(t, team.Team{
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
 		Members: []team.Member{{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-up-dry-json"}},
 	})
 	t.Setenv("AMQ_FAKE_VERSION", "0.48.0")
@@ -144,6 +179,15 @@ func TestUpDryRunJSONReportsPreFloorAMQAndRetainsFullPlan(t *testing.T) {
 	}
 	if !strings.Contains(env.Data.Plan[0].Command, "agent up") {
 		t.Fatalf("dry-run json omitted live command: %+v", env.Data.Plan[0])
+	}
+	for _, path := range []string{
+		filepath.Join(base, "floor-up-dry-json"),
+		briefPathForProfile(dir, team.DefaultProfile, "floor-up-dry-json"),
+		notificationWatcherRuntimePath(dir, team.DefaultProfile, "floor-up-dry-json"),
+	} {
+		if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+			t.Fatalf("pre-floor JSON up dry-run mutated %s: %v", path, statErr)
+		}
 	}
 }
 
@@ -230,6 +274,89 @@ func TestUpResetRejectsNewlyPreFloorResolutionBeforeByteIdenticalSessionDeletion
 	}
 	if _, err := os.Stat(briefPathForProfile(dir, team.DefaultProfile, "floor-reset-late")); !os.IsNotExist(err) {
 		t.Fatalf("pre-floor reset wrote brief: %v", err)
+	}
+}
+
+func TestUpResetExternalLeadConsumesPinnedAMQSnapshotAfterDeletion(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	seedTeam(t, team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "floor-reset-external"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "floor-reset-external"},
+		},
+	})
+	backend := useFakeBackend(t)
+	root := filepath.Join(base, "floor-reset-external")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "deleted-by-reset")
+	if err := os.WriteFile(sentinel, []byte("old session\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPane := currentPaneIdentity
+	currentPaneIdentity = func() (*tmuxpane.PaneIdentity, error) {
+		return &tmuxpane.PaneIdentity{
+			Session: "tmux-main", WindowID: "@7", WindowName: "shell", PaneID: "%5",
+		}, nil
+	}
+	t.Cleanup(func() { currentPaneIdentity = originalPane })
+	t.Setenv("AM_ME", "cto")
+	t.Setenv("AM_BASE_ROOT", base)
+	t.Setenv("AM_ROOT", root)
+	t.Setenv("AM_SESSION", "floor-reset-external")
+
+	originalResolver := resolveTeamLaunchAMQEnv
+	resolution := 0
+	resolveTeamLaunchAMQEnv = func(cwd, profile, session, handle string) (amqEnv, error) {
+		env, err := originalResolver(cwd, profile, session, handle)
+		resolution++
+		// Calls 1-4 are the two complete floor passes. Calls 5-6 build the
+		// complete pinned snapshot before reset. A seventh call would be the
+		// historical post-deletion external-lead re-resolution.
+		if err == nil && resolution >= 7 {
+			env.AMQVersion = "0.48.0"
+		}
+		return env, err
+	}
+	t.Cleanup(func() { resolveTeamLaunchAMQEnv = originalResolver })
+
+	originalStamp := stampCapturedLaunchPane
+	stampCalls := 0
+	stampCapturedLaunchPane = func(string, string, string) error {
+		stampCalls++
+		return nil
+	}
+	t.Cleanup(func() { stampCapturedLaunchPane = originalStamp })
+
+	_, _, err := captureOutput(t, func() error {
+		return runUp([]string{"floor-reset-external", "--reset", "--yes", "--terminal", "fake"})
+	})
+	if err != nil {
+		t.Fatalf("up --reset with pinned external lead: %v (resolution calls=%d)", err, resolution)
+	}
+	if resolution != 6 {
+		t.Fatalf("resolution calls=%d, want only six pre-reset roster resolutions", resolution)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("reset did not cross the destructive boundary: %v", err)
+	}
+	if stampCalls != 1 {
+		t.Fatalf("external lead pane stamps=%d, want 1", stampCalls)
+	}
+	if len(backend.launches) != 1 || len(backend.teams) != 1 ||
+		len(backend.teams[0].Members) != 1 || backend.teams[0].Members[0].Role != "qa" {
+		t.Fatalf("post-reset worker launch=%d teams=%+v", len(backend.launches), backend.teams)
+	}
+	rec, err := launch.Read(filepath.Join(root, "agents", "cto"))
+	if err != nil {
+		t.Fatalf("read pinned external lead record: %v", err)
+	}
+	if !rec.External || rec.Handle != "cto" || rec.Session != "floor-reset-external" {
+		t.Fatalf("pinned external lead record=%+v", rec)
 	}
 }
 

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -63,13 +63,20 @@ func (b *duplicateBlocker) Error() string {
 // agentLaunchPreflight inspects existing artifacts for a target agent identity
 // and reports whether a launch should be refused.
 type agentLaunchPreflight struct {
+	Role       string
+	CWD        string
 	AgentDir   string
 	Handle     string
 	Workstream string
 	Root       string
 	BaseRoot   string
 	Binary     string
-	Force      bool
+	AMQVersion string
+	// AMQFloorViolation is populated only for a dry-run whose resolved AMQ
+	// version would make the equivalent live launch refuse. Dry-run renders
+	// this diagnosis and continues the preview without mutating.
+	AMQFloorViolation string
+	Force             bool
 	// DryRun keeps the preflight inspection read-only: stale lock files are
 	// detected as non-blocking but never removed. Required for --dry-run paths
 	// where the operator expects zero side effects on disk.

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -70,6 +70,7 @@ type agentLaunchPreflight struct {
 	Workstream string
 	Root       string
 	BaseRoot   string
+	RootSource string
 	Binary     string
 	AMQVersion string
 	// AMQFloorViolation is populated only for a dry-run whose resolved AMQ

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -158,8 +158,11 @@ func TestRealAMQCompatibility(t *testing.T) {
 	t.Run("coop exec drains preexisting goal with zero injection", func(t *testing.T) {
 		realAMQCoopExecBaselineDrainContract(t, binary)
 	})
+	t.Run("production cleanup recovers owner-bound managed wake", func(t *testing.T) {
+		realAMQProductionOwnerBoundCleanupContract(t, binary, version)
+	})
 	t.Run("external wake suppresses backlog and injects post-baseline resend", func(t *testing.T) {
-		realAMQExternalWakeBaselineContract(t, binary)
+		realAMQExternalWakeBaselineContract(t, binary, version)
 	})
 	t.Run("doctor repairs malformed configured mailbox", func(t *testing.T) {
 		realAMQDoctorMailboxRepairContract(t, binary)
@@ -457,7 +460,86 @@ amq wake recover-owner --root "$AM_ROOT" --me "$AM_ME" --json >/dev/null
 	}
 }
 
-func realAMQExternalWakeBaselineContract(t *testing.T, binary string) {
+func realAMQProductionOwnerBoundCleanupContract(t *testing.T, binary, version string) {
+	t.Helper()
+	project := realAMQSafeInjectViaFixtureProject(t)
+	root := filepath.Join(project, ".agent-mail", "production-owner-cleanup")
+	realAMQInitAgents(t, binary, project, root, "member")
+	cleanEnv := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(os.Environ()))
+
+	injectionLog := filepath.Join(project, "owner-cleanup-injections.log")
+	injector := filepath.Join(project, "injector.sh")
+	member := filepath.Join(project, "member.sh")
+	ready := filepath.Join(project, "member.ready")
+	if err := os.WriteFile(injector, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$AMQ_TEST_INJECTION_LOG\"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	memberScript := `#!/bin/sh
+trap 'exit 0' TERM INT
+: > "$AMQ_TEST_MEMBER_READY"
+while :; do sleep 1; done
+`
+	if err := os.WriteFile(member, []byte(memberScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(
+		binary,
+		"coop", "exec", "--root", root, "--me", "member", "--require-wake",
+		"--wake-inject-via", injector, member,
+	)
+	cmd.Dir = project
+	cmd.Env = append(cleanEnv,
+		"AMQ_TEST_INJECTION_LOG="+injectionLog,
+		"AMQ_TEST_MEMBER_READY="+ready,
+	)
+	var commandLog bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &commandLog, &commandLog
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if !waited && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+	waitForRealWakeFile(t, ready, "owner-bound member readiness")
+	agentDir := filepath.Join(root, "agents", "member")
+	waitForRealWakeCondition(t, "owner-bound wake lock", func() bool {
+		_, err := os.Stat(wakeLockPath(agentDir))
+		return err == nil
+	})
+	lock, err := readWakeLock(agentDir)
+	if err != nil {
+		t.Fatalf("read owner-bound wake lock: %v", err)
+	}
+	rec := launch.Record{
+		CWD:           project,
+		AMQVersion:    version,
+		AgentPID:      cmd.Process.Pid,
+		WakePID:       lock.PID,
+		WakeInjectVia: injector,
+	}
+	term := newSignalTerminator(false)
+	if err := term.Terminate(rec.AgentPID); err != nil {
+		t.Fatalf("signal owner-bound member: %v", err)
+	}
+	result := reapStaleArtifacts(agentDir, "member", root, false, rec, term, defaultDuplicateLaunchProbe)
+	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved {
+		t.Fatalf("production owner-bound cleanup result=%+v\ncommand log:\n%s", result, commandLog.String())
+	}
+	_ = cmd.Wait()
+	waited = true
+	if defaultDuplicateLaunchProbe.PIDAlive(lock.PID) {
+		t.Fatalf("production owner-bound cleanup left wake pid %d alive", lock.PID)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
+		t.Fatalf("production owner-bound cleanup left wake lock: %v", err)
+	}
+}
+
+func realAMQExternalWakeBaselineContract(t *testing.T, binary, version string) {
 	t.Helper()
 	project := realAMQSafeInjectViaFixtureProject(t)
 	root := filepath.Join(project, ".agent-mail", "external-baseline")
@@ -521,8 +603,16 @@ func realAMQExternalWakeBaselineContract(t *testing.T, binary string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(injected, []byte("post-baseline goal resend")) || bytes.Contains(injected, []byte("original goal")) {
-		t.Fatalf("external wake injection did not isolate the post-baseline resend:\n%s", injected)
+	lines := nonemptyLines(string(injected))
+	if len(lines) != 1 {
+		t.Fatalf("external wake injected %d non-empty lines after one post-baseline resend, want 1:\n%s", len(lines), injected)
+	}
+	if semverMeetsStableFloor(version, historicalStandaloneWakeDoorbellAMQVersion) {
+		if lines[0] != realAMQCoopWakeDoorbell {
+			t.Fatalf("AMQ %s standalone wake = %q, want fixed doorbell %q", version, lines[0], realAMQCoopWakeDoorbell)
+		}
+	} else if !strings.Contains(lines[0], "post-baseline goal resend") || strings.Contains(lines[0], "original goal") {
+		t.Fatalf("AMQ %s standalone wake did not isolate the post-baseline subject:\n%s", version, injected)
 	}
 
 	_ = wake.Process.Kill()
@@ -667,12 +757,20 @@ func realAMQExactInjectViaWakeRetirement(t *testing.T, binary string) {
 	if mailID == "" {
 		t.Fatalf("pre-retirement mailbox send omitted stable id: %s", mailOut)
 	}
-	previous := runExactWakeRetire
+	previousRecover := runExactWakeRecoverOwner
+	runExactWakeRecoverOwner = func(req amqCommandRequest) ([]byte, error) {
+		out, err := realAMQTryCommand(binary, req.Dir, req.Env, req.Arg...)
+		return []byte(out), err
+	}
+	previousRetire := runExactWakeRetire
 	runExactWakeRetire = func(req amqCommandRequest) ([]byte, error) {
 		out, err := realAMQTryCommand(binary, req.Dir, req.Env, req.Arg...)
 		return []byte(out), err
 	}
-	t.Cleanup(func() { runExactWakeRetire = previous })
+	t.Cleanup(func() {
+		runExactWakeRecoverOwner = previousRecover
+		runExactWakeRetire = previousRetire
+	})
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- wake.Wait() }()
 	result := reapStaleArtifacts(filepath.Join(root, "agents", "consumer"), "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -29,8 +29,8 @@ func TestRealAMQGateCloseReplyRefsCompatibility(t *testing.T) {
 		t.Skipf("AMQ_SQUAD_REAL_AMQ is unavailable or not executable: %v", err)
 	}
 	version := strings.TrimSpace(realAMQCommand(t, binary, t.TempDir(), nil, "version"))
-	if !semverMeetsStableFloor(version, "0.43.1") {
-		t.Skipf("AMQ %s predates reply refs compatibility floor 0.43.1", version)
+	if !semverMeetsStableFloor(version, doctorMinAMQVersion) {
+		t.Fatalf("real AMQ %q is below supported floor %s", version, doctorMinAMQVersion)
 	}
 
 	project := t.TempDir()
@@ -149,27 +149,21 @@ func TestRealAMQCompatibility(t *testing.T) {
 	t.Run("three actor 100 message isolation", func(t *testing.T) {
 		realAMQThreeActorHundredMessageIsolation(t, binary)
 	})
-	if semverMeetsStableFloor(version, "0.45.0") {
-		t.Run("committed delivery wording contract", func(t *testing.T) {
-			realAMQCommittedDeliveryWordingContract(t, binary)
-		})
-		t.Run("exact inject-via wake retirement", func(t *testing.T) {
-			realAMQExactInjectViaWakeRetirement(t, binary)
-		})
-	}
-	if amqSupportsBaselineExisting(version) {
-		t.Run("coop exec drains preexisting goal with zero injection", func(t *testing.T) {
-			realAMQCoopExecBaselineDrainContract(t, binary)
-		})
-		t.Run("external wake suppresses backlog and injects post-baseline resend", func(t *testing.T) {
-			realAMQExternalWakeBaselineContract(t, binary)
-		})
-	}
-	if semverMeetsStableFloor(version, "0.48.0") {
-		t.Run("doctor repairs malformed configured mailbox", func(t *testing.T) {
-			realAMQDoctorMailboxRepairContract(t, binary)
-		})
-	}
+	t.Run("committed delivery wording contract", func(t *testing.T) {
+		realAMQCommittedDeliveryWordingContract(t, binary)
+	})
+	t.Run("exact inject-via wake retirement", func(t *testing.T) {
+		realAMQExactInjectViaWakeRetirement(t, binary)
+	})
+	t.Run("coop exec drains preexisting goal with zero injection", func(t *testing.T) {
+		realAMQCoopExecBaselineDrainContract(t, binary)
+	})
+	t.Run("external wake suppresses backlog and injects post-baseline resend", func(t *testing.T) {
+		realAMQExternalWakeBaselineContract(t, binary)
+	})
+	t.Run("doctor repairs malformed configured mailbox", func(t *testing.T) {
+		realAMQDoctorMailboxRepairContract(t, binary)
+	})
 
 	t.Run("post-coop child identity", func(t *testing.T) {
 		project := t.TempDir()
@@ -411,7 +405,6 @@ func realAMQCoopExecBaselineDrainContract(t *testing.T, binary string) {
 
 	injectionLog := filepath.Join(project, "injections.log")
 	drainLog := filepath.Join(project, "bootstrap-drain.log")
-	retireErrLog := filepath.Join(project, "retire-err.log")
 	injector := filepath.Join(project, "injector.sh")
 	member := filepath.Join(project, "member.sh")
 	if err := os.WriteFile(injector, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$AMQ_TEST_INJECTION_LOG\"\n"), 0o700); err != nil {
@@ -421,37 +414,32 @@ func realAMQCoopExecBaselineDrainContract(t *testing.T, binary string) {
 	// process starts. The delay leaves more than AMQ's debounce window for an
 	// un-suppressed backlog injection to become observable before the drain.
 	//
-	// This subtest's contract is zero injection plus drain engagement, not
-	// wake retirement mechanics (exact_inject-via_wake_retirement covers
-	// that, and passes on every tested AMQ version). Dropping the retire call
-	// entirely was tried and rejected: coop exec's spawned wake helper
-	// inherits the SAME stdout/stderr pipe as this test's own subprocess
-	// capture, and once coop exec execs into this script the wake helper is
-	// deliberately orphaned (left running) rather than killed; an orphan
-	// that never exits holds that pipe open, so the overall command blocks
-	// until it eventually stops on its own (~30s against AMQ 0.46, every
-	// run) instead of returning promptly. So retire is kept, but strictly
-	// best-effort ("|| true"): AMQ 0.46's own OS/timing-dependent internal
-	// wake lifecycle (avivsinai/agent-message-queue#267) can refuse it via
-	// two different races (lock busy pre-prepared, lock already gone) that
-	// this subtest does not need to win — a successful retire just also
-	// reaps the wake helper promptly in the common case, and a refused one
-	// leaves cleanup to coop exec/the OS without failing this contract.
-	// Diagnostics land in a log instead of being discarded, in case a retire
-	// failure is ever worth inspecting.
+	// AMQ 0.49.0 binds this inject-via wake to coop exec's exact owner
+	// lifecycle. The member must not call the ownerless `wake retire` path:
+	// retire correctly refuses an owner-bound claim. Instead the live member
+	// releases its own exact claim through `wake recover-owner`, authenticated
+	// by the inherited AMQ_WAKE_OWNER token and OS session. This replaces the
+	// pre-0.49 best-effort retire workaround with the supported owner contract.
 	memberScript := `#!/bin/sh
 sleep 1
 amq drain --include-body > "$AMQ_TEST_DRAIN_LOG"
-amq wake retire --root "$AM_ROOT" --me "$AM_ME" --inject-via "$AMQ_TEST_INJECTOR" >/dev/null 2>"$AMQ_TEST_RETIRE_ERR_LOG" || true
+amq wake recover-owner --root "$AM_ROOT" --me "$AM_ME" --json >/dev/null
 `
 	if err := os.WriteFile(member, []byte(memberScript), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	env := append([]string(nil), cleanEnv...)
-	env = append(env, "AMQ_TEST_INJECTION_LOG="+injectionLog, "AMQ_TEST_DRAIN_LOG="+drainLog, "AMQ_TEST_INJECTOR="+injector, "AMQ_TEST_RETIRE_ERR_LOG="+retireErrLog)
+	env = append(env, "AMQ_TEST_INJECTION_LOG="+injectionLog, "AMQ_TEST_DRAIN_LOG="+drainLog, "AMQ_TEST_INJECTOR="+injector)
+	started := time.Now()
 	realAMQCommand(t, binary, project, env,
 		"coop", "exec", "--root", root, "--me", "member", "--require-wake",
 		"--wake-inject-via", injector, member)
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
+		t.Fatalf("owner-bound coop exec teardown took %s; wake helper may still be holding the command pipe", elapsed)
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "member", ".wake.lock")); !os.IsNotExist(err) {
+		t.Fatalf("authenticated owner recovery left wake claim after member exit: %v", err)
+	}
 
 	drained, err := os.ReadFile(drainLog)
 	if err != nil {
@@ -687,8 +675,8 @@ func realAMQExactInjectViaWakeRetirement(t *testing.T, binary string) {
 	t.Cleanup(func() { runExactWakeRetire = previous })
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- wake.Wait() }()
-	result := reapStaleArtifacts(filepath.Join(root, "agents", "consumer"), "consumer", root, false, launch.Record{CWD: project, AMQVersion: "0.45.0", WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)
-	if result.failed() || (result.WakeRetirement != "amq_0_45_exact" && result.WakeRetirement != nativeWakeRetireSelfCleaned) || result.WakeKilled != wake.Process.Pid {
+	result := reapStaleArtifacts(filepath.Join(root, "agents", "consumer"), "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)
+	if result.failed() || (result.WakeRetirement != "amq_exact" && result.WakeRetirement != nativeWakeRetireSelfCleaned) || result.WakeKilled != wake.Process.Pid {
 		t.Fatalf("exact retirement result=%+v wake_log=%s", result, wakeLog.String())
 	}
 	select {

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -25,7 +25,7 @@ const realAMQCoopWakeDoorbell = ": AMQ doorbell run amq drain --include-body the
 // with latest rerun as a forward-compatibility canary. Unlike the Linux queue
 // compatibility test, every case here uses a disposable real tmux PTY and
 // fails (rather than skips) when tmux or native wake injection is unavailable
-// after the lane opts in. AMQ v0.48.0's Linux-only
+// after the lane opts in. AMQ v0.48.0's historical Linux-only
 // /proc/sys/dev/tty/legacy_tiocsti=0 degradation cannot be exercised by this
 // macOS lane; upstream AMQ unit tests own that non-input-notifier path.
 func TestRealAMQWakeCompatibility(t *testing.T) {
@@ -39,15 +39,16 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		t.Fatalf("required real-wake lane needs tmux: %v", err)
 	}
 	version := strings.TrimSpace(realWakeCommand(t, t.TempDir(), nil, amq, "version"))
+	if !semverMeetsStableFloor(version, doctorMinAMQVersion) {
+		t.Fatalf("real AMQ %q is below supported floor %s", version, doctorMinAMQVersion)
+	}
 	if expected := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ_VERSION")); expected != "" && expected != "latest" && strings.TrimPrefix(version, "v") != strings.TrimPrefix(expected, "v") {
 		t.Fatalf("real AMQ version = %q, expected requested %q", version, expected)
 	}
 	t.Logf("real wake compatibility: amq=%s version=%s tmux=%s", amq, version, tmux)
-	if semverMeetsStableFloor(version, "0.45.0") {
-		t.Run("exact inject-via wake retirement", func(t *testing.T) {
-			realAMQExactInjectViaWakeRetirement(t, amq)
-		})
-	}
+	t.Run("exact inject-via wake retirement", func(t *testing.T) {
+		realAMQExactInjectViaWakeRetirement(t, amq)
+	})
 
 	repo, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
@@ -66,7 +67,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 				h.start([]string{amq, "coop", "exec", "--root", h.root, "--me", "codex", "--require-wake", "--wake-inject-mode", mode, h.recorder})
 				h.send("sender", "codex", "native-"+mode, "native wake canary")
 				line := h.oneSubmittedLine()
-				assertRealAMQCoopWakePayload(t, version, line, "native-"+mode)
+				assertRealAMQCoopWakePayload(t, line)
 			})
 		}
 	})
@@ -90,7 +91,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		}
 		h.send("cto", "qa", "managed-raw", "managed wake canary")
 		line := h.oneSubmittedLine()
-		assertRealAMQCoopWakePayload(t, version, line, "managed-raw")
+		assertRealAMQCoopWakePayload(t, line)
 	})
 
 	t.Run("managed stop resume and cleanup", func(t *testing.T) {
@@ -169,7 +170,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		assertRealWakeProcessIdentity(t, resumed)
 		h.send("cto", "qa", "managed-resume", "managed resume wake canary")
 		line := h.oneSubmittedLine()
-		assertRealAMQCoopWakePayload(t, version, line, "managed-resume")
+		assertRealAMQCoopWakePayload(t, line)
 
 		realWakeCommand(t, h.project, h.env(), squad,
 			"stop", "--project", h.project, "--profile", team.DefaultProfile, "--session", h.session, "--role", "cto")
@@ -522,18 +523,11 @@ func assertMarkerFreeWake(t *testing.T, got string) {
 	}
 }
 
-func assertRealAMQCoopWakePayload(t *testing.T, version, got, legacySubject string) {
+func assertRealAMQCoopWakePayload(t *testing.T, got string) {
 	t.Helper()
 	assertMarkerFreeWake(t, got)
-	// Unparseable versions intentionally take the legacy branch so local dev binaries fail loudly.
-	if semverMeetsStableFloor(version, "0.47.1") {
-		if got != realAMQCoopWakeDoorbell {
-			t.Fatalf("submitted coop wake = %q, want fixed doorbell %q for AMQ %s", got, realAMQCoopWakeDoorbell, version)
-		}
-		return
-	}
-	if !strings.Contains(got, legacySubject) {
-		t.Fatalf("submitted legacy coop wake = %q, want subject %q for AMQ %s", got, legacySubject, version)
+	if got != realAMQCoopWakeDoorbell {
+		t.Fatalf("submitted coop wake = %q, want fixed doorbell %q", got, realAMQCoopWakeDoorbell)
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -927,22 +927,67 @@ type teamPlanMember struct {
 // plan: project/team-home + workstream + trust + profile + binary args +
 // per-member command lines.
 type teamPlan struct {
-	TeamHome      string                `json:"team_home"`
-	Project       string                `json:"project"`
-	Workstream    string                `json:"workstream"`
-	Profile       string                `json:"profile"`
-	Trust         string                `json:"trust"`
-	Orchestrated  bool                  `json:"orchestrated"`
-	Lead          string                `json:"lead,omitempty"`
-	Members       int                   `json:"members"`
-	BinaryArgs    map[string][]string   `json:"binary_args,omitempty"`
-	Operator      team.OperatorView     `json:"operator"`
-	Capabilities  team.Capabilities     `json:"capabilities"`
-	Autonomous    team.AutonomousStatus `json:"autonomous"`
-	Visibility    string                `json:"visibility,omitempty"`
-	Symphony      bool                  `json:"symphony,omitempty"`
-	LaunchCommand string                `json:"launch_command,omitempty"`
-	Plan          []teamPlanMember      `json:"plan"`
+	TeamHome           string                  `json:"team_home"`
+	Project            string                  `json:"project"`
+	Workstream         string                  `json:"workstream"`
+	Profile            string                  `json:"profile"`
+	Trust              string                  `json:"trust"`
+	Orchestrated       bool                    `json:"orchestrated"`
+	Lead               string                  `json:"lead,omitempty"`
+	Members            int                     `json:"members"`
+	BinaryArgs         map[string][]string     `json:"binary_args,omitempty"`
+	Operator           team.OperatorView       `json:"operator"`
+	Capabilities       team.Capabilities       `json:"capabilities"`
+	Autonomous         team.AutonomousStatus   `json:"autonomous"`
+	Visibility         string                  `json:"visibility,omitempty"`
+	Symphony           bool                    `json:"symphony,omitempty"`
+	LaunchCommand      string                  `json:"launch_command,omitempty"`
+	AMQFloorViolations []teamAMQFloorViolation `json:"amq_floor_violations,omitempty"`
+	Plan               []teamPlanMember        `json:"plan"`
+}
+
+type teamAMQFloorViolation struct {
+	Role        string `json:"role"`
+	Handle      string `json:"handle"`
+	AMQVersion  string `json:"amq_version"`
+	RequiredMin string `json:"required_min"`
+	LiveOutcome string `json:"live_outcome"`
+	Detail      string `json:"detail"`
+}
+
+func newTeamAMQFloorViolation(role, handle, version, detail string) teamAMQFloorViolation {
+	return teamAMQFloorViolation{
+		Role: strings.TrimSpace(role), Handle: strings.TrimSpace(handle),
+		AMQVersion: strings.TrimSpace(version), RequiredMin: doctorMinAMQVersion,
+		LiveOutcome: "refused", Detail: strings.TrimSpace(detail),
+	}
+}
+
+func teamAMQFloorViolationsForPreflights(preflights []agentLaunchPreflight) []teamAMQFloorViolation {
+	var out []teamAMQFloorViolation
+	for _, preflight := range preflights {
+		if strings.TrimSpace(preflight.AMQFloorViolation) == "" {
+			continue
+		}
+		out = append(out, newTeamAMQFloorViolation(
+			preflight.Role, preflight.Handle, preflight.AMQVersion, preflight.AMQFloorViolation,
+		))
+	}
+	return out
+}
+
+func renderTeamAMQFloorViolations(out io.Writer, violations []teamAMQFloorViolation) {
+	if len(violations) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "#")
+	fmt.Fprintln(out, "# AMQ FLOOR VIOLATIONS — LIVE LAUNCH WOULD REFUSE")
+	for _, violation := range violations {
+		fmt.Fprintf(out, "# role=%s handle=%s observed=%s required_min=%s live=%s\n",
+			violation.Role, violation.Handle, violation.AMQVersion, violation.RequiredMin, violation.LiveOutcome)
+		fmt.Fprintf(out, "#   %s\n", violation.Detail)
+	}
+	fmt.Fprintln(out, "#")
 }
 
 func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
@@ -1023,10 +1068,17 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 	// A launch-plan preview must validate the same AMQ context that live launch
 	// will use. Fresh default projects resolve structurally without writes;
 	// configured-root failures remain fatal instead of producing a false OK.
+	var floorViolations []teamAMQFloorViolation
 	for _, m := range members {
 		cwd := m.EffectiveCWD(t.Project)
-		if _, err := resolveAMQEnvForTeamLaunchProfile(cwd, opts.Profile, workstream, memberHandle(m)); err != nil {
+		env, err := resolveTeamLaunchAMQEnv(cwd, opts.Profile, workstream, memberHandle(m))
+		if err != nil {
 			return fmt.Errorf("resolve amq env for %s: %w", memberHandle(m), err)
+		}
+		if floorErr := validateLaunchAMQVersion(env.AMQVersion); floorErr != nil {
+			floorViolations = append(floorViolations, newTeamAMQFloorViolation(
+				m.Role, memberHandle(m), env.AMQVersion, floorErr.Error(),
+			))
 		}
 	}
 
@@ -1046,22 +1098,23 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 			profileName = team.DefaultProfile
 		}
 		plan := teamPlan{
-			TeamHome:      t.Project,
-			Project:       t.Project,
-			Workstream:    workstream,
-			Profile:       profileName,
-			Trust:         trustMode,
-			Orchestrated:  t.Orchestrated,
-			Lead:          t.Lead,
-			Members:       len(members),
-			BinaryArgs:    binaryArgs,
-			Operator:      team.EffectiveOperator(t),
-			Capabilities:  team.EffectiveCapabilities(t),
-			Autonomous:    team.EffectiveAutonomousStatus(t),
-			Visibility:    opts.Visibility,
-			Symphony:      opts.Symphony,
-			LaunchCommand: visibilityPreviewLaunchCommand(workstream, profileName, opts.Visibility),
-			Plan:          make([]teamPlanMember, 0, len(members)),
+			TeamHome:           t.Project,
+			Project:            t.Project,
+			Workstream:         workstream,
+			Profile:            profileName,
+			Trust:              trustMode,
+			Orchestrated:       t.Orchestrated,
+			Lead:               t.Lead,
+			Members:            len(members),
+			BinaryArgs:         binaryArgs,
+			Operator:           team.EffectiveOperator(t),
+			Capabilities:       team.EffectiveCapabilities(t),
+			Autonomous:         team.EffectiveAutonomousStatus(t),
+			Visibility:         opts.Visibility,
+			Symphony:           opts.Symphony,
+			LaunchCommand:      visibilityPreviewLaunchCommand(workstream, profileName, opts.Visibility),
+			AMQFloorViolations: floorViolations,
+			Plan:               make([]teamPlanMember, 0, len(members)),
 		}
 		for _, m := range members {
 			effectiveModel := memberResolvedModel(m, opts.ModelOverrides, binaryArgs)
@@ -1119,6 +1172,7 @@ func emitTeamCommands(projectDir string, opts emitTeamOptions) error {
 	fmt.Printf("# workstream: %s\n", workstream)
 	fmt.Printf("# trust:     %s\n", trustMode)
 	fmt.Printf("# members:   %d\n", len(members))
+	renderTeamAMQFloorViolations(os.Stdout, floorViolations)
 	if opts.Visibility != "" {
 		fmt.Printf("# visibility: %s\n", opts.Visibility)
 		if cmd := visibilityPreviewLaunchCommand(workstream, opts.Profile, opts.Visibility); cmd != "" {

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -261,6 +261,11 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 		}
 	}
 	if !opts.DryRun {
+		if err := validateResolvedTeamAMQVersions(t, opts.Profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+			return err
+		}
+	}
+	if !opts.DryRun {
 		initialIdentity, err := captureNamespaceEndpointIdentity(squadnamespace.Resolve(cwd, opts.Profile, workstream), "")
 		if err != nil {
 			return err
@@ -290,6 +295,9 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 			if err != nil {
 				return fmt.Errorf("team launch refused under admission: %w", err)
 			}
+		}
+		if err := validateResolvedTeamAMQVersions(currentTeam, opts.Profile, currentWorkstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+			return err
 		}
 		currentIdentity, err := captureNamespaceEndpointIdentity(squadnamespace.Resolve(cwd, opts.Profile, currentWorkstream), "")
 		if err != nil {
@@ -650,6 +658,28 @@ func buildTeamPreflights(t team.Team, opts teamLaunchOptions) ([]agentLaunchPref
 		})
 	}
 	return out, nil
+}
+
+type teamAMQEnvResolver func(cwd, profile, session, handle string) (amqEnv, error)
+
+// validateResolvedTeamAMQVersions applies the same fail-closed floor as
+// `agent up` to every member that belongs to the selected workstream. Parent
+// launch, resume, and reset paths call it before their first persistent side
+// effect so an incompatible child can never reject only after the parent has
+// changed roots, briefs, watchers, panes, or session state.
+func validateResolvedTeamAMQVersions(t team.Team, profile, workstream string, resolve teamAMQEnvResolver) error {
+	active, _ := filterMembersBySession(t.Members, workstream)
+	for _, m := range orderedTeamMembers(active) {
+		cwd := m.EffectiveCWD(t.Project)
+		env, err := resolve(cwd, profile, workstream, m.Handle)
+		if err != nil {
+			return fmt.Errorf("resolve amq env for %s: %w", m.Handle, err)
+		}
+		if err := validateLaunchAMQVersion(env.AMQVersion); err != nil {
+			return fmt.Errorf("%s: %w", m.Handle, err)
+		}
+	}
+	return nil
 }
 
 func registeredTeamLaunchTerminals() []string {

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -385,7 +385,7 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 			t = filtered
 			externalLeadFiltered = true
 		}
-	} else if filtered, skipped, err := maybeFilterCurrentExternalLead(t, opts.Workstream, opts.Profile, trustMode, mergedBinaryArgs, opts.ModelOverrides, !opts.DryRun); err != nil {
+	} else if filtered, skipped, err := maybeFilterCurrentExternalLeadFromPreflights(t, opts.Workstream, opts.Profile, trustMode, mergedBinaryArgs, opts.ModelOverrides, preflights, !opts.DryRun); err != nil {
 		return err
 	} else if skipped {
 		t = filtered
@@ -685,6 +685,7 @@ func buildTeamPreflights(t team.Team, opts teamLaunchOptions) ([]agentLaunchPref
 			Workstream:        env.SessionName,
 			Root:              root,
 			BaseRoot:          absoluteAMQRoot(cwd, env.BaseRoot),
+			RootSource:        env.RootSource,
 			Binary:            m.Binary,
 			AMQVersion:        env.AMQVersion,
 			AMQFloorViolation: floorViolation,
@@ -803,7 +804,59 @@ func buildTeamLaunchPanes(t team.Team, opts teamLaunchOptions) []teamLaunchPane 
 	return panes
 }
 
+type externalLeadAMQResolver func(team.Member, string, string, string, string) (amqEnv, error)
+
 func maybeFilterCurrentExternalLead(t team.Team, workstream, profile, trustMode string, binaryArgs map[string][]string, modelOverrides map[string]string, write bool) (team.Team, bool, error) {
+	return maybeFilterCurrentExternalLeadUsing(
+		t,
+		workstream,
+		profile,
+		trustMode,
+		binaryArgs,
+		modelOverrides,
+		func(_ team.Member, cwd, profile, workstream, handle string) (amqEnv, error) {
+			return resolveTeamLaunchAMQEnv(cwd, profile, workstream, handle)
+		},
+		write,
+	)
+}
+
+// maybeFilterCurrentExternalLeadFromPreflights is the only external-lead path
+// reachable from executeTeamLaunch. In particular, up --reset calls it after
+// deleting the prior session, so it must consume the pre-reset snapshot and
+// must never resolve AMQ again.
+func maybeFilterCurrentExternalLeadFromPreflights(t team.Team, workstream, profile, trustMode string, binaryArgs map[string][]string, modelOverrides map[string]string, preflights []agentLaunchPreflight, write bool) (team.Team, bool, error) {
+	return maybeFilterCurrentExternalLeadUsing(
+		t,
+		workstream,
+		profile,
+		trustMode,
+		binaryArgs,
+		modelOverrides,
+		func(lead team.Member, cwd, _ string, workstream, _ string) (amqEnv, error) {
+			for _, preflight := range preflights {
+				if !strings.EqualFold(strings.TrimSpace(preflight.Role), strings.TrimSpace(lead.Role)) {
+					continue
+				}
+				if !sameResolvedDir(preflight.CWD, cwd) || preflight.Workstream != workstream {
+					return amqEnv{}, fmt.Errorf("pinned AMQ preflight no longer matches external lead %s", lead.Role)
+				}
+				return amqEnv{
+					AMQVersion:  preflight.AMQVersion,
+					Root:        preflight.Root,
+					BaseRoot:    preflight.BaseRoot,
+					SessionName: preflight.Workstream,
+					Me:          preflight.Handle,
+					RootSource:  preflight.RootSource,
+				}, nil
+			}
+			return amqEnv{}, fmt.Errorf("pinned AMQ preflight is missing external lead %s", lead.Role)
+		},
+		write,
+	)
+}
+
+func maybeFilterCurrentExternalLeadUsing(t team.Team, workstream, profile, trustMode string, binaryArgs map[string][]string, modelOverrides map[string]string, resolve externalLeadAMQResolver, write bool) (team.Team, bool, error) {
 	if !t.Orchestrated || strings.TrimSpace(t.Lead) == "" {
 		return t, false, nil
 	}
@@ -817,7 +870,7 @@ func maybeFilterCurrentExternalLead(t team.Team, workstream, profile, trustMode 
 	}
 	cwd := lead.EffectiveCWD(t.Project)
 	handle := memberHandle(lead)
-	env, err := resolveTeamLaunchAMQEnv(cwd, profile, workstream, handle)
+	env, err := resolve(lead, cwd, profile, workstream, handle)
 	if err != nil {
 		if !write {
 			return t, false, nil

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -70,6 +70,11 @@ type teamLaunchOptions struct {
 	PreparedRunGuard      func(stage, role string) error
 	StagedClaim           string
 	PreserveLauncherFocus bool
+	// ResolvedAMQPreflights is a complete, floor-validated snapshot prepared
+	// by a parent command while it still owns the namespace admission and
+	// before any destructive reset. A non-nil slice prevents executeTeamLaunch
+	// from re-resolving AMQ after that parent's mutation boundary.
+	ResolvedAMQPreflights []agentLaunchPreflight
 }
 
 type teamLaunchResult struct {
@@ -116,6 +121,11 @@ type preparedTeamLaunchResultBackend interface {
 // should live in its own team_launch_<name>.go file and call
 // registerTeamLaunchBackend from init.
 var teamLaunchBackends = map[string]teamLaunchBackend{}
+
+// resolveTeamLaunchAMQEnv is the single injectable resolution seam for parent
+// team launch/reset paths. Every production call validates the returned AMQ
+// version before any persistent mutation or dry-run preview.
+var resolveTeamLaunchAMQEnv = resolveAMQEnvForTeamLaunchProfile
 
 func registerTeamLaunchBackend(backend teamLaunchBackend) {
 	name := backend.Name()
@@ -260,8 +270,8 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 			return nil
 		}
 	}
-	if !opts.DryRun {
-		if err := validateResolvedTeamAMQVersions(t, opts.Profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+	if !opts.DryRun && opts.ResolvedAMQPreflights == nil {
+		if err := validateResolvedTeamAMQVersions(t, opts.Profile, workstream, resolveTeamLaunchAMQEnv); err != nil {
 			return err
 		}
 	}
@@ -296,8 +306,10 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 				return fmt.Errorf("team launch refused under admission: %w", err)
 			}
 		}
-		if err := validateResolvedTeamAMQVersions(currentTeam, opts.Profile, currentWorkstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
-			return err
+		if opts.ResolvedAMQPreflights == nil {
+			if err := validateResolvedTeamAMQVersions(currentTeam, opts.Profile, currentWorkstream, resolveTeamLaunchAMQEnv); err != nil {
+				return err
+			}
 		}
 		currentIdentity, err := captureNamespaceEndpointIdentity(squadnamespace.Resolve(cwd, opts.Profile, currentWorkstream), "")
 		if err != nil {
@@ -347,6 +359,20 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 		memberRoles[strings.ToLower(m.Role)] = true
 	}
 	if err := validateModelOverrideKeys(opts.ModelOverrides, memberRoles); err != nil {
+		return err
+	}
+
+	// Resolve and floor-validate the complete active roster before the
+	// external-lead path can stamp a pane or write launch.json. Filtering the
+	// lead happens only after this read-only snapshot exists; the filtered
+	// preflight list is then reused without another AMQ resolution.
+	preflights := append([]agentLaunchPreflight(nil), opts.ResolvedAMQPreflights...)
+	if opts.ResolvedAMQPreflights == nil {
+		preflights, err = buildTeamPreflights(t, opts)
+		if err != nil {
+			return err
+		}
+	} else if err := validateResolvedTeamPreflights(t, opts.Workstream, preflights); err != nil {
 		return err
 	}
 	externalLeadFiltered := false
@@ -408,15 +434,13 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 
 	// Preflight the whole roster before any tmux command (or dry-run output)
 	// so a partially-launched team never appears.
-	preflights, err := buildTeamPreflights(t, opts)
-	if err != nil {
-		return err
-	}
+	preflights = filterResolvedTeamPreflights(preflights, t.Members)
 	if err := preflightTeam(preflights, defaultDuplicateLaunchProbe); err != nil {
 		return err
 	}
 
 	if opts.DryRun {
+		renderTeamAMQFloorViolations(os.Stdout, teamAMQFloorViolationsForPreflights(preflights))
 		return backend.DryRun(t, opts)
 	}
 	// Validate every configured custom launcher up front so a missing or
@@ -636,9 +660,16 @@ func buildTeamPreflights(t team.Team, opts teamLaunchOptions) ([]agentLaunchPref
 	out := make([]agentLaunchPreflight, 0, len(members))
 	for _, m := range members {
 		cwd := m.EffectiveCWD(t.Project)
-		env, err := resolveAMQEnvForTeamLaunchProfile(cwd, opts.Profile, opts.Workstream, m.Handle)
+		env, err := resolveTeamLaunchAMQEnv(cwd, opts.Profile, opts.Workstream, m.Handle)
 		if err != nil {
 			return nil, fmt.Errorf("resolve amq env for %s: %w", m.Handle, err)
+		}
+		floorViolation := ""
+		if err := validateLaunchAMQVersion(env.AMQVersion); err != nil {
+			if !opts.DryRun {
+				return nil, fmt.Errorf("%s: %w", m.Handle, err)
+			}
+			floorViolation = err.Error()
 		}
 		root := absoluteAMQRoot(cwd, env.Root)
 		handle := m.Handle
@@ -647,17 +678,62 @@ func buildTeamPreflights(t team.Team, opts teamLaunchOptions) ([]agentLaunchPref
 		}
 		agentDir := filepath.Join(root, "agents", handle)
 		out = append(out, agentLaunchPreflight{
-			AgentDir:   agentDir,
-			Handle:     handle,
-			Workstream: env.SessionName,
-			Root:       root,
-			BaseRoot:   absoluteAMQRoot(cwd, env.BaseRoot),
-			Binary:     m.Binary,
-			Force:      opts.ForceDuplicate,
-			DryRun:     opts.DryRun,
+			Role:              m.Role,
+			CWD:               cwd,
+			AgentDir:          agentDir,
+			Handle:            handle,
+			Workstream:        env.SessionName,
+			Root:              root,
+			BaseRoot:          absoluteAMQRoot(cwd, env.BaseRoot),
+			Binary:            m.Binary,
+			AMQVersion:        env.AMQVersion,
+			AMQFloorViolation: floorViolation,
+			Force:             opts.ForceDuplicate,
+			DryRun:            opts.DryRun,
 		})
 	}
 	return out, nil
+}
+
+func validateResolvedTeamPreflights(t team.Team, workstream string, preflights []agentLaunchPreflight) error {
+	active, _ := filterMembersBySession(t.Members, workstream)
+	expected := orderedTeamMembers(active)
+	if len(preflights) != len(expected) {
+		return fmt.Errorf("team launch refused: pinned AMQ preflight roster changed")
+	}
+	byRole := make(map[string]agentLaunchPreflight, len(preflights))
+	for _, preflight := range preflights {
+		role := strings.TrimSpace(preflight.Role)
+		if role == "" || strings.TrimSpace(preflight.CWD) == "" || strings.TrimSpace(preflight.Root) == "" {
+			return fmt.Errorf("team launch refused: pinned AMQ preflight is incomplete")
+		}
+		if _, exists := byRole[role]; exists {
+			return fmt.Errorf("team launch refused: duplicate pinned AMQ preflight role %q", role)
+		}
+		byRole[role] = preflight
+	}
+	for _, member := range expected {
+		preflight, ok := byRole[strings.TrimSpace(member.Role)]
+		if !ok || !sameResolvedDir(preflight.CWD, member.EffectiveCWD(t.Project)) ||
+			preflight.Workstream != workstream || strings.TrimSpace(preflight.Binary) != strings.TrimSpace(member.Binary) {
+			return fmt.Errorf("team launch refused: pinned AMQ preflight no longer matches role %q", member.Role)
+		}
+	}
+	return nil
+}
+
+func filterResolvedTeamPreflights(preflights []agentLaunchPreflight, members []team.Member) []agentLaunchPreflight {
+	active := make(map[string]bool, len(members))
+	for _, member := range members {
+		active[strings.TrimSpace(member.Role)] = true
+	}
+	out := make([]agentLaunchPreflight, 0, len(members))
+	for _, preflight := range preflights {
+		if active[strings.TrimSpace(preflight.Role)] {
+			out = append(out, preflight)
+		}
+	}
+	return out
 }
 
 type teamAMQEnvResolver func(cwd, profile, session, handle string) (amqEnv, error)
@@ -741,12 +817,18 @@ func maybeFilterCurrentExternalLead(t team.Team, workstream, profile, trustMode 
 	}
 	cwd := lead.EffectiveCWD(t.Project)
 	handle := memberHandle(lead)
-	env, err := resolveAMQEnvForTeamLaunchProfile(cwd, profile, workstream, handle)
+	env, err := resolveTeamLaunchAMQEnv(cwd, profile, workstream, handle)
 	if err != nil {
 		if !write {
 			return t, false, nil
 		}
 		return t, false, fmt.Errorf("resolve amq env for external lead %s: %w", handle, err)
+	}
+	if err := validateLaunchAMQVersion(env.AMQVersion); err != nil {
+		if !write {
+			return t, false, nil
+		}
+		return t, false, fmt.Errorf("%s: %w", handle, err)
 	}
 	if env.Me != "" {
 		handle = env.Me

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -192,7 +192,7 @@ func TestLeadRegisterWritesExternalRecordAndSetsLead(t *testing.T) {
 	if len(wakeOpts) != 1 {
 		t.Fatalf("wake start calls = %d, want 1", len(wakeOpts))
 	}
-	if wakeOpts[0].Root != filepath.Join(base, "issue-96") || wakeOpts[0].Handle != "cto" || wakeOpts[0].AMQVersion != "0.42.1" || !wakeOpts[0].Require {
+	if wakeOpts[0].Root != filepath.Join(base, "issue-96") || wakeOpts[0].Handle != "cto" || wakeOpts[0].AMQVersion != doctorMinAMQVersion || !wakeOpts[0].Require {
 		t.Fatalf("wake opts = %+v", wakeOpts[0])
 	}
 	if !strings.Contains(out, "wake: ready") {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -393,6 +393,9 @@ func executeResume(r resumeExecution) error {
 		return err
 	}
 	if r.Exec.Enabled {
+		if err := validateResolvedTeamAMQVersions(t, r.Profile, workstream, resolveAMQEnvForTeamProfile); err != nil {
+			return err
+		}
 		initialIdentity, err := captureNamespaceEndpointIdentity(squadnamespace.Resolve(r.ProjectDir, r.Profile, workstream), "")
 		if err != nil {
 			return err
@@ -408,6 +411,9 @@ func executeResume(r resumeExecution) error {
 		}
 		currentWorkstream, err := resolveTeamWorkstreamName(currentTeam, r.RequestedSession, r.ExplicitSession)
 		if err != nil {
+			return err
+		}
+		if err := validateResolvedTeamAMQVersions(currentTeam, r.Profile, currentWorkstream, resolveAMQEnvForTeamProfile); err != nil {
 			return err
 		}
 		currentIdentity, err := captureNamespaceEndpointIdentity(squadnamespace.Resolve(r.ProjectDir, r.Profile, currentWorkstream), "")

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -772,7 +772,7 @@ fi
 		t.Fatal(err)
 	}
 	t.Setenv("AMQ_FAKE_BASE", base)
-	t.Setenv("AMQ_FAKE_VERSION", "0.42.1")
+	t.Setenv("AMQ_FAKE_VERSION", doctorMinAMQVersion)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return base
 }

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -104,7 +104,7 @@ if [ "$1" = "env" ]; then
   if [ -n "$session" ]; then
     base_root=$(dirname "$root")
   fi
-  printf '{"schema_version":1,"amq_version":"0.43.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
+  printf '{"schema_version":1,"amq_version":"0.49.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
   exit 0
 fi
 if [ "$1" = "route" ] && [ "$2" = "explain" ]; then

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -263,6 +263,9 @@ Examples:
 	if err != nil {
 		return err
 	}
+	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+		return err
+	}
 	admission, err := acquireNamespaceWriterAdmission(cwd, profile, workstream)
 	if err != nil {
 		return err
@@ -294,6 +297,9 @@ Examples:
 		return err
 	}
 	resolvedContext, profile, t, workstream = currentContext, currentContext.Profile, currentTeam, currentWorkstream
+	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+		return err
+	}
 	if err := ensureNoNamespaceConflict("up", cwd, profile, workstream, flagWasSet(fs, "profile")); err != nil {
 		return err
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -263,7 +263,7 @@ Examples:
 	if err != nil {
 		return err
 	}
-	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveTeamLaunchAMQEnv); err != nil {
 		return err
 	}
 	admission, err := acquireNamespaceWriterAdmission(cwd, profile, workstream)
@@ -297,13 +297,56 @@ Examples:
 		return err
 	}
 	resolvedContext, profile, t, workstream = currentContext, currentContext.Profile, currentTeam, currentWorkstream
-	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveAMQEnvForTeamLaunchProfile); err != nil {
+	if err := validateResolvedTeamAMQVersions(t, profile, workstream, resolveTeamLaunchAMQEnv); err != nil {
 		return err
 	}
 	if err := ensureNoNamespaceConflict("up", cwd, profile, workstream, flagWasSet(fs, "profile")); err != nil {
 		return err
 	}
 	warnVersionAlignmentBeforeLaunch(version)
+
+	opts, err := buildLiveLaunchOptions(fs, pf, lf)
+	if err != nil {
+		return err
+	}
+	visibility := launchVisibilityForFlags(*visibilityFlag, flagWasSet(fs, "visibility"), flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"))
+	if err := applyLaunchVisibility(&opts, visibility, flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"), true); err != nil {
+		return err
+	}
+	// --fresh is reconciled to a no-op on `up`: refuse-existing is the default
+	// gate below, so the old opts.Fresh refusal must never re-fire here.
+	opts.Fresh = false
+	opts.Workstream = workstream
+	opts.SeedBriefContent = seedContent
+	opts.SeedBriefForce = *force || *reset
+	opts.Profile = profile
+	opts.PreparedRunToken = preparedToken
+	opts.ResultSink = resultSink
+	opts.WarnStubBrief = !hasBriefSource
+
+	// Pin the complete AMQ environment/preflight snapshot while the namespace
+	// admission is held and before --reset can delete the old session. The
+	// launch path consumes this snapshot and must not re-resolve AMQ after the
+	// destructive boundary.
+	preflightTeamConfig := t
+	if !preparedToken.empty() {
+		manifest, digest, err := readPreparedRunManifestSnapshot(cwd, profile, workstream)
+		if err != nil {
+			return fmt.Errorf("up refused before reset: read pinned prepared run: %w", err)
+		}
+		if err := validatePreparedRunToken(preparedToken, manifest, digest); err != nil {
+			return fmt.Errorf("up refused before reset: %w", err)
+		}
+		preflightTeamConfig, err = exactPreparedInitialTeam(preflightTeamConfig, manifest, workstream)
+		if err != nil {
+			return fmt.Errorf("up refused before reset: %w", err)
+		}
+	}
+	preflightTeamConfig.Members, _ = filterMembersBySession(preflightTeamConfig.Members, workstream)
+	opts.ResolvedAMQPreflights, err = buildTeamPreflights(preflightTeamConfig, opts)
+	if err != nil {
+		return err
+	}
 
 	exists, root, err := teamWorkstreamExistsOrRestorable(t, profile, workstream)
 	if err != nil {
@@ -326,28 +369,10 @@ Examples:
 		}
 	}
 
-	opts, err := buildLiveLaunchOptions(fs, pf, lf)
-	if err != nil {
-		return err
-	}
-	visibility := launchVisibilityForFlags(*visibilityFlag, flagWasSet(fs, "visibility"), flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"))
-	if err := applyLaunchVisibility(&opts, visibility, flagWasSet(fs, "terminal"), flagWasSet(fs, "target"), flagWasSet(fs, "terminal-session"), true); err != nil {
-		return err
-	}
-	// --fresh is reconciled to a no-op on `up`: refuse-existing is the default
-	// gate above, so the old opts.Fresh refusal must never re-fire here.
-	opts.Fresh = false
-	opts.Workstream = workstream
-	opts.SeedBriefContent = seedContent
-	opts.SeedBriefForce = *force || *reset
-	opts.Profile = profile
-	opts.PreparedRunToken = preparedToken
-	opts.ResultSink = resultSink
 	// When no brief source was supplied, the launch path auto-stubs the brief
 	// (ensureBriefStub) and we nudge the operator with a warn-if-stub notice
 	// AFTER the launch succeeds, so the message reflects a real launch. Carry
 	// the intent on opts so executeTeamLaunch can emit it post-launch.
-	opts.WarnStubBrief = !hasBriefSource
 	return executeTeamLaunch(opts, true, flagWasSet(fs, "trust"))
 }
 

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -11,8 +11,15 @@ import sys
 
 
 VERSION_RE = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
+# Keep the opening-block and field shapes aligned with the Go skill
+# frontmatter readers in internal/cli: strict byte-zero fence, LF/CRLF, no
+# BOM or leading whitespace, and no fallback to searching the document body.
+SKILL_FRONTMATTER_BLOCK_RE = re.compile(
+    r"\A---\r?\n(.*?)\r?\n---\r?(?:\n|\Z)",
+    re.DOTALL,
+)
 SKILL_FRONTMATTER_VERSION_RE = re.compile(
-    r'^version:\s*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
+    r'^version:[ \t]*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
     re.MULTILINE,
 )
 AMQ_MIN_VERSION = "0.49.0"
@@ -46,6 +53,16 @@ def normalize_policy_text(value: str) -> str:
     value = re.sub(r"<[^>]+>", "", value)
     value = value.replace("**", "").replace("__", "").replace("`", "")
     return " ".join(value.split())
+
+
+def skill_frontmatter_version(value: str) -> str | None:
+    block = SKILL_FRONTMATTER_BLOCK_RE.match(value)
+    if block is None:
+        return None
+    marker = SKILL_FRONTMATTER_VERSION_RE.search(block.group(1))
+    if marker is None:
+        return None
+    return marker.group(1)
 
 
 def require_release_notes(root: str, tag: str, failures: list[str]) -> None:
@@ -99,12 +116,12 @@ def main() -> int:
         ):
             skill_rel = f"plugins/{mirror}/skills/{skill_id}/SKILL.md"
             skill_body = read(os.path.join(root, skill_rel))
-            marker = SKILL_FRONTMATTER_VERSION_RE.search(skill_body)
-            if not marker:
+            skill_version = skill_frontmatter_version(skill_body)
+            if skill_version is None:
                 failures.append(f"{skill_rel}: missing frontmatter version")
-            elif marker.group(1) != version:
+            elif skill_version != version:
                 failures.append(
-                    f"{skill_rel}: frontmatter version {marker.group(1)!r} "
+                    f"{skill_rel}: frontmatter version {skill_version!r} "
                     f"!= {version!r}"
                 )
 

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import os
 import re
@@ -10,13 +11,18 @@ import sys
 
 
 VERSION_RE = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
-SKILL_MARKER_RE = re.compile(r"Skill version:\s*([0-9]+\.[0-9]+\.[0-9]+)")
+SKILL_FRONTMATTER_VERSION_RE = re.compile(
+    r'^version:\s*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
+    re.MULTILINE,
+)
 AMQ_MIN_VERSION = "0.49.0"
-AMQ_TESTED_CURRENT_VERSION = "0.49.0"
+AMQ_TESTED_CURRENT_VERSION = "0.49.1"
 AMQ_COMPATIBILITY_POLICY = (
-    f"AMQ {AMQ_MIN_VERSION} is the sole supported release. "
-    f"Both real-AMQ matrices validate pinned v{AMQ_TESTED_CURRENT_VERSION} and latest; "
-    "latest remains only a canary for any unexpected post-final release."
+    f"AMQ 0.49.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
+    f"supported release and compatibility tested through {AMQ_TESTED_CURRENT_VERSION}. "
+    f"Both real-AMQ matrices validate pinned v{AMQ_MIN_VERSION}, pinned "
+    f"v{AMQ_TESTED_CURRENT_VERSION}, and latest; latest remains a "
+    "forward-compatibility canary."
 )
 
 
@@ -31,8 +37,15 @@ def fail_if_missing(path: str, needle: str, failures: list[str]) -> None:
 
 
 def fail_if_missing_normalized(path: str, needle: str, failures: list[str]) -> None:
-    if " ".join(needle.split()) not in " ".join(read(path).split()):
+    if normalize_policy_text(needle) not in normalize_policy_text(read(path)):
         failures.append(f"{path}: missing normalized {needle!r}")
+
+
+def normalize_policy_text(value: str) -> str:
+    value = html.unescape(value)
+    value = re.sub(r"<[^>]+>", "", value)
+    value = value.replace("**", "").replace("__", "").replace("`", "")
+    return " ".join(value.split())
 
 
 def require_release_notes(root: str, tag: str, failures: list[str]) -> None:
@@ -86,14 +99,14 @@ def main() -> int:
         ):
             skill_rel = f"plugins/{mirror}/skills/{skill_id}/SKILL.md"
             skill_body = read(os.path.join(root, skill_rel))
-            marker = SKILL_MARKER_RE.search(skill_body)
+            marker = SKILL_FRONTMATTER_VERSION_RE.search(skill_body)
             if not marker:
-                failures.append(f"{skill_rel}: missing Skill version marker")
+                failures.append(f"{skill_rel}: missing frontmatter version")
             elif marker.group(1) != version:
-                failures.append(f"{skill_rel}: Skill version {marker.group(1)!r} != {version!r}")
-            expected_echo = f"amq-squad skill {tag}"
-            if expected_echo not in skill_body:
-                failures.append(f"{skill_rel}: missing startup echo {expected_echo!r}")
+                failures.append(
+                    f"{skill_rel}: frontmatter version {marker.group(1)!r} "
+                    f"!= {version!r}"
+                )
 
     readme = os.path.join(root, "README.md")
     fail_if_missing(readme, f"go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@{tag}", failures)

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -11,12 +11,12 @@ import sys
 
 VERSION_RE = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
 SKILL_MARKER_RE = re.compile(r"Skill version:\s*([0-9]+\.[0-9]+\.[0-9]+)")
-AMQ_MIN_VERSION = "0.42.1"
-AMQ_TESTED_CURRENT_VERSION = "0.45.0"
+AMQ_MIN_VERSION = "0.49.0"
+AMQ_TESTED_CURRENT_VERSION = "0.49.0"
 AMQ_COMPATIBILITY_POLICY = (
-    f"The minimum {AMQ_MIN_VERSION} compatibility floor is unchanged. "
-    f"This release is explicitly validated against pinned {AMQ_TESTED_CURRENT_VERSION}; "
-    "latest remains a forward-compatibility canary."
+    f"AMQ {AMQ_MIN_VERSION} is the sole supported release. "
+    f"Both real-AMQ matrices validate pinned v{AMQ_TESTED_CURRENT_VERSION} and latest; "
+    "latest remains only a canary for any unexpected post-final release."
 )
 
 
@@ -97,7 +97,7 @@ def main() -> int:
 
     readme = os.path.join(root, "README.md")
     fail_if_missing(readme, f"go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@{tag}", failures)
-    fail_if_missing(readme, f"- `amq` {AMQ_MIN_VERSION}+ on `PATH`", failures)
+    fail_if_missing(readme, f"- `amq` {AMQ_MIN_VERSION} on `PATH`", failures)
     for rel in (
         "README.md",
         "docs/skills.md",
@@ -113,7 +113,7 @@ def main() -> int:
         fail_if_missing(readme_html, f"github.com/omriariav/amq-squad/v2/cmd/amq-squad@{tag}", failures)
         fail_if_missing(
             readme_html,
-            f"<li><code>amq</code> {AMQ_MIN_VERSION}+ on <code>PATH</code></li>",
+            f"<li><code>amq</code> {AMQ_MIN_VERSION} on <code>PATH</code></li>",
             failures,
         )
         fail_if_missing_normalized(readme_html, AMQ_COMPATIBILITY_POLICY, failures)

--- a/scripts/test_check_release_version.py
+++ b/scripts/test_check_release_version.py
@@ -64,11 +64,53 @@ class RequireReleaseNotesTest(unittest.TestCase):
             "# CLI\n"
         )
 
-        marker = CHECK_RELEASE_VERSION.SKILL_FRONTMATTER_VERSION_RE.search(body)
+        version = CHECK_RELEASE_VERSION.skill_frontmatter_version(body)
 
-        self.assertIsNotNone(marker)
-        assert marker is not None
-        self.assertEqual(marker.group(1), "2.24.0")
+        self.assertEqual(version, "2.24.0")
+
+    def test_skill_frontmatter_version_matches_crlf_shape(self) -> None:
+        body = (
+            "---\r\n"
+            "name: cli\r\n"
+            'version:\t"2.24.0"\r\n'
+            "---\r\n"
+            "# CLI\r\n"
+        )
+
+        self.assertEqual(
+            CHECK_RELEASE_VERSION.skill_frontmatter_version(body),
+            "2.24.0",
+        )
+
+    def test_skill_frontmatter_version_ignores_body_version_line(self) -> None:
+        body = (
+            "---\n"
+            "name: cli\n"
+            "---\n"
+            "# CLI\n"
+            "```yaml\n"
+            "version: 9.9.9\n"
+            "```\n"
+        )
+
+        self.assertIsNone(CHECK_RELEASE_VERSION.skill_frontmatter_version(body))
+
+    def test_skill_frontmatter_version_requires_opening_frontmatter(self) -> None:
+        body = "# CLI\n\nversion: 9.9.9\n"
+
+        self.assertIsNone(CHECK_RELEASE_VERSION.skill_frontmatter_version(body))
+
+    def test_skill_frontmatter_version_rejects_split_field_value(self) -> None:
+        body = (
+            "---\n"
+            "name: cli\n"
+            "version:\n"
+            "9.9.9\n"
+            "---\n"
+            "# CLI\n"
+        )
+
+        self.assertIsNone(CHECK_RELEASE_VERSION.skill_frontmatter_version(body))
 
     def test_matching_canonical_release_notes_passes(self) -> None:
         with tempfile.TemporaryDirectory() as root:

--- a/scripts/test_check_release_version.py
+++ b/scripts/test_check_release_version.py
@@ -30,6 +30,46 @@ class RequireReleaseNotesTest(unittest.TestCase):
                 ["docs/v2.22.0-release-notes.md: missing canonical release notes"],
             )
 
+    def test_policy_normalization_ignores_markdown_and_html_markup(self) -> None:
+        policy = CHECK_RELEASE_VERSION.AMQ_COMPATIBILITY_POLICY
+        markdown = policy.replace(
+            "AMQ 0.49.x is the supported series",
+            "AMQ **0.49.x is the supported series**",
+        ).replace("latest", "`latest`")
+        html_body = (
+            "<p>"
+            + policy.replace(
+                "AMQ 0.49.x is the supported series",
+                "AMQ <strong>0.49.x is the supported series</strong>",
+            ).replace("latest", "<code>latest</code>")
+            + "</p>"
+        )
+
+        self.assertEqual(
+            CHECK_RELEASE_VERSION.normalize_policy_text(markdown),
+            CHECK_RELEASE_VERSION.normalize_policy_text(policy),
+        )
+        self.assertEqual(
+            CHECK_RELEASE_VERSION.normalize_policy_text(html_body),
+            CHECK_RELEASE_VERSION.normalize_policy_text(policy),
+        )
+
+    def test_skill_frontmatter_version_matches_generated_shape(self) -> None:
+        body = (
+            "---\n"
+            "name: cli\n"
+            'version: "2.24.0"  # x-release-please-version\n'
+            "description: test\n"
+            "---\n"
+            "# CLI\n"
+        )
+
+        marker = CHECK_RELEASE_VERSION.SKILL_FRONTMATTER_VERSION_RE.search(body)
+
+        self.assertIsNotNone(marker)
+        assert marker is not None
+        self.assertEqual(marker.group(1), "2.24.0")
+
     def test_matching_canonical_release_notes_passes(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             docs = os.path.join(root, "docs")


### PR DESCRIPTION
## Summary

- Support the AMQ 0.49.x series with v0.49.0 as the minimum and compatibility tested through v0.49.1; both real-AMQ matrices run pinned v0.49.0, pinned v0.49.1, and `latest` as a forward canary.
- Fail closed on older, missing, or unparseable AMQ versions in doctor, child `agent up`, parent team launch, `resume --exec`, and `up --reset`.
- Run parent version admission before roots, briefs, watchers, panes, or existing-session deletion; cover direct team launch, reset, and resume with zero-mutation regressions.
- Use structured owner-bound wake recovery and exact ownerless retirement for persisted inject-via wakes; treat refused or lock-remaining owner recovery as cleanup failure even when no wake PID was persisted.
- Scope release-version extraction to the strict opening frontmatter block, align LF/CRLF field parsing with the Go readers, and reject body-only or split-line version markers.
- Document the v0.49.0 trace/mailbox assessment and v0.49.2 forward-canary evidence without expanding the tested-through boundary.

The T7 carve-out is preserved: this PR does not modify `plugins/skills-src/**` or generated Claude/Codex skill mirrors.

## Verification

Exact head: `fa8207234b6b2cf9c9e3897755e5f4aec75f7a9a`

- `t10-fa82072-real-amq-v0490-001` — pinned v0.49.0 queue, gate, lifecycle, real-PTY wake, and cleanup suite; succeeded, finalized, and linked.
- `t10-fa82072-real-amq-v0491-001` — pinned v0.49.1 queue, gate, lifecycle, real-PTY wake, and cleanup suite; succeeded, finalized, and linked.
- `t10-fa82072-go-suite-001` — full `go test ./... -count=1`; succeeded, finalized, and linked.
- `python3 -B scripts/test_check_release_version.py` — 9/9 passed.
- `git diff --check` and Go formatting checks passed.

CI run `30251806279` is the authoritative GitHub execution for this head.

The direct release gate currently fails only on T7-owned skill source/mirrors that do not yet carry the ruled frontmatter version and canonical 0.49.x policy. It must be rerun after T7 integration.

Fixes #557
Fixes #566
