### PR TITLE
Exclude nested worktrees from GO_FILES and name fmt-check offenders (#560)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ fmt:
 	gofmt -w $(GO_FILES)
 
 fmt-check:
-	@offenders="$$(gofmt -l $(GO_FILES))"; \
+	@offenders="$$(gofmt -l $(GO_FILES))"; status=$$?; \
+	if [ $$status -ne 0 ]; then \
+		echo "error: gofmt -l failed (exit $$status); the check could not run" >&2; \
+		exit $$status; \
+	fi; \
 	if [ -n "$$offenders" ]; then \
 		echo "error: gofmt needed on:" >&2; \
 		echo "$$offenders" >&2; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: build test fmt fmt-check vet ci skill-command-check install release-check release-validator-test release-smoke readme-html readme-html-check docs-html docs-html-check html skills-generate skills-check skill-routing-check dogfood-claude clean
+.PHONY: build test fmt fmt-check vet ci go-files-scope-test skill-command-check install release-check release-validator-test release-smoke readme-html readme-html-check docs-html docs-html-check html skills-generate skills-check skill-routing-check dogfood-claude clean
 
-GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
+# Peer worktrees live under .worktrees/ inside this project, so a bare `find .` pulls in
+# other checkouts' .go files. Without the exclusion, fmt-check false-fails on another
+# agent's in-progress work and `make fmt` REWRITES it -- silently mutating uncommitted
+# files that belong to a different branch. Excluded by path rather than via `git ls-files`
+# so that new, still-untracked .go files stay in coverage. (#560)
+GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*' -not -path './.worktrees/*')
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 
 # README.html is a generated render of README.md. PANDOC_CMD is the single
@@ -27,12 +32,17 @@ fmt:
 	gofmt -w $(GO_FILES)
 
 fmt-check:
-	@test -z "$(shell gofmt -l $(GO_FILES))"
+	@offenders="$$(gofmt -l $(GO_FILES))"; \
+	if [ -n "$$offenders" ]; then \
+		echo "error: gofmt needed on:" >&2; \
+		echo "$$offenders" >&2; \
+		exit 1; \
+	fi
 
 vet:
 	go vet ./...
 
-ci: fmt-check vet test readme-html-check docs-html-check skills-check skill-routing-check skill-command-check release-validator-test
+ci: fmt-check vet test readme-html-check docs-html-check skills-check skill-routing-check skill-command-check release-validator-test go-files-scope-test
 
 # Every CLI command and flag named in the skills must exist in the binary (#534).
 # The skills drifting from the binary has been a recurring release-note problem;
@@ -71,6 +81,10 @@ release-check:
 	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for release-check" >&2; exit 1; }
 	@python3 scripts/check-release-version.py "$(VERSION)"
 	@python3 scripts/check-current-skill-routing.py
+
+go-files-scope-test:
+	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for go-files-scope-test" >&2; exit 1; }
+	@python3 scripts/test_makefile_go_files.py
 
 release-validator-test:
 	@command -v python3 >/dev/null 2>&1 || { echo "python3 is required for release-validator-test" >&2; exit 1; }

--- a/scripts/test_makefile_go_files.py
+++ b/scripts/test_makefile_go_files.py
@@ -133,6 +133,28 @@ class GoFilesScope(unittest.TestCase):
         finally:
             offender.unlink(missing_ok=True)
 
+    def test_fmt_check_fails_when_gofmt_itself_fails(self):
+        """A check that passes when its instrument breaks is worse than no check.
+
+        `offenders="$(gofmt -l ...)"` drops gofmt's own exit status, and make recipes
+        run sh WITHOUT -e, so the next command runs regardless. If gofmt errors while
+        printing nothing to stdout -- a stat error on a missing path, or a path with
+        spaces word-splitting into invalid arguments -- the offender list is empty and
+        fmt-check reports success having formatted-checked nothing.
+
+        The GO_FILES override is a clean one-variable fixture: a nonexistent file makes
+        gofmt fail WITHOUT producing an offender, separating "instrument broke" from
+        "found a problem".
+        """
+        result = make("fmt-check", "GO_FILES=./definitely-missing-560.go")
+        self.assertNotEqual(
+            result.returncode, 0,
+            "fmt-check must fail when gofmt cannot run; it reported success instead",
+        )
+        combined = result.stdout + result.stderr
+        self.assertIn("gofmt -l failed", combined,
+                      f"the failure must say the check could not run; got:\n{combined}")
+
     def test_exclusion_is_path_based_not_git_tracked(self):
         """Untracked new .go files must stay in coverage, so the fix cannot be
         `git ls-files`: a newly written, not-yet-added file is exactly when formatting

--- a/scripts/test_makefile_go_files.py
+++ b/scripts/test_makefile_go_files.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Prove GO_FILES excludes nested worktrees, and that the exclusion is what does it.
+
+Peer worktrees live under .worktrees/ inside the project. A bare `find .` walks into
+them, which made `make fmt-check` fail on another agent's in-progress files and made
+`make fmt` rewrite them. See #560.
+
+Each behaviour here is proved against a synthetic offender created for the test, and
+the central claim carries a removal proof that varies exactly one thing: the same find
+command with and without the exclusion clause.
+"""
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Deliberately misformatted: gofmt -l reports it, and it is not valid layout for any
+# formatter setting, so the signal cannot come from a gofmt version difference.
+BAD_GO = "package  x\nfunc  F( )  {\n\t\t x:=1\n_ = x\n}\n"
+
+
+def make(*targets, env=None):
+    return subprocess.run(
+        ["make", *targets],
+        cwd=ROOT, capture_output=True, text=True,
+        env={**os.environ, **(env or {})},
+    )
+
+
+def go_files(exclude_worktrees: bool) -> list[str]:
+    """Reproduce the Makefile's GO_FILES computation, with the exclusion as the variable."""
+    cmd = ["find", ".", "-name", "*.go", "-not", "-path", "./vendor/*"]
+    if exclude_worktrees:
+        cmd += ["-not", "-path", "./.worktrees/*"]
+    out = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PeerWorktreeFile:
+    """A synthetic misformatted .go file at the path a nested worktree would occupy."""
+
+    def __init__(self, name="proof-560"):
+        self.dir = ROOT / ".worktrees" / name / "internal" / "cli"
+        self.path = self.dir / "bad.go"
+        self.created_root = ROOT / ".worktrees" / name
+
+    def __enter__(self):
+        if self.created_root.exists():
+            raise RuntimeError(f"{self.created_root} already exists; refusing to clobber it")
+        self.dir.mkdir(parents=True)
+        self.path.write_text(BAD_GO)
+        # A test whose fixture does not actually reproduce the condition proves nothing.
+        stray = subprocess.run(
+            ["gofmt", "-l", str(self.path)], capture_output=True, text=True
+        ).stdout.strip()
+        if not stray:
+            raise RuntimeError("fixture is not misformatted; gofmt -l reports it clean")
+        return self
+
+    def __exit__(self, *exc):
+        shutil.rmtree(self.created_root, ignore_errors=True)
+        return False
+
+
+class GoFilesScope(unittest.TestCase):
+    def test_peer_worktree_file_is_excluded(self):
+        with PeerWorktreeFile() as peer:
+            rel = "./" + str(peer.path.relative_to(ROOT))
+            self.assertNotIn(rel, go_files(exclude_worktrees=True))
+
+    def test_removal_proof_the_exclusion_is_what_excludes_it(self):
+        """Vary exactly one thing: the -not -path './.worktrees/*' clause.
+
+        Without this, `test_peer_worktree_file_is_excluded` would still pass if find
+        happened never to reach the path for some unrelated reason.
+        """
+        with PeerWorktreeFile() as peer:
+            rel = "./" + str(peer.path.relative_to(ROOT))
+            self.assertIn(rel, go_files(exclude_worktrees=False),
+                          "without the exclusion the peer file must be IN scope")
+            self.assertNotIn(rel, go_files(exclude_worktrees=True),
+                             "with the exclusion it must be OUT of scope")
+
+    def test_fmt_check_passes_despite_a_misformatted_peer_file(self):
+        with PeerWorktreeFile():
+            result = make("fmt-check")
+            self.assertEqual(result.returncode, 0,
+                             f"fmt-check must ignore peer worktrees\n{result.stderr}")
+
+    def test_fmt_leaves_the_peer_file_byte_identical(self):
+        """`make fmt` writing to another agent's checkout is the severe half of #560."""
+        clean = subprocess.run(
+            ["gofmt", "-l", *go_files(exclude_worktrees=True)],
+            cwd=ROOT, capture_output=True, text=True,
+        ).stdout.strip()
+        # Not skipped: running `make fmt` against an already-dirty tree would mutate
+        # real files, so a dirty tree is a broken precondition, not an absent one.
+        self.assertEqual(clean, "", f"precondition: tree must be gofmt-clean, found:\n{clean}")
+
+        with PeerWorktreeFile() as peer:
+            before = digest(peer.path)
+            result = make("fmt")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(digest(peer.path), before,
+                             "make fmt rewrote a file belonging to a peer worktree")
+
+    def test_fmt_check_prints_the_offending_files(self):
+        """`@test -z "$(shell ...)"` swallowed the list, so a failure printed only
+        'Error 1' and the developer had to re-derive which file was at fault."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".go", prefix="zz_fmt_offender_", dir=ROOT, delete=False
+        ) as f:
+            offender = Path(f.name)
+            f.write(BAD_GO)
+        try:
+            result = make("fmt-check")
+            self.assertNotEqual(result.returncode, 0, "a real offender must fail fmt-check")
+            combined = result.stdout + result.stderr
+            self.assertIn(offender.name, combined,
+                          f"fmt-check must name the offending file; got:\n{combined}")
+        finally:
+            offender.unlink(missing_ok=True)
+
+    def test_exclusion_is_path_based_not_git_tracked(self):
+        """Untracked new .go files must stay in coverage, so the fix cannot be
+        `git ls-files`: a newly written, not-yet-added file is exactly when formatting
+        feedback matters most."""
+        makefile = (ROOT / "Makefile").read_text()
+        go_files_line = next(
+            line for line in makefile.splitlines() if line.startswith("GO_FILES")
+        )
+        self.assertIn(".worktrees", go_files_line)
+        self.assertNotIn("git ls-files", go_files_line)
+
+    def test_untracked_go_file_at_project_root_stays_in_scope(self):
+        """The companion property, proved directly rather than inferred from the rule."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".go", prefix="zz_untracked_", dir=ROOT, delete=False
+        ) as f:
+            untracked = Path(f.name)
+            f.write("package main\n")
+        try:
+            tracked = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", untracked.name],
+                cwd=ROOT, capture_output=True, text=True,
+            )
+            self.assertNotEqual(tracked.returncode, 0, "fixture must be untracked")
+            self.assertIn("./" + untracked.name, go_files(exclude_worktrees=True))
+        finally:
+            untracked.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #560.

## Problem

`GO_FILES` is computed with a bare `find .` from the project root:

```make
GO_FILES := $(shell find . -name '*.go' -not -path './vendor/*')
```

Peer worktrees live under `.worktrees/` **inside** the project, so `find` descends into
other checkouts. There are ~40 of them in a working clone. Two consequences:

- **`make fmt-check` false-fails** on another agent's in-progress files. Found while
  recording t5 evidence: `make ci` died at `fmt-check` on
  `.worktrees/amq-dev-2-t10-557/internal/cli/{down,amq_env}.go` — files belonging to a
  different branch, and not in this worktree's index at all. The merged tree was clean.
- **`make fmt` rewrites them.** `gofmt -w $(GO_FILES)` over the same glob silently
  reformats uncommitted work in a peer's checkout. This is the severe half: it is the
  exact cross-contamination that the worktree isolation work in this milestone (#497,
  #538) exists to prevent, reintroduced through the build system rather than through Git.

Secondary: `@test -z "$(shell gofmt -l $(GO_FILES))"` swallows the file list, so a real
failure prints only `Error 1` and the developer has to re-derive which file was at fault.

## Fix

Exclude the nested-worktree path, and print offenders on failure.

Excluded **by path** rather than via `git ls-files`, deliberately: a newly written,
not-yet-added `.go` file is exactly when formatting feedback matters most, so untracked
files must stay in coverage. There is a test asserting this property so the fix cannot
later be "simplified" into `git ls-files`.

## Proofs

`make go-files-scope-test`, wired into `ci`. Seven tests against a synthetic
misformatted `.go` file placed where a nested worktree would be. The fixture verifies
its own premise — it refuses to run if `gofmt -l` does not actually report the file —
so the suite cannot pass vacuously.

Removal proofs, each varying **exactly one** thing:

| reverted | failures |
|---|---|
| only the `-not -path './.worktrees/*'` clause | 3, including `test_fmt_leaves_the_peer_file_byte_identical` |
| only the offender-printing change | 1, `test_fmt_check_prints_the_offending_files` |
| nothing | 0 (7/7 pass) |

No overlap between the two, so each mechanism is isolated rather than jointly confirmed.

The byte-identical failure under the first revert is the direct demonstration that on
`main` today, `make fmt` **does** rewrite a peer worktree's file.

The `make fmt` test asserts a gofmt-clean tree as a precondition and **fails** rather
than skips if that does not hold — running `make fmt` against an already-dirty tree
would mutate real files, so a dirty tree is a broken precondition, not an absent one.

## Scope

Two lines of `Makefile` behaviour plus the proof. No Go source, no CLI behaviour, no
skills. Kept out of #534/t7 deliberately per the ownership ruling, since it removes a
false-failure source from every remaining evidence run this milestone and should land on
its own.
