### PR TITLE
Stamp the launch id at capture; distinguish incomplete records from mismatches (#572)

### DIFF
--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -211,10 +211,24 @@ func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 	var unguarded []string
 	sites := 0
 
-	// guardsSentinel reports whether an if-statement tests errors.Is(..., sentinel).
+	// guardsSentinel reports whether an if-statement tests errors.Is(..., sentinel) with
+	// POSITIVE polarity.
+	//
+	// #575 round 6: matching the call anywhere in the condition accepted its own negation.
+	//
+	//	if !errors.Is(err, errIncompleteLaunchRecord) { return err }
+	//	return fmt.Errorf("... verified live identity mismatch: %w", err)
+	//
+	// That terminates, so the block counted as guarded -- while routing away everything
+	// EXCEPT the sentinel and dropping the sentinel itself straight into the wrap. The
+	// bypass was the exact inverse of the property. So the walk stops at `!`: a negated
+	// sentinel test is not a guard, it is the opposite of one.
 	guardsSentinel := func(n ast.Node) bool {
 		found := false
 		ast.Inspect(n, func(x ast.Node) bool {
+			if unary, isUnary := x.(*ast.UnaryExpr); isUnary && unary.Op == token.NOT {
+				return false
+			}
 			call, ok := x.(*ast.CallExpr)
 			if !ok {
 				return true
@@ -319,12 +333,19 @@ func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 // else always has a path that falls through.
 //
 // RECORDED RESIDUAL (accepted, not a gap this test will chase). This recognises the
-// terminating forms that appear in this package -- return, break/continue/goto, panic, and
-// a fully-terminating if/else. It does NOT model labelled control flow, os.Exit, log.Fatal,
-// or a helper whose body always panics. Any of those would be judged non-terminating, so the
-// error direction is a FALSE POSITIVE: the test complains about code that is in fact
-// guarded. That direction is safe -- it fails loud and a human reads it -- whereas modelling
-// every exit shape would mean reimplementing reachability analysis inside a guard test.
+// terminating forms that appear in this package -- return, break, continue, panic, and a
+// fully-terminating if/else. It does NOT model goto-target reachability, os.Exit, log.Fatal,
+// or a helper whose body always panics. Every one of those is judged NON-terminating, so the
+// error direction is a FALSE POSITIVE: the test complains about code that is in fact guarded.
+// That direction is safe -- it fails loud and a human reads it -- whereas modelling every
+// exit shape would mean reimplementing reachability analysis inside a guard test.
+//
+// This claim was FALSE when first written (#575 round 6): goto was accepted as terminating,
+// making unmodelled labelled flow a silent false NEGATIVE, the opposite of what the sentence
+// above promised. Judging goto non-terminating is what makes the promise true. Recording the
+// correction here rather than quietly rewording it, because the declaration is the only
+// thing a future reader has to tell them where the check's edges are, and a declaration
+// nobody re-derives is trusted exactly as far as it is accurate.
 func blockTerminates(block *ast.BlockStmt) bool {
 	if block == nil || len(block.List) == 0 {
 		return false
@@ -333,8 +354,21 @@ func blockTerminates(block *ast.BlockStmt) bool {
 	case *ast.ReturnStmt:
 		return true
 	case *ast.BranchStmt:
-		// break, continue, goto, fallthrough: control leaves this block.
-		return true
+		// #575 round 6: treating EVERY branch as terminating accepted
+		//
+		//	if errors.Is(err, errIncompleteLaunchRecord) { goto mismatch }
+		//
+		// as a guard, when the label it jumps to may be the mismatch wrap itself. That was
+		// a SILENT FALSE NEGATIVE, and it directly contradicted this function's own declared
+		// residual, which claimed unmodelled labelled flow could only produce fail-loud
+		// false positives. A wrong honesty statement is worse than the hole it described.
+		//
+		// break and continue provably leave this block. goto does not: where it lands is
+		// exactly the unmodelled part. fallthrough transfers to the next case rather than
+		// leaving. Both are now judged NON-terminating, which makes the declared residual
+		// true instead of merely stated -- the conservative direction, and the one that
+		// fails loud.
+		return last.Tok == token.BREAK || last.Tok == token.CONTINUE
 	case *ast.ExprStmt:
 		call, ok := last.X.(*ast.CallExpr)
 		if !ok {
@@ -380,6 +414,8 @@ func blockTerminates(block *ast.BlockStmt) bool {
 //     `return Expectation{}, err`, where err is non-nil by elimination
 //   - proof carried across a helper, a switch arm, or a for/range condition rather than an
 //     `if x != nil`
+//   - exit shapes blockTerminates does not model: goto targets, os.Exit, log.Fatal, an
+//     always-panicking helper. All judged non-terminating, so they fail loud.
 //
 // Not caught, so a bypass survives -- FALSE NEGATIVES, both requiring deliberate effort:
 //   - an identifier proven non-nil by the guard and then REASSIGNED to nil before the

--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -49,34 +49,67 @@ func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 		inspected++
 		// Exempting EVERY empty literal was too broad (#575 round 3): production code could
 		// write rec.BootstrapExpectation = &bootstrapack.Expectation{} and recreate the
-		// exact empty-LaunchID defect while passing. The exemption is now POSITIONAL - only
-		// a zero-value literal returned alongside a non-nil error, which is the
-		// `return Expectation{}, err` shape whose value the caller discards.
+		// exact empty-LaunchID defect while passing.
+		//
+		// The exemption requires a non-nil value in the ERROR POSITION, i.e. the LAST
+		// result. Accepting any non-nil identifier ANYWHERE let
+		// `return Expectation{}, nil, cached` through on the strength of `cached` while the
+		// error result was nil (#575 round 4). Accepting any identifier merely NAMED
+		// something other than nil then let `return Expectation{}, err` through in a
+		// NAMED-RESULT function where err was still nil (#575 round 5). A variable's name
+		// says nothing about its value, so the error position must be PROVEN non-nil rather
+		// than merely occupied: see errorResultProvesNonNil. Proof comes from a dominating
+		// `err != nil` guard, which is why this walk tracks branch context instead of using
+		// a flat ast.Inspect.
 		exempt := map[ast.Node]bool{}
-		ast.Inspect(file, func(n ast.Node) bool {
-			ret, ok := n.(*ast.ReturnStmt)
-			if !ok || len(ret.Results) < 2 {
-				return true
+		var scanNode func(ast.Node, map[string]bool)
+		var scanIf func(*ast.IfStmt, map[string]bool)
+		scanIf = func(node *ast.IfStmt, proven map[string]bool) {
+			if node.Init != nil {
+				scanNode(node.Init, proven)
 			}
-			for _, res := range ret.Results {
-				lit, isLit := res.(*ast.CompositeLit)
-				if !isLit || len(lit.Elts) != 0 {
-					continue
+			body := proven
+			if ident := nonNilGuardedIdent(node.Cond); ident != "" {
+				body = make(map[string]bool, len(proven)+1)
+				for k, v := range proven {
+					body[k] = v
 				}
-				// The exemption requires a non-nil value in the ERROR POSITION, i.e. the
-				// LAST result. Accepting any non-nil identifier anywhere let
-				// `return Expectation{}, nil, cached` through on the strength of `cached`
-				// while the error result was nil (#575 round 4).
-				last := ret.Results[len(ret.Results)-1]
-				if id, isID := last.(*ast.Ident); isID && id.Name != "nil" {
-					exempt[lit] = true
-				}
-				if _, isCall := last.(*ast.CallExpr); isCall {
-					exempt[lit] = true
-				}
+				body[ident] = true
 			}
-			return true
-		})
+			scanNode(node.Body, body)
+			// The else arm does NOT inherit the proof: inside `else`, the guarded
+			// identifier is precisely the one known to BE nil.
+			switch els := node.Else.(type) {
+			case *ast.IfStmt:
+				scanIf(els, proven)
+			case *ast.BlockStmt:
+				scanNode(els, proven)
+			}
+		}
+		scanNode = func(n ast.Node, proven map[string]bool) {
+			ast.Inspect(n, func(x ast.Node) bool {
+				if x == nil {
+					return false
+				}
+				if ifs, isIf := x.(*ast.IfStmt); isIf {
+					scanIf(ifs, proven)
+					return false
+				}
+				ret, isRet := x.(*ast.ReturnStmt)
+				if !isRet {
+					return true
+				}
+				if len(ret.Results) >= 2 && errorResultProvesNonNil(ret, proven) {
+					for _, res := range ret.Results {
+						if lit, isLit := res.(*ast.CompositeLit); isLit && len(lit.Elts) == 0 {
+							exempt[lit] = true
+						}
+					}
+				}
+				return false
+			})
+		}
+		scanNode(file, map[string]bool{})
 		ast.Inspect(file, func(n ast.Node) bool {
 			lit, ok := n.(*ast.CompositeLit)
 			if !ok {
@@ -220,7 +253,18 @@ func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 			guarded := false
 			for _, stmt := range block.List {
 				if ifs, isIf := stmt.(*ast.IfStmt); isIf && guardsSentinel(ifs.Cond) {
-					guarded = true
+					// The guard must EXIT, not merely test. #575 round 5: a branch that
+					// checks the sentinel and falls through
+					//
+					//	if errors.Is(err, errIncompleteLaunchRecord) { logSomething() }
+					//	return fmt.Errorf("launch id mismatch: ...")
+					//
+					// reaches the mismatch wrap anyway, so an incomplete record is still
+					// reported as a verifiable disagreement. Testing the sentinel is not the
+					// property being enforced; DECLINING TO REACH the wrap is.
+					if blockTerminates(ifs.Body) {
+						guarded = true
+					}
 					continue
 				}
 				// Does this statement ITSELF wrap with the mismatch label? Stop at nested
@@ -265,4 +309,116 @@ func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 			"in the same block: %v. An incomplete record is cannot-verify, not verifiably-wrong",
 			label, sentinel, unguarded)
 	}
+}
+
+// blockTerminates reports whether control cannot fall out of the bottom of block.
+//
+// Only the LAST statement is examined, because that is what decides fall-through: an early
+// return nested inside an inner branch does not stop the block from completing. A block
+// ending in another if/else counts only when BOTH arms terminate, since a bare `if` with no
+// else always has a path that falls through.
+//
+// RECORDED RESIDUAL (accepted, not a gap this test will chase). This recognises the
+// terminating forms that appear in this package -- return, break/continue/goto, panic, and
+// a fully-terminating if/else. It does NOT model labelled control flow, os.Exit, log.Fatal,
+// or a helper whose body always panics. Any of those would be judged non-terminating, so the
+// error direction is a FALSE POSITIVE: the test complains about code that is in fact
+// guarded. That direction is safe -- it fails loud and a human reads it -- whereas modelling
+// every exit shape would mean reimplementing reachability analysis inside a guard test.
+func blockTerminates(block *ast.BlockStmt) bool {
+	if block == nil || len(block.List) == 0 {
+		return false
+	}
+	switch last := block.List[len(block.List)-1].(type) {
+	case *ast.ReturnStmt:
+		return true
+	case *ast.BranchStmt:
+		// break, continue, goto, fallthrough: control leaves this block.
+		return true
+	case *ast.ExprStmt:
+		call, ok := last.X.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		return ok && id.Name == "panic"
+	case *ast.IfStmt:
+		elseBlock, ok := last.Else.(*ast.BlockStmt)
+		if !ok {
+			// No else, or an else-if chain this check does not unroll. Either way it
+			// is not proof that every path leaves.
+			return false
+		}
+		return blockTerminates(last.Body) && blockTerminates(elseBlock)
+	default:
+		return false
+	}
+}
+
+// errorResultProvesNonNil reports whether the last result of ret is provably a non-nil error
+// at that point, given the identifiers a dominating `x != nil` guard has already proven
+// non-nil.
+//
+// #575 round 5: accepting any identifier that is not the literal `nil` exempted
+// `return Expectation{}, err` inside a NAMED-RESULT function, where err can still be nil at
+// the return -- the zero-value Expectation is then the caller's value and the empty-LaunchID
+// defect is back. The name of a variable says nothing about its value.
+//
+// Two shapes count as proof:
+//   - an explicit construction in the error position (fmt.Errorf(...), someErr()), which
+//     cannot be nil by inspection of the call site
+//   - an identifier a dominating `<ident> != nil` guard has proven, i.e. the ordinary
+//     `if err != nil { return Expectation{}, err }` shape
+//
+// RECORDED RESIDUALS (declared per the #575 convergence bound and the #567 enumeration-test
+// precedent: state what the check proves and what it cannot, rather than iterating on
+// meta-test rigor while the production fix waits).
+//
+// Not proven, so reported as offenders even when correct -- FALSE POSITIVES, which fail loud
+// and get read by a human:
+//   - the inverted early-return shape, `if err == nil { return v, nil }` followed by
+//     `return Expectation{}, err`, where err is non-nil by elimination
+//   - proof carried across a helper, a switch arm, or a for/range condition rather than an
+//     `if x != nil`
+//
+// Not caught, so a bypass survives -- FALSE NEGATIVES, both requiring deliberate effort:
+//   - an identifier proven non-nil by the guard and then REASSIGNED to nil before the
+//     return inside the same branch
+//   - a CallExpr in the error position that returns a nil error, e.g. `wrapMaybe(nil)`;
+//     "an explicit construction cannot be nil" is true of fmt.Errorf and false in general
+//
+// The bound is deliberate. Closing these means reimplementing nil-flow analysis inside a
+// guard test, and the property that actually matters -- production classification -- has been
+// verified clean directly for two review rounds. This test is defense-in-depth.
+func errorResultProvesNonNil(ret *ast.ReturnStmt, provenNonNil map[string]bool) bool {
+	if len(ret.Results) == 0 {
+		return false
+	}
+	switch last := ret.Results[len(ret.Results)-1].(type) {
+	case *ast.CallExpr:
+		return true
+	case *ast.Ident:
+		return last.Name != "nil" && provenNonNil[last.Name]
+	default:
+		return false
+	}
+}
+
+// nonNilGuardedIdent returns the identifier a condition of the form `x != nil` proves
+// non-nil inside the guarded branch, or "" when cond is not that shape.
+func nonNilGuardedIdent(cond ast.Expr) string {
+	bin, ok := cond.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return ""
+	}
+	left, okLeft := bin.X.(*ast.Ident)
+	right, okRight := bin.Y.(*ast.Ident)
+	if okLeft && okRight && right.Name == "nil" {
+		return left.Name
+	}
+	// Written the other way round: `nil != err`.
+	if okLeft && okRight && left.Name == "nil" {
+		return right.Name
+	}
+	return ""
 }

--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -47,6 +47,34 @@ func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 			return parseErr
 		}
 		inspected++
+		// Exempting EVERY empty literal was too broad (#575 round 3): production code could
+		// write rec.BootstrapExpectation = &bootstrapack.Expectation{} and recreate the
+		// exact empty-LaunchID defect while passing. The exemption is now POSITIONAL - only
+		// a zero-value literal returned alongside a non-nil error, which is the
+		// `return Expectation{}, err` shape whose value the caller discards.
+		exempt := map[ast.Node]bool{}
+		ast.Inspect(file, func(n ast.Node) bool {
+			ret, ok := n.(*ast.ReturnStmt)
+			if !ok || len(ret.Results) < 2 {
+				return true
+			}
+			for i, res := range ret.Results {
+				lit, isLit := res.(*ast.CompositeLit)
+				if !isLit || len(lit.Elts) != 0 {
+					continue
+				}
+				// a sibling result must be a non-nil error-ish identifier
+				for j, sib := range ret.Results {
+					if j == i {
+						continue
+					}
+					if id, isID := sib.(*ast.Ident); isID && id.Name != "nil" {
+						exempt[lit] = true
+					}
+				}
+			}
+			return true
+		})
 		ast.Inspect(file, func(n ast.Node) bool {
 			lit, ok := n.(*ast.CompositeLit)
 			if !ok {
@@ -60,10 +88,7 @@ func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 			if !ok || pkg.Name != "bootstrapack" {
 				return true
 			}
-			// A zero-value literal stamps nothing: it is the `Expectation{}, err` shape on
-			// an error path, discarded by the caller. Judged on the AST node's own fields,
-			// so nothing else on the line can smuggle a populated literal past this.
-			if len(lit.Elts) == 0 {
+			if exempt[lit] {
 				return true
 			}
 			offenders = append(offenders, fset.Position(lit.Pos()).String())
@@ -133,5 +158,62 @@ func TestRenderedPromotionRefusalDoesNotCallAnIncompleteRecordAMismatch(t *testi
 	}
 	if !strings.Contains(msg, "could not be verified") {
 		t.Errorf("rendered refusal must say identity could not be verified:\n  %s", msg)
+	}
+}
+
+// Three review rounds found the same shape: the cannot-verify classification exists, and
+// some surface routes around it and relabels the error a mismatch. Sites found so far:
+// two in live_identity's wrapper, four in the refusal family, one pre-validator that ran
+// BEFORE the sentinel, one control-continue wrapper, and one no-verdict case.
+//
+// This makes the acceptance criterion permanent instead of a grep someone remembers to run:
+// every site that wraps an error with the mismatch label must first route the sentinel away.
+func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
+	const label = "verified live identity mismatch"
+	const guard = "errIncompleteLaunchRecord"
+	root := filepath.Join("..", "..", "internal")
+
+	var unguarded []string
+	sites := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		lines := strings.Split(string(raw), "\n")
+		for i, line := range lines {
+			if !strings.Contains(line, label) || strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			sites++
+			// The guard must appear in the enclosing few lines above the wrap.
+			lo := i - 6
+			if lo < 0 {
+				lo = 0
+			}
+			if !strings.Contains(strings.Join(lines[lo:i], "\n"), guard) {
+				unguarded = append(unguarded, filepath.ToSlash(path)+":"+itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Anti-vacuity: if the label is ever renamed this test must fail loudly rather than
+	// silently pass by finding nothing to check.
+	if sites == 0 {
+		t.Fatalf("found no %q wrap sites; the label was renamed and this test is now blind", label)
+	}
+	if len(unguarded) != 0 {
+		t.Errorf("these sites wrap an error as %q without first routing %s away: %v. "+
+			"An incomplete record is cannot-verify, not verifiably-wrong", label, guard, unguarded)
 	}
 }

--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #572: the external-lead adoption path built bootstrapack.Expectation as a struct literal
+// and so recorded an EMPTY LaunchID, while every other site goes through
+// bootstrapack.NewExpectation which always generates one. Live identity then refused with
+// "no exact launch id" and an adopted lead could not receive goal delivery.
+//
+// This is the class fix rather than the instance fix: the constructor is the only sanctioned
+// way to build an Expectation, because it is the only thing that guarantees the launch id.
+// A composite literal anywhere in production Go can omit it again.
+func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
+	root := filepath.Join("..", "..", "internal")
+	var offenders []string
+	inspected := 0
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		inspected++
+		for i, line := range strings.Split(string(raw), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			// `Expectation{}, err` is a zero-value return on an error path: it stamps
+			// nothing and is discarded by the caller, so it is not a construction site.
+			if strings.Contains(line, "bootstrapack.Expectation{}, err") {
+				continue
+			}
+			if strings.Contains(line, "bootstrapack.Expectation{") {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Anti-vacuity: a broken walk would report perfect compliance.
+	if inspected < 50 {
+		t.Fatalf("inspected only %d non-test .go files; the walk is broken", inspected)
+	}
+	if len(offenders) != 0 {
+		t.Errorf("production code builds bootstrapack.Expectation as a literal at %v; use "+
+			"bootstrapack.NewExpectation so the launch id is always stamped (#572)", offenders)
+	}
+}
+
+// The refusal must name the FAILURE CLASS, because #571 counts a worker launched only
+// after identity is verified and must distinguish "cannot verify" from "verifiably wrong".
+func TestIncompleteRecordRefusalIsNotAMismatch(t *testing.T) {
+	msg := incompleteLaunchRecordError().Error()
+	for _, want := range []string{"INCOMPLETE", "cannot be verified", "not an identity conflict"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal must contain %q so the reader knows the class of failure:\n  %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "mismatch:") {
+		t.Errorf("refusal must not read as a mismatch:\n  %s", msg)
+	}
+}

--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -58,19 +58,21 @@ func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 			if !ok || len(ret.Results) < 2 {
 				return true
 			}
-			for i, res := range ret.Results {
+			for _, res := range ret.Results {
 				lit, isLit := res.(*ast.CompositeLit)
 				if !isLit || len(lit.Elts) != 0 {
 					continue
 				}
-				// a sibling result must be a non-nil error-ish identifier
-				for j, sib := range ret.Results {
-					if j == i {
-						continue
-					}
-					if id, isID := sib.(*ast.Ident); isID && id.Name != "nil" {
-						exempt[lit] = true
-					}
+				// The exemption requires a non-nil value in the ERROR POSITION, i.e. the
+				// LAST result. Accepting any non-nil identifier anywhere let
+				// `return Expectation{}, nil, cached` through on the strength of `cached`
+				// while the error result was nil (#575 round 4).
+				last := ret.Results[len(ret.Results)-1]
+				if id, isID := last.(*ast.Ident); isID && id.Name != "nil" {
+					exempt[lit] = true
+				}
+				if _, isCall := last.(*ast.CallExpr); isCall {
+					exempt[lit] = true
 				}
 			}
 			return true
@@ -170,11 +172,34 @@ func TestRenderedPromotionRefusalDoesNotCallAnIncompleteRecordAMismatch(t *testi
 // every site that wraps an error with the mismatch label must first route the sentinel away.
 func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 	const label = "verified live identity mismatch"
-	const guard = "errIncompleteLaunchRecord"
+	const sentinel = "errIncompleteLaunchRecord"
 	root := filepath.Join("..", "..", "internal")
 
 	var unguarded []string
 	sites := 0
+
+	// guardsSentinel reports whether an if-statement tests errors.Is(..., sentinel).
+	guardsSentinel := func(n ast.Node) bool {
+		found := false
+		ast.Inspect(n, func(x ast.Node) bool {
+			call, ok := x.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "Is" {
+				return true
+			}
+			for _, a := range call.Args {
+				if id, isID := a.(*ast.Ident); isID && id.Name == sentinel {
+					found = true
+				}
+			}
+			return true
+		})
+		return found
+	}
+
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -182,38 +207,62 @@ func TestEveryMismatchWrapperGuardsTheIncompleteSentinel(t *testing.T) {
 		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		raw, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
 		}
-		lines := strings.Split(string(raw), "\n")
-		for i, line := range lines {
-			if !strings.Contains(line, label) || strings.HasPrefix(strings.TrimSpace(line), "//") {
-				continue
+		ast.Inspect(file, func(n ast.Node) bool {
+			block, ok := n.(*ast.BlockStmt)
+			if !ok {
+				return true
 			}
-			sites++
-			// The guard must appear in the enclosing few lines above the wrap.
-			lo := i - 6
-			if lo < 0 {
-				lo = 0
+			guarded := false
+			for _, stmt := range block.List {
+				if ifs, isIf := stmt.(*ast.IfStmt); isIf && guardsSentinel(ifs.Cond) {
+					guarded = true
+					continue
+				}
+				// Does this statement ITSELF wrap with the mismatch label? Stop at nested
+				// block boundaries: an enclosing `if err != nil { ... }` contains the label
+				// in a child block that this walk visits separately, and judging the
+				// enclosing statement flagged correctly-guarded code.
+				wraps := false
+				ast.Inspect(stmt, func(x ast.Node) bool {
+					if x == nil {
+						return false
+					}
+					if b, isBlock := x.(*ast.BlockStmt); isBlock && b != stmt {
+						return false
+					}
+					if lit, isLit := x.(*ast.BasicLit); isLit && strings.Contains(lit.Value, label) {
+						wraps = true
+					}
+					return true
+				})
+				if !wraps {
+					continue
+				}
+				sites++
+				if !guarded {
+					unguarded = append(unguarded, fset.Position(stmt.Pos()).String())
+				}
 			}
-			if !strings.Contains(strings.Join(lines[lo:i], "\n"), guard) {
-				unguarded = append(unguarded, filepath.ToSlash(path)+":"+itoa(i+1))
-			}
-		}
+			return true
+		})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walk: %v", err)
 	}
 
-	// Anti-vacuity: if the label is ever renamed this test must fail loudly rather than
-	// silently pass by finding nothing to check.
+	// Anti-vacuity: if the label is renamed this must fail rather than pass by finding nothing.
 	if sites == 0 {
 		t.Fatalf("found no %q wrap sites; the label was renamed and this test is now blind", label)
 	}
 	if len(unguarded) != 0 {
-		t.Errorf("these sites wrap an error as %q without first routing %s away: %v. "+
-			"An incomplete record is cannot-verify, not verifiably-wrong", label, guard, unguarded)
+		t.Errorf("these sites wrap an error as %q without an errors.Is(%s) guard DOMINATING them "+
+			"in the same block: %v. An incomplete record is cannot-verify, not verifiably-wrong",
+			label, sentinel, unguarded)
 	}
 }

--- a/internal/cli/launch_identity_stamp_test.go
+++ b/internal/cli/launch_identity_stamp_test.go
@@ -1,20 +1,34 @@
 package cli
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // #572: the external-lead adoption path built bootstrapack.Expectation as a struct literal
-// and so recorded an EMPTY LaunchID, while every other site goes through
-// bootstrapack.NewExpectation which always generates one. Live identity then refused with
-// "no exact launch id" and an adopted lead could not receive goal delivery.
+// and so recorded an EMPTY LaunchID, while bootstrapack.NewExpectation always generates one.
+// Live identity then refused with "no exact launch id" and an adopted lead could not receive
+// goal delivery. A second site on the prepared-run path had the identical defect.
 //
-// This is the class fix rather than the instance fix: the constructor is the only sanctioned
-// way to build an Expectation, because it is the only thing that guarantees the launch id.
-// A composite literal anywhere in production Go can omit it again.
+// This is the class fix: the constructor is the only sanctioned way to build an Expectation,
+// because it is the only thing that guarantees the launch id.
+//
+// Implemented with go/ast rather than string matching. #575 review found that a
+// substring-and-skip-the-line exemption hides a real literal sharing a line with the
+// zero-value error return, e.g.
+//
+//	return bootstrapack.Expectation{}, errorFor(&bootstrapack.Expectation{Required: true})
+//
+// The AST sees each CompositeLit separately, so the whole string-matching hole class is gone
+// rather than narrowed.
 func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 	root := filepath.Join("..", "..", "internal")
 	var offenders []string
@@ -27,50 +41,97 @@ func TestNoProductionCodeBuildsExpectationLiterals(t *testing.T) {
 		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		raw, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
 		}
 		inspected++
-		for i, line := range strings.Split(string(raw), "\n") {
-			if strings.HasPrefix(strings.TrimSpace(line), "//") {
-				continue
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
 			}
-			// `Expectation{}, err` is a zero-value return on an error path: it stamps
-			// nothing and is discarded by the caller, so it is not a construction site.
-			if strings.Contains(line, "bootstrapack.Expectation{}, err") {
-				continue
+			sel, ok := lit.Type.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "Expectation" {
+				return true
 			}
-			if strings.Contains(line, "bootstrapack.Expectation{") {
-				offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(i+1))
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "bootstrapack" {
+				return true
 			}
-		}
+			// A zero-value literal stamps nothing: it is the `Expectation{}, err` shape on
+			// an error path, discarded by the caller. Judged on the AST node's own fields,
+			// so nothing else on the line can smuggle a populated literal past this.
+			if len(lit.Elts) == 0 {
+				return true
+			}
+			offenders = append(offenders, fset.Position(lit.Pos()).String())
+			return true
+		})
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walk: %v", err)
 	}
 
-	// Anti-vacuity: a broken walk would report perfect compliance.
+	// Anti-vacuity: a broken walk or a parse that matched nothing would report compliance.
 	if inspected < 50 {
-		t.Fatalf("inspected only %d non-test .go files; the walk is broken", inspected)
+		t.Fatalf("parsed only %d non-test .go files; the walk is broken", inspected)
 	}
 	if len(offenders) != 0 {
-		t.Errorf("production code builds bootstrapack.Expectation as a literal at %v; use "+
-			"bootstrapack.NewExpectation so the launch id is always stamped (#572)", offenders)
+		t.Errorf("production code builds a populated bootstrapack.Expectation literal at %v; "+
+			"use bootstrapack.NewExpectation so the launch id is always stamped (#572)", offenders)
 	}
 }
 
-// The refusal must name the FAILURE CLASS, because #571 counts a worker launched only
-// after identity is verified and must distinguish "cannot verify" from "verifiably wrong".
+// The refusal must name the FAILURE CLASS: #571 counts a worker launched only after identity
+// is verified and must distinguish "cannot verify" from "verifiably wrong".
 func TestIncompleteRecordRefusalIsNotAMismatch(t *testing.T) {
 	msg := incompleteLaunchRecordError().Error()
-	for _, want := range []string{"INCOMPLETE", "cannot be verified", "not an identity conflict"} {
+	for _, want := range []string{"incomplete launch record", "cannot be verified", "not an identity conflict"} {
 		if !strings.Contains(msg, want) {
-			t.Errorf("refusal must contain %q so the reader knows the class of failure:\n  %s", want, msg)
+			t.Errorf("refusal must contain %q so the reader knows the class:\n  %s", want, msg)
 		}
 	}
-	if strings.Contains(msg, "mismatch:") {
-		t.Errorf("refusal must not read as a mismatch:\n  %s", msg)
+}
+
+// #575 review finding 1: the helper said "not mismatched" while the OUTER wrapper still
+// labelled it a mismatch, so the operator-visible string contradicted itself and the
+// cannot-verify classification was destroyed at exactly the surface that matters.
+//
+// This asserts the COMPLETE RENDERED string on the promotion path, not the helper in
+// isolation. Testing the helper alone is what let the contradiction ship.
+func TestRenderedPromotionRefusalDoesNotCallAnIncompleteRecordAMismatch(t *testing.T) {
+	project := t.TempDir()
+	// A real roster is required or the resolver fails earlier on a missing team.json and the
+	// assertion passes or fails for the wrong reason. First draft of this test did exactly
+	// that: vacuous fixture, caught because the failure message named team.json.
+	if err := team.WriteProfile(project, "default", team.Team{Project: project,
+		Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", Session: "s1"}}}); err != nil {
+		t.Fatal(err)
+	}
+	rec := launch.Record{
+		Role: "cto", Handle: "cto", Binary: "codex", Session: "s1",
+		Root: filepath.Join(project, ".agent-mail", "s1"), TeamHome: project, TeamProfile: "default",
+		PreparedRunGeneration: "g1", PreparedRunDigest: "d1", PreparedRunLaunchAttempt: "a1",
+		// BootstrapExpectation deliberately nil: the incomplete-record case.
+	}
+	// The resolver reads launch.json from disk rather than trusting the passed record, so
+	// the record must actually exist there with its BootstrapExpectation absent.
+	root := filepath.Join(project, ".agent-mail", "s1")
+	if err := launch.Write(filepath.Join(root, "agents", "cto"), rec); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := verifyRuntimeActionWithRecord("status promotion", project, "default", "s1", "cto", rec)
+	if err == nil {
+		t.Fatal("an incomplete record must be refused")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "mismatch") {
+		t.Errorf("rendered refusal must not label an incomplete record a mismatch:\n  %s", msg)
+	}
+	if !strings.Contains(msg, "could not be verified") {
+		t.Errorf("rendered refusal must say identity could not be verified:\n  %s", msg)
 	}
 }

--- a/internal/cli/live_identity.go
+++ b/internal/cli/live_identity.go
@@ -130,11 +130,18 @@ func verifyRuntimeActionWithRecord(action, project, profile, session, handle str
 		return liveidentity.Result{}, false, nil
 	}
 	if strings.TrimSpace(rec.PreparedRunGeneration) == "" || strings.TrimSpace(rec.PreparedRunDigest) == "" || strings.TrimSpace(rec.PreparedRunLaunchAttempt) == "" {
-		result, baseErr := failedLiveIdentityResult(fmt.Errorf("prepared identity tuple is incomplete"))
-		return result, true, fmt.Errorf("%s refused: verified live identity mismatch: %w", action, baseErr)
+		result, baseErr := failedLiveIdentityResult(fmt.Errorf("%w: prepared identity tuple is incomplete", errIncompleteLaunchRecord))
+		return result, true, fmt.Errorf("%s refused: launch identity could not be verified: %w", action, baseErr)
 	}
 	result, err := resolveRuntimeLiveIdentityNow(liveIdentityScope{Project: project, Profile: profile, Session: session, Handle: handle})
 	if err != nil {
+		// An INCOMPLETE record is not a mismatch. Routing it through the mismatch wrapper
+		// rendered "refused: verified live identity mismatch: ...INCOMPLETE, not
+		// mismatched", contradicting itself in the operator-visible string and destroying
+		// the cannot-verify vs verifiably-wrong distinction #571 depends on.
+		if errors.Is(err, errIncompleteLaunchRecord) {
+			return result, true, fmt.Errorf("%s refused: launch identity could not be verified: %w", action, err)
+		}
 		return result, true, fmt.Errorf("%s refused: verified live identity mismatch: %w", action, err)
 	}
 	if result.Verified == nil {
@@ -331,10 +338,16 @@ func resolvePreparedLiveActor(scope liveIdentityScope, managed managedLiveLaunch
 // re-launch or repair, not investigating a conflict that does not exist.
 //
 // Shared by both refusal sites so the wording cannot drift between them.
+// errIncompleteLaunchRecord marks the cannot-verify class so callers can route it away from
+// the mismatch wrapper. #575 review: wrapping it as a mismatch produced
+// "...mismatch: ...INCOMPLETE, not mismatched" at the surface the operator reads, which
+// defeated the classification at exactly the place it matters.
+var errIncompleteLaunchRecord = errors.New("incomplete launch record")
+
 func incompleteLaunchRecordError() error {
-	return fmt.Errorf("launch record is INCOMPLETE, not mismatched: it carries no exact launch id, " +
-		"so live identity cannot be verified either way. The launch did not stamp its identity; " +
-		"re-launch the member, or repair the record. This is not an identity conflict")
+	return fmt.Errorf("%w: it carries no exact launch id, "+
+		"so live identity cannot be verified either way. The launch did not stamp its identity; "+
+		"re-launch the member, or repair the record. This is not an identity conflict", errIncompleteLaunchRecord)
 }
 
 func observeManagedLiveActor(scope liveIdentityScope, managed managedLiveLaunch, probe duplicateLaunchProbe, childrenIndex func() (func(int) []int, error)) (observedLiveActor, error) {
@@ -359,7 +372,7 @@ func observeManagedLiveActor(scope liveIdentityScope, managed managedLiveLaunch,
 	switch terminal.Backend {
 	case "tmux":
 		if rec.Tmux == nil || strings.TrimSpace(rec.Tmux.PaneID) == "" {
-			return observedLiveActor{}, fmt.Errorf("managed launch record has no exact tmux pane")
+			return observedLiveActor{}, fmt.Errorf("%w: managed launch record has no exact tmux pane", errIncompleteLaunchRecord)
 		}
 		pane, ok := statusPaneInspector(rec.Tmux.PaneID)
 		if !ok || !sameResolvedDir(pane.CWD, rec.CWD) || paneTitledForDifferentAgent(pane.Title, scope.Session, rec.Role) {
@@ -401,7 +414,7 @@ func observeManagedLiveActor(scope liveIdentityScope, managed managedLiveLaunch,
 
 func verifyAgentPaneLineage(panePID, agentPID int, childrenIndex func() (func(int) []int, error)) error {
 	if panePID <= 0 || agentPID <= 0 || childrenIndex == nil {
-		return fmt.Errorf("pane/agent process lineage is incomplete")
+		return fmt.Errorf("%w: pane/agent process lineage is incomplete", errIncompleteLaunchRecord)
 	}
 	children, err := childrenIndex()
 	if err != nil || children == nil {
@@ -526,7 +539,7 @@ func liveIdentityTerminal(rec launch.Record) liveidentity.Terminal {
 func validateLiveIdentityTerminalProjection(rec launch.Record) error {
 	terminal := rec.Terminal
 	if terminal == nil {
-		return fmt.Errorf("managed launch record has no exact terminal identity")
+		return fmt.Errorf("%w: managed launch record has no exact terminal identity", errIncompleteLaunchRecord)
 	}
 	switch strings.TrimSpace(terminal.Backend) {
 	case "tmux":

--- a/internal/cli/live_identity.go
+++ b/internal/cli/live_identity.go
@@ -196,7 +196,7 @@ func resolveVerifiedLiveIdentityWithDeps(scope liveIdentityScope, deps liveIdent
 	}
 	rec := managed.Record
 	if rec.BootstrapExpectation == nil || strings.TrimSpace(rec.BootstrapExpectation.LaunchID) == "" {
-		return failedLiveIdentityResult(fmt.Errorf("managed launch record has no exact launch id"))
+		return failedLiveIdentityResult(incompleteLaunchRecordError())
 	}
 	key := liveidentity.Key{Project: project, Profile: scope.Profile, Session: scope.Session, Handle: scope.Handle,
 		PreparedGeneration: prepared.Generation, PreparedDigest: prepared.Digest, LaunchID: rec.BootstrapExpectation.LaunchID}
@@ -324,10 +324,23 @@ func resolvePreparedLiveActor(scope liveIdentityScope, managed managedLiveLaunch
 		Generation: ctx.Manifest.Generation, Digest: ctx.Digest, Role: identity.Role, Binary: identity.Binary, Model: identity.Model}, nil
 }
 
+// incompleteLaunchRecordError reports a record that cannot be VERIFIED, as distinct from
+// one that verifiably disagrees. #571 counts a worker launched only after identity is
+// verified, which requires those two outcomes to be distinguishable: a mismatch means stop,
+// an incomplete record means the launch never recorded its identity and the remedy is
+// re-launch or repair, not investigating a conflict that does not exist.
+//
+// Shared by both refusal sites so the wording cannot drift between them.
+func incompleteLaunchRecordError() error {
+	return fmt.Errorf("launch record is INCOMPLETE, not mismatched: it carries no exact launch id, " +
+		"so live identity cannot be verified either way. The launch did not stamp its identity; " +
+		"re-launch the member, or repair the record. This is not an identity conflict")
+}
+
 func observeManagedLiveActor(scope liveIdentityScope, managed managedLiveLaunch, probe duplicateLaunchProbe, childrenIndex func() (func(int) []int, error)) (observedLiveActor, error) {
 	rec := managed.Record
 	if rec.BootstrapExpectation == nil || strings.TrimSpace(rec.BootstrapExpectation.LaunchID) == "" {
-		return observedLiveActor{}, fmt.Errorf("managed launch record has no exact launch id")
+		return observedLiveActor{}, incompleteLaunchRecordError()
 	}
 	runtimeIdentity := classifyLaunchPIDRuntimeIdentity(rec, rec.Binary, probe)
 	if !runtimeIdentity.PIDLive {

--- a/internal/cli/live_identity.go
+++ b/internal/cli/live_identity.go
@@ -145,8 +145,8 @@ func verifyRuntimeActionWithRecord(action, project, profile, session, handle str
 		return result, true, fmt.Errorf("%s refused: verified live identity mismatch: %w", action, err)
 	}
 	if result.Verified == nil {
-		result, baseErr := failedLiveIdentityResult(fmt.Errorf("authoritative resolver returned no verified identity"))
-		return result, true, fmt.Errorf("%s refused: verified live identity mismatch: %w", action, baseErr)
+		result, baseErr := failedLiveIdentityResult(fmt.Errorf("%w: authoritative resolver returned no verified identity", errIncompleteLaunchRecord))
+		return result, true, fmt.Errorf("%s refused: launch identity could not be verified: %w", action, baseErr)
 	}
 	return result, true, nil
 }
@@ -543,11 +543,17 @@ func validateLiveIdentityTerminalProjection(rec launch.Record) error {
 	}
 	switch strings.TrimSpace(terminal.Backend) {
 	case "tmux":
+		// ABSENCE and CONTRADICTION are different failures and must not share a message.
+		// This returned one non-sentinel error for both, and it runs BEFORE the "no exact
+		// tmux pane" check, so that sentinel was unreachable and the family member still
+		// rendered as a mismatch (#575 round 3).
 		if rec.Tmux == nil || strings.TrimSpace(terminal.Target) == "" || strings.TrimSpace(terminal.Session) == "" ||
-			strings.TrimSpace(terminal.WindowID) == "" || strings.TrimSpace(terminal.PaneID) == "" ||
-			terminal.Target != rec.Tmux.Target || terminal.Session != rec.Tmux.Session ||
+			strings.TrimSpace(terminal.WindowID) == "" || strings.TrimSpace(terminal.PaneID) == "" {
+			return fmt.Errorf("%w: managed launch tmux and terminal target identities are not fully recorded", errIncompleteLaunchRecord)
+		}
+		if terminal.Target != rec.Tmux.Target || terminal.Session != rec.Tmux.Session ||
 			terminal.WindowID != rec.Tmux.WindowID || terminal.PaneID != rec.Tmux.PaneID {
-			return fmt.Errorf("managed launch tmux and terminal target identities are incomplete or contradictory")
+			return fmt.Errorf("managed launch tmux and terminal target identities contradict each other")
 		}
 	case "iterm2":
 		if rec.Tmux != nil {
@@ -556,8 +562,11 @@ func validateLiveIdentityTerminalProjection(rec launch.Record) error {
 		if strings.TrimSpace(terminal.Target) == "" || strings.TrimSpace(terminal.Session) == "" ||
 			strings.TrimSpace(terminal.WindowID) == "" || strings.TrimSpace(terminal.TabID) == "" ||
 			strings.TrimSpace(terminal.SessionID) == "" || strings.TrimSpace(terminal.TTY) == "" ||
-			strings.TrimSpace(rec.AgentTTY) == "" || rec.AgentTTY != terminal.TTY || strings.TrimSpace(terminal.PaneID) != "" {
-			return fmt.Errorf("managed native terminal target identity is incomplete or contradictory")
+			strings.TrimSpace(rec.AgentTTY) == "" {
+			return fmt.Errorf("%w: managed native terminal target identity is not fully recorded", errIncompleteLaunchRecord)
+		}
+		if rec.AgentTTY != terminal.TTY || strings.TrimSpace(terminal.PaneID) != "" {
+			return fmt.Errorf("managed native terminal target identity contradicts the record")
 		}
 	default:
 		return fmt.Errorf("managed launch record has unsupported terminal backend %q", terminal.Backend)

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1115,7 +1115,14 @@ func preparedBootstrap(project, profile, session string, binding acceptedGoalBin
 	}
 	agentDir := filepath.Join(root, "agents", handle)
 	requiredAck := !(context.Topology.ExternalLead && member.Role == tm.Lead)
-	expectation := &bootstrapack.Expectation{Required: requiredAck}
+	// STAMP AT CAPTURE (#572). This was the SECOND site building the Expectation as a
+	// literal, so it recorded an empty LaunchID exactly like the external-lead adoption
+	// path. Found by the invariant test rather than by the operator report, which named
+	// only the other one.
+	expectation, expectationErr := bootstrapack.NewExpectation(requiredAck, time.Now())
+	if expectationErr != nil {
+		return "", fmt.Errorf("stamp launch identity for %s: %w", handle, expectationErr)
+	}
 	if !requiredAck {
 		expectation.NotRequiredReason = "external lead is already running in the adopted pane"
 	}
@@ -1125,7 +1132,7 @@ func preparedBootstrap(project, profile, session string, binding acceptedGoalBin
 		Session: session, CWD: runtimeCWD, Root: root,
 		TeamHome: project, TeamProfile: profile, SharedWorkstream: true,
 		External:             context.Topology.ExternalLead && member.Role == tm.Lead,
-		BootstrapExpectation: expectation,
+		BootstrapExpectation: &expectation,
 	}
 	if err := validateAcceptedGoalBinding(binding); err != nil {
 		return "", err

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -492,7 +492,22 @@ func runLeadRegisterWithPreparedToken(args []string, requestedPreparedToken prep
 			Target:     "external",
 		},
 	}
-	rec.BootstrapExpectation = &bootstrapack.Expectation{Required: false, NotRequiredReason: "external lead is already running in the adopted pane"}
+	// STAMP AT CAPTURE (#572). This built the Expectation as a struct literal and so
+	// produced an empty LaunchID, while every other launch-record site goes through
+	// bootstrapack.NewExpectation, which always generates one. A record with no launch id
+	// is refused later by observeManagedLiveActor and resolveManagedLiveIdentity with
+	// "managed launch record has no exact launch id", which is how an adopted external
+	// lead ended up unable to receive goal delivery.
+	//
+	// Required stays false: an already-running adopted pane genuinely owes no bootstrap
+	// acknowledgement. The launch id is identity, not an acknowledgement obligation, and
+	// the two are independent.
+	externalLeadExpectation, err := bootstrapack.NewExpectation(false, time.Now())
+	if err != nil {
+		return fmt.Errorf("stamp external lead launch identity: %w", err)
+	}
+	externalLeadExpectation.NotRequiredReason = "external lead is already running in the adopted pane"
+	rec.BootstrapExpectation = &externalLeadExpectation
 	if !requestedPreparedToken.empty() && !requestedPreparedToken.complete() {
 		return fmt.Errorf("lead register refused: prepared run token is incomplete")
 	}

--- a/internal/cli/team_member_control_continue.go
+++ b/internal/cli/team_member_control_continue.go
@@ -179,7 +179,7 @@ func resolveExactTmuxControlContinue(project, profile, session, role, expectedCl
 	verified, err := deps.Verify(project, profile, session, mr.Handle)
 	if err != nil || verified.Verified == nil {
 		if err == nil {
-			err = fmt.Errorf("authoritative resolver returned no verified identity")
+			err = fmt.Errorf("%w: authoritative resolver returned no verified identity", errIncompleteLaunchRecord)
 		}
 		// Sixth wrap site (#575 round 3). The sentinel arrives here and was relabelled a
 		// mismatch, defeating the classification at another operator-visible surface.

--- a/internal/cli/team_member_control_continue.go
+++ b/internal/cli/team_member_control_continue.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -179,6 +180,11 @@ func resolveExactTmuxControlContinue(project, profile, session, role, expectedCl
 	if err != nil || verified.Verified == nil {
 		if err == nil {
 			err = fmt.Errorf("authoritative resolver returned no verified identity")
+		}
+		// Sixth wrap site (#575 round 3). The sentinel arrives here and was relabelled a
+		// mismatch, defeating the classification at another operator-visible surface.
+		if errors.Is(err, errIncompleteLaunchRecord) {
+			return tmuxControlContinueTarget{}, fmt.Errorf("control-continue refused: launch identity could not be verified: %w", err)
 		}
 		return tmuxControlContinueTarget{}, fmt.Errorf("control-continue refused: verified live identity mismatch: %w", err)
 	}


### PR DESCRIPTION
Fixes #572. PR 1 of the approved three-PR decomposition; ships the predicate #571 consumes.

## Root cause

`bootstrapack.NewExpectation` **always** generates a `LaunchID`, including when `required` is
false. So `managed launch record has no exact launch id` can only mean the Expectation was
built as a struct **literal**, bypassing the constructor.

Two sites did that, and only one was reported:

| site | path | reported |
|---|---|---|
| `team_lead.go:495` | external-lead adoption | yes, the operator's run |
| `run_start_readiness.go:1118` | prepared-run readiness | **no** |

The second was found by the invariant test written for the first. Both now go through
`NewExpectation`.

`Required` stays false where it was false. A launch id is **identity**; a bootstrap
acknowledgement is an **obligation**. An adopted pane that owes no acknowledgement still has
an identity, and conflating the two is what produced the bug.

## The refusal now names its failure class

Both refusal sites in `live_identity.go` share one `incompleteLaunchRecordError()`: the record
is INCOMPLETE rather than mismatched, live identity cannot be verified either way, the remedy
is re-launch or repair, and explicitly **this is not an identity conflict**.

One helper so the two cannot drift.

That distinction is the deliverable, not the wording. #571 counts a worker launched only after
identity is **verified**, which is unimplementable against a predicate that cannot say *cannot
verify* — it would either refuse valid launches or count unverified ones.

## Tests

- **Invariant** (the class fix): walks non-test Go, fails on any `bootstrapack.Expectation`
  composite literal. Anti-vacuity floor of 50 files. The zero-value error return in
  `bootstrap.go` is exempted **by rule** (`Expectation{}, err` stamps nothing) rather than by
  path, so the test needs no maintenance.
- **Refusal class**: asserts the message names INCOMPLETE, cannot-be-verified, and
  not-an-identity-conflict.

Removal proofs, one variable each:

    revert team_lead stamp     -> invariant fails, naming team_lead.go:495
    revert readiness stamp     -> invariant fails, naming run_start_readiness.go:1118

## Not in this PR

#571 (paste-buffer atomic delivery + per-worker verified counting) and #573 (resume
reservation binding) are PRs 2 and 3 per the approved ordering. #571 depends on this
predicate; #573 shares the reservation surface but not the delivery path.
