### PR TITLE
feat: add read-only global NOC status board

### DIFF
--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -45,7 +45,16 @@ default; `--go` opens the window and launches the agent.
 amq-squad global start                                   # ~/Code, claude, preview
 amq-squad global start --root ~/work --agent codex --go  # launch a codex supervisor
 amq-squad global start --agent claude --model claude-opus-4-8 --go
+amq-squad global status --root ~/work                    # read-only board
+amq-squad global status --root ~/work --json             # schema-versioned data
 ```
+
+`global status` reads the stamped NOC registry exactly once and projects only
+its registered namespaces. Each row exposes the canonical lead, registration
+state and provenance, open operator gates and ages, watcher/backstop state,
+readiness, source errors, and inspect/repair action objects. The command never
+scans arbitrary repositories and never executes an action; every mutation is
+confirmation-gated.
 
 Then drive each run by explicit namespace (`goal draft`/`goal start`,
 `monitor --once`, `status`, `next`, `operator answer`). See the skill's

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -80,6 +80,7 @@ var completionNamespaceSubcommands = []string{"migrate", "recover", "rollback"}
 // completionGlobalSubcommands lists the `amq-squad global` subcommands.
 var completionGlobalSubcommands = []string{
 	"start",
+	"status",
 }
 
 // completionRunSubcommands lists the `amq-squad run` subcommands.

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -20,6 +20,21 @@ func TestRunCompletionRejectsMissingShell(t *testing.T) {
 	}
 }
 
+func TestCompletionIncludesGlobalStatus(t *testing.T) {
+	for shell, tc := range map[string]struct {
+		script string
+		want   string
+	}{
+		"bash": {script: bashCompletionScript, want: `compgen -W "start status"`},
+		"zsh":  {script: zshCompletionScript, want: `compadd -- 'start' 'status'`},
+		"fish": {script: fishCompletionScript, want: `__fish_seen_subcommand_from global" -a 'status'`},
+	} {
+		if !strings.Contains(tc.script, tc.want) {
+			t.Errorf("%s completion is missing exact global status branch %q:\n%s", shell, tc.want, tc.script)
+		}
+	}
+}
+
 func TestCompletionCoversBootstrapAck(t *testing.T) {
 	for shell, script := range map[string]string{"bash": bashCompletionScript, "zsh": zshCompletionScript, "fish": fishCompletionScript} {
 		for _, want := range []string{"bootstrap", "ack", "--skill-version", "--steps"} {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1530,6 +1530,7 @@ func doctorCheckWake(d doctorExecution) ([]doctorCheck, string) {
 		rec := classifyMemberStatus(t, profile, m, workstream, probe)
 		checks = append(checks, doctorCheckFromStatus(rec))
 	}
+	checks = append(checks, doctorCheckGlobalNOCRegistration(t, profile, workstream))
 	return checks, workstream
 }
 

--- a/internal/cli/global_status.go
+++ b/internal/cli/global_status.go
@@ -663,23 +663,29 @@ func globalStatusReadinessFor(health string, sourceErrors []globalStatusSourceEr
 
 func globalNOCStatusActions(root string, noc *globalStatusNOCView, registryState string) []runtimeActionJSON {
 	scope := " --root " + runtimeaction.ShellQuote(root)
-	repairAvailable := registryState == "missing" || (registryState == "healthy" && (noc == nil || noc.Health == globalStatusStopped))
-	repairReason := "confirm-gated: launches and persists a new global NOC runtime"
-	if !repairAvailable {
-		repairReason = "a new NOC launch is available only when the registry is absent or the current canonical runtime is stopped"
-	}
-	return runtimeaction.ApplyCanonical([]runtimeActionJSON{
+	actions := []runtimeActionJSON{
 		{
 			Kind: "global_status", Label: "inspect global NOC status", Scope: "global",
 			Command: "amq-squad global status" + scope + " --json",
 			Mutates: false, NeedsConfirmation: false, Available: true,
 		},
-		{
+	}
+	if noc != nil && noc.PersistedState == globalNOCLaunchStopped && noc.Runtime.Live {
+		return runtimeaction.ApplyCanonical(actions)
+	}
+	repairAvailable := registryState == "missing" || (registryState == "healthy" && (noc == nil || noc.Health == globalStatusStopped))
+	repairReason := "confirm-gated: launches and persists a new global NOC runtime"
+	if !repairAvailable {
+		repairReason = "a new NOC launch is available only when the registry is absent or the current canonical runtime is stopped"
+	}
+	actions = append(actions,
+		runtimeActionJSON{
 			Kind: "global_start", Label: "confirm launch global NOC", Scope: "global",
 			Command: "amq-squad global start" + scope + " --go",
 			Mutates: true, NeedsConfirmation: true, Available: repairAvailable, Reason: repairReason,
 		},
-	})
+	)
+	return runtimeaction.ApplyCanonical(actions)
 }
 
 func confirmGatedSessionActions(namespace squadnamespace.Ref) []runtimeActionJSON {

--- a/internal/cli/global_status.go
+++ b/internal/cli/global_status.go
@@ -288,6 +288,16 @@ func projectGlobalStatusNOC(item globalNOCLaunch, identityFn func(launch.Record,
 	case globalNOCLaunchStopped:
 		health = globalStatusStopped
 	}
+	detail := item.Detail
+	if item.State == globalNOCLaunchStopped && identity.Live {
+		health = globalStatusDegraded
+		contradiction := "persisted NOC state is stopped but the canonical runtime identity is live; start is withheld"
+		if strings.TrimSpace(detail) == "" {
+			detail = contradiction
+		} else {
+			detail += "; " + contradiction
+		}
+	}
 	paneID := ""
 	if item.Record.Tmux != nil {
 		paneID = item.Record.Tmux.PaneID
@@ -301,7 +311,7 @@ func projectGlobalStatusNOC(item globalNOCLaunch, identityFn func(launch.Record,
 			PIDAlive: identity.PIDAlive, BinaryMatch: identity.BinaryMatch,
 		},
 		Backstop: item.Backstop, CreatedAt: item.CreatedAt, UpdatedAt: item.UpdatedAt,
-		Detail: item.Detail,
+		Detail: detail,
 	}
 }
 
@@ -386,6 +396,9 @@ func projectGlobalStatusRun(s globalStatusExecution, registry globalNOCRegistry,
 			Status: status.Status, RecordState: status.RecordState, Detail: status.Detail,
 			Signals: status.Signals, Namespace: status.Namespace, Terminal: status.Terminal,
 		}
+		if strings.TrimSpace(status.ClassificationError) != "" {
+			appendRunSourceError("lead", status.ClassificationError)
+		}
 	}
 
 	operatorProjector := s.OperatorData
@@ -405,7 +418,11 @@ func projectGlobalStatusRun(s globalStatusExecution, registry globalNOCRegistry,
 		if !sameGlobalStatusNamespace(operatorData.Namespace, expectedNamespace) {
 			appendRunSourceError("operator_gates", "operator projection namespace contradicts the registered namespace")
 		} else {
-			row.OperatorGates = globalStatusOpenGates(operatorData.Attention)
+			var attentionErrors []string
+			row.OperatorGates, attentionErrors = globalStatusOpenGates(operatorData.Attention, expectedNamespace)
+			for _, detail := range attentionErrors {
+				appendRunSourceError("operator_gates", detail)
+			}
 		}
 	}
 
@@ -421,9 +438,6 @@ func projectGlobalStatusRun(s globalStatusExecution, registry globalNOCRegistry,
 }
 
 func globalStatusAMQBaseRoot(namespace squadnamespace.Ref) string {
-	if squadnamespace.NormalizeProfile(namespace.Profile) == team.DefaultProfile {
-		return filepath.Dir(namespace.AMQRoot)
-	}
 	return namespace.AMQRoot
 }
 
@@ -521,11 +535,22 @@ func validateGlobalStatusRegistration(registry globalNOCRegistry, run globalNOCR
 	}
 }
 
-func globalStatusOpenGates(items []operatorAttention) globalStatusGatesView {
+func globalStatusOpenGates(items []operatorAttention, expected squadnamespace.Ref) (globalStatusGatesView, []string) {
 	out := globalStatusGatesView{Items: []globalStatusGateView{}}
+	var sourceErrors []string
 	var oldest operatorAttention
 	for _, item := range items {
 		if !isOpenGateAttention(item) {
+			continue
+		}
+		if strings.TrimSpace(item.Profile) == "" ||
+			!squadnamespace.ProfilesEqual(item.Profile, expected.Profile) ||
+			item.Session != expected.Session ||
+			item.NamespaceID != expected.ID {
+			sourceErrors = append(sourceErrors, fmt.Sprintf(
+				"attention item %q contradicts registered namespace %s (profile=%q session=%q namespace_id=%q)",
+				item.Thread, expected.ID, item.Profile, item.Session, item.NamespaceID,
+			))
 			continue
 		}
 		out.Items = append(out.Items, globalStatusGateView{
@@ -546,7 +571,7 @@ func globalStatusOpenGates(items []operatorAttention) globalStatusGatesView {
 	if out.Open > 0 {
 		out.OldestAge = oldest.Age
 	}
-	return out
+	return out, sourceErrors
 }
 
 func globalStatusRunBackstop(run globalNOCRun, config globalNOCBackstop) globalStatusBackstopView {
@@ -650,7 +675,7 @@ func globalNOCStatusActions(root string, noc *globalStatusNOCView, registryState
 			Mutates: false, NeedsConfirmation: false, Available: true,
 		},
 		{
-			Kind: "global_start", Label: "launch global NOC", Scope: "global",
+			Kind: "global_start", Label: "confirm launch global NOC", Scope: "global",
 			Command: "amq-squad global start" + scope + " --go",
 			Mutates: true, NeedsConfirmation: true, Available: repairAvailable, Reason: repairReason,
 		},
@@ -668,6 +693,9 @@ func confirmGatedSessionActions(namespace squadnamespace.Ref) []runtimeActionJSO
 		}
 		if action.Mutates {
 			action.NeedsConfirmation = true
+			if !strings.Contains(strings.ToLower(action.Label), "confirm") {
+				action.Label = "confirm " + action.Label
+			}
 			action.Reason = "confirm-gated: mutates the registered session runtime"
 			runtimeaction.SyncUnavailableReason(&action)
 		}
@@ -688,15 +716,15 @@ func renderGlobalStatus(out io.Writer, data globalStatusEnvelopeData, jsonOut bo
 	}
 	if len(data.Runs) > 0 {
 		tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
-		fmt.Fprintln(tw, "NAMESPACE\tHEALTH\tLEAD\tREGISTRATION\tGATES\tWATCHER\tLAST-REFRESH")
+		fmt.Fprintln(tw, "NAMESPACE\tHEALTH\tLEAD\tDETAIL\tREGISTRATION\tGATES\tWATCHER\tLAST-REFRESH")
 		for _, row := range data.Runs {
 			gates := fmt.Sprintf("%d", row.OperatorGates.Open)
 			if row.OperatorGates.OldestAge != "" {
 				gates += " (" + row.OperatorGates.OldestAge + ")"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s/%s\t%s\t%s\t%s\t%s\n",
+			fmt.Fprintf(tw, "%s\t%s\t%s/%s\t%s\t%s\t%s\t%s\t%s\n",
 				row.Namespace.ID, row.Health, emptyCell(row.Lead.Role), emptyCell(row.Lead.Status),
-				row.Registration.State, gates, emptyCell(row.Watcher.Health), row.LastRefresh.Format(time.RFC3339))
+				emptyCell(row.Lead.Detail), row.Registration.State, gates, emptyCell(row.Watcher.Health), row.LastRefresh.Format(time.RFC3339))
 		}
 		_ = tw.Flush()
 	}

--- a/internal/cli/global_status.go
+++ b/internal/cli/global_status.go
@@ -1,0 +1,718 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimeaction"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+const (
+	globalStatusHealthy  = "healthy"
+	globalStatusDegraded = "degraded"
+	globalStatusStopped  = "stopped"
+	globalStatusUnknown  = "unknown"
+)
+
+// globalStatusSourceError is a structured, fail-visible projection failure.
+// Status never turns an unreadable or contradictory source into a healthy row.
+type globalStatusSourceError struct {
+	Source      string `json:"source"`
+	NamespaceID string `json:"namespace_id,omitempty"`
+	Detail      string `json:"detail"`
+}
+
+type globalStatusRegistryView struct {
+	State             string    `json:"state"`
+	Path              string    `json:"path"`
+	SchemaVersion     int       `json:"schema_version,omitempty"`
+	CurrentGeneration uint64    `json:"current_generation,omitempty"`
+	UpdatedAt         time.Time `json:"updated_at,omitempty"`
+}
+
+type globalStatusRuntimeIdentity struct {
+	Live        bool `json:"live"`
+	PIDLive     bool `json:"pid_live"`
+	PaneLive    bool `json:"pane_live"`
+	PIDAlive    bool `json:"pid_alive"`
+	BinaryMatch bool `json:"binary_match"`
+}
+
+type globalStatusNOCView struct {
+	LaunchID       string                      `json:"launch_id"`
+	Generation     uint64                      `json:"generation"`
+	PersistedState string                      `json:"persisted_state"`
+	Health         string                      `json:"health"`
+	Binary         string                      `json:"binary"`
+	Session        string                      `json:"session"`
+	Role           string                      `json:"role"`
+	PaneID         string                      `json:"pane_id,omitempty"`
+	Runtime        globalStatusRuntimeIdentity `json:"runtime"`
+	Backstop       globalNOCBackstop           `json:"stall_backstop"`
+	CreatedAt      time.Time                   `json:"created_at"`
+	UpdatedAt      time.Time                   `json:"updated_at"`
+	Detail         string                      `json:"detail,omitempty"`
+	Actions        []runtimeActionJSON         `json:"actions"`
+}
+
+type globalStatusLeadView struct {
+	Role        string               `json:"role"`
+	Handle      string               `json:"handle"`
+	Binary      string               `json:"binary"`
+	Status      statusState          `json:"status"`
+	RecordState string               `json:"record_state"`
+	Detail      string               `json:"detail,omitempty"`
+	Signals     statusSignals        `json:"signals"`
+	Namespace   squadnamespace.Ref   `json:"namespace"`
+	Terminal    *terminalRuntimeJSON `json:"terminal,omitempty"`
+}
+
+type globalStatusRegistrationView struct {
+	State      string                           `json:"state"`
+	Policy     string                           `json:"policy"`
+	Provenance *launch.OrchestratorRegistration `json:"provenance,omitempty"`
+}
+
+type globalStatusGateView struct {
+	Thread      string    `json:"thread"`
+	Subject     string    `json:"subject"`
+	GateKind    string    `json:"gate_kind,omitempty"`
+	Age         string    `json:"age"`
+	LastEventAt time.Time `json:"last_event_at,omitempty"`
+	Inspect     string    `json:"inspect"`
+}
+
+type globalStatusGatesView struct {
+	Open      int                    `json:"open"`
+	OldestAge string                 `json:"oldest_age,omitempty"`
+	Items     []globalStatusGateView `json:"items"`
+}
+
+type globalStatusBackstopView struct {
+	Health string            `json:"health"`
+	Mode   string            `json:"mode"`
+	Config globalNOCBackstop `json:"config"`
+	Detail string            `json:"detail,omitempty"`
+}
+
+type globalStatusReadiness struct {
+	State   string   `json:"state"`
+	Ready   bool     `json:"ready"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+type globalStatusRunView struct {
+	ID             string                       `json:"id"`
+	Namespace      squadnamespace.Ref           `json:"namespace"`
+	Project        string                       `json:"project"`
+	Profile        string                       `json:"profile"`
+	Session        string                       `json:"session"`
+	Health         string                       `json:"health"`
+	Lead           globalStatusLeadView         `json:"lead"`
+	Registration   globalStatusRegistrationView `json:"registration"`
+	OperatorGates  globalStatusGatesView        `json:"operator_gates"`
+	Watcher        notificationWatcherStatus    `json:"watcher"`
+	Backstop       globalStatusBackstopView     `json:"stall_backstop"`
+	Readiness      globalStatusReadiness        `json:"readiness"`
+	LastRefresh    time.Time                    `json:"last_refresh"`
+	RegistryUpdate time.Time                    `json:"registry_updated_at"`
+	SourceErrors   []globalStatusSourceError    `json:"source_errors"`
+	Actions        []runtimeActionJSON          `json:"actions"`
+}
+
+type globalStatusEnvelopeData struct {
+	ControlRoot  string                    `json:"control_root"`
+	ObservedAt   time.Time                 `json:"observed_at"`
+	Health       string                    `json:"health"`
+	ReadOnly     bool                      `json:"readonly"`
+	Registry     globalStatusRegistryView  `json:"registry"`
+	NOC          *globalStatusNOCView      `json:"noc,omitempty"`
+	Runs         []globalStatusRunView     `json:"runs"`
+	Readiness    globalStatusReadiness     `json:"readiness"`
+	SourceErrors []globalStatusSourceError `json:"source_errors"`
+	Actions      []runtimeActionJSON       `json:"actions"`
+}
+
+type globalStatusExecution struct {
+	ControlRoot string
+	Out         io.Writer
+	JSON        bool
+	Now         func() time.Time
+
+	ReadRegistry func(string) (globalNOCRegistry, error)
+	ReadTeam     func(string, string) (team.Team, error)
+	ClassifyLead func(team.Team, string, team.Member, string) statusRecord
+	OperatorData func(string, string, string, string, func() time.Time) (operatorStatusEnvelopeData, error)
+	Watcher      func(team.Team, string, string, time.Time) notificationWatcherStatus
+	NOCIdentity  func(launch.Record, string) launchRuntimeIdentity
+}
+
+func runGlobalStatus(args []string) error {
+	fs := flag.NewFlagSet("global status", flag.ContinueOnError)
+	root := fs.String("root", defaultGlobalNOCControlRoot(), "neutral NOC control root")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned global status envelope")
+	fs.Usage = func() { _ = runGlobal([]string{"-h"}) }
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return usageErrorf("unexpected argument %q", fs.Arg(0))
+	}
+	if strings.TrimSpace(*root) == "" {
+		return usageErrorf("global status requires --root (could not infer a home directory)")
+	}
+	return executeGlobalStatus(globalStatusExecution{
+		ControlRoot: *root,
+		Out:         os.Stdout,
+		JSON:        *jsonOut,
+	})
+}
+
+func executeGlobalStatus(s globalStatusExecution) error {
+	out := s.Out
+	if out == nil {
+		out = io.Discard
+	}
+	nowFn := s.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	observedAt := nowFn().UTC()
+	readRegistry := s.ReadRegistry
+	if readRegistry == nil {
+		readRegistry = readGlobalNOCRegistry
+	}
+
+	// The registry is read exactly once. Everything below projects this
+	// validated snapshot, so removal or replacement during the projection
+	// cannot splice two registry generations into one report.
+	registry, registryErr := readRegistry(s.ControlRoot)
+	controlRoot := strings.TrimSpace(s.ControlRoot)
+	if canonical, err := canonicalGlobalNOCControlRoot(s.ControlRoot); err == nil {
+		controlRoot = canonical
+	}
+	data := globalStatusEnvelopeData{
+		ControlRoot:  controlRoot,
+		ObservedAt:   observedAt,
+		Health:       globalStatusUnknown,
+		ReadOnly:     true,
+		Runs:         []globalStatusRunView{},
+		SourceErrors: []globalStatusSourceError{},
+		Registry: globalStatusRegistryView{
+			State: "healthy",
+			Path:  globalNOCRegistryPath(controlRoot),
+		},
+	}
+	if registryErr != nil {
+		state := "unreadable"
+		if errors.Is(registryErr, os.ErrNotExist) {
+			state = "missing"
+		}
+		sourceErr := globalStatusSourceError{Source: "registry", Detail: registryErr.Error()}
+		data.Registry.State = state
+		data.SourceErrors = append(data.SourceErrors, sourceErr)
+		data.Readiness = globalStatusReadiness{
+			State: globalStatusUnknown, Ready: false,
+			Reasons: []string{"NOC registry is " + state},
+		}
+		data.Actions = globalNOCStatusActions(controlRoot, nil, state)
+		return renderGlobalStatus(out, data, s.JSON)
+	}
+
+	data.ControlRoot = registry.ControlRoot
+	data.Registry = globalStatusRegistryView{
+		State:             "healthy",
+		Path:              globalNOCRegistryPath(registry.ControlRoot),
+		SchemaVersion:     registry.SchemaVersion,
+		CurrentGeneration: registry.CurrentGeneration,
+		UpdatedAt:         registry.UpdatedAt,
+	}
+	if len(registry.Launches) > 0 {
+		current := registry.Launches[len(registry.Launches)-1]
+		data.NOC = projectGlobalStatusNOC(current, s.NOCIdentity)
+	}
+	data.Actions = globalNOCStatusActions(registry.ControlRoot, data.NOC, "healthy")
+	if data.NOC != nil {
+		data.NOC.Actions = append([]runtimeActionJSON(nil), data.Actions...)
+	}
+
+	runs := append([]globalNOCRun(nil), registry.Runs...)
+	sort.SliceStable(runs, func(i, j int) bool {
+		if runs[i].Namespace.ID != runs[j].Namespace.ID {
+			return runs[i].Namespace.ID < runs[j].Namespace.ID
+		}
+		if runs[i].CreatedAt.Equal(runs[j].CreatedAt) {
+			return runs[i].ID < runs[j].ID
+		}
+		return runs[i].CreatedAt.Before(runs[j].CreatedAt)
+	})
+	for _, run := range runs {
+		row := projectGlobalStatusRun(s, registry, run, observedAt)
+		data.Runs = append(data.Runs, row)
+		data.SourceErrors = append(data.SourceErrors, row.SourceErrors...)
+	}
+	data.Health = globalStatusOverallHealth(data.NOC, data.Runs, data.SourceErrors)
+	data.Readiness = globalStatusReadinessFor(data.Health, data.SourceErrors)
+	return renderGlobalStatus(out, data, s.JSON)
+}
+
+func projectGlobalStatusNOC(item globalNOCLaunch, identityFn func(launch.Record, string) launchRuntimeIdentity) *globalStatusNOCView {
+	if identityFn == nil {
+		identityFn = globalNOCRuntimeIdentity
+	}
+	identity := identityFn(item.Record, "")
+	health := globalStatusStopped
+	switch item.State {
+	case globalNOCLaunchActive:
+		switch {
+		case identity.PIDLive && identity.PaneLive:
+			health = globalStatusHealthy
+		case identity.Live:
+			health = globalStatusDegraded
+		}
+	case globalNOCLaunchPrepared:
+		health = globalStatusDegraded
+	case globalNOCLaunchFailed:
+		health = globalStatusDegraded
+	case globalNOCLaunchStopped:
+		health = globalStatusStopped
+	}
+	paneID := ""
+	if item.Record.Tmux != nil {
+		paneID = item.Record.Tmux.PaneID
+	}
+	return &globalStatusNOCView{
+		LaunchID: item.ID, Generation: item.Generation, PersistedState: item.State,
+		Health: health, Binary: item.Record.Binary, Session: item.Record.Session,
+		Role: item.Record.Role, PaneID: paneID,
+		Runtime: globalStatusRuntimeIdentity{
+			Live: identity.Live, PIDLive: identity.PIDLive, PaneLive: identity.PaneLive,
+			PIDAlive: identity.PIDAlive, BinaryMatch: identity.BinaryMatch,
+		},
+		Backstop: item.Backstop, CreatedAt: item.CreatedAt, UpdatedAt: item.UpdatedAt,
+		Detail: item.Detail,
+	}
+}
+
+func projectGlobalStatusRun(s globalStatusExecution, registry globalNOCRegistry, run globalNOCRun, observedAt time.Time) globalStatusRunView {
+	row := globalStatusRunView{
+		ID: run.ID, Namespace: run.Namespace, Project: run.Namespace.TeamHome,
+		Profile: squadnamespace.NormalizeProfile(run.Namespace.Profile), Session: run.Namespace.Session,
+		Health: globalStatusUnknown, LastRefresh: observedAt, RegistryUpdate: run.UpdatedAt,
+		Lead: globalStatusLeadView{
+			Role: strings.TrimSpace(run.LeadRole), Namespace: run.Namespace,
+		},
+		Registration: globalStatusRegistrationView{
+			State: run.State, Policy: run.Policy, Provenance: run.ExternalRegistration,
+		},
+		OperatorGates: globalStatusGatesView{Items: []globalStatusGateView{}},
+		SourceErrors:  []globalStatusSourceError{},
+	}
+	backstop := globalNOCBackstop{}
+	if run.NOCGeneration > 0 && run.NOCGeneration <= uint64(len(registry.Launches)) {
+		backstop = registry.Launches[run.NOCGeneration-1].Backstop
+	}
+	row.Backstop = globalStatusRunBackstop(run, backstop)
+	appendRunSourceError := func(source, detail string) {
+		row.SourceErrors = append(row.SourceErrors, globalStatusSourceError{
+			Source: source, NamespaceID: run.Namespace.ID, Detail: detail,
+		})
+	}
+
+	expectedNamespace := squadnamespace.Resolve(run.Namespace.TeamHome, run.Namespace.Profile, run.Namespace.Session)
+	namespaceValid := sameGlobalStatusNamespace(run.Namespace, expectedNamespace) &&
+		strings.TrimSpace(run.Namespace.Session) != "" &&
+		globalStatusNamespacePathsAbsolute(run.Namespace)
+	if !namespaceValid {
+		appendRunSourceError("namespace", "registry namespace fields contradict the canonical project/profile/session resolution")
+	}
+	validateGlobalStatusRegistration(registry, run, appendRunSourceError)
+	if !namespaceValid {
+		row.Readiness = globalStatusReadinessFor(row.Health, row.SourceErrors)
+		row.Actions = []runtimeActionJSON{}
+		return row
+	}
+
+	readTeam := s.ReadTeam
+	if readTeam == nil {
+		readTeam = team.ReadProfile
+	}
+	tm, err := readTeam(run.Namespace.TeamHome, run.Namespace.Profile)
+	if err != nil {
+		appendRunSourceError("team", err.Error())
+		row.Readiness = globalStatusReadinessFor(row.Health, row.SourceErrors)
+		row.Actions = confirmGatedSessionActions(run.Namespace)
+		return row
+	}
+	if !sameGlobalStatusPath(tm.Project, run.Namespace.TeamHome) {
+		appendRunSourceError("team", "team project contradicts the registered namespace")
+		row.Readiness = globalStatusReadinessFor(row.Health, row.SourceErrors)
+		row.Actions = []runtimeActionJSON{}
+		return row
+	}
+	leadRole := strings.TrimSpace(run.LeadRole)
+	if leadRole == "" {
+		leadRole = strings.TrimSpace(tm.Lead)
+	}
+	if strings.TrimSpace(tm.Lead) != "" && leadRole != strings.TrimSpace(tm.Lead) {
+		appendRunSourceError("lead", fmt.Sprintf("registered lead role %q contradicts team lead role %q", leadRole, tm.Lead))
+	}
+	leadMember, ok := globalStatusLeadMember(tm, leadRole)
+	if !ok {
+		appendRunSourceError("lead", fmt.Sprintf("registered lead role %q is absent from the team", leadRole))
+		row.Lead.Role = leadRole
+	} else {
+		classify := s.ClassifyLead
+		if classify == nil {
+			classify = func(t team.Team, profile string, member team.Member, session string) statusRecord {
+				return classifyMemberStatus(t, profile, member, session, defaultDuplicateLaunchProbe)
+			}
+		}
+		status := classify(tm, run.Namespace.Profile, leadMember, run.Namespace.Session)
+		status.Namespace = expectedNamespace
+		row.Lead = globalStatusLeadView{
+			Role: status.Role, Handle: status.Handle, Binary: status.Binary,
+			Status: status.Status, RecordState: status.RecordState, Detail: status.Detail,
+			Signals: status.Signals, Namespace: status.Namespace, Terminal: status.Terminal,
+		}
+	}
+
+	operatorProjector := s.OperatorData
+	if operatorProjector == nil {
+		operatorProjector = func(project, profile, session, baseRoot string, now func() time.Time) (operatorStatusEnvelopeData, error) {
+			return buildOperatorStatusData(operatorExecution{
+				ProjectDir: project, Profile: profile, Session: session,
+				BaseRoot: baseRoot, Now: now,
+			})
+		}
+	}
+	baseRoot := globalStatusAMQBaseRoot(run.Namespace)
+	operatorData, operatorErr := operatorProjector(run.Namespace.TeamHome, run.Namespace.Profile, run.Namespace.Session, baseRoot, func() time.Time { return observedAt })
+	if operatorErr != nil {
+		appendRunSourceError("operator_gates", operatorErr.Error())
+	} else {
+		if !sameGlobalStatusNamespace(operatorData.Namespace, expectedNamespace) {
+			appendRunSourceError("operator_gates", "operator projection namespace contradicts the registered namespace")
+		} else {
+			row.OperatorGates = globalStatusOpenGates(operatorData.Attention)
+		}
+	}
+
+	watcher := s.Watcher
+	if watcher == nil {
+		watcher = inspectNotificationWatcher
+	}
+	row.Watcher = watcher(tm, run.Namespace.Profile, run.Namespace.Session, observedAt)
+	row.Actions = confirmGatedSessionActions(run.Namespace)
+	row.Health = globalStatusRunHealth(row)
+	row.Readiness = globalStatusReadinessFor(row.Health, row.SourceErrors)
+	return row
+}
+
+func globalStatusAMQBaseRoot(namespace squadnamespace.Ref) string {
+	if squadnamespace.NormalizeProfile(namespace.Profile) == team.DefaultProfile {
+		return filepath.Dir(namespace.AMQRoot)
+	}
+	return namespace.AMQRoot
+}
+
+func globalStatusNamespacePathsAbsolute(namespace squadnamespace.Ref) bool {
+	for _, path := range []string{
+		namespace.TeamHome,
+		namespace.AMQRoot,
+		namespace.Paths.ProfileConfig,
+		namespace.Paths.AMQRoot,
+		namespace.Paths.Brief,
+		namespace.Paths.Tasks,
+	} {
+		if strings.TrimSpace(path) == "" ||
+			!filepath.IsAbs(path) ||
+			filepath.Clean(path) != path {
+			return false
+		}
+	}
+	return true
+}
+
+func sameGlobalStatusNamespace(a, b squadnamespace.Ref) bool {
+	if !sameGlobalStatusPath(a.TeamHome, b.TeamHome) ||
+		a.Profile != b.Profile ||
+		a.Session != b.Session ||
+		a.ID != b.ID ||
+		a.Display != b.Display ||
+		a.AMQSession != b.AMQSession {
+		return false
+	}
+	for _, pair := range [][2]string{
+		{a.AMQRoot, b.AMQRoot},
+		{a.Paths.ProfileConfig, b.Paths.ProfileConfig},
+		{a.Paths.AMQRoot, b.Paths.AMQRoot},
+		{a.Paths.Brief, b.Paths.Brief},
+		{a.Paths.Tasks, b.Paths.Tasks},
+	} {
+		if !sameOptionalGlobalStatusPath(pair[0], pair[1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameOptionalGlobalStatusPath(a, b string) bool {
+	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
+		return strings.TrimSpace(a) == strings.TrimSpace(b)
+	}
+	return sameGlobalStatusPath(a, b)
+}
+
+func sameGlobalStatusPath(a, b string) bool {
+	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
+		return false
+	}
+	return canonicalFilesystemPath(a) == canonicalFilesystemPath(b)
+}
+
+func globalStatusLeadMember(t team.Team, role string) (team.Member, bool) {
+	for _, member := range t.Members {
+		if strings.TrimSpace(member.Role) == strings.TrimSpace(role) {
+			return member, true
+		}
+	}
+	return team.Member{}, false
+}
+
+func validateGlobalStatusRegistration(registry globalNOCRegistry, run globalNOCRun, add func(string, string)) {
+	registration := run.ExternalRegistration
+	if run.State == globalNOCRunRegistered && registration == nil {
+		add("registration", "wake_registered run has no external registration provenance")
+		return
+	}
+	if run.State != globalNOCRunRegistered && registration != nil {
+		add("registration", fmt.Sprintf("%s run unexpectedly carries wake registration provenance", run.State))
+	}
+	if registration == nil {
+		return
+	}
+	if strings.TrimSpace(registration.Policy) != strings.TrimSpace(run.Policy) ||
+		registration.State != globalNOCRunRegistered {
+		add("registration", "external registration policy/state contradicts the registry run")
+	}
+	if !sameGlobalStatusPath(registration.NOCControlRoot, registry.ControlRoot) ||
+		registration.NOCLaunchID != run.NOCLaunchID ||
+		registration.NOCGeneration != run.NOCGeneration ||
+		registration.NOCRunRegistrationID != run.ID {
+		add("registration", "external registration provenance contradicts the registry run binding")
+	}
+	if strings.TrimSpace(registration.Handle) == "" ||
+		strings.TrimSpace(registration.ExternalRegistrationID) == "" ||
+		registration.ExternalGeneration == 0 ||
+		registration.RegisteredAt.IsZero() {
+		add("registration", "external registration provenance is incomplete")
+	}
+}
+
+func globalStatusOpenGates(items []operatorAttention) globalStatusGatesView {
+	out := globalStatusGatesView{Items: []globalStatusGateView{}}
+	var oldest operatorAttention
+	for _, item := range items {
+		if !isOpenGateAttention(item) {
+			continue
+		}
+		out.Items = append(out.Items, globalStatusGateView{
+			Thread: item.Thread, Subject: item.Subject, GateKind: item.GateKind,
+			Age: item.Age, LastEventAt: item.LastEventAt, Inspect: item.Inspect,
+		})
+		if oldest.LastEventAt.IsZero() || (!item.LastEventAt.IsZero() && item.LastEventAt.Before(oldest.LastEventAt)) {
+			oldest = item
+		}
+	}
+	sort.SliceStable(out.Items, func(i, j int) bool {
+		if out.Items[i].LastEventAt.Equal(out.Items[j].LastEventAt) {
+			return out.Items[i].Thread < out.Items[j].Thread
+		}
+		return out.Items[i].LastEventAt.Before(out.Items[j].LastEventAt)
+	})
+	out.Open = len(out.Items)
+	if out.Open > 0 {
+		out.OldestAge = oldest.Age
+	}
+	return out
+}
+
+func globalStatusRunBackstop(run globalNOCRun, config globalNOCBackstop) globalStatusBackstopView {
+	out := globalStatusBackstopView{Config: config}
+	switch run.State {
+	case globalNOCRunRegistered:
+		out.Health = "standby"
+		out.Mode = "wake_with_bounded_polling_fallback"
+		out.Detail = "wake registration is primary; bounded polling remains the stall backstop"
+	case globalNOCRunPollRequired:
+		out.Health = "required"
+		out.Mode = "bounded_polling_required"
+		out.Detail = "wake registration is unavailable; bounded polling is required"
+	case globalNOCRunOptOut:
+		out.Health = "required"
+		out.Mode = "bounded_polling_opt_out"
+		out.Detail = "wake registration was explicitly declined; bounded polling is required"
+	default:
+		out.Health = "pending"
+		out.Mode = "registration_pending"
+		out.Detail = "registration has not reached a terminal projection state"
+	}
+	return out
+}
+
+func globalStatusRunHealth(row globalStatusRunView) string {
+	if len(row.SourceErrors) > 0 {
+		return globalStatusUnknown
+	}
+	switch row.Lead.Status {
+	case statusStateMissing, statusStateStale:
+		return globalStatusStopped
+	case statusStateWakeLive:
+		return globalStatusDegraded
+	case statusStateLive:
+	default:
+		return globalStatusUnknown
+	}
+	if row.Registration.State != globalNOCRunRegistered {
+		return globalStatusDegraded
+	}
+	if row.OperatorGates.Open > 0 {
+		return globalStatusDegraded
+	}
+	if row.Watcher.Enabled && row.Watcher.Health != "healthy" && row.Watcher.Health != "external-active" {
+		return globalStatusDegraded
+	}
+	return globalStatusHealthy
+}
+
+func globalStatusOverallHealth(noc *globalStatusNOCView, runs []globalStatusRunView, sourceErrors []globalStatusSourceError) string {
+	if len(sourceErrors) > 0 || noc == nil {
+		return globalStatusUnknown
+	}
+	health := noc.Health
+	for _, row := range runs {
+		switch row.Health {
+		case globalStatusUnknown:
+			return globalStatusUnknown
+		case globalStatusDegraded:
+			if health == globalStatusHealthy || health == globalStatusStopped {
+				health = globalStatusDegraded
+			}
+		case globalStatusStopped:
+			if health == globalStatusHealthy {
+				health = globalStatusDegraded
+			}
+		}
+	}
+	return health
+}
+
+func globalStatusReadinessFor(health string, sourceErrors []globalStatusSourceError) globalStatusReadiness {
+	out := globalStatusReadiness{State: health, Ready: health == globalStatusHealthy}
+	for _, sourceErr := range sourceErrors {
+		out.Reasons = append(out.Reasons, sourceErr.Source+": "+sourceErr.Detail)
+	}
+	switch {
+	case len(out.Reasons) > 0:
+	case health == globalStatusDegraded:
+		out.Reasons = append(out.Reasons, "one or more runtime, registration, watcher, or backstop signals are degraded")
+	case health == globalStatusStopped:
+		out.Reasons = append(out.Reasons, "canonical runtime identity is not live")
+	case health == globalStatusUnknown:
+		out.Reasons = append(out.Reasons, "required status evidence is incomplete")
+	}
+	return out
+}
+
+func globalNOCStatusActions(root string, noc *globalStatusNOCView, registryState string) []runtimeActionJSON {
+	scope := " --root " + runtimeaction.ShellQuote(root)
+	repairAvailable := registryState == "missing" || (registryState == "healthy" && (noc == nil || noc.Health == globalStatusStopped))
+	repairReason := "confirm-gated: launches and persists a new global NOC runtime"
+	if !repairAvailable {
+		repairReason = "a new NOC launch is available only when the registry is absent or the current canonical runtime is stopped"
+	}
+	return runtimeaction.ApplyCanonical([]runtimeActionJSON{
+		{
+			Kind: "global_status", Label: "inspect global NOC status", Scope: "global",
+			Command: "amq-squad global status" + scope + " --json",
+			Mutates: false, NeedsConfirmation: false, Available: true,
+		},
+		{
+			Kind: "global_start", Label: "launch global NOC", Scope: "global",
+			Command: "amq-squad global start" + scope + " --go",
+			Mutates: true, NeedsConfirmation: true, Available: repairAvailable, Reason: repairReason,
+		},
+	})
+}
+
+func confirmGatedSessionActions(namespace squadnamespace.Ref) []runtimeActionJSON {
+	actions := sessionActions(namespace.TeamHome, namespace.Profile, namespace.Session, "")
+	filtered := make([]runtimeActionJSON, 0, 3)
+	for _, action := range actions {
+		switch action.Kind {
+		case "status", "resume_preview", "resume_new_session":
+		default:
+			continue
+		}
+		if action.Mutates {
+			action.NeedsConfirmation = true
+			action.Reason = "confirm-gated: mutates the registered session runtime"
+			runtimeaction.SyncUnavailableReason(&action)
+		}
+		filtered = append(filtered, action)
+	}
+	return filtered
+}
+
+func renderGlobalStatus(out io.Writer, data globalStatusEnvelopeData, jsonOut bool) error {
+	if jsonOut {
+		return writeJSONEnvelope(out, "global_status", data)
+	}
+	fmt.Fprintf(out, "global NOC status: %s (registry: %s)\n", data.Health, data.Registry.State)
+	fmt.Fprintf(out, "root: %s\n", data.ControlRoot)
+	if data.NOC != nil {
+		fmt.Fprintf(out, "NOC: generation %d %s, runtime %s, pane %s\n",
+			data.NOC.Generation, data.NOC.PersistedState, data.NOC.Health, emptyCell(data.NOC.PaneID))
+	}
+	if len(data.Runs) > 0 {
+		tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAMESPACE\tHEALTH\tLEAD\tREGISTRATION\tGATES\tWATCHER\tLAST-REFRESH")
+		for _, row := range data.Runs {
+			gates := fmt.Sprintf("%d", row.OperatorGates.Open)
+			if row.OperatorGates.OldestAge != "" {
+				gates += " (" + row.OperatorGates.OldestAge + ")"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s/%s\t%s\t%s\t%s\t%s\n",
+				row.Namespace.ID, row.Health, emptyCell(row.Lead.Role), emptyCell(row.Lead.Status),
+				row.Registration.State, gates, emptyCell(row.Watcher.Health), row.LastRefresh.Format(time.RFC3339))
+		}
+		_ = tw.Flush()
+	}
+	for _, sourceErr := range data.SourceErrors {
+		scope := sourceErr.NamespaceID
+		if scope == "" {
+			scope = "global"
+		}
+		fmt.Fprintf(out, "source error [%s/%s]: %s\n", scope, sourceErr.Source, sourceErr.Detail)
+	}
+	return nil
+}
+
+func emptyCell[T ~string](value T) string {
+	if strings.TrimSpace(string(value)) == "" {
+		return "-"
+	}
+	return string(value)
+}

--- a/internal/cli/global_status_doctor.go
+++ b/internal/cli/global_status_doctor.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+const globalNOCRegistrationDoctorCheck = "global NOC registration"
+
+func doctorCheckGlobalNOCRegistration(t team.Team, profile, workstream string) doctorCheck {
+	leadRole := strings.TrimSpace(t.Lead)
+	if leadRole == "" {
+		return doctorCheck{
+			Name: globalNOCRegistrationDoctorCheck, Status: doctorOK,
+			Detail: "team has no global NOC registration claim",
+		}
+	}
+	lead, ok := globalStatusLeadMember(t, leadRole)
+	if !ok {
+		return doctorCheck{
+			Name: globalNOCRegistrationDoctorCheck, Status: doctorFail,
+			Detail: fmt.Sprintf("team lead role %q is absent; global NOC registration cannot be scoped", leadRole),
+		}
+	}
+	cwd := lead.EffectiveCWD(t.Project)
+	env, err := resolveAMQEnvForTeamProfile(cwd, profile, workstream, memberHandle(lead))
+	if err != nil {
+		return doctorCheck{
+			Name: globalNOCRegistrationDoctorCheck, Status: doctorWarn,
+			Detail: "could not resolve the exact session root for NOC registration inspection: " + err.Error(),
+		}
+	}
+	return doctorCheckGlobalNOCRegistrationAtRoot(t, profile, workstream, absoluteAMQRoot(cwd, env.Root))
+}
+
+func doctorCheckGlobalNOCRegistrationAtRoot(t team.Team, profile, workstream, root string) doctorCheck {
+	check := doctorCheck{Name: globalNOCRegistrationDoctorCheck}
+	agentsDir := filepath.Join(root, "agents")
+	entries, err := os.ReadDir(agentsDir)
+	if os.IsNotExist(err) {
+		check.Status = doctorOK
+		check.Detail = "exact session has no global NOC registration claim"
+		return check
+	}
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = "exact session agent registry is unreadable: " + err.Error()
+		return check
+	}
+
+	type candidate struct {
+		handle string
+		record launch.Record
+	}
+	var candidates []candidate
+	var unreadable []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		agentDir := filepath.Join(agentsDir, entry.Name())
+		rec, readErr := launch.Read(agentDir)
+		if os.IsNotExist(readErr) {
+			continue
+		}
+		if readErr != nil {
+			unreadable = append(unreadable, entry.Name()+": "+readErr.Error())
+			continue
+		}
+		if rec.OrchestratorRegistration == nil {
+			continue
+		}
+		if !rec.External {
+			check.Status = doctorFail
+			check.Detail = fmt.Sprintf("agent %s carries orchestrator registration provenance without an external launch identity", entry.Name())
+			return check
+		}
+		candidates = append(candidates, candidate{handle: entry.Name(), record: rec})
+	}
+	if len(unreadable) > 0 {
+		check.Status = doctorFail
+		check.Detail = "registration inspection is incomplete because launch records are unreadable: " + strings.Join(unreadable, "; ")
+		return check
+	}
+	switch len(candidates) {
+	case 0:
+		check.Status = doctorOK
+		check.Detail = "exact session has no global NOC registration claim"
+		return check
+	case 1:
+	default:
+		handles := make([]string, 0, len(candidates))
+		for _, item := range candidates {
+			handles = append(handles, item.handle)
+		}
+		check.Status = doctorFail
+		check.Detail = "multiple external orchestrator registration claims are present: " + strings.Join(handles, ", ")
+		return check
+	}
+
+	item := candidates[0]
+	registration := item.record.OrchestratorRegistration
+	if strings.TrimSpace(item.record.Handle) != item.handle ||
+		strings.TrimSpace(registration.Handle) != item.handle {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf(
+			"external orchestrator registration handle contradicts launch identity: agent=%s launch=%q registration=%q",
+			item.handle, item.record.Handle, registration.Handle,
+		)
+		return check
+	}
+	if strings.TrimSpace(item.record.Role) != goalOrchestratorRole ||
+		item.record.Session != workstream ||
+		!squadnamespace.ProfilesEqual(item.record.TeamProfile, profile) ||
+		!sameGlobalStatusPath(item.record.CWD, t.Project) ||
+		!sameGlobalStatusPath(item.record.Root, root) {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf(
+			"external orchestrator launch identity contradicts exact project/profile/session root for agent %s",
+			item.handle,
+		)
+		return check
+	}
+	if strings.TrimSpace(registration.Policy) == "" ||
+		registration.State != globalNOCRunRegistered ||
+		strings.TrimSpace(registration.Handle) == "" ||
+		strings.TrimSpace(registration.ExternalRegistrationID) == "" ||
+		registration.ExternalGeneration == 0 ||
+		registration.RegisteredAt.IsZero() {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf("external orchestrator %s carries incomplete registration provenance", item.handle)
+		return check
+	}
+
+	nocFields := 0
+	if strings.TrimSpace(registration.NOCControlRoot) != "" {
+		nocFields++
+	}
+	if strings.TrimSpace(registration.NOCLaunchID) != "" {
+		nocFields++
+	}
+	if registration.NOCGeneration != 0 {
+		nocFields++
+	}
+	if strings.TrimSpace(registration.NOCRunRegistrationID) != "" {
+		nocFields++
+	}
+	if nocFields == 0 {
+		check.Status = doctorOK
+		check.Detail = fmt.Sprintf(
+			"external orchestrator %s is registered by policy %s without a global NOC binding",
+			item.handle, registration.Policy,
+		)
+		return check
+	}
+	if nocFields != 4 {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf("external orchestrator %s carries a partial global NOC binding", item.handle)
+		return check
+	}
+
+	registry, err := readGlobalNOCRegistry(registration.NOCControlRoot)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = "claimed global NOC registry is unreadable or invalid: " + err.Error()
+		return check
+	}
+	expectedNamespace := squadnamespace.Resolve(t.Project, profile, workstream)
+	var run *globalNOCRun
+	for i := range registry.Runs {
+		if registry.Runs[i].ID == registration.NOCRunRegistrationID {
+			run = &registry.Runs[i]
+			break
+		}
+	}
+	if run == nil {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf("global NOC registry has no run registration %s", registration.NOCRunRegistrationID)
+		return check
+	}
+	if !sameGlobalStatusNamespace(run.Namespace, expectedNamespace) ||
+		run.NOCLaunchID != registration.NOCLaunchID ||
+		run.NOCGeneration != registration.NOCGeneration ||
+		run.State != globalNOCRunRegistered ||
+		run.ExternalRegistration == nil ||
+		!sameGlobalNOCRegistration(*run.ExternalRegistration, *registration) {
+		check.Status = doctorFail
+		check.Detail = "global NOC registry binding contradicts the exact project/profile/session launch provenance"
+		return check
+	}
+	check.Status = doctorOK
+	check.Detail = fmt.Sprintf(
+		"verified %s at NOC generation %d (run %s, external registration %s)",
+		run.State, run.NOCGeneration, run.ID, registration.ExternalRegistrationID,
+	)
+	return check
+}
+
+func sameGlobalNOCRegistration(a, b launch.OrchestratorRegistration) bool {
+	return strings.TrimSpace(a.Policy) == strings.TrimSpace(b.Policy) &&
+		a.State == b.State &&
+		strings.TrimSpace(a.Handle) == strings.TrimSpace(b.Handle) &&
+		a.ExternalRegistrationID == b.ExternalRegistrationID &&
+		a.ExternalGeneration == b.ExternalGeneration &&
+		sameGlobalStatusPath(a.NOCControlRoot, b.NOCControlRoot) &&
+		a.NOCLaunchID == b.NOCLaunchID &&
+		a.NOCGeneration == b.NOCGeneration &&
+		a.NOCRunRegistrationID == b.NOCRunRegistrationID &&
+		a.RegisteredAt.Equal(b.RegisteredAt)
+}

--- a/internal/cli/global_status_doctor.go
+++ b/internal/cli/global_status_doctor.go
@@ -172,18 +172,26 @@ func doctorCheckGlobalNOCRegistrationAtRoot(t team.Team, profile, workstream, ro
 		return check
 	}
 	expectedNamespace := squadnamespace.Resolve(t.Project, profile, workstream)
-	var run *globalNOCRun
+	var matchingRuns []globalNOCRun
 	for i := range registry.Runs {
 		if registry.Runs[i].ID == registration.NOCRunRegistrationID {
-			run = &registry.Runs[i]
-			break
+			matchingRuns = append(matchingRuns, registry.Runs[i])
 		}
 	}
-	if run == nil {
+	if len(matchingRuns) == 0 {
 		check.Status = doctorFail
 		check.Detail = fmt.Sprintf("global NOC registry has no run registration %s", registration.NOCRunRegistrationID)
 		return check
 	}
+	if len(matchingRuns) > 1 {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf(
+			"global NOC registry has %d duplicate run registrations for %s",
+			len(matchingRuns), registration.NOCRunRegistrationID,
+		)
+		return check
+	}
+	run := &matchingRuns[0]
 	if !sameGlobalStatusNamespace(run.Namespace, expectedNamespace) ||
 		run.NOCLaunchID != registration.NOCLaunchID ||
 		run.NOCGeneration != registration.NOCGeneration ||

--- a/internal/cli/global_status_test.go
+++ b/internal/cli/global_status_test.go
@@ -1,0 +1,818 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+type globalStatusTestEnvelope struct {
+	SchemaVersion int                      `json:"schema_version"`
+	Kind          string                   `json:"kind"`
+	Data          globalStatusEnvelopeData `json:"data"`
+}
+
+func decodeGlobalStatusTestEnvelope(t *testing.T, body []byte) globalStatusTestEnvelope {
+	t.Helper()
+	var env globalStatusTestEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode global status JSON: %v\n%s", err, body)
+	}
+	if env.SchemaVersion != JSONSchemaVersion || env.Kind != "global_status" {
+		t.Fatalf("global status envelope = schema:%d kind:%q", env.SchemaVersion, env.Kind)
+	}
+	return env
+}
+
+func TestGlobalStatusNamespaceComparisonCanonicalizesBothSides(t *testing.T) {
+	realRoot := t.TempDir()
+	aliasRoot := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(realRoot, aliasRoot); err != nil {
+		t.Fatalf("symlink namespace root: %v", err)
+	}
+
+	recorded := squadnamespace.Resolve(realRoot, team.DefaultProfile, "status-test")
+	projected := squadnamespace.Resolve(aliasRoot, team.DefaultProfile, "status-test")
+	if !sameGlobalStatusNamespace(recorded, projected) {
+		t.Fatalf("equivalent namespace paths compared unequal:\nrecorded=%+v\nprojected=%+v", recorded, projected)
+	}
+
+	projected.ID = "forged/session"
+	if sameGlobalStatusNamespace(recorded, projected) {
+		t.Fatal("namespace comparison ignored non-path identity contradiction")
+	}
+}
+
+func TestGlobalStatusMissingRegistryIsVisibleReadOnlyAndNonFatal(t *testing.T) {
+	var out bytes.Buffer
+	teamRead := false
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: "/missing-control-root",
+		Out:         &out,
+		JSON:        true,
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			return globalNOCRegistry{}, os.ErrNotExist
+		},
+		ReadTeam: func(string, string) (team.Team, error) {
+			teamRead = true
+			return team.Team{}, errors.New("must not scan projects without a registry")
+		},
+	})
+	if err != nil {
+		t.Fatalf("missing registry should render degradation without a command error: %v", err)
+	}
+	if teamRead {
+		t.Fatal("missing registry triggered arbitrary project scanning")
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	if !env.Data.ReadOnly || env.Data.Health != globalStatusUnknown ||
+		env.Data.Registry.State != "missing" || env.Data.Readiness.Ready {
+		t.Fatalf("missing registry projection = %+v", env.Data)
+	}
+	if len(env.Data.SourceErrors) != 1 || env.Data.SourceErrors[0].Source != "registry" {
+		t.Fatalf("missing registry source errors = %+v", env.Data.SourceErrors)
+	}
+	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions)
+}
+
+func TestRunGlobalStatusRoutesAndKeepsDegradationNonFatal(t *testing.T) {
+	root := t.TempDir()
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runGlobal([]string{"status", "--root", root, "--json"})
+	})
+	if err != nil {
+		t.Fatalf("global status with no registry should render degradation: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("global status JSON wrote stderr: %q", stderr)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, []byte(stdout))
+	if env.Data.Registry.State != "missing" || env.Data.Health != globalStatusUnknown ||
+		env.Data.Readiness.Ready || !env.Data.ReadOnly {
+		t.Fatalf("routed degraded status = %+v", env.Data)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, ".amq-squad")); !os.IsNotExist(statErr) {
+		t.Fatalf("read-only global status created control state: %v", statErr)
+	}
+}
+
+func TestRunGlobalStatusHumanOutputNamesVisibleDegradation(t *testing.T) {
+	root := t.TempDir()
+	stdout, _, err := captureOutput(t, func() error {
+		return runGlobal([]string{"status", "--root", root})
+	})
+	if err != nil {
+		t.Fatalf("human global status with no registry: %v", err)
+	}
+	for _, want := range []string{
+		"global NOC status: unknown (registry: missing)",
+		"source error [global/registry]",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("human global status missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestGlobalStatusProjectsMixedRunsFromOneRegistrySnapshot(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	registry.Runs = []globalNOCRun{
+		globalStatusTestRun(controlRoot, "/projects/ready", "ready", "run-ready", now),
+		globalStatusTestRun(controlRoot, "/projects/healthy", "healthy", "run-healthy", now),
+		globalStatusTestRun(controlRoot, "/projects/stale", "stale", "run-stale", now),
+		globalStatusTestRun(controlRoot, "/projects/watcher", "watcher", "run-watcher", now),
+		globalStatusTestRun(controlRoot, "/projects/stopped", "stopped", "run-stopped", now),
+		globalStatusTestRun(controlRoot, "/projects/unreadable", "unreadable", "run-unreadable", now),
+	}
+	registryCalls := 0
+	var out bytes.Buffer
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot,
+		Out:         &out,
+		JSON:        true,
+		Now:         func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			registryCalls++
+			if registryCalls > 1 {
+				t.Fatal("registry was read more than once")
+			}
+			return registry, nil
+		},
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{
+				Live: true, PIDLive: true, PaneLive: true, PIDAlive: true, BinaryMatch: true,
+			}
+		},
+		ReadTeam: func(project, profile string) (team.Team, error) {
+			if strings.Contains(project, "unreadable") {
+				return team.Team{}, errors.New("team config unreadable")
+			}
+			session := filepath.Base(project)
+			return team.Team{
+				Project: project, Lead: "cto", Orchestrated: true,
+				Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: session}},
+			}, nil
+		},
+		ClassifyLead: func(tm team.Team, _ string, member team.Member, session string) statusRecord {
+			state := statusStateLive
+			switch {
+			case strings.Contains(tm.Project, "stopped"):
+				state = statusStateMissing
+			case strings.Contains(tm.Project, "stale"):
+				state = statusStateStale
+			}
+			return statusRecord{
+				Role: member.Role, Handle: member.Handle, Binary: member.Binary,
+				Status: state, RecordState: string(state), Session: session,
+			}
+		},
+		OperatorData: func(project, profile, session, _ string, _ func() time.Time) (operatorStatusEnvelopeData, error) {
+			data := operatorStatusEnvelopeData{
+				Namespace: squadnamespace.Resolve(project, profile, session),
+				ReadOnly:  true,
+			}
+			if strings.Contains(project, "healthy") {
+				data.Attention = []operatorAttention{
+					{
+						EventType: "gate", Thread: "gate/newer", Subject: "APPROVAL: newer",
+						GateKind: "approval", Age: "1h", LastEventAt: now.Add(-time.Hour),
+						Inspect: "amq thread --id gate/newer", Actionable: true,
+					},
+					{
+						EventType: "gate", Thread: "gate/older", Subject: "APPROVAL: older",
+						GateKind: "approval", Age: "3h", LastEventAt: now.Add(-3 * time.Hour),
+						Inspect: "amq thread --id gate/older", Actionable: true,
+					},
+					{
+						EventType: "gate", Thread: "gate/cleared", Subject: "APPROVED",
+						Age: "4h", LastEventAt: now.Add(-4 * time.Hour),
+						Actionable: true, Cleared: true,
+					},
+				}
+			}
+			return data, nil
+		},
+		Watcher: func(tm team.Team, _ string, _ string, _ time.Time) notificationWatcherStatus {
+			if strings.Contains(tm.Project, "watcher") {
+				return notificationWatcherStatus{Enabled: true, Health: "stale", Reason: "heartbeat expired"}
+			}
+			return notificationWatcherStatus{Enabled: true, Health: "healthy"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("project mixed global status: %v", err)
+	}
+	if registryCalls != 1 {
+		t.Fatalf("registry calls = %d, want exactly one", registryCalls)
+	}
+
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	if env.Data.NOC == nil || env.Data.NOC.Health != globalStatusHealthy {
+		t.Fatalf("NOC projection = %+v", env.Data.NOC)
+	}
+	if len(env.Data.Runs) != 6 {
+		t.Fatalf("run count = %d, want 6", len(env.Data.Runs))
+	}
+	rows := globalStatusRowsBySession(env.Data.Runs)
+	if ready := rows["ready"]; ready.Health != globalStatusHealthy || !ready.Readiness.Ready {
+		t.Fatalf("ready row = %+v", ready)
+	}
+	healthy := rows["healthy"]
+	if healthy.Health != globalStatusDegraded || healthy.OperatorGates.Open != 2 ||
+		healthy.OperatorGates.OldestAge != "3h" {
+		t.Fatalf("healthy-with-open-gates row = %+v", healthy)
+	}
+	if got := []string{healthy.OperatorGates.Items[0].Thread, healthy.OperatorGates.Items[1].Thread}; !reflect.DeepEqual(got, []string{"gate/older", "gate/newer"}) {
+		t.Fatalf("gate order = %v", got)
+	}
+	if stopped := rows["stopped"]; stopped.Health != globalStatusStopped {
+		t.Fatalf("stopped row = %+v", stopped)
+	}
+	if stale := rows["stale"]; stale.Health != globalStatusStopped {
+		t.Fatalf("stale row = %+v", stale)
+	}
+	if watcher := rows["watcher"]; watcher.Health != globalStatusDegraded || watcher.Readiness.Ready {
+		t.Fatalf("watcher-degraded row = %+v", watcher)
+	}
+	unreadable := rows["unreadable"]
+	if unreadable.Health != globalStatusUnknown || len(unreadable.SourceErrors) == 0 ||
+		unreadable.SourceErrors[0].Source != "team" {
+		t.Fatalf("unreadable row = %+v", unreadable)
+	}
+	if env.Data.Health != globalStatusUnknown || env.Data.Readiness.Ready {
+		t.Fatalf("mixed overall readiness = %+v / health=%s", env.Data.Readiness, env.Data.Health)
+	}
+	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions)
+	for _, row := range env.Data.Runs {
+		assertGlobalStatusActionsConfirmGated(t, row.Actions)
+	}
+}
+
+func TestGlobalStatusNamedProfileUsesIsolatedAMQBaseRoot(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	project := "/projects/release"
+	session := "named-profile"
+	profile := "release"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	run := globalStatusTestRun(controlRoot, project, session, "run-named-profile", now)
+	run.Namespace = squadnamespace.Resolve(project, profile, session)
+	registry.Runs = []globalNOCRun{run}
+
+	var out bytes.Buffer
+	var projectedBaseRoot string
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot,
+		Out:         &out,
+		JSON:        true,
+		Now:         func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			return registry, nil
+		},
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+		},
+		ReadTeam: func(gotProject, gotProfile string) (team.Team, error) {
+			if gotProject != project || gotProfile != profile {
+				t.Fatalf("team read namespace = %s/%s, want %s/%s", gotProject, gotProfile, project, profile)
+			}
+			return team.Team{
+				Project: project, Lead: "cto", Orchestrated: true,
+				Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: session}},
+			}, nil
+		},
+		ClassifyLead: func(_ team.Team, _ string, member team.Member, session string) statusRecord {
+			return statusRecord{
+				Role: member.Role, Handle: member.Handle, Binary: member.Binary,
+				Status: statusStateLive, RecordState: "live", Session: session,
+			}
+		},
+		OperatorData: func(gotProject, gotProfile, gotSession, baseRoot string, _ func() time.Time) (operatorStatusEnvelopeData, error) {
+			projectedBaseRoot = baseRoot
+			return operatorStatusEnvelopeData{
+				Namespace: squadnamespace.Resolve(gotProject, gotProfile, gotSession),
+				ReadOnly:  true,
+			}, nil
+		},
+		Watcher: func(team.Team, string, string, time.Time) notificationWatcherStatus {
+			return notificationWatcherStatus{Enabled: true, Health: "healthy"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("named-profile global status: %v", err)
+	}
+	if projectedBaseRoot != run.Namespace.AMQRoot {
+		t.Fatalf("named-profile operator base root = %q, want isolated root %q", projectedBaseRoot, run.Namespace.AMQRoot)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	if len(env.Data.Runs) != 1 || env.Data.Runs[0].Health != globalStatusHealthy {
+		t.Fatalf("named-profile row = %+v", env.Data.Runs)
+	}
+}
+
+func TestGlobalStatusContradictorySourcesFailClosed(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	run := globalStatusTestRun(controlRoot, "/projects/contradictory", "session", "run-contradictory", now)
+	run.Namespace.ID = "forged-namespace"
+	run.ExternalRegistration.NOCLaunchID = "wrong-launch"
+	registry.Runs = []globalNOCRun{run}
+	var out bytes.Buffer
+	teamRead := false
+	operatorRead := false
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot,
+		Out:         &out,
+		JSON:        true,
+		Now:         func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			return registry, nil
+		},
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+		},
+		ReadTeam: func(project, _ string) (team.Team, error) {
+			teamRead = true
+			return team.Team{
+				Project: project, Lead: "cto", Orchestrated: true,
+				Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "session"}},
+			}, nil
+		},
+		ClassifyLead: func(_ team.Team, _ string, member team.Member, session string) statusRecord {
+			return statusRecord{
+				Role: member.Role, Handle: member.Handle, Binary: member.Binary,
+				Status: statusStateLive, RecordState: "live", Session: session,
+			}
+		},
+		OperatorData: func(project, profile, session, _ string, _ func() time.Time) (operatorStatusEnvelopeData, error) {
+			operatorRead = true
+			return operatorStatusEnvelopeData{
+				Namespace: squadnamespace.Resolve(project, profile, session),
+				ReadOnly:  true,
+			}, nil
+		},
+		Watcher: func(team.Team, string, string, time.Time) notificationWatcherStatus {
+			return notificationWatcherStatus{Enabled: true, Health: "healthy"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("contradictory global status should render fail-closed data: %v", err)
+	}
+	if teamRead || operatorRead {
+		t.Fatalf("contradictory namespace triggered cross-root reads: team=%t operator=%t", teamRead, operatorRead)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	row := env.Data.Runs[0]
+	if row.Health != globalStatusUnknown || row.Readiness.Ready || len(row.SourceErrors) < 2 || len(row.Actions) != 0 {
+		t.Fatalf("contradictory row did not fail closed: %+v", row)
+	}
+	details := ""
+	for _, sourceErr := range row.SourceErrors {
+		details += sourceErr.Source + ": " + sourceErr.Detail + "\n"
+	}
+	for _, want := range []string{"namespace", "registration"} {
+		if !strings.Contains(details, want) {
+			t.Fatalf("contradictory source errors missing %q:\n%s", want, details)
+		}
+	}
+}
+
+func TestGlobalStatusTeamProjectContradictionStopsCrossRootProjection(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	project := "/projects/registered"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	registry.Runs = []globalNOCRun{
+		globalStatusTestRun(controlRoot, project, "session", "run-team-contradiction", now),
+	}
+
+	var out bytes.Buffer
+	classified := false
+	operatorRead := false
+	watcherRead := false
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot,
+		Out:         &out,
+		JSON:        true,
+		Now:         func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			return registry, nil
+		},
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+		},
+		ReadTeam: func(string, string) (team.Team, error) {
+			return team.Team{
+				Project: "/projects/different", Lead: "cto", Orchestrated: true,
+				Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex"}},
+			}, nil
+		},
+		ClassifyLead: func(team.Team, string, team.Member, string) statusRecord {
+			classified = true
+			return statusRecord{}
+		},
+		OperatorData: func(string, string, string, string, func() time.Time) (operatorStatusEnvelopeData, error) {
+			operatorRead = true
+			return operatorStatusEnvelopeData{}, nil
+		},
+		Watcher: func(team.Team, string, string, time.Time) notificationWatcherStatus {
+			watcherRead = true
+			return notificationWatcherStatus{}
+		},
+	})
+	if err != nil {
+		t.Fatalf("team-project contradiction should render fail-closed data: %v", err)
+	}
+	if classified || operatorRead || watcherRead {
+		t.Fatalf("team-project contradiction reached downstream sources: classify=%t operator=%t watcher=%t", classified, operatorRead, watcherRead)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	row := env.Data.Runs[0]
+	if row.Health != globalStatusUnknown || row.Readiness.Ready || len(row.Actions) != 0 ||
+		len(row.SourceErrors) == 0 || row.SourceErrors[0].Source != "team" {
+		t.Fatalf("team-project contradiction row = %+v", row)
+	}
+}
+
+func TestGlobalStatusRootSessionCannotEscapeRegistryScope(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	project := "/projects/root-session"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	run := globalStatusTestRun(controlRoot, project, "ordinary", "run-root-session", now)
+	run.Namespace = squadnamespace.Resolve(project, team.DefaultProfile, "")
+	registry.Runs = []globalNOCRun{run}
+
+	var out bytes.Buffer
+	teamRead := false
+	operatorRead := false
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot,
+		Out:         &out,
+		JSON:        true,
+		Now:         func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) {
+			return registry, nil
+		},
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+		},
+		ReadTeam: func(string, string) (team.Team, error) {
+			teamRead = true
+			return team.Team{}, nil
+		},
+		OperatorData: func(string, string, string, string, func() time.Time) (operatorStatusEnvelopeData, error) {
+			operatorRead = true
+			return operatorStatusEnvelopeData{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("root-session registry entry should render fail-closed data: %v", err)
+	}
+	if teamRead || operatorRead {
+		t.Fatalf("root-session registry entry triggered scoped reads: team=%t operator=%t", teamRead, operatorRead)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	row := env.Data.Runs[0]
+	if row.Health != globalStatusUnknown || row.Readiness.Ready || len(row.Actions) != 0 ||
+		len(row.SourceErrors) == 0 || row.SourceErrors[0].Source != "namespace" {
+		t.Fatalf("root-session row = %+v", row)
+	}
+}
+
+func TestGlobalStatusRealRegistryReadIsBytePreserving(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	registry := globalNOCRegistry{
+		SchemaVersion: globalNOCRegistrySchema,
+		ControlRoot:   root,
+		UpdatedAt:     now,
+		Launches:      []globalNOCLaunch{},
+		Runs:          []globalNOCRun{},
+	}
+	body, err := json.MarshalIndent(registry, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := globalNOCRegistryPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeEntries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: root, Out: &out, JSON: true, Now: func() time.Time { return now },
+	}); err != nil {
+		t.Fatalf("real registry status: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterEntries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("global status mutated registry bytes")
+	}
+	if got, want := directoryEntryNames(afterEntries), directoryEntryNames(beforeEntries); !reflect.DeepEqual(got, want) {
+		t.Fatalf("global status changed registry directory entries: before=%v after=%v", want, got)
+	}
+}
+
+func TestStatusRecordProjectsOrchestratorRegistrationProvenance(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	project := t.TempDir()
+	session := "registration-visible"
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	member := team.Member{Role: "cto", Handle: "cto", Binary: "codex", Session: session}
+	tm := team.Team{
+		Project: project, Lead: member.Role, Orchestrated: true,
+		Members: []team.Member{member},
+	}
+	registration := &launch.OrchestratorRegistration{
+		Policy: "registered_noc_default", State: globalNOCRunRegistered, Handle: "global-orch",
+		ExternalRegistrationID: "external-1", ExternalGeneration: 4,
+		NOCControlRoot: "/noc-control", NOCLaunchID: "noc-launch-4", NOCGeneration: 4,
+		NOCRunRegistrationID: "run-1", RegisteredAt: now.Add(-time.Minute),
+	}
+	writeMemberLaunchRecord(t, base, session, member.Handle, launch.Record{
+		CWD: project, Root: filepath.Join(base, session), Binary: member.Binary, Role: member.Role,
+		AgentPID: 4242, StartedAt: now.Add(-time.Hour), OrchestratorRegistration: registration,
+	})
+	row := classifyMemberStatus(tm, team.DefaultProfile, member, session, statusProbe(
+		map[int]bool{4242: true},
+		map[int]bool{4242: true},
+		now,
+	))
+	if row.Status != statusStateLive || !reflect.DeepEqual(row.OrchestratorRegistration, registration) {
+		t.Fatalf("status registration projection = status:%s registration:%+v", row.Status, row.OrchestratorRegistration)
+	}
+	body, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"orchestrator_registration"`,
+		`"noc_launch_id":"noc-launch-4"`,
+		`"noc_run_registration_id":"run-1"`,
+	} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Fatalf("status JSON missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestDoctorGlobalNOCRegistrationProjection(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+
+	t.Run("no claim", func(t *testing.T) {
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: t.TempDir()},
+			team.DefaultProfile,
+			"session",
+			t.TempDir(),
+		)
+		if check.Status != doctorOK || !strings.Contains(check.Detail, "no global NOC registration claim") {
+			t.Fatalf("no-claim doctor check = %+v", check)
+		}
+	})
+
+	t.Run("verified binding", func(t *testing.T) {
+		controlRoot := t.TempDir()
+		canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		project := t.TempDir()
+		sessionRoot := t.TempDir()
+		session := "verified"
+		registry := globalStatusTestRegistry(canonicalControlRoot, now)
+		run := globalStatusTestRun(canonicalControlRoot, project, session, "run-verified", now)
+		registry.Runs = []globalNOCRun{run}
+		writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
+		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, session, run.ExternalRegistration)
+
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: project},
+			team.DefaultProfile,
+			session,
+			sessionRoot,
+		)
+		if check.Status != doctorOK ||
+			!strings.Contains(check.Detail, "verified wake_registered") ||
+			!strings.Contains(check.Detail, "run-verified") {
+			t.Fatalf("verified doctor check = %+v", check)
+		}
+	})
+
+	t.Run("partial binding fails closed", func(t *testing.T) {
+		project := t.TempDir()
+		sessionRoot := t.TempDir()
+		registration := &launch.OrchestratorRegistration{
+			Policy: "registered_noc_default", State: globalNOCRunRegistered, Handle: "global-orch",
+			ExternalRegistrationID: "external-1", ExternalGeneration: 1,
+			NOCControlRoot: t.TempDir(), NOCGeneration: 1,
+			NOCRunRegistrationID: "run-partial", RegisteredAt: now,
+		}
+		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, "partial", registration)
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: project},
+			team.DefaultProfile,
+			"partial",
+			sessionRoot,
+		)
+		if check.Status != doctorFail || !strings.Contains(check.Detail, "partial global NOC binding") {
+			t.Fatalf("partial-binding doctor check = %+v", check)
+		}
+	})
+
+	t.Run("forged registration handle fails closed", func(t *testing.T) {
+		controlRoot := t.TempDir()
+		canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		project := t.TempDir()
+		sessionRoot := t.TempDir()
+		session := "forged-handle"
+		registry := globalStatusTestRegistry(canonicalControlRoot, now)
+		run := globalStatusTestRun(canonicalControlRoot, project, session, "run-forged-handle", now)
+		run.ExternalRegistration.Handle = "different-orchestrator"
+		registry.Runs = []globalNOCRun{run}
+		writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
+		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, session, run.ExternalRegistration)
+
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: project},
+			team.DefaultProfile,
+			session,
+			sessionRoot,
+		)
+		if check.Status != doctorFail || !strings.Contains(check.Detail, "registration handle contradicts launch identity") {
+			t.Fatalf("forged-handle doctor check = %+v", check)
+		}
+	})
+
+	t.Run("copied launch identity fails closed", func(t *testing.T) {
+		controlRoot := t.TempDir()
+		canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		project := t.TempDir()
+		sessionRoot := t.TempDir()
+		session := "copied-launch"
+		registry := globalStatusTestRegistry(canonicalControlRoot, now)
+		run := globalStatusTestRun(canonicalControlRoot, project, session, "run-copied-launch", now)
+		registry.Runs = []globalNOCRun{run}
+		writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
+		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", filepath.Join(project, "different"), session, run.ExternalRegistration)
+
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: project},
+			team.DefaultProfile,
+			session,
+			sessionRoot,
+		)
+		if check.Status != doctorFail || !strings.Contains(check.Detail, "launch identity contradicts exact project/profile/session root") {
+			t.Fatalf("copied-launch doctor check = %+v", check)
+		}
+	})
+
+	t.Run("unreadable launch record fails closed", func(t *testing.T) {
+		sessionRoot := t.TempDir()
+		agentDir := filepath.Join(sessionRoot, "agents", "broken")
+		if err := os.MkdirAll(agentDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDir, launch.FileName), []byte("{not-json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: t.TempDir()},
+			team.DefaultProfile,
+			"broken",
+			sessionRoot,
+		)
+		if check.Status != doctorFail || !strings.Contains(check.Detail, "inspection is incomplete") {
+			t.Fatalf("unreadable doctor check = %+v", check)
+		}
+	})
+}
+
+func globalStatusTestRegistry(controlRoot string, now time.Time) globalNOCRegistry {
+	return globalNOCRegistry{
+		SchemaVersion:     globalNOCRegistrySchema,
+		ControlRoot:       controlRoot,
+		CurrentGeneration: 1,
+		UpdatedAt:         now,
+		Launches: []globalNOCLaunch{{
+			ID: "noc-launch-1", Generation: 1, State: globalNOCLaunchActive,
+			Record: launch.Record{
+				CWD: controlRoot, Binary: "codex", Session: "noc-1", Role: globalNOCRole,
+				AgentPID: 1234, Tmux: &launch.TmuxInfo{PaneID: "%1", WindowID: "@1", Session: "noc"},
+			},
+			BootstrapVersion: globalNOCBootstrapVersion,
+			BootstrapDigest:  "sha256:test",
+			Backstop:         globalNOCBackstop{IntervalSeconds: 30, TimeoutSeconds: 300, MaxTicks: 10},
+			CreatedAt:        now.Add(-time.Hour), UpdatedAt: now,
+		}},
+	}
+}
+
+func globalStatusTestRun(controlRoot, project, session, id string, now time.Time) globalNOCRun {
+	namespace := squadnamespace.Resolve(project, team.DefaultProfile, session)
+	return globalNOCRun{
+		ID: id, NOCLaunchID: "noc-launch-1", NOCGeneration: 1,
+		Namespace: namespace, LeadRole: "cto", Policy: "registered_noc_default",
+		State: globalNOCRunRegistered,
+		ExternalRegistration: &launch.OrchestratorRegistration{
+			Policy: "registered_noc_default", State: globalNOCRunRegistered, Handle: "global-orch",
+			ExternalRegistrationID: "external-" + id, ExternalGeneration: 1,
+			NOCControlRoot: controlRoot, NOCLaunchID: "noc-launch-1", NOCGeneration: 1,
+			NOCRunRegistrationID: id, RegisteredAt: now.Add(-30 * time.Minute),
+		},
+		CreatedAt: now.Add(-30 * time.Minute), UpdatedAt: now,
+	}
+}
+
+func writeGlobalStatusTestRegistry(t *testing.T, root string, registry globalNOCRegistry) {
+	t.Helper()
+	body, err := json.MarshalIndent(registry, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := globalNOCRegistryPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeGlobalStatusDoctorRecord(t *testing.T, root, handle, project, session string, registration *launch.OrchestratorRegistration) {
+	t.Helper()
+	agentDir := filepath.Join(root, "agents", handle)
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		CWD: project, Root: root, Binary: "codex", Handle: handle,
+		Role: goalOrchestratorRole, Session: session, External: true,
+		AgentPID: 4242, StartedAt: time.Now().UTC(),
+		OrchestratorRegistration: registration,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func globalStatusRowsBySession(rows []globalStatusRunView) map[string]globalStatusRunView {
+	out := make(map[string]globalStatusRunView, len(rows))
+	for _, row := range rows {
+		out[row.Session] = row
+	}
+	return out
+}
+
+func assertGlobalStatusActionsConfirmGated(t *testing.T, actions []runtimeActionJSON) {
+	t.Helper()
+	for _, action := range actions {
+		if action.Mutates && !action.NeedsConfirmation {
+			t.Errorf("mutating action is not confirm-gated: %+v", action)
+		}
+	}
+}
+
+func directoryEntryNames(entries []os.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/internal/cli/global_status_test.go
+++ b/internal/cli/global_status_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -82,7 +83,7 @@ func TestGlobalStatusMissingRegistryIsVisibleReadOnlyAndNonFatal(t *testing.T) {
 	if len(env.Data.SourceErrors) != 1 || env.Data.SourceErrors[0].Source != "registry" {
 		t.Fatalf("missing registry source errors = %+v", env.Data.SourceErrors)
 	}
-	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions)
+	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions, "global_status", "global_start")
 }
 
 func TestRunGlobalStatusRoutesAndKeepsDegradationNonFatal(t *testing.T) {
@@ -189,16 +190,19 @@ func TestGlobalStatusProjectsMixedRunsFromOneRegistrySnapshot(t *testing.T) {
 						EventType: "gate", Thread: "gate/newer", Subject: "APPROVAL: newer",
 						GateKind: "approval", Age: "1h", LastEventAt: now.Add(-time.Hour),
 						Inspect: "amq thread --id gate/newer", Actionable: true,
+						Profile: profile, Session: session, NamespaceID: squadnamespace.ID(profile, session),
 					},
 					{
 						EventType: "gate", Thread: "gate/older", Subject: "APPROVAL: older",
 						GateKind: "approval", Age: "3h", LastEventAt: now.Add(-3 * time.Hour),
 						Inspect: "amq thread --id gate/older", Actionable: true,
+						Profile: profile, Session: session, NamespaceID: squadnamespace.ID(profile, session),
 					},
 					{
 						EventType: "gate", Thread: "gate/cleared", Subject: "APPROVED",
 						Age: "4h", LastEventAt: now.Add(-4 * time.Hour),
 						Actionable: true, Cleared: true,
+						Profile: profile, Session: session, NamespaceID: squadnamespace.ID(profile, session),
 					},
 				}
 			}
@@ -254,9 +258,9 @@ func TestGlobalStatusProjectsMixedRunsFromOneRegistrySnapshot(t *testing.T) {
 	if env.Data.Health != globalStatusUnknown || env.Data.Readiness.Ready {
 		t.Fatalf("mixed overall readiness = %+v / health=%s", env.Data.Readiness, env.Data.Health)
 	}
-	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions)
+	assertGlobalStatusActionsConfirmGated(t, env.Data.Actions, "global_status", "global_start")
 	for _, row := range env.Data.Runs {
-		assertGlobalStatusActionsConfirmGated(t, row.Actions)
+		assertGlobalStatusActionsConfirmGated(t, row.Actions, "status", "resume_preview", "resume_new_session")
 	}
 }
 
@@ -319,6 +323,148 @@ func TestGlobalStatusNamedProfileUsesIsolatedAMQBaseRoot(t *testing.T) {
 	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
 	if len(env.Data.Runs) != 1 || env.Data.Runs[0].Health != globalStatusHealthy {
 		t.Fatalf("named-profile row = %+v", env.Data.Runs)
+	}
+}
+
+func TestGlobalStatusDefaultProfileScannerCannotReadSiblingSession(t *testing.T) {
+	project := t.TempDir()
+	registered := squadnamespace.Resolve(project, team.DefaultProfile, "registered")
+	sibling := squadnamespace.Resolve(project, team.DefaultProfile, "sibling")
+	for _, fixture := range []struct {
+		namespace squadnamespace.Ref
+		handle    string
+	}{
+		{registered, "registered-lead"},
+		{sibling, "sibling-lead"},
+	} {
+		agentDir := filepath.Join(fixture.namespace.AMQRoot, "agents", fixture.handle)
+		if err := os.MkdirAll(agentDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := launch.Write(agentDir, launch.Record{
+			CWD: project, Root: fixture.namespace.AMQRoot, Handle: fixture.handle,
+			Role: "cto", Binary: "codex", Session: fixture.namespace.Session,
+			TeamProfile: fixture.namespace.Profile, StartedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snapshot, err := state.Build(project, globalStatusAMQBaseRoot(registered), state.Probe{})
+	if err != nil {
+		t.Fatalf("build exact-session snapshot: %v", err)
+	}
+	if len(snapshot.Sessions) != 1 ||
+		snapshot.Sessions[0].Name != registered.Session ||
+		len(snapshot.Sessions[0].Agents) != 1 ||
+		snapshot.Sessions[0].Agents[0].Handle != "registered-lead" {
+		t.Fatalf("exact-session scanner crossed into sibling namespace: %+v", snapshot.Sessions)
+	}
+}
+
+func TestGlobalStatusMalformedLeadClassificationIsUnknownAndHumanVisible(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	project := t.TempDir()
+	session := "malformed-lead"
+	agentDir := filepath.Join(base, session, "agents", "cto")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, launch.FileName), []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	controlRoot := "/noc-control"
+	registry := globalStatusTestRegistry(controlRoot, now)
+	registry.Runs = []globalNOCRun{
+		globalStatusTestRun(controlRoot, project, session, "run-malformed-lead", now),
+	}
+	var out bytes.Buffer
+	err := executeGlobalStatus(globalStatusExecution{
+		ControlRoot: controlRoot, Out: &out, JSON: true, Now: func() time.Time { return now },
+		ReadRegistry: func(string) (globalNOCRegistry, error) { return registry, nil },
+		NOCIdentity: func(launch.Record, string) launchRuntimeIdentity {
+			return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+		},
+		ReadTeam: func(string, string) (team.Team, error) {
+			return team.Team{
+				Project: project, Lead: "cto", Orchestrated: true,
+				Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: session}},
+			}, nil
+		},
+		OperatorData: func(project, profile, session, _ string, _ func() time.Time) (operatorStatusEnvelopeData, error) {
+			return operatorStatusEnvelopeData{
+				Namespace: squadnamespace.Resolve(project, profile, session), ReadOnly: true,
+			}, nil
+		},
+		Watcher: func(team.Team, string, string, time.Time) notificationWatcherStatus {
+			return notificationWatcherStatus{Enabled: true, Health: "healthy"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("malformed lead projection: %v", err)
+	}
+	env := decodeGlobalStatusTestEnvelope(t, out.Bytes())
+	row := env.Data.Runs[0]
+	if row.Health != globalStatusUnknown || row.Readiness.Ready ||
+		!strings.Contains(row.Lead.Detail, "read launch record") {
+		t.Fatalf("malformed lead was normalized instead of fail-visible: %+v", row)
+	}
+	foundLeadError := false
+	for _, sourceErr := range row.SourceErrors {
+		foundLeadError = foundLeadError || (sourceErr.Source == "lead" && strings.Contains(sourceErr.Detail, "read launch record"))
+	}
+	if !foundLeadError {
+		t.Fatalf("malformed lead source error missing: %+v", row.SourceErrors)
+	}
+	var human bytes.Buffer
+	if err := renderGlobalStatus(&human, env.Data, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(human.String(), "read launch record") {
+		t.Fatalf("human status hid lead classification failure:\n%s", human.String())
+	}
+}
+
+func TestGlobalStatusStoppedNOCWithLiveRuntimeIsDegradedAndCannotStart(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	item := globalStatusTestRegistry("/noc-control", now).Launches[0]
+	item.State = globalNOCLaunchStopped
+	noc := projectGlobalStatusNOC(item, func(launch.Record, string) launchRuntimeIdentity {
+		return launchRuntimeIdentity{Live: true, PIDLive: true, PaneLive: true}
+	})
+	if noc.Health != globalStatusDegraded || !strings.Contains(noc.Detail, "persisted NOC state is stopped") {
+		t.Fatalf("stopped/live contradiction = %+v", noc)
+	}
+	actions := globalNOCStatusActions("/noc-control", noc, "healthy")
+	assertGlobalStatusActionsConfirmGated(t, actions, "global_status", "global_start")
+	for _, action := range actions {
+		if action.Kind == "global_start" && action.Available {
+			t.Fatalf("live canonical NOC exposed a second-start action: %+v", action)
+		}
+	}
+}
+
+func TestGlobalStatusOpenGatesRejectsForeignItemBinding(t *testing.T) {
+	expected := squadnamespace.Resolve("/projects/registered", team.DefaultProfile, "registered")
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	items := []operatorAttention{
+		{
+			EventType: "gate", Thread: "gate/registered", Subject: "APPROVAL: registered",
+			Actionable: true, Profile: expected.Profile, Session: expected.Session,
+			NamespaceID: expected.ID, LastEventAt: now, Age: "1m",
+		},
+		{
+			EventType: "gate", Thread: "gate/foreign", Subject: "APPROVAL: foreign",
+			Actionable: true, Profile: expected.Profile, Session: "foreign",
+			NamespaceID: squadnamespace.ID(expected.Profile, "foreign"), LastEventAt: now, Age: "1m",
+		},
+	}
+	gates, sourceErrors := globalStatusOpenGates(items, expected)
+	if gates.Open != 1 || gates.Items[0].Thread != "gate/registered" ||
+		len(sourceErrors) != 1 || !strings.Contains(sourceErrors[0], "gate/foreign") {
+		t.Fatalf("foreign attention binding was projected: gates=%+v errors=%+v", gates, sourceErrors)
 	}
 }
 
@@ -723,6 +869,32 @@ func TestDoctorGlobalNOCRegistrationProjection(t *testing.T) {
 			t.Fatalf("unreadable doctor check = %+v", check)
 		}
 	})
+
+	t.Run("duplicate run id fails closed", func(t *testing.T) {
+		controlRoot := t.TempDir()
+		canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		project := t.TempDir()
+		sessionRoot := t.TempDir()
+		session := "duplicate-run"
+		registry := globalStatusTestRegistry(canonicalControlRoot, now)
+		run := globalStatusTestRun(canonicalControlRoot, project, session, "run-duplicate", now)
+		registry.Runs = []globalNOCRun{run, run}
+		writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
+		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, session, run.ExternalRegistration)
+
+		check := doctorCheckGlobalNOCRegistrationAtRoot(
+			team.Team{Project: project},
+			team.DefaultProfile,
+			session,
+			sessionRoot,
+		)
+		if check.Status != doctorFail || !strings.Contains(check.Detail, "duplicate run registrations") {
+			t.Fatalf("duplicate-run doctor check = %+v", check)
+		}
+	})
 }
 
 func globalStatusTestRegistry(controlRoot string, now time.Time) globalNOCRegistry {
@@ -800,11 +972,29 @@ func globalStatusRowsBySession(rows []globalStatusRunView) map[string]globalStat
 	return out
 }
 
-func assertGlobalStatusActionsConfirmGated(t *testing.T, actions []runtimeActionJSON) {
+func assertGlobalStatusActionsConfirmGated(t *testing.T, actions []runtimeActionJSON, expectedKinds ...string) {
 	t.Helper()
+	if len(actions) == 0 {
+		t.Fatal("expected global status actions, got none")
+	}
+	byKind := make(map[string]runtimeActionJSON, len(actions))
 	for _, action := range actions {
-		if action.Mutates && !action.NeedsConfirmation {
-			t.Errorf("mutating action is not confirm-gated: %+v", action)
+		byKind[action.Kind] = action
+		if action.ID != action.Kind {
+			t.Errorf("action ID does not mirror kind: %+v", action)
+		}
+		if action.Mutates {
+			if !action.NeedsConfirmation || action.ActionKind != "run" ||
+				!strings.Contains(strings.ToLower(action.Label), "confirm") {
+				t.Errorf("mutating action is not explicitly confirm-gated: %+v", action)
+			}
+		} else if action.NeedsConfirmation || action.ActionKind != "display" {
+			t.Errorf("read-only action is not canonical display action: %+v", action)
+		}
+	}
+	for _, kind := range expectedKinds {
+		if _, ok := byKind[kind]; !ok {
+			t.Errorf("required action kind %q missing: %+v", kind, actions)
 		}
 	}
 }

--- a/internal/cli/global_status_test.go
+++ b/internal/cli/global_status_test.go
@@ -438,10 +438,10 @@ func TestGlobalStatusStoppedNOCWithLiveRuntimeIsDegradedAndCannotStart(t *testin
 		t.Fatalf("stopped/live contradiction = %+v", noc)
 	}
 	actions := globalNOCStatusActions("/noc-control", noc, "healthy")
-	assertGlobalStatusActionsConfirmGated(t, actions, "global_status", "global_start")
+	assertGlobalStatusActionsConfirmGated(t, actions, "global_status")
 	for _, action := range actions {
-		if action.Kind == "global_start" && action.Available {
-			t.Fatalf("live canonical NOC exposed a second-start action: %+v", action)
+		if action.Kind == "global_start" {
+			t.Fatalf("live canonical NOC exposed a second-start command: %+v", action)
 		}
 	}
 }
@@ -871,28 +871,49 @@ func TestDoctorGlobalNOCRegistrationProjection(t *testing.T) {
 	})
 
 	t.Run("duplicate run id fails closed", func(t *testing.T) {
-		controlRoot := t.TempDir()
-		canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
-		if err != nil {
-			t.Fatal(err)
-		}
-		project := t.TempDir()
-		sessionRoot := t.TempDir()
-		session := "duplicate-run"
-		registry := globalStatusTestRegistry(canonicalControlRoot, now)
-		run := globalStatusTestRun(canonicalControlRoot, project, session, "run-duplicate", now)
-		registry.Runs = []globalNOCRun{run, run}
-		writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
-		writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, session, run.ExternalRegistration)
+		for _, forgedFirst := range []bool{false, true} {
+			order := "legitimate_then_forged"
+			if forgedFirst {
+				order = "forged_then_legitimate"
+			}
+			t.Run(order, func(t *testing.T) {
+				controlRoot := t.TempDir()
+				canonicalControlRoot, err := canonicalGlobalNOCControlRoot(controlRoot)
+				if err != nil {
+					t.Fatal(err)
+				}
+				project := t.TempDir()
+				sessionRoot := t.TempDir()
+				session := "duplicate-run"
+				registry := globalStatusTestRegistry(canonicalControlRoot, now)
+				legitimate := globalStatusTestRun(canonicalControlRoot, project, session, "run-duplicate", now)
+				forged := globalStatusTestRun(
+					canonicalControlRoot,
+					filepath.Join(project, "forged"),
+					"forged-session",
+					"run-duplicate",
+					now,
+				)
+				registry.Runs = []globalNOCRun{legitimate, forged}
+				if forgedFirst {
+					registry.Runs = []globalNOCRun{forged, legitimate}
+				}
+				if reflect.DeepEqual(registry.Runs[0], registry.Runs[1]) {
+					t.Fatal("duplicate-ID fixture must use distinct legitimate and forged records")
+				}
+				writeGlobalStatusTestRegistry(t, canonicalControlRoot, registry)
+				writeGlobalStatusDoctorRecord(t, sessionRoot, "global-orch", project, session, legitimate.ExternalRegistration)
 
-		check := doctorCheckGlobalNOCRegistrationAtRoot(
-			team.Team{Project: project},
-			team.DefaultProfile,
-			session,
-			sessionRoot,
-		)
-		if check.Status != doctorFail || !strings.Contains(check.Detail, "duplicate run registrations") {
-			t.Fatalf("duplicate-run doctor check = %+v", check)
+				check := doctorCheckGlobalNOCRegistrationAtRoot(
+					team.Team{Project: project},
+					team.DefaultProfile,
+					session,
+					sessionRoot,
+				)
+				if check.Status != doctorFail || !strings.Contains(check.Detail, "duplicate run registrations") {
+					t.Fatalf("%s doctor check = %+v", order, check)
+				}
+			})
 		}
 	})
 }

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -53,6 +54,10 @@ const (
 // re-reading disk or re-running the probe.
 type agentLiveness struct {
 	Verdict agentLivenessVerdict
+	// SourceError preserves a non-ENOENT launch-record read failure. Callers
+	// must surface it as unknown/degraded evidence rather than normalizing the
+	// unreadable identity to an ordinary stopped member.
+	SourceError string
 	// Status is the statusState this verdict maps to, so classifyMemberStatus
 	// can adopt it directly.
 	Status statusState
@@ -138,6 +143,8 @@ func classifyAgentLivenessWithReplacementResolver(agentDir, root, expectedProfil
 			out.Detail = fmt.Sprintf("launch record explicitly stopped at %s", launchRec.StoppedAt.UTC().Format(time.RFC3339))
 			return out
 		}
+	} else if !os.IsNotExist(launchErr) {
+		out.SourceError = "read launch record: " + launchErr.Error()
 	}
 	wakeLock, wakeErr := readWakeLock(agentDir)
 	presence, presenceErr := readPresenceForEntry(agentDir)

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -158,6 +158,7 @@ func runGlobal(args []string) error {
 Usage:
   amq-squad global start [--root DIR] [--agent claude|codex] [--name WINDOW]
       [--monitor-interval D --monitor-timeout D --monitor-max-ticks N] [--go]
+  amq-squad global status [--root DIR] [--json]
 
 A global orchestrator is a control-plane conversation that supervises MANY runs
 across repos from a neutral root. global start injects the standing NOC contract
@@ -165,29 +166,38 @@ natively, records a stamped launch generation, and configures a bounded polling
 backstop. Runs started from that exact verified NOC pane default to wake
 registration; --no-register-orchestrator on run start is the explicit opt-out.
 
+global status is a read-only projection over that registry and each registered
+run's canonical lead, gates, notification watcher, and bounded backstop state.
+It never repairs, drains, answers, adopts, or scans arbitrary repositories.
+
 Preview by default (prints the deterministic bootstrap and launch plan); pass
 --go to create the stamped tmux window, persist its generation, and launch.
 `)
 		if len(args) == 0 {
-			return usageErrorf("global requires a subcommand (start)")
+			return usageErrorf("global requires a subcommand (start or status)")
 		}
 		return nil
 	}
 	switch args[0] {
 	case "start":
 		return runGlobalStart(args[1:])
+	case "status":
+		return runGlobalStatus(args[1:])
 	default:
-		return usageErrorf("unknown 'global' subcommand: %q. Try start.", args[0])
+		return usageErrorf("unknown 'global' subcommand: %q. Try start or status.", args[0])
 	}
+}
+
+func defaultGlobalNOCControlRoot() string {
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, "Code")
+	}
+	return ""
 }
 
 func runGlobalStart(args []string) error {
 	fs := flag.NewFlagSet("global start", flag.ContinueOnError)
-	defaultRoot := ""
-	if home, err := os.UserHomeDir(); err == nil {
-		defaultRoot = filepath.Join(home, "Code")
-	}
-	root := fs.String("root", defaultRoot, "neutral root directory the supervisor runs from")
+	root := fs.String("root", defaultGlobalNOCControlRoot(), "neutral root directory the supervisor runs from")
 	agent := fs.String("agent", "claude", "agent binary to launch: claude or codex")
 	name := fs.String("name", "global-orch", "tmux window name")
 	model := fs.String("model", "", "model to pass to the agent (e.g. claude-opus-4-8, gpt-5.6-terra)")

--- a/internal/cli/orchestrate_test.go
+++ b/internal/cli/orchestrate_test.go
@@ -1617,9 +1617,10 @@ func TestCompletionCoversGlobalRunSubcommands(t *testing.T) {
 				t.Errorf("%s completion missing top command %q", shell, verb)
 			}
 		}
-		// Each verb's sole subcommand is "start"; assert the script wires it.
-		if strings.Count(out, "start") == 0 {
-			t.Errorf("%s completion does not surface the start subcommand:\n%s", shell, out)
+		for _, subcommand := range []string{"start", "status"} {
+			if !strings.Contains(out, subcommand) {
+				t.Errorf("%s completion does not surface the %s subcommand:\n%s", shell, subcommand, out)
+			}
 		}
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -168,9 +168,13 @@ type statusRecord struct {
 	Status      statusState        `json:"status"`
 	RecordState string             `json:"record_state"`
 	Detail      string             `json:"detail,omitempty"`
-	Signals     statusSignals      `json:"signals"`
-	liveness    agentLiveness
-	goalBinding *launch.GoalBinding
+	// ClassificationError is fail-visible source evidence for callers that
+	// must distinguish an ordinary missing member from an unreadable or
+	// otherwise unclassifiable identity.
+	ClassificationError string        `json:"classification_error,omitempty"`
+	Signals             statusSignals `json:"signals"`
+	liveness            agentLiveness
+	goalBinding         *launch.GoalBinding
 	// Tmux is the persisted tmux runtime identity (exact pane/window ids) plus
 	// a computed pane_alive, so clients can target follow-up control. Omitted
 	// when the agent's launch record carried no tmux identity.
@@ -1703,6 +1707,7 @@ func classifyMemberStatusWithReplacementResolver(t team.Team, profile string, m 
 		rec.Status = statusStateMissing
 		rec.RecordState = "missing"
 		rec.Detail = "amq env unresolved: " + err.Error()
+		rec.ClassificationError = rec.Detail
 		return rec
 	}
 	if env.Me != "" {
@@ -1719,6 +1724,7 @@ func classifyMemberStatusWithReplacementResolver(t team.Team, profile string, m 
 	// verdict->statusState mapping lives in the classifier (Status field).
 	live := classifyAgentLivenessWithReplacementResolver(rec.AgentDir, root, profile, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe, replacement)
 	rec.liveness = live
+	rec.ClassificationError = live.SourceError
 	rec.Tmux = tmuxRuntimeFromInfo(live.Tmux)
 	if live.LaunchFound {
 		rec.Terminal = terminalRuntimeFromInfo(live.LaunchRecord.Terminal)
@@ -1766,6 +1772,9 @@ func classifyMemberStatusWithReplacementResolver(t team.Team, profile string, m 
 	}
 	if rec.LiveIdentityMode != "managed_refused" {
 		rec.Detail = live.Detail
+		if rec.ClassificationError != "" {
+			rec.Detail = rec.ClassificationError
+		}
 	}
 	if rec.Tmux != nil {
 		rec.AgentPaneID = strings.TrimSpace(rec.Tmux.PaneID)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -195,6 +195,11 @@ type statusRecord struct {
 	// client can positively identify the wakeable orchestrator identity rather
 	// than inferring it from lead role alone. Set from launch.Record.External.
 	External bool `json:"external,omitempty"`
+	// OrchestratorRegistration is the persisted provenance for the external
+	// orchestrator bound to this project run. Status exposes the exact policy,
+	// NOC launch generation, registration id, and timestamp rather than asking
+	// clients to infer registration from wake liveness or prose.
+	OrchestratorRegistration *launch.OrchestratorRegistration `json:"orchestrator_registration,omitempty"`
 	// WakeAutoDrain reports that this member's wake sidecar is configured to
 	// inject a drain instruction on each durable-message arrival (the launch
 	// record carries WakeInjectCmd). It means inbound messages are processed
@@ -1719,6 +1724,7 @@ func classifyMemberStatusWithReplacementResolver(t team.Team, profile string, m 
 		rec.Terminal = terminalRuntimeFromInfo(live.LaunchRecord.Terminal)
 		rec.goalBinding = live.LaunchRecord.GoalBinding
 		rec.External = live.LaunchRecord.External
+		rec.OrchestratorRegistration = live.LaunchRecord.OrchestratorRegistration
 		rec.WakeAutoDrain = strings.TrimSpace(live.LaunchRecord.WakeInjectCmd) != ""
 		rec.PreauthorizedActions = live.LaunchRecord.PreauthorizedActions
 		rec.AdoptionMode = strings.TrimSpace(live.LaunchRecord.AdoptionMode)

--- a/internal/runtimeaction/actions.go
+++ b/internal/runtimeaction/actions.go
@@ -32,7 +32,7 @@ type Action struct {
 // "display" means read-only or navigational and never mutates.
 func classifyActionKind(kind string) string {
 	switch kind {
-	case "focus", "status", "resume_preview", "task_list", "thread", "attach_control":
+	case "focus", "status", "global_status", "resume_preview", "task_list", "thread", "attach_control":
 		return "display"
 	default:
 		return "run"

--- a/internal/runtimeaction/actions_canonical_test.go
+++ b/internal/runtimeaction/actions_canonical_test.go
@@ -151,3 +151,13 @@ func TestSyncUnavailableReason(t *testing.T) {
 		t.Errorf("SyncUnavailableReason after re-enabling: UnavailableReason = %q, want empty", a.UnavailableReason)
 	}
 }
+
+func TestGlobalStatusActionIsDisplay(t *testing.T) {
+	actions := ApplyCanonical([]Action{{
+		Kind: "global_status", Label: "inspect global NOC status",
+		Available: true,
+	}})
+	if len(actions) != 1 || actions[0].ID != "global_status" || actions[0].ActionKind != "display" {
+		t.Fatalf("global status canonical action = %+v", actions)
+	}
+}


### PR DESCRIPTION
## Summary

- add `amq-squad global status` as a read-only, registry-driven NOC status board
- project exact registered namespaces, lead health, operator gates, watcher/backstop state, readiness, and canonical actions
- fail closed on contradictory/unreadable identity, foreign attention bindings, duplicate run registrations, and stopped/live NOC state
- expose external orchestrator registration provenance in status and doctor

## Validation

- focused global-status and doctor tests: PASS
- `go test ./internal/cli -count=1`: PASS
- task evidence `t8-0160a55-pr2-ci-001`: succeeded, finalized, linked, report sent

Part of #454
