### PR TITLE
Make resume preview consult the predicate admission enforces (#573)

### DIFF
--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -572,7 +572,12 @@ Examples:
 		defaultArgs = append([]string(nil), childArgs...)
 		applyPreparedRunTokenToRecord(&rec, requestedPreparedToken)
 	}
-	if !*dryRun && requestedPreparedToken.empty() && preparedLaunchContext != nil {
+	// #579 finding 5: this site computed its OWN verdict and used the predicate only for
+	// WORDING, so a change to the predicate moved the preview and left admission behind -- the
+	// two-deciders defect half-fixed. The predicate now owns the VERDICT here too: this site
+	// contributes only what is local to it (dry-run, and whether a token was supplied
+	// in-process), and required() decides whether the actor is governed at all.
+	if !*dryRun && requestedPreparedToken.empty() {
 		// #573: the refusal REASON is owned by preparedRunActorAdmission, not composed here,
 		// so `team resume` cannot describe this same state in different words. Sharing only a
 		// boolean would have let the two surfaces agree on the verdict and still disagree in
@@ -581,8 +586,15 @@ Examples:
 		// rec is passed as nil deliberately: this site decides about an IN-PROCESS token, not a
 		// persisted one. Passing the record would set Bindable and change nothing about the
 		// verdict, while implying admission consults record state, which it does not.
-		adm := preparedRunActorAdmission(preparedLaunchContext.Manifest, true, rec.Role, rec.Handle, nil)
-		return fmt.Errorf("agent up refused before launch-record or process side effects: %s", adm.Reason)
+		var manifest preparedRunManifest
+		prepared := preparedLaunchContext != nil
+		if prepared {
+			manifest = preparedLaunchContext.Manifest
+		}
+		adm := preparedRunActorAdmission(manifest, prepared, rec.Role, rec.Handle, nil)
+		if adm.required() {
+			return fmt.Errorf("agent up refused before launch-record or process side effects: %s", adm.Reason)
+		}
 	}
 	if requestedPreparedToken.empty() {
 		applyPreparedRunTokenToRecord(&rec, preparedRunTokenForContext(preparedLaunchContext))

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -587,11 +587,13 @@ Examples:
 		// persisted one. Passing the record would set Bindable and change nothing about the
 		// verdict, while implying admission consults record state, which it does not.
 		var manifest preparedRunManifest
+		var manifestDigest string
 		prepared := preparedLaunchContext != nil
 		if prepared {
 			manifest = preparedLaunchContext.Manifest
+			manifestDigest = preparedLaunchContext.Digest
 		}
-		adm := preparedRunActorAdmission(manifest, prepared, rec.Role, rec.Handle, nil)
+		adm := preparedRunActorAdmission(manifest, manifestDigest, prepared, rec.Role, rec.Handle, nil)
 		if adm.required() {
 			return fmt.Errorf("agent up refused before launch-record or process side effects: %s", adm.Reason)
 		}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -573,10 +573,16 @@ Examples:
 		applyPreparedRunTokenToRecord(&rec, requestedPreparedToken)
 	}
 	if !*dryRun && requestedPreparedToken.empty() && preparedLaunchContext != nil {
-		if containsRole(preparedLaunchContext.Manifest.StagedRoster, rec.Role) {
-			return fmt.Errorf("agent up refused before launch-record or process side effects: staged actor %s/%s requires an exact single-use spawn reservation for prepared generation %s", rec.Role, rec.Handle, preparedLaunchContext.Manifest.Generation)
-		}
-		return fmt.Errorf("agent up refused before launch-record or process side effects: prepared actor %s/%s requires the exact reserved generation token", rec.Role, rec.Handle)
+		// #573: the refusal REASON is owned by preparedRunActorAdmission, not composed here,
+		// so `team resume` cannot describe this same state in different words. Sharing only a
+		// boolean would have let the two surfaces agree on the verdict and still disagree in
+		// front of the operator, which is a weaker version of the bug being fixed.
+		//
+		// rec is passed as nil deliberately: this site decides about an IN-PROCESS token, not a
+		// persisted one. Passing the record would set Bindable and change nothing about the
+		// verdict, while implying admission consults record state, which it does not.
+		adm := preparedRunActorAdmission(preparedLaunchContext.Manifest, true, rec.Role, rec.Handle, nil)
+		return fmt.Errorf("agent up refused before launch-record or process side effects: %s", adm.Reason)
 	}
 	if requestedPreparedToken.empty() {
 		applyPreparedRunTokenToRecord(&rec, preparedRunTokenForContext(preparedLaunchContext))

--- a/internal/cli/prepared_run_admission.go
+++ b/internal/cli/prepared_run_admission.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+)
+
+// #573: `team resume` previewed prepared and staged actors as will-launch and emitted a
+// command that `agent up` then REFUSED, because admission requires a single-use spawn
+// reservation the preview knew nothing about. Preview and execution disagreed, and the
+// operator was handed a command the binary rejects.
+//
+// preparedRunActorAdmission is the SINGLE answer to "would admission refuse this actor for
+// lack of a reservation, and what binds one?". Admission (launch.go) and the resume planner
+// (team_resume.go) both call it, so they cannot disagree about the verdict OR about the
+// wording. Duplicating the condition is what produced #573 in the first place: the
+// `!prepared || !containsRole(manifest.StagedRoster, role)` clause was inlined at five
+// sites, and the planner simply was not one of them.
+//
+// RECORD-AWARE ON PURPOSE. "Governed by an accepted prepared generation" does NOT predict
+// admission. execRestoreRecord (restore.go) takes the token FROM THE PERSISTED RECORD and
+// falls back to an EMPTY token when the record carries none -- which admission refuses. So a
+// manifest-only predicate would report an actor bindable and then fail at exec, recreating
+// the very preview/execution disagreement this type exists to kill, one layer down.
+type preparedRunAdmission struct {
+	// Governed is true when an accepted prepared generation covers this session.
+	Governed bool
+	// Staged is true when the actor is in the staged roster rather than the initial one.
+	// It selects BOTH the refusal wording and the recovery command, which is why admission
+	// has always had two distinct messages here.
+	Staged bool
+	// Bindable is true when a persisted launch record already carries a COMPLETE token, so
+	// the managed restore path can bind without operator input.
+	Bindable bool
+	// Generation is the accepted prepared generation, named in the refusal so the operator
+	// can tell which reservation is being asked for.
+	Generation string
+	// Reason is the refusal text, owned HERE rather than at each call site. Admission and
+	// the planner render the same sentence because there is only one sentence.
+	Reason string
+	// Recovery is the exact operator-runnable command that binds a reservation. Empty when
+	// no reservation is required.
+	Recovery string
+}
+
+// required reports whether an actor with no in-process token would be refused.
+func (a preparedRunAdmission) required() bool { return a.Governed }
+
+// preparedRunActorAdmission classifies an actor against an ALREADY-LOADED manifest.
+//
+// The manifest is passed in rather than read here so admission, which has it in hand,
+// does not re-read it. A second read would open a window in which the preview and the
+// admission decision are made against different generations -- a different flavour of the
+// same disagreement.
+//
+// rec may be nil, meaning "no persisted record was found": that is not bindable.
+func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role, handle string, rec *launch.Record) preparedRunAdmission {
+	adm := preparedRunAdmission{Generation: strings.TrimSpace(manifest.Generation)}
+	if !prepared {
+		return adm
+	}
+	adm.Governed = true
+	adm.Staged = containsRole(manifest.StagedRoster, role)
+	if rec != nil {
+		adm.Bindable = preparedRunTokenFromRecord(*rec).complete()
+	}
+
+	if adm.Staged {
+		adm.Reason = fmt.Sprintf("staged actor %s/%s requires an exact single-use spawn reservation for prepared generation %s",
+			role, handle, adm.Generation)
+	} else {
+		adm.Reason = fmt.Sprintf("prepared actor %s/%s requires the exact reserved generation token", role, handle)
+	}
+
+	switch {
+	case adm.Bindable:
+		// The record carries the token, so the managed restore path binds it with no
+		// operator-supplied secret. This is the only case `resume --exec` can bind
+		// automatically.
+		adm.Recovery = "amq-squad restore --role " + shellQuote(role)
+	case adm.Staged:
+		// There is no hand-typable prepared-token flag; the staged pair is the ONLY
+		// operator-typable binding. The claim ID is deliberately left as a placeholder
+		// because it must come from the authoritative current claim, not from a guess.
+		adm.Recovery = "amq-squad agent up --role " + shellQuote(role) +
+			" --staged-spawn --staged-claim <exact active claim ID from `amq-squad status --json`>"
+	default:
+		// Prepared but unbindable and not staged: no operator-typable command exists, so
+		// naming one would be worse than admitting that. Point at the command that
+		// reserves instead of inventing a flag.
+		adm.Recovery = "amq-squad run start --profile <profile> --session " + shellQuote(strings.TrimSpace(manifest.Session)) +
+			" (re-reserves the generation; no operator-typable token flag exists for this case)"
+	}
+	return adm
+}
+
+// preparedRunAdmissionForMember loads the manifest and classifies one member. Used by the
+// resume planner, which -- unlike admission -- holds no manifest.
+//
+// preparedRunManifestForProjection is reused deliberately: it already distinguishes a
+// genuinely non-prepared session from a DAMAGED accepted state. A fresh reader written here
+// would almost certainly collapse that distinction into "not prepared", which is fail-OPEN
+// in the planner and would preview a command admission rejects -- #573 again.
+func preparedRunAdmissionForMember(project, profile, session, role, handle string, rec *launch.Record) (preparedRunAdmission, error) {
+	manifest, _, prepared, err := preparedRunManifestForProjection(project, profile, session)
+	if err != nil {
+		return preparedRunAdmission{}, err
+	}
+	return preparedRunActorAdmission(manifest, prepared, role, handle, rec), nil
+}

--- a/internal/cli/prepared_run_admission.go
+++ b/internal/cli/prepared_run_admission.go
@@ -56,7 +56,7 @@ func (a preparedRunAdmission) required() bool { return a.Governed }
 // same disagreement.
 //
 // rec may be nil, meaning "no persisted record was found": that is not bindable.
-func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role, handle string, rec *launch.Record) preparedRunAdmission {
+func preparedRunActorAdmission(manifest preparedRunManifest, digest string, prepared bool, role, handle string, rec *launch.Record) preparedRunAdmission {
 	adm := preparedRunAdmission{Generation: strings.TrimSpace(manifest.Generation)}
 
 	// #579 finding 1: Bindable required all four GENERATION fields and ignored
@@ -65,10 +65,20 @@ func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role
 	// refused it at prepared_run_state.go:312 -- the exact defect this predicate exists to kill,
 	// one field over. Bindable now means "the managed restore path can actually bind this",
 	// which requires the attempt.
+	// #579 round 3 F1: shape is not agreement. A COMPLETE, claim-bound token from a SUPERSEDED
+	// generation satisfied every field check, previewed as bindable (team_resume treats Bindable
+	// as not-blocked and offers `agent resume <role>`), and exec-side validation then refused it
+	// -- the refuse-on-exec/allow-in-preview defect this predicate exists to kill, one comparison
+	// short. samePreparedRunGeneration exists for exactly this comparison.
+	//
+	// My round-2 commit claimed "Bindable now means the managed restore path can actually bind
+	// this". That was false until this AND: it meant "the token has the right shape".
 	bindable := false
 	if rec != nil {
 		token := preparedRunTokenFromRecord(*rec)
-		bindable = token.complete() && strings.TrimSpace(token.LaunchAttempt) != ""
+		bindable = token.complete() &&
+			strings.TrimSpace(token.LaunchAttempt) != "" &&
+			samePreparedRunGeneration(token, preparedRunTokenFromSnapshot(manifest, digest))
 	}
 
 	if !prepared {
@@ -78,10 +88,18 @@ func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role
 		// manifest that is absent or different. A token-bearing record in a session with no
 		// accepted generation is CONTRADICTORY evidence, and contradictory evidence is
 		// ineligible, never best-effort.
-		if rec != nil && !preparedRunTokenFromRecord(*rec).empty() {
+		// #579 round 3 F2: empty() checks ONLY the four generation fields -- LaunchAttempt is not
+		// among them -- so a record carrying an orphaned attempt and nothing else fell through as
+		// UNGOVERNED and previewed a plain launch. An orphaned attempt IS prepared-run evidence,
+		// and evidence that contradicts an unprepared session must be governed, not ignored.
+		if rec != nil && recordCarriesPreparedRunEvidence(*rec) {
 			adm.Governed = true
 			adm.Reason = fmt.Sprintf("actor %s/%s carries a prepared-run token but this session has no accepted prepared generation; the token cannot be validated and execution will refuse it", role, handle)
-			adm.Recovery = "amq-squad run start --project " + shellQuote(strings.TrimSpace(manifest.Project)) + " --profile <profile> --session <session>"
+			// Fold-in of the round-2 residual: this branch has no accepted manifest, so
+			// manifest.Project is the zero value and the emitted form was --project '' -- an
+			// empty-quoted flag that LOOKS filled beside placeholders that look like
+			// placeholders. Blank fields render as visible placeholders.
+			adm.Recovery = "amq-squad run start --project " + projectOrPlaceholder(manifest.Project) + " --profile <profile> --session <session>"
 			return adm
 		}
 		return adm
@@ -117,14 +135,18 @@ func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role
 		if rec != nil && strings.TrimSpace(rec.Binary) != "" {
 			binary = strings.TrimSpace(rec.Binary)
 		}
-		adm.Recovery = "amq-squad agent up " + binary + " --role " + shellQuote(role) +
+		// #579 round 3 F4: rec.Binary was concatenated RAW. A path with spaces malforms the
+		// command and a metacharacter becomes syntax the moment the operator copies it. This
+		// disproved my round-2 claim that every emitted form was checked against the real command
+		// surface -- I checked the FLAGS, never the interpolated value.
+		adm.Recovery = "amq-squad agent up " + shellQuote(binary) + " --role " + shellQuote(role) +
 			" --staged-spawn --staged-claim <exact active claim ID from: amq-squad status --json>"
 	default:
 		// Prepared, not staged, and not bindable: no operator-typable token flag exists, so
 		// point at the command that re-reserves rather than inventing one.
-		adm.Recovery = "amq-squad run start --project " + shellQuote(strings.TrimSpace(manifest.Project)) +
-			" --profile " + shellQuote(strings.TrimSpace(manifest.Profile)) +
-			" --session " + shellQuote(strings.TrimSpace(manifest.Session))
+		adm.Recovery = "amq-squad run start --project " + projectOrPlaceholder(manifest.Project) +
+			" --profile " + fieldOrPlaceholder(manifest.Profile, "profile") +
+			" --session " + fieldOrPlaceholder(manifest.Session, "session")
 	}
 	return adm
 }
@@ -137,9 +159,37 @@ func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role
 // would almost certainly collapse that distinction into "not prepared", which is fail-OPEN
 // in the planner and would preview a command admission rejects -- #573 again.
 func preparedRunAdmissionForMember(project, profile, session, role, handle string, rec *launch.Record) (preparedRunAdmission, error) {
-	manifest, _, prepared, err := preparedRunManifestForProjection(project, profile, session)
+	manifest, digest, prepared, err := preparedRunManifestForProjection(project, profile, session)
 	if err != nil {
 		return preparedRunAdmission{}, err
 	}
-	return preparedRunActorAdmission(manifest, prepared, role, handle, rec), nil
+	return preparedRunActorAdmission(manifest, digest, prepared, role, handle, rec), nil
+}
+
+// recordCarriesPreparedRunEvidence reports whether a launch record carries ANY prepared-run
+// field, including an orphaned launch attempt.
+//
+// #579 round 3 F2: token.empty() answers a narrower question -- are the four GENERATION fields
+// all blank -- and LaunchAttempt is not one of them. Using empty() to mean "no prepared-run
+// evidence" let a record with only an attempt read as an ordinary actor.
+func recordCarriesPreparedRunEvidence(rec launch.Record) bool {
+	token := preparedRunTokenFromRecord(rec)
+	return !token.empty() || strings.TrimSpace(token.LaunchAttempt) != ""
+}
+
+// projectOrPlaceholder renders a project path for a COPYABLE command, or a visible placeholder
+// when it is blank.
+//
+// A blank value shell-quotes to ” , which looks like a filled argument and fails at runtime.
+// A placeholder looks unfinished, which is the honest rendering of an unknown value -- the same
+// executable-not-plausible rule that produced findings F3 and F4.
+func projectOrPlaceholder(project string) string {
+	return fieldOrPlaceholder(project, "project")
+}
+
+func fieldOrPlaceholder(value, name string) string {
+	if strings.TrimSpace(value) == "" {
+		return "<" + name + ">"
+	}
+	return shellQuote(strings.TrimSpace(value))
 }

--- a/internal/cli/prepared_run_admission.go
+++ b/internal/cli/prepared_run_admission.go
@@ -58,14 +58,37 @@ func (a preparedRunAdmission) required() bool { return a.Governed }
 // rec may be nil, meaning "no persisted record was found": that is not bindable.
 func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role, handle string, rec *launch.Record) preparedRunAdmission {
 	adm := preparedRunAdmission{Generation: strings.TrimSpace(manifest.Generation)}
+
+	// #579 finding 1: Bindable required all four GENERATION fields and ignored
+	// PreparedRunLaunchAttempt. token.complete() does not check it either. A record with a
+	// complete generation but no reserved attempt previewed will-launch and then managed resume
+	// refused it at prepared_run_state.go:312 -- the exact defect this predicate exists to kill,
+	// one field over. Bindable now means "the managed restore path can actually bind this",
+	// which requires the attempt.
+	bindable := false
+	if rec != nil {
+		token := preparedRunTokenFromRecord(*rec)
+		bindable = token.complete() && strings.TrimSpace(token.LaunchAttempt) != ""
+	}
+
 	if !prepared {
+		// #579 finding 2: returning here unconditionally ignored a record that CARRIES a
+		// prepared token while the session reads unprepared. The preview then emitted a plain
+		// launch that execution rejects, because the record's token is validated against a
+		// manifest that is absent or different. A token-bearing record in a session with no
+		// accepted generation is CONTRADICTORY evidence, and contradictory evidence is
+		// ineligible, never best-effort.
+		if rec != nil && !preparedRunTokenFromRecord(*rec).empty() {
+			adm.Governed = true
+			adm.Reason = fmt.Sprintf("actor %s/%s carries a prepared-run token but this session has no accepted prepared generation; the token cannot be validated and execution will refuse it", role, handle)
+			adm.Recovery = "amq-squad run start --project " + shellQuote(strings.TrimSpace(manifest.Project)) + " --profile <profile> --session <session>"
+			return adm
+		}
 		return adm
 	}
 	adm.Governed = true
 	adm.Staged = containsRole(manifest.StagedRoster, role)
-	if rec != nil {
-		adm.Bindable = preparedRunTokenFromRecord(*rec).complete()
-	}
+	adm.Bindable = bindable
 
 	if adm.Staged {
 		adm.Reason = fmt.Sprintf("staged actor %s/%s requires an exact single-use spawn reservation for prepared generation %s",
@@ -74,24 +97,34 @@ func preparedRunActorAdmission(manifest preparedRunManifest, prepared bool, role
 		adm.Reason = fmt.Sprintf("prepared actor %s/%s requires the exact reserved generation token", role, handle)
 	}
 
+	// #579 findings 3 and 4: every emitted form is now checked against the REAL command
+	// surface. The previous staged form omitted the mandatory <binary> positional and failed
+	// "agent up requires a binary", and the bindable form named a top-level `restore` verb that
+	// is NOT registered -- I had already run the registry grep that showed no registration and
+	// used the verb anyway. An emitted command must be executable, not plausible.
 	switch {
 	case adm.Bindable:
-		// The record carries the token, so the managed restore path binds it with no
-		// operator-supplied secret. This is the only case `resume --exec` can bind
-		// automatically.
-		adm.Recovery = "amq-squad restore --role " + shellQuote(role)
+		// The record carries a complete claim-bound token, so the managed path binds it with
+		// no operator-supplied secret. `agent resume <role>` is the registered verb
+		// (agent.go: "agent resume <role>"); there is no top-level `restore`.
+		adm.Recovery = "amq-squad agent resume " + shellQuote(role)
 	case adm.Staged:
-		// There is no hand-typable prepared-token flag; the staged pair is the ONLY
-		// operator-typable binding. The claim ID is deliberately left as a placeholder
-		// because it must come from the authoritative current claim, not from a guess.
-		adm.Recovery = "amq-squad agent up --role " + shellQuote(role) +
-			" --staged-spawn --staged-claim <exact active claim ID from `amq-squad status --json`>"
+		// The staged pair is the ONLY operator-typable binding: there is no prepared-token
+		// flag. <binary> is a required POSITIONAL, so it is present here rather than implied.
+		// The claim ID stays a placeholder because it must come from the authoritative current
+		// claim, and inventing one would be worse than asking for it.
+		binary := "<binary>"
+		if rec != nil && strings.TrimSpace(rec.Binary) != "" {
+			binary = strings.TrimSpace(rec.Binary)
+		}
+		adm.Recovery = "amq-squad agent up " + binary + " --role " + shellQuote(role) +
+			" --staged-spawn --staged-claim <exact active claim ID from: amq-squad status --json>"
 	default:
-		// Prepared but unbindable and not staged: no operator-typable command exists, so
-		// naming one would be worse than admitting that. Point at the command that
-		// reserves instead of inventing a flag.
-		adm.Recovery = "amq-squad run start --profile <profile> --session " + shellQuote(strings.TrimSpace(manifest.Session)) +
-			" (re-reserves the generation; no operator-typable token flag exists for this case)"
+		// Prepared, not staged, and not bindable: no operator-typable token flag exists, so
+		// point at the command that re-reserves rather than inventing one.
+		adm.Recovery = "amq-squad run start --project " + shellQuote(strings.TrimSpace(manifest.Project)) +
+			" --profile " + shellQuote(strings.TrimSpace(manifest.Profile)) +
+			" --session " + shellQuote(strings.TrimSpace(manifest.Session))
 	}
 	return adm
 }

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // #573: `team resume` previewed prepared and staged actors as will-launch and emitted a
@@ -177,8 +178,18 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 // mistake this milestone has now produced five times, and it is why the half-consolidation
 // shipped with a green test.
 //
-// This asserts the VERDICT FLOWS: at each site the predicate's result must reach a condition
-// (required()) or be returned, not merely be evaluated for a field.
+// WHAT THIS PROVES, stated exactly (#579 round 4 R4-3): required() sits in the CONDITION of an
+// if at each site, so the predicate governs a branch rather than being evaluated for a field.
+//
+// WHAT IT DOES NOT PROVE, declared rather than chased: that the guarded body actually refuses.
+// A body of `return nil` satisfies this check. Proving "the body provably refuses" in the AST is
+// a ladder with no top rung -- I climbed four rungs on this one test across rounds 2, 3 and 4,
+// each time closing the mutation I had just been shown and leaving the adjacent one. Ruled to
+// stop here: refusal semantics are reviewed AT THE SITE, and the verdict table plus the removal
+// proofs cover the behaviour directly.
+//
+// The honest description of what a check proves is worth more than an implied stronger claim,
+// because the implied version is what a future reader relies on.
 func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
 	for _, tc := range []struct {
 		file   string
@@ -391,5 +402,105 @@ func TestStagedRecoveryQuotesTheInterpolatedBinary(t *testing.T) {
 	// both were present.
 	if strings.Contains(adm.Recovery, "codex;rm -rf x") && !strings.Contains(adm.Recovery, shellQuote(rec.Binary)) {
 		t.Errorf("recovery carries the raw unquoted binary: %s", adm.Recovery)
+	}
+}
+
+// #579 round 4 R4-1: a LOADER-LEVEL falsifier. The round-3 stale-generation row calls the
+// predicate directly with a literal digest, so it proves the predicate and says nothing about
+// the CALL-SITE THREADING -- a loader passing a wrong or record-derived digest stayed green.
+// My falsifier proved the function; the claim was about the system.
+//
+// This drives preparedRunAdmissionForMember against REAL on-disk state where the record's token
+// matches a SUPERSEDED generation. It fails if either call site threads the wrong digest,
+// which is the property the claim actually asserts.
+func TestLoaderRefusesBindableForASupersededGeneration(t *testing.T) {
+	dir, manifest, token := preparedRunStateFixture(t)
+	attempt, err := reservePreparedRunLaunch(dir, team.DefaultProfile, "prepared", token)
+	if err != nil {
+		t.Fatalf("reserve launch: %v", err)
+	}
+	token.LaunchAttempt = attempt
+
+	// Anti-vacuity: the record's token must be bindable-shaped BEFORE the generation moves, or
+	// this test would pass for the wrong reason -- an unbindable token is refused anyway.
+	preRec := &launch.Record{
+		PreparedRunGeneration:    token.Generation,
+		PreparedRunDigest:        token.ManifestDigest,
+		PreparedRunGoalNamespace: token.GoalNamespace,
+		PreparedRunGoalDigest:    token.GoalDigest,
+		PreparedRunLaunchAttempt: token.LaunchAttempt,
+	}
+	before, err := preparedRunAdmissionForMember(dir, team.DefaultProfile, "prepared", manifest.Lead, manifest.Lead, preRec)
+	if err != nil {
+		t.Fatalf("loader on the current generation: %v", err)
+	}
+	if !before.Bindable {
+		t.Fatalf("fixture is not bindable on the CURRENT generation, so the supersede case below "+
+			"would pass for the wrong reason: %+v", before)
+	}
+
+	// Now publish a NEW generation. The record still carries the OLD one.
+	republishPreparedRunManifestForTest(t, manifest)
+
+	after, err := preparedRunAdmissionForMember(dir, team.DefaultProfile, "prepared", manifest.Lead, manifest.Lead, preRec)
+	if err != nil {
+		t.Fatalf("loader on the superseded generation: %v", err)
+	}
+	if after.Bindable {
+		t.Error("a record whose token names a SUPERSEDED generation must not be Bindable: preview would " +
+			"offer `agent resume` and exec-side validation would refuse it -- the allow-in-preview/" +
+			"refuse-on-exec defect this predicate exists to kill")
+	}
+	if !after.required() {
+		t.Error("a superseded-generation actor is still governed and must be blocked, not planned fresh")
+	}
+}
+
+// #579 round 4 R4-2: the ” assertion never received a BLANK field. Every table row reuses the
+// populated manifest, so reverting any helper to shellQuote("") stayed green -- an anti-vacuity
+// check that was itself vacuous, which is the sharpest version of this milestone's recurring
+// mistake.
+//
+// The zero manifest is the falsifying input: it is exactly the state the contradictory-evidence
+// branch sees, because that branch fires when NO accepted manifest exists.
+func TestUnpreparedRecoveryRendersPlaceholdersNotEmptyQuotes(t *testing.T) {
+	// Zero manifest: no Project, Profile or Session at all.
+	adm := preparedRunActorAdmission(preparedRunManifest{}, "", false, "qa", "qa-handle",
+		&launch.Record{PreparedRunLaunchAttempt: "a-orphan"})
+
+	if !adm.required() {
+		t.Fatal("a token-bearing record in an unprepared session must be governed")
+	}
+	if strings.Contains(adm.Recovery, "''") {
+		t.Errorf("recovery contains an EMPTY-QUOTED argument, which looks filled and fails at "+
+			"runtime -- the executable-not-plausible rule this PR asserts:\n%s", adm.Recovery)
+	}
+	for _, want := range []string{"<project>", "<profile>", "<session>"} {
+		if !strings.Contains(adm.Recovery, want) {
+			t.Errorf("a blank field must render as the visible placeholder %s:\n%s", want, adm.Recovery)
+		}
+	}
+}
+
+// #579 round 4 R4-4: Contains(shellQuote(binary)) is satisfied even when an ADDITIONAL unquoted
+// copy sits beside the quoted one, and the second Contains I wrote to catch that had the same
+// hole. Contains cannot prove absence.
+//
+// Exact equality is the only assertion that cannot be fooled: it pins the WHOLE emitted command,
+// so any extra, missing or reordered token fails.
+func TestStagedRecoveryIsExactlyTheExpectedCommand(t *testing.T) {
+	manifest := preparedRunManifest{
+		Generation: "g-7", Project: "/repo", Profile: "squad", Session: "v2-25-0",
+		GoalNamespace: "squad/v2-25-0", GoalDigest: "gd-7",
+		StagedRoster: []string{"qa"},
+	}
+	rec := &launch.Record{Binary: "/opt/my tools/codex"}
+
+	adm := preparedRunActorAdmission(manifest, "d-7", true, "qa", "qa-handle", rec)
+
+	want := "amq-squad agent up " + shellQuote(rec.Binary) + " --role " + shellQuote("qa") +
+		" --staged-spawn --staged-claim <exact active claim ID from: amq-squad status --json>"
+	if adm.Recovery != want {
+		t.Errorf("staged recovery must match EXACTLY -- Contains would accept an extra unquoted copy\n got: %s\nwant: %s", adm.Recovery, want)
 	}
 }

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -504,3 +504,71 @@ func TestStagedRecoveryIsExactlyTheExpectedCommand(t *testing.T) {
 		t.Errorf("staged recovery must match EXACTLY -- Contains would accept an extra unquoted copy\n got: %s\nwant: %s", adm.Recovery, want)
 	}
 }
+
+// #579 round 4, ruled pin. The admission site passes rec = nil, so Bindable is false there
+// regardless of the digest and the digest argument is INERT at that site. That is correct --
+// admission decides about an IN-PROCESS token, not a persisted one -- but it means the claim
+// "the digest is threaded at both call sites" is weaker than it sounds, and mutating the
+// admission digest leaves every test green.
+//
+// A comment saying so is how declarations die: four of today's findings were a comment
+// outliving its code. This pins the inertness STRUCTURALLY, which gives it a falsifying input:
+// the moment anyone passes a persisted record at admission, this fails and forces a ruling --
+// which is exactly the moment the digest would stop being inert and the threading would start
+// to matter.
+func TestAdmissionPassesNoRecordSoTheDigestIsProvablyInert(t *testing.T) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, filepath.Join(".", "launch.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse launch.go: %v", err)
+	}
+
+	calls := 0
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != "preparedRunActorAdmission" {
+			return true
+		}
+		calls++
+		if len(call.Args) == 0 {
+			t.Errorf("%s: call has no arguments", fset.Position(call.Pos()))
+			return true
+		}
+		last := call.Args[len(call.Args)-1]
+		lit, isIdent := last.(*ast.Ident)
+		if !isIdent || lit.Name != "nil" {
+			t.Errorf("%s: admission must pass the NIL LITERAL for the launch record.\n"+
+				"It passes %s instead, which means a persisted record now reaches admission -- so the "+
+				"digest argument is no longer inert there and the threading needs its own falsifier. "+
+				"Get a ruling rather than deleting this check.",
+				fset.Position(last.Pos()), typeName(last))
+		}
+		return true
+	})
+
+	// Anti-vacuity: if the call disappears or is renamed, this test must fail rather than pin
+	// nothing. Exactly one admission call site is expected.
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 preparedRunActorAdmission call in launch.go, found %d; the pin is "+
+			"either blind or the call site moved", calls)
+	}
+}
+
+// typeName renders an expression's kind for the failure message above, so the reader learns
+// WHAT was passed instead of just that something was.
+func typeName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return "identifier " + v.Name
+	case *ast.CallExpr:
+		return "a call expression"
+	case *ast.UnaryExpr:
+		return "a unary expression (likely &record)"
+	default:
+		return "a non-nil expression"
+	}
+}

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -28,14 +28,15 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 		Session:      "v2-25-0",
 		StagedRoster: []string{"qa"},
 	}
-	// A record whose token is COMPLETE. Bindable turns on this and nothing else, because
-	// execRestoreRecord takes the token from the record and falls back to an empty token --
-	// which admission refuses -- when the record has none.
+	// A record the managed path can ACTUALLY bind: complete generation AND the reserved launch
+	// attempt. #579 finding 1 -- the attempt was missing from this fixture and from the
+	// predicate, so a record like this previewed bindable and managed resume then refused it.
 	bound := &launch.Record{
 		PreparedRunGeneration:    "g-7",
 		PreparedRunDigest:        "d-7",
 		PreparedRunGoalNamespace: "squad/v2-25-0",
 		PreparedRunGoalDigest:    "gd-7",
+		PreparedRunLaunchAttempt: "a-1",
 	}
 	unbound := &launch.Record{}
 
@@ -68,12 +69,32 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 		{
 			// The row that makes the predicate record-aware. --exec CAN bind this through the
 			// managed restore path, so blocking it would refuse something that works.
-			name: "staged actor whose record carries a complete token", prepared: true, role: "qa", rec: bound,
-			wantRequired: true, wantStaged: true, wantBindable: true, wantRecovery: "restore",
+			name: "staged actor whose record carries a complete claim-bound token", prepared: true, role: "qa", rec: bound,
+			wantRequired: true, wantStaged: true, wantBindable: true, wantRecovery: "agent resume",
 		},
 		{
 			name: "prepared actor whose record carries a complete token", prepared: true, role: "cto", rec: bound,
-			wantRequired: true, wantStaged: false, wantBindable: true, wantRecovery: "restore",
+			wantRequired: true, wantStaged: false, wantBindable: true, wantRecovery: "agent resume",
+		},
+		// #579 finding 6: the rows below were all missing, and every one of them is a state the
+		// predicate can actually see. The table was six happy-ish rows.
+		{
+			// finding 1: complete generation, NO reserved attempt. Previewed will-launch and
+			// managed resume then refused it.
+			name: "complete generation but no reserved attempt is NOT bindable", prepared: true, role: "qa",
+			rec:          &launch.Record{PreparedRunGeneration: "g-7", PreparedRunDigest: "d-7", PreparedRunGoalNamespace: "squad/v2-25-0", PreparedRunGoalDigest: "gd-7"},
+			wantRequired: true, wantStaged: true, wantBindable: false, wantRecovery: "--staged-spawn",
+		},
+		{
+			name: "partial token is not bindable", prepared: true, role: "qa",
+			rec:          &launch.Record{PreparedRunGeneration: "g-7", PreparedRunLaunchAttempt: "a-1"},
+			wantRequired: true, wantStaged: true, wantBindable: false, wantRecovery: "--staged-spawn",
+		},
+		{
+			// finding 2: contradictory evidence -- a token-bearing record in a session with no
+			// accepted generation. Must be governed, never a plain launch.
+			name: "token-bearing record in an UNPREPARED session is governed", prepared: false, role: "qa", rec: bound,
+			wantRequired: true, wantStaged: false, wantBindable: false, wantRecovery: "run start",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -110,6 +131,89 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 			// The recovery command must be runnable, not a description of one.
 			if !strings.HasPrefix(adm.Recovery, "amq-squad ") {
 				t.Errorf("Recovery must be an exact command starting with amq-squad; got %q", adm.Recovery)
+			}
+		})
+	}
+}
+
+// #579 finding 5: the previous version of this test asserted only that a CALL EXPRESSION
+// exists, so it passed while admission called the predicate purely for its Reason string and
+// computed its own verdict. A call is not consumption. That is the same shape-not-proof
+// mistake this milestone has now produced five times, and it is why the half-consolidation
+// shipped with a green test.
+//
+// This asserts the VERDICT FLOWS: at each site the predicate's result must reach a condition
+// (required()) or be returned, not merely be evaluated for a field.
+func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		file   string
+		symbol string
+	}{
+		{"launch.go", "preparedRunActorAdmission"},
+		{"team_resume.go", "preparedRunAdmissionForMember"},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			fset := token.NewFileSet()
+			parsed, err := parser.ParseFile(fset, filepath.Join(".", tc.file), nil, 0)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			// Find the identifier the call result is assigned to, then require that identifier
+			// to appear in a call to required() somewhere in the same file.
+			var assigned []string
+			ast.Inspect(parsed, func(n ast.Node) bool {
+				as, ok := n.(*ast.AssignStmt)
+				if !ok {
+					return true
+				}
+				for _, rhs := range as.Rhs {
+					call, isCall := rhs.(*ast.CallExpr)
+					if !isCall {
+						continue
+					}
+					id, isID := call.Fun.(*ast.Ident)
+					if !isID || id.Name != tc.symbol {
+						continue
+					}
+					if len(as.Lhs) > 0 {
+						if target, ok := as.Lhs[0].(*ast.Ident); ok {
+							assigned = append(assigned, target.Name)
+						}
+					}
+				}
+				return true
+			})
+			if len(assigned) == 0 {
+				t.Fatalf("%s never assigns the result of %s; #573 requires the shared predicate to "+
+					"decide, and a result that is not bound cannot be consumed", tc.file, tc.symbol)
+			}
+
+			consumed := false
+			ast.Inspect(parsed, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel == nil || sel.Sel.Name != "required" {
+					return true
+				}
+				recv, ok := sel.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				for _, name := range assigned {
+					if recv.Name == name {
+						consumed = true
+					}
+				}
+				return true
+			})
+			if !consumed {
+				t.Errorf("%s calls %s but never consumes required() from its result -- so it is using "+
+					"the predicate for WORDING while computing its own verdict. A predicate change would "+
+					"move one surface and not the other, which is the disagreement #573 exists to end.",
+					tc.file, tc.symbol)
 			}
 		})
 	}

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -238,10 +238,11 @@ func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
 			// anywhere in the file, so a dead `_ = adm.required()` sitting beside an independent
 			// verdict computer passed. Consumption is not control.
 			//
-			// The verdict must appear in the CONDITION of an if that controls a refusal, so the
-			// branch is actually governed by the predicate. This is the seventh shape-versus-proof
-			// item in this milestone and the review reopened for safety anyway, so it is fixed
-			// rather than declared.
+			// The verdict must appear in the CONDITION of an if, so the predicate governs a
+			// conditional rather than being evaluated and discarded. Refusal semantics are reviewed
+			// at the site, not proven here -- see this test's header for the declared bound. This is
+			// the seventh shape-versus-proof item in this milestone and the review reopened for
+			// safety anyway, so the polarity part was fixed rather than declared.
 			consumed := false
 			ast.Inspect(parsed, func(n ast.Node) bool {
 				ifs, ok := n.(*ast.IfStmt)

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -21,12 +21,19 @@ import (
 // sufficient: correct verdicts in a predicate nobody calls fixes nothing, and a shared call
 // whose verdicts are wrong is worse than none.
 func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
+	// GoalNamespace and GoalDigest are REQUIRED here, not decoration: #579 round 3 F1 makes
+	// Bindable depend on the record's token AGREEING with the accepted generation, and
+	// preparedRunTokenFromSnapshot derives that generation from these fields. Omitting them made
+	// the fixture unable to model agreement at all -- every bindable row failed, and it would have
+	// been easy to misread that as the F1 fix being wrong rather than the fixture being incomplete.
 	manifest := preparedRunManifest{
-		Generation:   "g-7",
-		Project:      "/repo",
-		Profile:      "squad",
-		Session:      "v2-25-0",
-		StagedRoster: []string{"qa"},
+		Generation:    "g-7",
+		Project:       "/repo",
+		Profile:       "squad",
+		Session:       "v2-25-0",
+		GoalNamespace: "squad/v2-25-0",
+		GoalDigest:    "gd-7",
+		StagedRoster:  []string{"qa"},
 	}
 	// A record the managed path can ACTUALLY bind: complete generation AND the reserved launch
 	// attempt. #579 finding 1 -- the attempt was missing from this fixture and from the
@@ -96,9 +103,32 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 			name: "token-bearing record in an UNPREPARED session is governed", prepared: false, role: "qa", rec: bound,
 			wantRequired: true, wantStaged: false, wantBindable: false, wantRecovery: "run start",
 		},
+		// #579 round 3. Each row below is the FALSIFYING INPUT for a claim my round-2 commit
+		// message made and my round-2 checks could not disprove, because those checks confirmed a
+		// line existed rather than testing what would make the sentence false.
+		{
+			// F1's falsifying input: a COMPLETE, claim-bound token from a SUPERSEDED generation.
+			// Shape-perfect, agreement-absent. Round 2 called this bindable and offered
+			// `agent resume <role>`; exec-side validation refuses it.
+			name: "stale-generation token is NOT bindable", prepared: true, role: "qa",
+			rec: &launch.Record{
+				PreparedRunGeneration: "g-OLD", PreparedRunDigest: "d-OLD",
+				PreparedRunGoalNamespace: "squad/v2-25-0", PreparedRunGoalDigest: "gd-OLD",
+				PreparedRunLaunchAttempt: "a-1",
+			},
+			wantRequired: true, wantStaged: true, wantBindable: false, wantRecovery: "--staged-spawn",
+		},
+		{
+			// F2's falsifying input: ONLY an orphaned launch attempt. token.empty() is TRUE here --
+			// it checks only the four generation fields -- so round 2 let this fall through as an
+			// ordinary actor in an unprepared session.
+			name: "attempt-only record in an UNPREPARED session is governed", prepared: false, role: "qa",
+			rec:          &launch.Record{PreparedRunLaunchAttempt: "a-orphan"},
+			wantRequired: true, wantStaged: false, wantBindable: false, wantRecovery: "run start",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			adm := preparedRunActorAdmission(manifest, tc.prepared, tc.role, "handle-"+tc.role, tc.rec)
+			adm := preparedRunActorAdmission(manifest, "d-7", tc.prepared, tc.role, "handle-"+tc.role, tc.rec)
 
 			if adm.required() != tc.wantRequired {
 				t.Errorf("required() = %v, want %v", adm.required(), tc.wantRequired)
@@ -131,6 +161,11 @@ func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
 			// The recovery command must be runnable, not a description of one.
 			if !strings.HasPrefix(adm.Recovery, "amq-squad ") {
 				t.Errorf("Recovery must be an exact command starting with amq-squad; got %q", adm.Recovery)
+			}
+			// #579 round 3 fold-in: a BLANK field must render as a visible placeholder, never as
+			// '' -- an empty-quoted flag looks filled and fails at runtime.
+			if strings.Contains(adm.Recovery, "''") {
+				t.Errorf("Recovery contains an empty-quoted argument, which looks filled and is not: %q", adm.Recovery)
 			}
 		})
 	}
@@ -188,31 +223,67 @@ func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
 					"decide, and a result that is not bound cannot be consumed", tc.file, tc.symbol)
 			}
 
+			// #579 round 3 F3: the previous version accepted ANY same-named required() receiver
+			// anywhere in the file, so a dead `_ = adm.required()` sitting beside an independent
+			// verdict computer passed. Consumption is not control.
+			//
+			// The verdict must appear in the CONDITION of an if that controls a refusal, so the
+			// branch is actually governed by the predicate. This is the seventh shape-versus-proof
+			// item in this milestone and the review reopened for safety anyway, so it is fixed
+			// rather than declared.
 			consumed := false
 			ast.Inspect(parsed, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
+				ifs, ok := n.(*ast.IfStmt)
+				if !ok || ifs.Cond == nil {
 					return true
 				}
-				sel, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || sel.Sel == nil || sel.Sel.Name != "required" {
-					return true
-				}
-				recv, ok := sel.X.(*ast.Ident)
-				if !ok {
-					return true
-				}
-				for _, name := range assigned {
-					if recv.Name == name {
-						consumed = true
+				// Does this if's CONDITION call required() on one of the bound identifiers?
+				governed := false
+				ast.Inspect(ifs.Cond, func(c ast.Node) bool {
+					call, isCall := c.(*ast.CallExpr)
+					if !isCall {
+						return true
 					}
+					sel, isSel := call.Fun.(*ast.SelectorExpr)
+					if !isSel || sel.Sel == nil || sel.Sel.Name != "required" {
+						return true
+					}
+					recv, isID := sel.X.(*ast.Ident)
+					if !isID {
+						return true
+					}
+					for _, name := range assigned {
+						if recv.Name == name {
+							governed = true
+						}
+					}
+					return true
+				})
+				if !governed {
+					return true
 				}
+				// And does that if's body actually REFUSE -- return an error or set the blocked
+				// action? A governed condition guarding nothing is still not control.
+				ast.Inspect(ifs.Body, func(b ast.Node) bool {
+					switch node := b.(type) {
+					case *ast.ReturnStmt:
+						if len(node.Results) > 0 {
+							consumed = true
+						}
+					case *ast.Ident:
+						if node.Name == "resumeBlocked" {
+							consumed = true
+						}
+					}
+					return true
+				})
 				return true
 			})
 			if !consumed {
-				t.Errorf("%s calls %s but never consumes required() from its result -- so it is using "+
-					"the predicate for WORDING while computing its own verdict. A predicate change would "+
-					"move one surface and not the other, which is the disagreement #573 exists to end.",
+				t.Errorf("%s calls %s but its required() verdict never CONTROLS a refusing branch -- "+
+					"a dead `_ = x.required()` beside an independent verdict computer would look identical. "+
+					"The predicate must govern the condition, or a predicate change moves one surface and "+
+					"not the other, which is the disagreement #573 exists to end.",
 					tc.file, tc.symbol)
 			}
 		})
@@ -293,5 +364,32 @@ func TestPreviewAndAdmissionShareOnePredicate(t *testing.T) {
 	if !routed {
 		t.Errorf("%s must delegate to %s; otherwise the planner and admission answer independently "+
 			"while appearing to share a definition", loader, predicate)
+	}
+}
+
+// #579 round 3 F4's falsifying input. The round-2 check asserted the command prefix and the
+// --staged-spawn flag, both of which pass with the binary missing entirely or unquoted -- I
+// checked the FLAGS and never the interpolated value, then claimed every emitted form was
+// checked against the real command surface.
+//
+// This uses a binary path that BREAKS an unquoted command: a space plus a metacharacter.
+func TestStagedRecoveryQuotesTheInterpolatedBinary(t *testing.T) {
+	manifest := preparedRunManifest{
+		Generation: "g-7", Project: "/repo", Profile: "squad", Session: "v2-25-0",
+		GoalNamespace: "squad/v2-25-0", GoalDigest: "gd-7",
+		StagedRoster: []string{"qa"},
+	}
+	rec := &launch.Record{Binary: "/opt/my tools/codex;rm -rf x"}
+
+	adm := preparedRunActorAdmission(manifest, "d-7", true, "qa", "qa", rec)
+
+	if !strings.Contains(adm.Recovery, shellQuote(rec.Binary)) {
+		t.Errorf("the interpolated binary must be shell-quoted, or a path with spaces malforms the\n"+
+			"command and a metacharacter becomes SYNTAX when the operator copies it.\ngot: %s", adm.Recovery)
+	}
+	// The raw form must NOT appear unquoted: asserting the quoted form alone would also pass if
+	// both were present.
+	if strings.Contains(adm.Recovery, "codex;rm -rf x") && !strings.Contains(adm.Recovery, shellQuote(rec.Binary)) {
+		t.Errorf("recovery carries the raw unquoted binary: %s", adm.Recovery)
 	}
 }

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -273,8 +273,9 @@ func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
 				if !governed {
 					return true
 				}
-				// And does that if's body actually REFUSE -- return an error or set the blocked
-				// action? A governed condition guarding nothing is still not control.
+				// And does that if's body return a value or set the blocked action? This is a
+				// SHAPE check, not proof of refusal semantics: `return nil` satisfies it. Refusal
+				// semantics are reviewed at the site, per the ruling.
 				ast.Inspect(ifs.Body, func(b ast.Node) bool {
 					switch node := b.(type) {
 					case *ast.ReturnStmt:
@@ -291,10 +292,11 @@ func TestBothSurfacesConsumeThePredicateVerdict(t *testing.T) {
 				return true
 			})
 			if !consumed {
-				t.Errorf("%s calls %s but its required() verdict never CONTROLS a refusing branch -- "+
+				t.Errorf("%s calls %s but its required() verdict never appears in the CONDITION of an if -- "+
 					"a dead `_ = x.required()` beside an independent verdict computer would look identical. "+
-					"The predicate must govern the condition, or a predicate change moves one surface and "+
-					"not the other, which is the disagreement #573 exists to end.",
+					"The predicate must govern a conditional, or a predicate change moves one surface and "+
+					"not the other, which is the disagreement #573 exists to end. Refusal semantics "+
+					"themselves are reviewed at the site, not proven here.",
 					tc.file, tc.symbol)
 			}
 		})
@@ -411,8 +413,26 @@ func TestStagedRecoveryQuotesTheInterpolatedBinary(t *testing.T) {
 // My falsifier proved the function; the claim was about the system.
 //
 // This drives preparedRunAdmissionForMember against REAL on-disk state where the record's token
-// matches a SUPERSEDED generation. It fails if either call site threads the wrong digest,
-// which is the property the claim actually asserts.
+// matches a SUPERSEDED generation.
+//
+// SCOPE, per the ruling (#579 r5 R5-3): falsifier-proven AT THE LOADER. It says nothing about
+// the admission site, whose digest is INERT by construction (rec = nil) and pinned separately by
+// TestAdmissionPassesNoRecordSoTheDigestIsProvablyInert. The earlier wording -- "fails if either
+// call site threads the wrong digest" -- was written before that ruling and is false under it.
+//
+// DECLARED BOUND (#579 r5 R5-1): this row bites a loader threading a WRONG-VALUED digest,
+// because the before-assertion requires Bindable to be true on the current generation. It does
+// NOT bite a loader threading rec.PreparedRunDigest: the before-check passes (the values are
+// equal by fixture construction) and the after-check still rejects, because republishing rotates
+// the GENERATION ID and samePreparedRunGeneration compares that independently.
+//
+// The fixture that would bite it -- same generation id, different manifest digest -- CANNOT BE
+// BUILT through the sanctioned writer: publishPreparedRunGeneration installs the generation
+// manifest with durableCreateExclusive, which uses os.Link and therefore fails with EEXIST
+// rather than replacing. One generation id publishes exactly once, by design. Hand-writing the
+// artifacts would fabricate a state the system cannot produce, which is worse evidence than an
+// honest bound. So the record-derived mutation is closed STRUCTURALLY instead, by
+// TestLoaderThreadsTheProjectionDigestNotTheRecords.
 func TestLoaderRefusesBindableForASupersededGeneration(t *testing.T) {
 	dir, manifest, token := preparedRunStateFixture(t)
 	attempt, err := reservePreparedRunLaunch(dir, team.DefaultProfile, "prepared", token)
@@ -570,5 +590,85 @@ func typeName(e ast.Expr) string {
 		return "a unary expression (likely &record)"
 	default:
 		return "a non-nil expression"
+	}
+}
+
+// #579 r5 R5-1, structural closure of the mutation no behavioural fixture can reach.
+//
+// The loader must pass THE PROJECTION'S digest to the predicate -- the value returned by
+// preparedRunManifestForProjection -- and not one derived from the launch record. A
+// record-derived digest makes the comparison self-referential: the token is checked against a
+// snapshot built from its own field, so it always agrees and Bindable is true for a superseded
+// generation.
+//
+// Pinned structurally because the behavioural falsifier is impossible: the fixture would need
+// one generation id published twice with different content, and publishPreparedRunGeneration
+// installs generation artifacts with os.Link, which fails EEXIST rather than replacing. Same
+// reasoning as the admission inertness pin -- when a property cannot be given a falsifying
+// INPUT, give it a falsifying EDIT.
+func TestLoaderThreadsTheProjectionDigestNotTheRecords(t *testing.T) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, filepath.Join(".", "prepared_run_admission.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	checked := false
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "preparedRunAdmissionForMember" || fn.Body == nil {
+			return true
+		}
+		// The digest identifier the projection binds, taken from the assignment rather than
+		// assumed to be called "digest" -- a rename must not silently disable this pin.
+		projectionDigest := ""
+		ast.Inspect(fn.Body, func(x ast.Node) bool {
+			as, isAssign := x.(*ast.AssignStmt)
+			if !isAssign || len(as.Rhs) != 1 || len(as.Lhs) < 2 {
+				return true
+			}
+			call, isCall := as.Rhs[0].(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			id, isID := call.Fun.(*ast.Ident)
+			if !isID || id.Name != "preparedRunManifestForProjection" {
+				return true
+			}
+			if ident, ok := as.Lhs[1].(*ast.Ident); ok {
+				projectionDigest = ident.Name
+			}
+			return true
+		})
+		if projectionDigest == "" || projectionDigest == "_" {
+			t.Fatalf("the loader does not bind the projection's digest at all, so it cannot be passing it")
+		}
+
+		ast.Inspect(fn.Body, func(x ast.Node) bool {
+			call, isCall := x.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			id, isID := call.Fun.(*ast.Ident)
+			if !isID || id.Name != "preparedRunActorAdmission" || len(call.Args) < 2 {
+				return true
+			}
+			checked = true
+			arg, isIdent := call.Args[1].(*ast.Ident)
+			if !isIdent || arg.Name != projectionDigest {
+				t.Errorf("%s: the loader must pass the PROJECTION's digest (%s) as the digest argument.\n"+
+					"A record-derived digest makes the generation comparison self-referential -- the token is "+
+					"checked against a snapshot built from its own field, always agrees, and a SUPERSEDED "+
+					"generation reads as Bindable. No behavioural fixture can catch that, because one "+
+					"generation id cannot be published twice (os.Link EEXIST), which is why this is pinned.",
+					fset.Position(call.Args[1].Pos()), projectionDigest)
+			}
+			return true
+		})
+		return true
+	})
+
+	if !checked {
+		t.Fatal("found no preparedRunActorAdmission call inside preparedRunAdmissionForMember; the pin is blind")
 	}
 }

--- a/internal/cli/prepared_run_admission_test.go
+++ b/internal/cli/prepared_run_admission_test.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+)
+
+// #573: `team resume` previewed prepared and staged actors as will-launch and emitted a
+// command `agent up` then REFUSED, because admission required a spawn reservation the preview
+// knew nothing about. The condition was inlined at five sites and the planner was not one of
+// them.
+//
+// This table asserts the VERDICTS. The structural test below asserts that both surfaces
+// actually consult this predicate rather than agreeing by coincidence. Neither alone is
+// sufficient: correct verdicts in a predicate nobody calls fixes nothing, and a shared call
+// whose verdicts are wrong is worse than none.
+func TestPreparedRunActorAdmissionClassifiesEveryState(t *testing.T) {
+	manifest := preparedRunManifest{
+		Generation:   "g-7",
+		Project:      "/repo",
+		Profile:      "squad",
+		Session:      "v2-25-0",
+		StagedRoster: []string{"qa"},
+	}
+	// A record whose token is COMPLETE. Bindable turns on this and nothing else, because
+	// execRestoreRecord takes the token from the record and falls back to an empty token --
+	// which admission refuses -- when the record has none.
+	bound := &launch.Record{
+		PreparedRunGeneration:    "g-7",
+		PreparedRunDigest:        "d-7",
+		PreparedRunGoalNamespace: "squad/v2-25-0",
+		PreparedRunGoalDigest:    "gd-7",
+	}
+	unbound := &launch.Record{}
+
+	for _, tc := range []struct {
+		name         string
+		prepared     bool
+		role         string
+		rec          *launch.Record
+		wantRequired bool
+		wantStaged   bool
+		wantBindable bool
+		wantRecovery string
+	}{
+		{
+			name: "not a prepared session at all", prepared: false, role: "qa", rec: nil,
+			wantRequired: false,
+		},
+		{
+			name: "staged actor with no record", prepared: true, role: "qa", rec: nil,
+			wantRequired: true, wantStaged: true, wantRecovery: "--staged-spawn",
+		},
+		{
+			name: "prepared non-staged actor with no record", prepared: true, role: "cto", rec: nil,
+			wantRequired: true, wantStaged: false, wantRecovery: "run start",
+		},
+		{
+			name: "staged actor whose record carries no token", prepared: true, role: "qa", rec: unbound,
+			wantRequired: true, wantStaged: true, wantRecovery: "--staged-spawn",
+		},
+		{
+			// The row that makes the predicate record-aware. --exec CAN bind this through the
+			// managed restore path, so blocking it would refuse something that works.
+			name: "staged actor whose record carries a complete token", prepared: true, role: "qa", rec: bound,
+			wantRequired: true, wantStaged: true, wantBindable: true, wantRecovery: "restore",
+		},
+		{
+			name: "prepared actor whose record carries a complete token", prepared: true, role: "cto", rec: bound,
+			wantRequired: true, wantStaged: false, wantBindable: true, wantRecovery: "restore",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adm := preparedRunActorAdmission(manifest, tc.prepared, tc.role, "handle-"+tc.role, tc.rec)
+
+			if adm.required() != tc.wantRequired {
+				t.Errorf("required() = %v, want %v", adm.required(), tc.wantRequired)
+			}
+			if adm.Staged != tc.wantStaged {
+				t.Errorf("Staged = %v, want %v", adm.Staged, tc.wantStaged)
+			}
+			if adm.Bindable != tc.wantBindable {
+				t.Errorf("Bindable = %v, want %v", adm.Bindable, tc.wantBindable)
+			}
+			if !tc.wantRequired {
+				// A non-prepared session must not produce refusal text at all; an unused
+				// Reason string is how a caller ends up rendering a refusal for a fine actor.
+				if adm.Reason != "" || adm.Recovery != "" {
+					t.Errorf("a non-required verdict must carry no Reason/Recovery; got %q / %q", adm.Reason, adm.Recovery)
+				}
+				return
+			}
+			// The reason must name the ACTOR, so an operator with several blocked members can
+			// tell which row is which.
+			if !strings.Contains(adm.Reason, tc.role) {
+				t.Errorf("Reason must name the role %q: %s", tc.role, adm.Reason)
+			}
+			if tc.wantStaged && !strings.Contains(adm.Reason, manifest.Generation) {
+				t.Errorf("a staged refusal must name the generation whose reservation is required: %s", adm.Reason)
+			}
+			if !strings.Contains(adm.Recovery, tc.wantRecovery) {
+				t.Errorf("Recovery must offer %q; got %q", tc.wantRecovery, adm.Recovery)
+			}
+			// The recovery command must be runnable, not a description of one.
+			if !strings.HasPrefix(adm.Recovery, "amq-squad ") {
+				t.Errorf("Recovery must be an exact command starting with amq-squad; got %q", adm.Recovery)
+			}
+		})
+	}
+}
+
+// The locked requirement for #573 was a SHARED predicate, not a parallel reimplementation, so
+// that preview and admission cannot disagree. This asserts the sharing structurally: both the
+// admission path and the resume planner must reference the predicate.
+//
+// A behavioural end-to-end test would be satisfiable by two independent implementations that
+// happen to agree today, which is exactly how #573 arose -- the condition was inlined five
+// times and stayed consistent until one copy was missing.
+//
+// DECLARED BOUND: this proves both surfaces CALL the predicate. It does not execute a full
+// resume against an on-disk prepared session, so it cannot prove the planner's blocked row
+// renders end-to-end; the verdict table above covers the classification and the planner's
+// field-setting is reviewed by inspection at the call site.
+func TestPreviewAndAdmissionShareOnePredicate(t *testing.T) {
+	const predicate = "preparedRunActorAdmission"
+	const loader = "preparedRunAdmissionForMember"
+
+	want := map[string]string{
+		// admission -- the authority whose refusal the preview must not contradict
+		"launch.go": predicate,
+		// the resume planner, via the manifest-loading wrapper
+		"team_resume.go": loader,
+	}
+
+	for file, symbol := range want {
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, filepath.Join(".", file), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		found := false
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if id, isID := call.Fun.(*ast.Ident); isID && id.Name == symbol {
+				found = true
+			}
+			return true
+		})
+		if !found {
+			t.Errorf("%s does not call %s. #573 requires preview and admission to consult ONE "+
+				"predicate; a second copy of the condition is how they came to disagree.", file, symbol)
+		}
+	}
+
+	// Anti-vacuity: the loader must itself route through the predicate, or the planner would be
+	// calling a wrapper that answers independently and the "shared" claim would be hollow.
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, filepath.Join(".", "prepared_run_admission.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse predicate file: %v", err)
+	}
+	routed := false
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != loader {
+			return true
+		}
+		ast.Inspect(fn, func(x ast.Node) bool {
+			call, isCall := x.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			if id, isID := call.Fun.(*ast.Ident); isID && id.Name == predicate {
+				routed = true
+			}
+			return true
+		})
+		return true
+	})
+	if !routed {
+		t.Errorf("%s must delegate to %s; otherwise the planner and admission answer independently "+
+			"while appearing to share a definition", loader, predicate)
+	}
+}

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -1414,6 +1414,40 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 		}
 		plan.Saved = &resumeSavedLaunchSummary{Binary: rec.Binary, Model: rec.Model, Effort: savedEffort, NativeArgs: wizardSavedExtraArgs(rec.Binary, extraArgs)}
 	}
+	// #573: consult THE SAME predicate admission enforces. Without this the planner emitted a
+	// command for a prepared or staged actor and `agent up` then refused it, so preview and
+	// execution disagreed in front of the operator and the emitted command was unusable.
+	//
+	// Placed AFTER the restore-record lookup because the verdict is record-aware, and BEFORE
+	// the boundary-violation check so that a boundary violation still wins -- it is the more
+	// specific refusal and names a different problem.
+	var admRec *launch.Record
+	if recFound {
+		admRec = plan.RestoreRecord
+	}
+	adm, admErr := preparedRunAdmissionForMember(in.Team.Project, in.Profile, env.SessionName, m.Role, handle, admRec)
+	if admErr != nil {
+		// A damaged accepted state is an authority failure, not permission to plan a fresh
+		// launch. Fail CLOSED: the cost of blocking is one operator message, while the cost of
+		// emitting is a command the binary rejects.
+		plan.Action = resumeBlocked
+		plan.Command = ""
+		plan.Note = fmt.Sprintf("prepared-run state unreadable: %v", admErr)
+		plan.Liveness = &agentLiveness{Verdict: livenessMissing, Status: statusStateMissing, Detail: plan.Note}
+		return plan, nil
+	}
+	// Bindable is NOT blocked: a record carrying a complete token can be bound by --exec
+	// through the managed restore path, and refusing it would be the mirror-image error of the
+	// bug -- refusing something that works.
+	if adm.required() && !adm.Bindable {
+		plan.Action = resumeBlocked
+		// Clearing Command is what makes resumeLaunchState report "blocked". Setting Action
+		// alone would still classify, but would keep emitting the command admission rejects.
+		plan.Command = ""
+		plan.Note = adm.Reason + ". Bind with: " + adm.Recovery
+		plan.Liveness = &agentLiveness{Verdict: livenessMissing, Status: statusStateMissing, Detail: plan.Note}
+		return plan, nil
+	}
 	if recFound && projectLeadExternalRecordBoundaryViolation(in.Team, m, rec, in.Profile, env.SessionName, root, handle) {
 		plan.Action = resumeBlocked
 		plan.Command = ""


### PR DESCRIPTION
Fixes #573. Based on merged main (47c9c48).

**Shared symbol, per the locked requirement: `preparedRunActorAdmission`.**

`team resume` previewed prepared and staged actors as will-launch and emitted a
command that `agent up` then REFUSED. The operator was handed a command the
binary rejects, and neither surface was wrong on its own -- nothing compared
them.

The condition was inlined at five sites (launch.go twice,
prepared_run_staged_projection.go twice, prepared_run_state.go), and the resume
planner simply was not one of them. So the fix is one shared predicate rather
than a sixth copy: preparedRunActorAdmission. Both admission and the planner
call it.

It owns the refusal WORDING, not just the verdict. Sharing only a boolean would
have let the two surfaces agree on whether to refuse and still describe the same
state differently to the operator -- a weaker version of the bug being fixed.

RECORD-AWARE, which was a correction to the original design. "Governed by an
accepted prepared generation" does NOT predict admission: execRestoreRecord
takes the token from the persisted record and falls back to an EMPTY token when
the record carries none, which admission refuses. A manifest-only predicate
would therefore preview an actor as bindable and fail at exec -- the same
preview/execution disagreement one layer down. Bindable is computed from the
record's token and a bindable actor is deliberately NOT blocked, because --exec
can bind it through the managed restore path; blocking it would be the
mirror-image error.

The recovery command differs by staged/prepared because there is no
hand-typable prepared token: `agent up` has no such flag, and the only
operator-typable binding is the staged pair --staged-spawn --staged-claim. That
is why admission always had two messages, and the predicate now owns both.

Planner-side, all four fields are set together (Action, Command, Note, Liveness)
matching the existing blocked shape. Clearing Command is what makes
resumeLaunchState report "blocked"; leaving it set would keep emitting the
command admission rejects even with the action corrected. A damaged prepared
state fails CLOSED: the cost of blocking is one operator message, the cost of
emitting is a refused launch. Placed before the boundary-violation check so the
more specific refusal still wins.

REMOVAL PROOFS, one variable each, compile-gated first so no exit code is read
from a broken tree:
  A  drop the planner's call        -> FAIL: team_resume.go does not call the predicate
  B  make the predicate manifest-only -> FAIL: Bindable = false, want true, on both
                                        record-carrying rows
  C  revert admission's call        -> FAIL: launch.go does not call the predicate

Proof C corrects my own plan. I predicted a compile error on the shared symbol
and said I would state that plainly rather than manufacture an independent
proof. The build actually succeeds -- the predicate is still referenced by its
loader -- and the structural test catches the revert instead. That is a real
independent proof where I had expected to have none.

Note also what --exec already did: execResumePlan refuses when any plan is
blocked, listing each role with its Note, so marking these actors blocked yields
a correct refusal for free. --force-duplicate skips that refusal, but blocked
plans carry no Command and only panes entries launch, so forced runs IGNORE
blocked members rather than launching them unbound. No unsafe path existed;
bind-on-exec is added capability.

DECLARED BOUND: the structural test proves both surfaces CALL one predicate and
the table proves its verdicts. Neither executes a full resume against an
on-disk prepared session, so the planner's rendered row is reviewed at the call
site rather than end-to-end. A behavioural test alone would be satisfiable by
two implementations that agree today, which is exactly how this bug arose.

Fixes #573



---

## Documented residuals (round-2 cap; recorded rather than re-opened)

**1. Empty `--project` in the F2 recovery command (LOW, non-safety).** The F2 branch composes its recovery from `manifest.Project`, but in that branch the session by definition has no accepted manifest — from the `launch.go` call site the manifest is the zero value. So the operator is handed:

```
amq-squad run start --project '' --profile <profile> --session <session>
```

An empty-quoted flag that **looks filled**, sitting beside placeholders that look like placeholders. That is this PR's own F3/F4 principle — emitted commands must be executable, not plausible — violated by the fix for F2. The correct form is a `<project>` placeholder whenever the field is blank.

Not fixed here per the two-round cap. It rides the next PR touching this file; PR 5 is adjacent and will carry it.

**2. The verdict-flow test proves consumption, not control (declared bound).** `TestBothSurfacesConsumeThePredicateVerdict` finds the identifier the predicate's result is bound to and requires `required()` to be invoked on it. It does **not** prove the result *controls* the branch — a bare `_ = adm.required()` would satisfy it.

Stated rather than closed, because the honest description of what a check proves is more useful than an implied stronger claim. The verdict table covers the classification behaviour directly, and the property that actually matters — production classification — is verified by that table plus the removal proofs. This is the seventh shape-versus-proof item in this milestone and the first one I am shipping declared instead of iterated.
