### PR TITLE
feat: add managed AMQ notification watch (#454)

### DIFF
--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -57,11 +57,14 @@ scans arbitrary repositories and never executes an action; every mutation is
 confirmation-gated.
 
 For registered project runs, watcher state includes the managed AMQ backend,
-its exact operator mailbox binding, bounded restart count, and last
-watch/collect timestamps. `amq watch` is only a non-consuming wake signal; the
-scoped watcher then performs one root-correct safe collect and drives the
-existing attention notifier. Exhausted watch retries degrade visibly while the
-fsnotify/periodic-rescan path remains active. Use bounded
+its exact operator mailbox binding, running state, lifetime watch restart
+count, current failure streak, pending-collect state, collect retry count, and
+last watch/collect timestamps. `amq watch` is only a non-consuming wake signal;
+its JSON event is validated before the scoped watcher performs one root-correct
+safe collect and drives the existing attention notifier. Failed collects
+replay independently of later signals, including one safe replay pass at
+watcher startup. Exhausted watch retries render the backend not running and
+degraded while the fsnotify/periodic-rescan path remains active. Use bounded
 `amq-squad monitor --once` as the explicit manual fallback.
 
 Then drive each run by explicit namespace (`goal draft`/`goal start`,

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -56,6 +56,14 @@ readiness, source errors, and inspect/repair action objects. The command never
 scans arbitrary repositories and never executes an action; every mutation is
 confirmation-gated.
 
+For registered project runs, watcher state includes the managed AMQ backend,
+its exact operator mailbox binding, bounded restart count, and last
+watch/collect timestamps. `amq watch` is only a non-consuming wake signal; the
+scoped watcher then performs one root-correct safe collect and drives the
+existing attention notifier. Exhausted watch retries degrade visibly while the
+fsnotify/periodic-rescan path remains active. Use bounded
+`amq-squad monitor --once` as the explicit manual fallback.
+
 Then drive each run by explicit namespace (`goal draft`/`goal start`,
 `monitor --once`, `status`, `next`, `operator answer`). See the skill's
 multi-workstream board protocol.

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -15,6 +15,16 @@ inactive state. `status` and `doctor` expose watcher health without exposing
 command arguments, credentials, or other secrets. This add-on never answers a
 gate, clicks approval, or sends pane input.
 
+That same scoped owner runs the managed AMQ backend. It uses bounded
+`amq watch` only as a non-consuming signal for the canonical operator mailbox,
+then performs one kill-safe, exact-root collect before evaluating attention
+notifications. Watch output and doorbell text are never parsed as message
+content or authority. Duplicate signals that collect no unread message do not
+trigger another delivery scan. The watcher retries crashes with bounded
+backoff; after exhaustion, `status`/`doctor` report the backend and restart
+count as degraded while fsnotify plus periodic rescan remain active. Use a
+bounded `amq-squad monitor --once` when a manual backstop is needed.
+
 Delivery is **at least once**, not exactly once. The supervised watcher, a
 manual `operator watch`, and `notify --deliver` all coordinate through the same
 per-event/per-sink reservation and success-commit state in

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -18,12 +18,22 @@ gate, clicks approval, or sends pane input.
 That same scoped owner runs the managed AMQ backend. It uses bounded
 `amq watch` only as a non-consuming signal for the canonical operator mailbox,
 then performs one kill-safe, exact-root collect before evaluating attention
-notifications. Watch output and doorbell text are never parsed as message
-content or authority. Duplicate signals that collect no unread message do not
-trigger another delivery scan. The watcher retries crashes with bounded
-backoff; after exhaustion, `status`/`doctor` report the backend and restart
-count as degraded while fsnotify plus periodic rescan remain active. Use a
-bounded `amq-squad monitor --once` when a manual backstop is needed.
+notifications. The watch JSON is validated as an `existing` or `new_message`
+event with at least one message; malformed, truncated, empty, timeout, or
+unknown successful output is a visible backend failure and receives bounded
+backoff. Message fields and doorbell text remain untrusted data, never
+authority. A collect failure keeps its journal replay pending and retries it
+without waiting for another watch signal; each watcher generation also starts
+with one safe collect so a replay survives stop/crash and restart. Duplicate
+signals that collect no unread message do not trigger another delivery scan.
+
+Every watcher exit cancels and joins the owned AMQ child and any in-flight
+delivery within one nested shutdown budget before publishing a clean inactive
+lease. `status`/`doctor` expose backend-running state, lifetime watch restarts,
+the current failure streak, pending-collect state, and collect retry count
+separately. After bounded exhaustion the AMQ backend is explicitly not running
+and degraded while fsnotify plus periodic rescan remain active. Use a bounded
+`amq-squad monitor --once` when a manual backstop is needed.
 
 Delivery is **at least once**, not exactly once. The supervised watcher, a
 manual `operator watch`, and `notify --deliver` all coordinate through the same

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -20,10 +21,11 @@ import (
 )
 
 type amqCommandRequest struct {
-	Dir   string
-	Env   []string
-	Arg   []string
-	Stdin io.Reader // optional; nil means no stdin
+	Context context.Context
+	Dir     string
+	Env     []string
+	Arg     []string
+	Stdin   io.Reader // optional; nil means no stdin
 }
 
 type amqCommandRunner func(amqCommandRequest) ([]byte, error)
@@ -69,6 +71,9 @@ var appendAMQBoundaryAuditRecord = writeAMQBoundaryAuditRecord
 
 func defaultRunAMQCommand(req amqCommandRequest) ([]byte, error) {
 	cmd := exec.Command("amq", req.Arg...)
+	if req.Context != nil {
+		cmd = exec.CommandContext(req.Context, "amq", req.Arg...)
+	}
 	cmd.Env = amqexec.NoUpdateCheckEnv(req.Env)
 	cmd.Dir = req.Dir
 	cmd.Stdin = req.Stdin

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -172,6 +173,16 @@ func executeCollectWithWaitPosture(out io.Writer, ctx amqContext, timeout time.D
 }
 
 func executeCollectDrain(out io.Writer, ctx amqContext, includeBody bool) (bool, error) {
+	return executeCollectDrainContext(context.Background(), out, ctx, includeBody)
+}
+
+func executeCollectDrainContext(operation context.Context, out io.Writer, ctx amqContext, includeBody bool) (bool, error) {
+	if operation == nil {
+		operation = context.Background()
+	}
+	if err := operation.Err(); err != nil {
+		return false, err
+	}
 	journal := newCollectJournal(ctx)
 	unlock, err := lockCollectJournal(journal.Root)
 	if err != nil {
@@ -180,6 +191,9 @@ func executeCollectDrain(out io.Writer, ctx amqContext, includeBody bool) (bool,
 	defer unlock()
 
 	if err := journal.ensure(); err != nil {
+		return false, err
+	}
+	if err := operation.Err(); err != nil {
 		return false, err
 	}
 	now := collectNow()
@@ -197,7 +211,10 @@ func executeCollectDrain(out io.Writer, ctx amqContext, includeBody bool) (bool,
 		return false, nil
 	}
 	for _, entry := range entries {
-		if err := acknowledgeCollectEntry(ctx, entry); err != nil {
+		if err := operation.Err(); err != nil {
+			return true, err
+		}
+		if err := acknowledgeCollectEntryContext(operation, ctx, entry); err != nil {
 			return true, err
 		}
 	}
@@ -215,8 +232,12 @@ func executeCollectDrain(out io.Writer, ctx amqContext, includeBody bool) (bool,
 }
 
 func acknowledgeCollectEntry(ctx amqContext, entry collectJournalEntry) error {
+	return acknowledgeCollectEntryContext(context.Background(), ctx, entry)
+}
+
+func acknowledgeCollectEntryContext(operation context.Context, ctx amqContext, entry collectJournalEntry) error {
 	cmd := []string{"read", "--root", ctx.Root, "--me", ctx.Me, "--id", entry.ID}
-	out, err := runAMQCommand(amqCommandRequest{Dir: ctx.ProjectDir, Env: amqCommandEnv(ctx), Arg: cmd})
+	out, err := runAMQCommand(amqCommandRequest{Context: operation, Dir: ctx.ProjectDir, Env: amqCommandEnv(ctx), Arg: cmd})
 	if err != nil {
 		if isCollectAckRace(err, entry.ID) {
 			return nil

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -184,7 +184,7 @@ func executeCollectDrainContext(operation context.Context, out io.Writer, ctx am
 		return false, err
 	}
 	journal := newCollectJournal(ctx)
-	unlock, err := lockCollectJournal(journal.Root)
+	unlock, err := lockCollectJournalContext(operation, journal.Root)
 	if err != nil {
 		return false, err
 	}

--- a/internal/cli/collect_lock_exclusive.go
+++ b/internal/cli/collect_lock_exclusive.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	collectJournalExclusiveLockWait  = time.Second
+	collectJournalExclusiveLockRetry = 10 * time.Millisecond
+)
+
+// lockCollectJournalExclusiveContext implements the Windows collect lock with
+// an O_EXCL sentinel. Unlike a kernel-owned flock, that sentinel can survive a
+// killed collector, so even context.Background callers need a bounded wait.
+// The explicit maxWait argument keeps the stale-sentinel failure input fast and
+// deterministic in platform-independent tests.
+func lockCollectJournalExclusiveContext(ctx context.Context, root string, maxWait time.Duration) (func(), error) {
+	if err := os.MkdirAll(root, collectJournalDirectoryPerm); err != nil {
+		return nil, fmt.Errorf("ensure collect journal lock dir: %w", err)
+	}
+	path := filepath.Join(root, ".lock")
+	deadline := time.Now().Add(maxWait)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, collectJournalFilePerm)
+		if err == nil {
+			return func() {
+				_ = f.Close()
+				_ = os.Remove(path)
+			}, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("open collect journal lock: %w", err)
+		}
+		remaining := time.Until(deadline)
+		if maxWait <= 0 || remaining <= 0 {
+			return nil, fmt.Errorf("collect already running for this profile/session/recipient or stale lock persisted beyond %s: %s", maxWait, path)
+		}
+		delay := collectJournalExclusiveLockRetry
+		if remaining < delay {
+			delay = remaining
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/cli/collect_lock_exclusive_test.go
+++ b/internal/cli/collect_lock_exclusive_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLockCollectJournalExclusiveContextBoundsStaleSentinel(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".lock")
+	if err := os.WriteFile(path, []byte("orphaned collector"), collectJournalFilePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	started := time.Now()
+	unlock, err := lockCollectJournalExclusiveContext(context.Background(), root, 25*time.Millisecond)
+	elapsed := time.Since(started)
+	if unlock != nil {
+		unlock()
+		t.Fatal("stale sentinel unexpectedly acquired")
+	}
+	if err == nil || !strings.Contains(err.Error(), "collect already running") ||
+		!strings.Contains(err.Error(), "stale lock") || !strings.Contains(err.Error(), path) {
+		t.Fatalf("stale sentinel error = %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("stale sentinel wait was not bounded: %s", elapsed)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("stale sentinel must remain for explicit inspection: %v", statErr)
+	}
+}

--- a/internal/cli/collect_lock_unix.go
+++ b/internal/cli/collect_lock_unix.go
@@ -3,14 +3,16 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-func lockCollectJournal(root string) (func(), error) {
+func lockCollectJournalContext(ctx context.Context, root string) (func(), error) {
 	if err := os.MkdirAll(root, collectJournalDirectoryPerm); err != nil {
 		return nil, fmt.Errorf("ensure collect journal lock dir: %w", err)
 	}
@@ -19,9 +21,28 @@ func lockCollectJournal(root string) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("open collect journal lock: %w", err)
 	}
-	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("lock collect journal: %w", err)
+	for {
+		err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			break
+		}
+		if err != unix.EWOULDBLOCK && err != unix.EAGAIN {
+			_ = f.Close()
+			return nil, fmt.Errorf("lock collect journal: %w", err)
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			_ = f.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
 	}
 	return func() {
 		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)

--- a/internal/cli/collect_lock_windows.go
+++ b/internal/cli/collect_lock_windows.go
@@ -3,25 +3,40 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
-func lockCollectJournal(root string) (func(), error) {
+func lockCollectJournalContext(ctx context.Context, root string) (func(), error) {
 	if err := os.MkdirAll(root, collectJournalDirectoryPerm); err != nil {
 		return nil, fmt.Errorf("ensure collect journal lock dir: %w", err)
 	}
 	path := filepath.Join(root, ".lock")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, collectJournalFilePerm)
-	if err != nil {
-		if os.IsExist(err) {
-			return nil, fmt.Errorf("collect already running for this profile/session/recipient: %s", path)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, collectJournalFilePerm)
+		if err == nil {
+			return func() {
+				_ = f.Close()
+				_ = os.Remove(path)
+			}, nil
 		}
-		return nil, fmt.Errorf("open collect journal lock: %w", err)
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("open collect journal lock: %w", err)
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
 	}
-	return func() {
-		_ = f.Close()
-		_ = os.Remove(path)
-	}, nil
 }

--- a/internal/cli/collect_lock_windows.go
+++ b/internal/cli/collect_lock_windows.go
@@ -2,41 +2,8 @@
 
 package cli
 
-import (
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"time"
-)
+import "context"
 
 func lockCollectJournalContext(ctx context.Context, root string) (func(), error) {
-	if err := os.MkdirAll(root, collectJournalDirectoryPerm); err != nil {
-		return nil, fmt.Errorf("ensure collect journal lock dir: %w", err)
-	}
-	path := filepath.Join(root, ".lock")
-	for {
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, collectJournalFilePerm)
-		if err == nil {
-			return func() {
-				_ = f.Close()
-				_ = os.Remove(path)
-			}, nil
-		}
-		if !os.IsExist(err) {
-			return nil, fmt.Errorf("open collect journal lock: %w", err)
-		}
-		timer := time.NewTimer(10 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			return nil, ctx.Err()
-		case <-timer.C:
-		}
-	}
+	return lockCollectJournalExclusiveContext(ctx, root, collectJournalExclusiveLockWait)
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -913,15 +913,15 @@ func doctorCheckNotificationWatcher(d doctorExecution, workstream string) doctor
 		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("inactive (session cleanly stopped); runtime %s", watcher.RuntimePath)}
 	}
 	if watcher.Health == "external-active" {
-		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("active on remote watcher host %s; backend=%s mailbox=%s heartbeat=%s runtime=%s", watcher.Host, watcher.WatchBackend, watcher.WatchMailbox, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.RuntimePath)}
+		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("active on remote watcher host %s; backend=%s backend_running=%t mailbox=%s heartbeat=%s runtime=%s", watcher.Host, watcher.WatchBackend, watcher.WatchRunning, watcher.WatchMailbox, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.RuntimePath)}
 	}
 	if watcher.Health == "degraded" {
-		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("DEGRADED: notifications watcher active; backend=%s mailbox=%s restarts=%d/%d; %s (runtime %s)", watcher.WatchBackend, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchMaxRetries, watcher.Reason, watcher.RuntimePath)}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("DEGRADED: notifications watcher active; backend=%s backend_running=%t mailbox=%s watch_restarts=%d failure_streak=%d collect_pending=%t collect_retries=%d max_failures=%d; %s (runtime %s)", watcher.WatchBackend, watcher.WatchRunning, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchFailures, watcher.CollectPending, watcher.CollectRetries, watcher.WatchMaxRetries, watcher.Reason, watcher.RuntimePath)}
 	}
 	if watcher.Health != "healthy" {
 		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("UNHEALTHY: notifications_enabled=true; %s (runtime %s)", watcher.Reason, watcher.RuntimePath)}
 	}
-	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("healthy pid=%d host=%s backend=%s mailbox=%s restarts=%d/%d heartbeat=%s last_scan=%s last_watch=%s last_collect=%s state=%s schema=%d", watcher.PID, watcher.Host, watcher.WatchBackend, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchMaxRetries, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.LastScanAt.UTC().Format(time.RFC3339), watcher.LastWatchAt.UTC().Format(time.RFC3339), watcher.LastCollectAt.UTC().Format(time.RFC3339), watcher.StatePath, watcher.SchemaVersion)}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("healthy pid=%d host=%s backend=%s backend_running=%t mailbox=%s watch_restarts=%d failure_streak=%d collect_pending=%t collect_retries=%d max_failures=%d heartbeat=%s last_scan=%s last_watch=%s last_collect=%s state=%s schema=%d", watcher.PID, watcher.Host, watcher.WatchBackend, watcher.WatchRunning, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchFailures, watcher.CollectPending, watcher.CollectRetries, watcher.WatchMaxRetries, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.LastScanAt.UTC().Format(time.RFC3339), watcher.LastWatchAt.UTC().Format(time.RFC3339), watcher.LastCollectAt.UTC().Format(time.RFC3339), watcher.StatePath, watcher.SchemaVersion)}
 }
 
 func doctorCheckBootstrap(d doctorExecution) []doctorCheck {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -913,15 +913,15 @@ func doctorCheckNotificationWatcher(d doctorExecution, workstream string) doctor
 		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("inactive (session cleanly stopped); runtime %s", watcher.RuntimePath)}
 	}
 	if watcher.Health == "external-active" {
-		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("active on remote watcher host %s; heartbeat=%s runtime=%s", watcher.Host, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.RuntimePath)}
+		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("active on remote watcher host %s; backend=%s mailbox=%s heartbeat=%s runtime=%s", watcher.Host, watcher.WatchBackend, watcher.WatchMailbox, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.RuntimePath)}
 	}
 	if watcher.Health == "degraded" {
-		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("DEGRADED: notifications watcher active; %s (runtime %s)", watcher.Reason, watcher.RuntimePath)}
+		return doctorCheck{Name: name, Status: doctorWarn, Detail: fmt.Sprintf("DEGRADED: notifications watcher active; backend=%s mailbox=%s restarts=%d/%d; %s (runtime %s)", watcher.WatchBackend, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchMaxRetries, watcher.Reason, watcher.RuntimePath)}
 	}
 	if watcher.Health != "healthy" {
 		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("UNHEALTHY: notifications_enabled=true; %s (runtime %s)", watcher.Reason, watcher.RuntimePath)}
 	}
-	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("healthy pid=%d host=%s heartbeat=%s last_scan=%s state=%s schema=%d", watcher.PID, watcher.Host, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.LastScanAt.UTC().Format(time.RFC3339), watcher.StatePath, watcher.SchemaVersion)}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("healthy pid=%d host=%s backend=%s mailbox=%s restarts=%d/%d heartbeat=%s last_scan=%s last_watch=%s last_collect=%s state=%s schema=%d", watcher.PID, watcher.Host, watcher.WatchBackend, watcher.WatchMailbox, watcher.WatchRestarts, watcher.WatchMaxRetries, watcher.HeartbeatAt.UTC().Format(time.RFC3339), watcher.LastScanAt.UTC().Format(time.RFC3339), watcher.LastWatchAt.UTC().Format(time.RFC3339), watcher.LastCollectAt.UTC().Format(time.RFC3339), watcher.StatePath, watcher.SchemaVersion)}
 }
 
 func doctorCheckBootstrap(d doctorExecution) []doctorCheck {

--- a/internal/cli/global_noc.go
+++ b/internal/cli/global_noc.go
@@ -311,10 +311,16 @@ func validateGlobalNOCRegistry(registry globalNOCRegistry, expectedRoot string) 
 			return fmt.Errorf("NOC launch generation %d remained active after replacement", wantGeneration)
 		}
 	}
+	seenRunIDs := make(map[string]struct{}, len(registry.Runs))
 	for _, item := range registry.Runs {
-		if strings.TrimSpace(item.ID) == "" || item.NOCGeneration == 0 || item.NOCGeneration > registry.CurrentGeneration {
+		runID := strings.TrimSpace(item.ID)
+		if runID == "" || runID != item.ID || item.NOCGeneration == 0 || item.NOCGeneration > registry.CurrentGeneration {
 			return fmt.Errorf("NOC run registration identity is invalid")
 		}
+		if _, exists := seenRunIDs[runID]; exists {
+			return fmt.Errorf("duplicate run registrations share ID %q", runID)
+		}
+		seenRunIDs[runID] = struct{}{}
 		if registry.Launches[item.NOCGeneration-1].ID != item.NOCLaunchID {
 			return fmt.Errorf("NOC run registration launch binding mismatch")
 		}

--- a/internal/cli/global_noc_test.go
+++ b/internal/cli/global_noc_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -185,6 +186,47 @@ func TestGlobalNOCRegistrySupersedesGenerationAndTracksPollingRun(t *testing.T) 
 	}
 	if len(registry.Runs) != 1 || registry.Runs[0].State != globalNOCRunPollRequired || registry.Runs[0].NOCLaunchID != second.ID {
 		t.Fatalf("run registrations = %+v", registry.Runs)
+	}
+}
+
+func TestWriteGlobalNOCRegistryRejectsDuplicateRunIDsWithoutChangingBytes(t *testing.T) {
+	for _, position := range []string{"prepend", "append"} {
+		t.Run(position, func(t *testing.T) {
+			root := t.TempDir()
+			launchRecord := installActiveGlobalNOC(t, root)
+			now := launchRecord.UpdatedAt.Add(time.Second)
+			context := &globalNOCContext{ControlRoot: root, Launch: launchRecord}
+			run, err := beginGlobalNOCRun(context, filepath.Join(root, "project"), "release", "v2", "cto", "registered_noc_default", now)
+			if err != nil {
+				t.Fatalf("begin NOC run: %v", err)
+			}
+			registryPath := filepath.Join(root, ".amq-squad", globalNOCRegistryDir, globalNOCRegistryFile)
+			before, err := os.ReadFile(registryPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = writeGlobalNOCRegistry(root, func(registry *globalNOCRegistry) error {
+				duplicate := registry.Runs[0]
+				duplicate.Detail = "forged duplicate"
+				duplicate.UpdatedAt = duplicate.UpdatedAt.Add(time.Second)
+				if position == "prepend" {
+					registry.Runs = append([]globalNOCRun{duplicate}, registry.Runs...)
+				} else {
+					registry.Runs = append(registry.Runs, duplicate)
+				}
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "duplicate run registrations") || !strings.Contains(err.Error(), run.ID) {
+				t.Fatalf("duplicate write error = %v", err)
+			}
+			after, readErr := os.ReadFile(registryPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatal("duplicate-ID rejection changed registry bytes")
+			}
+		})
 	}
 }
 

--- a/internal/cli/notification_amq_watch.go
+++ b/internal/cli/notification_amq_watch.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/amqexec"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+type notificationAMQWatchFunc func(context.Context, amqContext, time.Duration) (bool, error)
+type notificationAMQCollectFunc func(context.Context, amqContext) (bool, error)
+
+var errNotificationAMQOwnershipLost = errors.New("notification watcher managed AMQ ownership lost")
+
+type notificationAMQWatchResult struct {
+	At               time.Time
+	Signaled         bool
+	CollectAttempted bool
+	Collected        bool
+	Failures         int
+	Exhausted        bool
+	Fatal            bool
+	Err              error
+}
+
+func notificationAMQWatchSettings(w notificationWatcherExecution) (time.Duration, int, time.Duration, time.Duration) {
+	timeout := w.AMQWatchTimeout
+	if timeout <= 0 {
+		timeout = defaultNotificationAMQWatchTimeout
+	}
+	maxRetries := w.AMQWatchMaxRetries
+	if maxRetries <= 0 {
+		maxRetries = defaultNotificationAMQWatchRetries
+	}
+	backoff := w.AMQWatchBackoff
+	if backoff <= 0 {
+		backoff = defaultNotificationAMQWatchBackoff
+	}
+	maxBackoff := w.AMQWatchMaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = maxNotificationAMQWatchBackoff
+	}
+	if maxBackoff < backoff {
+		maxBackoff = backoff
+	}
+	return timeout, maxRetries, backoff, maxBackoff
+}
+
+func notificationAMQContext(w notificationWatcherExecution, profile, mailbox string) amqContext {
+	root := filepath.Clean(filepath.Join(w.BaseRoot, w.Session))
+	return amqContext{
+		ProjectDir: w.ProjectDir,
+		Profile:    squadnamespace.NormalizeProfile(profile),
+		Env: amqEnv{
+			Root:        root,
+			BaseRoot:    filepath.Clean(w.BaseRoot),
+			SessionName: w.Session,
+			Me:          mailbox,
+			Project:     w.ProjectDir,
+		},
+		Root:    root,
+		Me:      strings.TrimSpace(mailbox),
+		Session: w.Session,
+		PinMode: amqPinExactRoot,
+	}
+}
+
+func validateNotificationAMQContext(ctx amqContext, w notificationWatcherExecution, profile, mailbox string) error {
+	wantRoot := filepath.Clean(filepath.Join(w.BaseRoot, w.Session))
+	if !filepath.IsAbs(wantRoot) ||
+		ctx.PinMode != amqPinExactRoot ||
+		filepath.Clean(ctx.ProjectDir) != filepath.Clean(w.ProjectDir) ||
+		ctx.Profile != squadnamespace.NormalizeProfile(profile) ||
+		ctx.Session != w.Session ||
+		filepath.Clean(ctx.Root) != wantRoot ||
+		filepath.Clean(ctx.Env.Root) != wantRoot ||
+		strings.TrimSpace(ctx.Me) == "" ||
+		ctx.Me != strings.TrimSpace(mailbox) {
+		return fmt.Errorf("notification watcher managed AMQ context does not match exact project/profile/session/operator mailbox binding")
+	}
+	return nil
+}
+
+func runNotificationAMQWatch(ctx context.Context, amqCtx amqContext, timeout time.Duration) (bool, error) {
+	if _, err := os.Stat(amqCtx.Root); err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("managed AMQ watch root: %w", err)
+		}
+		delay := timeout
+		if delay > 500*time.Millisecond {
+			delay = 500 * time.Millisecond
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+			return false, nil
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return false, ctx.Err()
+		}
+	}
+	args := []string{"watch", "--root", amqCtx.Root, "--me", amqCtx.Me, "--timeout", timeout.String(), "--json"}
+	cmd := exec.CommandContext(ctx, "amq", args...)
+	cmd.Dir = amqCtx.ProjectDir
+	cmd.Env = amqexec.NoUpdateCheckEnv(amqCommandEnv(amqCtx))
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if err != nil {
+		if isCollectWatchTimeout(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("managed AMQ watch: %w", err)
+	}
+	return true, nil
+}
+
+func collectNotificationAMQ(ctx context.Context, amqCtx amqContext) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	collected, err := executeCollectDrainContext(ctx, io.Discard, amqCtx, false)
+	if err != nil {
+		return collected, fmt.Errorf("managed AMQ collect: %w", err)
+	}
+	return collected, nil
+}
+
+func runManagedNotificationAMQWatch(
+	ctx context.Context,
+	amqCtx amqContext,
+	timeout time.Duration,
+	maxRetries int,
+	initialBackoff time.Duration,
+	maxBackoff time.Duration,
+	watch notificationAMQWatchFunc,
+	collect notificationAMQCollectFunc,
+	results chan<- notificationAMQWatchResult,
+) {
+	defer close(results)
+	failures := 0
+	backoff := initialBackoff
+	emit := func(result notificationAMQWatchResult) bool {
+		select {
+		case results <- result:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	for {
+		signaled, err := watch(ctx, amqCtx, timeout)
+		if ctx.Err() != nil {
+			return
+		}
+		result := notificationAMQWatchResult{At: time.Now().UTC(), Signaled: signaled}
+		if err == nil && signaled {
+			result.CollectAttempted = true
+			result.Collected, err = collect(ctx, amqCtx)
+			if ctx.Err() != nil {
+				return
+			}
+		}
+		if err == nil {
+			recovered := failures > 0
+			failures = 0
+			backoff = initialBackoff
+			if signaled || recovered {
+				if !emit(result) {
+					return
+				}
+			}
+			continue
+		}
+		failures++
+		result.Failures = failures
+		result.Fatal = errors.Is(err, errNotificationAMQOwnershipLost)
+		result.Exhausted = result.Fatal || failures >= maxRetries
+		result.Err = err
+		if !emit(result) || result.Exhausted {
+			return
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}

--- a/internal/cli/notification_amq_watch.go
+++ b/internal/cli/notification_amq_watch.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -25,10 +27,23 @@ type notificationAMQWatchResult struct {
 	Signaled         bool
 	CollectAttempted bool
 	Collected        bool
-	Failures         int
+	PendingCollect   bool
+	FailureStreak    int
+	WatchRestarts    int
+	CollectRetries   int
+	RetryStarted     bool
 	Exhausted        bool
 	Fatal            bool
 	Err              error
+}
+
+type notificationAMQWatchOutput struct {
+	Event    string                        `json:"event"`
+	Messages []notificationAMQWatchMessage `json:"messages,omitempty"`
+}
+
+type notificationAMQWatchMessage struct {
+	ID string `json:"id"`
 }
 
 func notificationAMQWatchSettings(w notificationWatcherExecution) (time.Duration, int, time.Duration, time.Duration) {
@@ -116,7 +131,8 @@ func runNotificationAMQWatch(ctx context.Context, amqCtx amqContext, timeout tim
 	cmd := exec.CommandContext(ctx, "amq", args...)
 	cmd.Dir = amqCtx.ProjectDir
 	cmd.Env = amqexec.NoUpdateCheckEnv(amqCommandEnv(amqCtx))
-	cmd.Stdout = io.Discard
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = io.Discard
 	err := cmd.Run()
 	if ctx.Err() != nil {
@@ -128,7 +144,36 @@ func runNotificationAMQWatch(ctx context.Context, amqCtx amqContext, timeout tim
 		}
 		return false, fmt.Errorf("managed AMQ watch: %w", err)
 	}
-	return true, nil
+	signaled, err := parseNotificationAMQWatchOutput(stdout.Bytes())
+	if err != nil {
+		return false, fmt.Errorf("managed AMQ watch output: %w", err)
+	}
+	return signaled, nil
+}
+
+func parseNotificationAMQWatchOutput(data []byte) (bool, error) {
+	var result notificationAMQWatchOutput
+	if err := json.Unmarshal(data, &result); err != nil {
+		return false, fmt.Errorf("parse JSON: %w", err)
+	}
+	switch result.Event {
+	case "existing", "new_message":
+		if len(result.Messages) == 0 {
+			return false, fmt.Errorf("event %q contained no messages", result.Event)
+		}
+		for i, message := range result.Messages {
+			if strings.TrimSpace(message.ID) == "" {
+				return false, fmt.Errorf("event %q message %d is missing id", result.Event, i)
+			}
+		}
+		return true, nil
+	case "timeout":
+		return false, fmt.Errorf("unexpected successful timeout event")
+	case "":
+		return false, fmt.Errorf("missing event")
+	default:
+		return false, fmt.Errorf("unsupported event %q", result.Event)
+	}
 }
 
 func collectNotificationAMQ(ctx context.Context, amqCtx amqContext) (bool, error) {
@@ -145,6 +190,7 @@ func collectNotificationAMQ(ctx context.Context, amqCtx amqContext) (bool, error
 func runManagedNotificationAMQWatch(
 	ctx context.Context,
 	amqCtx amqContext,
+	collectFirst bool,
 	timeout time.Duration,
 	maxRetries int,
 	initialBackoff time.Duration,
@@ -154,7 +200,10 @@ func runManagedNotificationAMQWatch(
 	results chan<- notificationAMQWatchResult,
 ) {
 	defer close(results)
-	failures := 0
+	failureStreak := 0
+	watchRestarts := 0
+	collectRetries := 0
+	pendingCollect := collectFirst
 	backoff := initialBackoff
 	emit := func(result notificationAMQWatchResult) bool {
 		select {
@@ -165,33 +214,53 @@ func runManagedNotificationAMQWatch(
 		}
 	}
 	for {
-		signaled, err := watch(ctx, amqCtx, timeout)
+		result := notificationAMQWatchResult{
+			At:             time.Now().UTC(),
+			PendingCollect: pendingCollect,
+			WatchRestarts:  watchRestarts,
+			CollectRetries: collectRetries,
+		}
+		var err error
+		if pendingCollect {
+			result.CollectAttempted = true
+			result.Collected, err = collect(ctx, amqCtx)
+		} else {
+			result.Signaled, err = watch(ctx, amqCtx, timeout)
+			if err == nil && result.Signaled {
+				pendingCollect = true
+				result.PendingCollect = true
+				result.CollectAttempted = true
+				result.Collected, err = collect(ctx, amqCtx)
+			}
+		}
 		if ctx.Err() != nil {
 			return
 		}
-		result := notificationAMQWatchResult{At: time.Now().UTC(), Signaled: signaled}
-		if err == nil && signaled {
-			result.CollectAttempted = true
-			result.Collected, err = collect(ctx, amqCtx)
-			if ctx.Err() != nil {
-				return
-			}
-		}
 		if err == nil {
-			recovered := failures > 0
-			failures = 0
+			if result.CollectAttempted {
+				pendingCollect = false
+			}
+			recovered := failureStreak > 0
+			failureStreak = 0
 			backoff = initialBackoff
-			if signaled || recovered {
+			result.PendingCollect = pendingCollect
+			result.FailureStreak = 0
+			result.WatchRestarts = watchRestarts
+			result.CollectRetries = collectRetries
+			if result.Signaled || result.CollectAttempted || recovered {
 				if !emit(result) {
 					return
 				}
 			}
 			continue
 		}
-		failures++
-		result.Failures = failures
+		failureStreak++
+		result.FailureStreak = failureStreak
+		result.PendingCollect = pendingCollect
 		result.Fatal = errors.Is(err, errNotificationAMQOwnershipLost)
-		result.Exhausted = result.Fatal || failures >= maxRetries
+		result.Exhausted = result.Fatal || failureStreak >= maxRetries
+		result.WatchRestarts = watchRestarts
+		result.CollectRetries = collectRetries
 		result.Err = err
 		if !emit(result) || result.Exhausted {
 			return
@@ -206,6 +275,22 @@ func runManagedNotificationAMQWatch(
 				default:
 				}
 			}
+			return
+		}
+		if result.CollectAttempted {
+			collectRetries++
+		} else {
+			watchRestarts++
+		}
+		if !emit(notificationAMQWatchResult{
+			At:             time.Now().UTC(),
+			PendingCollect: pendingCollect,
+			FailureStreak:  failureStreak,
+			WatchRestarts:  watchRestarts,
+			CollectRetries: collectRetries,
+			RetryStarted:   true,
+			Err:            err,
+		}) {
 			return
 		}
 		if backoff < maxBackoff {

--- a/internal/cli/notification_amq_watch_test.go
+++ b/internal/cli/notification_amq_watch_test.go
@@ -6,14 +6,26 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
+
+const notificationAMQRealChildEnv = "AMQ_SQUAD_NOTIFICATION_WATCH_REAL_CHILD"
+
+func TestNotificationAMQWatchRealChildHelper(t *testing.T) {
+	if os.Getenv(notificationAMQRealChildEnv) != "1" {
+		return
+	}
+	time.Sleep(time.Hour)
+}
 
 func TestManagedNotificationAMQWatchCollectsExactMailboxOncePerSignal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -49,7 +61,7 @@ func TestManagedNotificationAMQWatchCollectsExactMailboxOncePerSignal(t *testing
 		return true, nil
 	}
 	results := make(chan notificationAMQWatchResult, 1)
-	go runManagedNotificationAMQWatch(ctx, amqCtx, 20*time.Millisecond, 3, time.Millisecond, 2*time.Millisecond, watch, collect, results)
+	go runManagedNotificationAMQWatch(ctx, amqCtx, false, 20*time.Millisecond, 3, time.Millisecond, 2*time.Millisecond, watch, collect, results)
 	result := <-results
 	if !result.Signaled || !result.CollectAttempted || !result.Collected || result.Err != nil {
 		t.Fatalf("result = %+v", result)
@@ -68,6 +80,111 @@ func TestManagedNotificationAMQWatchCollectsExactMailboxOncePerSignal(t *testing
 	}
 }
 
+func TestManagedNotificationAMQWatchReplaysCollectBeforeFirstSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	results := make(chan notificationAMQWatchResult, 1)
+	var watches atomic.Int32
+	var collects atomic.Int32
+	go runManagedNotificationAMQWatch(
+		ctx,
+		amqContext{},
+		true,
+		time.Hour,
+		3,
+		time.Millisecond,
+		time.Millisecond,
+		func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+			watches.Add(1)
+			<-ctx.Done()
+			return false, ctx.Err()
+		},
+		func(context.Context, amqContext) (bool, error) {
+			collects.Add(1)
+			return true, nil
+		},
+		results,
+	)
+	result := <-results
+	if result.Signaled || !result.CollectAttempted || !result.Collected ||
+		result.PendingCollect || result.Err != nil || collects.Load() != 1 {
+		t.Fatalf("startup collect replay = %+v collects=%d", result, collects.Load())
+	}
+	cancel()
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("unexpected result after startup replay cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("startup replay watch did not stop; watches=%d", watches.Load())
+	}
+}
+
+func TestManagedNotificationAMQWatchRetriesPendingCollectWithoutAnotherSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := make(chan notificationAMQWatchResult, 3)
+	var watches atomic.Int32
+	var collects atomic.Int32
+	retryStarted := make(chan struct{})
+	allowRetry := make(chan struct{})
+	go runManagedNotificationAMQWatch(
+		ctx,
+		amqContext{},
+		false,
+		time.Second,
+		3,
+		time.Millisecond,
+		time.Millisecond,
+		func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+			if watches.Add(1) == 1 {
+				return true, nil
+			}
+			<-ctx.Done()
+			return false, ctx.Err()
+		},
+		func(context.Context, amqContext) (bool, error) {
+			if collects.Add(1) == 1 {
+				return true, errors.New("journal completion failed")
+			}
+			close(retryStarted)
+			<-allowRetry
+			return true, nil
+		},
+		results,
+	)
+	failed := <-results
+	retryState := <-results
+	<-retryStarted
+	if watches.Load() != 1 {
+		t.Fatalf("pending collect waited for another watch signal: watches=%d", watches.Load())
+	}
+	close(allowRetry)
+	recovered := <-results
+	if failed.Err == nil || !failed.PendingCollect || failed.CollectRetries != 0 ||
+		failed.WatchRestarts != 0 {
+		t.Fatalf("failed pending collect = %+v watches=%d", failed, watches.Load())
+	}
+	if !retryState.RetryStarted || !retryState.PendingCollect ||
+		retryState.CollectRetries != 1 || retryState.WatchRestarts != 0 ||
+		retryState.FailureStreak != 1 || retryState.Err == nil {
+		t.Fatalf("pending collect retry state = %+v", retryState)
+	}
+	if recovered.Err != nil || recovered.PendingCollect || !recovered.CollectAttempted ||
+		!recovered.Collected || recovered.CollectRetries != 1 || collects.Load() != 2 {
+		t.Fatalf("recovered pending collect = %+v watches=%d collects=%d", recovered, watches.Load(), collects.Load())
+	}
+	cancel()
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("unexpected result after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("managed watch did not stop after pending collect recovery")
+	}
+}
+
 func TestManagedNotificationAMQWatchBoundsCrashRestarts(t *testing.T) {
 	results := make(chan notificationAMQWatchResult, 1)
 	var calls atomic.Int32
@@ -75,6 +192,7 @@ func TestManagedNotificationAMQWatchBoundsCrashRestarts(t *testing.T) {
 	go runManagedNotificationAMQWatch(
 		context.Background(),
 		amqContext{},
+		false,
 		time.Millisecond,
 		3,
 		time.Millisecond,
@@ -91,8 +209,17 @@ func TestManagedNotificationAMQWatchBoundsCrashRestarts(t *testing.T) {
 	)
 	for want := 1; want <= 3; want++ {
 		result := <-results
-		if result.Failures != want || result.Exhausted != (want == 3) || !strings.Contains(result.Err.Error(), "watch crashed") {
+		wantRestarts := want - 1
+		if result.FailureStreak != want || result.WatchRestarts != wantRestarts ||
+			result.Exhausted != (want == 3) || !strings.Contains(result.Err.Error(), "watch crashed") {
 			t.Fatalf("attempt %d result = %+v", want, result)
+		}
+		if want < 3 {
+			retry := <-results
+			if !retry.RetryStarted || retry.WatchRestarts != want ||
+				retry.FailureStreak != want || retry.Err == nil {
+				t.Fatalf("attempt %d retry = %+v", want, retry)
+			}
 		}
 	}
 	if _, ok := <-results; ok {
@@ -114,6 +241,7 @@ func TestManagedNotificationAMQWatchRecoveryResetsFailureCount(t *testing.T) {
 	go runManagedNotificationAMQWatch(
 		ctx,
 		amqContext{},
+		false,
 		time.Millisecond,
 		3,
 		time.Millisecond,
@@ -133,11 +261,15 @@ func TestManagedNotificationAMQWatchRecoveryResetsFailureCount(t *testing.T) {
 		results,
 	)
 	failed := <-results
+	retry := <-results
 	recovered := <-results
-	if failed.Failures != 1 || failed.Err == nil {
+	if failed.FailureStreak != 1 || failed.WatchRestarts != 0 || failed.Err == nil {
 		t.Fatalf("failure result = %+v", failed)
 	}
-	if recovered.Err != nil || recovered.Failures != 0 || recovered.Signaled {
+	if !retry.RetryStarted || retry.FailureStreak != 1 || retry.WatchRestarts != 1 || retry.Err == nil {
+		t.Fatalf("retry result = %+v", retry)
+	}
+	if recovered.Err != nil || recovered.FailureStreak != 0 || recovered.WatchRestarts != 1 || recovered.Signaled {
 		t.Fatalf("recovery result = %+v", recovered)
 	}
 	cancel()
@@ -149,6 +281,7 @@ func TestManagedNotificationAMQWatchOwnershipLossIsFatalWithoutRetry(t *testing.
 	go runManagedNotificationAMQWatch(
 		context.Background(),
 		amqContext{},
+		false,
 		time.Second,
 		5,
 		time.Millisecond,
@@ -161,7 +294,7 @@ func TestManagedNotificationAMQWatchOwnershipLossIsFatalWithoutRetry(t *testing.
 		results,
 	)
 	result := <-results
-	if !result.Fatal || !result.Exhausted || result.Failures != 1 ||
+	if !result.Fatal || !result.Exhausted || result.FailureStreak != 1 || result.WatchRestarts != 0 ||
 		!errors.Is(result.Err, errNotificationAMQOwnershipLost) {
 		t.Fatalf("ownership-loss result = %+v", result)
 	}
@@ -180,6 +313,7 @@ func TestManagedNotificationAMQWatchStopCancelsBlockedWatch(t *testing.T) {
 	go runManagedNotificationAMQWatch(
 		ctx,
 		amqContext{},
+		false,
 		time.Hour,
 		3,
 		time.Millisecond,
@@ -202,6 +336,159 @@ func TestManagedNotificationAMQWatchStopCancelsBlockedWatch(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("blocked managed watch did not stop")
 	}
+}
+
+func TestNotificationWatcherReapsRealAMQChildOnEveryExitClass(t *testing.T) {
+	for _, exitClass := range []string{"signal", "policy_disabled", "ownership_lost"} {
+		t.Run(exitClass, func(t *testing.T) {
+			project, _, base := notificationWatcherTeam(t, team.DefaultProfile, "s")
+			stop := make(chan os.Signal, 1)
+			done := make(chan error, 1)
+			childStarted := make(chan int, 1)
+			childWaited := make(chan error, 1)
+			token := "real-child-" + exitClass
+			go func() {
+				done <- executeNotificationWatcher(notificationWatcherExecution{
+					ProjectDir: project, Profile: team.DefaultProfile, Session: "s", BaseRoot: base, Token: token,
+					TTL: time.Second, Heartbeat: 20 * time.Millisecond, Rescan: 20 * time.Millisecond,
+					Stop: stop,
+					WatchAMQ: func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+						cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestNotificationAMQWatchRealChildHelper$")
+						cmd.Env = append(os.Environ(), notificationAMQRealChildEnv+"=1")
+						if err := cmd.Start(); err != nil {
+							return false, err
+						}
+						childStarted <- cmd.Process.Pid
+						err := cmd.Wait()
+						childWaited <- err
+						if ctx.Err() != nil {
+							return false, ctx.Err()
+						}
+						return false, err
+					},
+					CollectAMQ: func(context.Context, amqContext) (bool, error) {
+						return false, nil
+					},
+					AMQWatchTimeout: time.Hour, AMQWatchMaxRetries: 3,
+					Deliver: func(context.Context, time.Time) (notifyDeliverySummary, error) {
+						return notifyDeliverySummary{}, nil
+					},
+				})
+			}()
+			var childPID int
+			select {
+			case childPID = <-childStarted:
+			case <-time.After(time.Second):
+				t.Fatal("real AMQ child did not start")
+			}
+			path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
+			rec := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
+				return r.OwnerToken == token && r.Health == "healthy" && !r.LastScanAt.IsZero()
+			})
+			switch exitClass {
+			case "signal":
+				stop <- os.Interrupt
+			case "policy_disabled":
+				current, err := team.ReadProfile(project, team.DefaultProfile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				current.Operator.Notifications.Enabled = false
+				if err := team.WriteProfile(project, team.DefaultProfile, current); err != nil {
+					t.Fatal(err)
+				}
+			case "ownership_lost":
+				if err := releaseNotificationWatcherLease(path, &rec, token, time.Now()); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var watcherErr error
+			select {
+			case watcherErr = <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s exit did not join the real AMQ child", exitClass)
+			}
+			if exitClass == "ownership_lost" {
+				if watcherErr == nil || !strings.Contains(watcherErr.Error(), "lease lost") {
+					t.Fatalf("ownership loss error = %v", watcherErr)
+				}
+			} else if watcherErr != nil {
+				t.Fatalf("%s exit error = %v", exitClass, watcherErr)
+			}
+			select {
+			case <-childWaited:
+			case <-time.After(250 * time.Millisecond):
+				t.Fatalf("%s exit returned before reaping child pid %d", exitClass, childPID)
+			}
+			if procinfo.Alive(childPID) {
+				t.Fatalf("%s exit left real AMQ child pid %d alive", exitClass, childPID)
+			}
+			if exitClass != "ownership_lost" {
+				assertInactiveWatcherTombstone(t, path)
+			}
+		})
+	}
+}
+
+func TestNotificationWatcherStopCancelsRealCollectWaitingOnJournalLock(t *testing.T) {
+	project, _, base := notificationWatcherTeam(t, team.DefaultProfile, "s")
+	execution := notificationWatcherExecution{
+		ProjectDir: project, Profile: team.DefaultProfile, Session: "s", BaseRoot: base,
+	}
+	amqCtx := notificationAMQContext(execution, team.DefaultProfile, "user")
+	journal := newCollectJournal(amqCtx)
+	if err := os.MkdirAll(journal.Root, collectJournalDirectoryPerm); err != nil {
+		t.Fatal(err)
+	}
+	held, err := flock.AcquireExclusive(filepath.Join(journal.Root, ".lock"))
+	if errors.Is(err, flock.ErrUnsupported) {
+		t.Skip("platform does not provide required advisory locks")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+
+	stop := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	collectStarted := make(chan struct{})
+	go func() {
+		done <- executeNotificationWatcher(notificationWatcherExecution{
+			ProjectDir: project, Profile: team.DefaultProfile, Session: "s", BaseRoot: base, Token: "real-collect-stop",
+			TTL: time.Second, Heartbeat: 20 * time.Millisecond, Rescan: time.Hour,
+			Stop: stop,
+			WatchAMQ: func(context.Context, amqContext, time.Duration) (bool, error) {
+				return true, nil
+			},
+			CollectAMQ: func(ctx context.Context, got amqContext) (bool, error) {
+				close(collectStarted)
+				return collectNotificationAMQ(ctx, got)
+			},
+			AMQWatchTimeout: time.Hour, AMQWatchMaxRetries: 3,
+			Deliver: func(context.Context, time.Time) (notifyDeliverySummary, error) {
+				return notifyDeliverySummary{}, nil
+			},
+		})
+	}()
+	select {
+	case <-collectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("real collect did not start")
+	}
+	started := time.Now()
+	stop <- os.Interrupt
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher stop did not cancel real collect waiting on the journal lock")
+	}
+	if elapsed := time.Since(started); elapsed >= 2*time.Second {
+		t.Fatalf("real collect stop exceeded supervisor budget: %s", elapsed)
+	}
+	assertInactiveWatcherTombstone(t, notificationWatcherRuntimePath(project, team.DefaultProfile, "s"))
 }
 
 func TestValidateNotificationAMQContextRejectsWrongRoot(t *testing.T) {
@@ -236,6 +523,33 @@ func TestRunNotificationAMQWatchWaitsForMissingRootWithoutCreatingIt(t *testing.
 	}
 }
 
+func TestParseNotificationAMQWatchOutputRequiresValidSignaledEvent(t *testing.T) {
+	for _, valid := range []string{
+		`{"event":"existing","messages":[{"id":"m1"}]}`,
+		`{"event":"new_message","messages":[{"id":"m2"}]}`,
+	} {
+		signaled, err := parseNotificationAMQWatchOutput([]byte(valid))
+		if err != nil || !signaled {
+			t.Fatalf("valid output %s signaled=%t err=%v", valid, signaled, err)
+		}
+	}
+	for _, invalid := range []string{
+		``,
+		`{"event":`,
+		`{"event":"existing"}`,
+		`{"event":"new_message","messages":[]}`,
+		`{"event":"existing","messages":[null]}`,
+		`{"event":"existing","messages":[{"id":""}]}`,
+		`{"event":"timeout"}`,
+		`{"event":"unknown","messages":[{"id":"m3"}]}`,
+		`{"messages":[{"id":"m4"}]}`,
+	} {
+		if signaled, err := parseNotificationAMQWatchOutput([]byte(invalid)); err == nil || signaled {
+			t.Fatalf("invalid output %q signaled=%t err=%v", invalid, signaled, err)
+		}
+	}
+}
+
 func TestExecuteCollectDrainContextStopsBeforeJournalMutation(t *testing.T) {
 	project := t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -267,7 +581,11 @@ func TestNotificationWatcherViewIncludesManagedAMQBackendState(t *testing.T) {
 		WatchRoot:       "/tmp/mail/run",
 		WatchMailbox:    "user",
 		WatchTimeout:    "30s",
+		WatchRunning:    true,
 		WatchRestarts:   2,
+		WatchFailures:   1,
+		CollectPending:  true,
+		CollectRetries:  3,
 		WatchMaxRetries: 5,
 		LastWatchAt:     now.Add(-2 * time.Second),
 		LastCollectAt:   now.Add(-time.Second),
@@ -280,7 +598,11 @@ func TestNotificationWatcherViewIncludesManagedAMQBackendState(t *testing.T) {
 		WatchBackend:    rec.WatchBackend,
 		WatchRoot:       rec.WatchRoot,
 		WatchMailbox:    rec.WatchMailbox,
+		WatchRunning:    rec.WatchRunning,
 		WatchRestarts:   rec.WatchRestarts,
+		WatchFailures:   rec.WatchFailures,
+		CollectPending:  rec.CollectPending,
+		CollectRetries:  rec.CollectRetries,
 		WatchMaxRetries: rec.WatchMaxRetries,
 		LastWatchAt:     rec.LastWatchAt,
 		LastCollectAt:   rec.LastCollectAt,
@@ -288,7 +610,8 @@ func TestNotificationWatcherViewIncludesManagedAMQBackendState(t *testing.T) {
 	}
 	view := buildNotificationWatcherView(true, status, now)
 	if !view.Running || view.WatchBackend != "amq-watch" || view.WatchMailbox != "user" ||
-		view.WatchRestarts != 2 || view.WatchMaxRetries != 5 ||
+		!view.WatchRunning || view.WatchRestarts != 2 || view.WatchFailures != 1 || !view.CollectPending ||
+		view.CollectRetries != 3 || view.WatchMaxRetries != 5 ||
 		!view.LastWatchAt.Equal(rec.LastWatchAt) || !view.LastCollectAt.Equal(rec.LastCollectAt) {
 		t.Fatalf("managed watcher view = %+v", view)
 	}
@@ -326,7 +649,7 @@ func TestNotificationWatcherDuplicateAMQSignalsDoNotNotifyWithoutCollection(t *t
 	}()
 	path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
 	rec := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
-		return r.Health == "healthy" && collectCalls.Load() == 2 && !r.LastCollectAt.IsZero()
+		return r.Health == "healthy" && collectCalls.Load() == 3 && !r.LastCollectAt.IsZero()
 	})
 	if scans.Load() != 1 {
 		t.Fatalf("duplicate empty AMQ signals triggered %d notification scans; record=%+v", scans.Load(), rec)
@@ -347,7 +670,7 @@ func TestNotificationWatcherAMQExhaustionIsVisibleAndKeepsFallbackActive(t *test
 				return false, errors.New("amq watch unsupported")
 			},
 			CollectAMQ: func(context.Context, amqContext) (bool, error) {
-				return false, errors.New("collect must not run")
+				return false, nil
 			},
 			AMQWatchTimeout: time.Second, AMQWatchMaxRetries: 2,
 			AMQWatchBackoff: time.Millisecond, AMQWatchMaxBackoff: time.Millisecond,
@@ -358,13 +681,21 @@ func TestNotificationWatcherAMQExhaustionIsVisibleAndKeepsFallbackActive(t *test
 	}()
 	path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
 	rec := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
-		return r.Health == "degraded" && r.WatchRestarts == 2 &&
+		return r.Health == "degraded" && !r.WatchRunning &&
+			r.WatchRestarts == 1 && r.WatchFailures == 2 &&
 			strings.Contains(r.LastError, "managed AMQ watch exhausted") &&
 			!r.LastScanAt.IsZero()
 	})
 	if rec.WatchBackend != "amq-watch" || rec.WatchMailbox != "user" ||
 		rec.WatchMaxRetries != 2 || !strings.Contains(rec.LastError, "fsnotify/rescan fallback remains active") {
 		t.Fatalf("exhausted watcher record = %+v", rec)
+	}
+	view := buildNotificationWatcherView(true, notificationWatcherStatus{
+		Enabled: true, Health: rec.Health, PID: rec.PID,
+		LeaseExpiresAt: rec.LeaseExpiresAt, record: rec,
+	}, time.Now())
+	if view.Running || view.WatchRunning {
+		t.Fatalf("exhausted managed backend rendered running: %+v", view)
 	}
 	firstScan := rec.LastScanAt
 	waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {

--- a/internal/cli/notification_amq_watch_test.go
+++ b/internal/cli/notification_amq_watch_test.go
@@ -1,0 +1,374 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func TestManagedNotificationAMQWatchCollectsExactMailboxOncePerSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	project := t.TempDir()
+	execution := notificationWatcherExecution{
+		ProjectDir: project,
+		Profile:    team.DefaultProfile,
+		Session:    "run",
+		BaseRoot:   filepath.Join(project, "mail"),
+	}
+	amqCtx := notificationAMQContext(execution, team.DefaultProfile, "user")
+	var watches atomic.Int32
+	var collects atomic.Int32
+	watch := func(ctx context.Context, got amqContext, timeout time.Duration) (bool, error) {
+		if got.Root != filepath.Join(execution.BaseRoot, execution.Session) || got.Me != "user" || got.PinMode != amqPinExactRoot {
+			t.Errorf("watch context = %+v", got)
+		}
+		if timeout != 20*time.Millisecond {
+			t.Errorf("watch timeout = %s", timeout)
+		}
+		if watches.Add(1) == 1 {
+			return true, nil
+		}
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	collect := func(_ context.Context, got amqContext) (bool, error) {
+		if got.Root != amqCtx.Root || got.Me != amqCtx.Me {
+			t.Errorf("collect context = %+v", got)
+		}
+		collects.Add(1)
+		return true, nil
+	}
+	results := make(chan notificationAMQWatchResult, 1)
+	go runManagedNotificationAMQWatch(ctx, amqCtx, 20*time.Millisecond, 3, time.Millisecond, 2*time.Millisecond, watch, collect, results)
+	result := <-results
+	if !result.Signaled || !result.CollectAttempted || !result.Collected || result.Err != nil {
+		t.Fatalf("result = %+v", result)
+	}
+	if collects.Load() != 1 {
+		t.Fatalf("collect calls = %d", collects.Load())
+	}
+	cancel()
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("unexpected result after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("managed watch did not stop after cancellation")
+	}
+}
+
+func TestManagedNotificationAMQWatchBoundsCrashRestarts(t *testing.T) {
+	results := make(chan notificationAMQWatchResult, 1)
+	var calls atomic.Int32
+	var collectCalled atomic.Bool
+	go runManagedNotificationAMQWatch(
+		context.Background(),
+		amqContext{},
+		time.Millisecond,
+		3,
+		time.Millisecond,
+		2*time.Millisecond,
+		func(context.Context, amqContext, time.Duration) (bool, error) {
+			calls.Add(1)
+			return false, errors.New("watch crashed")
+		},
+		func(context.Context, amqContext) (bool, error) {
+			collectCalled.Store(true)
+			return false, errors.New("unexpected collect")
+		},
+		results,
+	)
+	for want := 1; want <= 3; want++ {
+		result := <-results
+		if result.Failures != want || result.Exhausted != (want == 3) || !strings.Contains(result.Err.Error(), "watch crashed") {
+			t.Fatalf("attempt %d result = %+v", want, result)
+		}
+	}
+	if _, ok := <-results; ok {
+		t.Fatal("managed watch remained active after bounded exhaustion")
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("watch calls = %d", calls.Load())
+	}
+	if collectCalled.Load() {
+		t.Fatal("collect called after failed watch")
+	}
+}
+
+func TestManagedNotificationAMQWatchRecoveryResetsFailureCount(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := make(chan notificationAMQWatchResult, 2)
+	var calls atomic.Int32
+	go runManagedNotificationAMQWatch(
+		ctx,
+		amqContext{},
+		time.Millisecond,
+		3,
+		time.Millisecond,
+		time.Millisecond,
+		func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+			switch calls.Add(1) {
+			case 1:
+				return false, errors.New("temporary")
+			case 2:
+				return false, nil
+			default:
+				<-ctx.Done()
+				return false, ctx.Err()
+			}
+		},
+		func(context.Context, amqContext) (bool, error) { return false, nil },
+		results,
+	)
+	failed := <-results
+	recovered := <-results
+	if failed.Failures != 1 || failed.Err == nil {
+		t.Fatalf("failure result = %+v", failed)
+	}
+	if recovered.Err != nil || recovered.Failures != 0 || recovered.Signaled {
+		t.Fatalf("recovery result = %+v", recovered)
+	}
+	cancel()
+}
+
+func TestManagedNotificationAMQWatchOwnershipLossIsFatalWithoutRetry(t *testing.T) {
+	results := make(chan notificationAMQWatchResult, 1)
+	var calls atomic.Int32
+	go runManagedNotificationAMQWatch(
+		context.Background(),
+		amqContext{},
+		time.Second,
+		5,
+		time.Millisecond,
+		time.Millisecond,
+		func(context.Context, amqContext, time.Duration) (bool, error) {
+			calls.Add(1)
+			return false, fmt.Errorf("%w: replaced generation", errNotificationAMQOwnershipLost)
+		},
+		func(context.Context, amqContext) (bool, error) { return false, nil },
+		results,
+	)
+	result := <-results
+	if !result.Fatal || !result.Exhausted || result.Failures != 1 ||
+		!errors.Is(result.Err, errNotificationAMQOwnershipLost) {
+		t.Fatalf("ownership-loss result = %+v", result)
+	}
+	if _, ok := <-results; ok {
+		t.Fatal("ownership loss did not stop managed watch")
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("ownership-loss retries = %d", calls.Load())
+	}
+}
+
+func TestManagedNotificationAMQWatchStopCancelsBlockedWatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	results := make(chan notificationAMQWatchResult, 1)
+	go runManagedNotificationAMQWatch(
+		ctx,
+		amqContext{},
+		time.Hour,
+		3,
+		time.Millisecond,
+		time.Millisecond,
+		func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+			close(started)
+			<-ctx.Done()
+			return false, ctx.Err()
+		},
+		func(context.Context, amqContext) (bool, error) { return false, nil },
+		results,
+	)
+	<-started
+	cancel()
+	select {
+	case _, ok := <-results:
+		if ok {
+			t.Fatal("cancellation produced a retry result")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked managed watch did not stop")
+	}
+}
+
+func TestValidateNotificationAMQContextRejectsWrongRoot(t *testing.T) {
+	project := t.TempDir()
+	execution := notificationWatcherExecution{
+		ProjectDir: project,
+		Profile:    team.DefaultProfile,
+		Session:    "run",
+		BaseRoot:   filepath.Join(project, "mail"),
+	}
+	ctx := notificationAMQContext(execution, team.DefaultProfile, "user")
+	ctx.Root = filepath.Join(project, "other", "run")
+	if err := validateNotificationAMQContext(ctx, execution, team.DefaultProfile, "user"); err == nil || !strings.Contains(err.Error(), "exact project/profile/session/operator") {
+		t.Fatalf("wrong-root validation error = %v", err)
+	}
+}
+
+func TestRunNotificationAMQWatchWaitsForMissingRootWithoutCreatingIt(t *testing.T) {
+	project := t.TempDir()
+	root := filepath.Join(project, "mail", "run")
+	signaled, err := runNotificationAMQWatch(context.Background(), amqContext{
+		ProjectDir: project,
+		Root:       root,
+		Me:         "user",
+		PinMode:    amqPinExactRoot,
+	}, time.Millisecond)
+	if err != nil || signaled {
+		t.Fatalf("missing-root watch signaled=%v err=%v", signaled, err)
+	}
+	if _, statErr := os.Stat(root); !os.IsNotExist(statErr) {
+		t.Fatalf("managed watch created or altered missing root: %v", statErr)
+	}
+}
+
+func TestExecuteCollectDrainContextStopsBeforeJournalMutation(t *testing.T) {
+	project := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	amqCtx := amqContext{
+		ProjectDir: project,
+		Profile:    team.DefaultProfile,
+		Env:        amqEnv{SessionName: "run"},
+		Root:       filepath.Join(project, "mail", "run"),
+		Me:         "user",
+		Session:    "run",
+		PinMode:    amqPinExactRoot,
+	}
+	if _, err := executeCollectDrainContext(ctx, io.Discard, amqCtx, false); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled collect error = %v", err)
+	}
+	if _, err := os.Stat(newCollectJournal(amqCtx).Root); !os.IsNotExist(err) {
+		t.Fatalf("canceled collect mutated journal: %v", err)
+	}
+}
+
+func TestNotificationWatcherViewIncludesManagedAMQBackendState(t *testing.T) {
+	now := time.Now().UTC()
+	rec := notificationWatcherRecord{
+		SchemaVersion:   notificationWatcherSchema,
+		Expected:        true,
+		LeaseTTL:        time.Minute.String(),
+		WatchBackend:    "amq-watch",
+		WatchRoot:       "/tmp/mail/run",
+		WatchMailbox:    "user",
+		WatchTimeout:    "30s",
+		WatchRestarts:   2,
+		WatchMaxRetries: 5,
+		LastWatchAt:     now.Add(-2 * time.Second),
+		LastCollectAt:   now.Add(-time.Second),
+	}
+	status := notificationWatcherStatus{
+		Enabled:         true,
+		Health:          "degraded",
+		PID:             42,
+		LeaseExpiresAt:  now.Add(time.Minute),
+		WatchBackend:    rec.WatchBackend,
+		WatchRoot:       rec.WatchRoot,
+		WatchMailbox:    rec.WatchMailbox,
+		WatchRestarts:   rec.WatchRestarts,
+		WatchMaxRetries: rec.WatchMaxRetries,
+		LastWatchAt:     rec.LastWatchAt,
+		LastCollectAt:   rec.LastCollectAt,
+		record:          rec,
+	}
+	view := buildNotificationWatcherView(true, status, now)
+	if !view.Running || view.WatchBackend != "amq-watch" || view.WatchMailbox != "user" ||
+		view.WatchRestarts != 2 || view.WatchMaxRetries != 5 ||
+		!view.LastWatchAt.Equal(rec.LastWatchAt) || !view.LastCollectAt.Equal(rec.LastCollectAt) {
+		t.Fatalf("managed watcher view = %+v", view)
+	}
+}
+
+func TestNotificationWatcherDuplicateAMQSignalsDoNotNotifyWithoutCollection(t *testing.T) {
+	project, _, base := notificationWatcherTeam(t, team.DefaultProfile, "s")
+	stop := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	var watchCalls atomic.Int32
+	var collectCalls atomic.Int32
+	var scans atomic.Int32
+	go func() {
+		done <- executeNotificationWatcher(notificationWatcherExecution{
+			ProjectDir: project, Profile: team.DefaultProfile, Session: "s", BaseRoot: base, Token: "amq-duplicate",
+			TTL: time.Second, Heartbeat: 20 * time.Millisecond, Rescan: time.Hour,
+			Stop: stop,
+			WatchAMQ: func(ctx context.Context, _ amqContext, _ time.Duration) (bool, error) {
+				if watchCalls.Add(1) <= 2 {
+					return true, nil
+				}
+				<-ctx.Done()
+				return false, ctx.Err()
+			},
+			CollectAMQ: func(context.Context, amqContext) (bool, error) {
+				collectCalls.Add(1)
+				return false, nil
+			},
+			AMQWatchTimeout: time.Second, AMQWatchMaxRetries: 3,
+			Deliver: func(context.Context, time.Time) (notifyDeliverySummary, error) {
+				scans.Add(1)
+				return notifyDeliverySummary{}, nil
+			},
+		})
+	}()
+	path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
+	rec := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
+		return r.Health == "healthy" && collectCalls.Load() == 2 && !r.LastCollectAt.IsZero()
+	})
+	if scans.Load() != 1 {
+		t.Fatalf("duplicate empty AMQ signals triggered %d notification scans; record=%+v", scans.Load(), rec)
+	}
+	stopTestNotificationWatcher(t, stop, done)
+}
+
+func TestNotificationWatcherAMQExhaustionIsVisibleAndKeepsFallbackActive(t *testing.T) {
+	project, _, base := notificationWatcherTeam(t, team.DefaultProfile, "s")
+	stop := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- executeNotificationWatcher(notificationWatcherExecution{
+			ProjectDir: project, Profile: team.DefaultProfile, Session: "s", BaseRoot: base, Token: "amq-exhausted",
+			TTL: time.Second, Heartbeat: 20 * time.Millisecond, Rescan: 20 * time.Millisecond,
+			Stop: stop,
+			WatchAMQ: func(context.Context, amqContext, time.Duration) (bool, error) {
+				return false, errors.New("amq watch unsupported")
+			},
+			CollectAMQ: func(context.Context, amqContext) (bool, error) {
+				return false, errors.New("collect must not run")
+			},
+			AMQWatchTimeout: time.Second, AMQWatchMaxRetries: 2,
+			AMQWatchBackoff: time.Millisecond, AMQWatchMaxBackoff: time.Millisecond,
+			Deliver: func(context.Context, time.Time) (notifyDeliverySummary, error) {
+				return notifyDeliverySummary{}, nil
+			},
+		})
+	}()
+	path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
+	rec := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
+		return r.Health == "degraded" && r.WatchRestarts == 2 &&
+			strings.Contains(r.LastError, "managed AMQ watch exhausted") &&
+			!r.LastScanAt.IsZero()
+	})
+	if rec.WatchBackend != "amq-watch" || rec.WatchMailbox != "user" ||
+		rec.WatchMaxRetries != 2 || !strings.Contains(rec.LastError, "fsnotify/rescan fallback remains active") {
+		t.Fatalf("exhausted watcher record = %+v", rec)
+	}
+	firstScan := rec.LastScanAt
+	waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
+		return r.LastScanAt.After(firstScan)
+	})
+	stopTestNotificationWatcher(t, stop, done)
+}

--- a/internal/cli/notification_watcher.go
+++ b/internal/cli/notification_watcher.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -33,6 +34,7 @@ const (
 	defaultNotificationAMQWatchRetries = 5
 	defaultNotificationAMQWatchBackoff = 100 * time.Millisecond
 	maxNotificationAMQWatchBackoff     = 2 * time.Second
+	notificationWatcherShutdownTimeout = 1500 * time.Millisecond
 )
 
 var (
@@ -63,7 +65,11 @@ type notificationWatcherRecord struct {
 	WatchRoot       string    `json:"watch_root,omitempty"`
 	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
 	WatchTimeout    string    `json:"watch_timeout,omitempty"`
+	WatchRunning    bool      `json:"watch_running,omitempty"`
 	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchFailures   int       `json:"watch_failure_streak,omitempty"`
+	CollectPending  bool      `json:"collect_pending,omitempty"`
+	CollectRetries  int       `json:"collect_retries,omitempty"`
 	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
 	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
 	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
@@ -89,7 +95,11 @@ type notificationWatcherStatus struct {
 	WatchBackend    string    `json:"watch_backend,omitempty"`
 	WatchRoot       string    `json:"watch_root,omitempty"`
 	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
+	WatchRunning    bool      `json:"watch_running,omitempty"`
 	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchFailures   int       `json:"watch_failure_streak,omitempty"`
+	CollectPending  bool      `json:"collect_pending,omitempty"`
+	CollectRetries  int       `json:"collect_retries,omitempty"`
 	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
 	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
 	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
@@ -262,7 +272,11 @@ func inspectNotificationWatcher(t team.Team, profile, session string, now time.T
 	result.WatchBackend = rec.WatchBackend
 	result.WatchRoot = rec.WatchRoot
 	result.WatchMailbox = rec.WatchMailbox
+	result.WatchRunning = rec.WatchRunning
 	result.WatchRestarts = rec.WatchRestarts
+	result.WatchFailures = rec.WatchFailures
+	result.CollectPending = rec.CollectPending
+	result.CollectRetries = rec.CollectRetries
 	result.WatchMaxRetries = rec.WatchMaxRetries
 	result.LastWatchAt = rec.LastWatchAt
 	result.LastCollectAt = rec.LastCollectAt
@@ -280,6 +294,14 @@ func inspectNotificationWatcher(t team.Team, profile, session string, now time.T
 	}
 	host, _ := os.Hostname()
 	if strings.TrimSpace(rec.Host) != "" && strings.TrimSpace(rec.Host) != strings.TrimSpace(host) {
+		if rec.WatchBackend != "" && !rec.WatchRunning {
+			result.Health = "degraded"
+			result.Reason = fmt.Sprintf("notification watcher on host %s reports backend %s is not running", rec.Host, rec.WatchBackend)
+			if detail := strings.TrimSpace(rec.LastError); detail != "" {
+				result.Reason += ": " + detail
+			}
+			return result
+		}
 		switch rec.Health {
 		case "healthy":
 			result.Health = "external-active"
@@ -306,6 +328,14 @@ func inspectNotificationWatcher(t team.Team, profile, session string, now time.T
 	if !notificationWatcherProcessMatches(rec) {
 		result.Health = "unhealthy"
 		result.Reason = "notification watcher PID is absent or does not match its owner token"
+		return result
+	}
+	if rec.WatchBackend != "" && !rec.WatchRunning {
+		result.Health = "degraded"
+		result.Reason = fmt.Sprintf("notification watcher backend %s is not running", rec.WatchBackend)
+		if detail := strings.TrimSpace(rec.LastError); detail != "" {
+			result.Reason += ": " + detail
+		}
 		return result
 	}
 	if rec.Health != "healthy" {
@@ -419,7 +449,7 @@ func reconcileNotificationWatcherStarted(t team.Team, profile, session, baseRoot
 func notificationWatcherReady(status notificationWatcherStatus) bool {
 	switch status.Health {
 	case "healthy", "external-active":
-		return true
+		return !status.LastScanAt.IsZero()
 	case "degraded":
 		return !status.LastScanAt.IsZero()
 	default:
@@ -439,6 +469,7 @@ func expireDeadLocalNotificationWatcher(projectDir, profile, session string, obs
 		}
 		current.LeaseExpiresAt = now.UTC()
 		current.Health = "unhealthy"
+		current.WatchRunning = false
 		current.LastError = "local notification watcher process exited before lease expiry"
 		current.UpdatedAt = now.UTC()
 		return writeNotificationWatcherRecord(path, current)
@@ -580,6 +611,7 @@ func finalizeNotificationWatcherStop(projectDir, profile, session, path string, 
 		current.PID = 0
 		current.OwnerToken = ""
 		current.Expected = false
+		current.WatchRunning = false
 		current.Health = "inactive"
 		current.LastError = ""
 		current.HeartbeatAt = now
@@ -594,6 +626,7 @@ func notificationWatcherInactiveTombstoneForScope(rec notificationWatcherRecord,
 		rec.PID == 0 &&
 		strings.TrimSpace(rec.OwnerToken) == "" &&
 		!rec.Expected &&
+		!rec.WatchRunning &&
 		rec.Health == "inactive" &&
 		!rec.LeaseExpiresAt.After(now)
 }
@@ -669,7 +702,7 @@ func runNotificationWatcher(args []string) error {
 	})
 }
 
-func executeNotificationWatcher(w notificationWatcherExecution) error {
+func executeNotificationWatcher(w notificationWatcherExecution) (returnErr error) {
 	nowFn := w.Now
 	if nowFn == nil {
 		nowFn = time.Now
@@ -734,6 +767,8 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 		rec.WatchRoot = watchCtx.Root
 		rec.WatchMailbox = watchCtx.Me
 		rec.WatchTimeout = watchTimeout.String()
+		rec.WatchRunning = true
+		rec.CollectPending = true
 		rec.WatchMaxRetries = maxRetries
 	}
 	claimErr := flock.WithLock(notificationWatcherLockPath(w.ProjectDir, profile, w.Session), func() error {
@@ -804,7 +839,6 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 	rescan := time.NewTicker(w.Rescan)
 	defer rescan.Stop()
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	var amqDone <-chan notificationAMQWatchResult
 	if w.WatchAMQ != nil {
 		results := make(chan notificationAMQWatchResult, 1)
@@ -822,7 +856,7 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 			}
 			return w.CollectAMQ(operation, amqCtx)
 		}
-		go runManagedNotificationAMQWatch(ctx, watchCtx, watchTimeout, maxRetries, backoff, maxBackoff, watchAMQ, collectAMQ, results)
+		go runManagedNotificationAMQWatch(ctx, watchCtx, true, watchTimeout, maxRetries, backoff, maxBackoff, watchAMQ, collectAMQ, results)
 	}
 	type scanResult struct {
 		summary notifyDeliverySummary
@@ -842,6 +876,8 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 			rec.Health, rec.LastError = "degraded", amqDegraded
 		case fsDegraded != "":
 			rec.Health, rec.LastError = "degraded", fsDegraded
+		case rec.LastScanAt.IsZero():
+			rec.Health, rec.LastError = "starting", ""
 		default:
 			rec.Health, rec.LastError = "healthy", ""
 		}
@@ -862,6 +898,51 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 		}()
 		return nil
 	}
+	shutdownDone := false
+	var shutdownErr error
+	shutdown := func() error {
+		if shutdownDone {
+			return shutdownErr
+		}
+		shutdownDone = true
+		cancel()
+		waitAMQ := amqDone != nil
+		waitScan := inFlight
+		if !waitAMQ && !waitScan {
+			return nil
+		}
+		timer := time.NewTimer(notificationWatcherShutdownTimeout)
+		defer timer.Stop()
+		for waitAMQ || waitScan {
+			select {
+			case _, ok := <-amqDone:
+				if !ok {
+					amqDone = nil
+					waitAMQ = false
+				}
+			case <-scanDone:
+				inFlight = false
+				waitScan = false
+			case <-timer.C:
+				switch {
+				case waitAMQ && waitScan:
+					shutdownErr = fmt.Errorf("notification watcher AMQ watch and delivery did not stop within %s after cancellation", notificationWatcherShutdownTimeout)
+				case waitAMQ:
+					shutdownErr = fmt.Errorf("notification watcher AMQ watch did not stop within %s after cancellation", notificationWatcherShutdownTimeout)
+				default:
+					shutdownErr = fmt.Errorf("notification watcher delivery did not stop within %s after cancellation", notificationWatcherShutdownTimeout)
+				}
+				return shutdownErr
+			}
+		}
+		return nil
+	}
+	defer func() {
+		cleanupErr := shutdown()
+		if cleanupErr != nil && !errors.Is(returnErr, cleanupErr) {
+			returnErr = errors.Join(returnErr, cleanupErr)
+		}
+	}()
 	if err := startScan(); err != nil {
 		return err
 	}
@@ -877,32 +958,8 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 	for {
 		select {
 		case <-w.Stop:
-			cancel()
-			if amqDone != nil {
-				deadline := time.NewTimer(2 * time.Second)
-				for amqDone != nil {
-					select {
-					case _, ok := <-amqDone:
-						if !ok {
-							amqDone = nil
-						}
-					case <-deadline.C:
-						return fmt.Errorf("notification watcher AMQ watch did not stop after cancellation")
-					}
-				}
-				if !deadline.Stop() {
-					select {
-					case <-deadline.C:
-					default:
-					}
-				}
-			}
-			if inFlight {
-				select {
-				case <-scanDone:
-				case <-time.After(2 * time.Second):
-					return fmt.Errorf("notification watcher delivery did not stop after cancellation")
-				}
+			if err := shutdown(); err != nil {
+				return err
 			}
 			if err := releaseNotificationWatcherLease(path, &rec, w.Token, nowFn()); err != nil {
 				return err
@@ -911,9 +968,21 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 		case result, ok := <-amqDone:
 			if !ok {
 				amqDone = nil
+				if !shutdownDone && rec.WatchRunning {
+					rec.WatchRunning = false
+					amqDegraded = "managed AMQ watch stopped unexpectedly; fsnotify/rescan fallback remains active"
+					updateHealth()
+					if err := refreshNotificationWatcherLease(path, &rec, w.Token, nowFn()); err != nil {
+						return err
+					}
+				}
 				continue
 			}
-			rec.WatchRestarts = result.Failures
+			rec.WatchRunning = !result.Exhausted
+			rec.WatchRestarts = result.WatchRestarts
+			rec.WatchFailures = result.FailureStreak
+			rec.CollectPending = result.PendingCollect
+			rec.CollectRetries = result.CollectRetries
 			if result.Fatal {
 				return result.Err
 			}
@@ -927,7 +996,6 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 				amqDegraded = result.Err.Error()
 				if result.Exhausted {
 					amqDegraded += "; managed AMQ watch exhausted; fsnotify/rescan fallback remains active; use bounded amq-squad monitor for manual backstop"
-					amqDone = nil
 				}
 			} else {
 				amqDegraded = ""
@@ -996,6 +1064,9 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 			}
 			currentTeam, teamErr := team.ReadProfile(w.ProjectDir, profile)
 			if teamErr == nil && !team.EffectiveOperatorNotifications(currentTeam.Operator).Enabled {
+				if err := shutdown(); err != nil {
+					return err
+				}
 				if err := releaseNotificationWatcherLease(path, &rec, w.Token, nowFn()); err != nil {
 					return err
 				}
@@ -1109,6 +1180,7 @@ func releaseNotificationWatcherLease(path string, rec *notificationWatcherRecord
 		current.PID = 0
 		current.OwnerToken = ""
 		current.Expected = false
+		current.WatchRunning = false
 		current.Health = "inactive"
 		current.LastError = ""
 		current.HeartbeatAt = now

--- a/internal/cli/notification_watcher.go
+++ b/internal/cli/notification_watcher.go
@@ -24,11 +24,15 @@ import (
 )
 
 const (
-	notificationWatcherSchema         = 1
-	defaultNotificationWatcherTTL     = 15 * time.Second
-	defaultNotificationWatcherBeat    = 3 * time.Second
-	defaultNotificationWatcherRescan  = 5 * time.Second
-	defaultNotificationWatcherStartup = 5 * time.Second
+	notificationWatcherSchema          = 1
+	defaultNotificationWatcherTTL      = 15 * time.Second
+	defaultNotificationWatcherBeat     = 3 * time.Second
+	defaultNotificationWatcherRescan   = 5 * time.Second
+	defaultNotificationWatcherStartup  = 5 * time.Second
+	defaultNotificationAMQWatchTimeout = 30 * time.Second
+	defaultNotificationAMQWatchRetries = 5
+	defaultNotificationAMQWatchBackoff = 100 * time.Millisecond
+	maxNotificationAMQWatchBackoff     = 2 * time.Second
 )
 
 var (
@@ -41,57 +45,78 @@ var (
 // operator-loop: attention delivery is required even for lead_pane profiles
 // whose operator contract has poll_required=false.
 type notificationWatcherRecord struct {
-	SchemaVersion  int       `json:"schema_version"`
-	ProjectDir     string    `json:"project_dir"`
-	Profile        string    `json:"profile"`
-	Session        string    `json:"session"`
-	NamespaceID    string    `json:"namespace_id"`
-	PID            int       `json:"pid"`
-	Host           string    `json:"host"`
-	Owner          string    `json:"owner"`
-	OwnerToken     string    `json:"owner_token"`
-	LeaseTTL       string    `json:"lease_ttl"`
-	LeaseExpiresAt time.Time `json:"lease_expires_at"`
-	HeartbeatAt    time.Time `json:"heartbeat_at"`
-	LastScanAt     time.Time `json:"last_scan_at,omitempty"`
-	LastEventAt    time.Time `json:"last_event_at,omitempty"`
-	StatePath      string    `json:"state_path"`
-	Expected       bool      `json:"expected"`
-	Health         string    `json:"health"`
-	LastError      string    `json:"last_error,omitempty"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	SchemaVersion   int       `json:"schema_version"`
+	ProjectDir      string    `json:"project_dir"`
+	Profile         string    `json:"profile"`
+	Session         string    `json:"session"`
+	NamespaceID     string    `json:"namespace_id"`
+	PID             int       `json:"pid"`
+	Host            string    `json:"host"`
+	Owner           string    `json:"owner"`
+	OwnerToken      string    `json:"owner_token"`
+	LeaseTTL        string    `json:"lease_ttl"`
+	LeaseExpiresAt  time.Time `json:"lease_expires_at"`
+	HeartbeatAt     time.Time `json:"heartbeat_at"`
+	LastScanAt      time.Time `json:"last_scan_at,omitempty"`
+	LastEventAt     time.Time `json:"last_event_at,omitempty"`
+	WatchBackend    string    `json:"watch_backend,omitempty"`
+	WatchRoot       string    `json:"watch_root,omitempty"`
+	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
+	WatchTimeout    string    `json:"watch_timeout,omitempty"`
+	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
+	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
+	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
+	StatePath       string    `json:"state_path"`
+	Expected        bool      `json:"expected"`
+	Health          string    `json:"health"`
+	LastError       string    `json:"last_error,omitempty"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 type notificationWatcherStatus struct {
-	Enabled        bool      `json:"enabled"`
-	Health         string    `json:"health"`
-	Reason         string    `json:"reason,omitempty"`
-	RuntimePath    string    `json:"runtime_path"`
-	SchemaVersion  int       `json:"schema_version,omitempty"`
-	PID            int       `json:"pid,omitempty"`
-	Host           string    `json:"host,omitempty"`
-	Owner          string    `json:"owner,omitempty"`
-	LeaseExpiresAt time.Time `json:"lease_expires_at,omitempty"`
-	HeartbeatAt    time.Time `json:"heartbeat_at,omitempty"`
-	LastScanAt     time.Time `json:"last_scan_at,omitempty"`
-	StatePath      string    `json:"state_path,omitempty"`
-	record         notificationWatcherRecord
+	Enabled         bool      `json:"enabled"`
+	Health          string    `json:"health"`
+	Reason          string    `json:"reason,omitempty"`
+	RuntimePath     string    `json:"runtime_path"`
+	SchemaVersion   int       `json:"schema_version,omitempty"`
+	PID             int       `json:"pid,omitempty"`
+	Host            string    `json:"host,omitempty"`
+	Owner           string    `json:"owner,omitempty"`
+	LeaseExpiresAt  time.Time `json:"lease_expires_at,omitempty"`
+	HeartbeatAt     time.Time `json:"heartbeat_at,omitempty"`
+	LastScanAt      time.Time `json:"last_scan_at,omitempty"`
+	WatchBackend    string    `json:"watch_backend,omitempty"`
+	WatchRoot       string    `json:"watch_root,omitempty"`
+	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
+	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
+	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
+	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
+	StatePath       string    `json:"state_path,omitempty"`
+	record          notificationWatcherRecord
 }
 
 type notificationWatcherExecution struct {
-	ProjectDir string
-	Profile    string
-	Session    string
-	BaseRoot   string
-	Token      string
-	TTL        time.Duration
-	Heartbeat  time.Duration
-	Rescan     time.Duration
-	Now        func() time.Time
-	Out        io.Writer
-	Stop       <-chan os.Signal
-	NewFSWatch func() (*fsnotify.Watcher, error)
-	Deliver    func(context.Context, time.Time) (notifyDeliverySummary, error)
+	ProjectDir         string
+	Profile            string
+	Session            string
+	BaseRoot           string
+	Token              string
+	TTL                time.Duration
+	Heartbeat          time.Duration
+	Rescan             time.Duration
+	Now                func() time.Time
+	Out                io.Writer
+	Stop               <-chan os.Signal
+	NewFSWatch         func() (*fsnotify.Watcher, error)
+	Deliver            func(context.Context, time.Time) (notifyDeliverySummary, error)
+	WatchAMQ           notificationAMQWatchFunc
+	CollectAMQ         notificationAMQCollectFunc
+	AMQWatchTimeout    time.Duration
+	AMQWatchMaxRetries int
+	AMQWatchBackoff    time.Duration
+	AMQWatchMaxBackoff time.Duration
 }
 
 type notificationWatcherProcess interface {
@@ -234,6 +259,13 @@ func inspectNotificationWatcher(t team.Team, profile, session string, now time.T
 	result.LeaseExpiresAt = rec.LeaseExpiresAt
 	result.HeartbeatAt = rec.HeartbeatAt
 	result.LastScanAt = rec.LastScanAt
+	result.WatchBackend = rec.WatchBackend
+	result.WatchRoot = rec.WatchRoot
+	result.WatchMailbox = rec.WatchMailbox
+	result.WatchRestarts = rec.WatchRestarts
+	result.WatchMaxRetries = rec.WatchMaxRetries
+	result.LastWatchAt = rec.LastWatchAt
+	result.LastCollectAt = rec.LastCollectAt
 	result.StatePath = rec.StatePath
 	result.record = rec
 	if filepath.Clean(rec.ProjectDir) != filepath.Clean(t.Project) || rec.Profile != squadnamespace.NormalizeProfile(profile) || rec.Session != session || rec.NamespaceID != squadnamespace.ID(profile, session) {
@@ -629,6 +661,11 @@ func runNotificationWatcher(args []string) error {
 		ProjectDir: *project, Profile: *profile, Session: *session, BaseRoot: *baseRoot,
 		Token: *token, TTL: *ttl, Heartbeat: *heartbeat, Rescan: *rescan,
 		Now: time.Now, Out: os.Stdout, Stop: sigCh, NewFSWatch: fsnotify.NewWatcher,
+		WatchAMQ: runNotificationAMQWatch, CollectAMQ: collectNotificationAMQ,
+		AMQWatchTimeout:    defaultNotificationAMQWatchTimeout,
+		AMQWatchMaxRetries: defaultNotificationAMQWatchRetries,
+		AMQWatchBackoff:    defaultNotificationAMQWatchBackoff,
+		AMQWatchMaxBackoff: maxNotificationAMQWatchBackoff,
 	})
 }
 
@@ -670,6 +707,16 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 	if !team.EffectiveOperatorNotifications(t.Operator).Enabled {
 		return fmt.Errorf("notification watcher refused: notifications are disabled")
 	}
+	operator := team.EffectiveOperator(t)
+	watchCtx := notificationAMQContext(w, profile, operator.Handle)
+	if w.WatchAMQ != nil || w.CollectAMQ != nil {
+		if w.WatchAMQ == nil || w.CollectAMQ == nil {
+			return fmt.Errorf("notification watcher managed AMQ backend requires both watch and collect functions")
+		}
+		if err := validateNotificationAMQContext(watchCtx, w, profile, operator.Handle); err != nil {
+			return err
+		}
+	}
 	path := notificationWatcherRuntimePath(w.ProjectDir, profile, w.Session)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("ensure notification watcher runtime dir: %w", err)
@@ -680,6 +727,14 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 		Session: w.Session, NamespaceID: squadnamespace.ID(profile, w.Session), PID: os.Getpid(),
 		Host: host, Owner: "supervised", OwnerToken: w.Token, LeaseTTL: w.TTL.String(),
 		StatePath: defaultNotifyStatePath(w.ProjectDir), Expected: true, Health: "starting",
+	}
+	if w.WatchAMQ != nil {
+		watchTimeout, maxRetries, _, _ := notificationAMQWatchSettings(w)
+		rec.WatchBackend = "amq-watch"
+		rec.WatchRoot = watchCtx.Root
+		rec.WatchMailbox = watchCtx.Me
+		rec.WatchTimeout = watchTimeout.String()
+		rec.WatchMaxRetries = maxRetries
 	}
 	claimErr := flock.WithLock(notificationWatcherLockPath(w.ProjectDir, profile, w.Session), func() error {
 		current, err := readNotificationWatcherRecord(path)
@@ -750,6 +805,25 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 	defer rescan.Stop()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	var amqDone <-chan notificationAMQWatchResult
+	if w.WatchAMQ != nil {
+		results := make(chan notificationAMQWatchResult, 1)
+		amqDone = results
+		watchTimeout, maxRetries, backoff, maxBackoff := notificationAMQWatchSettings(w)
+		watchAMQ := func(operation context.Context, amqCtx amqContext, timeout time.Duration) (bool, error) {
+			if err := verifyNotificationWatcherOwnership(path, w.Token); err != nil {
+				return false, fmt.Errorf("%w: %v", errNotificationAMQOwnershipLost, err)
+			}
+			return w.WatchAMQ(operation, amqCtx, timeout)
+		}
+		collectAMQ := func(operation context.Context, amqCtx amqContext) (bool, error) {
+			if err := verifyNotificationWatcherOwnership(path, w.Token); err != nil {
+				return false, fmt.Errorf("%w: %v", errNotificationAMQOwnershipLost, err)
+			}
+			return w.CollectAMQ(operation, amqCtx)
+		}
+		go runManagedNotificationAMQWatch(ctx, watchCtx, watchTimeout, maxRetries, backoff, maxBackoff, watchAMQ, collectAMQ, results)
+	}
 	type scanResult struct {
 		summary notifyDeliverySummary
 		err     error
@@ -758,6 +832,20 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 	scanDone := make(chan scanResult, 1)
 	inFlight := false
 	pendingScan := false
+	deliveryDegraded := ""
+	amqDegraded := ""
+	updateHealth := func() {
+		switch {
+		case deliveryDegraded != "":
+			rec.Health, rec.LastError = "degraded", deliveryDegraded
+		case amqDegraded != "":
+			rec.Health, rec.LastError = "degraded", amqDegraded
+		case fsDegraded != "":
+			rec.Health, rec.LastError = "degraded", fsDegraded
+		default:
+			rec.Health, rec.LastError = "healthy", ""
+		}
+	}
 	startScan := func() error {
 		if inFlight {
 			pendingScan = true
@@ -790,6 +878,25 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 		select {
 		case <-w.Stop:
 			cancel()
+			if amqDone != nil {
+				deadline := time.NewTimer(2 * time.Second)
+				for amqDone != nil {
+					select {
+					case _, ok := <-amqDone:
+						if !ok {
+							amqDone = nil
+						}
+					case <-deadline.C:
+						return fmt.Errorf("notification watcher AMQ watch did not stop after cancellation")
+					}
+				}
+				if !deadline.Stop() {
+					select {
+					case <-deadline.C:
+					default:
+					}
+				}
+			}
 			if inFlight {
 				select {
 				case <-scanDone:
@@ -801,6 +908,39 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 				return err
 			}
 			return nil
+		case result, ok := <-amqDone:
+			if !ok {
+				amqDone = nil
+				continue
+			}
+			rec.WatchRestarts = result.Failures
+			if result.Fatal {
+				return result.Err
+			}
+			if result.Signaled {
+				rec.LastWatchAt = result.At.UTC()
+			}
+			if result.CollectAttempted {
+				rec.LastCollectAt = result.At.UTC()
+			}
+			if result.Err != nil {
+				amqDegraded = result.Err.Error()
+				if result.Exhausted {
+					amqDegraded += "; managed AMQ watch exhausted; fsnotify/rescan fallback remains active; use bounded amq-squad monitor for manual backstop"
+					amqDone = nil
+				}
+			} else {
+				amqDegraded = ""
+			}
+			updateHealth()
+			if err := refreshNotificationWatcherLease(path, &rec, w.Token, nowFn()); err != nil {
+				return err
+			}
+			if result.Collected {
+				if err := startScan(); err != nil {
+					return err
+				}
+			}
 		case event, ok := <-events:
 			if !ok {
 				events = nil
@@ -869,14 +1009,13 @@ func executeNotificationWatcher(w notificationWatcherExecution) error {
 			rec.LastScanAt = result.at.UTC()
 			switch {
 			case result.err != nil:
-				rec.Health, rec.LastError = "degraded", result.err.Error()
+				deliveryDegraded = result.err.Error()
 			case result.summary.Failed > 0:
-				rec.Health, rec.LastError = "degraded", fmt.Sprintf("%d notification sink delivery attempt(s) failed", result.summary.Failed)
-			case fsDegraded != "":
-				rec.Health, rec.LastError = "degraded", fsDegraded
+				deliveryDegraded = fmt.Sprintf("%d notification sink delivery attempt(s) failed", result.summary.Failed)
 			default:
-				rec.Health, rec.LastError = "healthy", ""
+				deliveryDegraded = ""
 			}
+			updateHealth()
 			if err := refreshNotificationWatcherLease(path, &rec, w.Token, nowFn()); err != nil {
 				return err
 			}

--- a/internal/cli/notification_watcher_test.go
+++ b/internal/cli/notification_watcher_test.go
@@ -107,7 +107,8 @@ func assertInactiveWatcherTombstone(t *testing.T, path string) notificationWatch
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rec.PID != 0 || rec.OwnerToken != "" || rec.Expected || rec.Health != "inactive" || rec.LeaseExpiresAt.After(time.Now()) {
+	if rec.PID != 0 || rec.OwnerToken != "" || rec.Expected || rec.WatchRunning ||
+		rec.Health != "inactive" || rec.LeaseExpiresAt.After(time.Now()) {
 		t.Fatalf("watcher did not publish an immediately reclaimable inactive tombstone: %+v", rec)
 	}
 	return rec
@@ -687,7 +688,7 @@ func TestNotificationWatcherFreshRemoteLeaseFencesAndStopRefuses(t *testing.T) {
 	}
 }
 
-func TestNotificationWatcherReadinessRequiresScanForDegradedOnly(t *testing.T) {
+func TestNotificationWatcherReadinessRequiresInitialScan(t *testing.T) {
 	scanned := time.Now().UTC()
 	tests := []struct {
 		name   string
@@ -695,8 +696,10 @@ func TestNotificationWatcherReadinessRequiresScanForDegradedOnly(t *testing.T) {
 		scan   time.Time
 		ready  bool
 	}{
-		{name: "healthy before scan", health: "healthy", ready: true},
-		{name: "external active before scan", health: "external-active", ready: true},
+		{name: "healthy before scan", health: "healthy", ready: false},
+		{name: "healthy after scan", health: "healthy", scan: scanned, ready: true},
+		{name: "external active before scan", health: "external-active", ready: false},
+		{name: "external active after scan", health: "external-active", scan: scanned, ready: true},
 		{name: "degraded before fallback scan", health: "degraded", ready: false},
 		{name: "degraded after fallback scan", health: "degraded", scan: scanned, ready: true},
 		{name: "starting", health: "starting", ready: false},
@@ -809,11 +812,23 @@ func TestNotificationWatcherRemoteHealthIsNotMaskedAndNeverSpawnsRival(t *testin
 	if status.Health != "external-active" || !status.LastScanAt.IsZero() {
 		t.Fatalf("remote initial external-active status=%+v", status)
 	}
-	if err := reconcileNotificationWatcherStarted(tm, team.DefaultProfile, "s", base); err != nil {
-		t.Fatalf("remote initial external-active reconcile=%v", err)
+	if err := reconcileNotificationWatcherStarted(tm, team.DefaultProfile, "s", base); err == nil || !strings.Contains(err.Error(), "active but unhealthy") {
+		t.Fatalf("remote unscanned external-active reconcile=%v", err)
 	}
 	if spawned {
 		t.Fatal("remote initial external-active lease spawned a rival")
+	}
+
+	writeRemote("healthy", "", true)
+	status = inspectNotificationWatcher(tm, team.DefaultProfile, "s", time.Now())
+	if status.Health != "external-active" || status.LastScanAt.IsZero() {
+		t.Fatalf("remote scanned external-active status=%+v", status)
+	}
+	if err := reconcileNotificationWatcherStarted(tm, team.DefaultProfile, "s", base); err != nil {
+		t.Fatalf("remote scanned external-active reconcile=%v", err)
+	}
+	if spawned {
+		t.Fatal("remote scanned external-active lease spawned a rival")
 	}
 
 	writeRemote("degraded", "fsnotify unavailable", true)
@@ -893,11 +908,14 @@ func TestNotificationWatcherHeartbeatContinuesAndStopCancelsBlockedSink(t *testi
 	<-started
 	path := notificationWatcherRuntimePath(project, team.DefaultProfile, "s")
 	first := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool { return r.OwnerToken == "blocking-token" })
+	if first.Health != "starting" {
+		t.Fatalf("watcher reported %q before its initial delivery scan completed", first.Health)
+	}
 	second := waitWatcherRecord(t, path, time.Second, func(r notificationWatcherRecord) bool {
 		return r.HeartbeatAt.After(first.HeartbeatAt) && r.LeaseExpiresAt.After(first.LeaseExpiresAt)
 	})
-	if !second.LastScanAt.IsZero() {
-		t.Fatal("blocked delivery incorrectly marked complete")
+	if second.Health != "starting" || !second.LastScanAt.IsZero() {
+		t.Fatalf("blocked initial delivery incorrectly reported ready: %+v", second)
 	}
 	stopTestNotificationWatcher(t, stop, done)
 }

--- a/internal/cli/notifications.go
+++ b/internal/cli/notifications.go
@@ -96,7 +96,11 @@ type notificationWatcherView struct {
 	WatchRoot       string    `json:"watch_root,omitempty"`
 	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
 	WatchTimeout    string    `json:"watch_timeout,omitempty"`
+	WatchRunning    bool      `json:"watch_running,omitempty"`
 	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchFailures   int       `json:"watch_failure_streak,omitempty"`
+	CollectPending  bool      `json:"collect_pending,omitempty"`
+	CollectRetries  int       `json:"collect_retries,omitempty"`
 	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
 	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
 	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
@@ -512,7 +516,8 @@ func buildNotificationPolicyView(policy team.OperatorNotificationPolicy) notific
 func buildNotificationWatcherView(expected bool, watcher notificationWatcherStatus, now time.Time) notificationWatcherView {
 	rec := watcher.record
 	runtimeExpected := rec.SchemaVersion == notificationWatcherSchema && rec.Expected
-	running := runtimeExpected && watcher.PID > 0 && now.Before(watcher.LeaseExpiresAt) && (watcher.Health == "healthy" || watcher.Health == "external-active" || watcher.Health == "degraded")
+	backendRunning := rec.WatchBackend == "" || rec.WatchRunning
+	running := runtimeExpected && backendRunning && watcher.PID > 0 && now.Before(watcher.LeaseExpiresAt) && (watcher.Health == "healthy" || watcher.Health == "external-active" || watcher.Health == "degraded")
 	return notificationWatcherView{
 		PolicyEnabled: expected, Expected: runtimeExpected, Running: running, Health: watcher.Health, Reason: boundedNotificationText(watcher.Reason),
 		RuntimePath: watcher.RuntimePath, SchemaVersion: watcher.SchemaVersion, PID: watcher.PID,
@@ -520,8 +525,11 @@ func buildNotificationWatcherView(expected bool, watcher notificationWatcherStat
 		LeaseExpiresAt: watcher.LeaseExpiresAt, HeartbeatAt: watcher.HeartbeatAt,
 		LastScanAt: watcher.LastScanAt, LastEventAt: rec.LastEventAt, StatePath: watcher.StatePath,
 		WatchBackend: rec.WatchBackend, WatchRoot: rec.WatchRoot, WatchMailbox: rec.WatchMailbox,
-		WatchTimeout: rec.WatchTimeout, WatchRestarts: rec.WatchRestarts, WatchMaxRetries: rec.WatchMaxRetries,
-		LastWatchAt: rec.LastWatchAt, LastCollectAt: rec.LastCollectAt,
+		WatchTimeout: rec.WatchTimeout, WatchRunning: rec.WatchRunning,
+		WatchRestarts: rec.WatchRestarts, WatchFailures: rec.WatchFailures,
+		CollectPending: rec.CollectPending, CollectRetries: rec.CollectRetries,
+		WatchMaxRetries: rec.WatchMaxRetries,
+		LastWatchAt:     rec.LastWatchAt, LastCollectAt: rec.LastCollectAt,
 		LastError: boundedNotificationText(rec.LastError),
 	}
 }
@@ -651,6 +659,9 @@ func renderNotificationsDoctor(out io.Writer, data notificationsDoctorData) erro
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "  pid=%d host=%s lease=%s heartbeat=%s last_scan=%s runtime=%s\n", data.Watcher.PID, data.Watcher.Host, formatNotificationTime(data.Watcher.LeaseExpiresAt), formatNotificationTime(data.Watcher.HeartbeatAt), formatNotificationTime(data.Watcher.LastScanAt), data.Watcher.RuntimePath)
+	if data.Watcher.WatchBackend != "" {
+		fmt.Fprintf(out, "  backend=%s running=%t mailbox=%s watch_restarts=%d failure_streak=%d collect_pending=%t collect_retries=%d max_failures=%d last_watch=%s last_collect=%s\n", data.Watcher.WatchBackend, data.Watcher.WatchRunning, data.Watcher.WatchMailbox, data.Watcher.WatchRestarts, data.Watcher.WatchFailures, data.Watcher.CollectPending, data.Watcher.CollectRetries, data.Watcher.WatchMaxRetries, formatNotificationTime(data.Watcher.LastWatchAt), formatNotificationTime(data.Watcher.LastCollectAt))
+	}
 	fmt.Fprintf(out, "State: path=%s schema=%d pending=%d events=%d shown=%d truncated=%t\n", data.State.Path, data.State.Schema, data.State.PendingEventCount, data.State.TotalEventCount, data.State.ShownEventCount, data.State.Truncated)
 	renderNotificationEvents(out, data.State.Events)
 	return nil

--- a/internal/cli/notifications.go
+++ b/internal/cli/notifications.go
@@ -77,23 +77,31 @@ type notificationsStateView struct {
 }
 
 type notificationWatcherView struct {
-	PolicyEnabled  bool      `json:"policy_enabled"`
-	Expected       bool      `json:"expected"`
-	Running        bool      `json:"running"`
-	Health         string    `json:"health"`
-	Reason         string    `json:"reason,omitempty"`
-	RuntimePath    string    `json:"runtime_path"`
-	SchemaVersion  int       `json:"schema_version,omitempty"`
-	PID            int       `json:"pid,omitempty"`
-	Host           string    `json:"host,omitempty"`
-	Owner          string    `json:"owner,omitempty"`
-	LeaseTTL       string    `json:"lease_ttl,omitempty"`
-	LeaseExpiresAt time.Time `json:"lease_expires_at,omitempty"`
-	HeartbeatAt    time.Time `json:"heartbeat_at,omitempty"`
-	LastScanAt     time.Time `json:"last_scan_at,omitempty"`
-	LastEventAt    time.Time `json:"last_event_at,omitempty"`
-	StatePath      string    `json:"state_path,omitempty"`
-	LastError      string    `json:"last_error,omitempty"`
+	PolicyEnabled   bool      `json:"policy_enabled"`
+	Expected        bool      `json:"expected"`
+	Running         bool      `json:"running"`
+	Health          string    `json:"health"`
+	Reason          string    `json:"reason,omitempty"`
+	RuntimePath     string    `json:"runtime_path"`
+	SchemaVersion   int       `json:"schema_version,omitempty"`
+	PID             int       `json:"pid,omitempty"`
+	Host            string    `json:"host,omitempty"`
+	Owner           string    `json:"owner,omitempty"`
+	LeaseTTL        string    `json:"lease_ttl,omitempty"`
+	LeaseExpiresAt  time.Time `json:"lease_expires_at,omitempty"`
+	HeartbeatAt     time.Time `json:"heartbeat_at,omitempty"`
+	LastScanAt      time.Time `json:"last_scan_at,omitempty"`
+	LastEventAt     time.Time `json:"last_event_at,omitempty"`
+	WatchBackend    string    `json:"watch_backend,omitempty"`
+	WatchRoot       string    `json:"watch_root,omitempty"`
+	WatchMailbox    string    `json:"watch_mailbox,omitempty"`
+	WatchTimeout    string    `json:"watch_timeout,omitempty"`
+	WatchRestarts   int       `json:"watch_restarts,omitempty"`
+	WatchMaxRetries int       `json:"watch_max_retries,omitempty"`
+	LastWatchAt     time.Time `json:"last_watch_at,omitempty"`
+	LastCollectAt   time.Time `json:"last_collect_at,omitempty"`
+	StatePath       string    `json:"state_path,omitempty"`
+	LastError       string    `json:"last_error,omitempty"`
 }
 
 type notificationsDoctorData struct {
@@ -511,6 +519,9 @@ func buildNotificationWatcherView(expected bool, watcher notificationWatcherStat
 		Host: watcher.Host, Owner: watcher.Owner, LeaseTTL: rec.LeaseTTL,
 		LeaseExpiresAt: watcher.LeaseExpiresAt, HeartbeatAt: watcher.HeartbeatAt,
 		LastScanAt: watcher.LastScanAt, LastEventAt: rec.LastEventAt, StatePath: watcher.StatePath,
+		WatchBackend: rec.WatchBackend, WatchRoot: rec.WatchRoot, WatchMailbox: rec.WatchMailbox,
+		WatchTimeout: rec.WatchTimeout, WatchRestarts: rec.WatchRestarts, WatchMaxRetries: rec.WatchMaxRetries,
+		LastWatchAt: rec.LastWatchAt, LastCollectAt: rec.LastCollectAt,
 		LastError: boundedNotificationText(rec.LastError),
 	}
 }


### PR DESCRIPTION
Closes #454.

This is PR 3 of the approved five-PR #454/#498 stack. It completes the deterministic NOC notification lifecycle; #498 remains in PR 4 and PR 5.

Summary:
- adds the lifecycle-owned exact-root AMQ watch adapter with strict JSON validation, bounded backoff, self-replaying collect, deterministic joined teardown, and honest health/counter projection
- requires an initial delivery scan before readiness and renders exhausted watchers as not running
- rejects duplicate global NOC run IDs transactionally in both record orders
- makes collect journal locking cancellation-aware and bounds the Windows exclusive sentinel so a stale lock degrades visibly instead of waiting forever
- documents managed-watch ownership, failure, replay, fallback, and operator inspection behavior

Safety invariants:
- every owner exit cancels, joins, and reaps the real watch child
- watch output is evidence, never authority; malformed or truncated output degrades with backoff
- failed collect replays without another watch signal and cannot be cleared by a timeout
- stopped, exhausted, or dead runtimes never project as running or healthy
- duplicate NOC identifiers never overwrite persisted bytes

Validation:
- focused watcher/doctor/collect suites passed, including real child reaping, real blocked collect cancellation, startup replay, strict JSON, retry accounting, and stale Windows sentinel coverage
- exact-head evidence t8-c513966-pr3-ci-001: process succeeded, finalization complete, linked true, report sent
- full make ci passed at c513966fc799ba7b10938c7eb933a170fd32bac6
- scoped Windows lock files cross-compiled successfully; package-wide Windows cross-compile remains blocked by unrelated existing unix.Statfs and syscall process-control portability failures
- reproducible detached test helper from #565 was cleaned by exact PID/build ID after the CI parent exited and absence was verified

No merge is performed by this author; the lead owns the converged merge pipeline.