### PR TITLE
Add fail-closed goal supervision assessment

### DIFF
--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -267,9 +267,14 @@ observations unknown in production. Therefore its production assessment cannot
 reach `native_goal_paused_eligible` by absence. PR5 must populate all three
 from durable stores, revalidate the exact typed goal and attempt against the
 generated command and accepted prepared-run goal, and use
-`fingerprint + attempt_id` as the claim key. The projected resume action stays
-unavailable until that claim-once execution path exists; every mutating action
-still carries its fingerprint, attempt ID, and confirmation wording.
+`namespace_id + pause_generation + attempt_id` as the durable claim key.
+`pause_generation` is stable across unrelated launch-record drift and binds
+the launch ID, goal-binding digest, attempt ID, and mode. The claim record
+stores the preclaim fingerprint as a staleness check; the fingerprint plus
+attempt ID remains the action binding, not the durable claim identity. The
+projected resume action stays unavailable until that claim-once execution path
+exists; every mutating action still carries its fingerprint, attempt ID, and
+confirmation wording.
 
 ## Wake outside a managed pane
 

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -227,6 +227,37 @@ CLI process to exit, then uses the exact pane/window IDs returned synchronously
 by the spawn backend. Missing IDs or tmux failures leave every agent running
 and surface a persistent `layout_finalization` warning in text and JSON status.
 
+## Read-only native goal supervision
+
+`status --json`, board session rows, and the doctor check with
+`kind: "goal_supervision"` project one shared assessment of the visible lead's
+native goal state. The object is schema-versioned, time-bounded, and
+fingerprinted across the exact project/profile/session namespace, lead and
+launch identity, recorded managed pane, prepared run, native goal attempt,
+pause generation, blocker/gate evidence, invariants, policy revision, claim
+projection, and retry budget.
+
+The state vocabulary is deliberately closed:
+
+- `running`, `parked_waiting_amq`, and `goal_terminal` are non-attention
+  lifecycle states.
+- `native_goal_paused_eligible` means every positive eligibility fact is
+  present.
+- `native_goal_blocked_human` means a known human decision, local input, open
+  gate, or unresolved known blocker remains.
+- `native_goal_blocked_unknown` means evidence is missing, stale,
+  contradictory, or ambiguous.
+- `lead_down` and `pane_busy_or_unverified` require restoration or inspection,
+  never inferred delivery.
+
+Policy modes are `manual`, `notify-only`, and `safe-auto`; missing policy is
+compatibility-safe `manual` revision 1, and cloned profiles discard the source
+policy. This assessment layer is read-only: it cannot claim an attempt, send a
+message, or inject `/goal resume`. A later delivery layer must consume the
+same fresh fingerprint and atomically establish claim-once state before any
+mutation. Fuzzy pane discovery, legacy name matching, raw tmux send-keys, and
+unknown source states are not eligible fallbacks.
+
 ## Wake outside a managed pane
 
 If a lead/orchestrator runs in a plain terminal **outside tmux**, the default

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -234,8 +234,12 @@ and surface a persistent `layout_finalization` warning in text and JSON status.
 native goal state. The object is schema-versioned, time-bounded, and
 fingerprinted across the exact project/profile/session namespace, lead and
 launch identity, recorded managed pane, prepared run, native goal attempt,
-pause generation, blocker/gate evidence, invariants, policy revision, claim
-projection, and retry budget.
+pause generation, fresh lifecycle, blocker/gate/local-input evidence,
+invariants, policy revision, claim projection, and retry budget. A managed
+pane requires the canonical launch target `current-window`, `new-window`, or
+`new-session`, plus exact pane ID, window ID, tmux session, and deterministic
+lead title. PID liveness, process-binary identity, and pane identity must all
+be positive; no one signal substitutes for the others.
 
 The state vocabulary is deliberately closed:
 
@@ -257,6 +261,15 @@ message, or inject `/goal resume`. A later delivery layer must consume the
 same fresh fingerprint and atomically establish claim-once state before any
 mutation. Fuzzy pane discovery, legacy name matching, raw tmux send-keys, and
 unknown source states are not eligible fallbacks.
+
+PR4 intentionally leaves durable claim, retry-budget, and blocker-resolution
+observations unknown in production. Therefore its production assessment cannot
+reach `native_goal_paused_eligible` by absence. PR5 must populate all three
+from durable stores, revalidate the exact typed goal and attempt against the
+generated command and accepted prepared-run goal, and use
+`fingerprint + attempt_id` as the claim key. The projected resume action stays
+unavailable until that claim-once execution path exists; every mutating action
+still carries its fingerprint, attempt ID, and confirmation wording.
 
 ## Wake outside a managed pane
 

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -269,6 +269,38 @@ amq-squad operator directive --project <project> --profile <profile> --session <
 Answer approval gates with `operator answer`; do not treat p2p prose such as
 "pending operator" or "manual approval" as an approval.
 
+## Inspect Native Goal Supervision
+
+The scoped status, board, and doctor JSON expose the same versioned,
+read-only `goal_supervision` assessment. This assessment does not claim an
+attempt, send AMQ, or write to a pane:
+
+```sh
+amq-squad status --project <project> --profile <profile> --session <session> --json |
+  jq '.data.goal_supervision'
+amq-squad status --project <project> --json |
+  jq '.data.sessions[] | select(.name == "<session>") | .goal_supervision'
+amq-squad doctor --project <project> --profile <profile> --session <session> --json |
+  jq '.data.checks[] | select(.kind == "goal_supervision") | .goal_supervision'
+```
+
+Its states are `running`, `parked_waiting_amq`,
+`native_goal_paused_eligible`, `native_goal_blocked_human`,
+`native_goal_blocked_unknown`, `lead_down`, `pane_busy_or_unverified`, and
+`goal_terminal`. Eligibility is a positive conjunction: exact namespace,
+lead, launch, pane, goal attempt, and pause generations; fresh complete
+sources; durable blocker resolution; no open or ambiguous gate; no local
+input; passing invariants; no prior claim; and available retry budget.
+Unknown, stale, missing, or contradictory evidence is ineligible.
+
+The policy projection is `manual`, `notify-only`, or `safe-auto`. Profiles
+without an explicit policy remain `manual` revision 1. In this read-only
+phase, even `safe-auto` only sets `automatic_resume_allowed` in the
+assessment; no automatic delivery occurs. Use the emitted inspect, restore,
+notify, and resume action objects as operator guidance, and re-read the
+assessment immediately before any manual action because its fingerprint and
+freshness bind the observed attempt.
+
 ## Common Failures
 
 ### Topology Or Launch Fault

--- a/docs/operator-cookbook.md
+++ b/docs/operator-cookbook.md
@@ -289,17 +289,22 @@ Its states are `running`, `parked_waiting_amq`,
 `native_goal_blocked_unknown`, `lead_down`, `pane_busy_or_unverified`, and
 `goal_terminal`. Eligibility is a positive conjunction: exact namespace,
 lead, launch, pane, goal attempt, and pause generations; fresh complete
-sources; durable blocker resolution; no open or ambiguous gate; no local
-input; passing invariants; no prior claim; and available retry budget.
+sources and lifecycle; full PID/process-binary/exact-pane identity; exact typed
+goal and attempt matching the generated command and accepted prepared-run
+goal; durable blocker resolution; no open or ambiguous gate; a successful
+lead-pane local-input scan showing no prompt; passing invariants; a durably
+clear claim; and a durably available retry budget.
 Unknown, stale, missing, or contradictory evidence is ineligible.
 
 The policy projection is `manual`, `notify-only`, or `safe-auto`. Profiles
 without an explicit policy remain `manual` revision 1. In this read-only
 phase, even `safe-auto` only sets `automatic_resume_allowed` in the
 assessment; no automatic delivery occurs. Use the emitted inspect, restore,
-notify, and resume action objects as operator guidance, and re-read the
-assessment immediately before any manual action because its fingerprint and
-freshness bind the observed attempt.
+and notify action objects as operator guidance. The resume action is
+deliberately unavailable until PR5 supplies durable blocker-resolution,
+claim, and budget evidence plus the claim-once executor. Mutating action
+objects carry the exact assessment fingerprint, attempt ID, and confirmation
+wording; re-read the assessment immediately before any manual action.
 
 ## Common Failures
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/bootstrapack"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -39,11 +40,12 @@ const (
 
 // doctorCheck is one diagnostic result.
 type doctorCheck struct {
-	Name   string       `json:"name"`
-	Status doctorStatus `json:"status"`
-	Detail string       `json:"detail,omitempty"`
-	Kind   string       `json:"kind,omitempty"`
-	Role   string       `json:"role,omitempty"`
+	Name            string                     `json:"name"`
+	Status          doctorStatus               `json:"status"`
+	Detail          string                     `json:"detail,omitempty"`
+	Kind            string                     `json:"kind,omitempty"`
+	Role            string                     `json:"role,omitempty"`
+	GoalSupervision *GoalSupervisionAssessment `json:"goal_supervision,omitempty"`
 }
 
 // doctorEnvelopeData is the kind="doctor" payload. team_home is the project
@@ -649,10 +651,72 @@ func runDoctorChecks(d doctorExecution) ([]doctorCheck, string) {
 	checks = append(checks, doctorCheckBootstrap(d)...)
 	wakeChecks, workstream := doctorCheckWake(d)
 	checks = append(checks, wakeChecks...)
+	checks = append(checks, doctorCheckGoalSupervision(d, workstream))
 	checks = append(checks, doctorCheckTaskCompletionEvidence(d, workstream))
 	checks = append(checks, doctorCheckNotificationWatcher(d, workstream))
 	checks = append(checks, doctorCheckWorktrees(d, workstream)...)
 	return checks, workstream
+}
+
+func doctorCheckGoalSupervision(d doctorExecution, workstream string) doctorCheck {
+	const name = "goal supervision"
+	profile := doctorProfile(d)
+	if strings.TrimSpace(workstream) == "" || !team.ExistsProfile(d.ProjectDir, profile) {
+		return doctorCheck{
+			Name: name, Kind: "goal_supervision", Status: doctorOK,
+			Detail: "no resolved team workstream; assessment skipped",
+		}
+	}
+	t, err := team.ReadProfile(d.ProjectDir, profile)
+	if err != nil {
+		return doctorCheck{
+			Name: name, Kind: "goal_supervision", Status: doctorWarn,
+			Detail: "team config unreadable; assessment unavailable",
+		}
+	}
+	probe := d.Probe
+	if probe.PIDAlive == nil {
+		probe.PIDAlive = defaultDuplicateLaunchProbe.PIDAlive
+	}
+	if probe.ProcessMatch == nil {
+		probe.ProcessMatch = defaultDuplicateLaunchProbe.ProcessMatch
+	}
+	if probe.ProcessTTY == nil {
+		probe.ProcessTTY = defaultDuplicateLaunchProbe.ProcessTTY
+	}
+	if probe.ProcessStartTime == nil {
+		probe.ProcessStartTime = defaultDuplicateLaunchProbe.ProcessStartTime
+	}
+	if probe.Now == nil {
+		probe.Now = defaultDuplicateLaunchProbe.Now
+	}
+	rows := buildStatusRows(t, profile, workstream, probe)
+	ctx := newSessionStatusContext(t, profile, workstream, firstLiveTmuxSession(rows))
+	ns := squadnamespace.Resolve(t.Project, ctx.Profile, workstream)
+	invariantErrors := annotateVisibilityInvariants(rows, ctx)
+	conflict := namespaceConflictForProfileSession(t.Project, profile, workstream)
+	now := time.Now().UTC()
+	if probe.Now != nil {
+		now = probe.Now().UTC()
+	}
+	gateObservation := inspectGoalSupervisionGates(t, profile, workstream, firstStatusRoot(rows), probe, now)
+	assessment := buildGoalSupervisionAssessment(
+		t, profile, workstream, ns, rows, gateObservation, invariantErrors,
+		conflict, probe, now,
+	)
+	status := doctorOK
+	if assessment.AttentionRequired || !assessment.Source.Complete || !assessment.Invariants.OK {
+		status = doctorWarn
+	}
+	return doctorCheck{
+		Name: name, Kind: "goal_supervision", Status: status,
+		Detail: fmt.Sprintf(
+			"state=%s eligible=%t automatic=%t policy=%s@%d fingerprint=%s",
+			assessment.State, assessment.Eligible, assessment.AutomaticResumeAllowed,
+			assessment.Policy.Mode, assessment.Policy.Revision, assessment.Fingerprint,
+		),
+		GoalSupervision: &assessment,
+	}
 }
 
 var worktreeDiagnosticKinds = []string{

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -663,8 +663,8 @@ func doctorCheckGoalSupervision(d doctorExecution, workstream string) doctorChec
 	profile := doctorProfile(d)
 	if strings.TrimSpace(workstream) == "" || !team.ExistsProfile(d.ProjectDir, profile) {
 		return doctorCheck{
-			Name: name, Kind: "goal_supervision", Status: doctorOK,
-			Detail: "no resolved team workstream; assessment skipped",
+			Name: name, Kind: "goal_supervision", Status: doctorWarn,
+			Detail: "no resolved team workstream; goal supervision assessment is unavailable",
 		}
 	}
 	t, err := team.ReadProfile(d.ProjectDir, profile)

--- a/internal/cli/goal_supervision.go
+++ b/internal/cli/goal_supervision.go
@@ -1,0 +1,687 @@
+package cli
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/runtimeaction"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+)
+
+const (
+	goalSupervisionAssessmentSchema = 1
+	goalSupervisionFreshness        = 30 * time.Second
+)
+
+type GoalSupervisionState string
+
+const (
+	GoalSupervisionRunning                  GoalSupervisionState = "running"
+	GoalSupervisionParkedWaitingAMQ         GoalSupervisionState = "parked_waiting_amq"
+	GoalSupervisionNativeGoalPausedEligible GoalSupervisionState = "native_goal_paused_eligible"
+	GoalSupervisionNativeGoalBlockedHuman   GoalSupervisionState = "native_goal_blocked_human"
+	GoalSupervisionNativeGoalBlockedUnknown GoalSupervisionState = "native_goal_blocked_unknown"
+	GoalSupervisionLeadDown                 GoalSupervisionState = "lead_down"
+	GoalSupervisionPaneBusyOrUnverified     GoalSupervisionState = "pane_busy_or_unverified"
+	GoalSupervisionGoalTerminal             GoalSupervisionState = "goal_terminal"
+)
+
+type GoalSupervisionSourceStatus struct {
+	Complete bool     `json:"complete"`
+	Errors   []string `json:"errors,omitempty"`
+}
+
+type GoalSupervisionRuntimeIdentity struct {
+	Live        bool `json:"live"`
+	PIDLive     bool `json:"pid_live"`
+	PaneLive    bool `json:"pane_live"`
+	PIDAlive    bool `json:"pid_alive"`
+	BinaryMatch bool `json:"binary_match"`
+}
+
+type GoalSupervisionPaneIdentity struct {
+	Managed    bool   `json:"managed"`
+	Session    string `json:"session,omitempty"`
+	WindowID   string `json:"window_id,omitempty"`
+	WindowName string `json:"window_name,omitempty"`
+	PaneID     string `json:"pane_id,omitempty"`
+	Target     string `json:"target,omitempty"`
+	BusyKnown  bool   `json:"busy_known"`
+	Busy       bool   `json:"busy"`
+}
+
+type GoalSupervisionGoalIdentity struct {
+	Mode          string `json:"mode,omitempty"`
+	NativeGoal    bool   `json:"native_goal"`
+	Verified      bool   `json:"verified"`
+	Source        string `json:"source,omitempty"`
+	DeliveryState string `json:"delivery_state,omitempty"`
+	GoalDigest    string `json:"goal_digest,omitempty"`
+	AttemptID     string `json:"attempt_id,omitempty"`
+	BindingDigest string `json:"binding_digest,omitempty"`
+	CommandDigest string `json:"command_digest,omitempty"`
+}
+
+type GoalSupervisionBinding struct {
+	Project               string                         `json:"project"`
+	Profile               string                         `json:"profile"`
+	Session               string                         `json:"session"`
+	NamespaceID           string                         `json:"namespace_id"`
+	LeadRole              string                         `json:"lead_role,omitempty"`
+	LeadHandle            string                         `json:"lead_handle,omitempty"`
+	LaunchID              string                         `json:"launch_id,omitempty"`
+	LaunchStartedAt       time.Time                      `json:"launch_started_at,omitempty"`
+	LaunchRecordDigest    string                         `json:"launch_record_digest,omitempty"`
+	LaunchRecordModTime   int64                          `json:"launch_record_mod_time,omitempty"`
+	Runtime               GoalSupervisionRuntimeIdentity `json:"runtime"`
+	Pane                  GoalSupervisionPaneIdentity    `json:"pane"`
+	Goal                  GoalSupervisionGoalIdentity    `json:"goal"`
+	PauseGeneration       string                         `json:"pause_generation,omitempty"`
+	PreparedRunGeneration string                         `json:"prepared_run_generation,omitempty"`
+	PreparedRunDigest     string                         `json:"prepared_run_digest,omitempty"`
+	PreparedLaunchAttempt string                         `json:"prepared_launch_attempt,omitempty"`
+	PreparedGoalNamespace string                         `json:"prepared_goal_namespace,omitempty"`
+	PreparedGoalDigest    string                         `json:"prepared_goal_digest,omitempty"`
+}
+
+type GoalSupervisionBlockerEvidence struct {
+	ID               string `json:"id,omitempty"`
+	Known            bool   `json:"known"`
+	Resolved         bool   `json:"resolved"`
+	Detail           string `json:"detail,omitempty"`
+	ResolutionDigest string `json:"resolution_digest,omitempty"`
+}
+
+type GoalSupervisionGateEvidence struct {
+	Known     bool `json:"known"`
+	Open      int  `json:"open"`
+	Ambiguous bool `json:"ambiguous"`
+}
+
+type GoalSupervisionLocalInputEvidence struct {
+	Observed    bool   `json:"observed"`
+	Kind        string `json:"kind,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Destructive bool   `json:"destructive,omitempty"`
+}
+
+type GoalSupervisionInvariantEvidence struct {
+	OK     bool     `json:"ok"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+type GoalSupervisionEligibilityReason struct {
+	Code   string `json:"code"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type GoalSupervisionClaimProjection struct {
+	State         string `json:"state"`
+	ClaimID       string `json:"claim_id,omitempty"`
+	DeliveryStage string `json:"delivery_stage,omitempty"`
+	Indeterminate bool   `json:"indeterminate,omitempty"`
+}
+
+type GoalSupervisionActions struct {
+	Inspect runtimeActionJSON `json:"inspect"`
+	Restore runtimeActionJSON `json:"restore"`
+	Notify  runtimeActionJSON `json:"notify"`
+	Resume  runtimeActionJSON `json:"resume"`
+}
+
+// GoalSupervisionAssessment is the versioned, read-only #498 supervision
+// object. PR5 consumes this exact binding/fingerprint before it may reserve or
+// deliver anything; this type performs no claim, AMQ send, or pane mutation.
+type GoalSupervisionAssessment struct {
+	SchemaVersion          int                                `json:"schema_version"`
+	ObservedAt             time.Time                          `json:"observed_at"`
+	FreshUntil             time.Time                          `json:"fresh_until"`
+	Fresh                  bool                               `json:"fresh"`
+	Fingerprint            string                             `json:"fingerprint"`
+	Source                 GoalSupervisionSourceStatus        `json:"source"`
+	State                  GoalSupervisionState               `json:"state"`
+	Eligible               bool                               `json:"eligible"`
+	AutomaticResumeAllowed bool                               `json:"automatic_resume_allowed"`
+	AttentionRequired      bool                               `json:"attention_required"`
+	Binding                GoalSupervisionBinding             `json:"binding"`
+	Blocker                GoalSupervisionBlockerEvidence     `json:"blocker"`
+	Gates                  GoalSupervisionGateEvidence        `json:"gates"`
+	LocalInput             GoalSupervisionLocalInputEvidence  `json:"local_input"`
+	Invariants             GoalSupervisionInvariantEvidence   `json:"invariants"`
+	Policy                 team.GoalSupervisionPolicyStatus   `json:"policy"`
+	Claim                  GoalSupervisionClaimProjection     `json:"claim"`
+	Reasons                []GoalSupervisionEligibilityReason `json:"eligibility_reasons"`
+	Actions                GoalSupervisionActions             `json:"actions"`
+}
+
+type goalSupervisionAssessmentInput struct {
+	ObservedAt       time.Time
+	Now              time.Time
+	MaxAge           time.Duration
+	SourceErrors     []string
+	Binding          GoalSupervisionBinding
+	GoalStateKnown   bool
+	NativePaused     bool
+	ParkedWaitingAMQ bool
+	GoalTerminal     bool
+	Blocker          GoalSupervisionBlockerEvidence
+	Gates            GoalSupervisionGateEvidence
+	LocalInput       GoalSupervisionLocalInputEvidence
+	InvariantErrors  []string
+	Policy           team.GoalSupervisionPolicyStatus
+	Claim            GoalSupervisionClaimProjection
+	ClaimClear       bool
+	BudgetAllowed    bool
+}
+
+type goalSupervisionGateObservation struct {
+	Evidence     GoalSupervisionGateEvidence
+	SourceErrors []string
+}
+
+func assessGoalSupervision(in goalSupervisionAssessmentInput) GoalSupervisionAssessment {
+	if in.ObservedAt.IsZero() {
+		in.ObservedAt = time.Now().UTC()
+	}
+	if in.MaxAge <= 0 {
+		in.MaxAge = goalSupervisionFreshness
+	}
+	if in.Now.IsZero() {
+		in.Now = in.ObservedAt
+	}
+	if !in.GoalStateKnown {
+		in.SourceErrors = append(in.SourceErrors, "native goal state is unverified")
+	}
+	if !in.Gates.Known {
+		in.SourceErrors = append(in.SourceErrors, "operator gate source is unknown")
+	}
+	if in.NativePaused && !in.Binding.Pane.BusyKnown {
+		in.SourceErrors = append(in.SourceErrors, "pane busy state is unknown")
+	}
+	if in.NativePaused && !in.Blocker.Known {
+		in.SourceErrors = append(in.SourceErrors, "native goal blocker is unknown")
+	}
+	if in.Claim.Indeterminate {
+		in.SourceErrors = append(in.SourceErrors, "claim state is indeterminate")
+	}
+	in.SourceErrors = stableUniqueStrings(in.SourceErrors)
+	in.InvariantErrors = stableUniqueStrings(in.InvariantErrors)
+	if in.Claim.State == "" {
+		in.Claim.State = "none"
+	}
+	if in.Policy.Mode == "" {
+		in.Policy = team.GoalSupervisionPolicyStatus{
+			Mode: team.GoalSupervisionManual, Revision: 1, Source: "compatibility-default",
+		}
+	}
+	a := GoalSupervisionAssessment{
+		SchemaVersion: goalSupervisionAssessmentSchema,
+		ObservedAt:    in.ObservedAt.UTC(),
+		FreshUntil:    in.ObservedAt.UTC().Add(in.MaxAge),
+		Fresh:         !in.Now.UTC().Before(in.ObservedAt.UTC()) && !in.Now.UTC().After(in.ObservedAt.UTC().Add(in.MaxAge)),
+		Source: GoalSupervisionSourceStatus{
+			Complete: len(in.SourceErrors) == 0,
+			Errors:   in.SourceErrors,
+		},
+		Binding:    in.Binding,
+		Blocker:    in.Blocker,
+		Gates:      in.Gates,
+		LocalInput: in.LocalInput,
+		Invariants: GoalSupervisionInvariantEvidence{
+			OK: len(in.InvariantErrors) == 0, Errors: in.InvariantErrors,
+		},
+		Policy: in.Policy,
+		Claim:  in.Claim,
+	}
+	a.Reasons = goalSupervisionEligibilityReasons(a, in)
+	a.Eligible = allGoalSupervisionReasonsPass(a.Reasons)
+	a.State = goalSupervisionStateFor(a, in)
+	a.AutomaticResumeAllowed = a.Eligible && a.Policy.Mode == team.GoalSupervisionSafeAuto
+	a.AttentionRequired = goalSupervisionNeedsAttention(a.State)
+	a.Fingerprint = goalSupervisionFingerprint(a)
+	a.Actions = goalSupervisionActions(a)
+	return a
+}
+
+func goalSupervisionEligibilityReasons(a GoalSupervisionAssessment, in goalSupervisionAssessmentInput) []GoalSupervisionEligibilityReason {
+	reason := func(code string, passed bool, detail string) GoalSupervisionEligibilityReason {
+		return GoalSupervisionEligibilityReason{Code: code, Passed: passed, Detail: detail}
+	}
+	b := a.Binding
+	return []GoalSupervisionEligibilityReason{
+		reason("fresh_assessment", a.Fresh, "assessment must remain inside its freshness window"),
+		reason("sources_complete", a.Source.Complete, strings.Join(a.Source.Errors, "; ")),
+		reason("exact_namespace", goalSupervisionAllNonBlank(b.Project, b.Profile, b.Session, b.NamespaceID), "project/profile/session/namespace must be exact"),
+		reason("exact_lead_identity", goalSupervisionAllNonBlank(b.LeadRole, b.LeadHandle), "lead role and handle must be exact"),
+		reason("resumable_lifecycle", !in.ParkedWaitingAMQ && !in.GoalTerminal, "parked and terminal lifecycles are never resume-eligible"),
+		reason("native_goal_paused", in.NativePaused && b.Goal.NativeGoal && b.Goal.Verified, "verified blocked native /goal binding required"),
+		reason("goal_attempt", b.Goal.Mode == "native_goal_blocked" && goalSupervisionAllNonBlank(b.Goal.Source, b.Goal.DeliveryState, b.Goal.GoalDigest, b.Goal.AttemptID, b.Goal.BindingDigest, b.Goal.CommandDigest), "exact blocked native goal, attempt, binding, delivery, and command digests required"),
+		reason("launch_generation", goalSupervisionAllNonBlank(b.LaunchID, b.LaunchRecordDigest) && b.LaunchRecordModTime > 0 && !b.LaunchStartedAt.IsZero(), "launch ID, digest, modtime, and start time required"),
+		reason("prepared_run_binding", goalSupervisionAllNonBlank(b.PreparedRunGeneration, b.PreparedRunDigest, b.PreparedLaunchAttempt, b.PreparedGoalNamespace, b.PreparedGoalDigest) && b.PreparedGoalNamespace == b.NamespaceID, "prepared run generation, launch attempt, and exact namespace goal binding required"),
+		reason("pause_generation", goalSupervisionAllNonBlank(b.PauseGeneration), "native pause generation required"),
+		reason("pane_identity", b.Pane.Managed && goalSupervisionAllNonBlank(b.Pane.PaneID) && b.Runtime.Live && b.Runtime.PaneLive, "exact managed live pane required"),
+		reason("pane_idle", b.Pane.BusyKnown && !b.Pane.Busy, "positive idle evidence required"),
+		reason("blocker_known", a.Blocker.Known && goalSupervisionAllNonBlank(a.Blocker.ID), "original blocker identity required"),
+		reason("blocker_resolved", a.Blocker.Resolved && goalSupervisionAllNonBlank(a.Blocker.ResolutionDigest), "durable blocker-resolution evidence required"),
+		reason("gates_known", a.Gates.Known, "gate source must be available"),
+		reason("no_open_gate", a.Gates.Known && a.Gates.Open == 0, "operator gates must be closed"),
+		reason("no_gate_ambiguity", !a.Gates.Ambiguous, "shadowed or unbound gate evidence is ineligible"),
+		reason("no_local_input", !a.LocalInput.Observed, "permission and local-input prompts require a human"),
+		reason("invariants_ok", a.Invariants.OK, strings.Join(a.Invariants.Errors, "; ")),
+		reason("claim_clear", in.ClaimClear && !a.Claim.Indeterminate, "no prior or indeterminate claim may exist"),
+		reason("retry_budget", in.BudgetAllowed, "retry/cooldown/loop budget must remain"),
+	}
+}
+
+func goalSupervisionAllNonBlank(values ...string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func goalSupervisionStateFor(a GoalSupervisionAssessment, in goalSupervisionAssessmentInput) GoalSupervisionState {
+	switch {
+	case in.GoalTerminal:
+		return GoalSupervisionGoalTerminal
+	case !a.Binding.Runtime.Live:
+		return GoalSupervisionLeadDown
+	case in.ParkedWaitingAMQ:
+		return GoalSupervisionParkedWaitingAMQ
+	case in.GoalStateKnown && !in.NativePaused:
+		return GoalSupervisionRunning
+	case !in.GoalStateKnown:
+		return GoalSupervisionNativeGoalBlockedUnknown
+	case !a.Binding.Pane.Managed || !a.Binding.Runtime.PaneLive || !a.Binding.Pane.BusyKnown || a.Binding.Pane.Busy:
+		return GoalSupervisionPaneBusyOrUnverified
+	case a.LocalInput.Observed || a.Gates.Known && a.Gates.Open > 0:
+		return GoalSupervisionNativeGoalBlockedHuman
+	case !a.Source.Complete || a.Gates.Ambiguous || !a.Invariants.OK || !a.Blocker.Known:
+		return GoalSupervisionNativeGoalBlockedUnknown
+	case a.Blocker.Known && !a.Blocker.Resolved:
+		return GoalSupervisionNativeGoalBlockedHuman
+	case a.Eligible:
+		return GoalSupervisionNativeGoalPausedEligible
+	default:
+		return GoalSupervisionNativeGoalBlockedUnknown
+	}
+}
+
+func goalSupervisionNeedsAttention(state GoalSupervisionState) bool {
+	switch state {
+	case GoalSupervisionNativeGoalPausedEligible, GoalSupervisionNativeGoalBlockedHuman,
+		GoalSupervisionNativeGoalBlockedUnknown, GoalSupervisionLeadDown,
+		GoalSupervisionPaneBusyOrUnverified:
+		return true
+	default:
+		return false
+	}
+}
+
+func allGoalSupervisionReasonsPass(reasons []GoalSupervisionEligibilityReason) bool {
+	if len(reasons) == 0 {
+		return false
+	}
+	for _, reason := range reasons {
+		if !reason.Passed {
+			return false
+		}
+	}
+	return true
+}
+
+func goalSupervisionFingerprint(a GoalSupervisionAssessment) string {
+	copy := a
+	copy.ObservedAt = time.Time{}
+	copy.FreshUntil = time.Time{}
+	copy.Fresh = false
+	copy.Fingerprint = ""
+	copy.Actions = GoalSupervisionActions{}
+	return digestJSON(copy)
+}
+
+func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions {
+	scope := runtimeActionScope(a.Binding.Project, a.Binding.Profile, a.Binding.Session)
+	namespaceID := a.Binding.NamespaceID
+	restoreAvailable := a.State == GoalSupervisionLeadDown &&
+		goalSupervisionReasonPassed(a.Reasons, "exact_namespace") &&
+		goalSupervisionReasonPassed(a.Reasons, "exact_lead_identity") &&
+		!a.Gates.Ambiguous
+	resumeAvailable := a.Eligible && a.Policy.Mode != team.GoalSupervisionNotifyOnly
+	resumeReason := ""
+	switch {
+	case !a.Eligible:
+		resumeReason = firstFailedGoalSupervisionReason(a.Reasons)
+	case a.Policy.Mode == team.GoalSupervisionNotifyOnly:
+		resumeReason = "goal supervision policy is notify-only"
+	}
+	actions := runtimeaction.ApplyCanonical([]runtimeaction.Action{
+		{
+			Kind: "goal_supervision_inspect", Label: "inspect goal supervision assessment",
+			Scope: "session", NamespaceID: namespaceID, Command: "amq-squad status" + scope + " --json",
+			Available: true,
+		},
+		{
+			Kind: "goal_supervision_restore", Label: "restore managed lead",
+			Scope: "session", NamespaceID: namespaceID, Command: "amq-squad resume" + scope + " --exec",
+			Mutates: true, NeedsConfirmation: true, Available: restoreAvailable,
+			Reason: unavailableUnless(restoreAvailable, "exact unambiguous lead-down scope is required"),
+		},
+		{
+			Kind: "goal_supervision_notify", Label: "preview goal-supervision notification",
+			Scope: "session", NamespaceID: namespaceID, Command: "amq-squad notify" + scope + " --dry-run --json",
+			Available: a.AttentionRequired,
+			Reason:    unavailableUnless(a.AttentionRequired, "assessment does not require attention"),
+		},
+		{
+			Kind: "native_goal_resume", Label: "resume exact native /goal attempt",
+			Scope: "agent", NamespaceID: namespaceID, Command: "/goal resume",
+			Mutates: true, NeedsConfirmation: a.Policy.Mode != team.GoalSupervisionSafeAuto,
+			Available: resumeAvailable, Reason: resumeReason,
+		},
+	})
+	// These two are read-only display actions even though their new kinds are
+	// unknown to the legacy runtimeaction classifier.
+	actions[0].ActionKind = "display"
+	actions[2].ActionKind = "display"
+	return GoalSupervisionActions{
+		Inspect: actions[0], Restore: actions[1], Notify: actions[2], Resume: actions[3],
+	}
+}
+
+func goalSupervisionReasonPassed(reasons []GoalSupervisionEligibilityReason, code string) bool {
+	for _, reason := range reasons {
+		if reason.Code == code {
+			return reason.Passed
+		}
+	}
+	return false
+}
+
+func runtimeActionScope(project, profile, session string) string {
+	return " --project " + shellQuote(project) +
+		" --profile " + shellQuote(squadnamespace.NormalizeProfile(profile)) +
+		" --session " + shellQuote(session)
+}
+
+func unavailableUnless(available bool, reason string) string {
+	if available {
+		return ""
+	}
+	return reason
+}
+
+func firstFailedGoalSupervisionReason(reasons []GoalSupervisionEligibilityReason) string {
+	for _, reason := range reasons {
+		if !reason.Passed {
+			if reason.Detail != "" {
+				return reason.Code + ": " + reason.Detail
+			}
+			return reason.Code
+		}
+	}
+	return "assessment is ineligible"
+}
+
+func stableUniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+var goalSupervisionPaneBusy = func(paneID string) (busy bool, known bool) {
+	busy, err := tmuxpane.PaneBusy(paneID)
+	return busy, err == nil
+}
+
+func buildGoalSupervisionAssessment(
+	t team.Team,
+	profile, session string,
+	ns squadnamespace.Ref,
+	rows []statusRecord,
+	gateObservation goalSupervisionGateObservation,
+	invariantErrors []executionInvariantError,
+	namespaceConflict *namespaceConflictData,
+	probe duplicateLaunchProbe,
+	now time.Time,
+) GoalSupervisionAssessment {
+	profile = squadnamespace.NormalizeProfile(profile)
+	bindingData := goalBindingForStatus(ns, newSessionStatusContext(t, profile, session, firstLiveTmuxSession(rows)), rows)
+	input := goalSupervisionAssessmentInput{
+		ObservedAt:      now.UTC(),
+		Now:             now.UTC(),
+		Policy:          team.EffectiveGoalSupervisionPolicy(t),
+		Claim:           GoalSupervisionClaimProjection{State: "none"},
+		ClaimClear:      true,
+		BudgetAllowed:   true,
+		SourceErrors:    append([]string(nil), gateObservation.SourceErrors...),
+		Gates:           gateObservation.Evidence,
+		InvariantErrors: goalSupervisionInvariantStrings(invariantErrors),
+		Binding: GoalSupervisionBinding{
+			Project: t.Project, Profile: profile, Session: session, NamespaceID: ns.ID,
+			LeadRole: strings.TrimSpace(t.Lead),
+		},
+	}
+	if namespaceConflict != nil {
+		input.SourceErrors = append(input.SourceErrors, "namespace/profile identity is ambiguous")
+		input.Gates.Ambiguous = true
+	}
+	if !t.Orchestrated || input.Binding.LeadRole == "" {
+		input.SourceErrors = append(input.SourceErrors, "profile has no configured visible lead")
+		return assessGoalSupervision(input)
+	}
+	leadMember, ok := teamMemberByRole(t, input.Binding.LeadRole)
+	if !ok {
+		input.SourceErrors = append(input.SourceErrors, "configured lead role does not resolve to one member")
+		return assessGoalSupervision(input)
+	}
+	input.Binding.LeadHandle = strings.TrimSpace(leadMember.Handle)
+	if input.Binding.LeadHandle == "" {
+		input.Binding.LeadHandle = leadMember.Role
+	}
+	var leadRows []statusRecord
+	for _, row := range rows {
+		if row.Role == input.Binding.LeadRole && row.Handle == input.Binding.LeadHandle {
+			leadRows = append(leadRows, row)
+		}
+	}
+	if len(leadRows) != 1 {
+		input.SourceErrors = append(input.SourceErrors, "visible lead runtime does not resolve to exactly one record")
+		return assessGoalSupervision(input)
+	}
+	row := leadRows[0]
+	if row.ClassificationError != "" {
+		input.SourceErrors = append(input.SourceErrors, "lead runtime classification: "+row.ClassificationError)
+	}
+	if !row.liveness.LaunchFound {
+		input.SourceErrors = append(input.SourceErrors, "lead launch record is missing")
+		return assessGoalSupervision(input)
+	}
+	rec := row.liveness.LaunchRecord
+	if rec.BootstrapExpectation != nil {
+		input.Binding.LaunchID = strings.TrimSpace(rec.BootstrapExpectation.LaunchID)
+	}
+	input.Binding.LaunchStartedAt = rec.StartedAt.UTC()
+	input.Binding.PreparedRunGeneration = strings.TrimSpace(rec.PreparedRunGeneration)
+	input.Binding.PreparedRunDigest = strings.TrimSpace(rec.PreparedRunDigest)
+	input.Binding.PreparedLaunchAttempt = strings.TrimSpace(rec.PreparedRunLaunchAttempt)
+	input.Binding.PreparedGoalNamespace = strings.TrimSpace(rec.PreparedRunGoalNamespace)
+	input.Binding.PreparedGoalDigest = strings.TrimSpace(rec.PreparedRunGoalDigest)
+	digest, modTime, generationErr := readGoalFileGeneration(launch.ExistingPath(row.AgentDir))
+	if generationErr != nil {
+		input.SourceErrors = append(input.SourceErrors, "capture launch generation: "+generationErr.Error())
+	} else {
+		input.Binding.LaunchRecordDigest = digest
+		input.Binding.LaunchRecordModTime = modTime
+	}
+	paneID := ""
+	if rec.Tmux != nil {
+		paneID = strings.TrimSpace(rec.Tmux.PaneID)
+		input.Binding.Pane = GoalSupervisionPaneIdentity{
+			Managed: paneID != "" && rec.Tmux.Target != "adopted",
+			Session: rec.Tmux.Session, WindowID: rec.Tmux.WindowID, WindowName: rec.Tmux.WindowName,
+			PaneID: paneID, Target: rec.Tmux.Target,
+		}
+	}
+	runtimeIdentity := classifyLaunchRuntimeIdentity(rec, leadMember.Binary, paneID, launchRuntimeProbeFromDuplicate(probe))
+	input.Binding.Runtime = GoalSupervisionRuntimeIdentity{
+		Live: runtimeIdentity.Live, PIDLive: runtimeIdentity.PIDLive, PaneLive: runtimeIdentity.PaneLive,
+		PIDAlive: runtimeIdentity.PIDAlive, BinaryMatch: runtimeIdentity.BinaryMatch,
+	}
+	if runtimeIdentity.PaneLive {
+		input.Binding.Pane.Busy, input.Binding.Pane.BusyKnown = goalSupervisionPaneBusy(paneID)
+	}
+	if row.goalBinding != nil {
+		input.Binding.Goal = GoalSupervisionGoalIdentity{
+			Mode: row.goalBinding.Mode, NativeGoal: row.goalBinding.NativeGoal,
+			Verified: bindingData.Verified,
+			Source:   row.goalBinding.Source, DeliveryState: row.goalBinding.DeliveryState,
+			GoalDigest: digestGoalSupervisionString(row.goalBinding.Goal), AttemptID: strings.TrimSpace(row.goalBinding.AttemptID),
+			BindingDigest: digestJSON(*row.goalBinding), CommandDigest: digestGoalSupervisionString(row.goalBinding.Command),
+		}
+		input.Binding.PauseGeneration = digestJSON(struct {
+			Launch  string
+			Binding string
+			Mode    string
+		}{digest, input.Binding.Goal.BindingDigest, row.goalBinding.Mode})
+	}
+	input.GoalStateKnown = bindingData.Verified
+	input.NativePaused = input.GoalStateKnown && bindingData.NativeGoal && bindingData.Mode == "native_goal_blocked"
+	if input.NativePaused {
+		detail := strings.TrimSpace(bindingData.Detail)
+		input.Blocker = GoalSupervisionBlockerEvidence{
+			ID: digestGoalSupervisionString(detail), Known: detail != "", Detail: detail,
+		}
+	}
+	if row.LocalInput != nil {
+		input.LocalInput = GoalSupervisionLocalInputEvidence{
+			Observed: true, Kind: row.LocalInput.Kind, Summary: row.LocalInput.Summary,
+			Destructive: row.LocalInput.Destructive,
+		}
+	}
+	if row.Activity != nil && !row.Activity.Stale {
+		switch strings.TrimSpace(row.Activity.Phase) {
+		case "parked_waiting_amq":
+			input.ParkedWaitingAMQ = true
+		case "goal_terminal":
+			input.GoalTerminal = true
+		}
+	}
+	return assessGoalSupervision(input)
+}
+
+func inspectGoalSupervisionGates(
+	t team.Team,
+	profile, session string,
+	observedSessionRoot string,
+	probe duplicateLaunchProbe,
+	now time.Time,
+) goalSupervisionGateObservation {
+	operator := team.EffectiveOperator(t)
+	if !team.SupportsOperatorGates(t) || !operator.Enabled {
+		return goalSupervisionGateObservation{
+			Evidence: GoalSupervisionGateEvidence{Known: true},
+		}
+	}
+	ns := squadnamespace.Resolve(t.Project, profile, session)
+	root := strings.TrimSpace(observedSessionRoot)
+	if root == "" {
+		root = strings.TrimSpace(ns.AMQRoot)
+	}
+	if root == "" {
+		return goalSupervisionGateObservation{
+			SourceErrors: []string{"operator gate namespace root is unavailable"},
+		}
+	}
+	baseRoot := root
+	if squadnamespace.ProfilesEqual(profile, team.DefaultProfile) {
+		baseRoot = filepath.Dir(root)
+	}
+	stateProbe := state.Probe{
+		PIDAlive:         probe.PIDAlive,
+		ProcessMatch:     probe.ProcessMatch,
+		ProcessTTY:       probe.ProcessTTY,
+		ProcessStartTime: probe.ProcessStartTime,
+		Now:              func() time.Time { return now },
+	}
+	data, err := buildOperatorStatusData(operatorExecution{
+		ProjectDir: t.Project,
+		Profile:    profile,
+		Session:    session,
+		BaseRoot:   baseRoot,
+		ReadOnly:   true,
+		Probe:      stateProbe,
+		Now:        func() time.Time { return now },
+	})
+	if err != nil {
+		return goalSupervisionGateObservation{
+			SourceErrors: []string{"inspect durable operator gates: " + err.Error()},
+		}
+	}
+	if data.Operator.Poll == nil {
+		return goalSupervisionGateObservation{
+			SourceErrors: []string{"durable operator gate projection is unavailable"},
+		}
+	}
+	var sourceErrors []string
+	for _, warning := range data.sourceWarnings {
+		detail := strings.TrimSpace(warning.Reason)
+		if path := strings.TrimSpace(warning.Path); path != "" {
+			detail = path + ": " + detail
+		}
+		if detail == "" {
+			detail = "durable operator gate scan reported an unspecified warning"
+		}
+		sourceErrors = append(sourceErrors, "inspect durable operator gates: "+detail)
+	}
+	return goalSupervisionGateObservation{
+		Evidence: GoalSupervisionGateEvidence{
+			Known:     true,
+			Open:      data.Operator.Poll.OpenGates,
+			Ambiguous: len(sourceErrors) > 0,
+		},
+		SourceErrors: stableUniqueStrings(sourceErrors),
+	}
+}
+
+func digestGoalSupervisionString(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	return digestBytes([]byte(value))
+}
+
+func goalSupervisionInvariantStrings(errors []executionInvariantError) []string {
+	values := make([]string, 0, len(errors))
+	for _, invariant := range errors {
+		code := strings.TrimSpace(invariant.Code)
+		message := strings.TrimSpace(invariant.Message)
+		switch {
+		case code != "" && message != "":
+			values = append(values, code+": "+message)
+		case code != "":
+			values = append(values, code)
+		case message != "":
+			values = append(values, message)
+		}
+	}
+	return stableUniqueStrings(values)
+}

--- a/internal/cli/goal_supervision.go
+++ b/internal/cli/goal_supervision.go
@@ -314,7 +314,7 @@ func goalSupervisionEligibilityReasons(a GoalSupervisionAssessment, in goalSuper
 		reason("exact_namespace", goalSupervisionAllNonBlank(b.Project, b.Profile, b.Session, b.NamespaceID), "project/profile/session/namespace must be exact"),
 		reason("exact_lead_identity", goalSupervisionAllNonBlank(b.LeadRole, b.LeadHandle), "lead role and handle must be exact"),
 		reason("lifecycle_known", a.Lifecycle.Known && a.Lifecycle.Fresh, "fresh durable lifecycle evidence is required"),
-		reason("resumable_lifecycle", a.Lifecycle.Known && a.Lifecycle.Fresh && a.Lifecycle.Phase != "parked_waiting_amq" && a.Lifecycle.Phase != "goal_terminal", "parked and terminal lifecycles are never resume-eligible"),
+		reason("resumable_lifecycle", a.Lifecycle.Known && a.Lifecycle.Fresh && a.Lifecycle.Phase == "goal_blocked", "only a fresh recognized goal_blocked lifecycle is resume-eligible"),
 		reason("native_goal_paused", nativePaused, "verified blocked native /goal binding required"),
 		reason("goal_binding_content", b.Goal.ContentExact, "typed goal and attempt must match the exact generated command and prepared-run goal"),
 		reason("goal_attempt", b.Goal.Mode == "native_goal_blocked" && goalSupervisionAllNonBlank(b.Goal.Source, b.Goal.DeliveryState, b.Goal.GoalDigest, b.Goal.AttemptID, b.Goal.BindingDigest, b.Goal.CommandDigest), "exact blocked native goal, attempt, binding, delivery, and command digests required"),
@@ -425,6 +425,8 @@ func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions 
 		goalSupervisionReasonPassed(a.Reasons, "exact_namespace") &&
 		goalSupervisionReasonPassed(a.Reasons, "exact_lead_identity") &&
 		goalSupervisionReasonPassed(a.Reasons, "launch_generation") &&
+		a.Binding.Pane.Managed &&
+		goalSupervisionManagedTmuxTarget(a.Binding.Pane.Target) &&
 		a.Gates.Known && a.Gates.Open == 0 && !a.Gates.Ambiguous &&
 		mutationBound
 	resumeReason := "claim-once native goal resume execution is reserved for PR5"
@@ -554,6 +556,8 @@ var goalSupervisionPaneBusy = func(paneID string) (busy bool, known bool) {
 var goalSupervisionPaneInspector = tmuxpane.InspectPaneExactByID
 
 var goalSupervisionLocalInputDetector = tmuxpane.DetectLocalInputBlocker
+
+var goalSupervisionBlockedBindingVerifier = verifyGoalSupervisionBlockedBinding
 
 func buildGoalSupervisionAssessment(
 	t team.Team,
@@ -703,7 +707,7 @@ func buildGoalSupervisionAssessment(
 			BindingDigest: digestJSON(*rec.GoalBinding), CommandDigest: digestGoalSupervisionString(rec.GoalBinding.Command),
 		}
 		if nativeGoalBindingBlocked(rec.GoalBinding) {
-			goal, attemptID, err := verifyGoalSupervisionBlockedBinding(
+			goal, attemptID, err := goalSupervisionBlockedBindingVerifier(
 				t, profile, session, leadMember, rec,
 			)
 			if err != nil {
@@ -711,20 +715,14 @@ func buildGoalSupervisionAssessment(
 				input.Binding.Goal.StateKnown = false
 				input.Binding.Goal.Verified = false
 			} else {
-				input.Binding.Goal.StateKnown = true
-				input.Binding.Goal.Verified = true
-				input.Binding.Goal.ContentExact = true
+				input.Binding.Goal.ContentExact = bindingData.Verified
 				input.Binding.Goal.GoalDigest = digestGoalSupervisionString(goal)
 				input.Binding.Goal.AttemptID = attemptID
 			}
 		} else {
 			input.Binding.Goal.ContentExact = bindingData.Verified
 		}
-		input.Binding.PauseGeneration = digestJSON(struct {
-			Launch  string
-			Binding string
-			Mode    string
-		}{digest, input.Binding.Goal.BindingDigest, rec.GoalBinding.Mode})
+		input.Binding.PauseGeneration = goalSupervisionPauseGeneration(input.Binding)
 	}
 	if goalSupervisionNativePaused(input.Binding.Goal) {
 		detail := strings.TrimSpace(rec.GoalBinding.Detail)
@@ -733,6 +731,20 @@ func buildGoalSupervisionAssessment(
 		}
 	}
 	return finish()
+}
+
+func goalSupervisionPauseGeneration(binding GoalSupervisionBinding) string {
+	return digestJSON(struct {
+		LaunchID      string
+		BindingDigest string
+		AttemptID     string
+		Mode          string
+	}{
+		LaunchID:      binding.LaunchID,
+		BindingDigest: binding.Goal.BindingDigest,
+		AttemptID:     binding.Goal.AttemptID,
+		Mode:          binding.Goal.Mode,
+	})
 }
 
 func readGoalSupervisionLaunchSnapshot(agentDir string) (launch.Record, string, int64, error) {
@@ -865,9 +877,22 @@ func goalSupervisionLifecycleObservation(
 		observedAt.Sub(snapshot.WrittenAt) > activity.DefaultStaleAfter {
 		return GoalSupervisionLifecycleEvidence{}
 	}
+	phase := strings.TrimSpace(snapshot.Phase)
+	if !goalSupervisionLifecyclePhaseKnown(phase) {
+		return GoalSupervisionLifecycleEvidence{}
+	}
 	return GoalSupervisionLifecycleEvidence{
 		Known: true, Fresh: true, Source: snapshot.Source,
-		Phase: strings.TrimSpace(snapshot.Phase),
+		Phase: phase,
+	}
+}
+
+func goalSupervisionLifecyclePhaseKnown(phase string) bool {
+	switch phase {
+	case "goal_blocked", "parked_waiting_amq", "goal_terminal":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/cli/goal_supervision.go
+++ b/internal/cli/goal_supervision.go
@@ -1,11 +1,16 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/activity"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/runtimeaction"
@@ -38,11 +43,14 @@ type GoalSupervisionSourceStatus struct {
 }
 
 type GoalSupervisionRuntimeIdentity struct {
-	Live        bool `json:"live"`
-	PIDLive     bool `json:"pid_live"`
-	PaneLive    bool `json:"pane_live"`
-	PIDAlive    bool `json:"pid_alive"`
-	BinaryMatch bool `json:"binary_match"`
+	Known        bool `json:"known"`
+	Live         bool `json:"live"`
+	FullLive     bool `json:"full_live"`
+	VerifiedDown bool `json:"verified_down"`
+	PIDLive      bool `json:"pid_live"`
+	PaneLive     bool `json:"pane_live"`
+	PIDAlive     bool `json:"pid_alive"`
+	BinaryMatch  bool `json:"binary_match"`
 }
 
 type GoalSupervisionPaneIdentity struct {
@@ -59,7 +67,9 @@ type GoalSupervisionPaneIdentity struct {
 type GoalSupervisionGoalIdentity struct {
 	Mode          string `json:"mode,omitempty"`
 	NativeGoal    bool   `json:"native_goal"`
+	StateKnown    bool   `json:"state_known"`
 	Verified      bool   `json:"verified"`
+	ContentExact  bool   `json:"content_exact"`
 	Source        string `json:"source,omitempty"`
 	DeliveryState string `json:"delivery_state,omitempty"`
 	GoalDigest    string `json:"goal_digest,omitempty"`
@@ -98,6 +108,13 @@ type GoalSupervisionBlockerEvidence struct {
 	ResolutionDigest string `json:"resolution_digest,omitempty"`
 }
 
+type GoalSupervisionLifecycleEvidence struct {
+	Known  bool   `json:"known"`
+	Fresh  bool   `json:"fresh"`
+	Source string `json:"source,omitempty"`
+	Phase  string `json:"phase,omitempty"`
+}
+
 type GoalSupervisionGateEvidence struct {
 	Known     bool `json:"known"`
 	Open      int  `json:"open"`
@@ -105,6 +122,7 @@ type GoalSupervisionGateEvidence struct {
 }
 
 type GoalSupervisionLocalInputEvidence struct {
+	Known       bool   `json:"known"`
 	Observed    bool   `json:"observed"`
 	Kind        string `json:"kind,omitempty"`
 	Summary     string `json:"summary,omitempty"`
@@ -123,17 +141,30 @@ type GoalSupervisionEligibilityReason struct {
 }
 
 type GoalSupervisionClaimProjection struct {
+	Known         bool   `json:"known"`
 	State         string `json:"state"`
 	ClaimID       string `json:"claim_id,omitempty"`
 	DeliveryStage string `json:"delivery_stage,omitempty"`
 	Indeterminate bool   `json:"indeterminate,omitempty"`
 }
 
+type GoalSupervisionBudgetEvidence struct {
+	Known   bool `json:"known"`
+	Allowed bool `json:"allowed"`
+}
+
+type GoalSupervisionAction struct {
+	runtimeaction.Action
+	Fingerprint  string `json:"fingerprint,omitempty"`
+	AttemptID    string `json:"attempt_id,omitempty"`
+	Confirmation string `json:"confirmation,omitempty"`
+}
+
 type GoalSupervisionActions struct {
-	Inspect runtimeActionJSON `json:"inspect"`
-	Restore runtimeActionJSON `json:"restore"`
-	Notify  runtimeActionJSON `json:"notify"`
-	Resume  runtimeActionJSON `json:"resume"`
+	Inspect GoalSupervisionAction `json:"inspect"`
+	Restore GoalSupervisionAction `json:"restore"`
+	Notify  GoalSupervisionAction `json:"notify"`
+	Resume  GoalSupervisionAction `json:"resume"`
 }
 
 // GoalSupervisionAssessment is the versioned, read-only #498 supervision
@@ -151,34 +182,32 @@ type GoalSupervisionAssessment struct {
 	AutomaticResumeAllowed bool                               `json:"automatic_resume_allowed"`
 	AttentionRequired      bool                               `json:"attention_required"`
 	Binding                GoalSupervisionBinding             `json:"binding"`
+	Lifecycle              GoalSupervisionLifecycleEvidence   `json:"lifecycle"`
 	Blocker                GoalSupervisionBlockerEvidence     `json:"blocker"`
 	Gates                  GoalSupervisionGateEvidence        `json:"gates"`
 	LocalInput             GoalSupervisionLocalInputEvidence  `json:"local_input"`
 	Invariants             GoalSupervisionInvariantEvidence   `json:"invariants"`
 	Policy                 team.GoalSupervisionPolicyStatus   `json:"policy"`
 	Claim                  GoalSupervisionClaimProjection     `json:"claim"`
+	Budget                 GoalSupervisionBudgetEvidence      `json:"budget"`
 	Reasons                []GoalSupervisionEligibilityReason `json:"eligibility_reasons"`
 	Actions                GoalSupervisionActions             `json:"actions"`
 }
 
 type goalSupervisionAssessmentInput struct {
-	ObservedAt       time.Time
-	Now              time.Time
-	MaxAge           time.Duration
-	SourceErrors     []string
-	Binding          GoalSupervisionBinding
-	GoalStateKnown   bool
-	NativePaused     bool
-	ParkedWaitingAMQ bool
-	GoalTerminal     bool
-	Blocker          GoalSupervisionBlockerEvidence
-	Gates            GoalSupervisionGateEvidence
-	LocalInput       GoalSupervisionLocalInputEvidence
-	InvariantErrors  []string
-	Policy           team.GoalSupervisionPolicyStatus
-	Claim            GoalSupervisionClaimProjection
-	ClaimClear       bool
-	BudgetAllowed    bool
+	ObservedAt      time.Time
+	Now             time.Time
+	MaxAge          time.Duration
+	SourceErrors    []string
+	Binding         GoalSupervisionBinding
+	Lifecycle       GoalSupervisionLifecycleEvidence
+	Blocker         GoalSupervisionBlockerEvidence
+	Gates           GoalSupervisionGateEvidence
+	LocalInput      GoalSupervisionLocalInputEvidence
+	InvariantErrors []string
+	Policy          team.GoalSupervisionPolicyStatus
+	Claim           GoalSupervisionClaimProjection
+	Budget          GoalSupervisionBudgetEvidence
 }
 
 type goalSupervisionGateObservation struct {
@@ -196,25 +225,46 @@ func assessGoalSupervision(in goalSupervisionAssessmentInput) GoalSupervisionAss
 	if in.Now.IsZero() {
 		in.Now = in.ObservedAt
 	}
-	if !in.GoalStateKnown {
+	in.Binding.Runtime.FullLive = goalSupervisionFullRuntimeLive(in.Binding.Runtime)
+	in.Binding.Runtime.VerifiedDown = goalSupervisionRuntimeVerifiedDown(in.Binding.Runtime)
+	nativePaused := goalSupervisionNativePaused(in.Binding.Goal)
+	nativeBlockedObserved := goalSupervisionNativeBlockedObserved(in.Binding.Goal)
+	if !in.Binding.Goal.StateKnown {
 		in.SourceErrors = append(in.SourceErrors, "native goal state is unverified")
+	}
+	if nativeBlockedObserved && !in.Binding.Goal.ContentExact {
+		in.SourceErrors = append(in.SourceErrors, "native goal binding contents are not exact")
+	}
+	if !in.Lifecycle.Known || !in.Lifecycle.Fresh {
+		in.SourceErrors = append(in.SourceErrors, "goal lifecycle evidence is absent, stale, or unreadable")
 	}
 	if !in.Gates.Known {
 		in.SourceErrors = append(in.SourceErrors, "operator gate source is unknown")
 	}
-	if in.NativePaused && !in.Binding.Pane.BusyKnown {
+	if in.Gates.Ambiguous {
+		in.SourceErrors = append(in.SourceErrors, "operator gate evidence is ambiguous")
+	}
+	if nativePaused && !in.Binding.Pane.BusyKnown {
 		in.SourceErrors = append(in.SourceErrors, "pane busy state is unknown")
 	}
-	if in.NativePaused && !in.Blocker.Known {
+	if nativePaused && in.Binding.Runtime.FullLive && !in.LocalInput.Known {
+		in.SourceErrors = append(in.SourceErrors, "lead local-input state is unknown")
+	}
+	if nativePaused && !in.Blocker.Known {
 		in.SourceErrors = append(in.SourceErrors, "native goal blocker is unknown")
 	}
-	if in.Claim.Indeterminate {
-		in.SourceErrors = append(in.SourceErrors, "claim state is indeterminate")
+	if nativePaused {
+		if !in.Claim.Known || in.Claim.Indeterminate {
+			in.SourceErrors = append(in.SourceErrors, "claim state is indeterminate")
+		}
+		if !in.Budget.Known {
+			in.SourceErrors = append(in.SourceErrors, "retry budget state is unknown")
+		}
 	}
 	in.SourceErrors = stableUniqueStrings(in.SourceErrors)
 	in.InvariantErrors = stableUniqueStrings(in.InvariantErrors)
 	if in.Claim.State == "" {
-		in.Claim.State = "none"
+		in.Claim.State = "unknown"
 	}
 	if in.Policy.Mode == "" {
 		in.Policy = team.GoalSupervisionPolicyStatus{
@@ -231,6 +281,7 @@ func assessGoalSupervision(in goalSupervisionAssessmentInput) GoalSupervisionAss
 			Errors:   in.SourceErrors,
 		},
 		Binding:    in.Binding,
+		Lifecycle:  in.Lifecycle,
 		Blocker:    in.Blocker,
 		Gates:      in.Gates,
 		LocalInput: in.LocalInput,
@@ -239,6 +290,7 @@ func assessGoalSupervision(in goalSupervisionAssessmentInput) GoalSupervisionAss
 		},
 		Policy: in.Policy,
 		Claim:  in.Claim,
+		Budget: in.Budget,
 	}
 	a.Reasons = goalSupervisionEligibilityReasons(a, in)
 	a.Eligible = allGoalSupervisionReasonsPass(a.Reasons)
@@ -255,28 +307,35 @@ func goalSupervisionEligibilityReasons(a GoalSupervisionAssessment, in goalSuper
 		return GoalSupervisionEligibilityReason{Code: code, Passed: passed, Detail: detail}
 	}
 	b := a.Binding
+	nativePaused := goalSupervisionNativePaused(b.Goal)
 	return []GoalSupervisionEligibilityReason{
 		reason("fresh_assessment", a.Fresh, "assessment must remain inside its freshness window"),
 		reason("sources_complete", a.Source.Complete, strings.Join(a.Source.Errors, "; ")),
 		reason("exact_namespace", goalSupervisionAllNonBlank(b.Project, b.Profile, b.Session, b.NamespaceID), "project/profile/session/namespace must be exact"),
 		reason("exact_lead_identity", goalSupervisionAllNonBlank(b.LeadRole, b.LeadHandle), "lead role and handle must be exact"),
-		reason("resumable_lifecycle", !in.ParkedWaitingAMQ && !in.GoalTerminal, "parked and terminal lifecycles are never resume-eligible"),
-		reason("native_goal_paused", in.NativePaused && b.Goal.NativeGoal && b.Goal.Verified, "verified blocked native /goal binding required"),
+		reason("lifecycle_known", a.Lifecycle.Known && a.Lifecycle.Fresh, "fresh durable lifecycle evidence is required"),
+		reason("resumable_lifecycle", a.Lifecycle.Known && a.Lifecycle.Fresh && a.Lifecycle.Phase != "parked_waiting_amq" && a.Lifecycle.Phase != "goal_terminal", "parked and terminal lifecycles are never resume-eligible"),
+		reason("native_goal_paused", nativePaused, "verified blocked native /goal binding required"),
+		reason("goal_binding_content", b.Goal.ContentExact, "typed goal and attempt must match the exact generated command and prepared-run goal"),
 		reason("goal_attempt", b.Goal.Mode == "native_goal_blocked" && goalSupervisionAllNonBlank(b.Goal.Source, b.Goal.DeliveryState, b.Goal.GoalDigest, b.Goal.AttemptID, b.Goal.BindingDigest, b.Goal.CommandDigest), "exact blocked native goal, attempt, binding, delivery, and command digests required"),
 		reason("launch_generation", goalSupervisionAllNonBlank(b.LaunchID, b.LaunchRecordDigest) && b.LaunchRecordModTime > 0 && !b.LaunchStartedAt.IsZero(), "launch ID, digest, modtime, and start time required"),
 		reason("prepared_run_binding", goalSupervisionAllNonBlank(b.PreparedRunGeneration, b.PreparedRunDigest, b.PreparedLaunchAttempt, b.PreparedGoalNamespace, b.PreparedGoalDigest) && b.PreparedGoalNamespace == b.NamespaceID, "prepared run generation, launch attempt, and exact namespace goal binding required"),
 		reason("pause_generation", goalSupervisionAllNonBlank(b.PauseGeneration), "native pause generation required"),
-		reason("pane_identity", b.Pane.Managed && goalSupervisionAllNonBlank(b.Pane.PaneID) && b.Runtime.Live && b.Runtime.PaneLive, "exact managed live pane required"),
+		reason("runtime_identity", b.Runtime.FullLive, "PID, process binary, and exact pane must all be positively live"),
+		reason("pane_identity", b.Pane.Managed && goalSupervisionAllNonBlank(b.Pane.PaneID) && b.Runtime.FullLive, "exact managed live pane required"),
 		reason("pane_idle", b.Pane.BusyKnown && !b.Pane.Busy, "positive idle evidence required"),
 		reason("blocker_known", a.Blocker.Known && goalSupervisionAllNonBlank(a.Blocker.ID), "original blocker identity required"),
 		reason("blocker_resolved", a.Blocker.Resolved && goalSupervisionAllNonBlank(a.Blocker.ResolutionDigest), "durable blocker-resolution evidence required"),
 		reason("gates_known", a.Gates.Known, "gate source must be available"),
 		reason("no_open_gate", a.Gates.Known && a.Gates.Open == 0, "operator gates must be closed"),
 		reason("no_gate_ambiguity", !a.Gates.Ambiguous, "shadowed or unbound gate evidence is ineligible"),
-		reason("no_local_input", !a.LocalInput.Observed, "permission and local-input prompts require a human"),
+		reason("local_input_known", a.LocalInput.Known, "lead pane local-input scan must succeed"),
+		reason("no_local_input", a.LocalInput.Known && !a.LocalInput.Observed, "permission and local-input prompts require a human"),
 		reason("invariants_ok", a.Invariants.OK, strings.Join(a.Invariants.Errors, "; ")),
-		reason("claim_clear", in.ClaimClear && !a.Claim.Indeterminate, "no prior or indeterminate claim may exist"),
-		reason("retry_budget", in.BudgetAllowed, "retry/cooldown/loop budget must remain"),
+		reason("claim_known", a.Claim.Known && !a.Claim.Indeterminate, "durable claim state must be observed"),
+		reason("claim_clear", a.Claim.Known && a.Claim.State == "none" && !a.Claim.Indeterminate, "no prior or indeterminate claim may exist"),
+		reason("retry_budget_known", a.Budget.Known, "durable retry/cooldown/loop budget state must be observed"),
+		reason("retry_budget", a.Budget.Known && a.Budget.Allowed, "retry/cooldown/loop budget must remain"),
 	}
 }
 
@@ -291,24 +350,31 @@ func goalSupervisionAllNonBlank(values ...string) bool {
 
 func goalSupervisionStateFor(a GoalSupervisionAssessment, in goalSupervisionAssessmentInput) GoalSupervisionState {
 	switch {
-	case in.GoalTerminal:
+	case a.Lifecycle.Known && a.Lifecycle.Fresh && a.Lifecycle.Phase == "goal_terminal":
 		return GoalSupervisionGoalTerminal
-	case !a.Binding.Runtime.Live:
-		return GoalSupervisionLeadDown
-	case in.ParkedWaitingAMQ:
+	case a.Lifecycle.Known && a.Lifecycle.Fresh && a.Lifecycle.Phase == "parked_waiting_amq":
 		return GoalSupervisionParkedWaitingAMQ
-	case in.GoalStateKnown && !in.NativePaused:
-		return GoalSupervisionRunning
-	case !in.GoalStateKnown:
-		return GoalSupervisionNativeGoalBlockedUnknown
-	case !a.Binding.Pane.Managed || !a.Binding.Runtime.PaneLive || !a.Binding.Pane.BusyKnown || a.Binding.Pane.Busy:
+	case a.LocalInput.Known && a.LocalInput.Observed || a.Gates.Known && a.Gates.Open > 0:
+		return GoalSupervisionNativeGoalBlockedHuman
+	case goalSupervisionNativePaused(a.Binding.Goal) && a.Blocker.Known && !a.Blocker.Resolved:
+		return GoalSupervisionNativeGoalBlockedHuman
+	case goalSupervisionNativePaused(a.Binding.Goal) &&
+		a.Binding.Runtime.FullLive &&
+		a.Binding.Pane.Managed &&
+		(!a.Binding.Pane.BusyKnown || a.Binding.Pane.Busy):
 		return GoalSupervisionPaneBusyOrUnverified
-	case a.LocalInput.Observed || a.Gates.Known && a.Gates.Open > 0:
-		return GoalSupervisionNativeGoalBlockedHuman
-	case !a.Source.Complete || a.Gates.Ambiguous || !a.Invariants.OK || !a.Blocker.Known:
+	case !a.Source.Complete:
 		return GoalSupervisionNativeGoalBlockedUnknown
-	case a.Blocker.Known && !a.Blocker.Resolved:
-		return GoalSupervisionNativeGoalBlockedHuman
+	case a.Binding.Runtime.VerifiedDown:
+		return GoalSupervisionLeadDown
+	case a.Binding.Goal.StateKnown && !goalSupervisionNativePaused(a.Binding.Goal):
+		return GoalSupervisionRunning
+	case !a.Binding.Goal.StateKnown:
+		return GoalSupervisionNativeGoalBlockedUnknown
+	case !a.Binding.Runtime.FullLive || !a.Binding.Pane.Managed || !a.Binding.Pane.BusyKnown || a.Binding.Pane.Busy:
+		return GoalSupervisionPaneBusyOrUnverified
+	case a.Gates.Ambiguous || !a.Invariants.OK || !a.Blocker.Known:
+		return GoalSupervisionNativeGoalBlockedUnknown
 	case a.Eligible:
 		return GoalSupervisionNativeGoalPausedEligible
 	default:
@@ -352,17 +418,18 @@ func goalSupervisionFingerprint(a GoalSupervisionAssessment) string {
 func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions {
 	scope := runtimeActionScope(a.Binding.Project, a.Binding.Profile, a.Binding.Session)
 	namespaceID := a.Binding.NamespaceID
+	mutationBound := goalSupervisionAllNonBlank(a.Fingerprint, a.Binding.Goal.AttemptID)
 	restoreAvailable := a.State == GoalSupervisionLeadDown &&
+		a.Source.Complete &&
+		a.Binding.Runtime.VerifiedDown &&
 		goalSupervisionReasonPassed(a.Reasons, "exact_namespace") &&
 		goalSupervisionReasonPassed(a.Reasons, "exact_lead_identity") &&
-		!a.Gates.Ambiguous
-	resumeAvailable := a.Eligible && a.Policy.Mode != team.GoalSupervisionNotifyOnly
-	resumeReason := ""
-	switch {
-	case !a.Eligible:
+		goalSupervisionReasonPassed(a.Reasons, "launch_generation") &&
+		a.Gates.Known && a.Gates.Open == 0 && !a.Gates.Ambiguous &&
+		mutationBound
+	resumeReason := "claim-once native goal resume execution is reserved for PR5"
+	if !a.Eligible {
 		resumeReason = firstFailedGoalSupervisionReason(a.Reasons)
-	case a.Policy.Mode == team.GoalSupervisionNotifyOnly:
-		resumeReason = "goal supervision policy is notify-only"
 	}
 	actions := runtimeaction.ApplyCanonical([]runtimeaction.Action{
 		{
@@ -384,18 +451,50 @@ func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions 
 		},
 		{
 			Kind: "native_goal_resume", Label: "resume exact native /goal attempt",
-			Scope: "agent", NamespaceID: namespaceID, Command: "/goal resume",
-			Mutates: true, NeedsConfirmation: a.Policy.Mode != team.GoalSupervisionSafeAuto,
-			Available: resumeAvailable, Reason: resumeReason,
+			Scope: "agent", NamespaceID: namespaceID,
+			Command: "amq-squad goal supervision-resume" + scope +
+				" --attempt-id " + shellQuote(a.Binding.Goal.AttemptID) +
+				" --assessment-fingerprint " + shellQuote(a.Fingerprint),
+			Mutates: true, NeedsConfirmation: true,
+			Available: false, Reason: resumeReason,
 		},
 	})
 	// These two are read-only display actions even though their new kinds are
 	// unknown to the legacy runtimeaction classifier.
 	actions[0].ActionKind = "display"
 	actions[2].ActionKind = "display"
-	return GoalSupervisionActions{
-		Inspect: actions[0], Restore: actions[1], Notify: actions[2], Resume: actions[3],
+	wrap := func(action runtimeaction.Action) GoalSupervisionAction {
+		out := GoalSupervisionAction{Action: action}
+		if action.Mutates {
+			out.Fingerprint = a.Fingerprint
+			out.AttemptID = a.Binding.Goal.AttemptID
+			out.Confirmation = "Reassess this exact fingerprint and attempt immediately before mutation."
+		}
+		return out
 	}
+	return GoalSupervisionActions{
+		Inspect: wrap(actions[0]), Restore: wrap(actions[1]),
+		Notify: wrap(actions[2]), Resume: wrap(actions[3]),
+	}
+}
+
+func goalSupervisionNativePaused(goal GoalSupervisionGoalIdentity) bool {
+	return goalSupervisionNativeBlockedObserved(goal) && goal.ContentExact
+}
+
+func goalSupervisionNativeBlockedObserved(goal GoalSupervisionGoalIdentity) bool {
+	return goal.StateKnown && goal.Verified && goal.NativeGoal &&
+		goal.Mode == "native_goal_blocked"
+}
+
+func goalSupervisionFullRuntimeLive(runtime GoalSupervisionRuntimeIdentity) bool {
+	return runtime.Known && runtime.Live && runtime.PIDLive && runtime.PaneLive &&
+		runtime.PIDAlive && runtime.BinaryMatch
+}
+
+func goalSupervisionRuntimeVerifiedDown(runtime GoalSupervisionRuntimeIdentity) bool {
+	return runtime.Known && !runtime.Live && !runtime.PIDLive && !runtime.PaneLive &&
+		!runtime.PIDAlive
 }
 
 func goalSupervisionReasonPassed(reasons []GoalSupervisionEligibilityReason, code string) bool {
@@ -452,6 +551,10 @@ var goalSupervisionPaneBusy = func(paneID string) (busy bool, known bool) {
 	return busy, err == nil
 }
 
+var goalSupervisionPaneInspector = tmuxpane.InspectPaneExactByID
+
+var goalSupervisionLocalInputDetector = tmuxpane.DetectLocalInputBlocker
+
 func buildGoalSupervisionAssessment(
 	t team.Team,
 	profile, session string,
@@ -464,14 +567,10 @@ func buildGoalSupervisionAssessment(
 	now time.Time,
 ) GoalSupervisionAssessment {
 	profile = squadnamespace.NormalizeProfile(profile)
-	bindingData := goalBindingForStatus(ns, newSessionStatusContext(t, profile, session, firstLiveTmuxSession(rows)), rows)
+	var lifecycle *activity.Snapshot
 	input := goalSupervisionAssessmentInput{
-		ObservedAt:      now.UTC(),
-		Now:             now.UTC(),
 		Policy:          team.EffectiveGoalSupervisionPolicy(t),
-		Claim:           GoalSupervisionClaimProjection{State: "none"},
-		ClaimClear:      true,
-		BudgetAllowed:   true,
+		Claim:           GoalSupervisionClaimProjection{State: "unknown"},
 		SourceErrors:    append([]string(nil), gateObservation.SourceErrors...),
 		Gates:           gateObservation.Evidence,
 		InvariantErrors: goalSupervisionInvariantStrings(invariantErrors),
@@ -480,18 +579,28 @@ func buildGoalSupervisionAssessment(
 			LeadRole: strings.TrimSpace(t.Lead),
 		},
 	}
+	finish := func() GoalSupervisionAssessment {
+		observedAt := time.Now().UTC()
+		if probe.Now != nil {
+			observedAt = probe.Now().UTC()
+		}
+		input.ObservedAt = observedAt
+		input.Now = observedAt
+		input.Lifecycle = goalSupervisionLifecycleObservation(lifecycle, observedAt)
+		return assessGoalSupervision(input)
+	}
 	if namespaceConflict != nil {
 		input.SourceErrors = append(input.SourceErrors, "namespace/profile identity is ambiguous")
 		input.Gates.Ambiguous = true
 	}
 	if !t.Orchestrated || input.Binding.LeadRole == "" {
 		input.SourceErrors = append(input.SourceErrors, "profile has no configured visible lead")
-		return assessGoalSupervision(input)
+		return finish()
 	}
 	leadMember, ok := teamMemberByRole(t, input.Binding.LeadRole)
 	if !ok {
 		input.SourceErrors = append(input.SourceErrors, "configured lead role does not resolve to one member")
-		return assessGoalSupervision(input)
+		return finish()
 	}
 	input.Binding.LeadHandle = strings.TrimSpace(leadMember.Handle)
 	if input.Binding.LeadHandle == "" {
@@ -505,17 +614,27 @@ func buildGoalSupervisionAssessment(
 	}
 	if len(leadRows) != 1 {
 		input.SourceErrors = append(input.SourceErrors, "visible lead runtime does not resolve to exactly one record")
-		return assessGoalSupervision(input)
+		return finish()
 	}
 	row := leadRows[0]
+	lifecycle = row.Activity
 	if row.ClassificationError != "" {
 		input.SourceErrors = append(input.SourceErrors, "lead runtime classification: "+row.ClassificationError)
 	}
 	if !row.liveness.LaunchFound {
 		input.SourceErrors = append(input.SourceErrors, "lead launch record is missing")
-		return assessGoalSupervision(input)
+		return finish()
 	}
-	rec := row.liveness.LaunchRecord
+	rec, digest, modTime, snapshotErr := readGoalSupervisionLaunchSnapshot(row.AgentDir)
+	if snapshotErr != nil {
+		input.SourceErrors = append(input.SourceErrors, "capture coherent launch snapshot: "+snapshotErr.Error())
+		return finish()
+	}
+	if digestJSON(row.liveness.LaunchRecord) != digestJSON(rec) {
+		input.SourceErrors = append(input.SourceErrors, "lead launch record drifted during status assessment")
+	}
+	input.Binding.LaunchRecordDigest = digest
+	input.Binding.LaunchRecordModTime = modTime
 	if rec.BootstrapExpectation != nil {
 		input.Binding.LaunchID = strings.TrimSpace(rec.BootstrapExpectation.LaunchID)
 	}
@@ -525,67 +644,240 @@ func buildGoalSupervisionAssessment(
 	input.Binding.PreparedLaunchAttempt = strings.TrimSpace(rec.PreparedRunLaunchAttempt)
 	input.Binding.PreparedGoalNamespace = strings.TrimSpace(rec.PreparedRunGoalNamespace)
 	input.Binding.PreparedGoalDigest = strings.TrimSpace(rec.PreparedRunGoalDigest)
-	digest, modTime, generationErr := readGoalFileGeneration(launch.ExistingPath(row.AgentDir))
-	if generationErr != nil {
-		input.SourceErrors = append(input.SourceErrors, "capture launch generation: "+generationErr.Error())
-	} else {
-		input.Binding.LaunchRecordDigest = digest
-		input.Binding.LaunchRecordModTime = modTime
-	}
 	paneID := ""
 	if rec.Tmux != nil {
 		paneID = strings.TrimSpace(rec.Tmux.PaneID)
 		input.Binding.Pane = GoalSupervisionPaneIdentity{
-			Managed: paneID != "" && rec.Tmux.Target != "adopted",
+			Managed: paneID != "" && goalSupervisionManagedTmuxTarget(rec.Tmux.Target),
 			Session: rec.Tmux.Session, WindowID: rec.Tmux.WindowID, WindowName: rec.Tmux.WindowName,
 			PaneID: paneID, Target: rec.Tmux.Target,
 		}
 	}
 	runtimeIdentity := classifyLaunchRuntimeIdentity(rec, leadMember.Binary, paneID, launchRuntimeProbeFromDuplicate(probe))
+	paneInspection := goalSupervisionPaneInspector(paneID)
+	paneObservationKnown := paneInspection.State == tmuxpane.PaneInspectionFound ||
+		paneInspection.State == tmuxpane.PaneInspectionGone
+	paneLive := false
+	if paneInspection.State == tmuxpane.PaneInspectionFound {
+		paneLive = goalSupervisionExactPaneIdentity(
+			paneInspection.Pane, rec.Tmux, session, input.Binding.LeadRole,
+		)
+		if !paneLive {
+			input.SourceErrors = append(input.SourceErrors, "live tmux pane does not match the exact recorded lead identity")
+			paneObservationKnown = false
+		}
+	} else if !paneObservationKnown {
+		detail := strings.TrimSpace(paneInspection.Detail)
+		if detail == "" {
+			detail = string(paneInspection.State)
+		}
+		input.SourceErrors = append(input.SourceErrors, "exact lead pane inspection unavailable: "+detail)
+	}
 	input.Binding.Runtime = GoalSupervisionRuntimeIdentity{
-		Live: runtimeIdentity.Live, PIDLive: runtimeIdentity.PIDLive, PaneLive: runtimeIdentity.PaneLive,
+		Known: probe.PIDAlive != nil && probe.ProcessMatch != nil &&
+			probe.ProcessTTY != nil && probe.ProcessStartTime != nil && paneObservationKnown,
+		Live: runtimeIdentity.PIDLive || paneLive, PIDLive: runtimeIdentity.PIDLive, PaneLive: paneLive,
 		PIDAlive: runtimeIdentity.PIDAlive, BinaryMatch: runtimeIdentity.BinaryMatch,
 	}
-	if runtimeIdentity.PaneLive {
+	if paneLive {
 		input.Binding.Pane.Busy, input.Binding.Pane.BusyKnown = goalSupervisionPaneBusy(paneID)
+		blocker, observed, err := goalSupervisionLocalInputDetector(paneID)
+		if err != nil {
+			input.SourceErrors = append(input.SourceErrors, "inspect lead local input: "+err.Error())
+		} else {
+			input.LocalInput = GoalSupervisionLocalInputEvidence{
+				Known: true, Observed: observed, Kind: blocker.Kind, Summary: blocker.Summary,
+				Destructive: blocker.Destructive,
+			}
+		}
 	}
-	if row.goalBinding != nil {
+	bindingData := goalBindingForStatus(
+		ns, newSessionStatusContext(t, profile, session, firstLiveTmuxSession(rows)), rows,
+	)
+	if rec.GoalBinding != nil {
 		input.Binding.Goal = GoalSupervisionGoalIdentity{
-			Mode: row.goalBinding.Mode, NativeGoal: row.goalBinding.NativeGoal,
-			Verified: bindingData.Verified,
-			Source:   row.goalBinding.Source, DeliveryState: row.goalBinding.DeliveryState,
-			GoalDigest: digestGoalSupervisionString(row.goalBinding.Goal), AttemptID: strings.TrimSpace(row.goalBinding.AttemptID),
-			BindingDigest: digestJSON(*row.goalBinding), CommandDigest: digestGoalSupervisionString(row.goalBinding.Command),
+			Mode: rec.GoalBinding.Mode, NativeGoal: rec.GoalBinding.NativeGoal,
+			StateKnown: bindingData.Verified, Verified: bindingData.Verified,
+			Source: rec.GoalBinding.Source, DeliveryState: rec.GoalBinding.DeliveryState,
+			GoalDigest: digestGoalSupervisionString(rec.GoalBinding.Goal), AttemptID: strings.TrimSpace(rec.GoalBinding.AttemptID),
+			BindingDigest: digestJSON(*rec.GoalBinding), CommandDigest: digestGoalSupervisionString(rec.GoalBinding.Command),
+		}
+		if nativeGoalBindingBlocked(rec.GoalBinding) {
+			goal, attemptID, err := verifyGoalSupervisionBlockedBinding(
+				t, profile, session, leadMember, rec,
+			)
+			if err != nil {
+				input.SourceErrors = append(input.SourceErrors, "verify blocked native goal binding: "+err.Error())
+				input.Binding.Goal.StateKnown = false
+				input.Binding.Goal.Verified = false
+			} else {
+				input.Binding.Goal.StateKnown = true
+				input.Binding.Goal.Verified = true
+				input.Binding.Goal.ContentExact = true
+				input.Binding.Goal.GoalDigest = digestGoalSupervisionString(goal)
+				input.Binding.Goal.AttemptID = attemptID
+			}
+		} else {
+			input.Binding.Goal.ContentExact = bindingData.Verified
 		}
 		input.Binding.PauseGeneration = digestJSON(struct {
 			Launch  string
 			Binding string
 			Mode    string
-		}{digest, input.Binding.Goal.BindingDigest, row.goalBinding.Mode})
+		}{digest, input.Binding.Goal.BindingDigest, rec.GoalBinding.Mode})
 	}
-	input.GoalStateKnown = bindingData.Verified
-	input.NativePaused = input.GoalStateKnown && bindingData.NativeGoal && bindingData.Mode == "native_goal_blocked"
-	if input.NativePaused {
-		detail := strings.TrimSpace(bindingData.Detail)
+	if goalSupervisionNativePaused(input.Binding.Goal) {
+		detail := strings.TrimSpace(rec.GoalBinding.Detail)
 		input.Blocker = GoalSupervisionBlockerEvidence{
 			ID: digestGoalSupervisionString(detail), Known: detail != "", Detail: detail,
 		}
 	}
-	if row.LocalInput != nil {
-		input.LocalInput = GoalSupervisionLocalInputEvidence{
-			Observed: true, Kind: row.LocalInput.Kind, Summary: row.LocalInput.Summary,
-			Destructive: row.LocalInput.Destructive,
-		}
+	return finish()
+}
+
+func readGoalSupervisionLaunchSnapshot(agentDir string) (launch.Record, string, int64, error) {
+	path := launch.ExistingPath(agentDir)
+	file, err := os.Open(path)
+	if err != nil {
+		return launch.Record{}, "", 0, err
 	}
-	if row.Activity != nil && !row.Activity.Stale {
-		switch strings.TrimSpace(row.Activity.Phase) {
-		case "parked_waiting_amq":
-			input.ParkedWaitingAMQ = true
-		case "goal_terminal":
-			input.GoalTerminal = true
-		}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return launch.Record{}, "", 0, err
 	}
-	return assessGoalSupervision(input)
+	payload, err := io.ReadAll(file)
+	if err != nil {
+		return launch.Record{}, "", 0, err
+	}
+	var rec launch.Record
+	if err := json.Unmarshal(payload, &rec); err != nil {
+		return launch.Record{}, "", 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return rec, digestBytes(payload), info.ModTime().UnixNano(), nil
+}
+
+func verifyGoalSupervisionBlockedBinding(
+	t team.Team,
+	profile, session string,
+	member team.Member,
+	rec launch.Record,
+) (string, string, error) {
+	binding := rec.GoalBinding
+	goal, attemptID, err := verifyGoalSupervisionBlockedBindingContents(
+		t, profile, session, member, binding,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	manifest, digest, err := readPreparedRunManifestSnapshot(t.Project, profile, session)
+	if err != nil {
+		return "", "", fmt.Errorf("read accepted prepared goal: %w", err)
+	}
+	if err := verifyGoalSupervisionPreparedGoal(
+		goal, profile, session, rec, manifest, digest,
+	); err != nil {
+		return "", "", err
+	}
+	return goal, attemptID, nil
+}
+
+func verifyGoalSupervisionBlockedBindingContents(
+	t team.Team,
+	profile, session string,
+	member team.Member,
+	binding *launch.GoalBinding,
+) (string, string, error) {
+	if binding == nil || binding.Mode != "native_goal_blocked" || !binding.NativeGoal {
+		return "", "", fmt.Errorf("binding is not a blocked native goal")
+	}
+	if binding.Source != "goal-runtime" || binding.DeliveryState != "blocked" {
+		return "", "", fmt.Errorf("binding source/delivery is not exact blocked runtime evidence")
+	}
+	if !goalSupervisionAllNonBlank(binding.Goal, binding.AttemptID, binding.Command) {
+		return "", "", fmt.Errorf("typed goal, attempt, and command are required")
+	}
+	goal, attemptID, err := parseNativeGoalBindingCommand(binding.Command)
+	if err != nil {
+		return "", "", err
+	}
+	if binding.Goal != goal || strings.TrimSpace(binding.AttemptID) != attemptID {
+		return "", "", fmt.Errorf("typed goal or attempt differs from the generated command")
+	}
+	contract, err := goalDeliveryContractForBinary(member.Binary)
+	if err != nil || !contract.NativeGoal {
+		return "", "", fmt.Errorf("lead binary does not support a native goal contract")
+	}
+	if binding.Command != contract.prompt(goal, t, profile, session, member.Role, attemptID) {
+		return "", "", fmt.Errorf("blocked binding command differs from the exact generated command")
+	}
+	return goal, attemptID, nil
+}
+
+func verifyGoalSupervisionPreparedGoal(
+	goal, profile, session string,
+	rec launch.Record,
+	manifest preparedRunManifest,
+	digest string,
+) error {
+	token := preparedRunTokenFromRecord(rec)
+	if !token.complete() || strings.TrimSpace(token.LaunchAttempt) == "" {
+		return fmt.Errorf("prepared launch identity is incomplete")
+	}
+	if err := validatePreparedRunToken(token, manifest, digest); err != nil {
+		return fmt.Errorf("prepared generation mismatch: %w", err)
+	}
+	if !squadnamespace.ProfilesEqual(manifest.Profile, profile) ||
+		manifest.Session != session ||
+		manifest.Namespace != squadnamespace.ID(profile, session) ||
+		manifest.GoalText != goal ||
+		manifest.GoalNamespace != squadnamespace.ID(profile, session) ||
+		manifest.GoalDigest != strings.TrimSpace(rec.PreparedRunGoalDigest) {
+		return fmt.Errorf("blocked goal differs from the accepted prepared-run goal")
+	}
+	return nil
+}
+
+func goalSupervisionExactPaneIdentity(
+	pane tmuxpane.TmuxPane,
+	recorded *launch.TmuxInfo,
+	session, role string,
+) bool {
+	if recorded == nil {
+		return false
+	}
+	return goalSupervisionAllNonBlank(
+		recorded.PaneID, recorded.WindowID, recorded.Session,
+		pane.PaneID, pane.WindowID, pane.Session, pane.Title,
+	) &&
+		pane.PaneID == recorded.PaneID &&
+		pane.WindowID == recorded.WindowID &&
+		pane.Session == recorded.Session &&
+		pane.Title == paneTitleToken(session, role)
+}
+
+func goalSupervisionLifecycleObservation(
+	snapshot *activity.Snapshot,
+	observedAt time.Time,
+) GoalSupervisionLifecycleEvidence {
+	if snapshot == nil || snapshot.Source != activity.SourceHeartbeat ||
+		snapshot.WrittenAt.IsZero() || observedAt.Before(snapshot.WrittenAt) ||
+		observedAt.Sub(snapshot.WrittenAt) > activity.DefaultStaleAfter {
+		return GoalSupervisionLifecycleEvidence{}
+	}
+	return GoalSupervisionLifecycleEvidence{
+		Known: true, Fresh: true, Source: snapshot.Source,
+		Phase: strings.TrimSpace(snapshot.Phase),
+	}
+}
+
+func goalSupervisionManagedTmuxTarget(target string) bool {
+	switch target {
+	case "current-window", "new-window", "new-session":
+		return true
+	default:
+		return false
+	}
 }
 
 func inspectGoalSupervisionGates(

--- a/internal/cli/goal_supervision_test.go
+++ b/internal/cli/goal_supervision_test.go
@@ -1,0 +1,427 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func eligibleGoalSupervisionInput() goalSupervisionAssessmentInput {
+	observedAt := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	return goalSupervisionAssessmentInput{
+		ObservedAt: observedAt,
+		Now:        observedAt.Add(time.Second),
+		MaxAge:     30 * time.Second,
+		Binding: GoalSupervisionBinding{
+			Project: "/project", Profile: "default", Session: "release", NamespaceID: "default/release",
+			LeadRole: "cto", LeadHandle: "cto", LaunchID: "launch-1",
+			LaunchStartedAt: observedAt.Add(-time.Minute), LaunchRecordDigest: "launch-digest",
+			LaunchRecordModTime: observedAt.Add(-time.Minute).UnixNano(),
+			Runtime: GoalSupervisionRuntimeIdentity{
+				Live: true, PIDLive: true, PaneLive: true, PIDAlive: true, BinaryMatch: true,
+			},
+			Pane: GoalSupervisionPaneIdentity{
+				Managed: true, Session: "amq", WindowID: "@1", WindowName: "cto",
+				PaneID: "%1", Target: "amq:cto", BusyKnown: true,
+			},
+			Goal: GoalSupervisionGoalIdentity{
+				Mode: "native_goal_blocked", NativeGoal: true, Verified: true,
+				Source: "launch-record", DeliveryState: "blocked", GoalDigest: "goal-digest",
+				AttemptID: "attempt-1", BindingDigest: "binding-digest", CommandDigest: "command-digest",
+			},
+			PauseGeneration:       "pause-generation",
+			PreparedRunGeneration: "prepared-generation",
+			PreparedRunDigest:     "prepared-digest",
+			PreparedLaunchAttempt: "prepared-attempt",
+			PreparedGoalNamespace: "default/release",
+			PreparedGoalDigest:    "prepared-goal-digest",
+		},
+		GoalStateKnown: true,
+		NativePaused:   true,
+		Blocker: GoalSupervisionBlockerEvidence{
+			ID: "blocker-1", Known: true, Resolved: true,
+			Detail: "dependency complete", ResolutionDigest: "resolution-digest",
+		},
+		Gates:         GoalSupervisionGateEvidence{Known: true},
+		Policy:        team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 2, Source: "profile"},
+		Claim:         GoalSupervisionClaimProjection{State: "none"},
+		ClaimClear:    true,
+		BudgetAllowed: true,
+	}
+}
+
+func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*goalSupervisionAssessmentInput)
+		state     GoalSupervisionState
+		eligible  bool
+		automatic bool
+	}{
+		{
+			name: "safe auto eligible", state: GoalSupervisionNativeGoalPausedEligible,
+			eligible: true, automatic: true,
+		},
+		{
+			name: "manual eligible but confirmation required",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Policy.Mode = team.GoalSupervisionManual
+			},
+			state: GoalSupervisionNativeGoalPausedEligible, eligible: true,
+		},
+		{
+			name: "notify only eligible but never resumes",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Policy.Mode = team.GoalSupervisionNotifyOnly
+			},
+			state: GoalSupervisionNativeGoalPausedEligible, eligible: true,
+		},
+		{
+			name: "running",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.NativePaused = false
+			},
+			state: GoalSupervisionRunning,
+		},
+		{
+			name: "goal state unverified",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.GoalStateKnown = false
+				in.NativePaused = false
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "parked waiting amq",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.ParkedWaitingAMQ = true
+			},
+			state: GoalSupervisionParkedWaitingAMQ,
+		},
+		{
+			name: "goal terminal",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.GoalTerminal = true
+			},
+			state: GoalSupervisionGoalTerminal,
+		},
+		{
+			name: "lead down",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Runtime.Live = false
+			},
+			state: GoalSupervisionLeadDown,
+		},
+		{
+			name: "lead down ambiguous scope",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Runtime.Live = false
+				in.Gates.Ambiguous = true
+			},
+			state: GoalSupervisionLeadDown,
+		},
+		{
+			name: "pane busy",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Pane.Busy = true
+			},
+			state: GoalSupervisionPaneBusyOrUnverified,
+		},
+		{
+			name: "pane idle unverified",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Pane.BusyKnown = false
+			},
+			state: GoalSupervisionPaneBusyOrUnverified,
+		},
+		{
+			name: "open gate requires human",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Gates.Open = 1
+			},
+			state: GoalSupervisionNativeGoalBlockedHuman,
+		},
+		{
+			name: "local input requires human",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.LocalInput = GoalSupervisionLocalInputEvidence{Observed: true, Kind: "permission"}
+			},
+			state: GoalSupervisionNativeGoalBlockedHuman,
+		},
+		{
+			name: "known unresolved blocker requires human",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Blocker.Resolved = false
+				in.Blocker.ResolutionDigest = ""
+			},
+			state: GoalSupervisionNativeGoalBlockedHuman,
+		},
+		{
+			name: "unknown blocker",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Blocker = GoalSupervisionBlockerEvidence{}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "incomplete source",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.SourceErrors = []string{"launch source unavailable"}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "ambiguous gate",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Gates.Ambiguous = true
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "gate source unknown is not a clear zero",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Gates = GoalSupervisionGateEvidence{}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "invariant violation",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.InvariantErrors = []string{"lead identity mismatch"}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "prior claim indeterminate",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Claim.Indeterminate = true
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "retry budget exhausted",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.BudgetAllowed = false
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "stale assessment",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Now = in.ObservedAt.Add(in.MaxAge + time.Nanosecond)
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "future observation",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Now = in.ObservedAt.Add(-time.Nanosecond)
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "attempt identity missing",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Goal.AttemptID = ""
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "prepared binding missing",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.PreparedRunGeneration = ""
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := eligibleGoalSupervisionInput()
+			if tc.mutate != nil {
+				tc.mutate(&in)
+			}
+			got := assessGoalSupervision(in)
+			if got.State != tc.state || got.Eligible != tc.eligible || got.AutomaticResumeAllowed != tc.automatic {
+				t.Fatalf("assessment = state %q eligible=%t automatic=%t, want %q/%t/%t; reasons=%+v",
+					got.State, got.Eligible, got.AutomaticResumeAllowed,
+					tc.state, tc.eligible, tc.automatic, got.Reasons)
+			}
+			if tc.name == "manual eligible but confirmation required" &&
+				(!got.Actions.Resume.Available || !got.Actions.Resume.NeedsConfirmation) {
+				t.Fatalf("manual resume action = %+v, want available with confirmation", got.Actions.Resume)
+			}
+			if tc.name == "notify only eligible but never resumes" && got.Actions.Resume.Available {
+				t.Fatalf("notify-only resume action = %+v, want unavailable", got.Actions.Resume)
+			}
+			if tc.name == "lead down" && !got.Actions.Restore.Available {
+				t.Fatalf("exact lead-down restore action = %+v, want available", got.Actions.Restore)
+			}
+			if tc.name == "lead down ambiguous scope" && got.Actions.Restore.Available {
+				t.Fatalf("ambiguous lead-down restore action = %+v, want unavailable", got.Actions.Restore)
+			}
+		})
+	}
+}
+
+func TestAssessGoalSupervisionEligibilityReasonsAreExplicitAndOrdered(t *testing.T) {
+	got := assessGoalSupervision(eligibleGoalSupervisionInput())
+	var codes []string
+	for _, reason := range got.Reasons {
+		if !reason.Passed {
+			t.Fatalf("eligible reason %q failed: %+v", reason.Code, reason)
+		}
+		codes = append(codes, reason.Code)
+	}
+	want := []string{
+		"fresh_assessment", "sources_complete", "exact_namespace", "exact_lead_identity",
+		"resumable_lifecycle", "native_goal_paused", "goal_attempt", "launch_generation", "prepared_run_binding",
+		"pause_generation", "pane_identity", "pane_idle", "blocker_known", "blocker_resolved",
+		"gates_known", "no_open_gate", "no_gate_ambiguity", "no_local_input",
+		"invariants_ok", "claim_clear", "retry_budget",
+	}
+	if !reflect.DeepEqual(gotCodes(got.Reasons), want) {
+		t.Fatalf("reason codes = %v, want %v", codes, want)
+	}
+}
+
+func TestGoalSupervisionFingerprintIgnoresObservationTimeButBindsAttempt(t *testing.T) {
+	firstInput := eligibleGoalSupervisionInput()
+	first := assessGoalSupervision(firstInput)
+
+	secondInput := eligibleGoalSupervisionInput()
+	secondInput.ObservedAt = secondInput.ObservedAt.Add(10 * time.Second)
+	secondInput.Now = secondInput.Now.Add(10 * time.Second)
+	second := assessGoalSupervision(secondInput)
+	if first.Fingerprint != second.Fingerprint {
+		t.Fatalf("fresh observations changed fingerprint: %q != %q", first.Fingerprint, second.Fingerprint)
+	}
+
+	secondInput.Binding.Goal.AttemptID = "attempt-2"
+	changed := assessGoalSupervision(secondInput)
+	if first.Fingerprint == changed.Fingerprint {
+		t.Fatalf("attempt change did not change fingerprint %q", first.Fingerprint)
+	}
+}
+
+func TestGoalSupervisionProjectionJSONConsistentAcrossStatusBoardDoctor(t *testing.T) {
+	assessment := assessGoalSupervision(eligibleGoalSupervisionInput())
+	surfaces := []struct {
+		name  string
+		value any
+	}{
+		{name: "status", value: statusEnvelopeData{GoalSupervision: assessment}},
+		{name: "board", value: sessionBoardRow{GoalSupervision: &assessment}},
+		{name: "doctor", value: doctorCheck{Kind: "goal_supervision", GoalSupervision: &assessment}},
+	}
+	var canonical json.RawMessage
+	for _, surface := range surfaces {
+		payload, err := json.Marshal(surface.value)
+		if err != nil {
+			t.Fatalf("%s marshal: %v", surface.name, err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &fields); err != nil {
+			t.Fatalf("%s decode: %v", surface.name, err)
+		}
+		got := fields["goal_supervision"]
+		if len(got) == 0 {
+			t.Fatalf("%s omitted goal_supervision: %s", surface.name, payload)
+		}
+		if canonical == nil {
+			canonical = append(json.RawMessage(nil), got...)
+			continue
+		}
+		if !bytes.Equal(canonical, got) {
+			t.Fatalf("%s projection differs:\n%s\n%s", surface.name, canonical, got)
+		}
+	}
+}
+
+func TestInspectGoalSupervisionGatesReadsDurableOpenGate(t *testing.T) {
+	project, base, _ := seedNotifyProject(t, team.DefaultOperator())
+	seedNotifyLaunch(t, project, base, "s", "cto")
+	seedNotifyMessage(t, base, "s", team.DefaultOperatorHandle, "new", notifyMsg{
+		ID:      "gate-1",
+		From:    "cto",
+		To:      team.DefaultOperatorHandle,
+		Thread:  "gate/release",
+		Subject: "APPROVAL: release",
+		Kind:    string(state.KindQuestion),
+		Created: notifyNow,
+	})
+	cfg, err := team.ReadProfile(project, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := inspectGoalSupervisionGates(cfg, team.DefaultProfile, "s", filepath.Join(base, "s"), duplicateLaunchProbe{
+		PIDAlive:     func(int) bool { return true },
+		ProcessMatch: func(int, func(string) bool) bool { return true },
+		Now:          func() time.Time { return notifyNow },
+	}, notifyNow)
+	if len(observation.SourceErrors) != 0 ||
+		!observation.Evidence.Known ||
+		observation.Evidence.Open != 1 {
+		t.Fatalf("gate observation = %+v, want known one durable open gate", observation)
+	}
+}
+
+func TestInspectGoalSupervisionGatesFailsClosedWhenNamespaceCannotBeScanned(t *testing.T) {
+	cfg := team.Team{
+		Project: t.TempDir(),
+		Operator: &team.OperatorConfig{
+			Enabled: true, Handle: team.DefaultOperatorHandle, Participant: true,
+		},
+	}
+	observation := inspectGoalSupervisionGates(
+		cfg, team.DefaultProfile, "missing", "", duplicateLaunchProbe{}, notifyNow,
+	)
+	if observation.Evidence.Known || len(observation.SourceErrors) == 0 {
+		t.Fatalf("gate observation = %+v, want unknown with source error", observation)
+	}
+}
+
+func TestInspectGoalSupervisionGatesMarksMailboxWarningsAmbiguous(t *testing.T) {
+	project, base, _ := seedNotifyProject(t, team.DefaultOperator())
+	seedNotifyLaunch(t, project, base, "s", "cto")
+	tornDir := filepath.Join(base, "s", "agents", team.DefaultOperatorHandle, "inbox", "new")
+	if err := os.MkdirAll(tornDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tornDir, "torn.md"), []byte("---json\n{\"id\":"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := team.ReadProfile(project, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := inspectGoalSupervisionGates(
+		cfg, team.DefaultProfile, "s", filepath.Join(base, "s"),
+		duplicateLaunchProbe{
+			PIDAlive:     func(int) bool { return true },
+			ProcessMatch: func(int, func(string) bool) bool { return true },
+			Now:          func() time.Time { return notifyNow },
+		},
+		notifyNow,
+	)
+	if !observation.Evidence.Known ||
+		!observation.Evidence.Ambiguous ||
+		len(observation.SourceErrors) == 0 {
+		t.Fatalf("gate observation = %+v, want known but ambiguous with source error", observation)
+	}
+}
+
+func gotCodes(reasons []GoalSupervisionEligibilityReason) []string {
+	codes := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		codes = append(codes, reason.Code)
+	}
+	return codes
+}

--- a/internal/cli/goal_supervision_test.go
+++ b/internal/cli/goal_supervision_test.go
@@ -394,6 +394,23 @@ func TestGoalSupervisionManagedTmuxTargetRequiresCanonicalManagedTarget(t *testi
 			}
 		})
 	}
+
+	t.Run("managed projection is an independent restore veto", func(t *testing.T) {
+		input := eligibleGoalSupervisionInput()
+		input.Binding.Pane.Target = "new-window"
+		input.Binding.Pane.Managed = false
+		input.Binding.Runtime.Live = false
+		input.Binding.Runtime.PIDLive = false
+		input.Binding.Runtime.PaneLive = false
+		input.Binding.Runtime.PIDAlive = false
+		input.Binding.Runtime.BinaryMatch = false
+		assessment := assessGoalSupervision(input)
+		if assessment.State != GoalSupervisionLeadDown ||
+			assessment.Actions.Restore.Available {
+			t.Fatalf("unmanaged lead-down restore was not refused: state=%q action=%+v",
+				assessment.State, assessment.Actions.Restore)
+		}
+	})
 }
 
 func TestGoalSupervisionExactPaneIdentityRequiresAllStableIDsAndTitle(t *testing.T) {
@@ -624,6 +641,29 @@ func TestGoalSupervisionLifecycleObservationFailsClosed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := goalSupervisionLifecycleObservation(snapshot, now); got.Known || got.Fresh {
 				t.Fatalf("%s lifecycle = %+v, want unknown", name, got)
+			}
+		})
+	}
+}
+
+func TestGoalSupervisionResumableLifecycleRequiresGoalBlockedPhase(t *testing.T) {
+	eligible := assessGoalSupervision(eligibleGoalSupervisionInput())
+	if !goalSupervisionReasonPassed(eligible.Reasons, "resumable_lifecycle") {
+		t.Fatalf("goal_blocked lifecycle was not resumable: %+v", eligible.Reasons)
+	}
+
+	for _, phase := range []string{"parked_waiting_amq", "goal_terminal", "testing"} {
+		t.Run(phase, func(t *testing.T) {
+			input := eligibleGoalSupervisionInput()
+			// Exercise the assessment boundary directly. The nonterminal
+			// "testing" row distinguishes the goal_blocked whitelist from the
+			// former parked/terminal blacklist.
+			input.Lifecycle = GoalSupervisionLifecycleEvidence{
+				Known: true, Fresh: true, Source: activity.SourceHeartbeat, Phase: phase,
+			}
+			assessment := assessGoalSupervision(input)
+			if goalSupervisionReasonPassed(assessment.Reasons, "resumable_lifecycle") {
+				t.Fatalf("phase %q passed resumable_lifecycle: %+v", phase, assessment.Reasons)
 			}
 		})
 	}

--- a/internal/cli/goal_supervision_test.go
+++ b/internal/cli/goal_supervision_test.go
@@ -6,11 +6,15 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/activity"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 func eligibleGoalSupervisionInput() goalSupervisionAssessmentInput {
@@ -25,14 +29,14 @@ func eligibleGoalSupervisionInput() goalSupervisionAssessmentInput {
 			LaunchStartedAt: observedAt.Add(-time.Minute), LaunchRecordDigest: "launch-digest",
 			LaunchRecordModTime: observedAt.Add(-time.Minute).UnixNano(),
 			Runtime: GoalSupervisionRuntimeIdentity{
-				Live: true, PIDLive: true, PaneLive: true, PIDAlive: true, BinaryMatch: true,
+				Known: true, Live: true, PIDLive: true, PaneLive: true, PIDAlive: true, BinaryMatch: true,
 			},
 			Pane: GoalSupervisionPaneIdentity{
 				Managed: true, Session: "amq", WindowID: "@1", WindowName: "cto",
-				PaneID: "%1", Target: "amq:cto", BusyKnown: true,
+				PaneID: "%1", Target: "new-window", BusyKnown: true,
 			},
 			Goal: GoalSupervisionGoalIdentity{
-				Mode: "native_goal_blocked", NativeGoal: true, Verified: true,
+				Mode: "native_goal_blocked", NativeGoal: true, StateKnown: true, Verified: true, ContentExact: true,
 				Source: "launch-record", DeliveryState: "blocked", GoalDigest: "goal-digest",
 				AttemptID: "attempt-1", BindingDigest: "binding-digest", CommandDigest: "command-digest",
 			},
@@ -43,17 +47,18 @@ func eligibleGoalSupervisionInput() goalSupervisionAssessmentInput {
 			PreparedGoalNamespace: "default/release",
 			PreparedGoalDigest:    "prepared-goal-digest",
 		},
-		GoalStateKnown: true,
-		NativePaused:   true,
+		Lifecycle: GoalSupervisionLifecycleEvidence{
+			Known: true, Fresh: true, Source: "heartbeat-file", Phase: "goal_blocked",
+		},
 		Blocker: GoalSupervisionBlockerEvidence{
 			ID: "blocker-1", Known: true, Resolved: true,
 			Detail: "dependency complete", ResolutionDigest: "resolution-digest",
 		},
-		Gates:         GoalSupervisionGateEvidence{Known: true},
-		Policy:        team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 2, Source: "profile"},
-		Claim:         GoalSupervisionClaimProjection{State: "none"},
-		ClaimClear:    true,
-		BudgetAllowed: true,
+		Gates:      GoalSupervisionGateEvidence{Known: true},
+		LocalInput: GoalSupervisionLocalInputEvidence{Known: true},
+		Policy:     team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 2, Source: "profile"},
+		Claim:      GoalSupervisionClaimProjection{Known: true, State: "none"},
+		Budget:     GoalSupervisionBudgetEvidence{Known: true, Allowed: true},
 	}
 }
 
@@ -86,29 +91,30 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 		{
 			name: "running",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.NativePaused = false
+				in.Binding.Goal.Mode = "native_goal"
 			},
 			state: GoalSupervisionRunning,
 		},
 		{
 			name: "goal state unverified",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.GoalStateKnown = false
-				in.NativePaused = false
+				in.Binding.Goal.StateKnown = false
+				in.Binding.Goal.Verified = false
+				in.Binding.Goal.ContentExact = false
 			},
 			state: GoalSupervisionNativeGoalBlockedUnknown,
 		},
 		{
 			name: "parked waiting amq",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.ParkedWaitingAMQ = true
+				in.Lifecycle.Phase = "parked_waiting_amq"
 			},
 			state: GoalSupervisionParkedWaitingAMQ,
 		},
 		{
 			name: "goal terminal",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.GoalTerminal = true
+				in.Lifecycle.Phase = "goal_terminal"
 			},
 			state: GoalSupervisionGoalTerminal,
 		},
@@ -116,6 +122,10 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 			name: "lead down",
 			mutate: func(in *goalSupervisionAssessmentInput) {
 				in.Binding.Runtime.Live = false
+				in.Binding.Runtime.PIDLive = false
+				in.Binding.Runtime.PaneLive = false
+				in.Binding.Runtime.PIDAlive = false
+				in.Binding.Runtime.BinaryMatch = false
 			},
 			state: GoalSupervisionLeadDown,
 		},
@@ -123,9 +133,13 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 			name: "lead down ambiguous scope",
 			mutate: func(in *goalSupervisionAssessmentInput) {
 				in.Binding.Runtime.Live = false
+				in.Binding.Runtime.PIDLive = false
+				in.Binding.Runtime.PaneLive = false
+				in.Binding.Runtime.PIDAlive = false
+				in.Binding.Runtime.BinaryMatch = false
 				in.Gates.Ambiguous = true
 			},
-			state: GoalSupervisionLeadDown,
+			state: GoalSupervisionNativeGoalBlockedUnknown,
 		},
 		{
 			name: "pane busy",
@@ -151,9 +165,16 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 		{
 			name: "local input requires human",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.LocalInput = GoalSupervisionLocalInputEvidence{Observed: true, Kind: "permission"}
+				in.LocalInput = GoalSupervisionLocalInputEvidence{Known: true, Observed: true, Kind: "permission"}
 			},
 			state: GoalSupervisionNativeGoalBlockedHuman,
+		},
+		{
+			name: "local input unknown",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.LocalInput = GoalSupervisionLocalInputEvidence{}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
 		},
 		{
 			name: "known unresolved blocker requires human",
@@ -201,16 +222,53 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 		{
 			name: "prior claim indeterminate",
 			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Claim.Known = false
 				in.Claim.Indeterminate = true
+				in.Claim.State = "unknown"
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "claim observation absent",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Claim = GoalSupervisionClaimProjection{State: "unknown"}
 			},
 			state: GoalSupervisionNativeGoalBlockedUnknown,
 		},
 		{
 			name: "retry budget exhausted",
 			mutate: func(in *goalSupervisionAssessmentInput) {
-				in.BudgetAllowed = false
+				in.Budget.Allowed = false
 			},
 			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "retry budget unknown",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Budget = GoalSupervisionBudgetEvidence{}
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "lifecycle stale",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Lifecycle.Fresh = false
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "binding content mismatch",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Goal.ContentExact = false
+			},
+			state: GoalSupervisionNativeGoalBlockedUnknown,
+		},
+		{
+			name: "runtime missing pid identity",
+			mutate: func(in *goalSupervisionAssessmentInput) {
+				in.Binding.Runtime.PIDLive = false
+			},
+			state: GoalSupervisionPaneBusyOrUnverified,
 		},
 		{
 			name: "stale assessment",
@@ -255,8 +313,11 @@ func TestAssessGoalSupervisionEligibilityTruthTable(t *testing.T) {
 					tc.state, tc.eligible, tc.automatic, got.Reasons)
 			}
 			if tc.name == "manual eligible but confirmation required" &&
-				(!got.Actions.Resume.Available || !got.Actions.Resume.NeedsConfirmation) {
-				t.Fatalf("manual resume action = %+v, want available with confirmation", got.Actions.Resume)
+				(got.Actions.Resume.Available || !got.Actions.Resume.NeedsConfirmation ||
+					got.Actions.Resume.Fingerprint != got.Fingerprint ||
+					got.Actions.Resume.AttemptID != got.Binding.Goal.AttemptID ||
+					got.Actions.Resume.Confirmation == "") {
+				t.Fatalf("manual resume action = %+v, want unavailable PR5 action with exact confirmation binding", got.Actions.Resume)
 			}
 			if tc.name == "notify only eligible but never resumes" && got.Actions.Resume.Available {
 				t.Fatalf("notify-only resume action = %+v, want unavailable", got.Actions.Resume)
@@ -282,13 +343,216 @@ func TestAssessGoalSupervisionEligibilityReasonsAreExplicitAndOrdered(t *testing
 	}
 	want := []string{
 		"fresh_assessment", "sources_complete", "exact_namespace", "exact_lead_identity",
-		"resumable_lifecycle", "native_goal_paused", "goal_attempt", "launch_generation", "prepared_run_binding",
-		"pause_generation", "pane_identity", "pane_idle", "blocker_known", "blocker_resolved",
-		"gates_known", "no_open_gate", "no_gate_ambiguity", "no_local_input",
-		"invariants_ok", "claim_clear", "retry_budget",
+		"lifecycle_known", "resumable_lifecycle", "native_goal_paused", "goal_binding_content",
+		"goal_attempt", "launch_generation", "prepared_run_binding", "pause_generation",
+		"runtime_identity", "pane_identity", "pane_idle", "blocker_known", "blocker_resolved",
+		"gates_known", "no_open_gate", "no_gate_ambiguity", "local_input_known",
+		"no_local_input", "invariants_ok", "claim_known", "claim_clear",
+		"retry_budget_known", "retry_budget",
 	}
 	if !reflect.DeepEqual(gotCodes(got.Reasons), want) {
 		t.Fatalf("reason codes = %v, want %v", codes, want)
+	}
+}
+
+func TestGoalSupervisionManagedTmuxTargetRequiresCanonicalManagedTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{target: "current-window", want: true},
+		{target: "new-window", want: true},
+		{target: "new-session", want: true},
+		{target: ""},
+		{target: "adopted"},
+		{target: "external"},
+		{target: "unknown"},
+		{target: " current-window"},
+		{target: "current-window "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.target, func(t *testing.T) {
+			if got := goalSupervisionManagedTmuxTarget(tc.target); got != tc.want {
+				t.Fatalf("goalSupervisionManagedTmuxTarget(%q) = %t, want %t", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGoalSupervisionExactPaneIdentityRequiresAllStableIDsAndTitle(t *testing.T) {
+	recorded := &launch.TmuxInfo{
+		Session: "squad", WindowID: "@1", PaneID: "%1", Target: "new-window",
+	}
+	valid := tmuxpane.TmuxPane{
+		Session: "squad", WindowID: "@1", PaneID: "%1",
+		Title: paneTitleToken("release", "cto"),
+	}
+	if !goalSupervisionExactPaneIdentity(valid, recorded, "release", "cto") {
+		t.Fatal("exact pane identity was rejected")
+	}
+	tests := []struct {
+		name   string
+		mutate func(*tmuxpane.TmuxPane)
+	}{
+		{name: "pane", mutate: func(p *tmuxpane.TmuxPane) { p.PaneID = "%2" }},
+		{name: "window", mutate: func(p *tmuxpane.TmuxPane) { p.WindowID = "@2" }},
+		{name: "session", mutate: func(p *tmuxpane.TmuxPane) { p.Session = "other" }},
+		{name: "title", mutate: func(p *tmuxpane.TmuxPane) { p.Title = "amq:release:other" }},
+		{name: "empty title", mutate: func(p *tmuxpane.TmuxPane) { p.Title = "" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := valid
+			tc.mutate(&got)
+			if goalSupervisionExactPaneIdentity(got, recorded, "release", "cto") {
+				t.Fatalf("mismatched %s identity was accepted: %+v", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestVerifyGoalSupervisionBlockedBindingContentsIsExact(t *testing.T) {
+	member := team.Member{Role: "cto", Binary: "claude", Handle: "cto"}
+	tm := team.Team{
+		Project: "/project", Orchestrated: true, Lead: "cto",
+		ExecutionMode: executionModeProjectLead, Members: []team.Member{member},
+	}
+	goal := "ship the accepted run"
+	attemptID := strings.Repeat("a", 32)
+	command := nativeGoalControlPrompt(
+		goal, tm, team.DefaultProfile, "release", member.Role, attemptID,
+	)
+	valid := launch.GoalBinding{
+		Mode: "native_goal_blocked", NativeGoal: true,
+		Source: "goal-runtime", DeliveryState: "blocked",
+		Goal: goal, AttemptID: attemptID, Command: command,
+	}
+	if gotGoal, gotAttempt, err := verifyGoalSupervisionBlockedBindingContents(
+		tm, team.DefaultProfile, "release", member, &valid,
+	); err != nil || gotGoal != goal || gotAttempt != attemptID {
+		t.Fatalf("valid blocked binding = goal %q attempt %q err %v", gotGoal, gotAttempt, err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*launch.GoalBinding)
+	}{
+		{name: "typed goal", mutate: func(b *launch.GoalBinding) { b.Goal = "different" }},
+		{name: "typed attempt", mutate: func(b *launch.GoalBinding) { b.AttemptID = strings.Repeat("b", 32) }},
+		{name: "command", mutate: func(b *launch.GoalBinding) { b.Command = strings.Replace(b.Command, "release", "other", 1) }},
+		{name: "source", mutate: func(b *launch.GoalBinding) { b.Source = "launch-record" }},
+		{name: "delivery", mutate: func(b *launch.GoalBinding) { b.DeliveryState = "delivered" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := valid
+			tc.mutate(&got)
+			if _, _, err := verifyGoalSupervisionBlockedBindingContents(
+				tm, team.DefaultProfile, "release", member, &got,
+			); err == nil {
+				t.Fatalf("mismatched %s binding was accepted: %+v", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestVerifyGoalSupervisionPreparedGoalRejectsGoalOrGenerationDrift(t *testing.T) {
+	generation := strings.Repeat("a", 32)
+	launchAttempt := strings.Repeat("b", 32)
+	manifestDigest := "sha256:manifest"
+	goalDigest := "sha256:goal"
+	manifest := preparedRunManifest{
+		Generation: generation, Profile: team.DefaultProfile,
+		Session: "release", Namespace: "default/release", GoalText: "ship",
+		GoalNamespace: "default/release", GoalDigest: goalDigest,
+	}
+	rec := launch.Record{
+		PreparedRunGeneration: generation, PreparedRunDigest: manifestDigest,
+		PreparedRunGoalNamespace: "default/release", PreparedRunGoalDigest: goalDigest,
+		PreparedRunLaunchAttempt: launchAttempt,
+	}
+	if err := verifyGoalSupervisionPreparedGoal(
+		"ship", team.DefaultProfile, "release", rec, manifest, manifestDigest,
+	); err != nil {
+		t.Fatalf("exact prepared goal rejected: %v", err)
+	}
+	changedGoal := manifest
+	changedGoal.GoalText = "different"
+	if err := verifyGoalSupervisionPreparedGoal(
+		"ship", team.DefaultProfile, "release", rec, changedGoal, manifestDigest,
+	); err == nil {
+		t.Fatal("prepared goal text drift was accepted")
+	}
+	changedGeneration := rec
+	changedGeneration.PreparedRunGeneration = strings.Repeat("c", 32)
+	if err := verifyGoalSupervisionPreparedGoal(
+		"ship", team.DefaultProfile, "release", changedGeneration, manifest, manifestDigest,
+	); err == nil {
+		t.Fatal("prepared generation drift was accepted")
+	}
+}
+
+func TestGoalSupervisionLifecycleObservationFailsClosed(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	fresh := &activity.Snapshot{
+		Source: activity.SourceHeartbeat, WrittenAt: now.Add(-time.Second),
+		Phase: "parked_waiting_amq",
+	}
+	if got := goalSupervisionLifecycleObservation(fresh, now); !got.Known || !got.Fresh || got.Phase != fresh.Phase {
+		t.Fatalf("fresh lifecycle = %+v", got)
+	}
+	for name, snapshot := range map[string]*activity.Snapshot{
+		"absent": nil,
+		"stale": {
+			Source:    activity.SourceHeartbeat,
+			WrittenAt: now.Add(-activity.DefaultStaleAfter - time.Nanosecond),
+		},
+		"future": {
+			Source:    activity.SourceHeartbeat,
+			WrittenAt: now.Add(time.Nanosecond),
+		},
+		"task store": {
+			Source:    activity.SourceTaskStore,
+			WrittenAt: now.Add(-time.Second),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := goalSupervisionLifecycleObservation(snapshot, now); got.Known || got.Fresh {
+				t.Fatalf("%s lifecycle = %+v, want unknown", name, got)
+			}
+		})
+	}
+}
+
+func TestGoalSupervisionMutatingActionsBindFingerprintAndAttempt(t *testing.T) {
+	got := assessGoalSupervision(eligibleGoalSupervisionInput())
+	for name, action := range map[string]GoalSupervisionAction{
+		"restore": got.Actions.Restore,
+		"resume":  got.Actions.Resume,
+	} {
+		if !action.Mutates || !action.NeedsConfirmation ||
+			action.Fingerprint != got.Fingerprint ||
+			action.AttemptID != got.Binding.Goal.AttemptID ||
+			action.Confirmation == "" {
+			t.Fatalf("%s action lacks exact mutation binding: %+v", name, action)
+		}
+	}
+	if got.Actions.Resume.Available ||
+		!strings.Contains(got.Actions.Resume.Command, got.Binding.Goal.AttemptID) ||
+		!strings.Contains(got.Actions.Resume.Command, got.Fingerprint) {
+		t.Fatalf("PR5-reserved resume action is not safely scoped: %+v", got.Actions.Resume)
+	}
+
+	missingAttempt := eligibleGoalSupervisionInput()
+	missingAttempt.Binding.Goal.AttemptID = ""
+	unbound := assessGoalSupervision(missingAttempt)
+	for name, action := range map[string]GoalSupervisionAction{
+		"restore": unbound.Actions.Restore,
+		"resume":  unbound.Actions.Resume,
+	} {
+		if !action.Mutates || !action.NeedsConfirmation || action.Available ||
+			action.Fingerprint != unbound.Fingerprint || action.Confirmation == "" {
+			t.Fatalf("%s unbound action misstates mutation semantics: %+v", name, action)
+		}
 	}
 }
 
@@ -342,6 +606,14 @@ func TestGoalSupervisionProjectionJSONConsistentAcrossStatusBoardDoctor(t *testi
 		if !bytes.Equal(canonical, got) {
 			t.Fatalf("%s projection differs:\n%s\n%s", surface.name, canonical, got)
 		}
+	}
+}
+
+func TestDoctorGoalSupervisionWarnsWhenAssessmentCannotResolve(t *testing.T) {
+	check := doctorCheckGoalSupervision(defaultDoctorExecution(t.TempDir()), "")
+	if check.Status != doctorWarn || check.GoalSupervision != nil ||
+		!strings.Contains(check.Detail, "assessment is unavailable") {
+		t.Fatalf("missing-workstream goal supervision check = %+v, want explicit warning", check)
 	}
 }
 

--- a/internal/cli/goal_supervision_test.go
+++ b/internal/cli/goal_supervision_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/activity"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/state"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -375,6 +376,22 @@ func TestGoalSupervisionManagedTmuxTargetRequiresCanonicalManagedTarget(t *testi
 			if got := goalSupervisionManagedTmuxTarget(tc.target); got != tc.want {
 				t.Fatalf("goalSupervisionManagedTmuxTarget(%q) = %t, want %t", tc.target, got, tc.want)
 			}
+
+			input := eligibleGoalSupervisionInput()
+			input.Binding.Pane.Target = tc.target
+			// Deliberately leave the projected bit true: restore must enforce
+			// the canonical target itself rather than trust a stale projection.
+			input.Binding.Pane.Managed = true
+			input.Binding.Runtime.Live = false
+			input.Binding.Runtime.PIDLive = false
+			input.Binding.Runtime.PaneLive = false
+			input.Binding.Runtime.PIDAlive = false
+			input.Binding.Runtime.BinaryMatch = false
+			assessment := assessGoalSupervision(input)
+			if assessment.Actions.Restore.Available != tc.want {
+				t.Fatalf("lead-down restore for target %q available = %t, want %t: %+v",
+					tc.target, assessment.Actions.Restore.Available, tc.want, assessment.Actions.Restore)
+			}
 		})
 	}
 }
@@ -455,6 +472,85 @@ func TestVerifyGoalSupervisionBlockedBindingContentsIsExact(t *testing.T) {
 	}
 }
 
+func TestBuildGoalSupervisionAssessmentContentVerificationDoesNotOverrideStatusVeto(t *testing.T) {
+	project := t.TempDir()
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	session := "release"
+	ns := squadnamespace.Resolve(project, team.DefaultProfile, session)
+	member := team.Member{Role: "cto", Handle: "cto", Binary: "codex"}
+	tm := team.Team{
+		Project: project, Orchestrated: true, Lead: member.Role,
+		ExecutionMode: executionModeProjectLead,
+		Members:       []team.Member{member},
+	}
+	agentDir := filepath.Join(ns.AMQRoot, "agents", member.Handle)
+	rec := launch.Record{
+		CWD: project, Binary: member.Binary, Handle: member.Handle, Role: member.Role,
+		Session: session, TeamProfile: team.DefaultProfile, AgentPID: 4242, StartedAt: now.Add(-time.Minute),
+		GoalBinding: &launch.GoalBinding{
+			Mode: "native_goal_blocked", NativeGoal: true, Source: "goal-runtime",
+			DeliveryState: "blocked", Goal: "ship", AttemptID: "attempt-1",
+			Command: "synthetic exact command", Detail: "waiting",
+		},
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := []statusRecord{{
+		Role: member.Role, Handle: member.Handle, Binary: member.Binary,
+		Session: session, Namespace: ns, AgentDir: agentDir,
+		// A refused managed identity is stale, so status must veto the
+		// otherwise content-exact blocked binding.
+		Status:           statusStateStale,
+		LiveIdentityMode: "managed_refused",
+		goalBinding:      stored.GoalBinding,
+		liveness: agentLiveness{
+			LaunchFound: true, LaunchRecord: stored,
+		},
+		Activity: &activity.Snapshot{
+			Source: activity.SourceHeartbeat, WrittenAt: now.Add(-time.Second),
+			Phase: "goal_blocked",
+		},
+	}}
+	if binding := goalBindingForStatus(
+		ns, newSessionStatusContext(tm, team.DefaultProfile, session, ""), rows,
+	); binding.Verified {
+		t.Fatalf("stale/refused status unexpectedly verified binding: %+v", binding)
+	}
+
+	previousVerifier := goalSupervisionBlockedBindingVerifier
+	goalSupervisionBlockedBindingVerifier = func(
+		team.Team, string, string, team.Member, launch.Record,
+	) (string, string, error) {
+		return "ship", "attempt-1", nil
+	}
+	t.Cleanup(func() { goalSupervisionBlockedBindingVerifier = previousVerifier })
+
+	assessment := buildGoalSupervisionAssessment(
+		tm, team.DefaultProfile, session, ns, rows,
+		goalSupervisionGateObservation{Evidence: GoalSupervisionGateEvidence{Known: true}},
+		nil, nil,
+		duplicateLaunchProbe{
+			PIDAlive:         func(int) bool { return false },
+			ProcessMatch:     func(int, func(string) bool) bool { return false },
+			ProcessTTY:       func(int) (string, bool) { return "", false },
+			ProcessStartTime: func(int) (time.Time, bool) { return time.Time{}, false },
+			Now:              func() time.Time { return now },
+		},
+		now,
+	)
+	if assessment.Binding.Goal.StateKnown ||
+		assessment.Binding.Goal.Verified ||
+		assessment.Binding.Goal.ContentExact ||
+		assessment.Eligible {
+		t.Fatalf("content verification overrode status veto: %+v", assessment.Binding.Goal)
+	}
+}
+
 func TestVerifyGoalSupervisionPreparedGoalRejectsGoalOrGenerationDrift(t *testing.T) {
 	generation := strings.Repeat("a", 32)
 	launchAttempt := strings.Repeat("b", 32)
@@ -509,6 +605,16 @@ func TestGoalSupervisionLifecycleObservationFailsClosed(t *testing.T) {
 		"future": {
 			Source:    activity.SourceHeartbeat,
 			WrittenAt: now.Add(time.Nanosecond),
+		},
+		"missing phase": {
+			Source:    activity.SourceHeartbeat,
+			WrittenAt: now.Add(-time.Second),
+			Phase:     "  ",
+		},
+		"unrecognized phase": {
+			Source:    activity.SourceHeartbeat,
+			WrittenAt: now.Add(-time.Second),
+			Phase:     "testing",
 		},
 		"task store": {
 			Source:    activity.SourceTaskStore,
@@ -572,6 +678,41 @@ func TestGoalSupervisionFingerprintIgnoresObservationTimeButBindsAttempt(t *test
 	changed := assessGoalSupervision(secondInput)
 	if first.Fingerprint == changed.Fingerprint {
 		t.Fatalf("attempt change did not change fingerprint %q", first.Fingerprint)
+	}
+}
+
+func TestGoalSupervisionPauseGenerationIgnoresUnrelatedLaunchRecordDrift(t *testing.T) {
+	binding := eligibleGoalSupervisionInput().Binding
+	first := goalSupervisionPauseGeneration(binding)
+
+	unrelatedDrift := binding
+	unrelatedDrift.LaunchRecordDigest = "different-launch-record-digest"
+	unrelatedDrift.LaunchRecordModTime++
+	if got := goalSupervisionPauseGeneration(unrelatedDrift); got != first {
+		t.Fatalf("unrelated launch-record drift rotated pause generation: %q != %q", got, first)
+	}
+
+	for name, mutate := range map[string]func(*GoalSupervisionBinding){
+		"launch id": func(b *GoalSupervisionBinding) {
+			b.LaunchID = "different-launch"
+		},
+		"binding digest": func(b *GoalSupervisionBinding) {
+			b.Goal.BindingDigest = "different-binding"
+		},
+		"attempt id": func(b *GoalSupervisionBinding) {
+			b.Goal.AttemptID = "different-attempt"
+		},
+		"mode": func(b *GoalSupervisionBinding) {
+			b.Goal.Mode = "different-mode"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := binding
+			mutate(&changed)
+			if got := goalSupervisionPauseGeneration(changed); got == first {
+				t.Fatalf("%s did not rotate pause generation %q", name, got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/operator.go
+++ b/internal/cli/operator.go
@@ -74,6 +74,7 @@ type operatorStatusEnvelopeData struct {
 	Message          string                       `json:"message,omitempty"`
 	Notifications    *operatorNotificationSummary `json:"notifications,omitempty"`
 	operatorCursor   string
+	sourceWarnings   []state.Warning
 }
 type operatorNotificationSummary struct {
 	Selected   int `json:"selected"`
@@ -1363,6 +1364,7 @@ func buildOperatorStatusData(o operatorExecution) (operatorStatusEnvelopeData, e
 	if sessionOK {
 		backlog = operatorUnreadBacklogWithProjected(session.Coordination.Threads, operator.Handle, items)
 		directivesUnacked = operatorDirectivesUnacked(session.Coordination.Threads, operator.Handle, teamLeadHandle(t))
+		data.sourceWarnings = append([]state.Warning(nil), session.Coordination.Warnings...)
 	}
 	if originalSessionOK {
 		operatorCursor = operatorInboxHighWater(originalSession.Coordination.Threads, operator.Handle)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -108,6 +108,7 @@ type statusEnvelopeData struct {
 	Lead                string                      `json:"lead,omitempty"`
 	LeadHandle          string                      `json:"lead_handle,omitempty"`
 	GoalBinding         goalBindingData             `json:"goal_binding"`
+	GoalSupervision     GoalSupervisionAssessment   `json:"goal_supervision"`
 	Autonomous          team.AutonomousStatus       `json:"autonomous"`
 	Execution           executionModeData           `json:"execution"`
 	Versions            versionAlignmentData        `json:"versions"`
@@ -405,6 +406,10 @@ func executeStatus(s statusExecution) error {
 		binding := goalBindingForStatus(ns, ctx, rows)
 		operatorView := statusOperatorForTeam(t, ns)
 		applyGoalBindingOpenBlockers(&operatorView, binding)
+		gateObservation := inspectGoalSupervisionGates(t, s.Profile, workstream, firstStatusRoot(rows), s.Probe, now)
+		if gateObservation.Evidence.Known && operatorView.Poll != nil {
+			operatorView.Poll.OpenGates = gateObservation.Evidence.Open
+		}
 		topology := statusTopologyForRows(rows, ctx.Orchestrated)
 		externalEvidence := statusExternalEvidence(t, s.Profile, workstream, rows, now)
 		version := strings.TrimSpace(s.RuntimeVersion)
@@ -421,6 +426,10 @@ func executeStatus(s statusExecution) error {
 		execution.InvariantOK = len(invariantErrors) == 0
 		execution.InvariantErrors = invariantErrors
 		applyLeadExecutionContract(&execution, t.LeadExecution)
+		goalSupervision := buildGoalSupervisionAssessment(
+			t, s.Profile, workstream, ns, rows, gateObservation, invariantErrors,
+			conflict, s.Probe, now,
+		)
 		return writeJSONEnvelope(s.Out, "status", statusEnvelopeData{
 			TeamHome:            t.Project,
 			Workstream:          workstream,
@@ -435,6 +444,7 @@ func executeStatus(s statusExecution) error {
 			Lead:                ctx.Lead,
 			LeadHandle:          ctx.LeadHandle,
 			GoalBinding:         binding,
+			GoalSupervision:     goalSupervision,
 			Autonomous:          team.EffectiveAutonomousStatus(t),
 			Execution:           execution,
 			Versions:            buildVersionAlignment(versionSources),

--- a/internal/cli/status_board.go
+++ b/internal/cli/status_board.go
@@ -91,6 +91,7 @@ type sessionBoardRow struct {
 	Orchestrated        bool                        `json:"orchestrated,omitempty"`
 	Lead                string                      `json:"lead,omitempty"`
 	LeadHandle          string                      `json:"lead_handle,omitempty"`
+	GoalSupervision     *GoalSupervisionAssessment  `json:"goal_supervision,omitempty"`
 	Autonomous          team.AutonomousStatus       `json:"autonomous"`
 	Execution           *executionModeData          `json:"execution,omitempty"`
 	OperatorDelivery    *operatorDeliveryData       `json:"operator_delivery,omitempty"`
@@ -279,6 +280,17 @@ func enrichBoardRow(profiles []boardProfile, sess state.Session, probe duplicate
 	binding := goalBindingForStatus(ns, ctx, statusRows)
 	topology := statusTopologyForRows(statusRows, ctx.Orchestrated)
 	invariantErrors := annotateVisibilityInvariants(statusRows, ctx)
+	conflict := namespaceConflictForProfileSession(t.Project, profile, sess.Name)
+	observedAt := time.Now().UTC()
+	if probe.Now != nil {
+		observedAt = probe.Now().UTC()
+	}
+	gateObservation := inspectGoalSupervisionGates(t, profile, sess.Name, sess.Root, probe, observedAt)
+	goalSupervision := buildGoalSupervisionAssessment(
+		t, profile, sess.Name, ns, statusRows, gateObservation, invariantErrors,
+		conflict, probe, observedAt,
+	)
+	row.GoalSupervision = &goalSupervision
 	row.Profile = ctx.Profile
 	row.Namespace = ns
 	row.Actions = ctx.Actions

--- a/internal/team/clone.go
+++ b/internal/team/clone.go
@@ -19,7 +19,9 @@ import (
 // A cloned profile starts with no self-operator policy: SelfOperatorPolicy is
 // keyed by exact session name, so a policy scoped to source's session would
 // never match the new one; callers configure it explicitly for the new
-// session via `team operator set` if needed.
+// session via `team operator set` if needed. GoalSupervisionPolicy also resets:
+// safe-auto is per profile/run and must never carry into a new session without
+// an explicit operator choice.
 func CloneRosterForSession(source Team, newSession string) (Team, error) {
 	if err := ValidateSessionName(newSession); err != nil {
 		return Team{}, fmt.Errorf("invalid session for cloned roster: %w", err)
@@ -42,5 +44,6 @@ func CloneRosterForSession(source Team, newSession string) (Team, error) {
 	if clone.Operator != nil {
 		clone.Operator.SelfOperator = nil
 	}
+	clone.GoalSupervision = nil
 	return clone, nil
 }

--- a/internal/team/goal_supervision_test.go
+++ b/internal/team/goal_supervision_test.go
@@ -1,0 +1,81 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEffectiveGoalSupervisionPolicyDefaultsToManual(t *testing.T) {
+	got := EffectiveGoalSupervisionPolicy(Team{})
+	if got.Mode != GoalSupervisionManual || got.Revision != 1 || got.Source != "compatibility-default" {
+		t.Fatalf("default policy = %+v, want compatibility manual revision 1", got)
+	}
+
+	got = EffectiveGoalSupervisionPolicy(Team{
+		GoalSupervision: &GoalSupervisionPolicy{Mode: GoalSupervisionSafeAuto, Revision: 7},
+	})
+	if got.Mode != GoalSupervisionSafeAuto || got.Revision != 7 || got.Source != "profile" {
+		t.Fatalf("explicit policy = %+v, want profile safe-auto revision 7", got)
+	}
+
+	got = EffectiveGoalSupervisionPolicy(Team{GoalSupervision: &GoalSupervisionPolicy{}})
+	if got.Mode != GoalSupervisionManual || got.Revision != 1 || got.Source != "profile" {
+		t.Fatalf("empty explicit policy = %+v, want profile manual revision 1", got)
+	}
+}
+
+func TestValidateGoalSupervisionPolicyModes(t *testing.T) {
+	for _, mode := range []string{"", GoalSupervisionManual, GoalSupervisionNotifyOnly, GoalSupervisionSafeAuto} {
+		if err := validateGoalSupervisionPolicy(&GoalSupervisionPolicy{Mode: mode}); err != nil {
+			t.Fatalf("mode %q: %v", mode, err)
+		}
+	}
+	if err := validateGoalSupervisionPolicy(&GoalSupervisionPolicy{Mode: "always"}); err == nil ||
+		!strings.Contains(err.Error(), "invalid mode") {
+		t.Fatalf("invalid mode error = %v, want invalid mode", err)
+	}
+	if err := validateGoalSupervisionPolicy(&GoalSupervisionPolicy{Mode: GoalSupervisionManual, Revision: -1}); err == nil ||
+		!strings.Contains(err.Error(), "cannot be negative") {
+		t.Fatalf("negative revision error = %v, want cannot be negative", err)
+	}
+}
+
+func TestCloneRosterForSessionDropsGoalSupervisionPolicy(t *testing.T) {
+	source := Team{
+		GoalSupervision: &GoalSupervisionPolicy{Mode: GoalSupervisionSafeAuto, Revision: 3},
+		Members:         []Member{{Role: "cto", Binary: "codex", Session: "old"}},
+	}
+	clone, err := CloneRosterForSession(source, "new")
+	if err != nil {
+		t.Fatalf("CloneRosterForSession: %v", err)
+	}
+	if clone.GoalSupervision != nil {
+		t.Fatalf("clone goal supervision = %+v, want nil fail-safe reset", clone.GoalSupervision)
+	}
+	if source.GoalSupervision == nil || source.GoalSupervision.Mode != GoalSupervisionSafeAuto {
+		t.Fatalf("clone mutated source policy: %+v", source.GoalSupervision)
+	}
+}
+
+func TestGoalSupervisionPolicyWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := Team{
+		GoalSupervision: &GoalSupervisionPolicy{Mode: GoalSupervisionNotifyOnly, Revision: 4},
+		Members: []Member{{
+			Role: "cto", Binary: "codex", Handle: "cto", Session: "release",
+			ActorMode: ActorModeReview,
+		}},
+	}
+	if err := WriteProfile(dir, "supervised", in); err != nil {
+		t.Fatalf("WriteProfile: %v", err)
+	}
+	got, err := ReadProfile(dir, "supervised")
+	if err != nil {
+		t.Fatalf("ReadProfile: %v", err)
+	}
+	if got.GoalSupervision == nil ||
+		got.GoalSupervision.Mode != GoalSupervisionNotifyOnly ||
+		got.GoalSupervision.Revision != 4 {
+		t.Fatalf("round-trip policy = %+v, want notify-only revision 4", got.GoalSupervision)
+	}
+}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -458,6 +458,9 @@ const (
 	IndependentReviewRequired           = "required"
 	IndependentReviewWaived             = "waived"
 	IndependentReviewComplete           = "complete"
+	GoalSupervisionManual               = "manual"
+	GoalSupervisionNotifyOnly           = "notify-only"
+	GoalSupervisionSafeAuto             = "safe-auto"
 )
 
 type AutonomousPolicy struct {
@@ -491,6 +494,39 @@ type AutonomousStatus struct {
 	BudgetTurns      int               `json:"budget_turns,omitempty"`
 	BudgetTurnsLeft  int               `json:"budget_turns_left,omitempty"`
 	OperatorRequired []string          `json:"operator_required,omitempty"`
+}
+
+// GoalSupervisionPolicy controls native /goal pause supervision for one team
+// profile. A missing policy is deliberately equivalent to manual revision 1:
+// existing profiles never gain automatic pane input after an upgrade.
+type GoalSupervisionPolicy struct {
+	Mode     string `json:"mode"`
+	Revision int    `json:"revision,omitempty"`
+}
+
+type GoalSupervisionPolicyStatus struct {
+	Mode     string `json:"mode"`
+	Revision int    `json:"revision"`
+	Source   string `json:"source"`
+}
+
+func EffectiveGoalSupervisionPolicy(t Team) GoalSupervisionPolicyStatus {
+	if t.GoalSupervision == nil {
+		return GoalSupervisionPolicyStatus{
+			Mode: GoalSupervisionManual, Revision: 1, Source: "compatibility-default",
+		}
+	}
+	mode := strings.TrimSpace(t.GoalSupervision.Mode)
+	if mode == "" {
+		mode = GoalSupervisionManual
+	}
+	revision := t.GoalSupervision.Revision
+	if revision == 0 {
+		revision = 1
+	}
+	return GoalSupervisionPolicyStatus{
+		Mode: mode, Revision: revision, Source: "profile",
+	}
 }
 
 // LeadExecution records the lead's declared delegation and review posture for
@@ -577,6 +613,10 @@ type Team struct {
 	Lead         string            `json:"lead,omitempty"`
 	Composition  string            `json:"composition,omitempty"`
 	Autonomous   *AutonomousPolicy `json:"autonomous,omitempty"`
+	// GoalSupervision is the read-only/native-goal supervision policy for this
+	// profile. Missing means manual; safe-auto is inert until the claim/delivery
+	// layer consumes a fully eligible assessment.
+	GoalSupervision *GoalSupervisionPolicy `json:"goal_supervision,omitempty"`
 	// ExecutionMode records the operator-visible ownership contract for this
 	// profile. Empty means callers apply the compatibility default.
 	ExecutionMode     string `json:"execution_mode,omitempty"`
@@ -1063,6 +1103,9 @@ func Validate(t Team) error {
 	if err := validateLeadExecution(t.LeadExecution); err != nil {
 		return err
 	}
+	if err := validateGoalSupervisionPolicy(t.GoalSupervision); err != nil {
+		return err
+	}
 	operatorHandle := ""
 	if err := validateOperatorNotifications(t.Operator); err != nil {
 		return err
@@ -1145,6 +1188,22 @@ func Validate(t Team) error {
 	}
 	if err := validateSelfOperator(t); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateGoalSupervisionPolicy(policy *GoalSupervisionPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	switch strings.TrimSpace(policy.Mode) {
+	case "", GoalSupervisionManual, GoalSupervisionNotifyOnly, GoalSupervisionSafeAuto:
+	default:
+		return fmt.Errorf("goal_supervision.mode: invalid mode %q: use %s, %s, or %s",
+			policy.Mode, GoalSupervisionManual, GoalSupervisionNotifyOnly, GoalSupervisionSafeAuto)
+	}
+	if policy.Revision < 0 {
+		return fmt.Errorf("goal_supervision.revision: cannot be negative")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

This adds a read-only, fail-closed `GoalSupervisionAssessment` and projects the same authoritative result through status, the status board, and doctor. It binds the assessment to the exact namespace, lead identity, launch generation, prepared-run goal, native blocked attempt, full runtime and pane identity, lifecycle, blocker, operator gates, local input, invariants, claim state, and retry budget.

Inspect and notify remain read-only. Restore is exposed only for an exact managed lead-down scope and still requires confirmation. Native goal resume remains unavailable and explicitly reserved for PR5.

## Round 4 safety vetoes and falsifiers

The round-3 review found the same failure pattern in strengthened checks: a stronger-looking check had replaced an earlier safety veto. Round 4 makes every strengthened check supplement its original veto.

1. **Status provenance AND content verification.** Exact command and content verification cannot restore a binding already rejected by runtime status. Falsifying input: a stale `managed_refused` row whose injected content verifier succeeds must still leave `StateKnown`, `Verified`, `ContentExact`, and `Eligible` false. Reverting the status veto makes `TestBuildGoalSupervisionAssessmentContentVerificationDoesNotOverrideStatusVeto` fail.
2. **Trusted lifecycle source AND recognized vocabulary.** A fresh heartbeat is not sufficient when its phase is blank or unknown. Falsifying inputs: blank and `testing` heartbeat phases must project as unknown and not fresh. Removing the recognized-phase filter makes `TestGoalSupervisionLifecycleObservationFailsClosed` fail.
3. **Recognized lifecycle AND exact resumable phase.** Resume eligibility is a whitelist: only fresh `goal_blocked` passes; `parked_waiting_amq`, `goal_terminal`, and every other phase fail. Falsifying input: a fresh trusted nonterminal `testing` phase injected directly at the assessment boundary must fail `resumable_lifecycle`; restoring the old blacklist admits it and makes `TestGoalSupervisionResumableLifecycleRequiresGoalBlockedPhase` fail.
4. **Managed ownership AND canonical tmux target.** Lead-down restore requires both `Pane.Managed` and a canonical target: `current-window`, `new-window`, or `new-session`. Falsifying inputs: managed=true with a noncanonical target, and managed=false with canonical `new-window`, must both keep `Restore.Available=false`. Deleting either conjunct makes `TestGoalSupervisionManagedTmuxTargetRequiresCanonicalManagedTarget` fail.

## Pause generation contract

`PauseGeneration` is the stable hash of the assessment-captured `LaunchID + Goal.BindingDigest + Goal.AttemptID + Goal.Mode`. It deliberately ignores unrelated launch-record digest and modtime drift. Changing any one of the four identity fields rotates the generation; changing unrelated launch-record metadata does not. `TestGoalSupervisionPauseGenerationIgnoresUnrelatedLaunchRecordDrift` pins both directions.

This is the ruled identity boundary for PR5, where the durable claim key derives from `(NamespaceID, PauseGeneration, AttemptID)`. The executor must consume a final `Fresh && Eligible` assessment without re-deriving eligibility.

## Round 4.5 safety pins

The production fixes converged at `c1d4aa9`, but review showed two mutation-surviving test gaps. The test-only `e29ca53` pins both independently:

- canonical `new-window` plus `Pane.Managed=false` plus verified lead-down refuses restore;
- positive `goal_blocked`, documented parked and terminal negatives, and the mutation-distinguishing fresh `testing` negative pin the whitelist at the assessment boundary.

## Review trail

- **Round 3 — `ebc91c8`:** independent review requested changes for three safety findings: content verification overriding status, unrecognized lifecycle phases remaining trusted, and restore skipping managed-target vetoes.
- **Round 4 — `c1d4aa9`:** lead and independent reviewer converged that all production fixes and the ruled pause-generation contract were correct. Both reviewers identified the same missing `Managed=false` pin; the independent reviewer also identified the lifecycle-whitelist pin gap.
- **Round 4.5 — `e29ca53`:** test-only delta. Lead and independent reviewer re-pinned the exact SHA and both approved; both regressions were verified mutation-killing against production.

## Validation and test-slot disclosure

- Focused round-4.5 regressions: PASS.
- `go test ./internal/cli ./internal/team -count=1`: PASS at `e29ca53` with `internal/cli` 521.003s and `internal/team` 1.044s.
- Exact parent and test PIDs were absent after exit; executable-filter scan found no `cli.test` or `__rename-claude-session` survivor.
- `git diff --check`: PASS; worktree clean.

For round 4, two affected-package runs were explicitly discarded after undeclared concurrent compilers were attributed, first to a peer window and then to a convergence reviewer. Neither observation was used as evidence. After actor-level quiescence, the third serial run was clean and attributable: `go test ./internal/cli ./internal/team -count=1` PASS with `internal/cli` 366.490s and `internal/team` 0.569s, followed by exact-process cleanup verification. The round-4.5 affected-package run above was likewise clean and attributable.
