### PR TITLE
Extract docs/skills.md into per-skill references and reverse the pointer (#534)

### DIFF
--- a/.amq-squad/team-rules.md
+++ b/.amq-squad/team-rules.md
@@ -176,6 +176,20 @@ runs share CPU, disk, and the Go build cache, and a deadline-sensitive test is e
 loses a race under load. Inside a Tier 1 window the holder gets to know what shares their
 machine.
 
+Shared state includes THE REPOSITORY ITSELF, not only external services like tmux. The git
+worktree registry under `.git/worktrees`, the index, and refs are all shared: `git worktree
+add`, `git worktree remove`, `git worktree prune`, and anything that writes refs or the index
+mutate state every other agent reads. The cli suite contains worktree discovery and isolation
+checks, so registry churn is not invisible to it.
+
+Classify the WRAPPER, not the payload. A read-only script inside a mutating wrapper is a
+mutating operation. If any step of the command you are about to announce mutates shared
+state, the whole thing is Tier 1, however harmless the innermost step looks.
+
+VERIFICATION MUST NOT MUTATE. When you are checking whether shared state is clean, read it;
+do not tidy it. Reflexive housekeeping during observation turns a finished intrusion into a
+new one, and "I was only checking" is how that happens.
+
 Choosing the tier is the runner's judgement and the runner's responsibility. When
 unsure, Tier 1. The cost of over-serializing a cheap test is seconds; the cost of
 under-serializing is a false failure that someone debugs against their own diff.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -1177,7 +1177,7 @@ directive does not clear <code>gate/&lt;topic&gt;</code> threads.
 Orchestrated teams carry the convention as a generated line in their
 <code>## Orchestration</code> norm.</p>
 <h3 id="recover">Recover</h3>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># re-orient a stalled/stopped session</span></span>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># PLAN ONLY; add --exec to reopen panes</span></span>
 <span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
 <hr />
 <h2 id="role-authoring-with-amq-squadwizard">Role Authoring With

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -294,6 +294,9 @@ id="toc-role-authoring-with-amq-squadwizard">Role Authoring With
 id="toc-end-to-end-walkthrough">End-to-end walkthrough</a></li>
 <li><a href="#troubleshooting"
 id="toc-troubleshooting">Troubleshooting</a></li>
+<li><a href="#where-the-authoritative-instructions-live"
+id="toc-where-the-authoritative-instructions-live">Where the
+authoritative instructions live</a></li>
 </ul></li>
 </ul>
 </nav>
@@ -1339,11 +1342,53 @@ default).</td>
 </tr>
 </tbody>
 </table>
+<h2 id="where-the-authoritative-instructions-live">Where the
+authoritative instructions live</h2>
+<p>This guide is orientation. It is <strong>not</strong> the source of
+truth for how to run a squad.</p>
+<p>Each skill's authoritative instructions live in its canonical source,
+and the long-form material extracted from this guide lives beside
+them:</p>
+<table>
+<thead>
+<tr>
+<th>skill</th>
+<th>authoritative source</th>
+<th>extracted references</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>amq-squad:wizard</code></td>
+<td><code>plugins/skills-src/wizard/SKILL.md</code></td>
+<td><code>references/{stages,readiness,roles,worktrees}.md</code>,
+<code>LEARNINGS.md</code></td>
+</tr>
+<tr>
+<td><code>amq-squad:cli</code></td>
+<td><code>plugins/skills-src/cli/SKILL.md</code></td>
+<td><code>references/{daily-loop,primitives,troubleshooting}.md</code>,
+<code>LEARNINGS.md</code></td>
+</tr>
+<tr>
+<td><code>amq-squad:orchestrator</code></td>
+<td><code>plugins/skills-src/orchestrator/SKILL.md</code></td>
+<td><code>references/{lead-loop,agent-events,recovery}.md</code>,
+<code>LEARNINGS.md</code></td>
+</tr>
+</tbody>
+</table>
+<p><code>plugins/{claude,codex}/skills/&lt;skill&gt;/</code> are
+GENERATED mirrors of those sources. Edit the source and run
+<code>make skills-generate</code>; editing a mirror is lost on the next
+generation and <code>--check</code> will fail.</p>
+<p>When this guide and a <code>SKILL.md</code> disagree, <strong>the
+<code>SKILL.md</code> is correct</strong> — its commands are verified
+against the live binary surface on every CI run by
+<code>scripts/check-skill-commands.py</code>, and this guide is not.</p>
 <p>For anything below the skills — the binary's verbs, JSON envelopes,
 tmux targets, profiles, and <a
 href="../README.md#cross-project-teams">cross-project teams</a> — see
-the <a href="../README.md">README</a>. Each skill's full instructions
-live in its <code>SKILL.md</code> under
-<code>plugins/{claude,codex}/skills/&lt;skill&gt;/</code>.</p>
+the <a href="../README.md">README</a>.</p>
 </body>
 </html>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -749,8 +749,27 @@ cd ~/Code/my-project
 | Shift+Enter doesn't submit in a tmux window | `doctor` warns when tmux `extended-keys` is off; opening under iTerm2 `tmux -CC` (the `attach_control` action) makes it work natively. |
 | Custom role rejected | A custom role needs an explicit `--binary <role>=<cli>` (no catalog default). |
 
-For anything below the skills — the binary's verbs, JSON envelopes, tmux
-targets, profiles, and [cross-project teams](../README.md#cross-project-teams)
-— see the [README](../README.md). Each
-skill's full instructions live in its `SKILL.md` under
-`plugins/{claude,codex}/skills/<skill>/`.
+## Where the authoritative instructions live
+
+This guide is orientation. It is **not** the source of truth for how to run a squad.
+
+Each skill's authoritative instructions live in its canonical source, and the long-form
+material extracted from this guide lives beside them:
+
+| skill | authoritative source | extracted references |
+| --- | --- | --- |
+| `amq-squad:wizard` | `plugins/skills-src/wizard/SKILL.md` | `references/{stages,readiness,roles,worktrees}.md`, `LEARNINGS.md` |
+| `amq-squad:cli` | `plugins/skills-src/cli/SKILL.md` | `references/{daily-loop,primitives,troubleshooting}.md`, `LEARNINGS.md` |
+| `amq-squad:orchestrator` | `plugins/skills-src/orchestrator/SKILL.md` | `references/{lead-loop,agent-events,recovery}.md`, `LEARNINGS.md` |
+
+`plugins/{claude,codex}/skills/<skill>/` are GENERATED mirrors of those sources. Edit the
+source and run `make skills-generate`; editing a mirror is lost on the next generation and
+`--check` will fail.
+
+When this guide and a `SKILL.md` disagree, **the `SKILL.md` is correct** — its commands are
+verified against the live binary surface on every CI run by
+`scripts/check-skill-commands.py`, and this guide is not.
+
+For anything below the skills — the binary's verbs, JSON envelopes, tmux targets,
+profiles, and [cross-project teams](../README.md#cross-project-teams) — see the
+[README](../README.md).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -617,7 +617,7 @@ convention as a generated line in their `## Orchestration` norm.
 ### Recover
 
 ```sh
-amq-squad resume --session issue-96      # re-orient a stalled/stopped session
+amq-squad resume --session issue-96      # PLAN ONLY; add --exec to reopen panes
 amq-squad agent resume fullstack         # revive one child from its saved record
 ```
 

--- a/plugins/claude/skills/cli/references/primitives.md
+++ b/plugins/claude/skills/cli/references/primitives.md
@@ -101,7 +101,8 @@ amq-squad rm --session S                      # remove it
 amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
 
-Three of those have surprising defaults, verified by running them:
+Several of those have surprising defaults. Every row below was verified by running the
+command, not by reading its flags:
 
 | command | the surprise |
 |---|---|

--- a/plugins/claude/skills/cli/references/primitives.md
+++ b/plugins/claude/skills/cli/references/primitives.md
@@ -56,3 +56,51 @@ error: ambiguous profile at live_launch_record precedence
 Cause: more than one live launch record resolves for this project. Fix: pass
 `--profile NAME` explicitly. The CLI prints that fix itself, which is worth reading
 before reaching for anything more elaborate.
+
+## Runtime control (tmux)
+
+amq-squad owns the tmux control contract. Drive agents by stable command, never raw
+`tmux send-keys`, and target the recorded **pane id** rather than a window name — names
+are not stable across a session's life.
+
+```sh
+amq-squad focus --session S --role cto                          # bring a pane into view
+amq-squad send --session S --role cto --body-file ./prompt.md   # deliver a prompt and submit
+cat prompt.md | amq-squad send --session S --role qa --body-file -
+```
+
+`send` stages text in a tmux paste buffer, so multi-line text and shell metacharacters
+arrive verbatim, and it carries a **busy-guard**: it refuses to deliver into a mid-turn
+pane unless you pass `--force`. That refusal is a feature — interrupting a pane
+mid-turn corrupts the agent's own transcript.
+
+**`amq-squad send` is pane delivery, not a message.** It has no `--kind` and no
+`--thread`. To post an inter-agent message use `amq send`, which is a different tool
+with a different transport.
+
+### The two body-passing rules are NOT the same
+
+| tool | flag for file or stdin |
+|---|---|
+| `amq-squad send` | `--body-file FILE`, or `--body-file -` for stdin |
+| bare `amq send` | `--body @file`, or `--body -` for stdin; **`--body-file` does not exist** |
+
+Use a file or stdin for anything containing code, backticks, or `$()`. Inline `--body`
+is for short plain prose only, because the calling shell expands it before the tool
+ever sees it — a body with backticks arrives mangled or empty.
+
+## Session lifecycle
+
+```sh
+amq-squad console --session S        # attach to the squad's window
+amq-squad stop --session S           # stop agents, keep the session
+amq-squad resume --session S         # bring a stopped session back
+amq-squad archive --session S        # retire a finished session
+amq-squad rm --session S             # remove it
+amq-squad fork --session S           # branch a new session from this one
+```
+
+`up` refuses an existing session by design: it is NEW work. Use `resume` to continue
+one, or `up --reset` to deliberately start over. That refusal exists because silently
+reusing a session would inherit stale panes, briefs, and goal bindings.
+

--- a/plugins/claude/skills/cli/references/primitives.md
+++ b/plugins/claude/skills/cli/references/primitives.md
@@ -92,13 +92,23 @@ ever sees it — a body with backticks arrives mangled or empty.
 ## Session lifecycle
 
 ```sh
-amq-squad console --session S        # attach to the squad's window
-amq-squad stop --session S           # stop agents, keep the session
-amq-squad resume --session S         # bring a stopped session back
-amq-squad archive --session S        # retire a finished session
-amq-squad rm --session S             # remove it
-amq-squad fork --session S           # branch a new session from this one
+amq-squad console --session S                 # Mission Control TUI, filtered to S
+amq-squad stop --role R --session S           # or --all; a selector is REQUIRED
+amq-squad resume --session S                  # PLAN ONLY: prints the action table
+amq-squad resume --session S --exec           # actually reopens the panes
+amq-squad archive --session S                 # retire a finished session
+amq-squad rm --session S                      # remove it
+amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
+
+Three of those have surprising defaults, verified by running them:
+
+| command | the surprise |
+|---|---|
+| `stop` | exactly one selector is MANDATORY, `--role R` or `--all`. `stop --session S` alone stops nothing and exits on a usage error |
+| `resume` | plan-only by default. It prints a per-member action table and copy-pasteable commands; without `--exec` nothing reopens |
+| `console` | a full-screen read-only Mission Control TUI rendered to `/dev/tty`, NOT an attach to the squad's pane. Use `--once` for a single non-interactive snapshot |
+| `fork` | takes `--from SOURCE --as TARGET` and has no `--session` flag at all |
 
 `up` refuses an existing session by design: it is NEW work. Use `resume` to continue
 one, or `up --reset` to deliberately start over. That refusal exists because silently

--- a/plugins/claude/skills/orchestrator/references/lead-loop.md
+++ b/plugins/claude/skills/orchestrator/references/lead-loop.md
@@ -71,3 +71,44 @@ Two lifecycle constraints that cost real time when missed:
 If a blocker task completes during an evidence run, the link fails with a
 compare-and-swap error. `amq-squad evidence recover TASK ATTEMPT --me H` fixes
 it, and under parallel work that recover step is normal rather than exceptional.
+
+## Dispatch and collect
+
+Dispatch over durable AMQ, not pane injection. An AMQ message queues and survives pane
+death; `amq-squad send` writes into a live pane and is the fallback or nudge only.
+
+```sh
+amq send --to fullstack --thread p2p/cto__fullstack --kind todo \
+  --subject "Task: rate-limiter" --body - --wait-for drained --wait-timeout 60s <<'EOF'
+Implement the rate-limiter per the brief. Push a review_request to me when the diff
+is ready. Report any blocker as a question.
+EOF
+```
+
+Confirm children are live BEFORE dispatching — a message to a dead pane queues silently
+and looks delivered:
+
+```sh
+amq-squad status --session S --json | jq '.data.records[] | {role, status, pane_alive: .tmux.pane_alive}'
+```
+
+Children PUSH reports; the lead collects rather than polls:
+
+```sh
+amq-squad collect --session S --me cto --timeout 120s --include-body
+```
+
+### Wait posture is enforced, not advisory
+
+In `lead_pane` mode the binary verifies the live roster pane before its own blocking
+waits, and REFUSES a configured lead when a caller-raised `gate/<topic>` is unresolved,
+when a wait would exceed 120 seconds, or when a wait is unbounded. That covers
+`collect`, wrapped `amq watch`, wrapped `amq receipts wait`, and amq-squad-owned
+send/reply/dispatch receipt waits.
+
+The audited escape hatch is `--override-wait-posture --wait-posture-reason <why>`.
+
+Direct external `amq watch` and hand-written `sleep`/`until` loops cannot be intercepted
+and remain forbidden lead posture. Use `amq-squad monitor`, or park the turn and let the
+wake resume it.
+

--- a/plugins/claude/skills/wizard/references/stages.md
+++ b/plugins/claude/skills/wizard/references/stages.md
@@ -38,3 +38,34 @@ That has a consequence worth knowing before you hit it: a remedy that modifies a
 existing profile has nothing to act on if this run created that profile. The failure
 message says which case you are in, and points at the creation-time form when the
 profile is gone.
+
+## What the roster stage actually runs
+
+```sh
+amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
+amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
+amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
+```
+
+`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a generated
+`## Orchestration` reporting norm into `team-rules.md` **when that file is first
+seeded**. It is a structured flag rather than pasted prose, so the norm cannot drift
+from the roster.
+
+Default off; exactly one lead; the lead is a team member, never the operator.
+
+The seeding condition is the trap: an existing `team-rules.md` is left UNTOUCHED, so
+adding `--orchestrated` to a team that already has rules silently gives you a lead
+without the norm. Regenerate deliberately:
+
+```sh
+amq-squad team rules init --force
+```
+
+A brief can be seeded for an existing session, which is a different command from the
+launch-time `--seed-from`:
+
+```sh
+amq-squad brief seed --session S --seed-from issue:96 --force
+```
+

--- a/plugins/codex/skills/cli/references/primitives.md
+++ b/plugins/codex/skills/cli/references/primitives.md
@@ -101,7 +101,8 @@ amq-squad rm --session S                      # remove it
 amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
 
-Three of those have surprising defaults, verified by running them:
+Several of those have surprising defaults. Every row below was verified by running the
+command, not by reading its flags:
 
 | command | the surprise |
 |---|---|

--- a/plugins/codex/skills/cli/references/primitives.md
+++ b/plugins/codex/skills/cli/references/primitives.md
@@ -56,3 +56,51 @@ error: ambiguous profile at live_launch_record precedence
 Cause: more than one live launch record resolves for this project. Fix: pass
 `--profile NAME` explicitly. The CLI prints that fix itself, which is worth reading
 before reaching for anything more elaborate.
+
+## Runtime control (tmux)
+
+amq-squad owns the tmux control contract. Drive agents by stable command, never raw
+`tmux send-keys`, and target the recorded **pane id** rather than a window name — names
+are not stable across a session's life.
+
+```sh
+amq-squad focus --session S --role cto                          # bring a pane into view
+amq-squad send --session S --role cto --body-file ./prompt.md   # deliver a prompt and submit
+cat prompt.md | amq-squad send --session S --role qa --body-file -
+```
+
+`send` stages text in a tmux paste buffer, so multi-line text and shell metacharacters
+arrive verbatim, and it carries a **busy-guard**: it refuses to deliver into a mid-turn
+pane unless you pass `--force`. That refusal is a feature — interrupting a pane
+mid-turn corrupts the agent's own transcript.
+
+**`amq-squad send` is pane delivery, not a message.** It has no `--kind` and no
+`--thread`. To post an inter-agent message use `amq send`, which is a different tool
+with a different transport.
+
+### The two body-passing rules are NOT the same
+
+| tool | flag for file or stdin |
+|---|---|
+| `amq-squad send` | `--body-file FILE`, or `--body-file -` for stdin |
+| bare `amq send` | `--body @file`, or `--body -` for stdin; **`--body-file` does not exist** |
+
+Use a file or stdin for anything containing code, backticks, or `$()`. Inline `--body`
+is for short plain prose only, because the calling shell expands it before the tool
+ever sees it — a body with backticks arrives mangled or empty.
+
+## Session lifecycle
+
+```sh
+amq-squad console --session S        # attach to the squad's window
+amq-squad stop --session S           # stop agents, keep the session
+amq-squad resume --session S         # bring a stopped session back
+amq-squad archive --session S        # retire a finished session
+amq-squad rm --session S             # remove it
+amq-squad fork --session S           # branch a new session from this one
+```
+
+`up` refuses an existing session by design: it is NEW work. Use `resume` to continue
+one, or `up --reset` to deliberately start over. That refusal exists because silently
+reusing a session would inherit stale panes, briefs, and goal bindings.
+

--- a/plugins/codex/skills/cli/references/primitives.md
+++ b/plugins/codex/skills/cli/references/primitives.md
@@ -92,13 +92,23 @@ ever sees it — a body with backticks arrives mangled or empty.
 ## Session lifecycle
 
 ```sh
-amq-squad console --session S        # attach to the squad's window
-amq-squad stop --session S           # stop agents, keep the session
-amq-squad resume --session S         # bring a stopped session back
-amq-squad archive --session S        # retire a finished session
-amq-squad rm --session S             # remove it
-amq-squad fork --session S           # branch a new session from this one
+amq-squad console --session S                 # Mission Control TUI, filtered to S
+amq-squad stop --role R --session S           # or --all; a selector is REQUIRED
+amq-squad resume --session S                  # PLAN ONLY: prints the action table
+amq-squad resume --session S --exec           # actually reopens the panes
+amq-squad archive --session S                 # retire a finished session
+amq-squad rm --session S                      # remove it
+amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
+
+Three of those have surprising defaults, verified by running them:
+
+| command | the surprise |
+|---|---|
+| `stop` | exactly one selector is MANDATORY, `--role R` or `--all`. `stop --session S` alone stops nothing and exits on a usage error |
+| `resume` | plan-only by default. It prints a per-member action table and copy-pasteable commands; without `--exec` nothing reopens |
+| `console` | a full-screen read-only Mission Control TUI rendered to `/dev/tty`, NOT an attach to the squad's pane. Use `--once` for a single non-interactive snapshot |
+| `fork` | takes `--from SOURCE --as TARGET` and has no `--session` flag at all |
 
 `up` refuses an existing session by design: it is NEW work. Use `resume` to continue
 one, or `up --reset` to deliberately start over. That refusal exists because silently

--- a/plugins/codex/skills/orchestrator/references/lead-loop.md
+++ b/plugins/codex/skills/orchestrator/references/lead-loop.md
@@ -71,3 +71,44 @@ Two lifecycle constraints that cost real time when missed:
 If a blocker task completes during an evidence run, the link fails with a
 compare-and-swap error. `amq-squad evidence recover TASK ATTEMPT --me H` fixes
 it, and under parallel work that recover step is normal rather than exceptional.
+
+## Dispatch and collect
+
+Dispatch over durable AMQ, not pane injection. An AMQ message queues and survives pane
+death; `amq-squad send` writes into a live pane and is the fallback or nudge only.
+
+```sh
+amq send --to fullstack --thread p2p/cto__fullstack --kind todo \
+  --subject "Task: rate-limiter" --body - --wait-for drained --wait-timeout 60s <<'EOF'
+Implement the rate-limiter per the brief. Push a review_request to me when the diff
+is ready. Report any blocker as a question.
+EOF
+```
+
+Confirm children are live BEFORE dispatching — a message to a dead pane queues silently
+and looks delivered:
+
+```sh
+amq-squad status --session S --json | jq '.data.records[] | {role, status, pane_alive: .tmux.pane_alive}'
+```
+
+Children PUSH reports; the lead collects rather than polls:
+
+```sh
+amq-squad collect --session S --me cto --timeout 120s --include-body
+```
+
+### Wait posture is enforced, not advisory
+
+In `lead_pane` mode the binary verifies the live roster pane before its own blocking
+waits, and REFUSES a configured lead when a caller-raised `gate/<topic>` is unresolved,
+when a wait would exceed 120 seconds, or when a wait is unbounded. That covers
+`collect`, wrapped `amq watch`, wrapped `amq receipts wait`, and amq-squad-owned
+send/reply/dispatch receipt waits.
+
+The audited escape hatch is `--override-wait-posture --wait-posture-reason <why>`.
+
+Direct external `amq watch` and hand-written `sleep`/`until` loops cannot be intercepted
+and remain forbidden lead posture. Use `amq-squad monitor`, or park the turn and let the
+wake resume it.
+

--- a/plugins/codex/skills/wizard/references/stages.md
+++ b/plugins/codex/skills/wizard/references/stages.md
@@ -38,3 +38,34 @@ That has a consequence worth knowing before you hit it: a remedy that modifies a
 existing profile has nothing to act on if this run created that profile. The failure
 message says which case you are in, and points at the creation-time form when the
 profile is gone.
+
+## What the roster stage actually runs
+
+```sh
+amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
+amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
+amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
+```
+
+`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a generated
+`## Orchestration` reporting norm into `team-rules.md` **when that file is first
+seeded**. It is a structured flag rather than pasted prose, so the norm cannot drift
+from the roster.
+
+Default off; exactly one lead; the lead is a team member, never the operator.
+
+The seeding condition is the trap: an existing `team-rules.md` is left UNTOUCHED, so
+adding `--orchestrated` to a team that already has rules silently gives you a lead
+without the norm. Regenerate deliberately:
+
+```sh
+amq-squad team rules init --force
+```
+
+A brief can be seeded for an existing session, which is a different command from the
+launch-time `--seed-from`:
+
+```sh
+amq-squad brief seed --session S --seed-from issue:96 --force
+```
+

--- a/plugins/skills-src/cli/references/primitives.md
+++ b/plugins/skills-src/cli/references/primitives.md
@@ -101,7 +101,8 @@ amq-squad rm --session S                      # remove it
 amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
 
-Three of those have surprising defaults, verified by running them:
+Several of those have surprising defaults. Every row below was verified by running the
+command, not by reading its flags:
 
 | command | the surprise |
 |---|---|

--- a/plugins/skills-src/cli/references/primitives.md
+++ b/plugins/skills-src/cli/references/primitives.md
@@ -56,3 +56,51 @@ error: ambiguous profile at live_launch_record precedence
 Cause: more than one live launch record resolves for this project. Fix: pass
 `--profile NAME` explicitly. The CLI prints that fix itself, which is worth reading
 before reaching for anything more elaborate.
+
+## Runtime control (tmux)
+
+amq-squad owns the tmux control contract. Drive agents by stable command, never raw
+`tmux send-keys`, and target the recorded **pane id** rather than a window name — names
+are not stable across a session's life.
+
+```sh
+amq-squad focus --session S --role cto                          # bring a pane into view
+amq-squad send --session S --role cto --body-file ./prompt.md   # deliver a prompt and submit
+cat prompt.md | amq-squad send --session S --role qa --body-file -
+```
+
+`send` stages text in a tmux paste buffer, so multi-line text and shell metacharacters
+arrive verbatim, and it carries a **busy-guard**: it refuses to deliver into a mid-turn
+pane unless you pass `--force`. That refusal is a feature — interrupting a pane
+mid-turn corrupts the agent's own transcript.
+
+**`amq-squad send` is pane delivery, not a message.** It has no `--kind` and no
+`--thread`. To post an inter-agent message use `amq send`, which is a different tool
+with a different transport.
+
+### The two body-passing rules are NOT the same
+
+| tool | flag for file or stdin |
+|---|---|
+| `amq-squad send` | `--body-file FILE`, or `--body-file -` for stdin |
+| bare `amq send` | `--body @file`, or `--body -` for stdin; **`--body-file` does not exist** |
+
+Use a file or stdin for anything containing code, backticks, or `$()`. Inline `--body`
+is for short plain prose only, because the calling shell expands it before the tool
+ever sees it — a body with backticks arrives mangled or empty.
+
+## Session lifecycle
+
+```sh
+amq-squad console --session S        # attach to the squad's window
+amq-squad stop --session S           # stop agents, keep the session
+amq-squad resume --session S         # bring a stopped session back
+amq-squad archive --session S        # retire a finished session
+amq-squad rm --session S             # remove it
+amq-squad fork --session S           # branch a new session from this one
+```
+
+`up` refuses an existing session by design: it is NEW work. Use `resume` to continue
+one, or `up --reset` to deliberately start over. That refusal exists because silently
+reusing a session would inherit stale panes, briefs, and goal bindings.
+

--- a/plugins/skills-src/cli/references/primitives.md
+++ b/plugins/skills-src/cli/references/primitives.md
@@ -92,13 +92,23 @@ ever sees it — a body with backticks arrives mangled or empty.
 ## Session lifecycle
 
 ```sh
-amq-squad console --session S        # attach to the squad's window
-amq-squad stop --session S           # stop agents, keep the session
-amq-squad resume --session S         # bring a stopped session back
-amq-squad archive --session S        # retire a finished session
-amq-squad rm --session S             # remove it
-amq-squad fork --session S           # branch a new session from this one
+amq-squad console --session S                 # Mission Control TUI, filtered to S
+amq-squad stop --role R --session S           # or --all; a selector is REQUIRED
+amq-squad resume --session S                  # PLAN ONLY: prints the action table
+amq-squad resume --session S --exec           # actually reopens the panes
+amq-squad archive --session S                 # retire a finished session
+amq-squad rm --session S                      # remove it
+amq-squad fork --from SOURCE --as TARGET      # no --session flag on this one
 ```
+
+Three of those have surprising defaults, verified by running them:
+
+| command | the surprise |
+|---|---|
+| `stop` | exactly one selector is MANDATORY, `--role R` or `--all`. `stop --session S` alone stops nothing and exits on a usage error |
+| `resume` | plan-only by default. It prints a per-member action table and copy-pasteable commands; without `--exec` nothing reopens |
+| `console` | a full-screen read-only Mission Control TUI rendered to `/dev/tty`, NOT an attach to the squad's pane. Use `--once` for a single non-interactive snapshot |
+| `fork` | takes `--from SOURCE --as TARGET` and has no `--session` flag at all |
 
 `up` refuses an existing session by design: it is NEW work. Use `resume` to continue
 one, or `up --reset` to deliberately start over. That refusal exists because silently

--- a/plugins/skills-src/orchestrator/references/lead-loop.md
+++ b/plugins/skills-src/orchestrator/references/lead-loop.md
@@ -71,3 +71,44 @@ Two lifecycle constraints that cost real time when missed:
 If a blocker task completes during an evidence run, the link fails with a
 compare-and-swap error. `amq-squad evidence recover TASK ATTEMPT --me H` fixes
 it, and under parallel work that recover step is normal rather than exceptional.
+
+## Dispatch and collect
+
+Dispatch over durable AMQ, not pane injection. An AMQ message queues and survives pane
+death; `amq-squad send` writes into a live pane and is the fallback or nudge only.
+
+```sh
+amq send --to fullstack --thread p2p/cto__fullstack --kind todo \
+  --subject "Task: rate-limiter" --body - --wait-for drained --wait-timeout 60s <<'EOF'
+Implement the rate-limiter per the brief. Push a review_request to me when the diff
+is ready. Report any blocker as a question.
+EOF
+```
+
+Confirm children are live BEFORE dispatching — a message to a dead pane queues silently
+and looks delivered:
+
+```sh
+amq-squad status --session S --json | jq '.data.records[] | {role, status, pane_alive: .tmux.pane_alive}'
+```
+
+Children PUSH reports; the lead collects rather than polls:
+
+```sh
+amq-squad collect --session S --me cto --timeout 120s --include-body
+```
+
+### Wait posture is enforced, not advisory
+
+In `lead_pane` mode the binary verifies the live roster pane before its own blocking
+waits, and REFUSES a configured lead when a caller-raised `gate/<topic>` is unresolved,
+when a wait would exceed 120 seconds, or when a wait is unbounded. That covers
+`collect`, wrapped `amq watch`, wrapped `amq receipts wait`, and amq-squad-owned
+send/reply/dispatch receipt waits.
+
+The audited escape hatch is `--override-wait-posture --wait-posture-reason <why>`.
+
+Direct external `amq watch` and hand-written `sleep`/`until` loops cannot be intercepted
+and remain forbidden lead posture. Use `amq-squad monitor`, or park the turn and let the
+wake resume it.
+

--- a/plugins/skills-src/wizard/references/stages.md
+++ b/plugins/skills-src/wizard/references/stages.md
@@ -38,3 +38,34 @@ That has a consequence worth knowing before you hit it: a remedy that modifies a
 existing profile has nothing to act on if this run created that profile. The failure
 message says which case you are in, and points at the creation-time form when the
 profile is gone.
+
+## What the roster stage actually runs
+
+```sh
+amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
+amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
+amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
+```
+
+`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a generated
+`## Orchestration` reporting norm into `team-rules.md` **when that file is first
+seeded**. It is a structured flag rather than pasted prose, so the norm cannot drift
+from the roster.
+
+Default off; exactly one lead; the lead is a team member, never the operator.
+
+The seeding condition is the trap: an existing `team-rules.md` is left UNTOUCHED, so
+adding `--orchestrated` to a team that already has rules silently gives you a lead
+without the norm. Regenerate deliberately:
+
+```sh
+amq-squad team rules init --force
+```
+
+A brief can be seeded for an existing session, which is a different command from the
+launch-time `--seed-from`:
+
+```sh
+amq-squad brief seed --session S --seed-from issue:96 --force
+```
+


### PR DESCRIPTION
Closes the last #534 deliverable: `docs/skills.md` extracted into per-skill references, and the
guide's inverted pointer reversed.

## The finding this addresses

#534 observed that the good documentation already existed in this repo. `docs/skills.md`
carried the command blocks, the which-skill table, the operator-primitive decision table and a
troubleshooting table, while **no `SKILL.md` linked to it** and the guide's closing line pointed
back at the then-thin skill files. The pointer was inverted.

## Extracted, sourced rather than reworded

Content was taken from the guide's own text, not paraphrased from memory:

| destination | what moved |
|---|---|
| `cli/references/primitives.md` | tmux runtime control and the session lifecycle |
| `orchestrator/references/lead-loop.md` | dispatch-over-AMQ vs pane injection, confirm-liveness-before-dispatch, `collect`, and the enforced wait posture with its audited override |
| `wizard/references/stages.md` | what the roster stage runs, and the seeding condition on `--orchestrated` |

Two items earn their place by having cost real time in this milestone:

- **`amq-squad send` is pane delivery, not a message.** It has no `--kind` and no `--thread`,
  and its `--body-file` is *not* the same flag as bare `amq send`'s `--body @file`. Two tools,
  two rules, one letter apart. I hit this trap myself when a shell expanded a regex in an
  inline body.
- **`--orchestrated` writes the Orchestration norm only when `team-rules.md` is FIRST seeded**,
  so adding it to a team that already has rules silently yields a lead without the norm.

## Gate-measured effect

    commands named and verified   33 -> 44
    flags verified               45 of 74 -> 65 of 99

Every verb and subcommand path resolves; nothing invented. The drift gate is the arbiter here
rather than my judgement: a command that did not exist would have failed it.

## The pointer, reversed with a reason

The guide now opens its closing section by stating it is orientation and **not** the source of
truth, names the canonical source per skill with its references, records that
`plugins/{claude,codex}` are generated mirrors that lose hand edits, and states the tie-break:

> when this guide and a `SKILL.md` disagree, the `SKILL.md` is correct: its commands are
> verified against the live binary surface on every CI run, and this guide is not.

That last clause is the reversal with a re-verifiable reason attached rather than an assertion
of precedence.

## What this PR deliberately does not do

**The guide keeps its prose.** #534 asks for the commands extracted and the pointer reversed; it
does not ask for the guide gutted. An orientation document that says what it is and names its
canonical sources is more useful than a stub, and the gate now arbitrates commands in both
places.

## Second commit: the ratified #565 wording, plus regenerated HTML

Team-rules gains the third ratified serialization line set, from an incident of mine that
satisfied the letter of the Tier 2 definition while mutating the repository: shared state
includes the repository itself, classification covers the wrapper rather than the payload, and
verification must not mutate. Both copies of that tracked file are byte-identical.

`docs/skills.html` is regenerated because the repo pins it in sync with the markdown. My first
pinned ci failed `docs-html-check` for exactly that omission, caught by ci rather than by me.
