### PR TITLE
Claim-once recovery transitions: one constructor, one CAS layer (#498)

### DIFF
--- a/internal/cli/codex_convergence_fix_pins_test.go
+++ b/internal/cli/codex_convergence_fix_pins_test.go
@@ -1,0 +1,713 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+)
+
+// PINS FOR THE CODEX CONVERGENCE FIXES 2, 3, 4 and 5.
+//
+// Each row exists because a REAL defect passed the previous suite. Where the old code was structurally
+// unable to fail a check, that is stated at the row, so a reader can see which assertion is load-bearing
+// rather than inferring it from the name.
+
+// ============================================================================================
+// FINDING 4: the durable contract accepted a NewAttemptID its own delivery reader rejects.
+// ============================================================================================
+
+// validRedeliverBaseForAttempt returns the redeliver base the constructor accepts, with NewAttemptID as the
+// ONE varied field.
+//
+// Copied in shape from recovery_transition_roundtrip_test.go's base rather than trimmed down: a minimal
+// record would refuse on some OTHER missing field and the row would pass without ever reaching the attempt-id
+// check, which is the void-proof failure this whole milestone keeps catching.
+func validRedeliverBaseForAttempt(project, profile, session, newAttemptID string) resumeGoalTransitionRecord {
+	const goalText = "ship it"
+	return resumeGoalTransitionRecord{
+		SchemaVersion:         resumeGoalTransitionSchemaVersion,
+		Project:               project,
+		Profile:               profile,
+		Session:               session,
+		Role:                  "cto",
+		Handle:                "cto",
+		MemberSession:         session,
+		MemberCWD:             project,
+		MemberBinary:          "codex",
+		GoalDigest:            digestBytes([]byte(goalText)),
+		OriginalAttemptID:     "attempt-abc",
+		OriginalBindingDigest: "digest-def",
+		OriginalAttemptDigest: "attempt-digest",
+		OriginalClaimDigest:   "claim-digest",
+		NewAttemptID:          newAttemptID,
+		LaunchID:              "launch-1",
+		LaunchStartedAt:       time.Now().UTC(),
+		TeamRecordDigest:      "team-digest",
+		TeamRecordModTime:     1,
+		LaunchRecordDigest:    "launch-digest",
+		LaunchRecordModTime:   1,
+		CreatedAt:             time.Now().UTC(),
+	}
+}
+
+// TestContractRefusesANewAttemptIDItsDeliveryReaderRejects is the writer/reader agreement pin.
+//
+// WHAT PASSED BEFORE: "../new" is nonblank, and for redeliver it also differs from the original attempt, so
+// every writer-side check accepted it and the record PUBLISHED -- while resume_goal.go:1176 refuses it via
+// goalAttemptPath at delivery. The result was durable evidence nothing could consume: the claim blocks at the
+// claim-once gate forever, and no code path deletes reservations.
+//
+// BOTH KINDS, because the finding was reported against redeliver only and native shared the hole through a
+// different derivation: native hashes NewAttemptID into its claim key, and a hash accepts any string.
+func TestContractRefusesANewAttemptIDItsDeliveryReaderRejects(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+
+	// Every value here is one the READER refuses. The loop below proves that claim rather than assuming it,
+	// so this table cannot drift away from goalAttemptPath's actual rule.
+	for _, unsafe := range []string{"../new", "sub/dir", "..", ".", `back\slash`} {
+		t.Run("refuses "+unsafe, func(t *testing.T) {
+			project := t.TempDir()
+
+			// THE READER'S VERDICT FIRST. If goalAttemptPath ever started accepting one of these, the row below
+			// would be testing a stricter writer than reader -- the opposite defect, and equally worth failing.
+			if _, err := goalAttemptPath(project, profile, session, unsafe); err == nil {
+				t.Fatalf("fixture is void: the delivery reader ACCEPTS %q, so the writer refusing it would be a "+
+					"writer/reader disagreement in the other direction", unsafe)
+			}
+
+			t.Run("native", func(t *testing.T) {
+				in := completeNativeTransitionInput(project, profile, session, unsafe)
+				if _, _, err := newRecoveryTransitionRecord(in); err == nil {
+					t.Fatalf("the constructor PUBLISHED a native claim whose attempt id %q the delivery path "+
+						"refuses. That record is durable evidence nothing can consume: the pause blocks at the "+
+						"claim-once gate permanently and nothing deletes reservations.", unsafe)
+				} else if !strings.Contains(err.Error(), "delivery reader accepts") {
+					t.Errorf("refusal must name the writer/reader disagreement, got: %v", err)
+				}
+			})
+
+			t.Run("redeliver", func(t *testing.T) {
+				_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+					Base:          validRedeliverBaseForAttempt(project, profile, session, unsafe),
+					Kind:          recoveryTransitionKindRedeliver,
+					AttemptID:     "attempt-abc",
+					BindingDigest: "digest-def",
+				})
+				if err == nil {
+					t.Fatalf("the constructor PUBLISHED a redeliver record whose new attempt id %q the delivery "+
+						"path refuses at resume_goal.go:1176", unsafe)
+				}
+				if !strings.Contains(err.Error(), "delivery reader accepts") {
+					t.Errorf("refusal must name the writer/reader disagreement, got: %v", err)
+				}
+			})
+		})
+	}
+}
+
+// ANTI-VACUITY FOR THE ROW ABOVE: the same fixtures with a READER-ACCEPTED attempt id must still be accepted.
+//
+// Without this, a contract that refused every attempt id would satisfy the refusal rows completely, and the
+// fix would read as correct while making all recovery impossible.
+func TestContractStillAcceptsAReaderValidNewAttemptID(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const safe = "attempt-xyz"
+	project := t.TempDir()
+
+	if _, err := goalAttemptPath(project, profile, session, safe); err != nil {
+		t.Fatalf("fixture is void: the reader refuses %q, so acceptance below would prove nothing: %v", safe, err)
+	}
+	if _, _, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, safe)); err != nil {
+		t.Errorf("native claim with a valid attempt id was refused: %v", err)
+	}
+	if _, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:          validRedeliverBaseForAttempt(project, profile, session, safe),
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-abc",
+		BindingDigest: "digest-def",
+	}); err != nil {
+		t.Errorf("redeliver record with a valid new attempt id was refused: %v", err)
+	}
+}
+
+// ============================================================================================
+// FINDING 2: the migration guard ignored native CONSUMED companions.
+// ============================================================================================
+
+// TestPlannerBlocksMigrationWhenTheSourceHoldsAnOrphanConsumedNativeCompanion is the WIRING row for finding 2.
+//
+// WHY THROUGH THE PLANNER: a helper-direct row would stay green if the production call site were deleted, and
+// that exact gap is why M-M1 exists. The through-the-caller rule applies per guard, and this is a new guard.
+//
+// THE OLD CODE COULD NOT FAIL THIS. recognizeRecoveryTransitionName classifies ".consumed.json" as
+// NotATransition, so the guard's single-step recognition ignored the file entirely, the adapter copied it
+// content-unchanged with its basename preserved, and in the destination the OLD claim key no longer matches
+// the NEW namespace -- so neither the consumed-state blocker nor the orphan-companion blocker can fire. Prior
+// consumption becomes invisible to claim-once, and invisible prior delivery is a SECOND delivery.
+//
+// ORPHAN (no reservation beside it) is the shape that reaches the gap: a present native reservation blocks on
+// its own. It is reachable in practice -- the guard's own remediation text used to tell operators to "resolve"
+// the claim, and deleting the reservation is how an operator does that.
+func TestPlannerBlocksMigrationWhenTheSourceHoldsAnOrphanConsumedNativeCompanion(t *testing.T) {
+	fx := newNamespaceMigrationFixture(t)
+
+	goalDir := goalAttemptDir(fx.project, fx.source.Profile, fx.source.Session)
+	if err := os.MkdirAll(goalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The reservation path comes from the REAL constructor, so the companion is named exactly as production
+	// would name it -- then the reservation itself is deliberately NOT written.
+	_, claimPath, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(fx.project, fx.source.Profile, fx.source.Session, "attempt-abc"))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+	companionPath := resumeGoalTransitionConsumedPath(claimPath)
+	if err := os.WriteFile(companionPath, []byte(`{"transition_id":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// ANTI-VACUITY 1: the reservation must be ABSENT, or this row would be blocked by the pre-existing
+	// reservation blocker and would prove nothing about companions.
+	if _, statErr := os.Stat(claimPath); statErr == nil {
+		t.Fatalf("fixture is void: the reservation %q exists, so the existing blocker would fire instead", claimPath)
+	}
+	// ANTI-VACUITY 2: the single-step recognition the guard used to rely on must classify this companion as
+	// NotATransition. That is the precise reason the old guard ignored it, and asserting it here is what makes
+	// this row a regression pin rather than a restatement.
+	if _, recognition := recognizeRecoveryTransitionName(filepath.Base(companionPath)); recognition != recoveryNameNotATransition {
+		t.Fatalf("fixture is void: %q is no longer classified NotATransition by the name parser, so it does not "+
+			"exercise the two-step recognition this fix added", filepath.Base(companionPath))
+	}
+	// ANTI-VACUITY 3: the companion must land in the directory the planner inspects.
+	if filepath.Dir(companionPath) != goalDir {
+		t.Fatalf("fixture is void: the companion landed at %q but the planner inspects %q", companionPath, goalDir)
+	}
+
+	plan, err := planNamespaceMigration(namespaceMigrationPlannerOptions{
+		ProjectDir: fx.project, Source: fx.source, Target: fx.target,
+		DryRun: true, Now: time.Now().UTC(), Probe: livenessProbe(nil, nil, time.Now()),
+	})
+	if err != nil {
+		t.Fatalf("planning must succeed and REPORT a blocker rather than erroring: %v", err)
+	}
+
+	joined := strings.Join(plan.Blockers, "\n")
+	if !strings.Contains(joined, "cannot be migrated safely") {
+		t.Fatalf("the PLAN did not block a namespace holding an orphan CONSUMED native companion.\n"+
+			"The adapter copies it unchanged with its basename, carrying the old namespace-derived claim key "+
+			"into the new namespace, where nothing matches it -- so the prior consumption disappears from the "+
+			"claim-once decision and a second delivery is permitted.\nblockers:\n%s", joined)
+	}
+	if !strings.Contains(joined, "COMPANION") {
+		t.Errorf("the blocker must say it is companion evidence, so an operator knows a reservation is NOT "+
+			"what they are looking for; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, filepath.Base(companionPath)) {
+		t.Errorf("the blocker must NAME the offending companion; got:\n%s", joined)
+	}
+}
+
+// A transition-LIKE companion that cannot be classified must block too: unknown is not absent applies to
+// companion names for the same reason it applies to reservations.
+func TestMigrationRefusesAMalformedTransitionLikeCompanion(t *testing.T) {
+	dir := t.TempDir()
+	companion := filepath.Join(dir, currentRecoveryTransitionPrefix+"not-a-valid-body.consumed.json")
+	if err := os.WriteFile(companion, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The fixture must actually reach the malformed branch THROUGH the companion step: base+".json" is what
+	// the guard now recognises, so that is what this assertion checks.
+	base, ok := companionReservationBase(filepath.Base(companion))
+	if !ok {
+		t.Fatalf("fixture is void: %q is not recognised as a companion", filepath.Base(companion))
+	}
+	if _, recognition := recognizeRecoveryTransitionName(base + ".json"); recognition != recoveryNameMalformed {
+		t.Fatalf("fixture is void: companion base %q does not classify as Malformed", base)
+	}
+
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+	if len(blockers) == 0 {
+		t.Fatal("an unclassifiable transition-like COMPANION raised no blocker. It might be consumption " +
+			"evidence for a native claim, and migrating it corrupts exactly the record we failed to read.")
+	}
+	joined := strings.Join(blockers, "\n")
+	if !strings.Contains(joined, "unknown is not absent") {
+		t.Errorf("blocker must give the unknown-is-not-absent reason, got: %s", joined)
+	}
+	if !strings.Contains(joined, "COMPANION") {
+		t.Errorf("blocker must identify it as a companion, got: %s", joined)
+	}
+}
+
+// THE NON-OVERBLOCKING HALF, and it is not optional: a LEGACY companion must NOT block.
+//
+// Legacy identities are not namespace-derived, so the adapter's rewrite is safe for them. A guard that
+// blocked these would make every namespace that has ever run a redelivery unmigratable -- strictly worse than
+// the corruption the guard was added to prevent, and the failure mode a refusal-only test cannot see.
+func TestMigrationAllowsALegacyConsumedCompanion(t *testing.T) {
+	dir := t.TempDir()
+	legacyBase := legacyRecoveryTransitionPrefix + strings.Repeat("c", 64)
+	companion := filepath.Join(dir, legacyBase+".consumed.json")
+	if err := os.WriteFile(companion, []byte(`{"transition_id":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Anti-vacuity: prove the guard's own two-step recognition sees this as a recognized LEGACY claim rather
+	// than ignoring the name outright, or the pass below would prove nothing about legacy tolerance.
+	base, ok := companionReservationBase(filepath.Base(companion))
+	if !ok {
+		t.Fatalf("fixture is void: %q is not recognised as a companion", filepath.Base(companion))
+	}
+	parsed, recognition := recognizeRecoveryTransitionName(base + ".json")
+	if recognition != recoveryNameRecognized || !parsed.Legacy {
+		t.Fatalf("fixture is void: companion base %q is not a recognized LEGACY claim (recognition=%v legacy=%t)",
+			base, recognition, parsed.Legacy)
+	}
+
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+	if len(blockers) != 0 {
+		t.Fatalf("a LEGACY consumed companion was BLOCKED: %s\nLegacy identities are not namespace-keyed, so "+
+			"the adapter rewrite is safe for them; blocking here is an outage for every namespace that ever "+
+			"ran a redelivery.", strings.Join(blockers, "\n"))
+	}
+}
+
+// The remediation text must never tell an operator to delete a reservation, because doing so MANUFACTURES the
+// orphan-companion state this guard exists to catch. My original wording said "Resolve or consume the claim",
+// and "resolve" is what an operator reads as "delete the file".
+func TestTheNativeClaimBlockerNeverAdvisesDeletingAReservation(t *testing.T) {
+	dir := t.TempDir()
+	project := t.TempDir()
+	_, claimPath, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, "squad", "v2-25-0", "attempt-abc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.Base(claimPath)), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+	if len(blockers) == 0 {
+		t.Fatal("fixture is void: no blocker was raised, so there is no remediation text to check")
+	}
+	joined := strings.Join(blockers, "\n")
+	if !strings.Contains(joined, "do NOT delete the reservation") {
+		t.Errorf("the blocker must warn against deleting the reservation; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "CONSUME the claim") {
+		t.Errorf("the blocker must name consuming as the remedy; got:\n%s", joined)
+	}
+}
+
+// ============================================================================================
+// FINDING 3: the gates did not run immediately before pane input.
+// FINDING 5: definite pre-input failures were reported as UNKNOWN.
+// ============================================================================================
+
+// TestDeliveryBoundaryRegatesAfterTheDirectiveAndImmediatelyBeforeInput is the ORDER pin, and the order is
+// the whole finding.
+//
+// Ratified text requires both: acceptance line 64 and line 352 say the gates run immediately before PANE
+// INPUT, and line 89 says the durable directive comes BEFORE input. The only sequence satisfying both is
+// directive -> gates -> input. The old code ran the gates before the closure and then published an `amq send`
+// subprocess plus a receipt persist -- unbounded duration -- with no re-check, so FreshUntil could pass, the
+// launch generation could change and the pane could go busy between the last check and the bytes.
+func TestDeliveryBoundaryRegatesAfterTheDirectiveAndImmediatelyBeforeInput(t *testing.T) {
+	assessment, _, payload, _, _ := u6DeliveringFixture(t)
+
+	var order []string
+	oldSend := sendPromptToPane
+	t.Cleanup(func() { sendPromptToPane = oldSend })
+	sendPromptToPane = func(string, string) error {
+		order = append(order, "input")
+		return nil
+	}
+
+	deliver := newSupervisionResumeDelivery(
+		func(GoalSupervisionAssessment, string, string) error {
+			order = append(order, "directive")
+			return nil
+		},
+		assessment, "supervisor-1",
+		func() *supervisionResumeRefusal {
+			order = append(order, "gate")
+			return nil
+		})
+
+	if err := deliver(payload); err != nil {
+		t.Fatalf("a delivery whose gate passes must succeed: %v", err)
+	}
+	want := "directive,gate,input"
+	if got := strings.Join(order, ","); got != want {
+		t.Fatalf("delivery order was %q, want %q.\nThe gate must sit AFTER the durable directive (U6 line 89) "+
+			"and IMMEDIATELY BEFORE pane input (U4.2 line 64, line 352). Any other order leaves an unbounded "+
+			"durable send between the last world-check and the bytes.", got, want)
+	}
+}
+
+// A gate refusal AFTER the directive types nothing, and says so definitively.
+func TestGateRefusalAfterTheDirectiveTypesNothingAndIsDefiniteNonDelivery(t *testing.T) {
+	assessment, _, payload, _, _ := u6DeliveringFixture(t)
+
+	directivePublished, sends := false, 0
+	oldSend := sendPromptToPane
+	t.Cleanup(func() { sendPromptToPane = oldSend })
+	sendPromptToPane = func(string, string) error { sends++; return nil }
+
+	refusal := &supervisionResumeRefusal{
+		Clause:   "the same launch generation ... remains current",
+		Detail:   "launch generation changed between the directive and pane input",
+		Recovery: "inspect the launch record",
+	}
+	deliver := newSupervisionResumeDelivery(
+		func(GoalSupervisionAssessment, string, string) error { directivePublished = true; return nil },
+		assessment, "supervisor-1",
+		func() *supervisionResumeRefusal { return refusal },
+	)
+
+	err := deliver(payload)
+	if err == nil {
+		t.Fatal("a post-directive gate refusal must return an error")
+	}
+	if sends != 0 {
+		t.Errorf("pane input happened %d time(s) after the gate refused; the refusal exists precisely to stop "+
+			"the bytes", sends)
+	}
+	if !directivePublished {
+		t.Error("fixture is void: the directive did not publish, so this row does not prove the gate runs AFTER it")
+	}
+	var definite *supervisionDefiniteNonDeliveryError
+	if !errors.As(err, &definite) {
+		t.Fatalf("a pre-input gate refusal must be typed as DEFINITE non-delivery, not left ambiguous: %v", err)
+	}
+	if definite.Refusal == nil || definite.Refusal.Clause != refusal.Clause {
+		t.Errorf("the gate's own verdict must travel with the error so the operator sees its clause and "+
+			"recovery rather than a paraphrase; got %+v", definite.Refusal)
+	}
+}
+
+// A MISSING GATE IS NOT A PASSING GATE. Without this, the whole re-check could be removed by dropping one
+// argument, and every test that supplies a gate would stay green while production validated nothing.
+func TestDeliveryBoundaryRefusesWhenNoGateIsSupplied(t *testing.T) {
+	assessment, _, payload, _, _ := u6DeliveringFixture(t)
+
+	directivePublished, sends := false, 0
+	oldSend := sendPromptToPane
+	t.Cleanup(func() { sendPromptToPane = oldSend })
+	sendPromptToPane = func(string, string) error { sends++; return nil }
+
+	deliver := newSupervisionResumeDelivery(
+		func(GoalSupervisionAssessment, string, string) error { directivePublished = true; return nil },
+		assessment, "supervisor-1", nil)
+
+	err := deliver(payload)
+	if err == nil {
+		t.Fatal("a nil delivery-time gate must REFUSE, never skip: a missing check that silently becomes a " +
+			"passing check is the authorization-seam defect")
+	}
+	if sends != 0 || directivePublished {
+		t.Errorf("nothing may happen without a gate (sends=%d directivePublished=%t): the wiring fault is "+
+			"detected before any durable or irreversible step", sends, directivePublished)
+	}
+	var definite *supervisionDefiniteNonDeliveryError
+	if !errors.As(err, &definite) {
+		t.Errorf("a wiring refusal is proven non-delivery and must be typed as such: %v", err)
+	}
+}
+
+// FINDING 5, PRODUCER AND CONSUMER IN ONE PRODUCTION-SHAPED ROW: a directive failure is PROVEN
+// non-delivery, so the BOUNDARY must emit the typed marker and the EXECUTOR must not report unknown.
+//
+// WHAT PASSED BEFORE: every error out of the boundary set DeliveryOutcomeUnknown, including this one -- while
+// the field's own documentation said it is set "ONLY on the pane-input error path". The operator was sent to
+// inspect a pane about a question with no ambiguity in it.
+//
+// THIS ROW WAS ITSELF DEFECTIVE ON FIRST WRITE, and dev-2's cross-gate caught it. It constructed
+// supervisionDefiniteNonDeliveryError directly inside a fake deliver callback, so it pinned only the
+// executor's branch: reverting the boundary's publisher-failure path to a plain fmt.Errorf would have left
+// this test GREEN. I tested the consumer and ASSERTED the producer -- the wiring-versus-guard defect I had
+// named twice today in other people's code, reproduced in my own falsifier for the finding about untested
+// distinctions. The deliver argument is now the REAL newSupervisionResumeDelivery, with a pass-through spy
+// that forwards the boundary's error verbatim so both halves can be asserted from one run.
+func TestDirectiveFailureIsReportedAsProvenNonDeliveryNotUnknown(t *testing.T) {
+	assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	// The pane-input seam must stay at ZERO: a failed directive means no bytes, and that is the property.
+	sends := 0
+	oldSend := sendPromptToPane
+	t.Cleanup(func() { sendPromptToPane = oldSend })
+	sendPromptToPane = func(string, string) error { sends++; return nil }
+
+	directiveFailure := errors.New("audit directive receipt did not persist")
+	gateRan := false
+	boundary := newSupervisionResumeDelivery(
+		func(GoalSupervisionAssessment, string, string) error { return directiveFailure },
+		assessment, "supervisor-1",
+		func() *supervisionResumeRefusal { gateRan = true; return nil },
+	)
+	var boundaryErr error
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(p string) error {
+			boundaryErr = boundary(p)
+			return boundaryErr
+		})
+
+	if err == nil {
+		t.Fatal("a failed directive must refuse the delivery")
+	}
+	// THE PRODUCER HALF. Without this, deleting the definite wrapper in the boundary's publisher-failure
+	// branch is invisible to the suite.
+	var producedDefinite *supervisionDefiniteNonDeliveryError
+	if !errors.As(boundaryErr, &producedDefinite) {
+		t.Fatalf("the BOUNDARY did not emit a typed definite-non-delivery error for a failed directive; it "+
+			"produced %#v. The executor's branch is then unreachable in production no matter how well it is "+
+			"tested.", boundaryErr)
+	}
+	if !errors.Is(boundaryErr, directiveFailure) {
+		t.Errorf("the publisher's own error must remain in the chain so an operator can see WHY the audit "+
+			"record failed; got: %v", boundaryErr)
+	}
+	if sends != 0 {
+		t.Errorf("pane input happened %d time(s) despite a failed audit directive; property (1) of the "+
+			"boundary is that a directive failure produces ZERO input", sends)
+	}
+	if gateRan {
+		t.Error("the delivery-time gate ran after the directive had already failed; the directive failure " +
+			"short-circuits before any further work")
+	}
+	if outcome.DeliveryOutcomeUnknown {
+		t.Error("DeliveryOutcomeUnknown=true for a failure that provably produced ZERO pane input.\n" +
+			"The directive is published BEFORE any input, so there are no bytes to be ambiguous about, and " +
+			"reporting ambiguity strands the pause in an operator decision that has no question in it.")
+	}
+	if outcome.Delivered || outcome.Consumed {
+		t.Errorf("nothing was delivered or consumed, got Delivered=%t Consumed=%t", outcome.Delivered, outcome.Consumed)
+	}
+	if !strings.Contains(err.Error(), "BEFORE any pane input") {
+		t.Errorf("the refusal must tell the operator no delivery occurred, got: %v", err)
+	}
+	// THE CLAIM IS NOT RELEASED. Proven non-delivery changes the REPORT only: a self-deleting claim would
+	// manufacture the orphan-companion state of finding 2, and nothing in this system deletes reservations.
+	if _, statErr := os.Stat(reservation); statErr != nil {
+		t.Errorf("the reservation must remain after a proven non-delivery: %v", statErr)
+	}
+}
+
+// The gate refusal reaches the operator with the gate's OWN clause plus the proven-no-input fact prepended.
+func TestPostDirectiveGateRefusalReportsBothTheProofAndTheGateClause(t *testing.T) {
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error {
+			return &supervisionDefiniteNonDeliveryError{
+				Detail: "the world changed between the audit directive and pane input, so nothing was typed",
+				Refusal: &supervisionResumeRefusal{
+					Clause:   "the same launch generation ... remains current",
+					Detail:   "launch generation changed between the directive and pane input",
+					Recovery: "inspect the launch record before any manual resume",
+				},
+			}
+		})
+
+	if err == nil {
+		t.Fatal("a post-directive gate refusal must refuse the delivery")
+	}
+	if outcome.DeliveryOutcomeUnknown {
+		t.Error("a gate refusal happens before any pane input, so it is not an unknown outcome")
+	}
+	if !strings.Contains(err.Error(), "NO PANE INPUT OCCURRED") {
+		t.Errorf("the operator must learn the proven fact first, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "launch generation changed") {
+		t.Errorf("the gate's own detail must survive, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "inspect the launch record") {
+		t.Errorf("the gate's own recovery must survive rather than being replaced by a paraphrase, got: %v", err)
+	}
+}
+
+// THE FIRST-EVER COVERAGE OF supervisionUnknownDeliveryError, through the REAL boundary.
+//
+// WHY THIS ROW HAD TO EXIST BEFORE THE BATCH COULD PASS: my adjudication of finding 5 said "a typed
+// distinction with zero readers and zero tests is a decorative field", and cto's ruling required the type's
+// first-ever tests as part of the fix. My initial batch shipped without them -- `rg
+// supervisionUnknownDeliveryError internal/cli/*_test.go` still returned nothing -- so the batch left intact
+// the precise defect it was adjudicating. dev-2's cross-gate caught that, and this row closes it.
+//
+// It drives the PRODUCER: a real newSupervisionResumeDelivery, a successful directive, a passing gate, and a
+// pane-input seam that returns tmuxpane's two genuinely ambiguous errors. Both must arrive as
+// supervisionUnknownDeliveryError with the original error still in the chain, and the executor must report
+// UNKNOWN rather than either success or definite failure -- treated as failure a retry could deliver twice,
+// treated as success a lost resume looks completed.
+func TestBothAmbiguousPaneInputResultsProduceTheTypedUnknownAndReportUnknown(t *testing.T) {
+	for _, row := range []struct {
+		name       string
+		fail       func(paneID string) error
+		wantDetail string
+	}{
+		{
+			name:       "queued input, arrival unconfirmed",
+			fail:       func(paneID string) error { return &tmuxpane.QueuedInputError{PaneID: paneID} },
+			wantDetail: "queued but arrival is unconfirmed",
+		},
+		{
+			// tmuxpane documents this one as EXPLICITLY ambiguous: the text was typed and the submit could not
+			// be confirmed, so the resume may well be running. I originally mapped it as an ordinary failure,
+			// which invites the retry that delivers twice.
+			name:       "typed input, submission unconfirmed",
+			fail:       func(paneID string) error { return &tmuxpane.SubmitUnconfirmedError{PaneID: paneID, Attempts: 3} },
+			wantDetail: "submission could not be confirmed",
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+			u6StubSeams(t,
+				func(GoalSupervisionAssessment, string, string) error { return nil },
+				func(GoalSupervisionAssessment) error { return nil },
+			)
+			loader := func(GoalSupervisionAssessment) (string, string, error) {
+				return payload, digestGoalSupervisionString(payload), nil
+			}
+
+			// The seam returns the ambiguous error for the pane the ASSESSMENT names, so the fixture cannot pass
+			// by reporting ambiguity about some other pane.
+			var raised error
+			sends := 0
+			oldSend := sendPromptToPane
+			t.Cleanup(func() { sendPromptToPane = oldSend })
+			sendPromptToPane = func(paneID string, _ string) error {
+				sends++
+				raised = row.fail(paneID)
+				return raised
+			}
+
+			directivePublished, gateRan := false, false
+			boundary := newSupervisionResumeDelivery(
+				func(GoalSupervisionAssessment, string, string) error { directivePublished = true; return nil },
+				assessment, "supervisor-1",
+				func() *supervisionResumeRefusal { gateRan = true; return nil },
+			)
+			var boundaryErr error
+			outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+				func() time.Time { return now }, loader,
+				passingGenerationReader(assessment), passingPaneReader(assessment),
+				readReservedRecoveryTransition,
+				func(p string) error {
+					boundaryErr = boundary(p)
+					return boundaryErr
+				})
+
+			if err == nil {
+				t.Fatal("an unconfirmed delivery must return an error; silence would let a caller treat an " +
+					"indeterminate pause as a completed one")
+			}
+			// FIXTURE INTEGRITY: the ambiguous error must have been reached through the real ordering, or this
+			// row proves nothing about the producer.
+			if !directivePublished || !gateRan || sends != 1 {
+				t.Fatalf("fixture is void: the ambiguous result must be reached AFTER a published directive and a "+
+					"passing gate, with exactly one input attempt (directive=%t gate=%t sends=%d)",
+					directivePublished, gateRan, sends)
+			}
+
+			// THE PRODUCER HALF -- the type's first coverage.
+			var unknown *supervisionUnknownDeliveryError
+			if !errors.As(boundaryErr, &unknown) {
+				t.Fatalf("the BOUNDARY did not map an ambiguous pane-input result to supervisionUnknownDeliveryError; "+
+					"it produced %#v. Collapsing ambiguity into failure invites a retry that delivers twice, and "+
+					"into success hides a lost resume.", boundaryErr)
+			}
+			if !strings.Contains(unknown.Detail, row.wantDetail) {
+				t.Errorf("the operator must be told WHICH ambiguity occurred; detail %q does not mention %q",
+					unknown.Detail, row.wantDetail)
+			}
+			if !errors.Is(boundaryErr, raised) {
+				t.Errorf("tmuxpane's own error must stay in the chain rather than being replaced by a summary; got: %v",
+					boundaryErr)
+			}
+
+			// THE CONSUMER HALF: unknown is neither delivered nor definite, and nothing is consumed.
+			if !outcome.DeliveryOutcomeUnknown {
+				t.Error("an ambiguous pane-input result was not reported as UNKNOWN. This is the one state that " +
+					"leaves a live reservation and an operator decision, and it must not be collapsed into a " +
+					"refusal or a delivery.")
+			}
+			if outcome.Delivered {
+				t.Error("Delivered=true for an UNCONFIRMED input; Delivered must mean KNOWN-successful")
+			}
+			if outcome.Consumed {
+				t.Error("Consumed=true after an unconfirmed delivery; the claim must stay reserved so claim-once " +
+					"refuses the next attempt rather than risking a second audited resume")
+			}
+			if _, statErr := os.Stat(reservation); statErr != nil {
+				t.Errorf("the reservation must survive an unknown outcome: %v", statErr)
+			}
+		})
+	}
+}
+
+// POLARITY PIN: an ordinary error from inside pane input STAYS unknown.
+//
+// This is the row that makes the fail-closed default real. Inverting the branch -- default definite, mark
+// unknown -- reads as equivalent code and is a fail-open at the one seam where being wrong costs a second
+// audited resume. TestUnknownPaneInputIsTerminalIndeterminateAndConsumesNothing covers the same polarity from
+// the outcome side; this row states it as the explicit default.
+func TestAnUntypedDeliveryErrorRemainsUnknownRatherThanDefinite(t *testing.T) {
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error { return errors.New("tmux refused the send for an unclassified reason") })
+
+	if err == nil {
+		t.Fatal("an unclassified delivery error must still refuse")
+	}
+	if !outcome.DeliveryOutcomeUnknown {
+		t.Error("an UNTYPED delivery error was downgraded to definite non-delivery.\nOnly the refusals that " +
+			"happen provably before sendPromptToPane may be definite; once control has entered pane input we " +
+			"cannot prove no bytes landed, and assuming so is the fail-open direction.")
+	}
+}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -261,6 +261,10 @@ var completionCommonFlags = []string{
 	"--approved",
 	"--artifact",
 	"--as",
+	// #498 U7: declared by the goal supervise-resume command (goal_supervise_resume.go). The coverage test
+	// walks every flag declaration in the package, so an unregistered flag is a real user-facing gap: an
+	// operator tab-completing the command is told the flag does not exist.
+	"--assessment-fingerprint",
 	"--at-risk-wait",
 	"--assign",
 	"--base",
@@ -457,6 +461,9 @@ var completionCommonFlags = []string{
 	"--staged-claim",
 	"--stale-after",
 	"--status",
+	// #498 U7: the supervisor identity flag on goal supervise-resume. Registered for the same reason as
+	// --assessment-fingerprint above.
+	"--supervisor",
 	"--stop",
 	"--stop-agents",
 	"--signing-key-file",

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/bootstrapack"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
-	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -667,43 +666,13 @@ func doctorCheckGoalSupervision(d doctorExecution, workstream string) doctorChec
 			Detail: "no resolved team workstream; goal supervision assessment is unavailable",
 		}
 	}
-	t, err := team.ReadProfile(d.ProjectDir, profile)
+	_, assessment, err := resolveGoalSupervisionAssessment(d.ProjectDir, profile, workstream, d.Probe)
 	if err != nil {
 		return doctorCheck{
 			Name: name, Kind: "goal_supervision", Status: doctorWarn,
 			Detail: "team config unreadable; assessment unavailable",
 		}
 	}
-	probe := d.Probe
-	if probe.PIDAlive == nil {
-		probe.PIDAlive = defaultDuplicateLaunchProbe.PIDAlive
-	}
-	if probe.ProcessMatch == nil {
-		probe.ProcessMatch = defaultDuplicateLaunchProbe.ProcessMatch
-	}
-	if probe.ProcessTTY == nil {
-		probe.ProcessTTY = defaultDuplicateLaunchProbe.ProcessTTY
-	}
-	if probe.ProcessStartTime == nil {
-		probe.ProcessStartTime = defaultDuplicateLaunchProbe.ProcessStartTime
-	}
-	if probe.Now == nil {
-		probe.Now = defaultDuplicateLaunchProbe.Now
-	}
-	rows := buildStatusRows(t, profile, workstream, probe)
-	ctx := newSessionStatusContext(t, profile, workstream, firstLiveTmuxSession(rows))
-	ns := squadnamespace.Resolve(t.Project, ctx.Profile, workstream)
-	invariantErrors := annotateVisibilityInvariants(rows, ctx)
-	conflict := namespaceConflictForProfileSession(t.Project, profile, workstream)
-	now := time.Now().UTC()
-	if probe.Now != nil {
-		now = probe.Now().UTC()
-	}
-	gateObservation := inspectGoalSupervisionGates(t, profile, workstream, firstStatusRoot(rows), probe, now)
-	assessment := buildGoalSupervisionAssessment(
-		t, profile, workstream, ns, rows, gateObservation, invariantErrors,
-		conflict, probe, now,
-	)
 	status := doctorOK
 	if assessment.AttentionRequired || !assessment.Source.Complete || !assessment.Invariants.OK {
 		status = doctorWarn

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -495,6 +495,8 @@ func runGoalWithVersion(args []string, version string) error {
 		return runGoalStart(args[1:])
 	case "apply":
 		return runGoalApply(args[1:])
+	case "supervise-resume":
+		return runGoalSuperviseResume(args[1:])
 	default:
 		return usageErrorf("unknown 'goal' subcommand %q. Run 'amq-squad goal --help' for available subcommands.", args[0])
 	}
@@ -1742,6 +1744,29 @@ func admitPreparedGoalClaim(opts *goalDeliveryOptions, contract goalDeliveryCont
 func validateTransitionGoalDeliveryBeforeSend(opts goalDeliveryOptions, reservation goalDeliveryReservation, prompt string, attemptID string) (memberRuntime, string, error) {
 	var runtime memberRuntime
 	var workstream string
+	// IDENTITY SYNC ENFORCED, not assumed (#498, cto 2026-07-28T09:42, handed off from dev-2's Unit B).
+	//
+	// This function takes the attempt to send BOTH ways: as the explicit attemptID parameter and inside
+	// opts.AttemptID. On every path today they are equal -- executeGoalDeliveryLocked sets
+	// opts.AttemptID = receipt.AttemptID, and the transition path reassigns BOTH from
+	// transition.NewAttemptID together -- and a package-wide search finds no other assignment to
+	// either. So this refusal is unreachable as the code stands.
+	//
+	// It exists because NOTHING ENFORCED that. A separate parameter exists precisely because
+	// divergence is expressible, and the consumed-recovery matching downstream derives delivery
+	// identity from opts.AttemptID: a future desync would silently match a consumed record for the
+	// WRONG attempt, which is a claim-once decision made against an identity nobody is delivering.
+	// Correct-today-for-a-reason-no-invariant-protects is the same shape as the cross-kind escape that
+	// keyed on fields its subjects never set, and it is cheaper to assert the invariant than to
+	// rediscover it.
+	//
+	// A WIRING FAULT, not a delivery failure. The operator can do nothing about it, so the message says
+	// so rather than suggesting a retry that would desync identically.
+	if strings.TrimSpace(opts.AttemptID) != strings.TrimSpace(attemptID) {
+		return runtime, workstream, fmt.Errorf(
+			"goal delivery refused (WIRING FAULT): delivery attempt identity is desynced -- opts.AttemptID %q does not equal the attempt being sent %q; the consumed-recovery mutex derives claim-once identity from the former, so proceeding would judge a different attempt than the one delivered",
+			opts.AttemptID, attemptID)
+	}
 	err := withCurrentGoalIdentityWriterLocks(opts, func(current memberRuntime, currentWorkstream string) error {
 		transition, err := validateResumeGoalTransitionForDelivery(opts, current)
 		if err != nil {

--- a/internal/cli/goal_delivery_identity_sync_test.go
+++ b/internal/cli/goal_delivery_identity_sync_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// #498: THE DELIVERY-IDENTITY SYNC GUARD.
+//
+// `validateTransitionGoalDeliveryBeforeSend` receives the attempt to send twice -- as the explicit
+// `attemptID` parameter and inside `opts.AttemptID` -- and the consumed-recovery mutex downstream
+// derives claim-once identity from the latter. They are equal on every path today, so the guard is
+// unreachable in production. It exists because nothing ENFORCED that equality, and a future desync
+// would silently make a claim-once decision about an attempt nobody is delivering.
+//
+// TESTING AN UNREACHABLE GUARD is exactly as valuable as testing a reachable one here, and for a
+// reason worth stating: the guard's whole purpose is to fire on a state that does not yet exist. If it
+// were only verified by production paths it would be verified by never running, and a guard that has
+// never fired even once is indistinguishable from a guard that cannot fire.
+//
+// The guard is testable with almost no fixture precisely BECAUSE it is placed first: it returns before
+// `withCurrentGoalIdentityWriterLocks`, so a desynced call never touches team state, locks, or the
+// filesystem. That is a property of the placement, not luck, and moving the guard below the locks
+// would break this test for reasons unrelated to the invariant -- which is the signal we would want.
+func TestDesyncedDeliveryAttemptIdentityIsRefusedAsAWiringFault(t *testing.T) {
+	opts := goalDeliveryOptions{
+		Project: t.TempDir(),
+		Profile: "squad",
+		Session: "v2-25-0",
+		Role:    "cto",
+		// The identity the consumed-recovery mutex would derive from.
+		AttemptID: "attempt-the-mutex-would-judge",
+	}
+
+	// The identity actually being sent. Different, which is the whole falsifying input.
+	_, _, err := validateTransitionGoalDeliveryBeforeSend(opts, goalDeliveryReservation{}, "prompt",
+		"attempt-actually-being-sent")
+
+	if err == nil {
+		t.Fatal("a desynced delivery identity must be REFUSED; proceeding would let the claim-once " +
+			"mutex judge one attempt while another is delivered")
+	}
+	if !strings.Contains(err.Error(), "WIRING FAULT") {
+		t.Errorf("refusal must be labelled a WIRING FAULT rather than a delivery failure, got: %v\n"+
+			"An operator can do nothing about a desync between two internal identities, so a message "+
+			"that reads like an operational failure invites a retry that would desync identically.", err)
+	}
+	// BOTH identities must appear, so a reader can see WHICH pair disagreed. A refusal that merely
+	// says "desynced" would send someone hunting through two call chains.
+	if !strings.Contains(err.Error(), "attempt-the-mutex-would-judge") ||
+		!strings.Contains(err.Error(), "attempt-actually-being-sent") {
+		t.Errorf("refusal must name both disagreeing identities, got: %v", err)
+	}
+}
+
+// THE ANTI-VACUITY CONTROL. Without it, the row above would pass even if the function refused
+// EVERYTHING -- including the synced case that production actually takes.
+//
+// This asserts only that the SYNCED call does not produce the wiring-fault refusal. It deliberately
+// does NOT assert success: with an empty project directory the call fails later for entirely unrelated
+// reasons (no team profile, no locks, a zero reservation), and demanding success would mean building a
+// full delivery fixture to prove a negative about one guard.
+func TestSyncedDeliveryAttemptIdentityDoesNotTripTheWiringGuard(t *testing.T) {
+	const attemptID = "attempt-abc"
+	opts := goalDeliveryOptions{
+		Project:   t.TempDir(),
+		Profile:   "squad",
+		Session:   "v2-25-0",
+		Role:      "cto",
+		AttemptID: attemptID,
+	}
+
+	_, _, err := validateTransitionGoalDeliveryBeforeSend(opts, goalDeliveryReservation{}, "prompt", attemptID)
+
+	// It will fail -- just not for THIS reason.
+	if err != nil && strings.Contains(err.Error(), "WIRING FAULT") {
+		t.Errorf("a SYNCED identity pair must not trip the wiring guard, got: %v.\nIf it does, the "+
+			"guard refuses the case production actually takes and the row above proves nothing.", err)
+	}
+}
+
+// WHITESPACE IS NOT A DESYNC. The guard compares trimmed values, because a stray space in one of two
+// internally-generated identifiers is not the class of divergence this exists to catch -- and refusing
+// it would turn a cosmetic difference into a blocked delivery.
+func TestWhitespaceDifferencesAreNotTreatedAsADesync(t *testing.T) {
+	opts := goalDeliveryOptions{
+		Project:   t.TempDir(),
+		Profile:   "squad",
+		Session:   "v2-25-0",
+		Role:      "cto",
+		AttemptID: "  attempt-abc  ",
+	}
+
+	_, _, err := validateTransitionGoalDeliveryBeforeSend(opts, goalDeliveryReservation{}, "prompt", "attempt-abc")
+
+	if err != nil && strings.Contains(err.Error(), "WIRING FAULT") {
+		t.Errorf("padding-only difference must not read as a desync, got: %v", err)
+	}
+}

--- a/internal/cli/goal_supervise_resume.go
+++ b/internal/cli/goal_supervise_resume.go
@@ -340,7 +340,22 @@ Exit codes:
 	// the executor as a function of the PAYLOAD ONLY. The executor therefore cannot influence which
 	// pane is written to or which directive is recorded -- only what bytes go out. Narrowing what a
 	// callee can vary is the same principle as the injected loader: capability is granted, not assumed.
-	deliver := newSupervisionResumeDelivery(supervisionProductionDirectivePublisher, assessment, supervisor)
+	//
+	// THE CLOCK AND THE TWO U5 READERS ARE CONSTRUCTED ONCE, HERE, AND SHARED (codex finding 3). The executor's
+	// pre-directive gate and the boundary's immediately-before-input re-check must consult the SAME clock and
+	// the SAME readers, or they are two deciders about one world and can disagree about whether delivery is
+	// safe. Building a second set inside the gate closure would have been the two-owners defect this milestone
+	// has spent the day closing, reintroduced by the fix for it.
+	clock := func() time.Time { return time.Now().UTC() }
+	readGeneration := newSupervisionGenerationReader()
+	readPane := newSupervisionPaneReader()
+	// The gate is CAPTURED by the boundary rather than passed to the returned closure, so the closure stays a
+	// function of the PAYLOAD ONLY: the executor supplies bytes and cannot choose whether the world is
+	// re-checked. Capability is granted, not assumed -- the same principle as the injected loader.
+	deliver := newSupervisionResumeDelivery(supervisionProductionDirectivePublisher, assessment, supervisor,
+		func() *supervisionResumeRefusal {
+			return evaluateSupervisionDeliveryTimeGates(assessment, clock, readGeneration, readPane)
+		})
 	// THE POLL'S OUTPUT DESTINATION DIFFERS BY MODE, and getting this wrong produced a real bug.
 	//
 	// I first pointed the poll at os.Stdout in BOTH modes. In --json that made executeStatus write a
@@ -363,11 +378,14 @@ Exit codes:
 	defer func() { pollSupervisionStatusOnce = previousPoll }()
 	pollSupervisionStatusOnce = newSupervisionStatusPoll(pollTarget, *jsonOut)
 	outcome, err := executeSupervisionResume(assessment, assessment.Actions.Resume, supervisor,
-		func() time.Time { return time.Now().UTC() }, loader,
+		clock, loader,
 		// U5's delivery-time readers, injected as PRODUCTION implementations. They are parameters
 		// rather than package globals precisely because they authorize an irreversible delivery: a
 		// mutable global that authorizes something can be nil'd into a silent pass.
-		newSupervisionGenerationReader(), newSupervisionPaneReader(),
+		//
+		// THE SAME VALUES the boundary's re-check captured above. Passing freshly constructed readers here
+		// would leave the two gates reading the world through different instances.
+		readGeneration, readPane,
 		readReservedRecoveryTransition,
 		deliver)
 	report.Outcome = &outcome

--- a/internal/cli/goal_supervise_resume.go
+++ b/internal/cli/goal_supervise_resume.go
@@ -1,0 +1,546 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// PR5 / #498 U1: the PRODUCTION CALLER.
+//
+// Round 1 shipped executeSupervisionResume as DEAD CODE -- grep across non-test files found only its
+// own definition, so #498's eligible live resume could not occur at all. This is the surface that
+// makes it reachable.
+//
+// WHY A NEW SURFACE RATHER THAN WIRING INTO AN EXISTING ONE: there was nothing to wire into. All
+// three production consumers of buildGoalSupervisionAssessment (status_board.go, status.go,
+// doctor.go) are READ-ONLY REPORTERS, and no sweep, autonomy loop, or operator loop exists anywhere
+// in internal/cli or internal/autonomy. Confirmed by grep before proposing, because "wire it into
+// the existing actor" was the obvious answer and it was not available.
+//
+// NO CONFIRMATION FLAG ON THE DELIVERING PATH (ruled). Policy.Mode == SafeAuto IS the operator's
+// consent, recorded once, deliberately. Re-asking per invocation converts automatic resume into
+// manual resume and defeats the point of #498. The accidental-invocation concern is answered by the
+// command's structure rather than by a prompt: a bare invocation is not a raw action, it is an entry
+// into the whole gate chain -- fresh, eligible, policy, action identity, claim-once, revalidation --
+// and under manual or notify-only policy its failure mode is a refusal, not a delivery.
+//
+// --dry-run is the inspection path an operator uses BEFORE enabling SafeAuto, and it must be truly
+// side-effect-free: no reservation, no bind, no consume, no directive publication, nothing written
+// to disk, no pane input. It reports the decision and the evidence only.
+
+// supervisorIdentityFlagHelp is stated once and used in both the flag help and the refusal, so the
+// requirement and its explanation cannot drift apart.
+const supervisorIdentityFlagHelp = "REQUIRED explicit supervisor identity recorded in the claim; never inferred from the lead"
+
+// resolveGoalSupervisionAssessment is the SINGLE assembly path for a supervision assessment.
+//
+// doctor.go had this sequence inline. Extracting it is not tidying: a second copy of "how an
+// assessment is built" is a second decider, and the whole failure class this milestone keeps hitting
+// is two places computing one thing and disagreeing. The probe defaulting in particular is easy to
+// get subtly wrong in a copy -- five nil checks, any of which silently changes what the assessment
+// observes.
+func resolveGoalSupervisionAssessment(projectDir, profile, session string, probe duplicateLaunchProbe) (team.Team, GoalSupervisionAssessment, error) {
+	t, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return team.Team{}, GoalSupervisionAssessment{}, fmt.Errorf("read team profile: %w", err)
+	}
+	if probe.PIDAlive == nil {
+		probe.PIDAlive = defaultDuplicateLaunchProbe.PIDAlive
+	}
+	if probe.ProcessMatch == nil {
+		probe.ProcessMatch = defaultDuplicateLaunchProbe.ProcessMatch
+	}
+	if probe.ProcessTTY == nil {
+		probe.ProcessTTY = defaultDuplicateLaunchProbe.ProcessTTY
+	}
+	if probe.ProcessStartTime == nil {
+		probe.ProcessStartTime = defaultDuplicateLaunchProbe.ProcessStartTime
+	}
+	if probe.Now == nil {
+		probe.Now = defaultDuplicateLaunchProbe.Now
+	}
+	rows := buildStatusRows(t, profile, session, probe)
+	ctx := newSessionStatusContext(t, profile, session, firstLiveTmuxSession(rows))
+	ns := squadnamespace.Resolve(t.Project, ctx.Profile, session)
+	invariantErrors := annotateVisibilityInvariants(rows, ctx)
+	conflict := namespaceConflictForProfileSession(t.Project, profile, session)
+	now := probe.Now().UTC()
+	gateObservation := inspectGoalSupervisionGates(t, profile, session, firstStatusRoot(rows), probe, now)
+	assessment := buildGoalSupervisionAssessment(
+		t, profile, session, ns, rows, gateObservation, invariantErrors,
+		conflict, probe, now,
+	)
+	return t, assessment, nil
+}
+
+// goalSuperviseResumeReport is the --dry-run and --json projection. It carries the claim key so an
+// operator can find the reservation the delivering path WOULD create, which is the whole point of
+// inspecting before enabling SafeAuto.
+type goalSuperviseResumeReport struct {
+	SchemaVersion          int      `json:"schema_version"`
+	DryRun                 bool     `json:"dry_run"`
+	Decision               string   `json:"decision"`
+	Detail                 string   `json:"detail,omitempty"`
+	State                  string   `json:"state"`
+	Fresh                  bool     `json:"fresh"`
+	Eligible               bool     `json:"eligible"`
+	AutomaticResumeAllowed bool     `json:"automatic_resume_allowed"`
+	PolicyMode             string   `json:"policy_mode"`
+	PolicyRevision         int      `json:"policy_revision"`
+	Fingerprint            string   `json:"fingerprint"`
+	AttemptID              string   `json:"attempt_id,omitempty"`
+	PauseGeneration        string   `json:"pause_generation,omitempty"`
+	ClaimKey               string   `json:"claim_key,omitempty"`
+	Supervisor             string   `json:"supervisor"`
+	Reasons                []string `json:"eligibility_reasons,omitempty"`
+
+	// Per-gate evidence. FailedGate names which gate refused, so a wrapper does not parse prose.
+	// SkippedGates and NotEvaluated exist so the report distinguishes three states -- passed, failed,
+	// and never-reached -- rather than presenting a prefix as the whole set.
+	Gates        []supervisionGateResult `json:"gates,omitempty"`
+	FailedGate   string                  `json:"failed_gate,omitempty"`
+	SkippedGates []string                `json:"skipped_gates,omitempty"`
+	NotEvaluated []string                `json:"delivery_time_gates_not_evaluated,omitempty"`
+
+	// Outcome carries the post-success bookkeeping result: delivered plus the two per-action flags and
+	// their error text. Present only on the delivering path.
+	Outcome *supervisionResumeOutcome `json:"outcome,omitempty"`
+
+	// PostDeliveryStatus is the captured post-delivery snapshot, embedded as ONE field of this document
+	// rather than emitted as a second top-level object.
+	PostDeliveryStatus      json.RawMessage `json:"post_delivery_status,omitempty"`
+	PostDeliveryStatusError string          `json:"post_delivery_status_error,omitempty"`
+}
+
+const goalSuperviseResumeSchemaVersion = 1
+
+func runGoalSuperviseResume(args []string) error {
+	fs := flag.NewFlagSet("goal supervise-resume", flag.ContinueOnError)
+	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
+	profileFlag := fs.String("profile", "", "team profile (default: default profile)")
+	sessionFlag := fs.String("session", "", "workstream session to assess")
+	supervisorFlag := fs.String("supervisor", "", supervisorIdentityFlagHelp)
+	attemptFlag := fs.String("attempt-id", "", "bind this invocation to one attempt; refuses if the fresh assessment is about a different one")
+	fingerprintFlag := fs.String("assessment-fingerprint", "", "bind this invocation to one assessment; refuses if the situation changed since the action was published")
+	dryRun := fs.Bool("dry-run", false, "report the decision, claim key and evidence WITHOUT reserving or delivering")
+	jsonOut := fs.Bool("json", false, "emit a schema-versioned decision report")
+	registerScopedFlagAliases(fs, projectFlag, sessionFlag, profileFlag)
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `amq-squad goal supervise-resume - deliver one audited native /goal resume, claim-once
+
+Usage:
+  amq-squad goal supervise-resume --session S --supervisor ID [--profile P] [--project DIR]
+                                  [--dry-run] [--json]
+
+CONSENT MODEL. There is deliberately NO confirmation flag. Automatic resume is
+authorized by team policy: Policy.Mode == safe_auto is the operator's recorded
+consent, given once when the policy is set. Asking again per invocation would
+convert automatic resume into manual resume, which is the stall this command
+exists to remove. Under manual or notify-only policy this command REFUSES.
+
+A bare invocation is not a raw action. It enters the full gate chain -- fresh
+assessment, eligibility, operator policy, action identity, claim-once
+reservation, delivery-time revalidation -- and any gate that does not hold
+produces a refusal with a recovery step, never a delivery.
+
+--dry-run reports the decision, the claim key that WOULD be reserved, and the
+supporting evidence, and performs no reservation, no bind, no consume, no
+directive publication and no pane input. Use it to inspect before enabling
+safe_auto.
+
+--supervisor is REQUIRED and is never inferred from the lead identity: the
+supervising actor is persisted in the claim, and a defaulted value would be
+indistinguishable on disk from a deliberate one. The published action renders it
+as a shell-quoted placeholder for exactly that reason: it is the one value a
+machine must not fill in for you. Pasting the template unedited REFUSES rather
+than recording the placeholder as an identity.
+
+--attempt-id and --assessment-fingerprint are optional but VALIDATED. The
+published action supplies both, which binds it to the pause it was published
+for: if the situation has moved, this command refuses and names which field
+drifted rather than acting on a different pause than the one you read about.
+Omitting them (a bare invocation) is allowed; the fresh assessment then stands
+on its own and the executor's binding checks still govern.
+
+Exit codes:
+  0   delivered, or dry-run reported
+  11  refused by operator policy (not allowed here) - distinct from failure
+  2   refused for any other reason, or delivery is INDETERMINATE
+`)
+	}
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return usageErrorf("goal supervise-resume takes no positional arguments")
+	}
+
+	supervisor := strings.TrimSpace(*supervisorFlag)
+	if supervisor == "" {
+		// REFUSE, never default. U1: explicit, nonblank, never inferred from lead identity.
+		return usageErrorf("goal supervise-resume requires --supervisor: %s", supervisorIdentityFlagHelp)
+	}
+	// Q2: THE UNFILLED PLACEHOLDER IS NOT AN IDENTITY. Blank was already refused, but the literal
+	// placeholder is NONBLANK, so it sailed through and would have been persisted in the claim as
+	// though it were an actor -- a durable record naming "<your-identity>" as the authorising
+	// supervisor, which is worse than a blank because it looks deliberate.
+	//
+	// Compared after trimming and against the SAME constant the action renders, so a template pasted
+	// without editing refuses instead of resuming.
+	if supervisor == supervisorIdentityPlaceholder {
+		return usageErrorf("--supervisor is still the placeholder %s: replace it with your own identity. "+
+			"The published command renders it as a placeholder because this is the one value that must "+
+			"come from a person, and recording the placeholder itself would leave a claim that cannot "+
+			"answer who authorised it", supervisorIdentityPlaceholder)
+	}
+	session := strings.TrimSpace(*sessionFlag)
+	if session == "" {
+		return usageErrorf("goal supervise-resume requires --session")
+	}
+	if err := team.ValidateSessionName(session); err != nil {
+		return usageErrorf("invalid --session: %v", err)
+	}
+	// The canonical scope resolver every other scoped command uses, rather than a local
+	// project/profile derivation. Scope resolution decides WHICH namespace this claim belongs to,
+	// and a second derivation of that is the same two-deciders defect as a second claim key.
+	ctx, err := resolveScopedCommandContext(*projectFlag, *profileFlag, session, "", fs)
+	if err != nil {
+		return err
+	}
+
+	_, assessment, err := resolveGoalSupervisionAssessment(ctx.ProjectDir, ctx.Profile, ctx.Session, duplicateLaunchProbe{})
+	if err != nil {
+		return err
+	}
+
+	// P1: BIND THE INVOCATION. Both flags are OPTIONAL but VALIDATED -- the published action always
+	// supplies them, a bare human invocation may not.
+	//
+	// This is what turns a published command from a generic trigger into a bound one. An operator
+	// pastes a command from a status board they read some time ago; the situation may have moved.
+	// Without this the pasted command would happily act on whatever the CURRENT assessment says,
+	// which is a different pause than the one they were looking at when they decided.
+	//
+	// Refusal names WHICH field drifted, because "the situation changed" without saying what changed
+	// leaves the operator re-reading everything.
+	if want := strings.TrimSpace(*attemptFlag); want != "" && want != strings.TrimSpace(assessment.Binding.Goal.AttemptID) {
+		return fmt.Errorf("the situation changed since this action was published: it was bound to attempt %q "+
+			"but the current assessment is about attempt %q. Re-read the assessment before acting",
+			want, assessment.Binding.Goal.AttemptID)
+	}
+	if want := strings.TrimSpace(*fingerprintFlag); want != "" && want != strings.TrimSpace(assessment.Fingerprint) {
+		return fmt.Errorf("the situation changed since this action was published: it was bound to assessment "+
+			"fingerprint %q but the current fingerprint is %q. Re-read the assessment before acting",
+			want, assessment.Fingerprint)
+	}
+
+	report := goalSuperviseResumeReport{
+		SchemaVersion:          goalSuperviseResumeSchemaVersion,
+		DryRun:                 *dryRun,
+		State:                  string(assessment.State),
+		Fresh:                  assessment.Fresh,
+		Eligible:               assessment.Eligible,
+		AutomaticResumeAllowed: assessment.AutomaticResumeAllowed,
+		PolicyMode:             string(assessment.Policy.Mode),
+		PolicyRevision:         assessment.Policy.Revision,
+		Fingerprint:            assessment.Fingerprint,
+		AttemptID:              assessment.Binding.Goal.AttemptID,
+		PauseGeneration:        assessment.Binding.PauseGeneration,
+		Supervisor:             supervisor,
+	}
+	for _, r := range assessment.Reasons {
+		if !r.Passed {
+			report.Reasons = append(report.Reasons, r.Code)
+		}
+	}
+	// The claim key the delivering path WOULD reserve. Derived for the report only; on the dry-run
+	// path nothing is written, so this is the operator's sole preview of the identity at stake.
+	if key, keyErr := supervisionClaimKey(assessment.Binding.NamespaceID, assessment.Binding.PauseGeneration,
+		assessment.Binding.Goal.AttemptID); keyErr == nil {
+		report.ClaimKey = key
+	}
+
+	// ONE EVALUATION, consumed by both paths (#498 F5). The dry-run does not re-implement the gates
+	// and does not check a subset of them: it runs the SAME evaluator the executor runs, which is what
+	// makes "the dry-run predicts the executor" a structural property instead of a claim.
+	//
+	// It also fixes the overclaim I shipped: the old dry-run reported "would_deliver" after checking
+	// AutomaticResumeAllowed ALONE, so an expired assessment or an existing claim would still print
+	// would_deliver. The verdict is now named for what was actually established.
+	agentDir, agentDirErr := agentDirForSupervisionResume(assessment)
+	if agentDirErr != nil {
+		// FAIL CLOSED before any evaluation: without a resolved agent directory there is no
+		// authoritative payload to authorize, and proceeding would let the loader read whatever a
+		// relative path happened to hit.
+		return agentDirErr
+	}
+	loader := launchRecordResumePayloadLoader(agentDir)
+	evaluation := evaluateSupervisionPreMutationGates(assessment, assessment.Actions.Resume, supervisor,
+		func() time.Time { return time.Now().UTC() }, loader, scanRecoveryTransitionsForPause)
+
+	report.Gates = evaluation.Results
+	for _, n := range evaluation.skippedGates() {
+		// NOT REACHED is its own state. Short-circuiting means the results are a PREFIX, and printing
+		// only the prefix would imply it is the whole set -- the same overclaim-by-omission as a
+		// mutation walk that drops an item silently.
+		report.SkippedGates = append(report.SkippedGates, string(n))
+	}
+	if *dryRun {
+		// A dry-run can NEVER evaluate these: they need the world at delivery time, after a
+		// reservation exists. Named rather than omitted, because "not checked" and "passed" are
+		// different facts and only one of them is evidence.
+		report.NotEvaluated = supervisionDeliveryTimeGates
+	}
+
+	if failed := evaluation.firstFailure(); failed != nil {
+		report.Decision = "refused"
+		report.FailedGate = string(failed.Name)
+		report.Detail = failed.Detail
+		if emitErr := emitGoalSuperviseResumeReport(report, *jsonOut); emitErr != nil {
+			return emitErr
+		}
+		if *dryRun {
+			// A dry-run REPORTS a refusal; reporting is its job, so this is not a failure exit.
+			return nil
+		}
+		// POLICY refusal keeps its own exit code so a wrapper can tell "not allowed here" from
+		// "broke". Keyed on WHICH GATE failed rather than on a re-check of the policy flag -- one
+		// evaluation, and the exit code derives from its verdict.
+		if failed.Name == gateOperatorPolicy {
+			return &ActionDecisionError{Decision: "denied", Message: failed.Detail}
+		}
+		return evaluation.refusal()
+	}
+
+	if *dryRun {
+		// NAMED FOR WHAT IT ESTABLISHED. Not "would_deliver": the delivery-time gates listed in
+		// NotEvaluated could still refuse, and a verdict implying delivery would be a prediction this
+		// command is not entitled to make.
+		report.Decision = "pre_mutation_gates_pass"
+		report.ClaimKey = evaluation.ClaimKey
+		return emitGoalSuperviseResumeReport(report, *jsonOut)
+	}
+
+	// The executor re-runs the evaluator itself rather than accepting this evaluation as an argument.
+	// That is deliberate: passing a pre-computed verdict in would make the executor trust a caller's
+	// claim that the gates passed, and the executor is the durable boundary -- it validates its own
+	// preconditions. The cost is one extra read-only evaluation; the alternative is a boundary that
+	// can be lied to.
+	// The delivery boundary is CONSTRUCTED here with the pane and directive it may use, then handed to
+	// the executor as a function of the PAYLOAD ONLY. The executor therefore cannot influence which
+	// pane is written to or which directive is recorded -- only what bytes go out. Narrowing what a
+	// callee can vary is the same principle as the injected loader: capability is granted, not assumed.
+	deliver := newSupervisionResumeDelivery(supervisionProductionDirectivePublisher, assessment, supervisor)
+	// THE POLL'S OUTPUT DESTINATION DIFFERS BY MODE, and getting this wrong produced a real bug.
+	//
+	// I first pointed the poll at os.Stdout in BOTH modes. In --json that made executeStatus write a
+	// complete status envelope to stdout and THEN the report write a second object -- two top-level JSON
+	// documents, which is not a parseable command response and violates the dedicated
+	// post_delivery_status ruling outright. "Render into the command's own output" is not the same as
+	// "write to stdout"; in JSON the command's output is ONE document.
+	//
+	// Text mode renders the labelled snapshot straight to stdout. JSON mode captures it into a
+	// command-owned buffer and embeds it as a field.
+	var statusBuf bytes.Buffer
+	pollTarget := io.Writer(os.Stdout)
+	if *jsonOut {
+		pollTarget = &statusBuf
+	}
+	// THE SEAM IS RESTORED ON EXIT. It is package-global, so leaving it set would leak this invocation's
+	// writer and json mode into the next in-process command or test -- a cross-test contamination that
+	// would be maddening to trace back to here.
+	previousPoll := pollSupervisionStatusOnce
+	defer func() { pollSupervisionStatusOnce = previousPoll }()
+	pollSupervisionStatusOnce = newSupervisionStatusPoll(pollTarget, *jsonOut)
+	outcome, err := executeSupervisionResume(assessment, assessment.Actions.Resume, supervisor,
+		func() time.Time { return time.Now().UTC() }, loader,
+		// U5's delivery-time readers, injected as PRODUCTION implementations. They are parameters
+		// rather than package globals precisely because they authorize an irreversible delivery: a
+		// mutable global that authorizes something can be nil'd into a silent pass.
+		newSupervisionGenerationReader(), newSupervisionPaneReader(),
+		readReservedRecoveryTransition,
+		deliver)
+	report.Outcome = &outcome
+	// EMBED the captured status as one field of the single report document, validating it first: an
+	// unparseable capture must not be spliced in raw, or the command's own response becomes invalid JSON
+	// because of a dependency's output.
+	if *jsonOut && statusBuf.Len() > 0 {
+		if json.Valid(statusBuf.Bytes()) {
+			report.PostDeliveryStatus = json.RawMessage(statusBuf.Bytes())
+		} else {
+			report.PostDeliveryStatusError = "post-delivery status output was not valid JSON and was omitted"
+		}
+	}
+	if err != nil {
+		// THE DECISION MUST NOT SAY "refused" ABOUT A COMPLETED DELIVERY. I assigned refused to every
+		// executor error, but a consume failure returns Delivered=true -- so the report claimed a refusal
+		// for an irreversible action that happened. Same return-value-versus-reality class as the
+		// Delivered=false bug, one layer up in the reporting.
+		report.Decision = supervisionResumeDecision(outcome)
+		report.Detail = err.Error()
+		// WARNINGS BEFORE THE RETURN. They were rendered only on the success path, so a consume failure --
+		// the case that most needs an operator to look -- returned without ever emitting its warning.
+		for _, w := range outcome.warnings() {
+			fmt.Fprintln(os.Stderr, "warning: "+w)
+		}
+		_ = emitGoalSuperviseResumeReport(report, *jsonOut)
+		// Nonzero for everything here, including indeterminate, so no wrapper reads an indeterminate
+		// outcome as success.
+		return err
+	}
+	report.Decision = "delivered"
+	// POST-SUCCESS FAILURES ARE VISIBLE, NOT SWALLOWED (#498 U6 ruling 3). Warnings go to STDERR so they
+	// cannot be mistaken for the command's data output, and the structured fields travel in --json. The
+	// EXIT CODE STAYS SUCCESS: the irreversible delivery happened, and a nonzero exit would invite a
+	// manual retry that the consumed claim would refuse -- but which an operator might attempt against a
+	// different pause instead.
+	for _, w := range outcome.warnings() {
+		fmt.Fprintln(os.Stderr, "warning: "+w)
+	}
+	return emitGoalSuperviseResumeReport(report, *jsonOut)
+}
+
+// supervisionResumeDecision maps an executor outcome to its reported decision literal.
+//
+// EXTRACTED FROM runGoalSuperviseResume, and the reason is evidentiary rather than aesthetic. Inline, the
+// mapping was only reachable by constructing a full command fixture -- team profile on disk, launch
+// record, pane lister, ledger -- so the only test I could write against it inspected the command's SOURCE
+// TEXT for the literals. That test asserts strings appear in a file. It does not execute the mapping, so
+// it survives SWAPPING the two indeterminate cases, which is precisely the confusion the
+// delivery_outcome_unknown rename was ruled to prevent.
+//
+// Pure function of the outcome, so the four states become four rows with struct literals.
+func supervisionResumeDecision(outcome supervisionResumeOutcome) string {
+	switch {
+	case outcome.DeliveryOutcomeUnknown:
+		// U6's unknown pane input: the bytes may or may not have landed. Distinct from a refusal, because
+		// a reservation exists and an operator must decide; and distinct from delivered_indeterminate,
+		// because delivery is NOT known to have happened.
+		//
+		// FIRST, and the precedence is load-bearing: a caller that defensively set both this and Delivered
+		// would otherwise be reported as a known delivery -- claiming an irreversible action that is not
+		// known to have happened, which is the more dangerous of the two errors.
+		//
+		// The literal is delivery_outcome_unknown, not delivery_indeterminate. My first name sat two
+		// characters from the adjacent delivered_indeterminate state, in the same switch, and both appear
+		// in operator evidence -- a distinction an operator cannot reliably see is not a distinction,
+		// however correct the code beneath it.
+		return "delivery_outcome_unknown"
+	case outcome.Delivered && !outcome.Consumed:
+		// U6's terminal INDETERMINATE state: the resume reached the pane and the claim was not consumed.
+		// Not a refusal -- nothing was declined -- and not a success either.
+		return "delivered_indeterminate"
+	case outcome.Delivered:
+		return "delivered_with_error"
+	default:
+		return "refused"
+	}
+}
+
+func emitGoalSuperviseResumeReport(report goalSuperviseResumeReport, asJSON bool) error {
+	if asJSON {
+		payload, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(payload))
+		return nil
+	}
+	fmt.Printf("decision=%s state=%s fresh=%t eligible=%t automatic=%t policy=%s@%d\n",
+		report.Decision, report.State, report.Fresh, report.Eligible,
+		report.AutomaticResumeAllowed, report.PolicyMode, report.PolicyRevision)
+	fmt.Printf("supervisor=%s attempt=%s pause_generation=%s\n",
+		report.Supervisor, report.AttemptID, report.PauseGeneration)
+	if report.ClaimKey != "" {
+		fmt.Printf("claim_key=%s\n", report.ClaimKey)
+	}
+	if report.Detail != "" {
+		fmt.Printf("detail=%s\n", report.Detail)
+	}
+	if len(report.Reasons) > 0 {
+		fmt.Printf("failed_eligibility_reasons=%s\n", strings.Join(report.Reasons, ","))
+	}
+	// The text surface prints the SAME three states as --json. A renderer that showed fewer would make
+	// the honest report available only to machines, and the operator inspecting before enabling
+	// safe_auto is exactly the human this output exists for.
+	for _, g := range report.Gates {
+		state := "pass"
+		if !g.Passed {
+			state = "FAIL"
+		}
+		fmt.Printf("gate %-40s %s\n", g.Name, state)
+	}
+	for _, n := range report.SkippedGates {
+		fmt.Printf("gate %-40s not reached\n", n)
+	}
+	for _, n := range report.NotEvaluated {
+		fmt.Printf("delivery-time gate NOT EVALUATED: %s\n", n)
+	}
+	if report.FailedGate != "" {
+		fmt.Printf("failed_gate=%s\n", report.FailedGate)
+	}
+	// THE HUMAN SURFACE CARRIES THE SAME MATERIAL OUTCOME AS --json. It printed neither delivered/consumed
+	// nor the directive/status flags, so the structured truth existed only for machines -- and the operator
+	// deciding whether to intervene is the reader who needs it most.
+	if report.Outcome != nil {
+		o := report.Outcome
+		fmt.Printf("delivered=%t delivery_outcome_unknown=%t consumed=%t delivered_directive_published=%t status_polled=%t\n",
+			o.Delivered, o.DeliveryOutcomeUnknown, o.Consumed, o.DeliveredDirectivePublished, o.StatusPolled)
+		// EXPLICIT ORDERED EMISSION, not a map range. My map version made CLI output order
+		// NONDETERMINISTIC -- Go randomises map iteration -- so stable evidence and any future golden test
+		// would have been flaky by construction. A convenience in the writing became instability in the
+		// artifact, which is the same trade I made with the exit-code pipe.
+		if o.ConsumeError != "" {
+			fmt.Printf("consume_error=%s\n", o.ConsumeError)
+		}
+		if o.DeliveredDirectiveError != "" {
+			fmt.Printf("delivered_directive_error=%s\n", o.DeliveredDirectiveError)
+		}
+		if o.StatusPollError != "" {
+			fmt.Printf("status_poll_error=%s\n", o.StatusPollError)
+		}
+	}
+	return nil
+}
+
+// launchRecordResumePayloadLoader is the PRODUCTION payload loader: read-only, reads the agent's
+// launch record, and returns the exact native resume payload with its digest.
+//
+// It returns the digest computed from the bytes it just read, NOT a digest carried alongside them.
+// That is deliberate and it is what makes the executor's two equalities independent: this loader can
+// only ever produce a self-consistent pair, so the FIRST equality is a corruption check on this
+// path, and the SECOND -- against assessment.Binding.Goal.CommandDigest, which PR4 captured
+// separately -- is the one that catches drift or substitution. A loader that returned a digest from
+// some other source would collapse both checks into one.
+//
+// Read-only by construction: launch.Read and a digest, nothing written, nothing signalled. The
+// executor calls it twice (pre-reserve and again at U5's gate), so it must be side-effect-free or
+// calling it twice would itself be a mutation.
+func launchRecordResumePayloadLoader(agentDir string) supervisionResumePayloadLoader {
+	return func(assessment GoalSupervisionAssessment) (string, string, error) {
+		rec, err := launch.Read(agentDir)
+		if err != nil {
+			return "", "", fmt.Errorf("read launch record: %w", err)
+		}
+		// launch.Read returns launch.Record BY VALUE, so there is no nil record to test -- my
+		// `rec == nil` was written for a pointer API I assumed instead of read. The fail-closed check
+		// that matters survives: no goal binding means nothing was authorized.
+		if rec.GoalBinding == nil {
+			// No binding means nothing was authorized. Refusing here rather than returning empty
+			// keeps "unauthorized" distinct from "authorized to send nothing".
+			return "", "", fmt.Errorf("launch record carries no goal binding, so no native resume payload is authorized")
+		}
+		payload := rec.GoalBinding.Command
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+}

--- a/internal/cli/goal_supervision.go
+++ b/internal/cli/goal_supervision.go
@@ -158,6 +158,20 @@ type GoalSupervisionAction struct {
 	Fingerprint  string `json:"fingerprint,omitempty"`
 	AttemptID    string `json:"attempt_id,omitempty"`
 	Confirmation string `json:"confirmation,omitempty"`
+
+	// CommandDigest is the digest of the NATIVE RESUME PAYLOAD this action authorizes -- the exact
+	// bytes the agent's pane must receive. It is deliberately NOT the digest of Command.
+	//
+	// Command and CommandDigest describe TWO DIFFERENT THINGS and conflating them was a
+	// wrong-payload delivery bug (#498 U1/F2):
+	//   Command       the SUPERVISOR INVOCATION -- what an operator types to trigger supervision.
+	//                 Operator-facing. NEVER delivered into an agent pane; typing it there would
+	//                 recursively invoke the supervisor inside the thing being supervised.
+	//   CommandDigest authorizes the NATIVE PAYLOAD, whose text lives on the launch record's
+	//                 GoalBinding.Command and is read at delivery time.
+	// The executor validates this digest against assessment.Binding.Goal.CommandDigest before any
+	// reserve, and again against the actual bytes immediately before typing them.
+	CommandDigest string `json:"command_digest,omitempty"`
 }
 
 type GoalSupervisionActions struct {
@@ -452,13 +466,51 @@ func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions 
 			Reason:    unavailableUnless(a.AttentionRequired, "assessment does not require attention"),
 		},
 		{
+			// #498 U1/F4: this metadata was NeedsConfirmation=true / Available=false as
+			// PLACEHOLDERS for a supervisor surface that did not exist. It exists now, so the
+			// metadata states the truth instead:
+			//   Available          mirrors the assessment's OWN conclusion. Publishing an action as
+			//                      available when the assessment says otherwise invites a caller to
+			//                      invoke it, and the executor now REFUSES an action the assessment
+			//                      marks unavailable rather than ignoring the field.
+			//   NeedsConfirmation  false ONLY under safe_auto, where the operator's consent is
+			//                      already recorded in policy. Manual and notify-only still need the
+			//                      human, so the flag stays true there -- the no-confirmation ruling
+			//                      is scoped to safe_auto, not global.
+			// The command name is corrected to the registered subcommand: it was
+			// "goal supervision-resume" while goal.go registers "goal supervise-resume", so the
+			// published action named a subcommand that does not exist.
+			// P1: the published command is a BOUND INVOCATION, not a generic trigger. It carries the
+			// attempt id and the assessment fingerprint, and the command validates both against its
+			// own FRESH assessment -- so this action can only ever fire against the pause it was
+			// published for. Pasting a stale one refuses instead of resuming something else.
+			//
+			// --supervisor renders as an EXPLICIT PLACEHOLDER, per the #579 precedent: the value must
+			// come from the operator, and inventing one would be worse than asking for it. So this is
+			// executable after exactly ONE human fill, which is what "supervisor is never inferred"
+			// means at the surface rather than merely in the executor.
+			//
+			// Available=true is HONEST under that rendering: every machine-fillable parameter is
+			// filled and correct, and the single placeholder is the one value that is definitionally
+			// the operator's to supply.
 			Kind: "native_goal_resume", Label: "resume exact native /goal attempt",
 			Scope: "agent", NamespaceID: namespaceID,
-			Command: "amq-squad goal supervision-resume" + scope +
+			Command: "amq-squad goal supervise-resume" + scope +
 				" --attempt-id " + shellQuote(a.Binding.Goal.AttemptID) +
-				" --assessment-fingerprint " + shellQuote(a.Fingerprint),
-			Mutates: true, NeedsConfirmation: true,
-			Available: false, Reason: resumeReason,
+				" --assessment-fingerprint " + shellQuote(a.Fingerprint) +
+				" --supervisor " + shellQuote(supervisorIdentityPlaceholder),
+			Mutates:   true,
+			Available: a.AutomaticResumeAllowed,
+			// Keyed on Policy.Mode, NOT on AutomaticResumeAllowed. The conjunction also folds in
+			// Eligible, so an ineligible actor under a safe_auto profile would otherwise flip back to
+			// needing confirmation -- which would misreport the operator's standing consent as absent
+			// because of an unrelated eligibility fact. The consent question is "what did the operator
+			// choose", and only Policy.Mode answers it.
+			NeedsConfirmation: a.Policy.Mode != team.GoalSupervisionSafeAuto,
+			// P3: Reason is populated ONLY when unavailable. An action that simultaneously reports
+			// "available" and carries a reason it cannot run is a false record, and a reader has no
+			// way to know which half to trust.
+			Reason: unavailableUnless(a.AutomaticResumeAllowed, resumeReason),
 		},
 	})
 	// These two are read-only display actions even though their new kinds are
@@ -471,6 +523,13 @@ func goalSupervisionActions(a GoalSupervisionAssessment) GoalSupervisionActions 
 			out.Fingerprint = a.Fingerprint
 			out.AttemptID = a.Binding.Goal.AttemptID
 			out.Confirmation = "Reassess this exact fingerprint and attempt immediately before mutation."
+		}
+		// The NATIVE PAYLOAD digest travels only on the action that actually authorizes a native
+		// resume. Attaching it to every mutating action would publish an authorization that those
+		// actions do not carry, and the executor compares this field for equality -- so a spurious
+		// value on an unrelated action is a claim that action was never entitled to make.
+		if action.Kind == "native_goal_resume" {
+			out.CommandDigest = a.Binding.Goal.CommandDigest
 		}
 		return out
 	}
@@ -513,6 +572,17 @@ func runtimeActionScope(project, profile, session string) string {
 		" --profile " + shellQuote(squadnamespace.NormalizeProfile(profile)) +
 		" --session " + shellQuote(session)
 }
+
+// supervisorIdentityPlaceholder is the literal a published action renders where the operator's own
+// identity belongs. ONE constant, used by rendering, help text, and validation, so the three cannot
+// drift into a state where the surface prints one string and the validator refuses another.
+//
+// It is rendered SHELL-QUOTED. Unquoted, "<your-identity>" is input redirection, not an argument:
+// pasting the template would make the shell try to read a file called your-identity and the CLI would
+// never see the placeholder at all, so the refusal that is supposed to catch an unfilled template
+// could not fire. Quoting turns shell SYNTAX into DATA, which is what makes the #579 placeholder
+// behaviour observable instead of delegated to shell parsing.
+const supervisorIdentityPlaceholder = "<your-identity>"
 
 func unavailableUnless(available bool, reason string) string {
 	if available {
@@ -1001,4 +1071,53 @@ func goalSupervisionInvariantStrings(errors []executionInvariantError) []string 
 		}
 	}
 	return stableUniqueStrings(values)
+}
+
+// canonicalExpectationFrom returns the canonical resume action this assessment published. ONE
+// derivation: the executor and the dry-run both compare against this rather than each restating what
+// canonical means.
+func (a GoalSupervisionAction) canonicalExpectationFrom(assessment GoalSupervisionAssessment) GoalSupervisionAction {
+	return assessment.Actions.Resume
+}
+
+// canonicalMismatch names the FIRST field that differs, or "" when the action matches canon.
+//
+// One field per comparison, deliberately: a single-field mutation must fail with that field named,
+// because a compound "metadata mismatch" tells an operator nothing about what to look at. Kind and ID
+// are both checked because runtimeaction.Action carries both and they are separately mutable.
+func (a GoalSupervisionAction) canonicalMismatch(expected GoalSupervisionAction, assessment GoalSupervisionAssessment) string {
+	for _, c := range []struct{ name, got, want, why string }{
+		{"kind", a.Kind, expected.Kind, "a different kind is not the native goal resume this contract governs"},
+		{"id", a.ID, expected.ID, "the id identifies the published action; a different id is a different action"},
+		{"action kind", a.ActionKind, expected.ActionKind, "the canonical classification must match or surface and executor disagree about what this is"},
+		{"scope", a.Scope, expected.Scope, "an action scoped elsewhere targets something other than this agent"},
+		{"namespace", a.NamespaceID, expected.NamespaceID, "a foreign namespace belongs to a different profile/session"},
+		{"invocation command", a.Command, expected.Command, "the invocation template differs from the published one"},
+	} {
+		if strings.TrimSpace(c.got) != strings.TrimSpace(c.want) {
+			return fmt.Sprintf("action %s %q does not match the canonical %q: %s", c.name, c.got, c.want, c.why)
+		}
+	}
+	if !a.Mutates {
+		return "the action does not declare Mutates, which would bypass every audit path keyed on that flag"
+	}
+	if a.Available != assessment.AutomaticResumeAllowed {
+		return fmt.Sprintf("action reports Available=%t while the assessment concludes AutomaticResumeAllowed=%t",
+			a.Available, assessment.AutomaticResumeAllowed)
+	}
+	if a.NeedsConfirmation != expected.NeedsConfirmation {
+		return fmt.Sprintf("action reports NeedsConfirmation=%t while the canonical action for this policy requires %t",
+			a.NeedsConfirmation, expected.NeedsConfirmation)
+	}
+	// P3 truth, BOTH DIRECTIONS. I enforced only the available=>blank half, which let an UNAVAILABLE
+	// action carry a blank or substituted Reason straight through the canonical gate -- and the Reason
+	// is the operator's only statement of WHY it cannot run, so a substituted one misdirects them and
+	// a blank one tells them nothing. Comparing against the canonical expectation covers both halves
+	// with one assertion and keeps the value deterministic rather than merely present.
+	if strings.TrimSpace(a.Reason) != strings.TrimSpace(expected.Reason) {
+		return fmt.Sprintf("action Reason %q does not match the canonical %q: the reason is the operator's "+
+			"only explanation of why an action cannot run, so a substituted or missing one misdirects them",
+			a.Reason, expected.Reason)
+	}
+	return ""
 }

--- a/internal/cli/goal_supervision_binding_revalidation.go
+++ b/internal/cli/goal_supervision_binding_revalidation.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// #498 U7: DELIVERY-TIME REVALIDATION OF EVERY BOUND FIELD.
+//
+// This is the reason the exact binding is persisted at all. dev-2's argument for full-depth U7 was that
+// "recovery/delivery cannot revalidate fields the record never persists" -- so persisting them without
+// revalidating them would satisfy the letter of the schema and none of its purpose. The record is the
+// recovery contract; this is where the contract is enforced.
+//
+// WHAT THIS CHECKS THAT THE U5 GATES DO NOT. The U5 delivery-time gates ask whether the WORLD still matches
+// the assessment: is the launch generation unchanged, is the pane still live, managed and idle, is the
+// assessment still fresh. This asks a different question: does the RESERVED CLAIM still describe the
+// assessment we are about to act on. Those come apart precisely in the case that matters -- a reservation
+// written for one pause, and a delivery driven by a different assessment that happens to pass every liveness
+// check. The pane can be perfectly alive and still be the wrong pane for THIS claim.
+//
+// EVERY FIELD THE NATIVE PATH PERSISTS IS COMPARED -- stated that precisely because the previous version of
+// this comment said "every persisted field" while the code compared the nested block plus three flat fields,
+// and dev-2 was right to call that the convenient-subset failure the sentence disclaims. A revalidation that
+// checks a subset tells an operator the binding was verified while leaving the unchecked fields free to
+// disagree, which is the shape of the payload-drift gate before it compared the digest AND the modtime.
+//
+// WHAT IS DELIBERATELY NOT COMPARED, so the absence is a recorded finding rather than an oversight:
+// MemberSession/MemberCWD/MemberBinary, GoalDigest, the four Original* fields, and the Team record
+// digest/modtime are REDELIVERY-PATH fields that a native reservation never populates. Comparing them would
+// compare two blanks and report agreement -- a pass manufactured by mutual absence, which is worse than no
+// check because it reads as coverage. TransitionID is not compared here either: it is the key the record is
+// FILED under, and publication already proves it matches both the filename and the canonical path, so a
+// disagreement cannot reach this function.
+//
+// LaunchStartedAt IS a genuine gap: eligibility requires it nonzero, so a native assessment always has one,
+// but the executor does not persist it and this function therefore cannot check it. Named here rather than
+// quietly omitted; it is out of scope for the four ruled blockers and belongs in a follow-up.
+func revalidateNativeBindingAgainstAssessment(record resumeGoalTransitionRecord, assessment GoalSupervisionAssessment) error {
+	// THE KIND FIRST, because everything below interprets the record AS a native claim.
+	//
+	// A record read back from disk can be any kind. Revalidating a redeliver record against a native
+	// assessment would compare a nil-or-absent binding field by field and report agreement wherever both
+	// sides happened to be blank -- a pass produced by two absences rather than by a match. Nothing
+	// downstream re-asks this question, so it has to be asked here.
+	if kind := recoveryTransitionKind(strings.TrimSpace(record.RecoveryKind)); kind != recoveryTransitionKindNativeGoalResume {
+		return fmt.Errorf(
+			"reserved claim kind %q is not %q: only a native goal-resume reservation carries the exact binding this revalidation is about, so a claim of any other kind cannot authorize a native delivery",
+			record.RecoveryKind, recoveryTransitionKindNativeGoalResume)
+	}
+	if record.NativeBinding == nil {
+		return fmt.Errorf("reserved native claim carries no exact binding: it cannot be revalidated, so it cannot authorize delivery")
+	}
+	bound := record.NativeBinding
+
+	// Compared by EXACT EQUALITY after trimming, never by substring or prefix. Each row names the field so a
+	// refusal sends an operator to the disagreeing value rather than to "the binding changed".
+	for _, row := range []struct {
+		field  string
+		bound  string
+		actual string
+		why    string
+	}{
+		{"namespace id", bound.NamespaceID, assessment.Binding.NamespaceID,
+			"a claim revalidated against a foreign namespace would authorize delivery into a session it was not written for"},
+		{"pane id", bound.PaneID, assessment.Binding.Pane.PaneID,
+			"the U5 gates prove the pane is live; this proves it is the pane THIS claim bound"},
+		{"goal mode", bound.GoalMode, assessment.Binding.Goal.Mode,
+			"a mode change means the delivery contract itself differs from the one that was authorized"},
+		{"goal attempt id", bound.GoalAttemptID, assessment.Binding.Goal.AttemptID,
+			"resuming a different attempt than the claim was written for is the double-delivery shape wearing a valid reservation"},
+		{"goal binding digest", bound.GoalBindingDigest, assessment.Binding.Goal.BindingDigest,
+			"the binding is what the goal IS; a different digest is a different goal"},
+		{"goal command digest", bound.GoalCommandDigest, assessment.Binding.Goal.CommandDigest,
+			"this is the digest the delivered payload is checked against, so a drifted one would authorize different bytes"},
+		{"blocker id", bound.BlockerID, assessment.Blocker.ID,
+			"the resume is authorized as the resolution of ONE blocker; a different blocker is a different authorization"},
+		{"blocker resolution digest", bound.BlockerResolutionDigest, assessment.Blocker.ResolutionDigest,
+			"the resolution evidence is what made the resume eligible, so it must be the same evidence at delivery"},
+		{"policy mode", bound.PolicyMode, assessment.Policy.Mode,
+			"a policy that changed between reservation and delivery may no longer permit automatic action at all"},
+	} {
+		if strings.TrimSpace(row.bound) != strings.TrimSpace(row.actual) {
+			return fmt.Errorf(
+				"reserved claim %s %q disagrees with the assessment's %q at delivery time: %s",
+				row.field, row.bound, row.actual, row.why)
+		}
+	}
+
+	// POLICY REVISION IS COMPARED SEPARATELY because it is an int, and a revision BUMP is the signal that an
+	// operator changed the policy after this claim was reserved. Equality is the requirement rather than
+	// monotonicity: a lower revision is just as much a disagreement, and treating "newer is fine" as
+	// acceptable would let a policy change silently re-authorize a claim made under the old one.
+	if bound.PolicyRevision != assessment.Policy.Revision {
+		return fmt.Errorf(
+			"reserved claim policy revision %d disagrees with the assessment's %d at delivery time: the operator changed policy after this claim was reserved, so the authorization it rests on is no longer the current one",
+			bound.PolicyRevision, assessment.Policy.Revision)
+	}
+
+	// THE FLAT IDENTITIES THE CLAIM ALSO BOUND. Skipping these because they live outside the nested block
+	// would be exactly the convenient-subset failure this function exists to avoid -- the field's location in
+	// the struct has nothing to do with whether it needs revalidating.
+	if strings.TrimSpace(record.Supervisor) == "" {
+		return fmt.Errorf("reserved claim carries no supervisor: delivery cannot proceed on a claim nobody is recorded as authorizing")
+	}
+	// THE FLAT SET, COMPLETED. dev-2's cross-gate found this function comparing the nested block in full
+	// while checking only three flat fields, and named it the convenient-subset failure the function's own
+	// header comment claims to avoid -- an accurate charge: I wrote "every persisted field is compared"
+	// above a loop over one struct. Coverage had followed my attention (I was building the nested block),
+	// not the record.
+	//
+	// EACH ROW IS HERE FOR A DISTINCT FAILURE, not for symmetry with the nested loop:
+	for _, row := range []struct {
+		field  string
+		bound  string
+		actual string
+		why    string
+	}{
+		{"project", record.Project, assessment.Binding.Project,
+			"a claim revalidated against a different project would authorize delivery into another repository entirely"},
+		{"profile", record.Profile, assessment.Binding.Profile,
+			"profile selects the namespace directory, so a disagreement means the claim and the assessment do not even share a ledger"},
+		{"session", record.Session, assessment.Binding.Session,
+			"the session is the workstream the resume belongs to; delivering into a different one resumes work nobody authorized here"},
+		{"lead role", record.Role, assessment.Binding.LeadRole,
+			"the claim records which lead's pause this is, and a different role is a different actor's work"},
+		{"lead handle", record.Handle, assessment.Binding.LeadHandle,
+			"role alone is ambiguous across handles, so the handle is what makes the bound identity exact"},
+		{"launch id", record.LaunchID, assessment.Binding.LaunchID,
+			"a different launch id means the runtime was relaunched: the pane can be perfectly live and belong to a process this claim never authorized"},
+		{"launch record digest", record.LaunchRecordDigest, assessment.Binding.LaunchRecordDigest,
+			"the launch record is the generation evidence, and a changed digest is a changed generation"},
+		{"preclaim fingerprint", record.PreclaimFingerprint, assessment.Fingerprint,
+			"the fingerprint is the staleness evidence the claim was reserved under; a rotated one means the claim evidence changed after the reservation"},
+	} {
+		if strings.TrimSpace(row.bound) != strings.TrimSpace(row.actual) {
+			return fmt.Errorf(
+				"reserved claim %s %q disagrees with the assessment's %q at delivery time: %s",
+				row.field, row.bound, row.actual, row.why)
+		}
+	}
+	// COMPARED AS AN INT, for the same reason PolicyRevision is: a numeric field trimmed into a string
+	// comparison would make 0 and "" the same answer, and zero is exactly the absent value that must not
+	// silently agree with anything. Equality rather than "newer is fine" -- a modtime that moved in either
+	// direction is a launch record that was rewritten, which is precisely the ABA case the digest alone
+	// misses when a relaunch reproduces identical bytes.
+	if record.LaunchRecordModTime != assessment.Binding.LaunchRecordModTime {
+		return fmt.Errorf(
+			"reserved claim launch record mod time %d disagrees with the assessment's %d at delivery time: the launch record was rewritten after this claim was reserved, so the generation it was authorized against no longer exists",
+			record.LaunchRecordModTime, assessment.Binding.LaunchRecordModTime)
+	}
+	if strings.TrimSpace(record.PauseGeneration) != strings.TrimSpace(assessment.Binding.PauseGeneration) {
+		return fmt.Errorf(
+			"reserved claim pause generation %q disagrees with the assessment's %q at delivery time: the pause this claim was written for is not the pause being resumed",
+			record.PauseGeneration, assessment.Binding.PauseGeneration)
+	}
+	// The intentional dual's invariant, re-checked at DELIVERY and not only at construction: the two fields
+	// may carry one value only while something enforces that they do, and construction-time enforcement says
+	// nothing about a record read back from disk.
+	if strings.TrimSpace(record.NewAttemptID) != strings.TrimSpace(bound.GoalAttemptID) {
+		return fmt.Errorf(
+			"reserved claim lifecycle attempt %q disagrees with its own bound goal attempt %q: a record whose two attempt identities differ is ambiguous evidence about which attempt was authorized",
+			record.NewAttemptID, bound.GoalAttemptID)
+	}
+	if record.SchemaVersion != resumeGoalTransitionSchemaVersion {
+		return fmt.Errorf(
+			"reserved claim schema version %d is not the current %d: a record its own readers do not accept cannot be revalidated",
+			record.SchemaVersion, resumeGoalTransitionSchemaVersion)
+	}
+	return nil
+}

--- a/internal/cli/goal_supervision_binding_revalidation_test.go
+++ b/internal/cli/goal_supervision_binding_revalidation_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// #498 U7: FALSIFIERS FOR DELIVERY-TIME REVALIDATION.
+//
+// Each row makes the ASSESSMENT disagree with the reserved claim in exactly ONE field. That direction is
+// deliberate: mutating the record would test that we notice a corrupted file, which is a different property.
+// The one that matters is a claim reserved for one observation being delivered against another -- and the
+// U5 gates cannot catch it, because a pane can be perfectly live, managed and idle while being the wrong
+// pane for THIS claim.
+func revalidationFixture(t *testing.T) (resumeGoalTransitionRecord, GoalSupervisionAssessment) {
+	t.Helper()
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+	ns := squadnamespace.ID(profile, session)
+	now := time.Now().UTC()
+
+	assessment := GoalSupervisionAssessment{
+		Fresh: true, Eligible: true, ObservedAt: now, FreshUntil: now.Add(time.Hour),
+		Policy:      team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 3, Source: "test"},
+		Fingerprint: "fingerprint-1",
+		Blocker:     GoalSupervisionBlockerEvidence{ID: "blocker-1", Known: true, Resolved: true, ResolutionDigest: "resolution-digest-1"},
+		Binding: GoalSupervisionBinding{
+			Project: project, Profile: profile, Session: session, NamespaceID: ns,
+			LeadRole: "cto", LeadHandle: "cto",
+			PauseGeneration: "pause-gen-1",
+			// THE LAUNCH GENERATION the assessment observed. Present on both sides of the comparison, or the
+			// launch rows below would drift a field the record never carried and refuse for absence instead
+			// of for disagreement.
+			LaunchID:           "launch-1",
+			LaunchRecordDigest: "launch-record-digest-1",
+			// Nonzero because eligibility requires it: a zero here would make the fixture describe a state
+			// no eligible assessment can reach.
+			LaunchRecordModTime: 1700000000,
+			Pane:                GoalSupervisionPaneIdentity{PaneID: "%7", Managed: true},
+			Goal: GoalSupervisionGoalIdentity{
+				// THE REAL MODE. This fixture said "native", which no production path emits: eligibility
+				// (goal_supervision.go:334) requires exactly "native_goal_blocked", so the old value pinned
+				// behaviour for a state the system cannot produce -- and a test asserting an unreachable
+				// state actively defends whatever the reachable one does instead.
+				Mode: fixtureNativeGoalMode, AttemptID: attemptID,
+				BindingDigest: "binding-digest-1", CommandDigest: "command-digest-1",
+			},
+		},
+	}
+	record := resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		Project:       project, Profile: profile, Session: session,
+		// The flat identities the claim also bound. Absent before, which meant the newly-compared rows
+		// would have refused on the ANTI-VACUITY control rather than on their own drift.
+		Role: "cto", Handle: "cto",
+		LaunchID:            "launch-1",
+		LaunchRecordDigest:  "launch-record-digest-1",
+		LaunchRecordModTime: 1700000000,
+		RecoveryKind:        string(recoveryTransitionKindNativeGoalResume),
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          "cto",
+		NewAttemptID:        attemptID,
+		NativeBinding: &resumeGoalNativeBinding{
+			NamespaceID: ns, PaneID: "%7", GoalMode: fixtureNativeGoalMode, GoalAttemptID: attemptID,
+			GoalBindingDigest: "binding-digest-1", GoalCommandDigest: "command-digest-1",
+			BlockerID: "blocker-1", BlockerResolutionDigest: "resolution-digest-1",
+			PolicyMode: team.GoalSupervisionSafeAuto, PolicyRevision: 3,
+		},
+	}
+	return record, assessment
+}
+
+// THE ANTI-VACUITY CONTROL. Without it every refusal row below would pass against an implementation that
+// refused everything, including the matching case production always presents.
+func TestRevalidationPassesWhenTheClaimStillMatchesTheAssessment(t *testing.T) {
+	record, assessment := revalidationFixture(t)
+	if err := revalidateNativeBindingAgainstAssessment(record, assessment); err != nil {
+		t.Fatalf("a claim that still matches its assessment must revalidate: %v", err)
+	}
+}
+
+// ONE ROW PER BOUND FIELD. Exhaustive on purpose: a revalidation that checks a convenient subset reports the
+// binding as verified while leaving the unchecked fields free to disagree.
+func TestRevalidationRefusesEveryDisagreeingBoundField(t *testing.T) {
+	for _, row := range []struct {
+		name    string
+		drift   func(*GoalSupervisionAssessment)
+		wantErr string
+	}{
+		{"namespace id", func(a *GoalSupervisionAssessment) { a.Binding.NamespaceID = "squad/other" }, "namespace id"},
+		{"pane id", func(a *GoalSupervisionAssessment) { a.Binding.Pane.PaneID = "%999" }, "pane id"},
+		{"goal mode", func(a *GoalSupervisionAssessment) { a.Binding.Goal.Mode = "prompt" }, "goal mode"},
+		{"goal attempt id", func(a *GoalSupervisionAssessment) { a.Binding.Goal.AttemptID = "attempt-other" }, "goal attempt id"},
+		{"goal binding digest", func(a *GoalSupervisionAssessment) { a.Binding.Goal.BindingDigest = "drifted" }, "goal binding digest"},
+		{"goal command digest", func(a *GoalSupervisionAssessment) { a.Binding.Goal.CommandDigest = "drifted" }, "goal command digest"},
+		{"blocker id", func(a *GoalSupervisionAssessment) { a.Blocker.ID = "blocker-other" }, "blocker id"},
+		{"blocker resolution digest", func(a *GoalSupervisionAssessment) { a.Blocker.ResolutionDigest = "drifted" }, "blocker resolution digest"},
+		{"policy mode", func(a *GoalSupervisionAssessment) { a.Policy.Mode = "manual" }, "policy mode"},
+		// A REVISION BUMP is the operator changing policy after the claim was reserved.
+		{"policy revision bumped", func(a *GoalSupervisionAssessment) { a.Policy.Revision = 4 }, "policy revision"},
+		// A LOWER revision is just as much a disagreement. Equality is the rule, not monotonicity: treating
+		// "newer is fine" as acceptable would let a policy change silently re-authorize an old claim.
+		{"policy revision lowered", func(a *GoalSupervisionAssessment) { a.Policy.Revision = 2 }, "policy revision"},
+		{"pause generation", func(a *GoalSupervisionAssessment) { a.Binding.PauseGeneration = "pause-other" }, "pause generation"},
+
+		// THE FLAT SET dev-2's cross-gate found uncompared. One row per field, each drifted ALONE, because a
+		// row that drifted two fields would stay green if either check were deleted -- and the whole reason
+		// these rows exist is that the checks were absent while the function claimed to be exhaustive.
+		{"project", func(a *GoalSupervisionAssessment) { a.Binding.Project = "/other/project" }, "project"},
+		{"profile", func(a *GoalSupervisionAssessment) { a.Binding.Profile = "other-profile" }, "profile"},
+		{"session", func(a *GoalSupervisionAssessment) { a.Binding.Session = "v9-99-9" }, "session"},
+		{"lead role", func(a *GoalSupervisionAssessment) { a.Binding.LeadRole = "worker" }, "lead role"},
+		// Role and handle drift SEPARATELY on purpose: the fixture deliberately sets both to "cto", so a
+		// single row changing one value could be satisfied by a check that compared the other. This pair only
+		// distinguishes the two checks because each row leaves the other field matching.
+		{"lead handle", func(a *GoalSupervisionAssessment) { a.Binding.LeadHandle = "cto-2" }, "lead handle"},
+		// A DIFFERENT LAUNCH ID is a relaunch: the pane can be live, managed and idle while belonging to a
+		// process this claim never authorized. This is the drift the U5 gates cannot see.
+		{"launch id", func(a *GoalSupervisionAssessment) { a.Binding.LaunchID = "launch-2" }, "launch id"},
+		{"launch record digest", func(a *GoalSupervisionAssessment) { a.Binding.LaunchRecordDigest = "drifted" },
+			"launch record digest"},
+		// THE ABA CASE: modtime moves while the digest is identical, so only the modtime row can catch it.
+		// This is the same asymmetry M-U5b proved for the U5 generation gate, applied to the persisted claim.
+		{"launch record mod time", func(a *GoalSupervisionAssessment) { a.Binding.LaunchRecordModTime = 1800000000 },
+			"launch record mod time"},
+		// AND THE OTHER DIRECTION, because equality is the rule rather than monotonicity: a modtime that went
+		// BACKWARDS is a rewritten launch record too, and "newer is fine" would accept it.
+		{"launch record mod time lowered", func(a *GoalSupervisionAssessment) { a.Binding.LaunchRecordModTime = 1600000000 },
+			"launch record mod time"},
+		{"preclaim fingerprint", func(a *GoalSupervisionAssessment) { a.Fingerprint = "fingerprint-rotated" },
+			"preclaim fingerprint"},
+	} {
+		record, assessment := revalidationFixture(t)
+		row.drift(&assessment)
+		err := revalidateNativeBindingAgainstAssessment(record, assessment)
+		if err == nil {
+			t.Errorf("%s: a disagreeing bound field must REFUSE delivery", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the field, got: %v", row.name, err)
+		}
+	}
+}
+
+// THE RECORD'S OWN INTERNAL INVARIANTS, re-checked at delivery rather than trusted from construction.
+// Construction-time enforcement says nothing about a record read back from disk.
+func TestRevalidationRefusesAnInternallyInconsistentClaim(t *testing.T) {
+	for _, row := range []struct {
+		name    string
+		corrupt func(*resumeGoalTransitionRecord)
+		wantErr string
+	}{
+		// THE KIND MUST BE NATIVE. A redeliver record reaching this function would be compared field by field
+		// against a native assessment, and wherever both sides were blank it would report agreement -- a pass
+		// manufactured by mutual absence. The binding block is left INTACT in this row so the refusal can only
+		// come from the kind check: nulling it too would be caught by the row below and prove nothing.
+		{"redeliver kind", func(r *resumeGoalTransitionRecord) {
+			r.RecoveryKind = string(recoveryTransitionKindRedeliver)
+		}, "kind"},
+		{"blank kind", func(r *resumeGoalTransitionRecord) { r.RecoveryKind = "" }, "kind"},
+		{"absent binding block", func(r *resumeGoalTransitionRecord) { r.NativeBinding = nil }, "carries no exact binding"},
+		{"missing supervisor", func(r *resumeGoalTransitionRecord) { r.Supervisor = "" }, "carries no supervisor"},
+		// The intentional dual disagreeing WITH ITSELF: two attempt identities in one record that differ is
+		// ambiguous evidence about which attempt was authorized.
+		{"dual attempt identities disagree", func(r *resumeGoalTransitionRecord) { r.NewAttemptID = "attempt-other" },
+			"disagrees with its own bound goal attempt"},
+		{"stale schema version", func(r *resumeGoalTransitionRecord) { r.SchemaVersion = 0 }, "schema version"},
+	} {
+		record, assessment := revalidationFixture(t)
+		row.corrupt(&record)
+		err := revalidateNativeBindingAgainstAssessment(record, assessment)
+		if err == nil {
+			t.Errorf("%s: must REFUSE", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the cause, got: %v", row.name, err)
+		}
+	}
+}

--- a/internal/cli/goal_supervision_decision_test.go
+++ b/internal/cli/goal_supervision_decision_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import "testing"
+
+// #498 U6: THE DECISION MAPPING, EXECUTED rather than read.
+//
+// This REPLACES TestTheTwoIndeterminateStatesRenderAsDistinctLiterals, which asserted that two string
+// literals APPEAR in goal_supervise_resume.go. That is a fact about a file, not about behaviour: it
+// survives SWAPPING the two switch cases, which is exactly the confusion the delivery_outcome_unknown
+// rename was ruled to prevent. I disclosed it as the weakest thing in the U5/U6 work at the time; this is
+// the promised replacement, made possible by extracting the mapping into a pure function.
+func TestEveryOutcomeStateMapsToItsOwnDecisionLiteral(t *testing.T) {
+	// HAND-WRITTEN expectations, deliberately NOT referencing whatever the mapping computes. Comparing the
+	// function against its own constants would pass however the pair drifted -- including back into
+	// near-identical names, the defect the rename fixed. Same reason the gate-order row compares against a
+	// literal instead of against supervisionPreMutationGateOrder.
+	rows := []struct {
+		name    string
+		outcome supervisionResumeOutcome
+		want    string
+	}{
+		{
+			// Unknown pane input. Delivered stays FALSE because success is not known; the discriminator is
+			// the only thing separating this from an ordinary refusal.
+			name:    "unconfirmed pane input",
+			outcome: supervisionResumeOutcome{DeliveryOutcomeUnknown: true},
+			want:    "delivery_outcome_unknown",
+		},
+		{
+			// KNOWN delivery, consume failed. Materially different from the row above: here an
+			// irreversible action demonstrably happened.
+			name:    "known delivery with failed consume",
+			outcome: supervisionResumeOutcome{Delivered: true, ConsumeError: "publish failed"},
+			want:    "delivered_indeterminate",
+		},
+		{
+			name:    "known delivery and consume, later error",
+			outcome: supervisionResumeOutcome{Delivered: true, Consumed: true},
+			want:    "delivered_with_error",
+		},
+		{
+			// The zero outcome: refused before anything happened.
+			name:    "ordinary pre-delivery refusal",
+			outcome: supervisionResumeOutcome{},
+			want:    "refused",
+		},
+	}
+
+	seen := map[string]string{}
+	for _, row := range rows {
+		got := supervisionResumeDecision(row.outcome)
+		if got != row.want {
+			t.Errorf("%s: decision = %q, want %q", row.name, got, row.want)
+		}
+		// NO TWO STATES MAY SHARE A LITERAL. Four rows each asserting their own value would still pass if
+		// two states collapsed onto one string, and a collapsed pair is exactly what U6 kept
+		// rediscovering -- unknown delivery reported as "refused".
+		if prev, dup := seen[got]; dup {
+			t.Errorf("%s and %s both report %q; distinct outcome states must be distinguishable in "+
+				"operator evidence", prev, row.name, got)
+		}
+		seen[got] = row.name
+	}
+	if len(seen) != len(rows) {
+		t.Errorf("%d outcome states produced only %d distinct literals", len(rows), len(seen))
+	}
+}
+
+// PRECEDENCE. DeliveryOutcomeUnknown must outrank Delivered, because a defensive caller that set both
+// would otherwise be reported as a known delivery -- claiming an irreversible action that is NOT known to
+// have happened. Over-reporting an irreversible action is worse than under-reporting it, so uncertainty
+// wins.
+func TestUnknownDeliveryOutranksDeliveredWhenBothAreSet(t *testing.T) {
+	got := supervisionResumeDecision(supervisionResumeOutcome{DeliveryOutcomeUnknown: true, Delivered: true})
+	if got != "delivery_outcome_unknown" {
+		t.Errorf("decision = %q, want %q: uncertainty must outrank a claimed delivery", got, "delivery_outcome_unknown")
+	}
+}
+
+// THE TWO INDETERMINATE LITERALS MUST STAY DISTINGUISHABLE AT A GLANCE. Technically-unequal strings that
+// differ by two characters are practically identical in an operator's evidence, which is the defect the
+// rename corrected. This keeps that property enforced now that the source-text row is gone.
+func TestTheTwoIndeterminateLiteralsAreNotConfusable(t *testing.T) {
+	unknownDelivery := supervisionResumeDecision(supervisionResumeOutcome{DeliveryOutcomeUnknown: true})
+	knownUnconsumed := supervisionResumeDecision(supervisionResumeOutcome{Delivered: true})
+
+	if unknownDelivery == knownUnconsumed {
+		t.Fatalf("both states report %q", unknownDelivery)
+	}
+	shared := 0
+	for shared < len(unknownDelivery) && shared < len(knownUnconsumed) &&
+		unknownDelivery[shared] == knownUnconsumed[shared] {
+		shared++
+	}
+	if shared > len("delivered") {
+		t.Errorf("%q and %q share a %d-character prefix -- too long to tell apart in operator evidence",
+			unknownDelivery, knownUnconsumed, shared)
+	}
+}

--- a/internal/cli/goal_supervision_delivery.go
+++ b/internal/cli/goal_supervision_delivery.go
@@ -14,13 +14,22 @@ import (
 
 // PR5 / #498 U6: the OWNED DELIVERY BOUNDARY.
 //
-// Three properties, and each has a named failure mode:
+// FOUR properties, and each has a named failure mode. Property (1b) was added by codex finding 3: this
+// header said "three" while the boundary published a durable directive between the last world-check and
+// pane input, which is the U4.2 violation. A property list that omits the ordering requirement is how the
+// gap survived a review that read this comment.
 //
 //  1. THE DIRECTIVE IS DURABLE AND COMES FIRST. An audited automatic action must leave a record of
 //     WHY it happened that survives the process, and it must exist BEFORE the pane is touched. After
 //     is too late: a crash between input and record produces a delivery nobody can explain, which is
 //     the worst outcome for an operator trying to reconstruct what an automatic system did to their
 //     agent. Directive failure or unknown result therefore produces ZERO pane input.
+//
+//  1b. THE DELIVERY-TIME GATES RE-RUN AFTER THE DIRECTIVE, IMMEDIATELY BEFORE INPUT. Property (1) puts
+//     an unbounded durable send between the executor's world-check and the pane, so freshness, launch
+//     generation and pane state must all be re-established here or the last check is a check about a
+//     world that has moved. Ratified text: acceptance line 64 and line 352 say pane INPUT; line 89 says
+//     the directive comes before input. Both hold only in this order.
 //
 //  2. THE INPUT GOES THROUGH THE OWNED ABSTRACTION, never raw send-keys. sendPromptToPane is the
 //     package's pane-input seam (runtime_actions.go:247, wrapping tmuxpane.SendPromptToPane) and it
@@ -54,6 +63,48 @@ func (e *supervisionUnknownDeliveryError) Error() string {
 	return "native resume delivery result is UNKNOWN: " + e.Detail
 }
 func (e *supervisionUnknownDeliveryError) Unwrap() error { return e.Cause }
+
+// supervisionDefiniteNonDeliveryError marks a delivery failure PROVEN to have produced ZERO pane input
+// (codex finding 5).
+//
+// WHY IT EXISTS. Every error out of this boundary was reported by the executor as
+// DeliveryOutcomeUnknown -- "the bytes may or may not have landed". Three of the boundary's refusals
+// happen strictly BEFORE sendPromptToPane is called at all, so no bytes exist to be ambiguous about:
+// a blank pane id, a missing directive publisher, and a failed directive publication. Reporting proven
+// non-delivery as ambiguous strands the pause in an operator decision that has no question in it, and
+// the field's own documentation (goal_supervision_resume.go:91) said it is set "ONLY on the pane-input
+// error path" while its single write site set it for all of these.
+//
+// THE FIX IS REPORT FIDELITY ONLY, ruled and deliberately narrow. This type NEVER causes the
+// reservation to be cleared, released or deleted. A claim that removes itself on a proven
+// non-delivery would manufacture exactly the orphan-companion state codex finding 2 is about, and
+// nothing in this system deletes reservations. What changes is what the operator is TOLD: "no delivery
+// occurred" instead of "inspect the pane to find out".
+//
+// POLARITY IS FAIL-CLOSED, and this is the part to preserve if anyone edits it: UNKNOWN REMAINS THE
+// DEFAULT and a definite verdict requires PROOF. The executor marks unknown unless this type is
+// present. The inverse -- assume definite, mark unknown -- reads as equivalent and is a fail-open at
+// the one seam where a wrong answer costs a double delivery.
+type supervisionDefiniteNonDeliveryError struct {
+	Detail string
+	Cause  error
+	// Refusal carries the delivery-time gate verdict when that is what stopped the delivery, so the
+	// operator sees the gate's own clause/detail/recovery rather than a paraphrase composed here. Nil
+	// for the pre-directive wiring refusals, which have no gate verdict to report.
+	Refusal *supervisionResumeRefusal
+}
+
+func (e *supervisionDefiniteNonDeliveryError) Error() string {
+	return "native resume was NOT delivered and no pane input occurred: " + e.Detail
+}
+func (e *supervisionDefiniteNonDeliveryError) Unwrap() error { return e.Cause }
+
+// supervisionDeliveryTimeGate re-runs the U5/U4.2 delivery-time gates from INSIDE this boundary.
+//
+// It is a captured dependency rather than a parameter of the returned closure because the closure must
+// stay a function of the PAYLOAD ONLY -- see newSupervisionResumeDelivery. The executor supplies bytes;
+// it does not get to choose whether the world is re-checked.
+type supervisionDeliveryTimeGate func() *supervisionResumeRefusal
 
 // agentDirForSupervisionResume resolves the agent directory whose launch record holds the goal
 // binding. Derived from the assessment's own binding rather than re-resolved from flags, so the
@@ -91,21 +142,70 @@ func newSupervisionResumeDelivery(
 	publishDirective supervisionDirectivePublisher,
 	assessment GoalSupervisionAssessment,
 	supervisor string,
+	// regate is the U4.2 requirement: the gates must be re-checked HERE, after the durable directive and
+	// immediately before pane input. See the call site below for why this cannot live in the executor.
+	regate supervisionDeliveryTimeGate,
 ) func(string) error {
 	return func(payload string) error {
 		paneID := strings.TrimSpace(assessment.Binding.Pane.PaneID)
 		if paneID == "" {
-			return fmt.Errorf("no pane identity in the assessment binding; refusing to deliver to an unresolved target")
+			return &supervisionDefiniteNonDeliveryError{
+				Detail: "no pane identity in the assessment binding; refusing to deliver to an unresolved target",
+			}
 		}
 		if publishDirective == nil {
 			// A missing publisher is a wiring fault, and delivering without an audit record is exactly
 			// what property (1) forbids. It refuses rather than degrading to an unaudited delivery.
-			return fmt.Errorf("no directive publisher supplied; an audited resume is never delivered unaudited")
+			return &supervisionDefiniteNonDeliveryError{
+				Detail: "no directive publisher supplied; an audited resume is never delivered unaudited",
+			}
+		}
+		if regate == nil {
+			// A MISSING GATE IS NOT A PASSING GATE -- the same rule as the nil reserved-claim loader. Without
+			// this the whole point of the re-check could be removed by dropping one argument, and every test
+			// that supplied a gate would stay green while production re-validated nothing.
+			return &supervisionDefiniteNonDeliveryError{
+				Detail: "no delivery-time gate was supplied, so the world cannot be re-checked immediately before pane input; refusing rather than typing against unverified state",
+			}
 		}
 
 		// (1) DIRECTIVE FIRST, durably. Any failure here means zero pane input.
 		if err := publishDirective(assessment, supervisor, payload); err != nil {
-			return fmt.Errorf("durable audit directive failed, so nothing was delivered: %w", err)
+			return &supervisionDefiniteNonDeliveryError{
+				Detail: "durable audit directive failed, so nothing was delivered: " + err.Error(),
+				Cause:  err,
+			}
+		}
+
+		// (1b) THE GATES, RE-RUN AFTER THE DIRECTIVE AND IMMEDIATELY BEFORE INPUT (codex finding 3).
+		//
+		// THIS ORDER IS FORCED BY THE RATIFIED TEXT, not chosen. Two requirements have to hold at once:
+		//   U4 gate 2 (acceptance line 64): "physically after reserve/bind/U2 rescan and immediately before
+		//     PANE INPUT"; A-clarification line 352 repeats "immediately before INPUT".
+		//   U6 (line 89): "Before input, durably record/send the AMQ directive".
+		// The only sequence satisfying both is reserve/bind -> rescan -> DIRECTIVE -> GATES -> pane input.
+		//
+		// WHAT WAS WRONG BEFORE. The executor's gate call was immediately before this CLOSURE, not before
+		// pane input, and publishDirective sits in between -- an `amq send` SUBPROCESS plus a receipt
+		// persist, of unbounded duration. In that window FreshUntil can pass, the launch generation can
+		// change (a relaunch is the one drift U5 exists to catch), and the pane can go busy or be replaced.
+		// The old code then typed into it with no re-check. I coded to U5 line 77's looser phrasing
+		// ("immediately before DELIVERY") and wrote the tighter one in my own comment.
+		//
+		// THE EXECUTOR'S PRE-DIRECTIVE GATE STAYS, and is not redundant with this one: it is what keeps a
+		// doomed delivery from publishing a durable directive at all. Both are killable -- one by asserting
+		// no directive is published when the world has already drifted, one by asserting a refusal AFTER a
+		// published directive -- so neither is decoration.
+		//
+		// A refusal here is DEFINITE non-delivery: nothing has been typed. The directive already published
+		// says "AUTHORIZED and being attempted" and explicitly "does not assert that the resume was
+		// delivered" (see supervisionProductionDirectivePublisher), so a published-then-refused record is
+		// honest under its existing wording and needs no new record type.
+		if refusal := regate(); refusal != nil {
+			return &supervisionDefiniteNonDeliveryError{
+				Detail:  "the world changed between the audit directive and pane input, so nothing was typed: " + refusal.Detail,
+				Refusal: refusal,
+			}
 		}
 
 		// (2) OWNED ABSTRACTION. Never tmux send-keys.
@@ -134,6 +234,11 @@ func newSupervisionResumeDelivery(
 				Cause:  err,
 			}
 		}
+		// DELIBERATELY NOT WRAPPED AS DEFINITE NON-DELIVERY, and the restraint is the point. Control has
+		// already passed into sendPromptToPane, so this error is reported by the layer that was handling the
+		// bytes -- we cannot prove from here that none of them reached the pane. Only the refusals ABOVE this
+		// call are provably input-free. Widening the definite class to "any error that is not one of the two
+		// typed unknowns" would be the fail-open polarity wearing a tidier shape.
 		return fmt.Errorf("deliver native resume to pane %s: %w", paneID, err)
 	}
 }

--- a/internal/cli/goal_supervision_delivery.go
+++ b/internal/cli/goal_supervision_delivery.go
@@ -1,0 +1,386 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+)
+
+// PR5 / #498 U6: the OWNED DELIVERY BOUNDARY.
+//
+// Three properties, and each has a named failure mode:
+//
+//  1. THE DIRECTIVE IS DURABLE AND COMES FIRST. An audited automatic action must leave a record of
+//     WHY it happened that survives the process, and it must exist BEFORE the pane is touched. After
+//     is too late: a crash between input and record produces a delivery nobody can explain, which is
+//     the worst outcome for an operator trying to reconstruct what an automatic system did to their
+//     agent. Directive failure or unknown result therefore produces ZERO pane input.
+//
+//  2. THE INPUT GOES THROUGH THE OWNED ABSTRACTION, never raw send-keys. sendPromptToPane is the
+//     package's pane-input seam (runtime_actions.go:247, wrapping tmuxpane.SendPromptToPane) and it
+//     is what goal delivery already uses. Raw `tmux send-keys` bypasses the queueing, target
+//     validation and error typing that abstraction owns -- and the error typing is load-bearing here,
+//     see (3).
+//
+//  3. THERE ARE THREE OUTCOMES, NOT TWO. Success, failure, and UNKNOWN. tmuxpane.QueuedInputError
+//     means the input was queued but its arrival is unconfirmed: the bytes may or may not have
+//     reached the pane. Collapsing that into either success or failure is the double-delivery bug --
+//     treated as failure a retry could deliver twice, treated as success a lost resume looks
+//     completed. It is returned as its own typed condition so the executor leaves the reservation
+//     INDETERMINATE and no automatic path retries.
+
+// supervisionDirectivePublisher records the durable audit directive. Injected so the
+// directive-failure and directive-unknown falsifiers are expressible; production supplies the real
+// publisher.
+type supervisionDirectivePublisher func(assessment GoalSupervisionAssessment, supervisor, payload string) error
+
+// supervisionUnknownDeliveryError marks a delivery whose arrival could not be confirmed.
+//
+// A distinct type rather than a sentinel string because callers must be able to branch on it: the
+// executor's handling of unknown differs from its handling of failure, and matching on message text
+// would break the moment a message is reworded.
+type supervisionUnknownDeliveryError struct {
+	Detail string
+	Cause  error
+}
+
+func (e *supervisionUnknownDeliveryError) Error() string {
+	return "native resume delivery result is UNKNOWN: " + e.Detail
+}
+func (e *supervisionUnknownDeliveryError) Unwrap() error { return e.Cause }
+
+// agentDirForSupervisionResume resolves the agent directory whose launch record holds the goal
+// binding. Derived from the assessment's own binding rather than re-resolved from flags, so the
+// payload is read from the SAME agent the assessment is about.
+func agentDirForSupervisionResume(assessment GoalSupervisionAssessment) (string, error) {
+	handle := strings.TrimSpace(assessment.Binding.LeadHandle)
+	if handle == "" {
+		// RETURNS AN ERROR, NOT AN EMPTY PATH. My first version returned "" and claimed the loader
+		// would refuse it. It would not: launch.Read("") resolves a RELATIVE path against the process
+		// cwd, so a coincidental record there becomes a wrong-target read of somebody else's binding.
+		// An empty string is not an error value -- using absence as a sentinel is how a missing input
+		// becomes a silently different input, which is the same class as treating a failed probe as
+		// proven vacancy.
+		return "", fmt.Errorf("no agent handle in the assessment binding; refusing to resolve an agent directory")
+	}
+	// CANONICAL, PROFILE-AWARE root. My hand-built <project>/.agent-mail/<session> ignored Profile
+	// entirely and would have read the DEFAULT profile's agent for a named-profile workstream --
+	// silently the wrong agent, with no error anywhere. squadnamespace.AMQRoot owns this layout; a
+	// second hand-rolled copy of a path convention is the same two-deciders defect as a second claim
+	// key, and paths fail silently where keys fail loudly.
+	root := squadnamespace.AMQRoot(assessment.Binding.Project, assessment.Binding.Profile,
+		assessment.Binding.Session)
+	dir := filepath.Join(root, "agents", handle)
+	if !filepath.IsAbs(dir) {
+		// A relative agent dir would be resolved against whatever cwd the process happens to have.
+		return "", fmt.Errorf("resolved agent directory %q is not absolute; refusing a cwd-relative read", dir)
+	}
+	return dir, nil
+}
+
+// newSupervisionResumeDelivery builds the delivery boundary. Everything it needs is captured here so
+// the executor's deliver signature stays a single-argument function of the PAYLOAD -- the executor
+// must not be able to influence which pane or which directive, only what bytes.
+func newSupervisionResumeDelivery(
+	publishDirective supervisionDirectivePublisher,
+	assessment GoalSupervisionAssessment,
+	supervisor string,
+) func(string) error {
+	return func(payload string) error {
+		paneID := strings.TrimSpace(assessment.Binding.Pane.PaneID)
+		if paneID == "" {
+			return fmt.Errorf("no pane identity in the assessment binding; refusing to deliver to an unresolved target")
+		}
+		if publishDirective == nil {
+			// A missing publisher is a wiring fault, and delivering without an audit record is exactly
+			// what property (1) forbids. It refuses rather than degrading to an unaudited delivery.
+			return fmt.Errorf("no directive publisher supplied; an audited resume is never delivered unaudited")
+		}
+
+		// (1) DIRECTIVE FIRST, durably. Any failure here means zero pane input.
+		if err := publishDirective(assessment, supervisor, payload); err != nil {
+			return fmt.Errorf("durable audit directive failed, so nothing was delivered: %w", err)
+		}
+
+		// (2) OWNED ABSTRACTION. Never tmux send-keys.
+		err := sendPromptToPane(paneID, payload)
+		if err == nil {
+			return nil
+		}
+
+		// (3) UNKNOWN IS NOT FAILURE, and there are TWO unknown shapes, not one. I mapped only
+		// QueuedInputError and wrapped SubmitUnconfirmedError as an ordinary failure -- but tmuxpane
+		// documents it as EXPLICITLY AMBIGUOUS (deliver.go:270,289,297): the text was typed and the
+		// submit could not be confirmed, so the resume may well be running. Calling that a failure
+		// invites a retry that delivers twice, which is the exact harm this whole PR exists to prevent.
+		// Both map to unknown; they are reported distinctly so the operator knows WHICH ambiguity.
+		var queued *tmuxpane.QueuedInputError
+		if errors.As(err, &queued) {
+			return &supervisionUnknownDeliveryError{
+				Detail: fmt.Sprintf("input to pane %s was queued but arrival is unconfirmed", paneID),
+				Cause:  err,
+			}
+		}
+		var unconfirmed *tmuxpane.SubmitUnconfirmedError
+		if errors.As(err, &unconfirmed) {
+			return &supervisionUnknownDeliveryError{
+				Detail: fmt.Sprintf("input to pane %s was typed but submission could not be confirmed", paneID),
+				Cause:  err,
+			}
+		}
+		return fmt.Errorf("deliver native resume to pane %s: %w", paneID, err)
+	}
+}
+
+// supervisionProductionDirectivePublisher is the DURABLE audit directive, on the canonical owned path.
+//
+// Modelled on sendOperatorAMQ (operator.go:842) rather than invented: dispatchSendArgs composes the
+// send, runOwnedDurableSend executes it and persists a receipt under .amq-squad/receipts/ with
+// at-most-once semantics. That receipt IS the audit property U6 requires -- a record of why an
+// automatic action happened that survives the process.
+//
+// THE SUPERVISOR IS THE SENDER, NEVER THE OPERATOR. The supervisor is the authorizing identity under
+// U1, and sending this as the operator would attribute an automatic action to a human who did not
+// take it -- the impersonation amq.go explicitly refuses. So `from` is the supervisor and the thread
+// is the canonical p2p pair between the supervisor and the resumed agent, derived through
+// receiptCanonicalP2P so the ordering matches every other thread in the system rather than being
+// composed by hand here.
+//
+// A RECEIPT THAT CANNOT PERSIST IS A FAILED DIRECTIVE. durableFinalReceiptPersistError is returned as
+// an error, not swallowed: an unpersisted receipt means the audit record does not durably exist, and
+// property (1) says no pane input happens without one. This is the branch that makes
+// "refuse without a directive" true rather than aspirational -- the send may have gone out, but if
+// its record did not land we do not proceed to type into the pane.
+func supervisionProductionDirectivePublisher(assessment GoalSupervisionAssessment, supervisor, payload string) error {
+	to := strings.TrimSpace(assessment.Binding.LeadHandle)
+	if to == "" {
+		return fmt.Errorf("no agent handle in the assessment binding; an audit directive with no recipient is not a record")
+	}
+	ctx, err := resolveAMQContextForNamespace(assessment.Binding.Project, assessment.Binding.Profile,
+		assessment.Binding.Session, supervisor)
+	if err != nil {
+		return fmt.Errorf("resolve amq root for the supervision directive: %w", err)
+	}
+	ctx.Me = supervisor
+
+	// The body states the DECISION and the EXACT EVIDENCE, so the record answers "why did this happen"
+	// without a reader needing to reconstruct the assessment. The payload digest is included rather
+	// than the payload: the bytes went to the pane, and the digest is what ties this record to them.
+	// THE PRE-INPUT DIRECTIVE SAYS ATTEMPTING, NEVER DELIVERED.
+	//
+	// My first version's subject and body both said "delivered" -- published BEFORE sendPromptToPane
+	// ran. If the input then failed or came back unknown, the durable audit record would assert a
+	// completed delivery that never completed. An audit record that can be false is worse than no
+	// audit record: it is the artifact an operator trusts when reconstructing what happened, and I
+	// built it to be trustworthy and then had it state something not yet true.
+	// Only a post-known-success record may claim delivered, and that record is still owed (see U6's
+	// remaining work: consume/receipt then one observability-only status poll).
+	body := strings.Join([]string{
+		"Automatic native /goal resume AUTHORIZED and being attempted by supervision.",
+		"This record is written BEFORE pane input. It does not assert that the resume was delivered.",
+		"supervisor: " + supervisor,
+		"namespace: " + assessment.Binding.NamespaceID,
+		"policy: " + string(assessment.Policy.Mode) + " revision " + fmt.Sprint(assessment.Policy.Revision),
+		"attempt: " + assessment.Binding.Goal.AttemptID,
+		"pause generation: " + assessment.Binding.PauseGeneration,
+		"assessment fingerprint: " + assessment.Fingerprint,
+		"goal binding digest: " + assessment.Binding.Goal.BindingDigest,
+		"goal command digest: " + assessment.Binding.Goal.CommandDigest,
+		"authorized payload digest: " + digestGoalSupervisionString(payload),
+		"launch record digest: " + assessment.Binding.LaunchRecordDigest,
+		"launch record modtime: " + fmt.Sprint(assessment.Binding.LaunchRecordModTime),
+		"launch id: " + assessment.Binding.LaunchID,
+		"pane: " + assessment.Binding.Pane.PaneID,
+	}, "\n")
+
+	// Machine-readable context alongside the readable text, so a reconstruction does not depend on
+	// parsing prose. dispatchSendArgs takes it via --context, the same way sendOperatorAMQ does.
+	contextJSON, marshalErr := json.Marshal(map[string]any{
+		"decision":                  "authorized_attempting",
+		"supervisor":                supervisor,
+		"namespace_id":              assessment.Binding.NamespaceID,
+		"policy_mode":               string(assessment.Policy.Mode),
+		"policy_revision":           assessment.Policy.Revision,
+		"attempt_id":                assessment.Binding.Goal.AttemptID,
+		"pause_generation":          assessment.Binding.PauseGeneration,
+		"assessment_fingerprint":    assessment.Fingerprint,
+		"goal_binding_digest":       assessment.Binding.Goal.BindingDigest,
+		"goal_command_digest":       assessment.Binding.Goal.CommandDigest,
+		"authorized_payload_digest": digestGoalSupervisionString(payload),
+		"launch_record_digest":      assessment.Binding.LaunchRecordDigest,
+		"launch_record_mod_time":    assessment.Binding.LaunchRecordModTime,
+		"launch_id":                 assessment.Binding.LaunchID,
+		"pane_id":                   assessment.Binding.Pane.PaneID,
+	})
+	if marshalErr != nil {
+		return fmt.Errorf("encode supervision directive context: %w", marshalErr)
+	}
+
+	args := dispatchSendArgs(ctx.Root, supervisor, to,
+		receiptCanonicalP2P(supervisor, to), "status",
+		"Automatic native /goal resume AUTHORIZED (attempting)", body, "", "", 0)
+	args = append(args, "--context", string(contextJSON))
+
+	_, _, sendErr := runOwnedDurableSend(
+		durableSendOptions{
+			ProjectDir: assessment.Binding.Project,
+			Profile:    assessment.Binding.Profile,
+			Session:    assessment.Binding.Session,
+			// Kind identifies the actor in the receipt namespace. The command name lives HERE and
+			// nowhere else.
+			Kind: "supervision_resume",
+			// Invocation is DELIBERATELY UNSET. It is a durableInvocationBoundary -- a struct wrapping
+			// a run callback -- not a label, and my first version assigned the string
+			// "goal supervise-resume" to it. That could not compile, and dev-2 caught it by READING
+			// rather than by building, which is the gate doing precisely what it exists for.
+			//
+			// Left at its zero value so runOwnedDurableSend uses its own default boundary. Supplying a
+			// custom one would mean this publisher wanted to control retry/reconciliation semantics,
+			// and it does not: it wants the STANDARD at-most-once receipt behaviour, which is exactly
+			// what the default provides. Overloading a typed field to carry a name would have put a
+			// label where a behaviour belongs.
+		},
+		amqCommandRequest{Dir: assessment.Binding.Project, Env: amqCommandEnv(ctx), Arg: args},
+	)
+	var persistErr *durableFinalReceiptPersistError
+	if errors.As(sendErr, &persistErr) {
+		return fmt.Errorf("audit directive receipt did not persist, so no delivery proceeds: %w", sendErr)
+	}
+	if sendErr != nil {
+		return fmt.Errorf("publish supervision audit directive: %w", sendErr)
+	}
+	return nil
+}
+
+// PR5 / #498 U6 post-success seams. Package-level function vars, matching sendPromptToPane's shape
+// (runtime_actions.go:247), so tests can substitute them and the directive/poll failure paths are
+// expressible.
+//
+// BOTH ARE CALLED ONLY AFTER A KNOWN-SUCCESSFUL DELIVERY AND A COMPLETED CONSUME, and their errors are
+// REPORTED IN THE OUTCOME rather than returned. Two corrections are folded in here, both of which I got
+// wrong first:
+//
+//   - REPLAY PROTECTION IS CLAIM-ONCE, NOT THIS RETURN VALUE. The stale version of this comment said
+//     surfacing a bookkeeping failure "invites a retry that would deliver a second audited resume". That
+//     is false: a consumed claim BLOCKS re-entry at the claim-once gate, so no automatic retry reaches
+//     delivery. I corrected this in the executor and left this copy standing -- fixing one instance of a
+//     claim and leaving another is its own recurring defect.
+//   - THE REAL REASON IS CONFLATION. Callers read a returned error as "the action failed". Here the
+//     action SUCCEEDED and only its bookkeeping did not, so an ordinary error would make a completed,
+//     irreversible delivery indistinguishable from one that never happened.
+//
+// Nor are the errors discarded any more: they travel in supervisionResumeOutcome and surface as operator
+// warnings. Failure never authorizes replay AND failure evidence never disappears.
+var (
+	// publishDeliveredDirective records the DELIVERED audit directive -- the counterpart to the
+	// pre-input AUTHORIZED one. Only this record may claim delivery, because only here is it true.
+	publishDeliveredDirective supervisionDirectivePublisher = supervisionDeliveredDirectivePublisher
+
+	// pollSupervisionStatusOnce performs the ONE fresh post-delivery status read, RENDERED so somebody can
+	// see it (#498 U6 ruling 1).
+	//
+	// The entry point is executeStatus, the COMMAND-LEVEL read that includes rendering -- not
+	// buildStatusRows, which is the row builder one layer below. That distinction is the ruling: a read
+	// whose output goes nowhere makes nothing observable, so io.Discard would be ceremony rather than
+	// observability. cto's first pointer named the lower layer and its "the read itself refreshes
+	// observability" rationale was withdrawn; dev-2's identification is the one implemented here.
+	//
+	// It renders into the INVOKING COMMAND's output, so the invoker -- human or wrapper -- receives it as
+	// data. That is why the writer is a parameter rather than a package default.
+	pollSupervisionStatusOnce func(GoalSupervisionAssessment) error
+)
+
+// supervisionDeliveredDirectivePublisher publishes the post-success DELIVERED record on the same
+// canonical owned path as the authorized one, differing only in what it asserts -- which is the entire
+// point of having two records instead of one optimistic record written early.
+func supervisionDeliveredDirectivePublisher(assessment GoalSupervisionAssessment, supervisor, payload string) error {
+	to := strings.TrimSpace(assessment.Binding.LeadHandle)
+	if to == "" {
+		return fmt.Errorf("no agent handle in the assessment binding")
+	}
+	ctx, err := resolveAMQContextForNamespace(assessment.Binding.Project, assessment.Binding.Profile,
+		assessment.Binding.Session, supervisor)
+	if err != nil {
+		return fmt.Errorf("resolve amq root for the delivered directive: %w", err)
+	}
+	ctx.Me = supervisor
+
+	body := strings.Join([]string{
+		"Automatic native /goal resume DELIVERED and the claim is consumed.",
+		"This record is written AFTER known-successful pane input and a completed consume.",
+		"supervisor: " + supervisor,
+		"attempt: " + assessment.Binding.Goal.AttemptID,
+		"pause generation: " + assessment.Binding.PauseGeneration,
+		"delivered payload digest: " + digestGoalSupervisionString(payload),
+		"pane: " + assessment.Binding.Pane.PaneID,
+	}, "\n")
+
+	contextJSON, marshalErr := json.Marshal(map[string]any{
+		"decision":                 "delivered_and_consumed",
+		"supervisor":               supervisor,
+		"attempt_id":               assessment.Binding.Goal.AttemptID,
+		"pause_generation":         assessment.Binding.PauseGeneration,
+		"delivered_payload_digest": digestGoalSupervisionString(payload),
+		"pane_id":                  assessment.Binding.Pane.PaneID,
+	})
+	if marshalErr != nil {
+		return fmt.Errorf("encode delivered directive context: %w", marshalErr)
+	}
+
+	args := dispatchSendArgs(ctx.Root, supervisor, to,
+		receiptCanonicalP2P(supervisor, to), "status",
+		"Automatic native /goal resume DELIVERED", body, "", "", 0)
+	args = append(args, "--context", string(contextJSON))
+
+	_, _, sendErr := runOwnedDurableSend(
+		durableSendOptions{
+			ProjectDir: assessment.Binding.Project,
+			Profile:    assessment.Binding.Profile,
+			Session:    assessment.Binding.Session,
+			Kind:       "supervision_resume_delivered",
+		},
+		amqCommandRequest{Dir: assessment.Binding.Project, Env: amqCommandEnv(ctx), Arg: args},
+	)
+	if sendErr != nil {
+		return fmt.Errorf("publish delivered directive: %w", sendErr)
+	}
+	return nil
+}
+
+// newSupervisionStatusPoll builds the post-delivery status poll, rendering into the supplied writer.
+//
+// ONE read, not a wait loop, and its result is never consulted for a decision: it runs AFTER consume, so
+// nothing downstream depends on it. A poll whose output influenced control flow would be a post-consume
+// decider, which the no-post-claim-reassessment rule forbids -- the output is for the INVOKER, not for
+// this code.
+func newSupervisionStatusPoll(out io.Writer, asJSON bool) func(GoalSupervisionAssessment) error {
+	return func(assessment GoalSupervisionAssessment) error {
+		if out == nil {
+			return fmt.Errorf("no writer for the post-delivery status snapshot; an unrendered poll observes nothing")
+		}
+		if !asJSON {
+			// LABELLED, so a reader can tell this snapshot is post-delivery rather than the pre-delivery
+			// state they were looking at when they invoked.
+			fmt.Fprintln(out, "--- post-delivery status snapshot ---")
+		}
+		// FIELD NAMES READ FROM status.go:349, not guessed. My first version wrote Session; the field is
+		// RequestedSession with an ExplicitSession companion, and ExplicitSession=true matters -- the
+		// assessment is ABOUT one exact session, so the poll must not fall back to inferring a different
+		// one. Third time today I typed a field name from expectation instead of from the declaration.
+		return executeStatus(statusExecution{
+			ProjectDir:       assessment.Binding.Project,
+			Profile:          assessment.Binding.Profile,
+			RequestedSession: assessment.Binding.Session,
+			ExplicitSession:  true,
+			Probe:            defaultDuplicateLaunchProbe,
+			JSON:             asJSON,
+			Out:              out,
+		})
+	}
+}

--- a/internal/cli/goal_supervision_delivery_gates.go
+++ b/internal/cli/goal_supervision_delivery_gates.go
@@ -1,0 +1,285 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+)
+
+// #498 U5: THE DELIVERY-TIME GATES.
+//
+// These are the checks that CANNOT be satisfied before the ledger work, and the reason is not
+// fastidiousness. Reserve, bind and the cross-kind rescan all perform filesystem I/O, so real time
+// passes and the real world moves between "this assessment was validated" and "these bytes are typed
+// into a pane". A pre-mutation gate proves a fact about the past; a delivery-time gate proves it is
+// still true at the only moment that matters.
+//
+// WHY THESE ARE INJECTED PARAMETERS AND NOT PACKAGE GLOBALS. The post-success seams in this package
+// (publishDeliveredDirective, pollSupervisionStatusOnce) are package-level vars, and that is
+// defensible for them: they perform bookkeeping and observability AFTER an irreversible action, their
+// failure is reported rather than authorizing anything, and a nil one simply skips a non-decision.
+// These readers are the opposite kind of thing. They AUTHORIZE an irreversible delivery, and a
+// mutable package global that authorizes something can be silently replaced or nil'd by any code in
+// the package -- turning "the gate did not refuse" into "the gate was not there". An injected
+// parameter cannot be bypassed without changing every caller, which is the property an authorization
+// seam needs and an observability seam does not.
+//
+// A NIL READER IS A REFUSAL, NEVER A SKIP, for the same reason: the absence of evidence about a live
+// pane is not evidence of a live pane.
+
+// supervisionGenerationReader re-reads the launch generation. It returns the digest and modtime of
+// the launch record as it exists NOW, so drift against the bound generation can be detected.
+type supervisionGenerationReader func(GoalSupervisionAssessment) (digest string, modTime int64, err error)
+
+// supervisionPaneReader observes the exact recorded pane. It is strictly read-only: it must never
+// create, resurrect, or repair a pane, because a gate that fixes what it inspects cannot refuse.
+type supervisionPaneReader func(GoalSupervisionAssessment) (supervisionPaneObservation, error)
+
+// supervisionPaneObservation is the pane facts U5 requires, kept as an explicit struct rather than a
+// bool so that UNKNOWN is representable. A boolean cannot distinguish "the pane is not idle" from
+// "whether the pane is idle could not be determined", and those must both refuse for DIFFERENT
+// stated reasons -- collapsing them would report a busy pane when the truth is a failed probe.
+type supervisionPaneObservation struct {
+	// PaneID is what was actually inspected, so a refusal can name the pane rather than asserting
+	// something about a pane the reader may not have looked at.
+	PaneID string
+	// Managed reports whether this pane is one the supervisor manages. Delivering into an unmanaged
+	// pane types bytes into something a human owns.
+	Managed bool
+	// Found is true ONLY for an affirmative exact-id hit. Gone, Unavailable and Malformed are all
+	// false, and State carries which one for the refusal detail.
+	Found bool
+	State string
+	// PID is the pane's foreground process id. Zero means no live process, which is the case a
+	// pane-exists check alone would pass: a pane can survive its process.
+	PID int
+	// IdleKnown separates "not idle" from "idle unknown". See the struct comment.
+	IdleKnown bool
+	Idle      bool
+}
+
+// evaluateSupervisionDeliveryTimeGates runs the three owed U5 gates immediately before pane input and
+// returns a refusal, or nil to proceed. The payload-drift gate is NOT here: it lives inline in the
+// executor because it must consume the AuthorizedDigest baseline established before reserve, and
+// moving it would separate that comparison from the baseline it depends on.
+//
+// ORDER, AND MY FIRST ORDER WAS WRONG. I put the wall clock FIRST, reasoning cheapest-and-most-certain
+// first: an expired assessment could then be refused without touching the filesystem or tmux. That is
+// a real efficiency argument and it lost to a correctness one, which dev-2 named. The generation read
+// and the pane inspection both perform real I/O -- the pane read includes bounded tmux retries -- so a
+// freshness check placed BEFORE them is not the "FreshUntil re-checked immediately before pane input"
+// the contract requires. An assessment fresh at entry could expire during those reads and be
+// delivered anyway, with no clock left to consult.
+//
+// So the order is now:
+//  1. generation -- if the launch record moved, the assessment's pane identity describes a generation
+//     that no longer exists, so inspecting that pane would be asking about the wrong program.
+//  2. pane -- the most expensive and most failure-prone read.
+//  3. wall clock, LAST, sampled after both reads and immediately before the caller types anything.
+//
+// ONE freshness check, not two. An early cheap check plus a late authoritative one would be gate
+// redundancy: deleting the early one would change nothing observable, so no mutation could kill it,
+// and a gate no mutation can kill is decoration.
+//
+// The clock is a supervisionResumeClock rather than a sampled time.Time precisely so the last sample
+// happens HERE. A caller-sampled instant cannot express "after the slow reads" no matter where the
+// comparison sits.
+func evaluateSupervisionDeliveryTimeGates(
+	assessment GoalSupervisionAssessment,
+	now supervisionResumeClock,
+	readGeneration supervisionGenerationReader,
+	readPane supervisionPaneReader,
+) *supervisionResumeRefusal {
+	// GATE 2: LAUNCH GENERATION DRIFT, digest AND modtime.
+	//
+	// BOTH are compared because each catches what the other misses. A digest change means the content
+	// differs. A modtime change with an identical digest means the record was REWRITTEN with the same
+	// bytes -- which is a relaunch that happens to produce identical content, and the pane behind it
+	// may be entirely different. Comparing only the digest would silently accept that.
+	if readGeneration == nil {
+		return &supervisionResumeRefusal{
+			Clause:   "the same launch generation ... remains current",
+			Detail:   "no launch-generation reader was supplied, so generation drift cannot be checked",
+			Recovery: "this is a wiring fault: the delivery-time gates must be injected, because a missing check is not a passing check",
+		}
+	}
+	digest, modTime, err := readGeneration(assessment)
+	if err != nil {
+		// UNKNOWN IS A REFUSAL. A generation that cannot be read is not a generation that has not
+		// changed, and the whole point of this gate is that the record may have moved.
+		return &supervisionResumeRefusal{
+			Clause:   "the same launch generation ... remains current",
+			Detail:   "cannot re-read the launch generation immediately before delivery: " + err.Error(),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; inspect the launch record before any manual resume",
+		}
+	}
+	if digest != assessment.Binding.LaunchRecordDigest || modTime != assessment.Binding.LaunchRecordModTime {
+		return &supervisionResumeRefusal{
+			Clause: "the same launch generation ... remains current",
+			Detail: fmt.Sprintf(
+				"launch generation changed between reservation and delivery: bound digest %q modtime %d, now digest %q modtime %d",
+				assessment.Binding.LaunchRecordDigest, assessment.Binding.LaunchRecordModTime, digest, modTime),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; drift is a refusal, never a re-authorization of whatever the record now says",
+		}
+	}
+
+	// GATE 3: LIVE PANE REVALIDATION -- exact, managed, present, idle, nonzero PID.
+	//
+	// Every conjunct is load-bearing and each has its own failure mode:
+	//   - MANAGED: an unmanaged pane belongs to a human, and typing a resume into it is input
+	//     injection into somebody's terminal.
+	//   - FOUND by exact id: a pane matched by anything looser could be a different pane that
+	//     happens to fit, and the assessment's authority is over one exact pane.
+	//   - NONZERO PID: a pane can OUTLIVE its process. Existence proves a container, not a listener,
+	//     and bytes typed into a pane with no process are silently discarded -- a delivery that
+	//     reports success and did nothing.
+	//   - IDLE, and idle KNOWN: delivering into a busy pane interleaves with whatever is running.
+	//     Unknown busyness refuses separately, because a failed probe is not an idle pane.
+	if readPane == nil {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   "no pane reader was supplied, so the live pane cannot be revalidated",
+			Recovery: "this is a wiring fault: a missing pane check is not a passing pane check",
+		}
+	}
+	pane, err := readPane(assessment)
+	if err != nil {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   "cannot inspect the recorded pane immediately before delivery: " + err.Error(),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; inspect the pane before any manual resume",
+		}
+	}
+	// The reader must have looked at the pane the ASSESSMENT names. A reader that inspected a
+	// different pane would return facts about the wrong target, and those facts passing the gate is
+	// worse than the gate failing.
+	if want := assessment.Binding.Pane.PaneID; pane.PaneID != want {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   fmt.Sprintf("pane observation is for %q but the assessment binds pane %q", pane.PaneID, want),
+			Recovery: "this is a wiring fault: the observation does not describe the bound pane, so it proves nothing about it",
+		}
+	}
+	if !pane.Managed {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   fmt.Sprintf("pane %s is not managed at delivery time", pane.PaneID),
+			Recovery: "an unmanaged pane belongs to a human; the reservation is left unconsumed and no input is sent",
+		}
+	}
+	if !pane.Found {
+		return &supervisionResumeRefusal{
+			Clause: "the same ... pane identity ... remains current",
+			Detail: fmt.Sprintf("pane %s is not affirmatively present at delivery time (state %q)",
+				pane.PaneID, pane.State),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; a pane that is gone or unreadable cannot receive an audited resume",
+		}
+	}
+	if pane.PID <= 0 {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   fmt.Sprintf("pane %s has no live foreground process (pid %d)", pane.PaneID, pane.PID),
+			Recovery: "a pane can outlive its process; bytes sent to a paneless process are discarded, so this refuses rather than reporting a delivery that did nothing",
+		}
+	}
+	if !pane.IdleKnown {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   fmt.Sprintf("pane %s busy state is UNKNOWN at delivery time", pane.PaneID),
+			Recovery: "unknown busyness is not idleness; the reservation is left unconsumed and must be inspected",
+		}
+	}
+	if !pane.Idle {
+		return &supervisionResumeRefusal{
+			Clause:   "the same ... pane identity ... remains current",
+			Detail:   fmt.Sprintf("pane %s is BUSY at delivery time", pane.PaneID),
+			Recovery: "delivering into a busy pane interleaves with whatever is running; re-run the sweep once the pane is idle",
+		}
+	}
+
+	// GATE 3 (LAST): DELIVERY-TIME WALL CLOCK, sampled after every read above.
+	//
+	// U4 requires a SECOND FreshUntil check, and this is the last point before the caller types. The
+	// pre-mutation clock gate ran before reserve/bind/rescan; this one runs after those AND after the
+	// generation and pane reads, which is the only placement that makes "immediately before pane
+	// input" true.
+	//
+	// THE BOUNDARY IS !Before, NOT After, and matching it matters more than which one is right. The
+	// pre-mutation gate at goal_supervision_gates.go:240 uses !now().Before(FreshUntil), so exact
+	// equality is EXPIRED there. My After() treated the same instant as fresh, which means the two
+	// gates disagreed about one field at one value -- two deciders for one definition, the defect this
+	// milestone keeps producing. Consistency here is not stylistic: a dry-run predicting refusal while
+	// the delivering path proceeds is exactly the divergence the shared evaluator exists to prevent.
+	if sampled := now(); !assessment.FreshUntil.IsZero() && !sampled.Before(assessment.FreshUntil) {
+		return &supervisionResumeRefusal{
+			Clause: "the assessment remains fresh at the moment of delivery",
+			Detail: fmt.Sprintf(
+				"assessment expired before pane input: FreshUntil %s, now %s",
+				assessment.FreshUntil.UTC().Format(time.RFC3339Nano),
+				sampled.UTC().Format(time.RFC3339Nano)),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; re-run the sweep for a fresh assessment rather than delivering on an expired one",
+		}
+	}
+	return nil
+}
+
+// newSupervisionGenerationReader is the PRODUCTION generation reader. It consumes the SAME canonical
+// snapshot function the assessment used (readGoalSupervisionLaunchSnapshot), so the two sides of the
+// comparison are produced by one derivation owner. If this read used a different mechanism, a
+// mismatch could mean "the generation changed" OR "the two readers disagree", and a gate that cannot
+// tell those apart is a coin flip wearing a refusal message.
+func newSupervisionGenerationReader() supervisionGenerationReader {
+	return func(assessment GoalSupervisionAssessment) (string, int64, error) {
+		agentDir, err := agentDirForSupervisionResume(assessment)
+		if err != nil {
+			return "", 0, err
+		}
+		_, digest, modTime, err := readGoalSupervisionLaunchSnapshot(agentDir)
+		if err != nil {
+			return "", 0, err
+		}
+		return digest, modTime, nil
+	}
+}
+
+// newSupervisionPaneReader is the PRODUCTION pane reader, built on the exact-id inspection rather
+// than the global pane scan. InspectPaneExactByID reports Gone only from affirmative exact-id
+// evidence and stays Unavailable for generic failures, which is the distinction this gate needs: an
+// unreadable pane and an absent pane are both refusals here, but they are not the same refusal, and
+// the state is carried through so the message can say which.
+//
+// Managed is taken from the ASSESSMENT, not re-derived: whether a pane is supervisor-managed is a
+// fact about how it was launched, which the binding already owns. Re-deciding it here would make
+// this a second owner of that classification.
+func newSupervisionPaneReader() supervisionPaneReader {
+	return func(assessment GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+		paneID := assessment.Binding.Pane.PaneID
+		observation := supervisionPaneObservation{
+			PaneID:  paneID,
+			Managed: assessment.Binding.Pane.Managed,
+		}
+		inspection := tmuxpane.InspectPaneExactByID(paneID)
+		observation.State = string(inspection.State)
+		if inspection.State == tmuxpane.PaneInspectionFound {
+			observation.Found = true
+			observation.PID = inspection.Pane.PID
+		}
+		// BUSY IS PROBED LIVE, not read from the assessment's BusyKnown/Busy. Those were observed
+		// during the sweep, and busyness is the single most volatile fact here -- a pane idle at
+		// assessment time is routinely busy by delivery time, which is precisely the race this gate
+		// exists to catch. Reusing the stale value would make the gate agree with itself.
+		if observation.Found {
+			busy, err := tmuxpane.PaneBusy(paneID)
+			if err == nil {
+				observation.IdleKnown = true
+				observation.Idle = !busy
+			}
+			// A probe error leaves IdleKnown false, which the gate refuses on with its own stated
+			// reason. The error is deliberately NOT returned: returning it would collapse "cannot
+			// determine busyness" into "cannot inspect the pane at all", and those refusals send an
+			// operator to different places.
+		}
+		return observation, nil
+	}
+}

--- a/internal/cli/goal_supervision_delivery_gates_test.go
+++ b/internal/cli/goal_supervision_delivery_gates_test.go
@@ -1,0 +1,413 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #498 U5: FALSIFIERS FOR THE THREE DELIVERY-TIME GATES.
+//
+// Each row supplies an input that is valid in EVERY dimension except the one under test. That is the
+// r9 lesson applied: a row that is invalid in two dimensions cannot tell you which gate refused, so
+// deleting the gate it names may change nothing and the row still passes.
+//
+// Every row also asserts NO DELIVERY OCCURRED. A refusal that still delivered would be the worst
+// possible outcome here, and a row checking only the error text would not notice.
+
+// wantFreshnessDetail is the fragment every delivery-time freshness assertion expects.
+//
+// IT EXISTS BECAUSE ITS ABSENCE COST A WINDOW. Two rows asserted this same refusal with two different
+// expected wordings: when I renamed the detail from "expired during ledger work" to "expired before
+// pane input" (accurate once the sample moved after the reads), I updated the code and the new row and
+// left the older row asserting a string that no longer existed. It failed in the integration window --
+// while the gate underneath it worked perfectly.
+//
+// HAND-WRITTEN, AND DELIBERATELY NOT REFERENCING THE PRODUCTION FORMAT STRING. A constant sourced from
+// production would let expectation and implementation drift together in silence, which is the co-drift
+// trap the gate-order literal avoids for the same reason. Shared among the TESTS only, a production
+// wording change now fails every row that depends on it, loudly and together -- which is what I wanted
+// the first time and did not build.
+const wantFreshnessDetail = "expired before pane input"
+
+// The three refusal CLAUSES, hand-written for the same reason as the detail fragment above: imported
+// from production they would drift together in silence. A clause identifies WHICH #498 contract gate
+// refused, so asserting it catches MISCLASSIFICATION -- a refusal that is correct about refusing and
+// wrong about why, which reads as a pass to any test that only checks that an error occurred.
+//
+// CLAUSE AND DETAIL ARE NOT REDUNDANT, and I checked this against the rule that a gate no mutation can
+// kill is decoration. They are two properties of one refusal with two INDEPENDENT falsifiers: mutate
+// the clause mapping and the identity assertion fails while the detail still matches; garble the detail
+// and the fragment fails while the clause still matches. Two assertions each killable by a distinct
+// mutation are coverage, not decoration.
+const (
+	wantFreshnessClause  = "the assessment remains fresh at the moment of delivery"
+	wantGenerationClause = "the same launch generation ... remains current"
+	wantPaneClause       = "the same ... pane identity ... remains current"
+)
+
+// passingGenerationReader echoes the fixture's OWN bound generation back, so the drift gate passes.
+// It deliberately reads from the assessment rather than returning constants: constants would drift
+// from the fixture silently, and a reader whose "no drift" answer is wrong makes every OTHER row's
+// green meaningless.
+func passingGenerationReader(a GoalSupervisionAssessment) supervisionGenerationReader {
+	return func(GoalSupervisionAssessment) (string, int64, error) {
+		return a.Binding.LaunchRecordDigest, a.Binding.LaunchRecordModTime, nil
+	}
+}
+
+// passingPaneReader reports the fixture's own pane as managed, present, idle, with a live PID.
+func passingPaneReader(a GoalSupervisionAssessment) supervisionPaneReader {
+	// Built from passingObservation so there is exactly ONE definition of "a healthy pane". Two
+	// identical literals are two owners of one fact, and the rows below mutate a COPY of this one --
+	// if the reader's version drifted, every row would fail for a reason unrelated to its own gate.
+	return func(GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+		return passingObservation(a), nil
+	}
+}
+
+// deliveryGateRefusal drives the executor with one deliberately-broken reader and returns the refusal
+// plus how many deliveries occurred. Sharing this makes every row below differ ONLY in the dimension
+// it breaks, which is what makes each row attributable to one gate.
+func deliveryGateRefusal(
+	t *testing.T,
+	clock supervisionResumeClock,
+	readGeneration supervisionGenerationReader,
+	readPane supervisionPaneReader,
+) (int, error) {
+	t.Helper()
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+	if clock == nil {
+		clock = func() time.Time { return now }
+	}
+	if readGeneration == nil {
+		readGeneration = passingGenerationReader(assessment)
+	}
+	if readPane == nil {
+		readPane = passingPaneReader(assessment)
+	}
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	delivered := 0
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		clock, loader, readGeneration, readPane,
+		readReservedRecoveryTransition,
+		func(string) error { delivered++; return nil })
+	if outcome.Delivered {
+		t.Error("outcome reports Delivered=true for a refused delivery")
+	}
+	return delivered, err
+}
+
+func requireDeliveryGateRefusal(t *testing.T, delivered int, err error, wantClause, wantDetail string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected a refusal with clause %q mentioning %q, got nil", wantClause, wantDetail)
+	}
+	if delivered != 0 {
+		t.Errorf("delivered %d times despite a refusal; a gate that refuses AFTER delivering has "+
+			"already caused the harm it exists to prevent", delivered)
+	}
+	var refusal supervisionResumeRefusal
+	if !errors.As(err, &refusal) {
+		t.Fatalf("refusal must be the typed supervisionResumeRefusal, got %T: %v", err, err)
+	}
+	// IDENTITY FIRST, by EXACT equality rather than substring. Which gate refused is a machine-facing
+	// fact, and a substring could match another clause's text -- the same existence-for-identity
+	// substitution that produced the arbitrary-payload hole earlier in this PR.
+	if refusal.Clause != wantClause {
+		t.Errorf("refusal clause = %q, want exactly %q -- a refusal that is right to refuse and wrong "+
+			"about WHICH contract clause it enforces is a misclassification, and it reads as a pass to "+
+			"any assertion that only checks an error occurred", refusal.Clause, wantClause)
+	}
+	if !strings.Contains(refusal.Detail, wantDetail) {
+		t.Errorf("refusal detail = %q, want it to contain %q -- a refusal that does not name its "+
+			"cause sends an operator to the wrong place", refusal.Detail, wantDetail)
+	}
+}
+
+// GATE 1 FALSIFIER: the assessment expires DURING the ledger work.
+//
+// THE ISOLATION PROBLEM, and it is the reason this row needs a stepping clock rather than a constant
+// expired time. A constantly-expired clock is refused by the PRE-MUTATION wall-clock gate, which runs
+// first; the delivery-time gate would never execute, and deleting it would leave this row green. That
+// is gate redundancy defeating the falsifier -- the same trap the policy row hit.
+//
+// So the clock reports FRESH until the reservation exists on disk, then EXPIRED. That is not a trick
+// to dodge a gate: it is exactly the real scenario U4 names, where reserve/bind/rescan consume enough
+// wall time for a fresh assessment to expire before the bytes are typed. Keying on the artifact rather
+// than a call count also survives refactoring, whereas "expire on the 4th now() call" would silently
+// stop isolating the moment anyone adds a clock read.
+func TestAnAssessmentThatExpiresDuringLedgerWorkIsRefusedAtDeliveryTime(t *testing.T) {
+	assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+	expired := assessment.FreshUntil.Add(time.Minute)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	clock := func() time.Time {
+		if _, err := os.Stat(reservation); err == nil {
+			return expired
+		}
+		return now
+	}
+	delivered := 0
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		clock, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error { delivered++; return nil })
+
+	if outcome.Delivered || delivered != 0 {
+		t.Errorf("delivered=%d Delivered=%t; an assessment that expired before input must not be "+
+			"delivered, because the contract already declared that observation too old to act on",
+			delivered, outcome.Delivered)
+	}
+	requireDeliveryGateRefusal(t, delivered, err, wantFreshnessClause, wantFreshnessDetail)
+	// PROOF OF ISOLATION: the reservation must EXIST. If it does not, the run was refused before
+	// reserve, which means the pre-mutation gate caught it and this row proved nothing about the
+	// delivery-time gate it claims to test.
+	if _, statErr := os.Stat(reservation); statErr != nil {
+		t.Error("no reservation exists, so the refusal happened BEFORE reserve -- this row did not " +
+			"reach the delivery-time clock gate and its green would be meaningless")
+	}
+}
+
+// GATE 2 FALSIFIERS: generation drift, one row per compared component.
+//
+// TWO ROWS, not one. Comparing only the digest would leave the modtime comparison untested, and an
+// untested half of a conjunction is where the omitempty defect lived earlier in this PR. The
+// same-digest-different-modtime case is the one a digest-only gate silently accepts: a relaunch that
+// reproduces identical bytes, behind which the pane may be a different process entirely.
+func TestLaunchGenerationDigestDriftIsRefusedAtDeliveryTime(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil,
+		func(a GoalSupervisionAssessment) (string, int64, error) {
+			return "a-different-digest", a.Binding.LaunchRecordModTime, nil
+		}, nil)
+	requireDeliveryGateRefusal(t, delivered, err, wantGenerationClause, "launch generation changed")
+}
+
+func TestLaunchGenerationModTimeDriftIsRefusedEvenWithAnIdenticalDigest(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil,
+		func(a GoalSupervisionAssessment) (string, int64, error) {
+			// IDENTICAL digest, different modtime. A digest-only comparison passes this.
+			return a.Binding.LaunchRecordDigest, a.Binding.LaunchRecordModTime + 1, nil
+		}, nil)
+	requireDeliveryGateRefusal(t, delivered, err, wantGenerationClause, "launch generation changed")
+}
+
+// An UNREADABLE generation must refuse. Unknown is not unchanged, and this gate exists precisely
+// because the record may have moved.
+func TestAnUnreadableLaunchGenerationIsRefusedRatherThanAssumedUnchanged(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil,
+		func(GoalSupervisionAssessment) (string, int64, error) {
+			return "", 0, errors.New("launch record vanished")
+		}, nil)
+	requireDeliveryGateRefusal(t, delivered, err, wantGenerationClause, "cannot re-read the launch generation")
+}
+
+// GATE 3 FALSIFIERS: one row per pane conjunct, each valid in every other dimension.
+func TestUnmanagedPaneIsRefusedAtDeliveryTime(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.Managed = false
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "is not managed at delivery time")
+}
+
+func TestAPaneThatIsNotAffirmativelyPresentIsRefused(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.Found = false
+			o.State = "unavailable"
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "not affirmatively present")
+}
+
+// THE PANE-OUTLIVES-ITS-PROCESS ROW. A pane-exists check passes this input; bytes typed into a pane
+// with no live process are silently discarded, which is a delivery that reports success and did
+// nothing. That is why PID is a separate conjunct rather than folded into presence.
+func TestAPresentPaneWithNoLiveProcessIsRefused(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.PID = 0
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "no live foreground process")
+}
+
+// UNKNOWN busyness and BUSY are separate rows with separate messages. Collapsing them would report a
+// busy pane when the truth is a failed probe, sending an operator to wait for a pane that is idle.
+func TestUnknownPaneBusynessIsRefusedSeparatelyFromBusy(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.IdleKnown = false
+			o.Idle = false
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "busy state is UNKNOWN")
+}
+
+func TestABusyPaneIsRefusedAtDeliveryTime(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.IdleKnown = true
+			o.Idle = false
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "is BUSY at delivery time")
+}
+
+// A reader that inspected the WRONG pane must refuse. Its facts may all look healthy; they are simply
+// about something else, and healthy facts about the wrong target passing a gate is worse than the
+// gate failing.
+func TestAnObservationForADifferentPaneIsRefused(t *testing.T) {
+	delivered, err := deliveryGateRefusal(t, nil, nil,
+		func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+			o := passingObservation(a)
+			o.PaneID = "%999"
+			return o, nil
+		})
+	requireDeliveryGateRefusal(t, delivered, err, wantPaneClause, "but the assessment binds pane")
+}
+
+// NIL READERS REFUSE. A missing check is not a passing check, and these are authorization seams: if a
+// nil reader skipped, deleting the injection at the call site would silently disable the gate while
+// every test that supplies a reader stayed green.
+func TestNilDeliveryTimeReadersRefuseRatherThanSkip(t *testing.T) {
+	assessment, _, _, _, now := u6DeliveringFixture(t)
+
+	if refusal := evaluateSupervisionDeliveryTimeGates(assessment, func() time.Time { return now }, nil, passingPaneReader(assessment)); refusal == nil {
+		t.Error("a nil generation reader must REFUSE; skipping would make an absent check " +
+			"indistinguishable from a passing one")
+	} else if refusal.Clause != wantGenerationClause || !strings.Contains(refusal.Detail, "no launch-generation reader") {
+		t.Errorf("nil generation reader refusal must carry clause %q and name the wiring fault; got clause %q detail %q",
+			wantGenerationClause, refusal.Clause, refusal.Detail)
+	}
+	if refusal := evaluateSupervisionDeliveryTimeGates(assessment, func() time.Time { return now }, passingGenerationReader(assessment), nil); refusal == nil {
+		t.Error("a nil pane reader must REFUSE")
+	} else if refusal.Clause != wantPaneClause || !strings.Contains(refusal.Detail, "no pane reader") {
+		t.Errorf("nil pane reader refusal must carry clause %q and name the wiring fault; got clause %q detail %q",
+			wantPaneClause, refusal.Clause, refusal.Detail)
+	}
+}
+
+// THE ALL-VALID CONTROL. Without it, every row above could be passing because the fixture refuses for
+// some unrelated reason, and the suite would look thorough while proving nothing.
+func TestAllDeliveryTimeGatesPassForAValidObservation(t *testing.T) {
+	assessment, _, _, _, now := u6DeliveringFixture(t)
+	if refusal := evaluateSupervisionDeliveryTimeGates(assessment, func() time.Time { return now },
+		passingGenerationReader(assessment), passingPaneReader(assessment)); refusal != nil {
+		t.Fatalf("the all-valid delivery-time fixture must pass every gate; refused with: %s", refusal.Detail)
+	}
+}
+
+func passingObservation(a GoalSupervisionAssessment) supervisionPaneObservation {
+	return supervisionPaneObservation{
+		PaneID:    a.Binding.Pane.PaneID,
+		Managed:   true,
+		Found:     true,
+		State:     "found",
+		PID:       4242,
+		IdleKnown: true,
+		Idle:      true,
+	}
+}
+
+// GATE 3 FALSIFIER, dev-2's finding: the assessment is FRESH at evaluator entry and expires DURING the
+// generation/pane reads.
+//
+// WHY THE EARLIER ROW DID NOT COVER THIS, which is the part worth keeping. The artifact-keyed row makes
+// the clock return expired as soon as the reservation exists, so with freshness checked FIRST it
+// refused at evaluator entry. It therefore proved that an already-expired assessment is refused -- and
+// said nothing about one that expires between entry and input. My gate order made that gap invisible:
+// a check placed before the two slowest reads cannot observe time passing during them.
+//
+// THE FALSIFYING INPUT advances the clock from INSIDE a reader. That is exactly the real scenario --
+// the pane read performs bounded tmux retries and can take real time -- and it is only catchable if
+// the freshness sample happens after the readers. Move the sample back before them, or delete it, and
+// this row fails.
+func TestAnAssessmentExpiringDuringTheDeliveryTimeReadsIsRefused(t *testing.T) {
+	assessment, action, payload, _, base := u6DeliveringFixture(t)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	// The clock is FRESH until a reader advances it. Nothing before the readers can see the expiry.
+	current := base
+	expiredAtEntry := false
+	clock := func() time.Time { return current }
+	readGeneration := func(a GoalSupervisionAssessment) (string, int64, error) {
+		// Record whether the assessment was already expired when the reads began. If it was, this row
+		// is not testing what it claims -- it would have degenerated into the earlier row.
+		expiredAtEntry = !current.Before(a.FreshUntil)
+		return a.Binding.LaunchRecordDigest, a.Binding.LaunchRecordModTime, nil
+	}
+	readPane := func(a GoalSupervisionAssessment) (supervisionPaneObservation, error) {
+		// TIME PASSES HERE, standing in for the bounded tmux retries a real pane read performs.
+		current = a.FreshUntil.Add(time.Second)
+		return passingObservation(a), nil
+	}
+
+	delivered := 0
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		clock, loader, readGeneration, readPane,
+		readReservedRecoveryTransition,
+		func(string) error { delivered++; return nil })
+
+	if expiredAtEntry {
+		t.Fatal("the assessment was already expired when the delivery-time reads began, so this row " +
+			"degenerated into the already-expired case and proves nothing about expiry DURING the reads")
+	}
+	if delivered != 0 || outcome.Delivered {
+		t.Errorf("delivered=%d Delivered=%t; an assessment that expired during the delivery-time reads "+
+			"must not reach the pane", delivered, outcome.Delivered)
+	}
+	requireDeliveryGateRefusal(t, delivered, err, wantFreshnessClause, wantFreshnessDetail)
+}
+
+// THE BOUNDARY ROW. At EXACT equality with FreshUntil the assessment is EXPIRED, because the
+// pre-mutation gate defines it that way with !now().Before(FreshUntil). Two gates reading one field
+// must not disagree at any value; my first version used After(), which called this instant fresh.
+func TestExactFreshUntilEqualityIsExpiredAtDeliveryTime(t *testing.T) {
+	assessment, _, _, _, _ := u6DeliveringFixture(t)
+	atBoundary := assessment.FreshUntil
+	refusal := evaluateSupervisionDeliveryTimeGates(assessment, func() time.Time { return atBoundary },
+		passingGenerationReader(assessment), passingPaneReader(assessment))
+	if refusal == nil {
+		t.Fatal("an instant exactly equal to FreshUntil must be EXPIRED here, matching " +
+			"goal_supervision_gates.go's !now().Before(FreshUntil); treating it as fresh makes the " +
+			"dry-run and the delivering path disagree at that instant")
+	}
+	// CLAUSE AND DETAIL, same as the helper enforces. Without the clause this row would pass if the
+	// boundary instant were refused by a DIFFERENT gate that happened to mention the same fragment.
+	if refusal.Clause != wantFreshnessClause {
+		t.Errorf("boundary refusal clause = %q, want exactly %q", refusal.Clause, wantFreshnessClause)
+	}
+	if !strings.Contains(refusal.Detail, wantFreshnessDetail) {
+		t.Errorf("boundary refusal must be the freshness one, got %q", refusal.Detail)
+	}
+}

--- a/internal/cli/goal_supervision_gates.go
+++ b/internal/cli/goal_supervision_gates.go
@@ -1,0 +1,346 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PR5 / #498 F5: ONE pre-mutation gate evaluator, consumed by BOTH the executor and --dry-run.
+//
+// WHY THIS IS ONE FUNCTION AND NOT TWO. The dry-run's entire purpose is to PREDICT the executor. If
+// it evaluated its own copy of the gates, the two would drift, and the drift would be invisible
+// precisely where it matters most: a dry-run reporting "would deliver" while the real path refuses,
+// or worse, reporting a refusal the real path does not make. That is the two-deciders defect in the
+// one place whose whole job is agreement. So there is one evaluator, one gate list, one set of
+// verdicts, and the dry-run is nothing more than "run it and print instead of act".
+//
+// EVERY GATE HERE IS READ-ONLY. No reservation, no bind, no consume, no directive, no pane input.
+// That is what makes the dry-run genuinely side-effect-free rather than side-effect-free by
+// convention -- the property is structural, because the evaluator has nothing that writes.
+//
+// THE DELIVERY-TIME GATES ARE DELIBERATELY NOT HERE, and that absence is reported rather than
+// hidden: the payload-drift recheck, the launch-generation comparison, and the live pane
+// revalidation all require the world AT DELIVERY TIME, after a reservation exists. A dry-run cannot
+// evaluate them without reserving, so it names them as NOT EVALUATED instead of implying a verdict
+// it did not reach.
+
+type supervisionGateName string
+
+const (
+	gateWiring             supervisionGateName = "wiring"
+	gateSupervisorID       supervisionGateName = "supervisor-identity"
+	gateActionCanonical    supervisionGateName = "action-canonical-metadata"
+	gateActionBinding      supervisionGateName = "action-identity-binding"
+	gatePayloadAuthorized  supervisionGateName = "payload-authorization"
+	gateAssessmentFresh    supervisionGateName = "assessment-fresh"
+	gateWallClock          supervisionGateName = "wall-clock-freshness"
+	gateAssessmentEligible supervisionGateName = "assessment-eligible"
+	gateOperatorPolicy     supervisionGateName = "operator-policy"
+	gateDeliverableNoConf  supervisionGateName = "delivering-path-needs-no-confirmation"
+	gateClaimOnce          supervisionGateName = "claim-once-ledger"
+)
+
+// supervisionDeliveryTimeGates are the gates a dry-run CANNOT evaluate, listed so its report can say
+// so explicitly. Naming them is the difference between "these passed" and "these were not checked".
+var supervisionDeliveryTimeGates = []string{
+	"payload-drift (re-read the goal binding immediately before input)",
+	"launch-generation drift (digest and modtime against the bound generation)",
+	"live pane revalidation (exact managed, alive, idle pane with a nonzero PID)",
+	// U4 requires a SECOND wall-clock FreshUntil check after reserve/bind/rescan and immediately
+	// before pane input. The pre-mutation clock gate above does not satisfy it: time passes during the
+	// ledger work, so an assessment fresh at evaluation can expire before the bytes are typed.
+	"delivery-time wall-clock freshness (FreshUntil re-checked immediately before pane input)",
+}
+
+type supervisionGateResult struct {
+	Name     supervisionGateName `json:"gate"`
+	Passed   bool                `json:"passed"`
+	Clause   string              `json:"clause,omitempty"`
+	Detail   string              `json:"detail,omitempty"`
+	Recovery string              `json:"recovery,omitempty"`
+}
+
+// supervisionPreMutationEvaluation is the whole verdict. Payload is populated ONLY when every gate
+// passed: a partially-validated payload must not be reachable, because the next reader would have no
+// way to know which validations it survived.
+type supervisionPreMutationEvaluation struct {
+	Results []supervisionGateResult `json:"gates"`
+	Payload string                  `json:"-"`
+
+	// AuthorizedDigest is the digest that PASSED the pre-reserve equalities -- the exact suppliedDigest
+	// the loader returned, having been checked against the payload bytes, the binding's CommandDigest,
+	// and the action's CommandDigest.
+	//
+	// IT EXISTS TO BE A TEMPORAL BASELINE, and that is why it must be carried rather than recomputed.
+	// The delivery-time drift gate asks "is the binding still what it was when I authorized it", which
+	// is a question about TWO MOMENTS. Recomputing a digest after the reserve -- or deriving one from
+	// the re-read, or substituting the action's or binding's value -- would compare the present against
+	// the present and always agree. That is not a weaker check, it is a tautology wearing a check's
+	// shape, and it would silently delete the drift protection entirely.
+	//
+	// My F5 extraction lost this by returning Payload alone, which is how the drift gate ended up
+	// referencing an out-of-scope local. The compiler caught it; a recomputing "fix" would have
+	// compiled cleanly and been wrong.
+	AuthorizedDigest string `json:"-"`
+
+	ClaimKey  string `json:"claim_key,omitempty"`
+	Dir       string `json:"-"`
+	LegacyKey string `json:"-"`
+}
+
+// firstFailure returns the gate that refused, or nil. Order matters and is the contract: gates are
+// evaluated in the order a caller would want them diagnosed, so a wiring fault is never reported as
+// a policy problem.
+func (e supervisionPreMutationEvaluation) firstFailure() *supervisionGateResult {
+	for i := range e.Results {
+		if !e.Results[i].Passed {
+			return &e.Results[i]
+		}
+	}
+	return nil
+}
+
+func (e supervisionPreMutationEvaluation) allPassed() bool { return e.firstFailure() == nil }
+
+// refusal converts the failed gate into the executor's refusal type, so the executor and the dry-run
+// report the SAME clause, detail and recovery for the same condition. Two renderings of one verdict
+// is a smaller version of two deciders.
+func (e supervisionPreMutationEvaluation) refusal() error {
+	f := e.firstFailure()
+	if f == nil {
+		return nil
+	}
+	return supervisionResumeRefusal{Clause: f.Clause, Detail: f.Detail, Recovery: f.Recovery}
+}
+
+// evaluateSupervisionPreMutationGates runs every read-only gate and STOPS AT THE FIRST FAILURE.
+//
+// Short-circuiting is deliberate rather than an optimisation: later gates read inputs earlier gates
+// validate, so evaluating past a failure would either produce cascading noise or, worse, execute a
+// read against inputs already known to be untrustworthy.
+func evaluateSupervisionPreMutationGates(
+	assessment GoalSupervisionAssessment,
+	action GoalSupervisionAction,
+	supervisor string,
+	now supervisionResumeClock,
+	loadPayload supervisionResumePayloadLoader,
+	scan func(dir, claimKey, legacyKey string) (pauseLedgerScan, error),
+) supervisionPreMutationEvaluation {
+	var out supervisionPreMutationEvaluation
+	pass := func(n supervisionGateName) {
+		out.Results = append(out.Results, supervisionGateResult{Name: n, Passed: true})
+	}
+	fail := func(n supervisionGateName, clause, detail, recovery string) supervisionPreMutationEvaluation {
+		out.Results = append(out.Results, supervisionGateResult{
+			Name: n, Passed: false, Clause: clause, Detail: detail, Recovery: recovery,
+		})
+		return out
+	}
+
+	// WIRING first: a nil seam is a programming fault in the caller, and diagnosing it as anything
+	// else sends the wrong person to the wrong place.
+	if now == nil {
+		return fail(gateWiring, "the executor requires an explicit time source",
+			"no clock supplied", "this is a wiring bug, not an operator condition")
+	}
+	if loadPayload == nil {
+		return fail(gateWiring, "the executor requires a payload loader",
+			"no payload loader supplied", "this is a wiring bug; bytes that cannot be authorized are never delivered")
+	}
+	if scan == nil {
+		return fail(gateWiring, "the executor requires a ledger scanner",
+			"no ledger scanner supplied", "this is a wiring bug; an unscanned ledger is never treated as vacant")
+	}
+	pass(gateWiring)
+
+	if strings.TrimSpace(supervisor) == "" {
+		return fail(gateSupervisorID, "supervisor identity is explicit, nonblank, and never inferred",
+			"no supervisor identity supplied",
+			"supply the supervising actor; it is persisted in the claim and is not derivable from the lead")
+	}
+	if strings.TrimSpace(supervisor) == supervisorIdentityPlaceholder {
+		return fail(gateSupervisorID, "the placeholder is not an identity and is never persisted as one",
+			fmt.Sprintf("supervisor identity is still the literal placeholder %s", supervisorIdentityPlaceholder),
+			"supply the real supervising actor; a claim recording the placeholder cannot answer who authorised it")
+	}
+	pass(gateSupervisorID)
+
+	// CANONICAL METADATA, derived ONCE from the assessment. One field per check so a single-field
+	// mutation fails a NAMED gate rather than a compound one.
+	expected := action.canonicalExpectationFrom(assessment)
+	if detail := action.canonicalMismatch(expected, assessment); detail != "" {
+		return fail(gateActionCanonical, "the invoked action must be the canonical resume action this assessment published",
+			detail, "re-read the assessment and invoke its published resume action verbatim")
+	}
+	pass(gateActionCanonical)
+
+	if strings.TrimSpace(action.Fingerprint) != strings.TrimSpace(assessment.Fingerprint) {
+		return fail(gateActionBinding, "the invoked action must be the one this assessment authorised",
+			fmt.Sprintf("action fingerprint %q does not match assessment fingerprint %q", action.Fingerprint, assessment.Fingerprint),
+			"re-read the assessment; a stale action is never delivered")
+	}
+	if strings.TrimSpace(action.AttemptID) != strings.TrimSpace(assessment.Binding.Goal.AttemptID) {
+		return fail(gateActionBinding, "the invoked action must target the attempt this assessment is about",
+			fmt.Sprintf("action attempt %q does not match assessment attempt %q", action.AttemptID, assessment.Binding.Goal.AttemptID),
+			"re-read the assessment; delivering to a different attempt is a wrong-target delivery")
+	}
+	pass(gateActionBinding)
+
+	// PAYLOAD AUTHORIZATION. Four independent equalities; see the executor for why independence
+	// matters and why they are not collapsed.
+	payload, suppliedDigest, payloadErr := loadPayload(assessment)
+	switch {
+	case payloadErr != nil:
+		return fail(gatePayloadAuthorized, "the delivered payload is the assessment-authorized native resume payload",
+			"cannot load the native resume payload: "+payloadErr.Error(),
+			"inspect the goal binding; an unreadable payload is never delivered and nothing was reserved")
+	case strings.TrimSpace(payload) == "":
+		return fail(gatePayloadAuthorized, "the delivered payload is the assessment-authorized native resume payload",
+			"the native resume payload is empty",
+			"inspect the goal binding; delivering nothing would consume the claim without resuming anything")
+	case digestGoalSupervisionString(payload) != strings.TrimSpace(suppliedDigest):
+		return fail(gatePayloadAuthorized, "the payload bytes must match the digest that accompanies them",
+			fmt.Sprintf("payload digest %q does not describe the supplied bytes (their digest is %q)",
+				suppliedDigest, digestGoalSupervisionString(payload)),
+			"bytes and digest disagree; this is corruption or substitution, not a retryable condition")
+	case strings.TrimSpace(suppliedDigest) == "" ||
+		strings.TrimSpace(suppliedDigest) != strings.TrimSpace(assessment.Binding.Goal.CommandDigest):
+		// RESTORED. My refactor dropped this and left the comment claiming four equalities over three
+		// -- transitively implied, and I had argued against exactly that reasoning when I added the
+		// direct payload<->action check. Reintroducing transitivity in a refactor of the fix that
+		// removed it is worth naming: a consolidation is a place where assertions quietly merge, and
+		// "the comment says four" was the only surviving evidence that one had gone.
+		return fail(gatePayloadAuthorized, "the loaded payload's digest must be the one the binding authorizes",
+			fmt.Sprintf("loaded payload digest %q does not match the assessment's bound digest %q",
+				suppliedDigest, assessment.Binding.Goal.CommandDigest),
+			"the loader returned a payload the durable binding does not authorize; nothing was reserved")
+	case strings.TrimSpace(action.CommandDigest) == "" ||
+		strings.TrimSpace(action.CommandDigest) != strings.TrimSpace(assessment.Binding.Goal.CommandDigest):
+		return fail(gatePayloadAuthorized, "the delivered payload is the assessment-authorized native resume payload",
+			fmt.Sprintf("action command digest %q does not match the assessment's bound digest %q",
+				action.CommandDigest, assessment.Binding.Goal.CommandDigest),
+			"re-read the assessment; a payload the binding does not authorize is never delivered")
+	case digestGoalSupervisionString(payload) != strings.TrimSpace(action.CommandDigest):
+		return fail(gatePayloadAuthorized, "the payload bytes must be the ones the invoked action authorizes",
+			fmt.Sprintf("digest of the loaded payload %q does not match the action's authorized digest %q",
+				digestGoalSupervisionString(payload), action.CommandDigest),
+			"the action and the payload describe different bytes; nothing was reserved")
+	}
+	pass(gatePayloadAuthorized)
+
+	if !assessment.Fresh {
+		return fail(gateAssessmentFresh, "one fresh assessment",
+			fmt.Sprintf("assessment observed at %s is no longer fresh (valid until %s)", assessment.ObservedAt, assessment.FreshUntil),
+			"re-run the supervision sweep; a stale assessment is never delivered from")
+	}
+	pass(gateAssessmentFresh)
+
+	// WALL CLOCK. assessment.Fresh is a static bool from when the assessment was BUILT; freshness must
+	// hold at the moment of delivery, and only a clock read can express that.
+	if !assessment.FreshUntil.IsZero() && !now().Before(assessment.FreshUntil) {
+		return fail(gateWallClock, "one fresh assessment",
+			fmt.Sprintf("assessment expired at %s and it is now %s", assessment.FreshUntil, now()),
+			"re-run the supervision sweep; delivering from an expired observation is the stale-evidence action #498 forbids")
+	}
+	pass(gateWallClock)
+
+	// ELIGIBILITY IS ITS OWN GATE AND ITS OWN DIAGNOSIS. I collapsed this into the policy gate on the
+	// grounds that AutomaticResumeAllowed == Eligible && safe_auto, so a policy refusal "covered" it.
+	// It does not: an actor with contradictory or unknown evidence would be reported as an
+	// OPERATOR-POLICY refusal, sending the operator to inspect their policy configuration when the
+	// real problem is the evidence. A lossy substitute for a gate is not the gate.
+	// It also contradicted this file's own header, which states assessment.Eligible is AUTHORITATIVE.
+	//
+	// CONSUMED, never re-derived: the assessment owns the eligibility conjunction and this reports its
+	// deterministic reasons rather than forming a second opinion.
+	if !assessment.Eligible {
+		return fail(gateAssessmentEligible,
+			"unknown or contradictory evidence is ineligible, not a best-effort resume",
+			"assessment reports ineligible: "+firstFailedGoalSupervisionReason(assessment.Reasons),
+			assessment.Actions.Inspect.Command)
+	}
+	pass(gateAssessmentEligible)
+
+	if !assessment.AutomaticResumeAllowed {
+		return fail(gateOperatorPolicy, "operator policy: automatic resume permitted",
+			fmt.Sprintf("policy mode %s does not permit automatic native resume", assessment.Policy.Mode),
+			assessment.Actions.Inspect.Command)
+	}
+	pass(gateOperatorPolicy)
+
+	if action.NeedsConfirmation {
+		return fail(gateDeliverableNoConf, "the delivering path requires an action that needs no confirmation",
+			"the resume action requires confirmation, so this profile's policy is not safe_auto",
+			"under manual or notify-only policy a human performs the resume; automatic delivery is refused")
+	}
+	pass(gateDeliverableNoConf)
+
+	// CLAIM-ONCE, a READ. Both derivations are scanned: a live redelivery reservation is an
+	// authoritative claim on this pause even though it lives under a different filename derivation.
+	key, keyErr := supervisionClaimKey(assessment.Binding.NamespaceID, assessment.Binding.PauseGeneration,
+		assessment.Binding.Goal.AttemptID)
+	if keyErr != nil {
+		return fail(gateClaimOnce, "claim-once",
+			"cannot derive the claim key for this pause: "+keyErr.Error(),
+			assessment.Actions.Inspect.Command)
+	}
+	dir := goalAttemptDir(assessment.Binding.Project, assessment.Binding.Profile, assessment.Binding.Session)
+	legacyKey := resumeGoalTransitionID(assessment.Binding.Goal.AttemptID, assessment.Binding.Goal.BindingDigest)
+	existing, scanErr := scan(dir, key, legacyKey)
+	if scanErr != nil {
+		return fail(gateClaimOnce, "no earlier resume claim ... delivered or remains indeterminate",
+			"cannot read the recovery transition ledger for this pause: "+scanErr.Error(),
+			"inspect the transition directory; an unreadable ledger is never treated as vacant")
+	}
+	if blocker := existing.blocking(); blocker != nil {
+		return fail(gateClaimOnce, "no earlier resume claim ... delivered or remains indeterminate",
+			blocker.describe(), blocker.recovery())
+	}
+	pass(gateClaimOnce)
+
+	// Populated ONLY here, after every gate passed, alongside Payload. A partially-validated baseline
+	// would be worse than none: the drift gate would compare against a value whose authorization is
+	// unknown.
+	out.Payload = payload
+	out.AuthorizedDigest = strings.TrimSpace(suppliedDigest)
+	out.ClaimKey = key
+	out.Dir = dir
+	out.LegacyKey = legacyKey
+	return out
+}
+
+// supervisionPreMutationGateOrder is the COMPLETE pre-mutation gate list, in evaluation order.
+//
+// It exists because the evaluator SHORT-CIRCUITS: Results holds the passed prefix plus the first
+// failure, and nothing after it. A report printing only Results would imply that prefix is the whole
+// set -- the same overclaim-by-omission as a mutation walk that silently drops an item. With this
+// list, a caller can name every gate it did NOT reach as skipped, so "passed", "failed" and
+// "not reached" are three distinct states in the output rather than two states and a gap.
+var supervisionPreMutationGateOrder = []supervisionGateName{
+	gateWiring,
+	gateSupervisorID,
+	gateActionCanonical,
+	gateActionBinding,
+	gatePayloadAuthorized,
+	gateAssessmentFresh,
+	gateWallClock,
+	gateAssessmentEligible,
+	gateOperatorPolicy,
+	gateDeliverableNoConf,
+	gateClaimOnce,
+}
+
+// skippedGates returns the gates the evaluation never reached, in order. Empty when everything ran.
+func (e supervisionPreMutationEvaluation) skippedGates() []supervisionGateName {
+	reached := map[supervisionGateName]bool{}
+	for _, r := range e.Results {
+		reached[r.Name] = true
+	}
+	var skipped []supervisionGateName
+	for _, n := range supervisionPreMutationGateOrder {
+		if !reached[n] {
+			skipped = append(skipped, n)
+		}
+	}
+	return skipped
+}

--- a/internal/cli/goal_supervision_gates_test.go
+++ b/internal/cli/goal_supervision_gates_test.go
@@ -1,0 +1,358 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// PR5 / #498: THE GATE-ORDER TABLE. Every row asserts WHICH gate fails AND the exact prefix of gates
+// evaluated before it.
+//
+// THE PREFIX ASSERTION IS WHY THIS CAN CLAIM "ORDER". dev-2 caught that my first version could not:
+// every row had exactly ONE failing gate with all others passing, so moving that gate earlier or later
+// still left it the first and only failure and the row stayed green. It proved defect-to-gate identity
+// and it detected fixture decay -- both real -- but the NAME claimed order, which it did not pin. Same
+// false-name problem I have hit twice today, so the name now states what is proven.
+//
+// This exists because of a specific failure of mine, and the mechanism is cto's ratified fix for it.
+// I wrote a policy-refusal row, then added the canonical-metadata gate UPSTREAM of it, and the row
+// silently re-aimed: it still refused, still passed its "did it refuse" assertion for a while, and was
+// no longer testing the policy boundary at all. Only the error-text assertion caught it, and only by
+// accident of wording.
+//
+// SINGLE-DEFECT-PER-ROW IS NOT A PROPERTY A ROW HAS. It is a property that DECAYS every time a gate is
+// added ahead of it. Asserting the gate NAME converts it from something I have to remember into
+// something the suite enforces: add a gate upstream of any row and this table fails loudly, naming the
+// row whose meaning just changed.
+//
+// Each row is otherwise-valid and carries EXACTLY ONE defect. A row that could fail for two reasons
+// proves nothing about either.
+
+// canonicalGateOrderLiteral is the expected evaluation order written out BY HAND.
+//
+// It deliberately does NOT reference supervisionPreMutationGateOrder. Comparing the evaluator against
+// the package's own list would be a same-helper assertion: if someone reorders the evaluator and
+// updates that list to match, both move together and every test stays green while the actual order --
+// the thing that decides which fault an operator is told about -- has changed.
+//
+// This is the golden-vector argument from PR5's compatibility proof, applied to ordering rather than to
+// a digest: a literal is the only expectation that cannot drift WITH the implementation. If this list
+// and supervisionPreMutationGateOrder disagree, that disagreement is the finding.
+var canonicalGateOrderLiteral = []supervisionGateName{
+	"wiring",
+	"supervisor-identity",
+	"action-canonical-metadata",
+	"action-identity-binding",
+	"payload-authorization",
+	"assessment-fresh",
+	"wall-clock-freshness",
+	"assessment-eligible",
+	"operator-policy",
+	"delivering-path-needs-no-confirmation",
+	"claim-once-ledger",
+}
+
+// gateNamesOf extracts the reported gate names in order, so a row can assert the exact PREFIX the
+// evaluation walked rather than only which gate failed last.
+func gateNamesOf(results []supervisionGateResult) []supervisionGateName {
+	out := make([]supervisionGateName, 0, len(results))
+	for _, r := range results {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func gateNamesEqual(a, b []supervisionGateName) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// gateFixture builds an assessment/action/loader triple that passes EVERY gate. Rows then break one
+// thing. Building "all valid" once and mutating from it is what makes one-defect-per-row mechanically
+// true rather than aspirational -- hand-building each row invites two defects by omission.
+func gateFixture(t *testing.T) (GoalSupervisionAssessment, GoalSupervisionAction, supervisionResumePayloadLoader, supervisionResumeClock) {
+	t.Helper()
+	const payload = "/goal resume attempt-abc"
+	now := time.Now().UTC()
+	project := t.TempDir()
+
+	assessment := GoalSupervisionAssessment{
+		Fresh:                  true,
+		Eligible:               true,
+		AutomaticResumeAllowed: true,
+		Fingerprint:            "fingerprint-1",
+		ObservedAt:             now,
+		FreshUntil:             now.Add(time.Hour),
+		// SAFE-AUTO explicitly: the constructor derives NeedsConfirmation from Policy.Mode, and the
+		// all-valid fixture must reach the delivering-path gate, which requires false.
+		Policy: team.GoalSupervisionPolicyStatus{
+			Mode: team.GoalSupervisionSafeAuto, Revision: 1, Source: "test",
+		},
+		Binding: GoalSupervisionBinding{
+			Project: project, Profile: "squad", Session: "v2-25-0",
+			NamespaceID: squadnamespace.ID("squad", "v2-25-0"),
+			LeadRole:    "cto", LeadHandle: "cto",
+			Goal: GoalSupervisionGoalIdentity{
+				AttemptID: "attempt-abc", BindingDigest: "digest-def",
+				CommandDigest: digestGoalSupervisionString(payload),
+			},
+			PauseGeneration: "pause-gen-1",
+			Pane:            GoalSupervisionPaneIdentity{PaneID: "%7", Managed: true},
+		},
+	}
+	// FROM THE PRODUCTION CONSTRUCTOR. I hand-built this action first and it carried the identical
+	// defect dev-2 caught in the policy row: a fixture that copies canonical fields is a second
+	// definition of canon and drifts from goalSupervisionActions. Consuming the constructor means every
+	// canonical field -- Kind, ID, ActionKind, Scope, NamespaceID, Command, Mutates, Available,
+	// NeedsConfirmation, Reason -- plus Fingerprint/AttemptID/CommandDigest comes from production, so a
+	// row can only fail the canonical gate by DELIBERATELY diverging.
+	assessment.Actions = goalSupervisionActions(assessment)
+	action := assessment.Actions.Resume
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	clock := func() time.Time { return now }
+	return assessment, action, loader, clock
+}
+
+func TestPreMutationGateOrderAndFirstFailureArePinned(t *testing.T) {
+	// A scan that always reports a vacant ledger, so no row fails on claim-once unless it means to.
+	vacantScan := func(string, string, string) (pauseLedgerScan, error) { return pauseLedgerScan{}, nil }
+
+	for _, tc := range []struct {
+		name string
+		// mutate introduces EXACTLY ONE defect.
+		mutate   func(*GoalSupervisionAssessment, *GoalSupervisionAction, *supervisionResumePayloadLoader, *supervisionResumeClock)
+		wantGate supervisionGateName
+	}{
+		{
+			name: "nil clock is a wiring fault, not an operator condition",
+			mutate: func(_ *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, c *supervisionResumeClock) {
+				*c = nil
+			},
+			wantGate: gateWiring,
+		},
+		{
+			name: "blank supervisor",
+			mutate: func(_ *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+			},
+			wantGate: gateSupervisorID,
+		},
+		{
+			name: "invocation command diverges from canon",
+			mutate: func(_ *GoalSupervisionAssessment, a *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				a.Command = "amq-squad goal supervise-resume --session SOMETHING-ELSE"
+			},
+			wantGate: gateActionCanonical,
+		},
+		{
+			name: "action fingerprint diverges",
+			mutate: func(_ *GoalSupervisionAssessment, a *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				a.Fingerprint = "fingerprint-STALE"
+			},
+			wantGate: gateActionBinding,
+		},
+		{
+			name: "loader returns bytes that disagree with their own digest",
+			mutate: func(_ *GoalSupervisionAssessment, _ *GoalSupervisionAction, l *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				*l = func(GoalSupervisionAssessment) (string, string, error) {
+					return "/goal resume SOMETHING-ELSE", digestGoalSupervisionString("/goal resume attempt-abc"), nil
+				}
+			},
+			wantGate: gatePayloadAuthorized,
+		},
+		{
+			name: "assessment not fresh",
+			mutate: func(as *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				as.Fresh = false
+			},
+			wantGate: gateAssessmentFresh,
+		},
+		{
+			name: "clock is one tick past FreshUntil",
+			mutate: func(as *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, c *supervisionResumeClock) {
+				expired := as.FreshUntil.Add(time.Nanosecond)
+				*c = func() time.Time { return expired }
+			},
+			wantGate: gateWallClock,
+		},
+		{
+			name: "ineligible evidence is NOT a policy refusal",
+			mutate: func(as *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				as.Eligible = false
+				// AutomaticResumeAllowed stays true so ONLY eligibility is wrong. This is the row that
+				// proves collapsing Eligible into the policy gate is a misdiagnosis rather than a
+				// shortcut: with the gates collapsed, this input reported an operator-policy failure.
+			},
+			wantGate: gateAssessmentEligible,
+		},
+		{
+			name: "policy forbids automatic resume",
+			mutate: func(as *GoalSupervisionAssessment, a *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				as.AutomaticResumeAllowed = false
+				as.Policy.Mode = team.GoalSupervisionNotifyOnly
+				// Re-derive through the CONSTRUCTOR rather than patching Available by hand, so the
+				// canonical action stays whatever production says it is for this policy. Patching
+				// fields here would re-introduce the second-definition problem inside the very table
+				// built to catch decay.
+				as.Actions = goalSupervisionActions(*as)
+				*a = as.Actions.Resume
+			},
+			wantGate: gateOperatorPolicy,
+		},
+		{
+			// dev-2's breadth finding: my first nine rows covered the first nine gates and left the LAST
+			// TWO with no failure identity at all. The all-valid companion walks through them, but
+			// walking through a gate is not the same as proving what it refuses -- a gate that never
+			// fails in any test is a gate whose refusal is unproven.
+			name: "action requires confirmation, so the delivering path refuses",
+			mutate: func(as *GoalSupervisionAssessment, a *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				// MECHANISM, stated accurately: this DIRECTLY PATCHES the invoked action and the
+				// assessment-published canon together. It does NOT call goalSupervisionActions -- my
+				// earlier comment claimed it was "re-derived through the constructor", which was simply
+				// false, and dev-2 caught the comment describing a mechanism the code does not use.
+				//
+				// The patching is deliberate and it is what isolates this gate: setting
+				// NeedsConfirmation on BOTH sides keeps action-canonical passing (the equality is
+				// action-vs-canon, and both moved), while operator-policy still passes because safe-auto
+				// leaves AutomaticResumeAllowed true. So the delivering-path guard is the SOLE refuser,
+				// which is the only way to prove its refusal identity.
+				//
+				// LIMITATION, since a fixture that cannot occur in production proves less than one that
+				// can: the production constructor derives NeedsConfirmation FROM Policy.Mode, so
+				// safe-auto with NeedsConfirmation=true is a state production would never build. This is
+				// a direct-evaluator isolation fixture, not a production-realistic assessment. It proves
+				// what the gate refuses; it does not prove that state is reachable.
+				a.NeedsConfirmation = true
+				as.Actions.Resume = *a
+			},
+			wantGate: gateDeliverableNoConf,
+		},
+		{
+			name: "an existing claim for this pause blocks",
+			mutate: func(_ *GoalSupervisionAssessment, _ *GoalSupervisionAction, _ *supervisionResumePayloadLoader, _ *supervisionResumeClock) {
+				// Signalled via the blockingScan sentinel below rather than by mutating inputs, because
+				// the claim-once gate is the only one whose verdict comes from the SCAN rather than from
+				// the assessment or action.
+			},
+			wantGate: gateClaimOnce,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assessment, action, loader, clock := gateFixture(t)
+			supervisor := "supervisor-1"
+			if tc.wantGate == gateSupervisorID {
+				supervisor = "   "
+			}
+			tc.mutate(&assessment, &action, &loader, &clock)
+
+			scan := vacantScan
+			if tc.wantGate == gateClaimOnce {
+				// A ledger that reports an existing reservation for this pause. The blocker carries a
+				// path so describe()/recovery() produce a real operator-facing refusal rather than an
+				// empty one.
+				scan = func(dir, _, _ string) (pauseLedgerScan, error) {
+					return pauseLedgerScan{Blockers: []recoveryTransitionBlocker{{
+						Path:   dir + "/.recovery-native-goal-resume-existing.json",
+						Reason: "a recovery transition for this pause is reserved and NOT consumed",
+					}}}, nil
+				}
+			}
+			eval := evaluateSupervisionPreMutationGates(assessment, action, supervisor, clock, loader, scan)
+
+			failed := eval.firstFailure()
+			if failed == nil {
+				t.Fatalf("expected gate %q to fail, but every gate passed", tc.wantGate)
+			}
+			// THE ORDER ASSERTION: the exact sequence of gates evaluated, prefix and all. This is what
+			// makes reordering the evaluator break a test -- checking only the last entry cannot.
+			gotNames := gateNamesOf(eval.Results)
+			wantPrefix := canonicalGateOrderLiteral[:indexOfGate(t, tc.wantGate)+1]
+			if !gateNamesEqual(gotNames, wantPrefix) {
+				t.Errorf("evaluated gate SEQUENCE = %v, want exactly %v.\nA row that only checked its "+
+					"failing gate would stay green if the evaluator reordered, because a single failure is "+
+					"the first failure wherever it sits.", gotNames, wantPrefix)
+			}
+			if failed.Name != tc.wantGate {
+				t.Errorf("FIRST FAILING GATE = %q, want %q.\nThe row still refuses, so a "+
+					"did-it-refuse assertion would have passed while this row silently stopped testing "+
+					"what it is named for. If a gate was added upstream, re-derive this row's defect "+
+					"rather than re-pointing the expectation.", failed.Name, tc.wantGate)
+			}
+			// A failed evaluation must expose NO validated payload: a partially-authorized payload
+			// reaching a caller is worse than none, because its authorization state is unknowable.
+			if eval.Payload != "" || eval.AuthorizedDigest != "" {
+				t.Errorf("a failed evaluation leaked a payload/digest baseline (payload=%q digest=%q)",
+					eval.Payload, eval.AuthorizedDigest)
+			}
+			// And the unreached suffix must be reported, not silently dropped.
+			if len(eval.skippedGates()) == 0 && failed.Name != gateClaimOnce {
+				t.Errorf("gate %q failed but no gates were reported as skipped; the report presents a "+
+					"prefix as the whole set", failed.Name)
+			}
+		})
+	}
+}
+
+// The companion: the all-valid fixture must PASS every gate. Without it, every row above could be
+// satisfied by an evaluator that refuses unconditionally.
+func TestPreMutationGatesPassForAValidFixture(t *testing.T) {
+	assessment, action, loader, clock := gateFixture(t)
+	vacantScan := func(string, string, string) (pauseLedgerScan, error) { return pauseLedgerScan{}, nil }
+
+	eval := evaluateSupervisionPreMutationGates(assessment, action, "supervisor-1", clock, loader, vacantScan)
+
+	if f := eval.firstFailure(); f != nil {
+		t.Fatalf("the all-valid fixture must pass every gate; %q failed: %s", f.Name, f.Detail)
+	}
+	// Full sequence against the LITERAL, not against the package's list -- see
+	// canonicalGateOrderLiteral for why comparing to supervisionPreMutationGateOrder would permit
+	// evaluator and list to drift together.
+	if got := gateNamesOf(eval.Results); !gateNamesEqual(got, canonicalGateOrderLiteral) {
+		t.Errorf("full-pass gate SEQUENCE = %v, want exactly %v", got, canonicalGateOrderLiteral)
+	}
+	// And the package's own ordering list must agree with the literal. If it does not, one of them is
+	// wrong and this names the disagreement instead of letting the pair drift.
+	if !gateNamesEqual(supervisionPreMutationGateOrder, canonicalGateOrderLiteral) {
+		t.Errorf("supervisionPreMutationGateOrder %v disagrees with the hand-written canonical order %v",
+			supervisionPreMutationGateOrder, canonicalGateOrderLiteral)
+	}
+	if eval.Payload == "" || eval.AuthorizedDigest == "" {
+		t.Error("a full pass must carry the validated payload AND its pre-reserve digest baseline; " +
+			"without the baseline the delivery-time drift gate has nothing to compare against")
+	}
+	if eval.AuthorizedDigest != digestGoalSupervisionString(eval.Payload) {
+		t.Errorf("the carried baseline must be the digest of the carried payload")
+	}
+	if got := len(eval.skippedGates()); got != 0 {
+		t.Errorf("a full pass skips nothing, got %d skipped", got)
+	}
+	if eval.ClaimKey == "" {
+		t.Error("a full pass must carry the claim key: the dry-run reports it as the identity that " +
+			"WOULD be reserved, and an empty one makes that report useless")
+	}
+}
+
+// indexOfGate locates a gate in the literal order, failing loudly if the row names a gate the canonical
+// list does not contain -- which would mean the row and the contract disagree about what gates exist.
+func indexOfGate(t *testing.T, name supervisionGateName) int {
+	t.Helper()
+	for i, n := range canonicalGateOrderLiteral {
+		if n == name {
+			return i
+		}
+	}
+	t.Fatalf("row names gate %q which is absent from the canonical order literal", name)
+	return -1
+}

--- a/internal/cli/goal_supervision_policy_mutation_test.go
+++ b/internal/cli/goal_supervision_policy_mutation_test.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// PR5 / #498 U9: THE POLICY-GATE MUTATION ROW, driving the EXECUTOR.
+//
+// MY FIRST VERSION DID NOT SATISFY THIS AND dev-2's REASON IS THE SHARPEST FINDING ON THIS ROW SO FAR.
+// It called evaluateSupervisionPreMutationGates only. That evaluator is structurally read-only and has
+// no reservation or delivery capability whatsoever, so:
+//
+//   - its zero-ledger-write assertion was GUARANTEED regardless of my writability probe. I had built the
+//     probe to make an absence meaningful and then asserted the absence against code that cannot write,
+//     which is the vacuity I was trying to close, one level up.
+//   - deleting the policy gate would merely make the evaluation return success, and the test would die
+//     at `failed == nil` BEFORE any executor, reserve, bind, rescan, delivery or consume ran. It would
+//     have "failed under mutation" for the wrong reason -- which is worse than surviving, because a kill
+//     for the wrong reason reads as proof that the mutation was caught.
+//
+// So this drives executeSupervisionResume, and every downstream field is valid specifically so that
+// REMOVING the policy guard can reach reserve -> bind -> rescan -> deliver -> consume. That reachability
+// is the whole point: a mutation can only be killed by a test that would otherwise get further.
+//
+// NO PRE-EXECUTOR FATAL. dev-2's point 5, and it is subtle: an evaluator assertion placed ahead of
+// execution would kill the test under the policy mutation before the behaviour being falsified occurs.
+// Diagnostics about gate skipping belong AFTER the executor assertions, where they cannot pre-empt them.
+//
+// LIMITATION, stated not buried: safe-auto with AutomaticResumeAllowed forced false is NOT
+// production-reachable -- production computes that field as Eligible && Mode==safe-auto. Forcing it is
+// the only way to make operator-policy the SOLE refuser, which is the only condition under which
+// deleting it is falsifiable. This is a direct executor isolation input.
+func TestPolicyGateBlocksTheExecutorFromReservingOrDelivering(t *testing.T) {
+	const payload = "/goal resume attempt-abc"
+	const profile = "squad"
+	const session = "v2-25-0"
+	now := time.Now().UTC()
+	project := t.TempDir()
+
+	assessment := GoalSupervisionAssessment{
+		Fresh:      true,
+		Eligible:   true,
+		ObservedAt: now,
+		FreshUntil: now.Add(time.Hour),
+		// SAFE-AUTO so the canonical action carries NeedsConfirmation=false and the delivering-path
+		// guard PASSES instead of co-refusing. Without this, deleting the policy gate changes nothing
+		// observable and the mutation is masked by redundancy.
+		Policy:      team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 1, Source: "test"},
+		Fingerprint: "fingerprint-1",
+		// THE BLOCKER EVIDENCE, by exactly the reasoning the launch-generation comment below already gives.
+		// The exact binding requires a nonblank blocker id and resolution digest, so without these the
+		// MUTATED run dies at construction instead of reaching delivery -- and a mutation that dies before
+		// the behaviour it targets proves nothing about the policy gate. Same failure dev-2's point 3
+		// identified for bind, one step earlier in the pipeline.
+		Blocker: GoalSupervisionBlockerEvidence{
+			ID: "blocker-1", Known: true, Resolved: true, ResolutionDigest: "resolution-digest-1",
+		},
+		Binding: GoalSupervisionBinding{
+			Project: project, Profile: profile, Session: session,
+			NamespaceID: squadnamespace.ID(profile, session),
+			LeadRole:    "cto", LeadHandle: "cto",
+			LaunchID: "launch-1",
+			// NONBLANK launch generation, per dev-2's point 3: bind consumes these, so blank values
+			// would stop the mutated run at bind instead of letting it reach delivery -- and a mutation
+			// that dies at bind proves nothing about the policy gate.
+			LaunchRecordDigest:  "launch-digest-1",
+			LaunchRecordModTime: 1700000000,
+			LaunchStartedAt:     now.Add(-time.Minute),
+			Goal: GoalSupervisionGoalIdentity{
+				// The mode production emits for a blocked native goal. Required by the exact binding, and
+				// absent here for the same reason it was absent everywhere else: no gate on this path read it.
+				Mode:      fixtureNativeGoalMode,
+				AttemptID: "attempt-abc", BindingDigest: "digest-def",
+				CommandDigest: digestGoalSupervisionString(payload),
+			},
+			PauseGeneration: "pause-gen-1",
+			Pane:            GoalSupervisionPaneIdentity{PaneID: "%7", Managed: true},
+		},
+	}
+	// FORCED after the policy is set: this is what makes operator-policy the sole refuser.
+	assessment.AutomaticResumeAllowed = false
+	assessment.Actions = goalSupervisionActions(assessment)
+	action := assessment.Actions.Resume
+
+	// The ledger directory exists and is PROVED writable, so "no transition artifact" distinguishes
+	// "declined to write" from "could not write". Under the mutation the executor really can write here,
+	// which is what makes the absence evidence rather than a guarantee.
+	dir := goalAttemptDir(project, profile, session)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create ledger directory: %v", err)
+	}
+	probe := filepath.Join(dir, ".writability-probe")
+	if err := os.WriteFile(probe, []byte("x"), 0o644); err != nil {
+		t.Fatalf("ledger directory not writable, so a zero-artifact assertion would prove nothing: %v", err)
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatalf("remove writability probe: %v", err)
+	}
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	// THE DELIVERY CALLBACK asserts the EXACT native payload and counts invocations. Counting alone
+	// would not catch a delivery of the wrong bytes, and asserting bytes without counting would not
+	// catch a double delivery.
+	delivered := 0
+	var deliveredPayload string
+	deliver := func(got string) error {
+		delivered++
+		deliveredPayload = got
+		if got != payload {
+			t.Errorf("delivered payload = %q, want the digest-authorized native payload %q", got, payload)
+		}
+		return nil
+	}
+
+	// The outcome is captured so a policy refusal can be shown to carry NO delivered=true -- a refusal
+	// that reported delivery would be the worst possible disagreement between return value and reality.
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition, deliver)
+
+	// 1. THE REFUSAL MUST BE THE POLICY ONE, BY TYPE AND EXACT CLAUSE.
+	//
+	// My previous version labelled itself "by identity and not merely by existence" and then used
+	// strings.Contains(err.Error(), "automatic resume") -- a SUBSTRING, which is existence. dev-2 caught
+	// the label and the check disagreeing. A substring can match another refusal's Detail or Recovery
+	// text, so it cannot establish WHICH gate refused; and this is the same existence-for-identity
+	// substitution that produced the arbitrary-payload hole earlier in this PR.
+	//
+	// NOT t.Fatal on a nil error, per dev-2's point 2: under the policy-guard mutation the executor
+	// returns nil, and stopping here would suppress the delivered-count and artifact evidence below.
+	// The mutation artifact must SHOW that one exact-payload delivery occurred and that reservation
+	// artifacts appeared -- "expected refusal, got nil" does not demonstrate the behaviour U9 names.
+	if err == nil {
+		t.Error("the executor must refuse when policy forbids automatic resume; continuing so the " +
+			"delivered-count and ledger-artifact evidence below is still reported")
+	} else {
+		var refusal supervisionResumeRefusal
+		if !errors.As(err, &refusal) {
+			t.Errorf("refusal must be a typed supervisionResumeRefusal, got %T: %v", err, err)
+		} else if refusal.Clause != "operator policy: automatic resume permitted" {
+			t.Errorf("refusal Clause = %q, want exactly %q.\nAny other clause means the fixture stopped "+
+				"isolating the policy gate and the mutation cannot be falsified through this input.",
+				refusal.Clause, "operator policy: automatic resume permitted")
+		}
+	}
+
+	// 2a. THE OUTCOME MUST NOT CLAIM DELIVERY. A refusal whose return value said delivered=true would be
+	// a disagreement between what happened and what was reported -- and the reported value is what a
+	// wrapper acts on.
+	if outcome.Delivered {
+		t.Error("a policy refusal returned an outcome claiming Delivered=true")
+	}
+
+	// 2. ZERO DELIVERIES, and no payload reached the callback at all.
+	if delivered != 0 {
+		t.Errorf("policy refusal delivered %d time(s) with payload %q; the operator's policy forbids it",
+			delivered, deliveredPayload)
+	}
+
+	// 3. NO TRANSITION ARTIFACT in a directory we proved writable.
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read ledger directory: %v", readErr)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), currentRecoveryTransitionPrefix) ||
+			strings.HasPrefix(e.Name(), legacyRecoveryTransitionPrefix) {
+			t.Errorf("a policy refusal left %s behind in a writable ledger directory", e.Name())
+		}
+	}
+
+	// 4. DIAGNOSTIC COMPANION, placed AFTER the executor assertions on purpose (dev-2's point 5). Run
+	// ahead of them it would abort the test under the policy mutation before the behaviour above could
+	// be observed, so a mutation kill would not mean what it appears to mean.
+	eval := evaluateSupervisionPreMutationGates(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader, scanRecoveryTransitionsForPause)
+	if f := eval.firstFailure(); f != nil && f.Name != gateOperatorPolicy {
+		t.Errorf("diagnostic: first failing gate = %q, want %q -- the fixture is no longer isolating the "+
+			"policy gate", f.Name, gateOperatorPolicy)
+	}
+}

--- a/internal/cli/goal_supervision_resume.go
+++ b/internal/cli/goal_supervision_resume.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"strings"
 	"time"
 )
@@ -89,7 +90,12 @@ type supervisionResumeOutcome struct {
 	// Consumed reports the claim-lifecycle completion separately from Delivered, because they can
 	// genuinely disagree: delivery is irreversible and consume can fail after it.
 	// DeliveryOutcomeUnknown is set ONLY on the pane-input error path, where the bytes may or may not have
-	// landed. It cannot be inferred from Delivered: Delivered must stay FALSE when success is not known,
+	// landed. THAT SENTENCE WAS FALSE UNTIL codex finding 5: the single write site set it for EVERY error out
+	// of the delivery boundary, including a failed durable directive that provably never reached the pane. The
+	// field documented the contract correctly and the code did not implement it, which is the inverse of
+	// comment-outlives-code and just as expensive. It is now enforced by a typed branch on
+	// supervisionDefiniteNonDeliveryError, with unknown as the fail-closed default.
+	// It cannot be inferred from Delivered: Delivered must stay FALSE when success is not known,
 	// so the unknown case and an ordinary pre-delivery refusal are indistinguishable without this flag --
 	// and they are the two states U6 most needs separated, because one leaves a live reservation and an
 	// operator decision, and the other leaves nothing at all.
@@ -440,16 +446,55 @@ func executeSupervisionResume(
 		}
 	}
 
-	// THE REMAINING THREE U5 GATES, immediately before input and after the payload re-read. They run
+	// THE REMAINING THREE U5 GATES, after the payload re-read and before the delivery boundary. They run
 	// LAST on purpose: everything above establishes that the CLAIM is sound, and these establish that
 	// the WORLD still matches the claim. A refusal here leaves the reservation unconsumed and
 	// INDETERMINATE, identical to payload drift, because the ordering guarantee is the same -- nothing
 	// has been typed yet, so refusing costs a re-run while proceeding could cost a wrong delivery.
+	//
+	// THIS IS NOT THE U4.2 CHECK, and the comment here used to claim it was ("immediately before input").
+	// It is not: the delivery boundary publishes a durable directive after this point and before pane input
+	// (codex finding 3). The authoritative immediately-before-input re-check lives INSIDE the boundary, and
+	// this call is now the cheap pre-directive filter that keeps an already-doomed delivery from writing an
+	// audit record. Both exist, and each is killable on its own: remove this one and a drifted world still
+	// publishes a directive; remove the one in the boundary and drift between directive and input is invisible.
 	if refusal := evaluateSupervisionDeliveryTimeGates(assessment, now, readGeneration, readPane); refusal != nil {
 		return supervisionResumeOutcome{}, *refusal
 	}
 
 	if err := deliver(currentPayload); err != nil {
+		// PROVEN NON-DELIVERY IS NOT UNKNOWN (codex finding 5). The boundary marks the refusals that happen
+		// strictly before sendPromptToPane -- blank pane id, missing publisher, missing gate, failed durable
+		// directive, and the post-directive gate refusal -- with a typed error, because for those no bytes
+		// exist to be ambiguous about. Reporting them as unknown told the operator to go inspect a pane about
+		// a question that has no ambiguity in it, and it stranded the pause behind an "operator must decide"
+		// state with nothing to decide.
+		//
+		// POLARITY: UNKNOWN IS THE DEFAULT AND A DEFINITE VERDICT REQUIRES PROOF. This branch downgrades to
+		// definite ONLY on the typed marker; everything else, including an error from inside sendPromptToPane,
+		// keeps DeliveryOutcomeUnknown. Inverting it -- default definite, mark unknown -- reads as the same
+		// code and is a fail-open at the one seam where being wrong costs a second audited resume.
+		//
+		// THE RESERVATION IS NOT TOUCHED EITHER WAY, ruled. Proven non-delivery does NOT release, clear or
+		// delete the claim: nothing in this system deletes reservations, and a self-deleting claim would
+		// manufacture the orphan-companion state of finding 2. Only the REPORT changes.
+		var definite *supervisionDefiniteNonDeliveryError
+		if errors.As(err, &definite) {
+			if definite.Refusal != nil {
+				// THE GATE'S OWN VERDICT, not a paraphrase: its clause and recovery are what the operator needs,
+				// and re-composing them here would be a second opinion about why the world failed the check. The
+				// proven fact is PREPENDED so the operator learns it before the gate's detail. A copy is taken so
+				// the boundary's refusal value is never mutated.
+				refusal := *definite.Refusal
+				refusal.Detail = "NO PANE INPUT OCCURRED -- the durable directive was published, the world was then re-checked immediately before input, and it refused: " + refusal.Detail
+				return supervisionResumeOutcome{}, refusal
+			}
+			return supervisionResumeOutcome{}, supervisionResumeRefusal{
+				Clause:   "claim-once",
+				Detail:   "the claim was recorded and delivery was refused BEFORE any pane input: " + err.Error(),
+				Recovery: "no delivery occurred, so the pane needs no inspection; the reservation remains and must be consumed or cleared deliberately before another automatic attempt",
+			}
+		}
 		// TERMINAL INDETERMINATE, reported through the OUTCOME rather than inferred from it. Returning the
 		// zero outcome here made this case indistinguishable from an ordinary pre-delivery refusal, so the
 		// command reported "refused" for exactly U6's unknown-pane-input state -- the one state that leaves

--- a/internal/cli/goal_supervision_resume.go
+++ b/internal/cli/goal_supervision_resume.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
-	"fmt"
 	"strings"
+	"time"
 )
 
 // PR5 / #498: the claim-once native /goal resume. This file owns the CLAIM MACHINERY and no
@@ -49,99 +49,161 @@ const (
 	stepConsume         supervisionResumeStep = "consume"
 )
 
+// supervisionResumePayloadLoader obtains the EXACT native resume payload bytes, read-only.
+//
+// THE SEAM IS FOR TESTABILITY; THE BINDING IS FOR SECURITY. I had this backwards and dev-2
+// corrected it (#498 P4), so it is stated plainly here: injection is what MAKES substitution
+// possible -- a test substitutes this loader by design, and that is the point of it being a seam.
+// It is not a barrier against substitution and claiming otherwise credits the seam with work it
+// does not do.
+//
+// The actual security property: NO loader output authorizes a delivery -- not self-consistent
+// output, not output a caller vouches for, not output from the production reader -- unless BOTH
+// equalities hold against assessment.Binding.Goal.CommandDigest, which PR4 captured from the launch
+// record independently of anything this loader returns. The durable binding digest is the
+// third party, and it is the only thing standing between a substituted payload and a pane.
+//
+// A nil loader REFUSES, same posture as a nil clock: it is a wiring fault, not a condition to
+// default around, and defaulting would let a caller silently opt out of payload authorization.
+type supervisionResumePayloadLoader func(GoalSupervisionAssessment) (payload string, digest string, err error)
+
+// supervisionResumeOutcome is the STRUCTURED post-success report (#498 U6 finding 3).
+//
+// It exists because I first made post-consume failures SILENT. U6 says failure never authorizes replay;
+// it does not say failure evidence may disappear, and discarding an audit-directive error makes a failed
+// AUDIT RECORD invisible -- the opposite of what an audit path is for. I over-corrected from "must not
+// retry" to "must be quiet".
+//
+// Delivered is the irreversible fact. The two post-success actions report SEPARATELY, each carrying its
+// own error text, so a caller can see that delivery succeeded while its bookkeeping did not -- which is a
+// real and reportable state, not a contradiction.
+type supervisionResumeOutcome struct {
+	// Delivered becomes true IMMEDIATELY after known-successful pane input, INDEPENDENTLY of consume.
+	//
+	// The previous wording here said "and a completed consume" -- which is exactly the bug dev-2 caught in
+	// the code, left behind in the doc comment after I fixed the code. Delivery is the irreversible fact;
+	// consume is bookkeeping that can fail after it, and Consumed reports that separately. A field comment
+	// that describes the old semantics is worse than none, because it is the first thing a reader trusts.
+	Delivered bool `json:"delivered"`
+
+	// Consumed reports the claim-lifecycle completion separately from Delivered, because they can
+	// genuinely disagree: delivery is irreversible and consume can fail after it.
+	// DeliveryOutcomeUnknown is set ONLY on the pane-input error path, where the bytes may or may not have
+	// landed. It cannot be inferred from Delivered: Delivered must stay FALSE when success is not known,
+	// so the unknown case and an ordinary pre-delivery refusal are indistinguishable without this flag --
+	// and they are the two states U6 most needs separated, because one leaves a live reservation and an
+	// operator decision, and the other leaves nothing at all.
+	DeliveryOutcomeUnknown bool `json:"delivery_outcome_unknown"`
+
+	Consumed     bool   `json:"consumed"`
+	ConsumeError string `json:"consume_error,omitempty"`
+
+	DeliveredDirectivePublished bool   `json:"delivered_directive_published"`
+	DeliveredDirectiveError     string `json:"delivered_directive_error,omitempty"`
+
+	StatusPolled    bool   `json:"status_polled"`
+	StatusPollError string `json:"status_poll_error,omitempty"`
+}
+
+// warnings renders the post-success failures for stderr. Empty when everything succeeded.
+func (o supervisionResumeOutcome) warnings() []string {
+	var out []string
+	if o.ConsumeError != "" {
+		out = append(out, "the resume WAS delivered but consuming the claim FAILED: "+o.ConsumeError+
+			" (the pause is now INDETERMINATE; automatic replay stays blocked at the reserved claim, and it "+
+			"must be inspected before any manual resume)")
+	}
+	if o.DeliveredDirectiveError != "" {
+		out = append(out, "delivered audit directive FAILED after a completed delivery: "+o.DeliveredDirectiveError+
+			" (the resume DID happen and the claim is consumed; re-invocation is refused at the consumed claim)")
+	}
+	if o.StatusPollError != "" {
+		out = append(out, "post-delivery status poll FAILED: "+o.StatusPollError+
+			" (observability only; the resume is unaffected)")
+	}
+	return out
+}
+
+// supervisionResumeClock is the INJECTED time source. It is a seam, not a convenience: with a bare
+// time.Now() inside the check, the expiry falsifier would have to sleep, and a test that sleeps to
+// cross a deadline is timing-dependent and therefore flaky in exactly the direction that makes
+// people delete it. Injected, the falsifier is deterministic -- advance one tick past FreshUntil.
+type supervisionResumeClock func() time.Time
+
 // executeSupervisionResume runs the confirmed sequence. The ordering is the contract, not a
 // preference, and each deviation has a named failure mode:
 //
-//		final assessment -> exclusion reads -> RESERVE -> bind -> CROSS-KIND RESCAN -> deliver -> consume
+//		action/identity -> final assessment -> wall clock -> policy -> exclusion reads -> RESERVE
+//		-> bind -> CROSS-KIND RESCAN -> deliver -> consume
 //
 //	  - reserve BEFORE deliver, so a crash between them reads as INDETERMINATE rather than
-//	    undelivered. #498: "no earlier resume claim for this pause generation has been delivered
-//	    or remains indeterminate". Reserving after delivery would make a crash look fresh and
-//	    permit a second audited resume.
+//	    undelivered. #498: "no earlier resume claim for this pause generation has been delivered or
+//	    remains indeterminate". Reserving after delivery would make a crash look fresh and permit a
+//	    second audited resume.
 //	  - no reassessment after the reserve, because this actor's own claim write changes claim
-//	    evidence and therefore the fingerprint; a post-claim recheck would fail every time and
-//	    read as a bug in the assessment surface rather than as the expected self-write.
+//	    evidence and therefore the fingerprint; a post-claim recheck would fail every time and read
+//	    as a bug in the assessment surface rather than as the expected self-write.
 //	  - the cross-kind rescan is NOT a reassessment. It reads the ledger only -- never the
 //	    fingerprint, never eligibility -- so the no-post-claim-reassessment rule is untouched.
-func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func(string) error) error {
-	// STEP 1. #498: "Automatic native resume is allowed only when all of the following remain
-	// true in ONE FRESH ASSESSMENT". Freshness and eligibility are the assessment's to decide.
-	if !assessment.Fresh {
-		return supervisionResumeRefusal{
-			Clause: "one fresh assessment",
-			Detail: fmt.Sprintf("assessment observed at %s is no longer fresh (valid until %s)", assessment.ObservedAt, assessment.FreshUntil),
-			// Not an error the operator fixes; it is a retry with a current observation.
-			Recovery: "re-run the supervision sweep; a stale assessment is never delivered from",
-		}
-	}
-	// #498: "Unknown or contradictory evidence is ineligible, not a best-effort resume."
-	// Consumed, not re-derived: the assessment enforces unknown/stale/missing/ambiguous.
-	if !assessment.Eligible {
-		return supervisionResumeRefusal{
-			Clause:   "unknown or contradictory evidence is ineligible, not a best-effort resume",
-			Detail:   "assessment reports ineligible: " + summarizeEligibilityReasons(assessment.Reasons),
-			Recovery: assessment.Actions.Inspect.Command,
-		}
-	}
-
-	// STEP 1b, the POLICY BOUNDARY -- and this was absent from the first scaffold entirely.
-	// #498 operator-policy clause: manual and notify-only profiles must not silently enter the
-	// automatic executor. Eligible answers "is this actor resumable"; it does NOT answer "is
-	// automatic action permitted here". Conflating them is how an operator who chose
-	// notify-only gets an automatic /goal resume. Checked BEFORE any reserve, and it does not
-	// weaken Eligible as the sole eligibility conjunction.
-	if !assessment.AutomaticResumeAllowed {
-		return supervisionResumeRefusal{
-			Clause:   "operator policy: automatic resume permitted",
-			Detail:   "this profile does not permit automatic native resume (manual or notify-only)",
-			Recovery: assessment.Actions.Inspect.Command,
-		}
-	}
-
-	// STEP 2, the exclusion reads. All of them precede any write, and every one fails CLOSED.
-	// #498: "no earlier resume claim for this pause generation has been delivered or remains
-	// indeterminate".
+//
+// This doc block was ORPHANED for a while: inserting supervisionResumeClock between it and the
+// function left it documenting the type instead. Third instance of that defect in this milestone
+// (r9's formatArgs comment, r10's paneLookupDefinitelyGone contract), and always the same cause --
+// a new declaration inserted between a comment and what it describes. Worth a habit, not just a
+// fix: after inserting a declaration, check what the comment ABOVE the insertion point now
+// documents.
+//
+// executeSupervisionResume takes the CANONICAL ACTION and the SUPERVISOR IDENTITY as explicit
+// inputs, not as things it derives.
+//
+// U1: the action is compared against the assessment BEFORE any reserve. Passing the action in is
+// what makes that comparison mean anything -- if the executor re-derived the resume command from the
+// assessment it would agree with itself by construction, which is the shape of a check that cannot
+// fail. The action arriving from outside is what lets it disagree, and disagreement is what a stale
+// or substituted invocation looks like.
+//
+// The supervisor identity is likewise supplied, never inferred from the lead. Two different actors,
+// two different accountabilities: inferring the supervisor from LeadRole would record the wrong one
+// in the durable claim and there would be no way to tell afterwards.
+func executeSupervisionResume(
+	assessment GoalSupervisionAssessment,
+	action GoalSupervisionAction,
+	supervisor string,
+	now supervisionResumeClock,
+	loadPayload supervisionResumePayloadLoader,
+	readGeneration supervisionGenerationReader,
+	readPane supervisionPaneReader,
+	// #498 U7 ruled option (d): the reserved claim is READ BACK FROM DISK and revalidated, so the comparison
+	// has two independent sides instead of comparing the assessment to itself. Injected rather than called
+	// directly for the same reason the U5 readers are: a test must be able to hand this path a drifted record,
+	// and a production call hard-wired here would make that impossible without touching the filesystem.
+	loadReservedClaim supervisionReservedClaimLoader,
+	deliver func(string) error,
+) (supervisionResumeOutcome, error) {
+	// ALL PRE-MUTATION GATES, through the ONE shared evaluator (#498 F5).
 	//
-	// The claim key CONSUMES assessment.Binding.PauseGeneration. It does NOT recompute it.
-	// PR4 alone derives it from captured LaunchID + Goal.BindingDigest + Goal.AttemptID +
-	// Goal.Mode, and a second derivation owner reading a different or current snapshot -- or
-	// drifting from the approved formula -- is the one-decider failure this whole milestone
-	// keeps producing. My first scaffold computed the hash here, which would have made this
-	// file a second owner of an identity PR4 owns.
-	key, keyErr := supervisionClaimKey(assessment.Binding.NamespaceID, assessment.Binding.PauseGeneration, assessment.Binding.Goal.AttemptID)
-	if keyErr != nil {
-		// A blank component would silently collapse distinct pauses onto one key, so the key
-		// builder refuses rather than hashing an incomplete identity. Surfaced, not swallowed.
-		return supervisionResumeRefusal{
-			Clause:   "claim-once",
-			Detail:   "cannot derive the claim key for this pause: " + keyErr.Error(),
-			Recovery: assessment.Actions.Inspect.Command,
-		}
+	// These checks used to be inline here. They now live in evaluateSupervisionPreMutationGates so the
+	// executor and --dry-run consume the SAME gate list, in the same order, producing the same
+	// verdicts. That is not tidying: the dry-run exists to PREDICT this function, and a second copy of
+	// the gates would drift exactly where agreement is the entire point -- a dry-run reporting
+	// "would deliver" where this path refuses.
+	//
+	// Every gate is READ-ONLY, so nothing below this line has written anything yet. That is what makes
+	// U1's "zero ledger writes on mismatch" structural rather than a promise: the first write is the
+	// reserve, and it is after this block.
+	eval := evaluateSupervisionPreMutationGates(assessment, action, supervisor, now, loadPayload,
+		scanRecoveryTransitionsForPause)
+	if !eval.allPassed() {
+		// The failed gate carries its own clause, detail and recovery, so the refusal an operator sees
+		// is identical whether they hit it here or in a dry-run.
+		return supervisionResumeOutcome{}, eval.refusal()
 	}
-	// BOTH derivations are scanned, which is the whole point of the kind-agnostic ledger. The
-	// legacy key is redelivery's own identity for this attempt: if a redelivery reservation
-	// exists for the same attempt, it is an authoritative existing claim on this pause even
-	// though it lives under a different filename derivation, and a scan that looked only at the
-	// current key would step straight over it into a second delivery.
-	dir := goalAttemptDir(assessment.Binding.Project, assessment.Binding.Profile, assessment.Binding.Session)
-	legacyKey := resumeGoalTransitionID(assessment.Binding.Goal.AttemptID, assessment.Binding.Goal.BindingDigest)
-	existing, err := scanRecoveryTransitionsForPause(dir, key, legacyKey)
-	if err != nil {
-		// A ledger that cannot be read is not an empty ledger. This is the
-		// absence-as-evidence class that both #577 and PR4 were caught by.
-		return supervisionResumeRefusal{
-			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
-			Detail:   "cannot read the recovery transition ledger for this pause: " + err.Error(),
-			Recovery: "inspect the transition directory; an unreadable ledger is never treated as vacant",
-		}
-	}
-	if blocker := existing.blocking(); blocker != nil {
-		return supervisionResumeRefusal{
-			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
-			Detail:   blocker.describe(),
-			Recovery: blocker.recovery(),
-		}
-	}
+	payload := eval.Payload
+	// THE PRE-RESERVE BASELINE, captured before any write. The delivery-time drift gate compares
+	// against THIS, not against anything re-derived after the reserve -- see AuthorizedDigest's
+	// definition for why recomputation would turn the comparison into a tautology.
+	authorizedDigest := eval.AuthorizedDigest
+	key, dir, legacyKey := eval.ClaimKey, eval.Dir, eval.LegacyKey
 
 	// STEP 3. RESERVE through the single CAS owner. The record AND its path both come from the
 	// one constructor -- this executor derives neither, so there is no second path owner and
@@ -155,15 +217,59 @@ func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func
 			Session: assessment.Binding.Session,
 			Role:    assessment.Binding.LeadRole,
 			Handle:  assessment.Binding.LeadHandle,
+			// THE FLAT LAUNCH GENERATION, consumed from the same assessment. dev-2's cross-gate found these
+			// three unpopulated: the record persisted the nested block and left the launch generation it was
+			// reserved against absent, so delivery-time revalidation had nothing to compare. A record that
+			// cannot answer "which launch was this claim made against" is not a recovery contract for the
+			// one drift that actually ends a session -- the runtime being relaunched under the claim.
+			//
+			// The U5 gate reads the CURRENT generation and compares it against the assessment; this persists
+			// what the assessment SAW, so a process that crashes and restarts can still tell the two apart.
+			// Without it, recovery revalidates the assessment against itself.
+			LaunchID:            assessment.Binding.LaunchID,
+			LaunchRecordDigest:  assessment.Binding.LaunchRecordDigest,
+			LaunchRecordModTime: assessment.Binding.LaunchRecordModTime,
+			// CREATEDAT, decided rather than left ambiguous (dev-2's blocker 4 found native persisting the
+			// ZERO time because no native caller set it). Ruling asked for acceptable-by-design or a caller
+			// fix; this is the caller fix, because the zero value is not merely cosmetic here: an operator
+			// investigating an unexpected resume reads this record to establish WHEN the claim was made, and
+			// a zero timestamp is indistinguishable from a corrupted one while looking like data.
+			//
+			// time.Now() rather than the injected clock deliberately: the resume clock is the FRESHNESS
+			// decider, and freshness comparisons are gate logic. Using it here would make an audit timestamp
+			// a function of a decision input, so a test that manipulates the clock to drive a gate would
+			// silently rewrite the record's provenance too.
+			CreatedAt: time.Now().UTC(),
 		},
 		Kind:                recoveryTransitionKindNativeGoalResume,
 		NamespaceID:         assessment.Binding.NamespaceID,
 		AttemptID:           assessment.Binding.Goal.AttemptID,
 		PauseGeneration:     assessment.Binding.PauseGeneration,
 		PreclaimFingerprint: assessment.Fingerprint,
+		Supervisor:          supervisor,
+		// THE U7 EXACT BINDING, supplied through the EXPLICIT input and never through Base. Base.NativeBinding
+		// is a side door the constructor refuses on both kinds, so populating it here would be refused --
+		// correctly, and the refusal is what makes this route the only one.
+		//
+		// Every value is CONSUMED from the assessment rather than recomputed. The assessment is the single
+		// observation this claim is made against; recomputing any of these here would bind the record to a
+		// DIFFERENT moment than the one that authorized it, which is the one-identity-two-owners shape whose
+		// symptom is double delivery.
+		NativeBinding: &resumeGoalNativeBinding{
+			NamespaceID:             assessment.Binding.NamespaceID,
+			PaneID:                  assessment.Binding.Pane.PaneID,
+			GoalMode:                assessment.Binding.Goal.Mode,
+			GoalAttemptID:           assessment.Binding.Goal.AttemptID,
+			GoalBindingDigest:       assessment.Binding.Goal.BindingDigest,
+			GoalCommandDigest:       assessment.Binding.Goal.CommandDigest,
+			BlockerID:               assessment.Blocker.ID,
+			BlockerResolutionDigest: assessment.Blocker.ResolutionDigest,
+			PolicyMode:              assessment.Policy.Mode,
+			PolicyRevision:          assessment.Policy.Revision,
+		},
 	})
 	if err != nil {
-		return supervisionResumeRefusal{
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
 			Clause:   "claim-once",
 			Detail:   "cannot construct the resume claim: " + err.Error(),
 			Recovery: assessment.Actions.Inspect.Command,
@@ -171,7 +277,7 @@ func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func
 	}
 	reservation, err := reserveRecoveryTransition(record, path)
 	if err != nil {
-		return supervisionResumeRefusal{
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
 			Clause:   "claim-once",
 			Detail:   "could not reserve the resume claim: " + err.Error(),
 			Recovery: "another actor holds or held the claim for this pause; inspect the ledger",
@@ -187,23 +293,28 @@ func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func
 	// authorised it, and would quietly make this file a second observer of a generation PR4 owns.
 	if err := bindRecoveryTransitionGeneration(reservation,
 		assessment.Binding.LaunchRecordDigest, assessment.Binding.LaunchRecordModTime); err != nil {
-		return supervisionResumeRefusal{
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
 			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
 			Detail:   "launch generation could not be bound after reservation: " + err.Error(),
 			Recovery: "the reservation is left unconsumed; re-run the sweep after the launch generation settles",
 		}
 	}
 
-	// STEP 5, the cross-kind rescan. Step 2 plus O_EXCL arbitrate only actors racing to the
-	// SAME path. Two actors of different kinds -- or old-vs-new derivation -- race to DIFFERENT
-	// paths: both pass step 2, both win their own O_EXCL, both deliver. Kind is in the filename,
-	// so the filesystem CANNOT arbitrate across kinds; this read is the cross-kind mutex.
+	// STEP 5, the cross-kind rescan. Step 2 plus the link(2) publication arbitrate only actors
+	// racing to the SAME path. Two actors of different kinds -- or old-vs-new derivation -- race to
+	// DIFFERENT paths: both pass step 2, both win their own link, both deliver. Kind is in the
+	// filename, so the filesystem CANNOT arbitrate across kinds; this read is the cross-kind mutex.
+	//
+	// The primitive is named correctly here now. It said O_EXCL twice, FIFTY LINES BELOW the step-3
+	// comment in this same file that corrects it to link(2) and explicitly narrates having been
+	// wrong about exactly that. Not a comment that aged out of date -- a contradiction authored in
+	// one sitting, in one file, where the correction and the uncorrected claim sat together.
 	//
 	// Both racers refusing is the CORRECT outcome. The contract prefers
 	// indeterminate-with-recovery over double delivery, and the window is small.
 	after, err := scanRecoveryTransitionsForPause(dir, key, legacyKey)
 	if err != nil {
-		return supervisionResumeRefusal{
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
 			Clause:   "claim-once",
 			Detail:   "cannot re-scan the ledger after reserving: " + err.Error(),
 			Recovery: "the reservation is left unconsumed and must be inspected before any manual resume",
@@ -213,41 +324,203 @@ func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func
 	// the ledger that must not block us, and any weaker match (same key, same kind, prefix) could
 	// exclude a competitor too.
 	if competitor := after.competingWith(reservation.Path); competitor != nil {
-		return supervisionResumeRefusal{
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
 			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
 			Detail:   "another recovery transition for this pause appeared concurrently: " + competitor.describe(),
 			Recovery: competitor.recovery(),
 		}
 	}
 
-	// STEP 6. ONE audited delivery. Exactly one call, on the confirmation-safe path.
-	if err := deliver(assessment.Actions.Resume.Command); err != nil {
-		// The reservation stays UNCONSUMED on purpose: delivery may or may not have landed, so
-		// the pause is indeterminate and step 2 will refuse the next attempt rather than
-		// risking a second audited resume.
-		return supervisionResumeRefusal{
+	// STEP 6. ONE audited delivery of the DIGEST-VERIFIED NATIVE PAYLOAD.
+	//
+	// Neither action.Command nor assessment.Actions.Resume.Command is ever delivered: both are the
+	// operator-facing supervisor invocation, and typing either into the agent's pane would
+	// recursively invoke the supervisor inside the thing being supervised.
+	//
+	// The payload comes from the INJECTED loader, never threaded in as caller data, so there is no
+	// substitutable intermediary between authorization and send.
+	//
+	// (This comment previously named resolveAuthorizedResumePayload, a delivery-time-only helper that
+	// A2 removed. Fourth comment-outlives-code instance this milestone -- the deletion is not done
+	// until every mention of the deleted thing is reclassified as history or corrected.)
+	// U5's FOUR DELIVERY-TIME CLAUSES ARE NOW ALL PRESENT. The payload-drift gate is inline here
+	// because it consumes the AuthorizedDigest baseline established BEFORE reserve, and separating the
+	// comparison from its baseline is how that gate became a tautology once already. The other three --
+	// delivery-time wall clock, launch-generation digest+modtime drift, and exact live managed-idle
+	// pane revalidation with a nonzero PID -- are in evaluateSupervisionDeliveryTimeGates, called
+	// immediately below, so all four run between the rescan and the input.
+	//
+	// This does NOT replace the pre-reserve check; it catches drift that happened AFTER it. The current record is re-read and its
+	// GoalBinding.Command digest re-verified, so bytes that were authorized at reserve time but have
+	// since changed are refused here with the reservation left INDETERMINATE -- same posture as
+	// generation drift, and deliberately not a silent re-authorization of whatever the record now
+	// says.
+	currentPayload, currentDigest, rereadErr := loadPayload(assessment)
+	if rereadErr != nil {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same native goal command/binding remains current",
+			Detail:   "cannot re-read the native resume payload immediately before delivery: " + rereadErr.Error(),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; inspect the goal binding before any manual resume",
+		}
+	}
+	if currentDigest != authorizedDigest || currentPayload != payload ||
+		digestGoalSupervisionString(currentPayload) != strings.TrimSpace(assessment.Binding.Goal.CommandDigest) {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same native goal command/binding remains current",
+			Detail:   "the native goal binding changed between reservation and delivery; the authorized payload is no longer current",
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; drift is a refusal, never a re-authorization",
+		}
+	}
+	// U7 REVALIDATION, before the U5 world-checks. Order is deliberate: this asks whether the RESERVED
+	// CLAIM still describes the assessment we are acting on, and there is no point proving the pane is live
+	// and idle if the claim was written for a different pane, attempt, or policy revision. Cheap comparisons
+	// of already-loaded values, and they gate the expensive tmux reads that follow.
+	// READ THE CLAIM BACK FROM DISK FIRST. Revalidating reservation.Record here was a TAUTOLOGY: that record was
+	// built field-by-field from `assessment` twenty lines above, so comparing it to `assessment` compared the
+	// assessment to itself and could never fail. The comparison only means something when the two sides come
+	// from different places, so the left side now comes off the filesystem through the real unmarshal.
+	//
+	// NIL LOADER REFUSES, never skips -- the M-U5g rule. A missing check that silently becomes a passing check
+	// is the authorization-seam defect, and every test that supplies a loader would stay green while production
+	// validated nothing.
+	if loadReservedClaim == nil {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail:   "no reserved-claim loader was supplied, so the persisted claim cannot be revalidated before delivery",
+			Recovery: "this is a wiring fault, not an operator condition; the caller must supply the read-back loader",
+		}
+	}
+	persisted, readErr := loadReservedClaim(reservation.Path)
+	if readErr != nil {
+		// UNREADABLE IS NOT UNCHANGED. We just wrote this file; if it cannot be read back, the write did not
+		// land as intended or something moved it, and either way we cannot prove what the ledger now holds.
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail:   "the reserved claim could not be read back from its canonical path: " + readErr.Error(),
+			Recovery: "the reservation may exist but is unverifiable; inspect the ledger path before any manual resume",
+		}
+	}
+	// RE-ESTABLISH THE DURABLE CONTRACT AFTER DISK I/O, through the ONE existing validator.
+	//
+	// dev-2's blocker: revalidateNativeBindingAgainstAssessment deliberately EXCLUDES TransitionID, and its own
+	// comment gives the reason -- "publication already proves name+path agree". That reason was sound at the old
+	// call site and I INVALIDATED IT by adding a step after publication: the read-back exists precisely to catch
+	// bad serialization and concurrent mutation, so a proof established before the write is stale here. A loader
+	// returning the real record with only TransitionID changed to another well-shaped 64-hex value passed every
+	// comparison and reached pane input, under a body that no longer matches its own filename or derived key.
+	//
+	// I moved a validator across a boundary and did not re-derive the assumptions its exclusions rest on. The
+	// fix is NOT a second field list here -- it is to run the same publication contract again, now against the
+	// PERSISTED body and the path it actually occupies, which re-proves schema, kind, required fields, the
+	// recomputed derived identity, and filename/full-path agreement on the bytes that are really on disk.
+	if err := validateRecoveryTransitionPublication(persisted, reservation.Path); err != nil {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail:   "the PERSISTED claim does not satisfy the durable-record contract at its own path: " + err.Error(),
+			Recovery: "the reservation exists but its persisted body is not valid evidence; inspect the claim on disk before any manual resume",
+		}
+	}
+	// SUPERVISOR BY EQUALITY, not by presence. The validator checks only nonblank, so a persisted claim naming a
+	// DIFFERENT nonblank actor passed -- delivery would proceed under a claim attributing the authorization to
+	// someone other than the caller. Presence-where-identity-was-required is the predicate-weaker-than-property
+	// class, and an audit field is exactly where it matters most: a wrong attribution looks like an answer.
+	if strings.TrimSpace(persisted.Supervisor) != strings.TrimSpace(supervisor) {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause: "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail: "the PERSISTED claim records supervisor " + persisted.Supervisor +
+				" but this resume was authorized by " + supervisor,
+			Recovery: "the durable claim attributes the resume to a different actor; do not deliver until the ledger is inspected",
+		}
+	}
+	if err := revalidateNativeBindingAgainstAssessment(persisted, assessment); err != nil {
+		return supervisionResumeOutcome{}, supervisionResumeRefusal{
+			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail:   "the PERSISTED claim does not match the assessment at delivery time: " + err.Error(),
+			Recovery: "the reservation is left unconsumed and INDETERMINATE; inspect the claim on disk and the assessment before any manual resume",
+		}
+	}
+
+	// THE REMAINING THREE U5 GATES, immediately before input and after the payload re-read. They run
+	// LAST on purpose: everything above establishes that the CLAIM is sound, and these establish that
+	// the WORLD still matches the claim. A refusal here leaves the reservation unconsumed and
+	// INDETERMINATE, identical to payload drift, because the ordering guarantee is the same -- nothing
+	// has been typed yet, so refusing costs a re-run while proceeding could cost a wrong delivery.
+	if refusal := evaluateSupervisionDeliveryTimeGates(assessment, now, readGeneration, readPane); refusal != nil {
+		return supervisionResumeOutcome{}, *refusal
+	}
+
+	if err := deliver(currentPayload); err != nil {
+		// TERMINAL INDETERMINATE, reported through the OUTCOME rather than inferred from it. Returning the
+		// zero outcome here made this case indistinguishable from an ordinary pre-delivery refusal, so the
+		// command reported "refused" for exactly U6's unknown-pane-input state -- the one state that leaves
+		// a live reservation and an operator decision behind.
+		//
+		// The reservation stays UNCONSUMED on purpose: the input may or may not have landed, so the pause is
+		// indeterminate and the claim-once gate refuses the next attempt rather than risking a second
+		// audited resume.
+		return supervisionResumeOutcome{DeliveryOutcomeUnknown: true}, supervisionResumeRefusal{
 			Clause:   "claim-once",
 			Detail:   "delivery failed after the claim was recorded; this pause is now INDETERMINATE: " + err.Error(),
 			Recovery: "inspect the pane, then clear or consume the reservation deliberately; automatic resume will not retry",
 		}
 	}
 
-	// STEP 7. CONSUME. Only now is the claim complete.
-	return consumeRecoveryTransition(reservation.Record.TransitionID, reservation.Record.NewAttemptID, reservation.Path)
-}
+	// DELIVERED IS TRUE FROM HERE, before consume is attempted.
+	//
+	// I set this AFTER consume succeeded, so a known-successful delivery followed by a consume FAILURE
+	// returned the ZERO outcome -- Delivered=false about a delivery that demonstrably happened. That is the
+	// same return-value-versus-reality disagreement my own policy row guards in the opposite direction,
+	// and dev-2 caught me enforcing it one way while violating it the other.
+	//
+	// The irreversible fact is established by the delivery, not by the bookkeeping that follows it. An
+	// outcome that denies a completed delivery is the most dangerous possible report here, because a
+	// caller reading Delivered=false may reasonably try again.
+	outcome := supervisionResumeOutcome{Delivered: true}
 
-// summarizeEligibilityReasons renders the assessment's own deterministic reasons.
-//
-// It does NOT re-derive them: #498 rules Eligible authoritative and PR4 owns the conjunction.
-// This exists so a refusal can quote WHY without the executor forming a second opinion about
-// eligibility -- the distinction that #573's preview/admission split was about.
-func summarizeEligibilityReasons(reasons []GoalSupervisionEligibilityReason) string {
-	if len(reasons) == 0 {
-		return "assessment reported no deterministic reason"
+	// STEP 7. CONSUME. Reached ONLY on a KNOWN-SUCCESSFUL delivery; an unknown result returned above
+	// without consuming, which is what leaves the pause indeterminate rather than recorded as done.
+	if err := consumeRecoveryTransition(reservation.Record.TransitionID, reservation.Record.NewAttemptID, reservation.Path); err != nil {
+		// The claim stays RESERVED-and-unconsumed, so the pause reads indeterminate and automatic replay
+		// is still blocked at the gate. But the delivery HAPPENED, so the outcome must say so while the
+		// error reports the bookkeeping failure. Returning both is the only honest shape: a bare error
+		// would erase the delivery, and a bare outcome would hide the failure.
+		outcome.ConsumeError = err.Error()
+		return outcome, err
 	}
-	parts := make([]string, 0, len(reasons))
-	for _, r := range reasons {
-		parts = append(parts, r.Code)
+	outcome.Consumed = true
+
+	// STEP 8. POST-SUCCESS BOOKKEEPING AND OBSERVABILITY, reported rather than swallowed.
+	//
+	// WHY NOT RETURN AN ORDINARY ERROR HERE -- and my first rationale was WRONG, so the correct one is
+	// recorded instead. I wrote that returning an error "would deliver a second audited resume". It would
+	// not: CLAIM-ONCE ALREADY PREVENTS THAT. The reservation is consumed, and a consumed claim BLOCKS, so
+	// any automatic re-entry refuses at the claim-once gate before any input. The ledger is the replay
+	// protection, not this function's return value, and my comment credited the wrong mechanism -- the
+	// same error as crediting an injected seam with a durable binding's security.
+	//
+	// The sound reason is CONFLATION: every caller convention treats a returned error as "the action
+	// failed". Here the action SUCCEEDED and only its bookkeeping did not, so an ordinary error would make
+	// a completed, irreversible delivery indistinguishable from one that never happened.
+	//
+	// So failures are REPORTED in the outcome instead of returned, and the exit code stays success. That
+	// satisfies both halves of U6's sentence: failure never authorizes replay (the ledger stays consumed),
+	// and failure evidence never disappears (structured fields plus caller-rendered warnings).
+	// ORDER IS PART OF THE CONTRACT: consume (above) -> DELIVERED directive -> status poll. The directive
+	// may only claim delivery after the consume that makes it true, and the poll observes the world after
+	// both.
+	if publishDeliveredDirective != nil {
+		if err := publishDeliveredDirective(assessment, supervisor, currentPayload); err != nil {
+			outcome.DeliveredDirectiveError = err.Error()
+		} else {
+			outcome.DeliveredDirectivePublished = true
+		}
 	}
-	return strings.Join(parts, "; ")
+	if pollSupervisionStatusOnce != nil {
+		if err := pollSupervisionStatusOnce(assessment); err != nil {
+			outcome.StatusPollError = err.Error()
+		} else {
+			outcome.StatusPolled = true
+		}
+	}
+	return outcome, nil
 }

--- a/internal/cli/goal_supervision_resume.go
+++ b/internal/cli/goal_supervision_resume.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PR5 / #498: the claim-once native /goal resume. This file owns the CLAIM MACHINERY and no
+// store: every durable write goes through the one recovery-transition CAS owner in
+// resume_goal.go, per the ruling that a parallel store is the two-deciders defect at the exact
+// spot whose failure mode is DOUBLE DELIVERY of an audited resume.
+//
+// Each eligibility clause below quotes #498 verbatim beside its check, so review is
+// contract-to-code rather than re-deriving the design. Where the check is "consult the
+// assessment", that is deliberate and ruled: assessment.Eligible is AUTHORITATIVE and this
+// executor does not maintain a second eligibility policy. Two places computing one policy is
+// how #573's preview and admission came to disagree.
+
+// supervisionResumeRefusal explains a refusal in the operator's terms, always with a recovery
+// command. A refusal without a next action is a dead end the operator cannot clear.
+type supervisionResumeRefusal struct {
+	Clause   string // the #498 contract clause that was not satisfied
+	Detail   string
+	Recovery string
+}
+
+func (r supervisionResumeRefusal) Error() string {
+	msg := "native goal resume refused: " + r.Detail
+	if r.Clause != "" {
+		msg += " [#498: " + r.Clause + "]"
+	}
+	if r.Recovery != "" {
+		msg += "\nRecovery: " + r.Recovery
+	}
+	return msg
+}
+
+// supervisionResumeStep is the ruled sequence, named so the audit trail and the tests refer to
+// the same steps rather than to line numbers.
+type supervisionResumeStep string
+
+const (
+	stepFinalAssessment supervisionResumeStep = "final-assessment"
+	stepExclusionReads  supervisionResumeStep = "exclusion-reads"
+	stepReserve         supervisionResumeStep = "reserve"
+	stepBind            supervisionResumeStep = "bind"
+	stepCrossKindRescan supervisionResumeStep = "cross-kind-rescan"
+	stepDeliver         supervisionResumeStep = "deliver"
+	stepConsume         supervisionResumeStep = "consume"
+)
+
+// executeSupervisionResume runs the confirmed sequence. The ordering is the contract, not a
+// preference, and each deviation has a named failure mode:
+//
+//		final assessment -> exclusion reads -> RESERVE -> bind -> CROSS-KIND RESCAN -> deliver -> consume
+//
+//	  - reserve BEFORE deliver, so a crash between them reads as INDETERMINATE rather than
+//	    undelivered. #498: "no earlier resume claim for this pause generation has been delivered
+//	    or remains indeterminate". Reserving after delivery would make a crash look fresh and
+//	    permit a second audited resume.
+//	  - no reassessment after the reserve, because this actor's own claim write changes claim
+//	    evidence and therefore the fingerprint; a post-claim recheck would fail every time and
+//	    read as a bug in the assessment surface rather than as the expected self-write.
+//	  - the cross-kind rescan is NOT a reassessment. It reads the ledger only -- never the
+//	    fingerprint, never eligibility -- so the no-post-claim-reassessment rule is untouched.
+func executeSupervisionResume(assessment GoalSupervisionAssessment, deliver func(string) error) error {
+	// STEP 1. #498: "Automatic native resume is allowed only when all of the following remain
+	// true in ONE FRESH ASSESSMENT". Freshness and eligibility are the assessment's to decide.
+	if !assessment.Fresh {
+		return supervisionResumeRefusal{
+			Clause: "one fresh assessment",
+			Detail: fmt.Sprintf("assessment observed at %s is no longer fresh (valid until %s)", assessment.ObservedAt, assessment.FreshUntil),
+			// Not an error the operator fixes; it is a retry with a current observation.
+			Recovery: "re-run the supervision sweep; a stale assessment is never delivered from",
+		}
+	}
+	// #498: "Unknown or contradictory evidence is ineligible, not a best-effort resume."
+	// Consumed, not re-derived: the assessment enforces unknown/stale/missing/ambiguous.
+	if !assessment.Eligible {
+		return supervisionResumeRefusal{
+			Clause:   "unknown or contradictory evidence is ineligible, not a best-effort resume",
+			Detail:   "assessment reports ineligible: " + summarizeEligibilityReasons(assessment.Reasons),
+			Recovery: assessment.Actions.Inspect.Command,
+		}
+	}
+
+	// STEP 1b, the POLICY BOUNDARY -- and this was absent from the first scaffold entirely.
+	// #498 operator-policy clause: manual and notify-only profiles must not silently enter the
+	// automatic executor. Eligible answers "is this actor resumable"; it does NOT answer "is
+	// automatic action permitted here". Conflating them is how an operator who chose
+	// notify-only gets an automatic /goal resume. Checked BEFORE any reserve, and it does not
+	// weaken Eligible as the sole eligibility conjunction.
+	if !assessment.AutomaticResumeAllowed {
+		return supervisionResumeRefusal{
+			Clause:   "operator policy: automatic resume permitted",
+			Detail:   "this profile does not permit automatic native resume (manual or notify-only)",
+			Recovery: assessment.Actions.Inspect.Command,
+		}
+	}
+
+	// STEP 2, the exclusion reads. All of them precede any write, and every one fails CLOSED.
+	// #498: "no earlier resume claim for this pause generation has been delivered or remains
+	// indeterminate".
+	//
+	// The claim key CONSUMES assessment.Binding.PauseGeneration. It does NOT recompute it.
+	// PR4 alone derives it from captured LaunchID + Goal.BindingDigest + Goal.AttemptID +
+	// Goal.Mode, and a second derivation owner reading a different or current snapshot -- or
+	// drifting from the approved formula -- is the one-decider failure this whole milestone
+	// keeps producing. My first scaffold computed the hash here, which would have made this
+	// file a second owner of an identity PR4 owns.
+	key, keyErr := supervisionClaimKey(assessment.Binding.NamespaceID, assessment.Binding.PauseGeneration, assessment.Binding.Goal.AttemptID)
+	if keyErr != nil {
+		// A blank component would silently collapse distinct pauses onto one key, so the key
+		// builder refuses rather than hashing an incomplete identity. Surfaced, not swallowed.
+		return supervisionResumeRefusal{
+			Clause:   "claim-once",
+			Detail:   "cannot derive the claim key for this pause: " + keyErr.Error(),
+			Recovery: assessment.Actions.Inspect.Command,
+		}
+	}
+	// BOTH derivations are scanned, which is the whole point of the kind-agnostic ledger. The
+	// legacy key is redelivery's own identity for this attempt: if a redelivery reservation
+	// exists for the same attempt, it is an authoritative existing claim on this pause even
+	// though it lives under a different filename derivation, and a scan that looked only at the
+	// current key would step straight over it into a second delivery.
+	dir := goalAttemptDir(assessment.Binding.Project, assessment.Binding.Profile, assessment.Binding.Session)
+	legacyKey := resumeGoalTransitionID(assessment.Binding.Goal.AttemptID, assessment.Binding.Goal.BindingDigest)
+	existing, err := scanRecoveryTransitionsForPause(dir, key, legacyKey)
+	if err != nil {
+		// A ledger that cannot be read is not an empty ledger. This is the
+		// absence-as-evidence class that both #577 and PR4 were caught by.
+		return supervisionResumeRefusal{
+			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
+			Detail:   "cannot read the recovery transition ledger for this pause: " + err.Error(),
+			Recovery: "inspect the transition directory; an unreadable ledger is never treated as vacant",
+		}
+	}
+	if blocker := existing.blocking(); blocker != nil {
+		return supervisionResumeRefusal{
+			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
+			Detail:   blocker.describe(),
+			Recovery: blocker.recovery(),
+		}
+	}
+
+	// STEP 3. RESERVE through the single CAS owner. The record AND its path both come from the
+	// one constructor -- this executor derives neither, so there is no second path owner and
+	// nothing for the AST pin to catch. publishGoalJSON's link(2) is the first-writer primitive;
+	// a lost race is a refusal, never an overwrite. (It is NOT O_EXCL; I had assumed that and was
+	// wrong, and an enforcement test written against the assumption detected nothing.)
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: assessment.Binding.Project,
+			Profile: assessment.Binding.Profile,
+			Session: assessment.Binding.Session,
+			Role:    assessment.Binding.LeadRole,
+			Handle:  assessment.Binding.LeadHandle,
+		},
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         assessment.Binding.NamespaceID,
+		AttemptID:           assessment.Binding.Goal.AttemptID,
+		PauseGeneration:     assessment.Binding.PauseGeneration,
+		PreclaimFingerprint: assessment.Fingerprint,
+	})
+	if err != nil {
+		return supervisionResumeRefusal{
+			Clause:   "claim-once",
+			Detail:   "cannot construct the resume claim: " + err.Error(),
+			Recovery: assessment.Actions.Inspect.Command,
+		}
+	}
+	reservation, err := reserveRecoveryTransition(record, path)
+	if err != nil {
+		return supervisionResumeRefusal{
+			Clause:   "claim-once",
+			Detail:   "could not reserve the resume claim: " + err.Error(),
+			Recovery: "another actor holds or held the claim for this pause; inspect the ledger",
+		}
+	}
+
+	// STEP 4. BIND the launch generation, so a generation change after reservation is DETECTED
+	// rather than assumed stable -- the same protection redelivery already takes.
+	//
+	// The generation is CONSUMED from the assessment, not re-read here. PR4 captured
+	// LaunchRecordDigest/LaunchRecordModTime as part of the observation this claim is being made
+	// against; re-reading them would bind the claim to a DIFFERENT moment than the one that
+	// authorised it, and would quietly make this file a second observer of a generation PR4 owns.
+	if err := bindRecoveryTransitionGeneration(reservation,
+		assessment.Binding.LaunchRecordDigest, assessment.Binding.LaunchRecordModTime); err != nil {
+		return supervisionResumeRefusal{
+			Clause:   "the same launch generation, pane identity, native goal command/binding, and attempt identity remain current",
+			Detail:   "launch generation could not be bound after reservation: " + err.Error(),
+			Recovery: "the reservation is left unconsumed; re-run the sweep after the launch generation settles",
+		}
+	}
+
+	// STEP 5, the cross-kind rescan. Step 2 plus O_EXCL arbitrate only actors racing to the
+	// SAME path. Two actors of different kinds -- or old-vs-new derivation -- race to DIFFERENT
+	// paths: both pass step 2, both win their own O_EXCL, both deliver. Kind is in the filename,
+	// so the filesystem CANNOT arbitrate across kinds; this read is the cross-kind mutex.
+	//
+	// Both racers refusing is the CORRECT outcome. The contract prefers
+	// indeterminate-with-recovery over double delivery, and the window is small.
+	after, err := scanRecoveryTransitionsForPause(dir, key, legacyKey)
+	if err != nil {
+		return supervisionResumeRefusal{
+			Clause:   "claim-once",
+			Detail:   "cannot re-scan the ledger after reserving: " + err.Error(),
+			Recovery: "the reservation is left unconsumed and must be inspected before any manual resume",
+		}
+	}
+	// Excluded by EXACT PATH EQUALITY and nothing looser: our own reservation is the one thing in
+	// the ledger that must not block us, and any weaker match (same key, same kind, prefix) could
+	// exclude a competitor too.
+	if competitor := after.competingWith(reservation.Path); competitor != nil {
+		return supervisionResumeRefusal{
+			Clause:   "no earlier resume claim ... delivered or remains indeterminate",
+			Detail:   "another recovery transition for this pause appeared concurrently: " + competitor.describe(),
+			Recovery: competitor.recovery(),
+		}
+	}
+
+	// STEP 6. ONE audited delivery. Exactly one call, on the confirmation-safe path.
+	if err := deliver(assessment.Actions.Resume.Command); err != nil {
+		// The reservation stays UNCONSUMED on purpose: delivery may or may not have landed, so
+		// the pause is indeterminate and step 2 will refuse the next attempt rather than
+		// risking a second audited resume.
+		return supervisionResumeRefusal{
+			Clause:   "claim-once",
+			Detail:   "delivery failed after the claim was recorded; this pause is now INDETERMINATE: " + err.Error(),
+			Recovery: "inspect the pane, then clear or consume the reservation deliberately; automatic resume will not retry",
+		}
+	}
+
+	// STEP 7. CONSUME. Only now is the claim complete.
+	return consumeRecoveryTransition(reservation.Record.TransitionID, reservation.Record.NewAttemptID, reservation.Path)
+}
+
+// summarizeEligibilityReasons renders the assessment's own deterministic reasons.
+//
+// It does NOT re-derive them: #498 rules Eligible authoritative and PR4 owns the conjunction.
+// This exists so a refusal can quote WHY without the executor forming a second opinion about
+// eligibility -- the distinction that #573's preview/admission split was about.
+func summarizeEligibilityReasons(reasons []GoalSupervisionEligibilityReason) string {
+	if len(reasons) == 0 {
+		return "assessment reported no deterministic reason"
+	}
+	parts := make([]string, 0, len(reasons))
+	for _, r := range reasons {
+		parts = append(parts, r.Code)
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/cli/goal_supervision_resume_test.go
+++ b/internal/cli/goal_supervision_resume_test.go
@@ -5,8 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // dev-2's three PR5 falsifiers, plus the mismatched-NamespaceID row.
@@ -38,12 +40,17 @@ func TestSupervisionResumeConsumesThePauseGenerationItIsGiven(t *testing.T) {
 	namespaceID := squadnamespace.ID(profile, session)
 
 	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
-		Base:                resumeGoalTransitionRecord{Project: project, Profile: profile, Session: session},
+		Base:                nativeTransitionBase(project, profile, session),
 		Kind:                recoveryTransitionKindNativeGoalResume,
+		Supervisor:          "supervisor-1",
 		NamespaceID:         namespaceID,
 		AttemptID:           attemptID,
 		PauseGeneration:     authoritative,
 		PreclaimFingerprint: "fingerprint-1",
+		// THE EXACT BINDING, required for native. Absent here before, which made this row -- whose whole
+		// subject is that the pause generation is CONSUMED -- refuse at the binding check instead, so it
+		// asserted nothing about consumption.
+		NativeBinding: validNativeBinding(namespaceID, attemptID),
 	})
 	if err != nil {
 		t.Fatalf("a complete supervision input must be accepted: %v", err)
@@ -81,23 +88,76 @@ func TestSupervisionResumeConsumesThePauseGenerationItIsGiven(t *testing.T) {
 // THE FALSIFYING INPUT is precisely the combination that a single-flag check would let through:
 // everything eligibility-related is GREEN, and only the policy flag is false. An assessment that
 // was also ineligible would refuse for the other reason and prove nothing about this gate.
+// nativeResumePayload is the exact bytes a native resume would type into the pane -- NOT the CLI
+// invocation. Kept as a named fixture so every row that needs an authorized payload agrees on one
+// value rather than each inventing its own.
+const nativeResumePayload = "/goal resume attempt-abc"
+
 func TestEligibleButPolicyForbiddenRefusesWithoutReservingOrDelivering(t *testing.T) {
 	project := t.TempDir()
+	now := time.Now().UTC()
 	assessment := GoalSupervisionAssessment{
 		Fresh:                  true,
 		Eligible:               true, // GREEN
 		AutomaticResumeAllowed: false,
 		Fingerprint:            "fingerprint-1",
+		// FreshUntil must be in the FUTURE, or this row would refuse on the new wall-clock gate
+		// and stop proving anything about the policy boundary it is named for -- the
+		// single-defect-per-row property, applied to a row an unrelated change could have
+		// silently repurposed.
+		ObservedAt: now,
+		FreshUntil: now.Add(time.Hour),
+		// EXPLICIT non-safe-auto policy. The constructor derives Available from
+		// AutomaticResumeAllowed and NeedsConfirmation from Policy.Mode, so leaving Mode at its zero
+		// value would have the fixture depend on what the zero value happens to mean today.
+		Policy: team.GoalSupervisionPolicyStatus{
+			Mode: team.GoalSupervisionNotifyOnly, Revision: 1, Source: "test",
+		},
 		Binding: GoalSupervisionBinding{
 			Project: project, Profile: "squad", Session: "v2-25-0",
 			NamespaceID:     squadnamespace.ID("squad", "v2-25-0"),
 			PauseGeneration: "pause-gen-1",
-			Goal:            GoalSupervisionGoalIdentity{AttemptID: "attempt-abc", BindingDigest: "digest-def"},
+			Goal: GoalSupervisionGoalIdentity{
+				AttemptID: "attempt-abc", BindingDigest: "digest-def",
+				// Binds the digest of nativeResumePayload so authorization passes and the POLICY gate
+				// is what this row actually tests.
+				CommandDigest: digestGoalSupervisionString(nativeResumePayload),
+			},
 		},
 	}
 
 	delivered := 0
-	err := executeSupervisionResume(assessment, func(string) error { delivered++; return nil })
+	// The clock is INJECTED and this call site is explicit rather than defaulted: the executor
+	// refuses a nil clock instead of falling back to time.Now(), so no caller can silently opt out
+	// of the gate the seam exists for.
+	// The action is passed EXPLICITLY and must match the assessment, so this row exercises the
+	// policy gate rather than tripping the new action-binding check ahead of it. Building it from
+	// the assessment's own fields is correct HERE because the subject of this test is the policy
+	// boundary; the binding check gets its own rows with deliberately mismatched actions.
+	// THE ACTION COMES FROM THE PRODUCTION CONSTRUCTOR, not hand-synchronized field by field.
+	//
+	// dev-2's correction, and it is strictly better than what I proposed. My version set Command and
+	// Available by hand and I had already missed Mutates once; every canonical field I copy manually
+	// makes this fixture a SECOND DEFINITION of what the canonical action is, and it will drift from
+	// goalSupervisionActions exactly as it drifted from the gates. Consuming the constructor means the
+	// fixture cannot disagree with production about canon -- the same single-decider rule the
+	// production code follows, applied to the test.
+	assessment.Actions = goalSupervisionActions(assessment)
+	action := assessment.Actions.Resume
+
+	// A loader that returns a SELF-CONSISTENT pair matching the assessment's bound digest, so this
+	// row still exercises the policy gate rather than tripping payload authorization ahead of it.
+	// The payload-mismatch and digest-mismatch cases get their own rows -- single defect per row,
+	// applied again as gates accumulate upstream of an existing test.
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return nativeResumePayload, digestGoalSupervisionString(nativeResumePayload), nil
+	}
+
+	_, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error { delivered++; return nil })
 
 	if err == nil {
 		t.Fatal("a profile that forbids automatic resume must refuse even when the actor is ELIGIBLE: " +
@@ -186,12 +246,18 @@ func TestSupervisionResumeRefusesAForeignNamespaceID(t *testing.T) {
 	}
 
 	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
-		Base:                resumeGoalTransitionRecord{Project: project, Profile: profile, Session: session},
+		Base:                nativeTransitionBase(project, profile, session),
 		Kind:                recoveryTransitionKindNativeGoalResume,
+		Supervisor:          "supervisor-1",
 		NamespaceID:         foreign,
 		AttemptID:           "attempt-abc",
 		PauseGeneration:     "pause-gen-1",
 		PreclaimFingerprint: "fingerprint-1",
+		// The binding AGREES with the foreign namespace on purpose, so the sole defect is that the namespace
+		// is not canonical for this profile/session. A binding carrying the CANONICAL namespace would refuse
+		// on the binding-versus-claim namespace disagreement instead -- a different check, and this row
+		// would then pass while proving the wrong thing.
+		NativeBinding: validNativeBinding(foreign, "attempt-abc"),
 	})
 	if err == nil {
 		t.Fatal("a namespace id that is not canonical for this profile/session must be refused: the " +

--- a/internal/cli/goal_supervision_resume_test.go
+++ b/internal/cli/goal_supervision_resume_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+// dev-2's three PR5 falsifiers, plus the mismatched-NamespaceID row.
+//
+// Each is written as a FALSIFYING INPUT rather than a confirming one: an input under which the
+// property is false if the code has the defect, not an input under which the code happens to be
+// right. That distinction is the one this milestone keeps re-learning, most recently as an r9
+// rejection test that asserted a struct field and survived deletion of the guard it named.
+
+// FALSIFIER 1: PauseGeneration is CONSUMED, never recomputed.
+//
+// PR4 derives the pause generation from captured LaunchID + Goal.BindingDigest + Goal.AttemptID +
+// Goal.Mode. If PR5 recomputes it -- from a current snapshot, or from a drifted formula -- the two
+// owners can disagree, and a claim written under a generation nobody else computes is unmatchable
+// on read, therefore treated as absent, therefore a second delivery.
+//
+// THE FALSIFYING INPUT: a pause generation that NO derivation could have produced. Every real
+// derivation yields sha256 hex; this one is a sentence. If the constructor recomputes, the record
+// cannot come back carrying it. A hex-shaped fixture would be indistinguishable from a recomputed
+// value and would prove nothing -- which is why the value is deliberately not hex.
+func TestSupervisionResumeConsumesThePauseGenerationItIsGiven(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	// Not hex, not 64 chars, not derivable by any formula in this package.
+	const authoritative = "pause-generation-that-no-local-formula-could-produce"
+
+	project := t.TempDir()
+	namespaceID := squadnamespace.ID(profile, session)
+
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                resumeGoalTransitionRecord{Project: project, Profile: profile, Session: session},
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         namespaceID,
+		AttemptID:           attemptID,
+		PauseGeneration:     authoritative,
+		PreclaimFingerprint: "fingerprint-1",
+	})
+	if err != nil {
+		t.Fatalf("a complete supervision input must be accepted: %v", err)
+	}
+
+	if record.PauseGeneration != authoritative {
+		t.Errorf("PauseGeneration = %q, want the AUTHORITATIVE %q.\nPR4 owns this derivation. A "+
+			"value that differs was recomputed here, and two owners of one identity can disagree.",
+			record.PauseGeneration, authoritative)
+	}
+
+	// The identity must be keyed on the authoritative value too, not merely stored alongside a
+	// key derived from something else. Storing the right value while keying on a recomputed one
+	// is the SAME defect with the evidence field papering over it.
+	wantKey, keyErr := supervisionClaimKey(namespaceID, authoritative, attemptID)
+	if keyErr != nil {
+		t.Fatalf("canonical claim key: %v", keyErr)
+	}
+	if record.TransitionID != wantKey {
+		t.Errorf("TransitionID = %q, want %q -- the claim must be KEYED on the authoritative pause "+
+			"generation, not merely carry it as a field", record.TransitionID, wantKey)
+	}
+	if got := filepath.Base(path); got != currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, wantKey) {
+		t.Errorf("filename = %q; a claim written under a key nobody else computes is invisible to "+
+			"the scanner that would find it", got)
+	}
+}
+
+// FALSIFIER 2: Eligible=true with AutomaticResumeAllowed=false must REFUSE.
+//
+// These answer different questions and conflating them is how an operator who chose notify-only
+// gets an automatic /goal resume. Eligible asks "is this actor resumable"; AutomaticResumeAllowed
+// asks "is automatic action permitted here".
+//
+// THE FALSIFYING INPUT is precisely the combination that a single-flag check would let through:
+// everything eligibility-related is GREEN, and only the policy flag is false. An assessment that
+// was also ineligible would refuse for the other reason and prove nothing about this gate.
+func TestEligibleButPolicyForbiddenRefusesWithoutReservingOrDelivering(t *testing.T) {
+	project := t.TempDir()
+	assessment := GoalSupervisionAssessment{
+		Fresh:                  true,
+		Eligible:               true, // GREEN
+		AutomaticResumeAllowed: false,
+		Fingerprint:            "fingerprint-1",
+		Binding: GoalSupervisionBinding{
+			Project: project, Profile: "squad", Session: "v2-25-0",
+			NamespaceID:     squadnamespace.ID("squad", "v2-25-0"),
+			PauseGeneration: "pause-gen-1",
+			Goal:            GoalSupervisionGoalIdentity{AttemptID: "attempt-abc", BindingDigest: "digest-def"},
+		},
+	}
+
+	delivered := 0
+	err := executeSupervisionResume(assessment, func(string) error { delivered++; return nil })
+
+	if err == nil {
+		t.Fatal("a profile that forbids automatic resume must refuse even when the actor is ELIGIBLE: " +
+			"eligibility is about the actor, policy is about whether we may act")
+	}
+	if delivered != 0 {
+		t.Errorf("refused but STILL delivered %d time(s): the operator chose manual or notify-only", delivered)
+	}
+	// NO SIDE EFFECT. A refusal that left a reservation behind would wedge the pause for the
+	// manual resume the operator actually wanted -- the refusal would create the mess it exists
+	// to avoid. Checked by observing the directory rather than by trusting the return.
+	dir := goalAttemptDir(project, "squad", "v2-25-0")
+	entries, readErr := os.ReadDir(dir)
+	if readErr == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), currentRecoveryTransitionPrefix) ||
+				strings.HasPrefix(e.Name(), legacyRecoveryTransitionPrefix) {
+				t.Errorf("a policy refusal wrote a reservation (%s); it must leave no claim behind", e.Name())
+			}
+		}
+	}
+	// The refusal must name the policy clause, or the operator cannot tell it from ineligibility
+	// and will go looking for evidence problems that do not exist.
+	if !strings.Contains(err.Error(), "automatic resume") {
+		t.Errorf("refusal must name the POLICY reason, not a generic ineligibility: %v", err)
+	}
+}
+
+// FALSIFIER 3: filename-kind and record-kind must AGREE, or the reservation BLOCKS.
+//
+// A renamed file would otherwise silently change what a reservation means. Disagreement is
+// ambiguous evidence, and ambiguous evidence refuses -- it is not a tie to be broken by
+// preferring one source.
+//
+// THE FALSIFYING INPUT is the pairing a name-trusting scan cannot see: a current-derivation
+// filename that says native-goal-resume over a body that says redeliver. A scan that reads only
+// the name reports a clean native claim; a scan that reads only the body reports a clean
+// redelivery claim; only comparing them sees that neither is trustworthy.
+func TestReservationWhoseFilenameAndBodyDisagreeAboutKindBlocks(t *testing.T) {
+	dir := t.TempDir()
+	key := strings.Repeat("a", 64)
+
+	// Filename says native-goal-resume.
+	name := currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key)
+	// Body says redeliver.
+	body := `{"recovery_kind":"redeliver","transition_id":"` + key + `"}`
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	blocker := reservationBlocker(path)
+	if blocker == nil {
+		t.Fatal("a reservation whose filename and body disagree about its KIND must BLOCK: a rename " +
+			"would otherwise silently change what a claim means, and neither reading can be trusted")
+	}
+	if !strings.Contains(blocker.Reason, "kind disagrees") {
+		t.Errorf("the blocker must name the disagreement so an operator can resolve it; got %q", blocker.Reason)
+	}
+	// Every refusal carries a runnable next step. A dead-end refusal is what #498 was filed about.
+	if strings.TrimSpace(blocker.recovery()) == "" {
+		t.Error("a blocker with no recovery command is the stall this milestone exists to remove")
+	}
+}
+
+// FALSIFIER 4 (mine, not dev-2's): a NamespaceID that is not the canonical id for the
+// profile/session must be REFUSED at construction.
+//
+// This is the r6 lesson at the container level: I closed the NAME and left the DIRECTORY. A
+// correct hash written under a foreign namespace is present on disk and invisible to every
+// scanner that would look for it -- the claim exists and blocks nothing.
+//
+// THE FALSIFYING INPUT is a WELL-FORMED namespace id belonging to a DIFFERENT profile. A garbage
+// string would be caught by any shape check and would prove only that blanks are rejected; this
+// one is exactly as valid-looking as the right answer, and differs only in being someone else's.
+func TestSupervisionResumeRefusesAForeignNamespaceID(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	foreign := squadnamespace.ID("other-profile", session)
+	canonical := squadnamespace.ID(profile, session)
+	if foreign == canonical {
+		t.Fatal("fixture is void: the foreign namespace id equals the canonical one, so this test " +
+			"cannot distinguish acceptance from refusal")
+	}
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                resumeGoalTransitionRecord{Project: project, Profile: profile, Session: session},
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         foreign,
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+	})
+	if err == nil {
+		t.Fatal("a namespace id that is not canonical for this profile/session must be refused: the " +
+			"claim would be written where no scanner looks, so it would exist and block nothing")
+	}
+	if !strings.Contains(err.Error(), "namespace") {
+		t.Errorf("the refusal must name the namespace mismatch: %v", err)
+	}
+}

--- a/internal/cli/goal_supervision_test.go
+++ b/internal/cli/goal_supervision_test.go
@@ -670,35 +670,81 @@ func TestGoalSupervisionResumableLifecycleRequiresGoalBlockedPhase(t *testing.T)
 }
 
 func TestGoalSupervisionMutatingActionsBindFingerprintAndAttempt(t *testing.T) {
+	// UPDATED FOR #498 U1/F4, and the answer came from the source rather than from preference. This test
+	// asserted NeedsConfirmation=true and Available=false for the resume action. goal_supervision.go:469-479
+	// states that those two values WERE PLACEHOLDERS "for a supervisor surface that did not exist" and that
+	// the surface exists now, so the metadata states the truth instead:
+	//   Available          mirrors the assessment's own conclusion (AutomaticResumeAllowed);
+	//   NeedsConfirmation  false ONLY under safe_auto, where operator consent is already recorded in policy.
+	// eligibleGoalSupervisionInput uses safe_auto (goal_supervision_test.go:40), so the ratified values for
+	// this fixture are Available=true and NeedsConfirmation=false. The old assertions pinned the placeholders
+	// that U1/F4 explicitly replaced, which is why they failed the first honest compile.
 	got := assessGoalSupervision(eligibleGoalSupervisionInput())
-	for name, action := range map[string]GoalSupervisionAction{
-		"restore": got.Actions.Restore,
-		"resume":  got.Actions.Resume,
-	} {
-		if !action.Mutates || !action.NeedsConfirmation ||
-			action.Fingerprint != got.Fingerprint ||
-			action.AttemptID != got.Binding.Goal.AttemptID ||
-			action.Confirmation == "" {
-			t.Fatalf("%s action lacks exact mutation binding: %+v", name, action)
-		}
-	}
-	if got.Actions.Resume.Available ||
-		!strings.Contains(got.Actions.Resume.Command, got.Binding.Goal.AttemptID) ||
-		!strings.Contains(got.Actions.Resume.Command, got.Fingerprint) {
-		t.Fatalf("PR5-reserved resume action is not safely scoped: %+v", got.Actions.Resume)
+
+	// RESTORE is unconditionally NeedsConfirmation=true (goal_supervision.go:459) -- the no-confirmation
+	// ruling is scoped to the resume action under safe_auto, NOT global. Checked separately from resume for
+	// exactly that reason: folding them into one loop is what made this test assert a global invariant that
+	// the contract never had.
+	if r := got.Actions.Restore; !r.Mutates || !r.NeedsConfirmation ||
+		r.Fingerprint != got.Fingerprint ||
+		r.AttemptID != got.Binding.Goal.AttemptID ||
+		r.Confirmation == "" {
+		t.Fatalf("restore action lacks exact mutation binding: %+v", got.Actions.Restore)
 	}
 
+	// RESUME: the bindings that are unconditional stay unconditional; the two policy-derived fields are
+	// asserted against the POLICY rather than against a frozen literal, so this row cannot go stale again the
+	// next time a policy mode is added.
+	resume := got.Actions.Resume
+	wantConfirmation := got.Policy.Mode != team.GoalSupervisionSafeAuto
+	if !resume.Mutates ||
+		resume.Fingerprint != got.Fingerprint ||
+		resume.AttemptID != got.Binding.Goal.AttemptID ||
+		resume.Confirmation == "" {
+		t.Fatalf("resume action lacks exact mutation binding: %+v", resume)
+	}
+	if resume.NeedsConfirmation != wantConfirmation {
+		t.Fatalf("resume NeedsConfirmation=%t, want %t for policy mode %q: the no-confirmation ruling is "+
+			"scoped to safe_auto, where the operator's consent is already recorded in policy",
+			resume.NeedsConfirmation, wantConfirmation, got.Policy.Mode)
+	}
+	if resume.Available != got.AutomaticResumeAllowed {
+		t.Fatalf("resume Available=%t but the assessment's AutomaticResumeAllowed=%t: the published action "+
+			"must mirror the assessment's own conclusion, or a caller is invited to invoke something the "+
+			"assessment refuses", resume.Available, got.AutomaticResumeAllowed)
+	}
+	// STILL UNCONDITIONAL, and still the point of the test: the published command is a BOUND invocation.
+	if !strings.Contains(resume.Command, got.Binding.Goal.AttemptID) ||
+		!strings.Contains(resume.Command, got.Fingerprint) {
+		t.Fatalf("resume action is not safely scoped to its attempt and fingerprint: %+v", resume)
+	}
+
+	// THE UNBOUND CASE: no attempt id, so the assessment is ineligible and NEITHER action may be available.
+	// Split for the same reason as above -- this loop would have failed identically once the first Fatalf
+	// stopped short-circuiting it, so fixing only the first half would have moved the failure rather than
+	// removed it. I checked that rather than assuming the one reported failure was the only one.
 	missingAttempt := eligibleGoalSupervisionInput()
 	missingAttempt.Binding.Goal.AttemptID = ""
 	unbound := assessGoalSupervision(missingAttempt)
-	for name, action := range map[string]GoalSupervisionAction{
-		"restore": unbound.Actions.Restore,
-		"resume":  unbound.Actions.Resume,
-	} {
-		if !action.Mutates || !action.NeedsConfirmation || action.Available ||
-			action.Fingerprint != unbound.Fingerprint || action.Confirmation == "" {
-			t.Fatalf("%s unbound action misstates mutation semantics: %+v", name, action)
-		}
+
+	if r := unbound.Actions.Restore; !r.Mutates || !r.NeedsConfirmation || r.Available ||
+		r.Fingerprint != unbound.Fingerprint || r.Confirmation == "" {
+		t.Fatalf("restore unbound action misstates mutation semantics: %+v", r)
+	}
+
+	ur := unbound.Actions.Resume
+	// UNAVAILABILITY is the invariant that matters here and it is NOT policy-derived: an ineligible
+	// assessment must never publish an available mutating action, whatever the policy says.
+	if !ur.Mutates || ur.Available ||
+		ur.Fingerprint != unbound.Fingerprint || ur.Confirmation == "" {
+		t.Fatalf("resume unbound action misstates mutation semantics: %+v", ur)
+	}
+	// NeedsConfirmation stays keyed on Policy.Mode ALONE, deliberately: goal_supervision.go:505-508 notes that
+	// folding eligibility into it would flip an ineligible actor under safe_auto back to needing confirmation,
+	// misreporting the operator's standing consent as absent because of an unrelated eligibility fact.
+	if want := unbound.Policy.Mode != team.GoalSupervisionSafeAuto; ur.NeedsConfirmation != want {
+		t.Fatalf("resume unbound NeedsConfirmation=%t, want %t for policy mode %q: consent is a question "+
+			"about policy, not about eligibility", ur.NeedsConfirmation, want, unbound.Policy.Mode)
 	}
 }
 

--- a/internal/cli/goal_supervision_u6_falsifiers_test.go
+++ b/internal/cli/goal_supervision_u6_falsifiers_test.go
@@ -1,0 +1,1232 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// PR5 / #498 U6: THE BEHAVIOURAL FALSIFIERS for post-delivery reporting.
+//
+// U6's sentence has two halves and they are independently falsifiable: failure never authorizes
+// replay, AND failure evidence never disappears. Every row below attacks the second half, because
+// the first half was already load-bearing in the claim-once rows while the second half was, until
+// dev-2 named it, satisfied by code that silently discarded errors.
+//
+// WHY ORDER IS PROVEN BY ARTIFACT AND NOT BY A RECORDED LABEL. A recorded event log
+// (append "consume", append "directive", append "poll") only proves the order in which my STUBS
+// were called. It cannot prove that consume actually completed before the directive claimed
+// delivery, because a stub that records a label is agnostic about what the code did. So ordering
+// here is established from the LEDGER: consume publishes a `.consumed.json` companion beside the
+// reservation, so the directive stub asserting that companion EXISTS proves consume completed
+// first, and the same assertion inverted inside `deliver` proves it had not. That is the
+// difference between observing a sequence and proving a happens-before.
+
+// u6DeliveringFixture builds the one fixture that passes all eleven pre-mutation gates and reaches
+// delivery, so post-delivery behaviour is reachable at all. It is deliberately the same shape as the
+// U9 policy row's fixture with AutomaticResumeAllowed TRUE -- which here is production-consistent
+// rather than forced, since Eligible && Mode==safe_auto is exactly how production computes it.
+//
+// It returns the reservation path the executor WILL create, computed from the canonical claim key
+// rather than guessed, so the ordering assertions inspect the real artifact.
+func u6DeliveringFixture(t *testing.T) (GoalSupervisionAssessment, GoalSupervisionAction, string, string, time.Time) {
+	t.Helper()
+
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	const pauseGeneration = "pause-gen-1"
+	const payload = "/goal resume attempt-abc"
+
+	now := time.Now().UTC()
+	project := t.TempDir()
+	namespaceID := squadnamespace.ID(profile, session)
+
+	assessment := GoalSupervisionAssessment{
+		Fresh:       true,
+		Eligible:    true,
+		ObservedAt:  now,
+		FreshUntil:  now.Add(time.Hour),
+		Policy:      team.GoalSupervisionPolicyStatus{Mode: team.GoalSupervisionSafeAuto, Revision: 1, Source: "test"},
+		Fingerprint: "fingerprint-1",
+		// THE BLOCKER EVIDENCE, which this fixture was missing entirely.
+		//
+		// It sets Eligible=true DIRECTLY rather than letting eligibility be computed, so the absent blocker
+		// never showed up as an ineligible assessment -- the gates read the flag, not the fields behind it.
+		// That is a fixture asserting a state production cannot reach: eligibility
+		// (goal_supervision.go:341-342) requires Known + nonblank ID + Resolved + nonblank ResolutionDigest,
+		// so no real eligible assessment has a blank blocker. The executor now persists these into the exact
+		// binding, where the constructor requires them, and construction would refuse this fixture outright.
+		Blocker: GoalSupervisionBlockerEvidence{
+			ID: "blocker-1", Known: true, Resolved: true, ResolutionDigest: "resolution-digest-1",
+		},
+		Binding: GoalSupervisionBinding{
+			Project: project, Profile: profile, Session: session,
+			NamespaceID: namespaceID,
+			LeadRole:    "cto", LeadHandle: "cto",
+			LaunchID:            "launch-1",
+			LaunchRecordDigest:  "launch-digest-1",
+			LaunchRecordModTime: 1700000000,
+			LaunchStartedAt:     now.Add(-time.Minute),
+			Goal: GoalSupervisionGoalIdentity{
+				// Mode was ABSENT here for the same reason the blocker was: nothing in the gate path read it.
+				// The exact binding does, and it requires the value production actually emits.
+				Mode:      fixtureNativeGoalMode,
+				AttemptID: attemptID, BindingDigest: "digest-def",
+				CommandDigest: digestGoalSupervisionString(payload),
+			},
+			PauseGeneration: pauseGeneration,
+			Pane:            GoalSupervisionPaneIdentity{PaneID: "%7", Managed: true},
+		},
+	}
+	assessment.AutomaticResumeAllowed = true
+	assessment.Actions = goalSupervisionActions(assessment)
+
+	dir := goalAttemptDir(project, profile, session)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create ledger directory: %v", err)
+	}
+
+	// The reservation path is DERIVED from the canonical key, not hardcoded. A literal filename here
+	// would silently stop matching if the naming changed, and every ordering assertion below would
+	// then pass vacuously against a path that never exists -- the zero-effect-assertion trap.
+	key, err := supervisionClaimKey(namespaceID, pauseGeneration, attemptID)
+	if err != nil {
+		t.Fatalf("canonical claim key: %v", err)
+	}
+	reservation := filepath.Join(dir, currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key))
+
+	return assessment, assessment.Actions.Resume, payload, reservation, now
+}
+
+// u6StubSeams replaces the two package-global post-success seams and restores them. Restoration is
+// not hygiene theatre: these are package globals, so a leaked stub would silently rewire the NEXT
+// test in the same binary, and the production directive publisher would otherwise try to write into
+// a real AMQ root during a unit test.
+func u6StubSeams(t *testing.T, directive supervisionDirectivePublisher, poll func(GoalSupervisionAssessment) error) {
+	t.Helper()
+	previousDirective, previousPoll := publishDeliveredDirective, pollSupervisionStatusOnce
+	t.Cleanup(func() {
+		publishDeliveredDirective = previousDirective
+		pollSupervisionStatusOnce = previousPoll
+	})
+	publishDeliveredDirective = directive
+	pollSupervisionStatusOnce = poll
+}
+
+// FALSIFIER 1: a failed DELIVERED directive is REPORTED, not swallowed, and does not fail the command.
+//
+// THE FALSIFYING INPUT is a directive publisher that returns an error after a delivery that
+// succeeded and a consume that succeeded. If the executor swallows the error -- its original
+// behaviour -- DeliveredDirectiveError is empty and the operator never learns the audit record is
+// missing for a resume that really happened. If the executor instead RETURNS the error, a completed
+// irreversible delivery is reported as a failed command, which is the conflation dev-2 named.
+//
+// So this row asserts BOTH directions at once: evidence present AND exit success. A row asserting
+// only one of them would be satisfied by the defect on the other side.
+func TestFailedDeliveredDirectiveIsReportedWithoutFailingTheCommand(t *testing.T) {
+	assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+	directiveErr := errors.New("audit root unwritable")
+
+	consumedBeforeDirective := false
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error {
+			// ORDERING, proven from the ledger: consume publishes the .consumed.json companion, so its
+			// existence here means consume completed BEFORE this directive claimed delivery. A directive
+			// that says DELIVERED before the claim is consumed would be an audit record asserting
+			// something not yet true.
+			_, statErr := os.Stat(resumeGoalTransitionConsumedPath(reservation))
+			consumedBeforeDirective = statErr == nil
+			return directiveErr
+		},
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error { return nil })
+
+	if err != nil {
+		t.Fatalf("a directive failure after a completed delivery must NOT fail the command; got %v.\n"+
+			"An ordinary error here makes a delivery that HAPPENED indistinguishable from one that did not.", err)
+	}
+	if !outcome.Delivered || !outcome.Consumed {
+		t.Errorf("Delivered=%t Consumed=%t; both must be true -- the directive is bookkeeping ABOUT a "+
+			"delivery, and its failure cannot retroactively unmake the delivery or the consume",
+			outcome.Delivered, outcome.Consumed)
+	}
+	if outcome.DeliveredDirectivePublished {
+		t.Error("DeliveredDirectivePublished=true after the publisher returned an error")
+	}
+	if !strings.Contains(outcome.DeliveredDirectiveError, directiveErr.Error()) {
+		t.Errorf("DeliveredDirectiveError = %q, want it to carry %q.\nU6 permits failure to not authorize "+
+			"replay; it does not permit failure evidence to disappear.",
+			outcome.DeliveredDirectiveError, directiveErr.Error())
+	}
+	if !consumedBeforeDirective {
+		t.Error("the .consumed.json companion did not exist when the DELIVERED directive ran, so the " +
+			"directive claimed delivery before the consume that makes the claim true")
+	}
+	// The warning is the OPERATOR-VISIBLE half. A structured field nobody renders is evidence only for
+	// machines, and this failure needs a human to notice a missing audit record.
+	if got := outcome.warnings(); len(got) != 1 || !strings.Contains(got[0], directiveErr.Error()) {
+		t.Errorf("warnings() = %v, want exactly one carrying the directive error", got)
+	}
+}
+
+// FALSIFIER 2: a failed status poll is REPORTED, is observability-only, and does not fail the command.
+//
+// Distinct from falsifier 1 despite the identical shape, because the two failures have different
+// MEANINGS and the outcome must not flatten them: a missing audit directive is a durable
+// record-keeping hole, a failed poll costs only a refreshed view. Sharing one error field, or one
+// warning phrasing, would tell an operator the wrong severity.
+func TestFailedStatusPollIsReportedAsObservabilityOnly(t *testing.T) {
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+	pollErr := errors.New("status probe timed out")
+
+	directiveRan := false
+	pollRanAfterDirective := false
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { directiveRan = true; return nil },
+		func(GoalSupervisionAssessment) error {
+			pollRanAfterDirective = directiveRan
+			return pollErr
+		},
+	)
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error { return nil })
+
+	if err != nil {
+		t.Fatalf("an observability failure must not fail a completed resume; got %v", err)
+	}
+	if !outcome.Delivered || !outcome.Consumed || !outcome.DeliveredDirectivePublished {
+		t.Errorf("Delivered=%t Consumed=%t DirectivePublished=%t; a poll failure must leave every "+
+			"preceding success intact", outcome.Delivered, outcome.Consumed, outcome.DeliveredDirectivePublished)
+	}
+	if outcome.StatusPolled {
+		t.Error("StatusPolled=true after the poll returned an error")
+	}
+	if !strings.Contains(outcome.StatusPollError, pollErr.Error()) {
+		t.Errorf("StatusPollError = %q, want it to carry %q", outcome.StatusPollError, pollErr.Error())
+	}
+	if !pollRanAfterDirective {
+		t.Error("the poll ran BEFORE the DELIVERED directive; the contract is consume -> directive -> " +
+			"poll, so the poll observes a world in which the directive already exists")
+	}
+	// SEVERITY, not merely presence. The poll warning must say the resume is unaffected; if it read like
+	// the directive warning an operator would investigate a resume that is entirely fine.
+	got := outcome.warnings()
+	if len(got) != 1 || !strings.Contains(got[0], "observability only") {
+		t.Errorf("warnings() = %v, want exactly one marked observability only -- a poll failure and a "+
+			"lost audit record must not read as the same severity", got)
+	}
+}
+
+// FALSIFIER 3: an UNKNOWN pane-input result is terminal-indeterminate, not a refusal, and reaches
+// neither consume nor any post-success step.
+//
+// This is the row for the state dev-2 twice found collapsed. The zero outcome made an unknown
+// delivery byte-identical to an ordinary pre-delivery refusal, so the command reported "refused" for
+// the one case that leaves a live reservation and an operator decision behind.
+//
+// THE FALSIFYING INPUT is a deliver callback that returns an error AFTER the claim is reserved. The
+// row then asserts the four things that must all hold together: the discriminator is set, Delivered
+// is NOT set (success is unknown, and claiming it would be worse than claiming failure), the claim is
+// NOT consumed, and no post-success step ran at all.
+func TestUnknownPaneInputIsTerminalIndeterminateAndConsumesNothing(t *testing.T) {
+	assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+	inputErr := errors.New("pane input could not be confirmed")
+
+	directiveRan, pollRan := false, false
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { directiveRan = true; return nil },
+		func(GoalSupervisionAssessment) error { pollRan = true; return nil },
+	)
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	reservedAtDelivery := false
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(string) error {
+			// RESERVE-BEFORE-DELIVER, proven rather than assumed: the reservation must already exist when
+			// delivery is attempted, because that ordering is what makes a crash here read as
+			// indeterminate instead of invisible.
+			_, statErr := os.Stat(reservation)
+			reservedAtDelivery = statErr == nil
+			return inputErr
+		})
+
+	if err == nil {
+		t.Error("an unconfirmed delivery must return an error; silence would let a caller treat an " +
+			"indeterminate pause as a completed one")
+	}
+	if !outcome.DeliveryOutcomeUnknown {
+		t.Error("DeliveryOutcomeUnknown=false after an unconfirmed pane input.\nWithout this " +
+			"discriminator the outcome is byte-identical to an ordinary pre-delivery refusal, and the " +
+			"command reports refused for a pause that may well have been resumed.")
+	}
+	if outcome.Delivered {
+		t.Error("Delivered=true for an UNCONFIRMED input; Delivered must mean KNOWN-successful, " +
+			"because a caller reading it as truth would skip the inspection this state requires")
+	}
+	if outcome.Consumed {
+		t.Error("Consumed=true after an unconfirmed delivery; the claim must stay reserved so " +
+			"claim-once refuses the next attempt rather than risking a second audited resume")
+	}
+	if !reservedAtDelivery {
+		t.Error("the reservation did not exist when delivery was attempted, so a crash at delivery " +
+			"would leave no evidence that a resume may have been sent")
+	}
+	if _, statErr := os.Stat(resumeGoalTransitionConsumedPath(reservation)); statErr == nil {
+		t.Error("a .consumed.json companion exists after an unconfirmed delivery; consuming an " +
+			"indeterminate claim would record a completion nobody established")
+	}
+	if directiveRan || pollRan {
+		t.Errorf("post-success steps ran after an unconfirmed delivery (directive=%t poll=%t); both "+
+			"assert a completed resume, and neither fact is available here", directiveRan, pollRan)
+	}
+}
+
+// FALSIFIER 4: a consume failure after a KNOWN delivery reports the delivery AND the failure.
+//
+// The honesty row. Delivered was originally set only after consume succeeded, so a successful
+// delivery followed by a failed consume returned Delivered=false -- a report denying an
+// irreversible action that demonstrably happened, which is the most dangerous shape available here
+// because a caller may reasonably retry.
+//
+// INDUCTION METHOD, and it is worth naming because it is not obvious: consume is called directly
+// rather than through a seam, so it cannot be stubbed. Instead the ledger directory is made
+// read-only from INSIDE the deliver callback -- the one point that runs after reserve and before
+// consume. Delivery therefore succeeds and the subsequent companion publish genuinely fails, which
+// exercises the real consume code path rather than a fake standing in for it.
+func TestConsumeFailureAfterKnownDeliveryReportsBothFacts(t *testing.T) {
+	assessment, action, payload, reservation, now := u6DeliveringFixture(t)
+	dir := filepath.Dir(reservation)
+
+	directiveRan, pollRan := false, false
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { directiveRan = true; return nil },
+		func(GoalSupervisionAssessment) error { pollRan = true; return nil },
+	)
+
+	loader := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+	deliveredPayload := ""
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loader,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		readReservedRecoveryTransition,
+		func(got string) error {
+			deliveredPayload = got
+			// Read-only ledger directory: the delivery below is a genuine success and the consume that
+			// follows genuinely cannot publish its companion.
+			if chmodErr := os.Chmod(dir, 0o555); chmodErr != nil {
+				t.Fatalf("make ledger directory read-only: %v", chmodErr)
+			}
+			// Restored so t.TempDir cleanup can remove the tree; without this the failure surfaces as an
+			// unrelated cleanup error and obscures this row's result.
+			t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+			// THE PREMISE IS PROVED, NOT ASSUMED. Mode 0555 does not stop a privileged user, so under root
+			// the consume would SUCCEED and this row would fail while reporting nothing about the
+			// return-value-versus-reality property it exists to guard. A probe turns that from a confusing
+			// failure into an explicit skip, and it is the same reason the policy row probes writability
+			// in the opposite direction.
+			probe := filepath.Join(dir, ".consume-failure-premise-probe")
+			if probeErr := os.WriteFile(probe, []byte("x"), 0o644); probeErr == nil {
+				_ = os.Remove(probe)
+				t.Skip("ledger directory is still writable at mode 0555 (privileged user?), so a consume " +
+					"failure cannot be induced this way and this row would prove nothing")
+			}
+			return nil
+		})
+
+	if err == nil {
+		t.Fatal("a failed consume must be reported as an error; the claim is left reserved and an " +
+			"operator has to resolve it, so silence would strand an indeterminate pause")
+	}
+	if !outcome.Delivered {
+		t.Error("Delivered=false after a KNOWN-successful delivery whose consume failed.\nThe " +
+			"irreversible fact is established by the delivery, not by the bookkeeping after it, and a " +
+			"caller reading Delivered=false may retry a resume that already landed.")
+	}
+	if outcome.Consumed {
+		t.Error("Consumed=true although the companion publish failed")
+	}
+	if outcome.DeliveryOutcomeUnknown {
+		t.Error("DeliveryOutcomeUnknown=true for a delivery that was KNOWN to succeed; this row and " +
+			"falsifier 3 are different states and flattening them loses the distinction dev-2 required")
+	}
+	if outcome.ConsumeError == "" {
+		t.Error("ConsumeError empty after a failed consume; the outcome must carry both facts, because " +
+			"a bare error would erase the delivery and a bare outcome would hide the failure")
+	}
+	if deliveredPayload != payload {
+		t.Errorf("delivered payload = %q, want the digest-authorized native payload %q", deliveredPayload, payload)
+	}
+	// Post-success steps must NOT run: both would claim a consumed claim that does not exist.
+	if directiveRan || pollRan {
+		t.Errorf("post-success steps ran after a failed consume (directive=%t poll=%t)", directiveRan, pollRan)
+	}
+	if got := outcome.warnings(); len(got) != 1 || !strings.Contains(got[0], "INDETERMINATE") {
+		t.Errorf("warnings() = %v, want exactly one marking the pause INDETERMINATE", got)
+	}
+}
+
+// #498 U7 SLICE / cross-kind mutex prerequisite: native reservations must persist a MATCHABLE
+// attempt identity (cto ruling 2026-07-28T09:25, handed off from dev-2's Unit B).
+//
+// WHY THIS EXISTS AT ALL: the redelivery-side mutex tries to prove a current reservation belongs to a
+// DIFFERENT pause before ignoring it. That escape keyed on record fields native reservations never
+// populated, so it could never open -- the code read as conditional while behaving unconditionally,
+// and every native pause blocked every redelivery forever. The fix is to persist what a reader can
+// match on.
+func TestNativeReservationPersistsTheResumedAttemptAsItsMatchableIdentity(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+
+	record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		Supervisor:          "supervisor-1",
+		NamespaceID:         squadnamespace.ID(profile, session),
+		AttemptID:           attemptID,
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), attemptID),
+	})
+	if err != nil {
+		t.Fatalf("a complete native input must be accepted: %v", err)
+	}
+	if record.NewAttemptID != attemptID {
+		t.Errorf("NewAttemptID = %q, want the resumed attempt %q.\nA native record with no matchable "+
+			"attempt makes the redelivery mutex's proves-different escape unreachable, so every native "+
+			"pause blocks every redelivery permanently.", record.NewAttemptID, attemptID)
+	}
+	if strings.TrimSpace(record.NewAttemptID) == "" {
+		t.Error("NewAttemptID is blank; the ruling requires it NONBLANK, because a blank field is " +
+			"indistinguishable from the unpopulated state this fixes")
+	}
+}
+
+// FALSIFIER: a caller cannot smuggle a DIFFERENT attempt id through Base.
+//
+// The constructor owns identity. If Base could override it, a record could be filed under the claim
+// key for one attempt while claiming another -- exactly the filename-versus-body disagreement that
+// the scan treats as ambiguous evidence, manufactured at write time instead of by corruption.
+func TestNativeReservationRefusesASmuggledDisagreeingAttemptID(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	smuggled := nativeTransitionBase(project, profile, session)
+	// A DIFFERENT attempt than the one being resumed. Applied to the complete base rather than replacing
+	// it, so the smuggled id is the row's ONLY defect and the launch generation stays valid.
+	smuggled.NewAttemptID = "attempt-somebody-elses"
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                smuggled,
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		Supervisor:          "supervisor-1",
+		NamespaceID:         squadnamespace.ID(profile, session),
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+	})
+	if err == nil {
+		t.Fatal("a Base-supplied NewAttemptID disagreeing with the attempt being resumed must be " +
+			"REFUSED; silently overwriting it would hide a caller bug, and honouring it would file the " +
+			"record under one attempt while it claims another")
+	}
+	if !strings.Contains(err.Error(), "disagrees with the attempt being resumed") {
+		t.Errorf("refusal must name the disagreement, got: %v", err)
+	}
+}
+
+// REGRESSION GUARD for a change I made in SHARED code.
+//
+// The NewAttemptID derivation lives inside the native branch, but it is in the constructor both kinds
+// use. If it ever leaks to the redeliver branch it would overwrite redelivery's NewAttemptID with the
+// ORIGINAL attempt id -- and redelivery has two validators that REJECT exactly that ("transition
+// reuses the original attempt id"). The field's meaning is inverted between kinds, so a leak here
+// does not merely change a value, it violates the other kind's invariant.
+func TestRedeliverReservationKeepsItsOwnNewAttemptIDUntouched(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const originalAttempt = "attempt-original"
+	const freshAttempt = "attempt-freshly-created"
+	project := t.TempDir()
+
+	record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: originalAttempt, OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID: freshAttempt,
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     originalAttempt,
+		BindingDigest: "binding-digest-1",
+	})
+	if err != nil {
+		t.Fatalf("a complete redeliver input must still be accepted: %v", err)
+	}
+	if record.NewAttemptID != freshAttempt {
+		t.Errorf("redeliver NewAttemptID = %q, want the caller's fresh attempt %q -- the native "+
+			"derivation must not reach this branch", record.NewAttemptID, freshAttempt)
+	}
+	if record.NewAttemptID == record.OriginalAttemptID {
+		t.Error("redeliver NewAttemptID now equals OriginalAttemptID, which its own validators reject " +
+			"as \"transition reuses the original attempt id\"")
+	}
+}
+
+// #498 U7 REMAINDER: the SUPERVISOR is persisted on native reservations.
+//
+// WHY IT MATTERS: the pre-mutation gates already refuse a blank or placeholder supervisor, and the
+// DELIVERED directive names it -- and then it was discarded. So a durable claim could not answer the one
+// question an operator asks about an unexpected resume: who authorised this. Validating an identity and
+// then not recording it is accountability that exists only while the process is alive.
+func TestNativeReservationPersistsTheAuthorisingSupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         squadnamespace.ID(profile, session),
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          "cto",
+		NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+	})
+	if err != nil {
+		t.Fatalf("a complete native input must be accepted: %v", err)
+	}
+	if record.Supervisor != "cto" {
+		t.Errorf("Supervisor = %q, want %q -- a claim nobody is recorded as authorising cannot be "+
+			"audited after the fact", record.Supervisor, "cto")
+	}
+}
+
+// A BLANK supervisor REFUSES at the constructor, not only at the gate.
+//
+// The gate protects the delivering path; this protects the RECORD. Any future caller that skips the gate
+// would otherwise write an unattributable claim, and a durable identity field whose only guard lives in
+// one caller is guarded by convention rather than by construction.
+func TestNativeReservationRefusesABlankSupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         squadnamespace.ID(profile, session),
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		// EVERYTHING ELSE VALID, including the exact binding: the missing supervisor must be the only
+		// defect. The constructor happens to check the supervisor before the binding, so this row would
+		// still refuse for the right reason today -- but relying on check ORDER for the single-defect
+		// property means a harmless reordering silently changes what this row proves.
+		NativeBinding: validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+		// Supervisor deliberately absent.
+	})
+	if err == nil {
+		t.Fatal("a native reservation without a supervisor must be REFUSED")
+	}
+	if !strings.Contains(err.Error(), "requires the supervisor identity") {
+		t.Errorf("refusal must name the missing supervisor, got: %v", err)
+	}
+}
+
+// THE PLACEHOLDER is refused too, and this is the sharper of the two: a blank field is visibly empty,
+// whereas the literal "<your-identity>" LOOKS like an answer while attributing the resume to nobody.
+func TestNativeReservationRefusesThePlaceholderSupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         squadnamespace.ID(profile, session),
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          supervisorIdentityPlaceholder,
+		NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+	})
+	if err == nil {
+		t.Fatal("the literal placeholder must be REFUSED as a supervisor identity")
+	}
+	if !strings.Contains(err.Error(), "still the literal placeholder") {
+		t.Errorf("refusal must name the placeholder, got: %v", err)
+	}
+}
+
+// REDELIVER MUST NOT CARRY A SUPERVISOR, the same asymmetry as PauseGeneration.
+//
+// That path holds no assessment and no supervising actor, so a value there was invented rather than
+// observed. Refusing is what keeps "supervisor present" a reliable signal that a record came from the
+// supervised path -- if redelivery could carry one, the field would stop distinguishing the two origins.
+func TestRedeliverReservationRefusesASuppliedSupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID: "attempt-fresh",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+		Supervisor:    "cto",
+	})
+	if err == nil {
+		t.Fatal("a redeliver reservation carrying a supervisor must be REFUSED: that path has no " +
+			"supervising actor, so the value was invented")
+	}
+	if !strings.Contains(err.Error(), "must NOT carry a supervisor") {
+		t.Errorf("refusal must name the supervisor, got: %v", err)
+	}
+}
+
+// ANTI-VACUITY CONTROL for the row above. Without it, that row would pass even if redeliver refused
+// EVERYTHING -- including the supervisor-less form production actually writes.
+func TestRedeliverReservationStillSucceedsWithoutASupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID: "attempt-fresh",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+	})
+	if err != nil {
+		t.Fatalf("the supervisor-less redeliver form production writes must still be accepted: %v", err)
+	}
+	if record.Supervisor != "" {
+		t.Errorf("Supervisor = %q on a redeliver record, want empty -- omitempty keeps it absent from "+
+			"the round trip so a reader cannot mistake it for a deliberate value", record.Supervisor)
+	}
+}
+
+// FALSIFIER for the route my first version left open: a supervisor smuggled through BASE on a redeliver.
+//
+// DISTINCT FROM TestRedeliverReservationRefusesASuppliedSupervisor, and the distinction is the whole
+// point: that row supplies `in.Supervisor` and my original guard caught it. This one leaves in.Supervisor
+// EMPTY and puts the value on Base, which `record := in.Base` copies straight into the returned record. My
+// first version persisted it -- so the asymmetry was defeated through the door I left open, and a
+// redeliver record would have carried a supervisor, making "supervisor present" an unreliable signal that
+// a record came from the supervised path.
+func TestRedeliverReservationRefusesASupervisorSmuggledThroughBase(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID: "attempt-fresh",
+			// The smuggled value. in.Supervisor is deliberately left EMPTY.
+			Supervisor: "smuggled-supervisor",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+	})
+	if err == nil {
+		t.Fatal("a supervisor arriving via Base must be REFUSED on redeliver; guarding only the explicit " +
+			"input leaves the Base route open and persists an invented supervisor")
+	}
+	if !strings.Contains(err.Error(), "must NOT carry a supervisor") {
+		t.Errorf("refusal must name the supervisor, got: %v", err)
+	}
+	// The refusal must NAME THE ROUTE, so a caller can tell which of the two doors it came through.
+	if !strings.Contains(err.Error(), "Base record") {
+		t.Errorf("refusal must identify the Base route so the caller knows where the value came from, got: %v", err)
+	}
+	// NOTHING PERSISTED. A refusal that still returned a usable record and path would let a caller write
+	// it anyway, which is the return-value-versus-reality class one layer down.
+	if record.Supervisor != "" || path != "" {
+		t.Errorf("a refused construction must return no usable record or path; got supervisor=%q path=%q",
+			record.Supervisor, path)
+	}
+}
+
+// WHITESPACE-ONLY is refused too, which is dev-2's sharper catch: `omitempty` does NOT omit a
+// whitespace-only string, because the raw value is nonempty. So a trimmed guard would let it through and
+// the record would serialise a present-but-meaningless supervisor -- an answer-shaped non-answer, the same
+// defect class as the placeholder.
+func TestRedeliverReservationRefusesAWhitespaceOnlySupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID: "attempt-fresh",
+			Supervisor:   "   ",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+	})
+	if err == nil {
+		t.Fatal("a whitespace-only supervisor must be REFUSED: omitempty keeps it in the JSON because the " +
+			"raw string is nonempty, so a trimmed guard would persist a meaningless value")
+	}
+}
+
+// NATIVE: a DISAGREEING Base.Supervisor is refused rather than silently overwritten.
+//
+// The overwrite would have been SAFE -- the validated input wins, so the persisted attribution is correct
+// and nothing breaks. That is precisely why it is worth refusing: a caller passing a different supervisor
+// through Base believes something false about what this record will say, and silently correcting them hides
+// a caller bug that surfaces somewhere less observable. Same rule as the attempt id one file over.
+//
+// AGREEING values are fine, and the second half of this row proves the guard is not simply "refuse any
+// Base value" -- which would be a stricter rule that breaks a legitimate caller.
+func TestNativeReservationRefusesADisagreeingBaseSupervisor(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	base := func(supervisor string) resumeGoalTransitionRecord {
+		b := nativeTransitionBase(project, profile, session)
+		b.Supervisor = supervisor
+		return b
+	}
+	input := func(b resumeGoalTransitionRecord) recoveryTransitionInput {
+		return recoveryTransitionInput{
+			Base:                b,
+			Kind:                recoveryTransitionKindNativeGoalResume,
+			NamespaceID:         squadnamespace.ID(profile, session),
+			AttemptID:           "attempt-abc",
+			PauseGeneration:     "pause-gen-1",
+			PreclaimFingerprint: "fingerprint-1",
+			Supervisor:          "cto",
+			NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+		}
+	}
+
+	_, _, err := newRecoveryTransitionRecord(input(base("someone-else")))
+	if err == nil {
+		t.Fatal("a Base.Supervisor disagreeing with the validated supervisor must be REFUSED, not " +
+			"silently overwritten -- the overwrite is safe, which is what makes it hide a caller bug")
+	}
+	if !strings.Contains(err.Error(), "disagrees with the Base-supplied") {
+		t.Errorf("refusal must name the disagreement, got: %v", err)
+	}
+
+	// AGREEING is accepted: the guard must not degenerate into "refuse any Base value", which would
+	// reject a legitimate caller that populated Base consistently.
+	record, _, agreeErr := newRecoveryTransitionRecord(input(base("cto")))
+	if agreeErr != nil {
+		t.Fatalf("an AGREEING Base.Supervisor must be accepted: %v", agreeErr)
+	}
+	if record.Supervisor != "cto" {
+		t.Errorf("Supervisor = %q, want %q", record.Supervisor, "cto")
+	}
+}
+
+// dev-2's THIRD instance of the Base-route class: a PauseGeneration smuggled through Base on a redeliver.
+//
+// DISTINGUISHABLE FROM TestRedeliverInputCarryingAPauseGenerationIsRefused (recovery_transition_roundtrip_test.go),
+// which supplies the EXPLICIT input and was always caught. This row leaves in.PauseGeneration EMPTY and puts
+// the value on Base, which `record := in.Base` copies straight into the returned record.
+//
+// THE UNCOMFORTABLE PART: that older guard is the one I used as the TEMPLATE when adding the Supervisor
+// field, so it propagated its own defect into the new field. The Supervisor bug was inherited, not
+// independently invented -- which is why the fix is the whole class plus a stated posture rule, not a third
+// one-off patch.
+func TestRedeliverReservationRefusesAPauseGenerationSmuggledThroughBase(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID:    "attempt-fresh",
+			PauseGeneration: "smuggled-pause",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+		// in.PauseGeneration intentionally empty.
+	})
+	if err == nil {
+		t.Fatal("a pause generation arriving via Base must be REFUSED on redeliver: that path holds no " +
+			"assessment, so the value was recomputed or invented")
+	}
+	if !strings.Contains(err.Error(), "must NOT carry a pause generation") {
+		t.Errorf("refusal must name the pause generation, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Base record") {
+		t.Errorf("refusal must identify the Base route, got: %v", err)
+	}
+	if record.PauseGeneration != "" || path != "" {
+		t.Errorf("a refused construction must return no usable record or path; got pause=%q path=%q",
+			record.PauseGeneration, path)
+	}
+}
+
+// WHITESPACE-ONLY through Base, the omitempty case: a raw nonempty string still serialises.
+func TestRedeliverReservationRefusesAWhitespaceOnlyPauseGeneration(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: profile, Session: session,
+			OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1",
+			NewAttemptID:    "attempt-fresh",
+			PauseGeneration: "  ",
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-original",
+		BindingDigest: "binding-digest-1",
+	})
+	if err == nil {
+		t.Fatal("a whitespace-only pause generation must be REFUSED: omitempty keeps it in the JSON " +
+			"because the raw string is nonempty")
+	}
+}
+
+// NATIVE: the two remaining derived fields refuse a DISAGREEING Base value, completing the class.
+//
+// Both were silent overwrites until this fix. Each row also asserts the AGREEING case is accepted, so
+// neither guard can degenerate into "refuse any Base value" and reject a consistent caller.
+func TestNativeReservationRefusesDisagreeingBaseDerivedFields(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+
+	build := func(mutate func(*recoveryTransitionInput)) (resumeGoalTransitionRecord, error) {
+		in := recoveryTransitionInput{
+			Base:                nativeTransitionBase(project, profile, session),
+			Kind:                recoveryTransitionKindNativeGoalResume,
+			NamespaceID:         squadnamespace.ID(profile, session),
+			AttemptID:           "attempt-abc",
+			PauseGeneration:     "pause-gen-1",
+			PreclaimFingerprint: "fingerprint-1",
+			Supervisor:          "cto",
+			NativeBinding:       validNativeBinding(squadnamespace.ID(profile, session), "attempt-abc"),
+		}
+		mutate(&in)
+		rec, _, err := newRecoveryTransitionRecord(in)
+		return rec, err
+	}
+
+	for _, row := range []struct {
+		name    string
+		mutate  func(*recoveryTransitionInput)
+		wantErr string
+	}{
+		{"disagreeing Base pause generation",
+			func(in *recoveryTransitionInput) { in.Base.PauseGeneration = "someone-elses-pause" },
+			"pause generation"},
+		{"disagreeing Base preclaim fingerprint",
+			func(in *recoveryTransitionInput) { in.Base.PreclaimFingerprint = "someone-elses-fingerprint" },
+			"preclaim fingerprint"},
+	} {
+		_, err := build(row.mutate)
+		if err == nil {
+			t.Errorf("%s: must be REFUSED rather than silently overwritten", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) || !strings.Contains(err.Error(), "disagrees with the Base-supplied") {
+			t.Errorf("%s: refusal must name the field and the disagreement, got: %v", row.name, err)
+		}
+	}
+
+	// AGREEING values are accepted, for both fields at once.
+	rec, err := build(func(in *recoveryTransitionInput) {
+		in.Base.PauseGeneration = "pause-gen-1"
+		in.Base.PreclaimFingerprint = "fingerprint-1"
+	})
+	if err != nil {
+		t.Fatalf("AGREEING Base values must be accepted, else the guard rejects a consistent caller: %v", err)
+	}
+	if rec.PauseGeneration != "pause-gen-1" || rec.PreclaimFingerprint != "fingerprint-1" {
+		t.Errorf("agreeing values must persist; got pause=%q fingerprint=%q",
+			rec.PauseGeneration, rec.PreclaimFingerprint)
+	}
+}
+
+// THE FLAT LAUNCH GENERATION IS REQUIRED FOR NATIVE, one row per field.
+//
+// These exist because the requirement and its falsifiers must land together. I shipped the publication
+// validator with no falsifiers at all and dev-2 found a hole in it by reading; a required field whose
+// absence nothing tests is the same thing one layer down -- a guard that is only as good as my reading of
+// it. Each row removes EXACTLY ONE field from a complete input, so a row can only pass because that
+// specific requirement fired.
+//
+// WHY THE FIELDS MATTER: the record is the recovery contract. A reserved native claim that does not say
+// which launch generation it was made against cannot be revalidated after a crash, so a relaunched runtime
+// looks identical to the one the claim authorized -- and the pane can be perfectly live, managed and idle
+// while belonging to a different process entirely. That is the one drift the U5 liveness gates cannot see.
+func TestNativeReservationRequiresTheFlatLaunchGeneration(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+
+	for _, row := range []struct {
+		name    string
+		break1  func(*recoveryTransitionInput)
+		wantErr string
+	}{
+		{"missing launch id", func(in *recoveryTransitionInput) { in.Base.LaunchID = "" }, "launch id"},
+		{"missing launch record digest", func(in *recoveryTransitionInput) { in.Base.LaunchRecordDigest = "" },
+			"launch record digest"},
+		// ZERO is the absent value, and it is the dangerous one: it is what an unset field looks like, so a
+		// lenient writer would persist a generation no stat call could ever reproduce.
+		{"zero launch record mod time", func(in *recoveryTransitionInput) { in.Base.LaunchRecordModTime = 0 },
+			"positive launch record mod time"},
+		// A NEGATIVE modtime is not a plausible observation either. Without this row a guard written as
+		// `== 0` would pass while accepting a value no filesystem produces.
+		{"negative launch record mod time", func(in *recoveryTransitionInput) { in.Base.LaunchRecordModTime = -1 },
+			"positive launch record mod time"},
+	} {
+		in := completeNativeTransitionInput(project, profile, session, attemptID)
+		row.break1(&in)
+		_, _, err := newRecoveryTransitionRecord(in)
+		if err == nil {
+			t.Errorf("%s: a native reservation missing its launch generation must REFUSE -- the claim it "+
+				"would write cannot be revalidated against the runtime it was made against", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the field, got: %v", row.name, err)
+		}
+	}
+}
+
+// THE ANTI-VACUITY CONTROL for the rows above: the complete fixture must be ACCEPTED.
+//
+// Without it, all four rows would be satisfied by a constructor that refused every native input, which is
+// precisely the failure mode that makes a wall of refusal tests worthless.
+func TestTheCompleteNativeFixtureIsAccepted(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+
+	record, path, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, attemptID))
+	if err != nil {
+		t.Fatalf("the shared complete native fixture must be accepted: %v\nEvery single-defect row in this "+
+			"package derives from this fixture, so if it is refused, all of them pass for the wrong reason.", err)
+	}
+	// The persisted launch generation must be the one supplied, not a default.
+	if record.LaunchID != fixtureLaunchID || record.LaunchRecordDigest != fixtureLaunchDigest ||
+		record.LaunchRecordModTime != fixtureLaunchModTime {
+		t.Errorf("the launch generation was not persisted as supplied: got %q/%q/%d",
+			record.LaunchID, record.LaunchRecordDigest, record.LaunchRecordModTime)
+	}
+	if path == "" {
+		t.Error("constructor returned an empty path for an accepted native input")
+	}
+}
+
+// ===== U7 PHASE 1: the exact-binding block =====
+//
+// validNativeBinding is the all-valid block, shared so every refusal row below differs from it in exactly
+// ONE field. A row invalid in two dimensions cannot tell you which validation refused.
+func validNativeBinding(namespaceID, attemptID string) *resumeGoalNativeBinding {
+	return &resumeGoalNativeBinding{
+		NamespaceID: namespaceID,
+		PaneID:      "%7",
+		// THE MODE PRODUCTION ACTUALLY EMITS. This said "native", which no path produces: eligibility
+		// (goal_supervision.go:334) requires exactly "native_goal_blocked". The constructor only checks
+		// GoalMode for NONBLANKNESS, so the wrong value passed every guard -- the SAME defect class as the
+		// "safe_auto" lookalike noted four lines below, in the same helper, one field apart. Two instances
+		// of one class in one struct is why fixtures now come from production values rather than being
+		// invented next to the assertion that needs them.
+		GoalMode:                fixtureNativeGoalMode,
+		GoalAttemptID:           attemptID,
+		GoalBindingDigest:       "binding-digest-1",
+		GoalCommandDigest:       "command-digest-1",
+		BlockerID:               "blocker-1",
+		BlockerResolutionDigest: "resolution-digest-1",
+		// The REAL constant, not a lookalike literal. I first hardcoded "safe_auto" with an underscore
+		// while production uses "safe-auto" with a hyphen. The constructor only checks nonblank here so it
+		// passed -- a fixture carrying a value production never emits, which is the unreachable-state
+		// problem in milder form: green, and describing a system that does not exist.
+		PolicyMode:     team.GoalSupervisionSafeAuto,
+		PolicyRevision: 1,
+	}
+}
+
+// THE ANTI-VACUITY CONTROL, and it is the row that replaces the deleted blocker-less-passes row.
+//
+// That deleted row asserted a state the system CANNOT PRODUCE -- eligibility requires nonblank Blocker.ID
+// and ResolutionDigest -- so it would have pinned support for an impossibility and gone red when someone
+// correctly tightened the constructor. This control proves the guards do not refuse everything using a
+// state production actually produces.
+func TestNativeReservationAcceptsTheCompleteExactBinding(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+	ns := squadnamespace.ID(profile, session)
+
+	record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         ns,
+		AttemptID:           attemptID,
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          "cto",
+		NativeBinding:       validNativeBinding(ns, attemptID),
+	})
+	if err != nil {
+		t.Fatalf("the complete ratified binding must be accepted: %v", err)
+	}
+	if record.NativeBinding == nil {
+		t.Fatal("record.NativeBinding is nil after an accepted native construction")
+	}
+	if record.SchemaVersion != resumeGoalTransitionSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d -- native records persisted ZERO before this change while "+
+			"four readers validate nonzero", record.SchemaVersion, resumeGoalTransitionSchemaVersion)
+	}
+	// FRESH VALUE, NOT AN ALIAS: mutating the caller's struct afterwards must not reach the record.
+	// A pointer assignment would leave the record aliasing memory the caller still holds, so the
+	// validation would expire the moment the caller touched it again.
+	supplied := validNativeBinding(ns, attemptID)
+	rec2, _, err2 := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         ns,
+		AttemptID:           attemptID,
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          "cto",
+		NativeBinding:       supplied,
+	})
+	if err2 != nil {
+		t.Fatalf("second construction: %v", err2)
+	}
+	supplied.PaneID = "%999"
+	if rec2.NativeBinding.PaneID == "%999" {
+		t.Error("the record ALIASES the caller's binding: a caller mutation reached a validated record, " +
+			"so the validation expired the moment the caller touched its own struct again")
+	}
+}
+
+// EVERY REQUIRED FIELD REFUSES WHEN BLANK, one dimension at a time.
+//
+// The blocker rows are the ones I originally proposed as OPTIONAL. dev-2 disproved that premise from the
+// executable contract (goal_supervision.go:341-342 make both nonblank a condition of ELIGIBILITY, and the
+// executor refuses ineligible assessments before reserve), so accepting empty would let a gate-skipping
+// caller write a record the executor could never authorize.
+func TestNativeExactBindingRefusesEachMissingField(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+	ns := squadnamespace.ID(profile, session)
+
+	for _, row := range []struct {
+		name    string
+		blank   func(*resumeGoalNativeBinding)
+		wantErr string
+	}{
+		{"pane id", func(b *resumeGoalNativeBinding) { b.PaneID = "" }, "pane id"},
+		{"goal mode", func(b *resumeGoalNativeBinding) { b.GoalMode = "" }, "goal mode"},
+		{"goal binding digest", func(b *resumeGoalNativeBinding) { b.GoalBindingDigest = "" }, "goal binding digest"},
+		{"goal command digest", func(b *resumeGoalNativeBinding) { b.GoalCommandDigest = "" }, "goal command digest"},
+		{"blocker id", func(b *resumeGoalNativeBinding) { b.BlockerID = "" }, "blocker id"},
+		{"blocker resolution digest", func(b *resumeGoalNativeBinding) { b.BlockerResolutionDigest = "" }, "blocker resolution digest"},
+		{"policy mode", func(b *resumeGoalNativeBinding) { b.PolicyMode = "" }, "policy mode"},
+		// The expected substring follows the SHARED CONTRACT's wording, which is deliberately more specific
+		// than the constructor's old message: interior refusals are prefixed "native binding ..." so an
+		// operator can tell an interior failure from a flat one. Ruled to change the TEST rather than weaken
+		// the message -- trading diagnostic value for a green substring is backwards.
+		{"policy revision zero", func(b *resumeGoalNativeBinding) { b.PolicyRevision = 0 },
+			"positive native binding policy revision"},
+	} {
+		nb := validNativeBinding(ns, attemptID)
+		row.blank(nb)
+		_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+			Base:                nativeTransitionBase(project, profile, session),
+			Kind:                recoveryTransitionKindNativeGoalResume,
+			NamespaceID:         ns,
+			AttemptID:           attemptID,
+			PauseGeneration:     "pause-gen-1",
+			PreclaimFingerprint: "fingerprint-1",
+			Supervisor:          "cto",
+			NativeBinding:       nb,
+		})
+		if err == nil {
+			t.Errorf("%s: a blank required binding field must REFUSE", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the field, got: %v", row.name, err)
+		}
+	}
+}
+
+// THE ONE COLLAPSED SIDE DOOR: a Base-supplied binding block is refused on BOTH kinds, even when the
+// values would have been valid. Nesting turned fifteen potential Base doors into one; this proves the one
+// is locked, which is the difference between concentrating risk and removing it.
+func TestBaseSuppliedNativeBindingIsRefusedOnBothKinds(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	project := t.TempDir()
+	ns := squadnamespace.ID(profile, session)
+
+	for _, row := range []struct {
+		name string
+		in   recoveryTransitionInput
+	}{
+		{"native", recoveryTransitionInput{
+			Base: resumeGoalTransitionRecord{
+				Project: project, Profile: profile, Session: session,
+				NativeBinding: validNativeBinding(ns, attemptID),
+			},
+			Kind: recoveryTransitionKindNativeGoalResume, NamespaceID: ns, AttemptID: attemptID,
+			PauseGeneration: "pause-gen-1", PreclaimFingerprint: "fingerprint-1", Supervisor: "cto",
+			NativeBinding: validNativeBinding(ns, attemptID),
+		}},
+		{"redeliver", recoveryTransitionInput{
+			Base: resumeGoalTransitionRecord{
+				Project: project, Profile: profile, Session: session,
+				OriginalAttemptID: "attempt-original", OriginalBindingDigest: "binding-digest-1", NewAttemptID: "attempt-fresh",
+				NativeBinding: validNativeBinding(ns, attemptID),
+			},
+			Kind: recoveryTransitionKindRedeliver, AttemptID: "attempt-original", BindingDigest: "bd-1",
+		}},
+	} {
+		record, path, err := newRecoveryTransitionRecord(row.in)
+		if err == nil {
+			t.Errorf("%s: a Base-supplied native binding must be REFUSED even when its values are valid, "+
+				"because there is no legitimate Base source for a block the constructor alone populates", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "must not carry a Base-supplied native binding") {
+			t.Errorf("%s: refusal must name the Base binding, got: %v", row.name, err)
+		}
+		if record.NativeBinding != nil || path != "" {
+			t.Errorf("%s: refused construction must return no usable record or path", row.name)
+		}
+	}
+}
+
+// REDELIVER MUST NOT CARRY THE BLOCK through the explicit input either, and the anti-vacuity half proves
+// redeliver still succeeds without it -- the form production actually writes.
+func TestRedeliverRefusesAnExplicitNativeBindingButSucceedsWithout(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+	// THE DIGEST MUST MATCH THE INPUT'S ("bd-1", not the "binding-digest-1" used elsewhere in this file).
+	// The shared contract RECOMPUTES the redeliver identity from the record's own OriginalAttemptID and
+	// OriginalBindingDigest, so a Base digest that disagreed with the input's would refuse on the identity
+	// check and this row's anti-vacuity half would fail for a reason unrelated to native bindings. I hit
+	// exactly that by bulk-adding one digest value across the file -- the mechanical edit that fixed seven
+	// sites broke the eighth, which is why the check below is a script and not a reread.
+	base := resumeGoalTransitionRecord{
+		Project: project, Profile: profile, Session: session,
+		OriginalAttemptID: "attempt-original", OriginalBindingDigest: "bd-1", NewAttemptID: "attempt-fresh",
+	}
+
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: base, Kind: recoveryTransitionKindRedeliver,
+		AttemptID: "attempt-original", BindingDigest: "bd-1",
+		NativeBinding: validNativeBinding(squadnamespace.ID(profile, session), "attempt-original"),
+	})
+	if err == nil {
+		t.Fatal("redeliver must REFUSE an explicit native binding: that block is the assessment's exact " +
+			"binding and this path holds no assessment")
+	}
+	if !strings.Contains(err.Error(), "must NOT carry a native binding") {
+		t.Errorf("refusal must name the native binding, got: %v", err)
+	}
+
+	rec, _, okErr := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: base, Kind: recoveryTransitionKindRedeliver,
+		AttemptID: "attempt-original", BindingDigest: "bd-1",
+	})
+	if okErr != nil {
+		t.Fatalf("the binding-less redeliver form production writes must still be accepted: %v", okErr)
+	}
+	if rec.NativeBinding != nil {
+		t.Error("redeliver record carries a native binding; the pointer must stay nil so omitempty omits it")
+	}
+}
+
+// THE INTENTIONAL DUAL'S INVARIANT. GoalAttemptID and the flat NewAttemptID legitimately carry one value
+// ONLY because equality is enforced; without the check they would be two of the five accidental duplicates
+// dev-2 rejected from my draft.
+func TestNativeBindingAttemptIdentityMustEqualTheReservationAttempt(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+	ns := squadnamespace.ID(profile, session)
+
+	nb := validNativeBinding(ns, "attempt-from-somewhere-else")
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:                nativeTransitionBase(project, profile, session),
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         ns,
+		AttemptID:           "attempt-abc",
+		PauseGeneration:     "pause-gen-1",
+		PreclaimFingerprint: "fingerprint-1",
+		Supervisor:          "cto",
+		NativeBinding:       nb,
+	})
+	if err == nil {
+		t.Fatal("a native binding whose goal attempt id differs from the reservation attempt must REFUSE: " +
+			"the authorized identity and the lifecycle identity must be the same attempt")
+	}
+	if !strings.Contains(err.Error(), "disagrees with the reservation attempt") {
+		t.Errorf("refusal must name the disagreement, got: %v", err)
+	}
+}

--- a/internal/cli/namespace_migration_native_claims.go
+++ b/internal/cli/namespace_migration_native_claims.go
@@ -65,10 +65,47 @@ func inspectNamespaceNativeRecoveryClaims(goalAttemptsSource string, blockers *[
 			inspectNamespaceNativeRecoveryClaims(filepath.Join(goalAttemptsSource, entry.Name()), blockers)
 			continue
 		}
-		// ONE RECOGNITION OWNER. recognizeRecoveryTransitionName is the same parser the pause scan uses, so
-		// this guard cannot drift from the scanner's idea of what a claim file is. A string-prefix test here
-		// would be a second opinion about naming, which is the two-deciders shape.
-		parsed, recognition := recognizeRecoveryTransitionName(entry.Name())
+		// TWO-STEP RECOGNITION, IN THE SCAN'S ORDER -- companion base FIRST, then the name parser (codex
+		// finding 2).
+		//
+		// THE COMMENT THAT USED TO BE HERE WAS FALSE, and its falsity is the whole defect. It said
+		// "ONE RECOGNITION OWNER: recognizeRecoveryTransitionName is the same parser the pause scan uses, so
+		// this guard cannot drift from the scanner's idea of what a claim file is." The scan recognises in TWO
+		// steps -- companionReservationBase at recovery_transition_scan.go:95, THEN
+		// recognizeRecoveryTransitionName at :101. This guard adopted the second and not the first, then
+		// asserted non-drift. A PARTIAL COPY OF A TWO-STEP DECIDER, under a comment claiming it is the whole
+		// decider, is worse than an honest second opinion: the comment is what stops the next reader looking.
+		//
+		// WHAT THE MISS COST. recognizeRecoveryTransitionName classifies .consumed.json/.bound.json as
+		// recoveryNameNotATransition (recovery_transition.go:189) because companions "are handled by their own
+		// path" -- true in the scan, which has that other path, and false here, which had none. So a native
+		// CONSUMED companion raised no blocker; the adapter copies it content-unchanged
+		// (namespace_migration_adapters.go:131-137) and the copier preserves its basename verbatim
+		// (namespace_migration_tx.go:442), carrying the OLD namespace-derived claim key into the new
+		// namespace. In the destination, companionBelongsToPause matches by substring against the NEW claim
+		// key (scan.go:218-220), so the companion is never collected -- which means neither the consumed-state
+		// blocker NOR the orphan-companion blocker can fire for it. The prior consumption becomes invisible to
+		// the claim-once decision, and invisible prior delivery is a SECOND delivery.
+		//
+		// NO RESERVATION-REQUIRED PRECONDITION, ruled. It is tempting to block only companions whose
+		// reservation is absent, since a present native reservation already blocks on its own. That would make
+		// this guard's correctness depend on the ORDER files are read and on another entry existing, and the
+		// question here is "is this namespace safe to migrate AT ALL". A companion carrying a namespace-derived
+		// key in its NAME is exactly as unmigratable as its reservation, so it is judged on its own.
+		name := entry.Name()
+		inspect, isCompanion := name, false
+		if base, ok := companionReservationBase(name); ok {
+			// The companion is judged by the RESERVATION NAME it belongs to, because that is where the claim
+			// key lives -- companion paths are the reservation path plus a suffix (resume_goal.go:431,435).
+			inspect, isCompanion = base+".json", true
+		}
+		subject := "native recovery-transition claim"
+		unreadable := "recovery-transition-like file"
+		if isCompanion {
+			subject = "native recovery-transition COMPANION (consumption/binding evidence)"
+			unreadable = "recovery-transition-like COMPANION file"
+		}
+		parsed, recognition := recognizeRecoveryTransitionName(inspect)
 		switch recognition {
 		case recoveryNameRecognized:
 			// LEGACY-shaped records are what the adapter already handles: they carry no kind in the name and
@@ -78,18 +115,20 @@ func inspectNamespaceNativeRecoveryClaims(goalAttemptsSource string, blockers *[
 				continue
 			}
 			*blockers = append(*blockers, fmt.Sprintf(
-				"native recovery-transition claim %s cannot be migrated safely: its claim key is derived from the namespace, so rewriting profile/session would make the claim unmatchable on read (treated as ABSENT, permitting a second delivery). Resolve or consume the claim before migrating; native-aware migration is tracked separately",
-				filepath.Join(goalAttemptsSource, entry.Name())))
+				"%s %s cannot be migrated safely: its claim key is derived from the namespace, so rewriting profile/session would make it unmatchable on read (treated as ABSENT, permitting a second delivery). CONSUME the claim, or complete the resume it records, before migrating -- do NOT delete the reservation: removing it leaves an orphan companion, which the pause scan treats as tampering and which this guard would then be the only thing standing between you and a corrupted record. Native-aware migration is tracked separately",
+				subject, filepath.Join(goalAttemptsSource, name)))
 		case recoveryNameMalformed:
 			// UNKNOWN IS NOT ABSENT -- the same rule the pause scan enforces, and the reason this case is
 			// listed explicitly rather than folded into the default. A transition-like name we cannot classify
 			// might be a native claim; treating it as "no native claims present" would migrate anyway and
 			// corrupt exactly the record we failed to read.
 			*blockers = append(*blockers, fmt.Sprintf(
-				"recovery-transition-like file %s cannot be classified, so it cannot be shown safe to migrate: unknown is not absent, and a native claim here would be corrupted by a namespace rewrite",
-				filepath.Join(goalAttemptsSource, entry.Name())))
+				"%s %s cannot be classified, so it cannot be shown safe to migrate: unknown is not absent, and a native claim here would be corrupted by a namespace rewrite",
+				unreadable, filepath.Join(goalAttemptsSource, name)))
 		}
 		// recoveryNameNotATransition: an ordinary attempt/claim file. Ignored, because blocking on those would
-		// make every namespace unmigratable, which is amendment 1 overcorrected into an outage.
+		// make every namespace unmigratable, which is amendment 1 overcorrected into an outage. A companion of
+		// an ordinary file lands here too, and correctly: <attempt>.claim.json is not a companion suffix, so
+		// nothing ordinary reaches the companion branch above.
 	}
 }

--- a/internal/cli/namespace_migration_native_claims.go
+++ b/internal/cli/namespace_migration_native_claims.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// #498 U7: FAIL-CLOSED GUARD against migrating a namespace that holds NATIVE recovery-transition claims.
+//
+// WHY THIS EXISTS. The migration adapter rewrites a transition record's Profile and Session and re-marshals it
+// (namespace_migration_adapters.go, the .resume-redelivery- branch). For a NATIVE claim that is silent
+// corruption: the claim key is derived from NamespaceID(profile, session) + pause generation + attempt, so
+// rewriting profile/session WITHOUT recomputing the identity leaves a record whose id no longer matches its own
+// namespace. Unmatchable on read means treated as ABSENT, and absent means "no prior claim" -- which is a SECOND
+// DELIVERY of an audited resume. That is precisely the failure #498 exists to prevent, reached through a code
+// path nobody had enumerated until the re-decider sweep.
+//
+// The adapter also only recognises the LEGACY ".resume-redelivery-" prefix, so a current-prefix native file
+// falls through to the goal-attempt branch and fails the migration in a confusing way rather than a clear one.
+//
+// SCOPE, deliberately minimal and ruled: this guard REFUSES. It does not recompute claim keys and it does not
+// teach the adapter the native prefix. Full native-migration support is a separate v2.26.0 issue ranked above
+// #583 because it is a correctness bug rather than breadth. Silent corruption becomes an explicit refusal, and
+// that is the whole intended delta.
+//
+// IT IS A NAMESPACE PRE-CHECK, not a per-file refusal, and that placement is load-bearing: a per-file refusal
+// discovered mid-rewrite would abort a multi-file migration halfway, which is its own corruption mode. The
+// question this answers is "is this namespace safe to migrate AT ALL", asked before anything is rewritten.
+func inspectNamespaceNativeRecoveryClaims(goalAttemptsSource string, blockers *[]string) {
+	if goalAttemptsSource == "" {
+		return
+	}
+	entries, err := os.ReadDir(goalAttemptsSource)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No goal-attempts tree at all means no claims to corrupt. Absence here is genuinely absence,
+			// unlike the malformed case below, because the directory's non-existence is not ambiguous.
+			return
+		}
+		// UNREADABLE IS NOT EMPTY. If the directory cannot be listed we do not know whether native claims are
+		// present, and proceeding would gamble the double-delivery outcome on an unverified assumption.
+		*blockers = append(*blockers, fmt.Sprintf(
+			"cannot inspect %s for native recovery-transition claims, so migration safety cannot be established: %v",
+			goalAttemptsSource, err))
+		return
+	}
+	for _, entry := range entries {
+		// SYMLINKS ARE SKIPPED EXPLICITLY, before the directory branch.
+		//
+		// os.ReadDir reports entry types from the directory record without following links, so a symlink to a
+		// directory already has IsDir()==false and could not drive recursion. This guard therefore changes no
+		// behaviour -- it makes the cycle-safety LOCAL instead of inherited from a stdlib detail every future
+		// reader has to re-derive. A traversal whose termination depends on an unstated property of its
+		// iteration primitive is correct by coincidence.
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		// RECURSE TO ANY DEPTH. The comment here previously said "recurse one level" while the code recursed on
+		// every directory entry -- the behaviour was intended and the comment was wrong, which is
+		// comment-outlives-code at birth. Unbounded is CORRECT rather than merely tolerated: claims live beside
+		// attempt records under per-session directories, and a depth guess would silently miss a native claim
+		// one level below wherever the guess landed, which is exactly the failure this guard exists to prevent.
+		if entry.IsDir() {
+			inspectNamespaceNativeRecoveryClaims(filepath.Join(goalAttemptsSource, entry.Name()), blockers)
+			continue
+		}
+		// ONE RECOGNITION OWNER. recognizeRecoveryTransitionName is the same parser the pause scan uses, so
+		// this guard cannot drift from the scanner's idea of what a claim file is. A string-prefix test here
+		// would be a second opinion about naming, which is the two-deciders shape.
+		parsed, recognition := recognizeRecoveryTransitionName(entry.Name())
+		switch recognition {
+		case recoveryNameRecognized:
+			// LEGACY-shaped records are what the adapter already handles: they carry no kind in the name and
+			// their identity does not depend on the namespace, so rewriting profile/session is safe for them.
+			// Only current-derivation claims are refused.
+			if parsed.Legacy {
+				continue
+			}
+			*blockers = append(*blockers, fmt.Sprintf(
+				"native recovery-transition claim %s cannot be migrated safely: its claim key is derived from the namespace, so rewriting profile/session would make the claim unmatchable on read (treated as ABSENT, permitting a second delivery). Resolve or consume the claim before migrating; native-aware migration is tracked separately",
+				filepath.Join(goalAttemptsSource, entry.Name())))
+		case recoveryNameMalformed:
+			// UNKNOWN IS NOT ABSENT -- the same rule the pause scan enforces, and the reason this case is
+			// listed explicitly rather than folded into the default. A transition-like name we cannot classify
+			// might be a native claim; treating it as "no native claims present" would migrate anyway and
+			// corrupt exactly the record we failed to read.
+			*blockers = append(*blockers, fmt.Sprintf(
+				"recovery-transition-like file %s cannot be classified, so it cannot be shown safe to migrate: unknown is not absent, and a native claim here would be corrupted by a namespace rewrite",
+				filepath.Join(goalAttemptsSource, entry.Name())))
+		}
+		// recoveryNameNotATransition: an ordinary attempt/claim file. Ignored, because blocking on those would
+		// make every namespace unmigratable, which is amendment 1 overcorrected into an outage.
+	}
+}

--- a/internal/cli/namespace_migration_native_claims_test.go
+++ b/internal/cli/namespace_migration_native_claims_test.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #498 U7: BOTH DIRECTIONS for the fail-closed native-claim migration guard.
+//
+// The refusal half alone would be satisfied by a guard that blocked EVERY migration, so the compatibility half
+// is not optional decoration -- it is the claim that this guard does not break migration for the population that
+// exists today, which is legacy redelivery records.
+func TestMigrationRefusesANamespaceHoldingNativeRecoveryClaims(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	for _, row := range []struct {
+		name    string
+		write   func(t *testing.T, dir string) string
+		wantErr string
+	}{
+		{
+			// THE REAL CASE: a current-prefix native claim, named exactly as the constructor would name it, so
+			// this row cannot pass by using a name production never emits.
+			name: "native claim refuses",
+			write: func(t *testing.T, dir string) string {
+				project := t.TempDir()
+				_, path, err := newRecoveryTransitionRecord(
+					completeNativeTransitionInput(project, profile, session, attemptID))
+				if err != nil {
+					t.Fatalf("the complete native fixture must be accepted: %v", err)
+				}
+				name := filepath.Base(path)
+				if _, recognition := recognizeRecoveryTransitionName(name); recognition != recoveryNameRecognized {
+					t.Fatalf("fixture is void: %q is not a recognized claim name, so the guard would ignore it", name)
+				}
+				full := filepath.Join(dir, name)
+				if err := os.WriteFile(full, []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return full
+			},
+			wantErr: "cannot be migrated safely",
+		},
+		{
+			// UNKNOWN IS NOT ABSENT. A transition-like name the parser cannot classify must block, because it
+			// might BE a native claim and migrating it would corrupt the record we failed to read. Without this
+			// row, a guard that treated malformed as "nothing here" would look correct.
+			name: "malformed transition-like name refuses",
+			write: func(t *testing.T, dir string) string {
+				// Carries the current recovery prefix but no parseable kind/key, so the tri-state returns
+				// Malformed rather than NotATransition.
+				full := filepath.Join(dir, currentRecoveryTransitionPrefix+"not-a-valid-body.json")
+				if _, recognition := recognizeRecoveryTransitionName(filepath.Base(full)); recognition != recoveryNameMalformed {
+					t.Fatalf("fixture is void: %q is not classified Malformed", filepath.Base(full))
+				}
+				if err := os.WriteFile(full, []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return full
+			},
+			wantErr: "unknown is not absent",
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			dir := t.TempDir()
+			written := row.write(t, dir)
+
+			var blockers []string
+			inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+
+			if len(blockers) == 0 {
+				t.Fatalf("no blocker raised for %s. Migrating it rewrites profile/session without recomputing "+
+					"the namespace-derived claim key, leaving the claim unmatchable on read -- absent means no "+
+					"prior claim, which means a SECOND DELIVERY.", written)
+			}
+			joined := strings.Join(blockers, "\n")
+			if !strings.Contains(joined, row.wantErr) {
+				t.Errorf("blocker must explain the refusal (want %q), got: %s", row.wantErr, joined)
+			}
+			if !strings.Contains(joined, filepath.Base(written)) {
+				t.Errorf("blocker must NAME the offending file so an operator can act on it, got: %s", joined)
+			}
+		})
+	}
+}
+
+// THE COMPATIBILITY HALF, AT THE HELPER LEVEL: a namespace holding only LEGACY redelivery records must not
+// be blocked. RENAMED from TestMigrationStillAllows... per the ruling: it exercises the helper, not an
+// actual plan or migration, and a name that claims more than the test checks is the same defect as a
+// comment that outlives its code.
+//
+// Legacy claims carry no kind in the name and their identity is not namespace-derived, so the existing adapter
+// rewrite is safe for them. If this row ever fails, the guard has become an outage for every namespace that has
+// ever run a redelivery -- which is strictly worse than the corruption it was added to prevent.
+func TestHelperAllowsANamespaceWithOnlyLegacyRedeliveryRecords(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, legacyRecoveryTransitionPrefix+strings.Repeat("c", 64)+".json")
+	if err := os.WriteFile(legacy, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Anti-vacuity on the fixture itself: prove the guard's own parser classifies this as a recognized LEGACY
+	// claim, not as an unrelated file. Otherwise this row would pass because the name was ignored entirely,
+	// proving nothing about legacy tolerance.
+	parsed, recognition := recognizeRecoveryTransitionName(filepath.Base(legacy))
+	if recognition != recoveryNameRecognized || !parsed.Legacy {
+		t.Fatalf("fixture is void: %q is not a recognized LEGACY claim (recognition=%v legacy=%t)",
+			filepath.Base(legacy), recognition, parsed.Legacy)
+	}
+
+	// An ordinary attempt file alongside it, which must also be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "attempt-abc.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+	if len(blockers) != 0 {
+		t.Fatalf("legacy-only namespace was BLOCKED: %s\nLegacy claims are not namespace-keyed, so the adapter "+
+			"rewrite is safe for them; blocking here would make every namespace that ever ran a redelivery "+
+			"unmigratable.", strings.Join(blockers, "\n"))
+	}
+}
+
+// AN UNREADABLE DIRECTORY BLOCKS, for the same unknown-is-not-absent reason as a malformed name.
+func TestMigrationRefusesWhenTheClaimDirectoryCannotBeInspected(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "session")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(nested, 0o000); err != nil {
+		t.Skipf("cannot make a directory unreadable in this environment: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(nested, 0o755) })
+
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(dir, &blockers)
+	if len(blockers) == 0 {
+		t.Fatal("an unreadable claim directory raised no blocker. If the directory cannot be listed we do not " +
+			"know whether native claims are present, and migrating anyway gambles the double-delivery outcome " +
+			"on an unverified assumption.")
+	}
+	if !strings.Contains(strings.Join(blockers, "\n"), "cannot inspect") {
+		t.Errorf("blocker must say the directory could not be inspected, got: %s", strings.Join(blockers, "\n"))
+	}
+}
+
+// THE PLANNER-LEVEL WIRING TEST. This is the row dev-2's blocker 2 required and my first four rows could not
+// substitute for.
+//
+// ALL FOUR of my other tests call inspectNamespaceNativeRecoveryClaims DIRECTLY, so deleting the single
+// production call in namespace_migration_plan.go leaves every one of them green while migration happily
+// corrupts native claims. That is the wiring gap I identified for the U7 revalidation earlier in this same
+// delta, articulated as "the through-the-caller rule applies PER GUARD, not per file" — and then reproduced one
+// file later in a guard I wrote myself. Naming a rule is not applying it.
+//
+// This row drives the REAL planner with the REAL fixture and requires the blocker, so removing the production
+// call kills it.
+func TestPlannerBlocksMigrationWhenTheSourceHoldsANativeRecoveryClaim(t *testing.T) {
+	fx := newNamespaceMigrationFixture(t)
+
+	// The claim is placed under the SOURCE goal-attempts artifact the planner actually inspects, at a name the
+	// REAL constructor produces -- not a hand-written filename, which could pass while production emits
+	// something the guard never sees.
+	goalDir := goalAttemptDir(fx.project, fx.source.Profile, fx.source.Session)
+	if err := os.MkdirAll(goalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, claimPath, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(fx.project, fx.source.Profile, fx.source.Session, "attempt-abc"))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+	if err := os.WriteFile(claimPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// ANTI-VACUITY ON PLACEMENT: if the claim did not land inside the directory the planner inspects, this row
+	// would pass for the wrong reason once the guard was deleted... and fail to prove anything now.
+	if filepath.Dir(claimPath) != goalDir {
+		t.Fatalf("fixture is void: the claim landed at %q but the planner inspects %q", claimPath, goalDir)
+	}
+
+	plan, err := planNamespaceMigration(namespaceMigrationPlannerOptions{
+		ProjectDir: fx.project, Source: fx.source, Target: fx.target,
+		DryRun: true, Now: time.Now().UTC(), Probe: livenessProbe(nil, nil, time.Now()),
+	})
+	if err != nil {
+		t.Fatalf("planning must succeed and REPORT a blocker rather than erroring: %v", err)
+	}
+
+	joined := strings.Join(plan.Blockers, "\n")
+	if !strings.Contains(joined, "cannot be migrated safely") {
+		t.Fatalf("the PLAN did not carry the native-claim blocker.\nMigration rewrites profile/session without "+
+			"recomputing the namespace-derived claim key, so this namespace must refuse at plan time.\n"+
+			"blockers:\n%s", joined)
+	}
+	if !strings.Contains(joined, filepath.Base(claimPath)) {
+		t.Errorf("the blocker must NAME the offending claim so an operator can act on it; got:\n%s", joined)
+	}
+}
+
+// A MISSING directory is genuinely absence and must NOT block -- the distinction the malformed case turns on.
+func TestMigrationDoesNotBlockWhenThereIsNoClaimDirectoryAtAll(t *testing.T) {
+	var blockers []string
+	inspectNamespaceNativeRecoveryClaims(filepath.Join(t.TempDir(), "does-not-exist"), &blockers)
+	if len(blockers) != 0 {
+		t.Fatalf("a nonexistent goal-attempts tree blocked migration: %s\nNo directory means no claims to "+
+			"corrupt; that absence is unambiguous, unlike an unreadable or unclassifiable one.",
+			strings.Join(blockers, "\n"))
+	}
+}

--- a/internal/cli/namespace_migration_plan.go
+++ b/internal/cli/namespace_migration_plan.go
@@ -177,6 +177,13 @@ func planNamespaceMigration(opts namespaceMigrationPlannerOptions) (namespaceMig
 		}
 	}
 
+	// #498 U7 FAIL-CLOSED: refuse a namespace holding NATIVE recovery-transition claims BEFORE anything is
+	// rewritten. The adapter rewrites profile/session without recomputing the namespace-derived claim key, so
+	// migrating such a claim leaves it unmatchable on read -- treated as ABSENT, which permits a second
+	// delivery. Placed among the other pre-migration blockers so the refusal happens at PLAN time rather than
+	// halfway through a multi-file rewrite.
+	inspectNamespaceNativeRecoveryClaims(migrationPlanArtifact(plan, "goal_attempts").Source, &plan.Blockers)
+
 	plan.Liveness = append(plan.Liveness, inspectNamespaceEndpointLiveness("source", sourceTeam, opts.Source, opts.Probe, opts.Now, &plan.Blockers)...)
 	plan.Liveness = append(plan.Liveness, inspectNamespaceEndpointLiveness("target", targetTeam, opts.Target, opts.Probe, opts.Now, &plan.Blockers)...)
 	inspectNamespaceOperationalOwners("source", project, sourceTeam, opts.Source, opts.Now, &plan)

--- a/internal/cli/recovery_transition.go
+++ b/internal/cli/recovery_transition.go
@@ -1,0 +1,334 @@
+package cli
+
+// PR5 / #498 ledger extension. Additive to resume_goal.go's existing recovery-transition
+// machinery: ONE store, ONE CAS owner, ONE parser. goal_attempt.go stays read-only and there is
+// no second claim store and no adapter, per the ruling that a parallel store is the
+// two-deciders defect at the exact spot whose failure mode is double delivery of an audited
+// /goal resume.
+//
+// READ THIS FIRST IF THE PREFIXES LOOK REDUNDANT. There are two derivations on purpose:
+//   - LEGACY: ".resume-redelivery-<sha256(attemptID \x00 bindingDigest)>.json", the identity
+//     resume_goal.go has always written. It stays READABLE for recovery and loses its writer
+//     path; a hit at that derivation is an AUTHORITATIVE existing claim.
+//   - CURRENT: ".recovery-<kind>-<sha256(namespaceID \x00 pauseGeneration \x00 attemptID)>.json",
+//     the ruled stable key. PauseGeneration is CONSUMED from the assessment, never recomputed
+//     here -- PR4 owns that derivation and a second owner reading a different snapshot is the
+//     failure this milestone kept producing.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+// recoveryTransitionKind distinguishes what a reservation is FOR. It lives in BOTH the filename
+// prefix and the record body, and the parser requires them to agree.
+//
+// Why both: the prefix makes the kind-agnostic pause scan cheap and the directory human-
+// readable, while the body makes it durable evidence rather than a naming convention. Requiring
+// AGREEMENT is what stops a renamed file from silently changing what a reservation means --
+// disagreement is ambiguous evidence, and ambiguous evidence refuses.
+type recoveryTransitionKind string
+
+const (
+	recoveryTransitionKindRedeliver        recoveryTransitionKind = "redeliver"
+	recoveryTransitionKindNativeGoalResume recoveryTransitionKind = "native-goal-resume"
+)
+
+// legacyRecoveryTransitionPrefix is the pre-PR5 filename prefix. Readable, never written.
+const legacyRecoveryTransitionPrefix = ".resume-redelivery-"
+
+// currentRecoveryTransitionPrefix is the kind-carrying prefix for the ruled stable key.
+const currentRecoveryTransitionPrefix = ".recovery-"
+
+// supervisionClaimKey builds the ruled durable identity: NamespaceID + PauseGeneration +
+// AttemptID.
+//
+// Every component is CONSUMED, none derived here. PauseGeneration in particular arrives from
+// GoalSupervisionAssessment.Binding.PauseGeneration, which PR4 computes from captured LaunchID +
+// Goal.BindingDigest + Goal.AttemptID + Goal.Mode. Recomputing it in this file would make PR5 a
+// second derivation owner, and the defect that produces is not a field-sensitivity issue -- it
+// is one identity with two owners that can disagree.
+//
+// PreclaimFingerprint is deliberately NOT part of this key. It rotates when claim evidence
+// changes, and writing the claim IS a change to claim evidence, so a fingerprint-keyed claim
+// would rotate its own identity at the moment of being recorded and become unmatchable. It is
+// stored as staleness evidence instead.
+func supervisionClaimKey(namespaceID, pauseGeneration, attemptID string) (string, error) {
+	namespaceID = strings.TrimSpace(namespaceID)
+	pauseGeneration = strings.TrimSpace(pauseGeneration)
+	attemptID = strings.TrimSpace(attemptID)
+	// Each component is required. A blank one would silently collapse distinct pauses onto one
+	// key, which is the double-delivery failure wearing a hash.
+	if namespaceID == "" || pauseGeneration == "" || attemptID == "" {
+		return "", fmt.Errorf("recovery claim key requires namespace, pause generation and attempt id (got %q/%q/%q)",
+			namespaceID, pauseGeneration, attemptID)
+	}
+	sum := sha256.Sum256([]byte(namespaceID + "\x00" + pauseGeneration + "\x00" + attemptID))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// currentRecoveryTransitionName renders the kind-carrying filename for a claim key.
+func currentRecoveryTransitionName(kind recoveryTransitionKind, claimKey string) string {
+	return currentRecoveryTransitionPrefix + string(kind) + "-" + claimKey + ".json"
+}
+
+// parsedRecoveryTransitionName is what the ONE parser returns.
+type parsedRecoveryTransitionName struct {
+	Kind     recoveryTransitionKind
+	ClaimKey string
+	Legacy   bool
+}
+
+// parseRecoveryTransitionName is the SINGLE parser for both derivations.
+//
+// It rejects rather than guesses. Unknown, missing, malformed or mismatched kind refuses,
+// because a reservation whose purpose cannot be determined is exactly the ambiguous evidence
+// that must not be treated as absent. The caller then compares Kind against the record body's
+// kind; this function cannot do that comparison itself because it only sees the name.
+func parseRecoveryTransitionName(name string) (parsedRecoveryTransitionName, bool) {
+	switch {
+	case strings.HasSuffix(name, ".consumed.json"), strings.HasSuffix(name, ".bound.json"):
+		// Companion artifacts, not reservations. Named explicitly so a future companion
+		// suffix cannot be silently misread as a reservation.
+		return parsedRecoveryTransitionName{}, false
+	case !strings.HasSuffix(name, ".json"):
+		return parsedRecoveryTransitionName{}, false
+	}
+
+	if rest, ok := trimPrefixExact(name, legacyRecoveryTransitionPrefix); ok {
+		key := strings.TrimSuffix(rest, ".json")
+		if !isRecoveryClaimKey(key) {
+			return parsedRecoveryTransitionName{}, false
+		}
+		// Legacy names carry NO kind. They are redelivery reservations by construction, which
+		// is recorded here rather than inferred at each call site.
+		return parsedRecoveryTransitionName{Kind: recoveryTransitionKindRedeliver, ClaimKey: key, Legacy: true}, true
+	}
+
+	rest, ok := trimPrefixExact(name, currentRecoveryTransitionPrefix)
+	if !ok {
+		return parsedRecoveryTransitionName{}, false
+	}
+	body := strings.TrimSuffix(rest, ".json")
+	// Split from the RIGHT: the claim key is a fixed-length hex tail, and kinds contain
+	// hyphens ("native-goal-resume"), so splitting from the left would mangle them.
+	cut := strings.LastIndex(body, "-")
+	if cut <= 0 {
+		return parsedRecoveryTransitionName{}, false
+	}
+	kind := recoveryTransitionKind(body[:cut])
+	key := body[cut+1:]
+	if !isRecoveryClaimKey(key) || !knownRecoveryTransitionKind(kind) {
+		return parsedRecoveryTransitionName{}, false
+	}
+	return parsedRecoveryTransitionName{Kind: kind, ClaimKey: key}, true
+}
+
+// knownRecoveryTransitionKind refuses unknown kinds rather than passing them through.
+//
+// An unrecognised kind is not a new kind to be tolerated: it means this binary does not
+// understand a reservation that exists, and proceeding would ignore a claim it cannot read.
+func knownRecoveryTransitionKind(kind recoveryTransitionKind) bool {
+	switch kind {
+	case recoveryTransitionKindRedeliver, recoveryTransitionKindNativeGoalResume:
+		return true
+	default:
+		return false
+	}
+}
+
+// isRecoveryClaimKey validates the sha256 hex shape both derivations use.
+func isRecoveryClaimKey(key string) bool {
+	if len(key) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(key)
+	return err == nil
+}
+
+// trimPrefixExact is strings.TrimPrefix plus a report of whether it applied, so a caller cannot
+// mistake "no prefix" for "empty remainder".
+func trimPrefixExact(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(s, prefix), true
+}
+
+// recoveryNameRecognition is the TRI-STATE the scan needs, per dev-2's binding correction.
+//
+// A boolean cannot express this directory's reality. goalAttemptDir holds ordinary
+// <attempt>.json and <attempt>.claim.json files alongside recovery transitions, so:
+//   - NotATransition: definitely not ours. IGNORED. Blocking here would let normal attempt files
+//     wedge all recovery permanently, which is amendment 1 overcorrected into an outage.
+//   - Recognized: parses completely. INSPECTED.
+//   - Malformed: TRANSITION-LIKE -- it carries a recovery prefix -- but its structure, kind or key
+//     cannot be read. BLOCKS, and deliberately WITHOUT requiring a key match: if corruption
+//     destroyed the key, demanding the key be present proves nothing about ownership while
+//     quietly permitting delivery. That was my fail-open, fast-rejected.
+type recoveryNameRecognition int
+
+const (
+	recoveryNameNotATransition recoveryNameRecognition = iota
+	recoveryNameRecognized
+	recoveryNameMalformed
+)
+
+// recognizeRecoveryTransitionName is the one recognition point for both derivations.
+//
+// It distinguishes "not a transition" from "a transition I cannot read" by PREFIX first: only a
+// name carrying a recovery prefix can be malformed-transition-like. Everything else is somebody
+// else's file and is ignored.
+func recognizeRecoveryTransitionName(name string) (parsedRecoveryTransitionName, recoveryNameRecognition) {
+	switch {
+	case strings.HasSuffix(name, ".consumed.json"), strings.HasSuffix(name, ".bound.json"):
+		// Companions are handled by their own path; not reservations.
+		return parsedRecoveryTransitionName{}, recoveryNameNotATransition
+	case !strings.HasPrefix(name, legacyRecoveryTransitionPrefix) && !strings.HasPrefix(name, currentRecoveryTransitionPrefix):
+		// No recovery prefix: an ordinary attempt/claim file or an unrelated one.
+		return parsedRecoveryTransitionName{}, recoveryNameNotATransition
+	case !strings.HasSuffix(name, ".json"):
+		// Prefixed but not a JSON artifact: transition-like and unreadable.
+		return parsedRecoveryTransitionName{}, recoveryNameMalformed
+	}
+	parsed, ok := parseRecoveryTransitionName(name)
+	if !ok {
+		return parsedRecoveryTransitionName{}, recoveryNameMalformed
+	}
+	return parsed, recoveryNameRecognized
+}
+
+// newRecoveryTransitionRecord is the SINGLE constructor AND the single path deriver for every
+// recovery-transition reservation. It returns the record and the filename that must hold it, so
+// no caller can pair a validated record with a PATH of its own choosing.
+//
+// It returns the CANONICAL FULL PATH, not a basename (dev-2's correction). A basename leaves the
+// DIRECTORY to the caller, so a correct hash for namespace A could be written into namespace B's
+// directory and each scanner would miss it -- the claim would exist and be invisible to both.
+// That is the same gap as r6's session layer: I closed the name and left the container. There is
+// deliberately no filename-only API, so there is nothing to redirect.
+//
+// dev-2's original correction was about the id:
+// otherwise the redelivery site could keep passing its own id and write a current-looking record
+// under the legacy key.
+//
+// PER-KIND VALIDATION, and the reason is POSSESSION rather than preference. A future kind should
+// copy the DISPATCH, not one of its branches:
+//
+//	redeliver           has no assessment in hand, so it has NO PauseGeneration. Requiring one
+//	                    would force either local recomputation (forbidden -- PR4 owns that
+//	                    derivation) or a faked value, which is worse than the literal this
+//	                    constructor replaces. It requires what that path genuinely holds:
+//	                    AttemptID and BindingDigest.
+//	native-goal-resume  consumes a full assessment, so it requires the whole ruled set:
+//	                    NamespaceID, assessment-captured PauseGeneration, AttemptID and
+//	                    PreclaimFingerprint. None recomputed.
+//
+// BOTH DIRECTIONS ARE ENFORCED. A redeliver write carrying a PauseGeneration is REFUSED too: it
+// cannot honestly have one, so its presence means someone recomputed or invented it, which is the
+// failure the dispatch exists to prevent. A contract that only checks for missing fields lets the
+// other half through.
+//
+// READ vs WRITE asymmetry (ruled): on READ, absent PR5 fields mean legacy/redeliver, identified
+// by the legacy key and blocking per the consumed-blocks ruling. On WRITE, absence of a required
+// field refuses -- a defaulted identity field is indistinguishable on disk from a legacy record,
+// so a lenient writer silently enrols new records into the legacy population.
+func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransitionRecord, string, error) {
+	kind := recoveryTransitionKind(strings.TrimSpace(string(in.Kind)))
+	if !knownRecoveryTransitionKind(kind) {
+		return resumeGoalTransitionRecord{}, "", fmt.Errorf("recovery transition requires a known kind, got %q", in.Kind)
+	}
+	attemptID := strings.TrimSpace(in.AttemptID)
+	if attemptID == "" {
+		return resumeGoalTransitionRecord{}, "", fmt.Errorf("recovery transition (%s) requires an attempt id", kind)
+	}
+	pause := strings.TrimSpace(in.PauseGeneration)
+	fingerprint := strings.TrimSpace(in.PreclaimFingerprint)
+
+	record := in.Base
+	record.RecoveryKind = string(kind)
+
+	switch kind {
+	case recoveryTransitionKindRedeliver:
+		// This path holds no assessment. Presence of a pause generation here is evidence that
+		// someone derived one locally, so it refuses rather than storing it.
+		if pause != "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transitions must NOT carry a pause generation: this path holds no assessment, so a value here was recomputed or invented (got %q)", pause)
+		}
+		if strings.TrimSpace(in.BindingDigest) == "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transition requires the binding digest its identity is derived from")
+		}
+		// The canonical redeliver identity is unchanged, so redelivery's own readers are
+		// untouched -- PR5 does not refactor that read side. It is now emitted HERE, which is
+		// what makes "no write bypasses the one constructor" true in meaning.
+		record.TransitionID = resumeGoalTransitionID(attemptID, in.BindingDigest)
+		record.PreclaimFingerprint = fingerprint // optional evidence on this path
+		// Derived through resumeGoalTransitionPath so redelivery's EXISTING readers are
+		// untouched: the path they already compute is the path this constructor emits.
+		path, err := resumeGoalTransitionPath(in.Base.Project, in.Base.Profile, in.Base.Session, record.TransitionID)
+		if err != nil {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("derive redeliver transition path: %w", err)
+		}
+		return record, path, nil
+
+	case recoveryTransitionKindNativeGoalResume:
+		// Scope consistency: the record's own triple must match what the caller claims, or the
+		// path and the record would describe different namespaces.
+		if strings.TrimSpace(in.Base.Project) == "" || strings.TrimSpace(in.Base.Profile) == "" || strings.TrimSpace(in.Base.Session) == "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires an exact project/profile/session triple")
+		}
+		// NamespaceID must equal the canonical id for this profile/session, or a correct hash
+		// could be written under a namespace it does not belong to -- present on disk and
+		// invisible to the scanner that would look for it.
+		//
+		// squadnamespace.ID is at internal/namespace/namespace.go:46 (verified by reading it, not
+		// by trusting the citation). My earlier search failed because I assumed the package
+		// DIRECTORY matched the import alias: the alias is squadnamespace, the path is
+		// internal/namespace.
+		if want := squadnamespace.ID(in.Base.Profile, in.Base.Session); strings.TrimSpace(in.NamespaceID) != want {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume namespace id %q does not match the canonical id %q for profile/session: a claim written under a foreign namespace is invisible to the scanner that would find it", in.NamespaceID, want)
+		}
+		if pause == "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires the assessment-captured pause generation; extend the assessment-to-plan binding rather than omitting it")
+		}
+		if fingerprint == "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires the preclaim fingerprint as staleness evidence")
+		}
+		key, err := supervisionClaimKey(in.NamespaceID, pause, attemptID)
+		if err != nil {
+			return resumeGoalTransitionRecord{}, "", err
+		}
+		// DERIVED here, never accepted from the caller. dev-2's correction: a caller-supplied id
+		// would let a legacy or one-byte-wrong value through, writing a current-looking record
+		// under the wrong key -- unmatched on read, therefore absent, therefore a second
+		// delivery.
+		record.TransitionID = key
+		record.PauseGeneration = pause
+		record.PreclaimFingerprint = fingerprint
+		// The DIRECTORY is derived from the same validated triple, inside the constructor. A
+		// caller joining a basename could place a namespace-A claim in namespace-B's directory,
+		// where neither scanner would find it.
+		return record, filepath.Join(goalAttemptDir(in.Base.Project, in.Base.Profile, in.Base.Session), currentRecoveryTransitionName(kind, key)), nil
+	}
+	return resumeGoalTransitionRecord{}, "", fmt.Errorf("unhandled recovery transition kind %q", kind)
+}
+
+// recoveryTransitionInput is what a caller supplies. It carries NO TransitionID field on purpose:
+// the identity is DERIVED per kind, so there is nothing for a caller to get wrong or to smuggle.
+//
+// Base carries what the existing redelivery writer already computes, which is what makes routing
+// that writer through here additive rather than a rewrite of what it records.
+type recoveryTransitionInput struct {
+	Base                resumeGoalTransitionRecord
+	Kind                recoveryTransitionKind
+	NamespaceID         string
+	AttemptID           string
+	BindingDigest       string
+	PauseGeneration     string
+	PreclaimFingerprint string
+}

--- a/internal/cli/recovery_transition.go
+++ b/internal/cli/recovery_transition.go
@@ -225,9 +225,24 @@ func recognizeRecoveryTransitionName(name string) (parsedRecoveryTransitionName,
 //	                    derivation) or a faked value, which is worse than the literal this
 //	                    constructor replaces. It requires what that path genuinely holds:
 //	                    AttemptID and BindingDigest.
-//	native-goal-resume  consumes a full assessment, so it requires the whole ruled set:
-//	                    NamespaceID, assessment-captured PauseGeneration, AttemptID and
-//	                    PreclaimFingerprint. None recomputed.
+//	native-goal-resume  consumes a full assessment and requires the RATIFIED U7 SET:
+//	                    NamespaceID, assessment-captured PauseGeneration, AttemptID,
+//	                    PreclaimFingerprint, an explicit Supervisor, a persisted SchemaVersion, a
+//	                    derived NewAttemptID, and the exact-binding block (PaneID, Goal
+//	                    Mode/AttemptID/BindingDigest/CommandDigest, Blocker ID/ResolutionDigest,
+//	                    Policy Mode/Revision). None recomputed; all consumed from the one
+//	                    observation that authorized the claim.
+//
+// THE RECORD IS THE RECOVERY CONTRACT. It must be sufficient to REVALIDATE THE EXACT AUTHORIZED
+// OBSERVATION, not merely to derive a filename -- recovery cannot revalidate a field the record never
+// persisted, which is why the set is exhaustive rather than convenient.
+//
+// THIS COMMENT WAS ITSELF A DEFECT TWICE, in opposite directions, which is why it now states the rule
+// and the enforcement point together. It first claimed the whole ruled set was required when only four
+// fields were; it was corrected to list what was missing; then Supervisor became required in code while
+// this text still listed it as missing. A comment that tracks intent rather than behaviour is wrong at
+// every point where the two differ, and it drifts in BOTH directions -- overclaiming, then underclaiming
+// after the code caught up.
 //
 // BOTH DIRECTIONS ARE ENFORCED. A redeliver write carrying a PauseGeneration is REFUSED too: it
 // cannot honestly have one, so its presence means someone recomputed or invented it, which is the
@@ -238,8 +253,44 @@ func recognizeRecoveryTransitionName(name string) (parsedRecoveryTransitionName,
 // by the legacy key and blocking per the consumed-blocks ruling. On WRITE, absence of a required
 // field refuses -- a defaulted identity field is indistinguishable on disk from a legacy record,
 // so a lenient writer silently enrols new records into the legacy population.
+// THE CONSTRUCTOR'S POSTURE TOWARD SIDE-DOOR (Base-carried) VALUES, stated once because THREE separate
+// defects of this exact shape were found in it in one day: a smuggled NewAttemptID (U7b), a smuggled
+// Supervisor, and a smuggled PauseGeneration. Every one checked the explicit INPUT and trusted
+// `record := in.Base`, which copies whatever a caller cared to set.
+//
+// TWO POSTURES, and the distinction is what makes the exception principled rather than an oversight:
+//
+//  1. A field DERIVED FROM A VALIDATED INPUT (PauseGeneration, PreclaimFingerprint, NewAttemptID,
+//     Supervisor) REFUSES when a Base value DISAGREES. The overwrite would be safe -- the correct value
+//     wins -- which is exactly why it must not be silent: a caller that set Base differently believes
+//     something false about the record it is creating, and silent correction defers that discovery
+//     somewhere less observable. An AGREEING Base value is ACCEPTED, so the guard cannot degenerate into
+//     "refuse any Base value" and reject a caller who populated Base consistently.
+//
+//  2. TransitionID is the ONE EXCEPTION and stays OVERWRITE, because no legitimate caller-supplied value
+//     exists for it: it is fully derived per kind, so a Base value is meaningless rather than
+//     contradictory. That posture is already pinned by TestConstructorOverwritesASmuggledTransitionID,
+//     which proves a smuggled id cannot survive. Refusing there would add a failure mode with nothing to
+//     protect.
+//
+// A field a caller MUST NOT SUPPLY AT ALL for this kind (redeliver's PauseGeneration and Supervisor)
+// refuses ANY nonempty value on EITHER route, compared RAW: `omitempty` does not omit a whitespace-only
+// string, so a trimmed guard would persist a present-but-meaningless value.
+//
+// Redeliver's PreclaimFingerprint is deliberately NOT guarded -- it is optional evidence on that path
+// rather than a derived identity, so a caller-supplied value is legitimate there.
 func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransitionRecord, string, error) {
 	kind := recoveryTransitionKind(strings.TrimSpace(string(in.Kind)))
+	// SCHEMA VERSION FOR EVERY KIND. Native reservations previously persisted ZERO -- nothing on that path
+	// set it -- while four readers validate nonzero (resume_goal.go:351, :403, :1131, :1210). Dormant only
+	// because today's readers are redelivery-path: any reader that starts validating a native reservation
+	// would reject every one as malformed. ZERO from Base is ABSENT, not disagreement, because that is what
+	// every legacy caller passes; a disagreeing NONZERO value refuses.
+	if v := in.Base.SchemaVersion; v != 0 && v != resumeGoalTransitionSchemaVersion {
+		return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+			"recovery transition schema version %d disagrees with the current %d: a record written under a version its readers do not accept is undiscoverable evidence",
+			v, resumeGoalTransitionSchemaVersion)
+	}
 	if !knownRecoveryTransitionKind(kind) {
 		return resumeGoalTransitionRecord{}, "", fmt.Errorf("recovery transition requires a known kind, got %q", in.Kind)
 	}
@@ -252,22 +303,87 @@ func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransiti
 
 	record := in.Base
 	record.RecoveryKind = string(kind)
+	record.SchemaVersion = resumeGoalTransitionSchemaVersion
+
+	// THE ONE COLLAPSED SIDE DOOR, LOCKED. Nesting the U7 block turned fifteen potential Base-carried
+	// side doors into one, and cto's condition was that the one must be guarded NOW or we have merely
+	// concentrated the risk. It refuses on BOTH kinds and EVEN WHEN THE VALUES AGREE -- deliberately
+	// stricter than the flat posture rule above, and dev-2's reason is why: for a flat derived field an
+	// agreeing Base value means a consistent caller, but there is NO legitimate Base source for this block
+	// at all, so agreement proves nothing about intent. "Refuse any presence" is the correct posture for a
+	// field the constructor alone may populate.
+	if record.NativeBinding != nil {
+		return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+			"recovery transition (%s) must not carry a Base-supplied native binding: this block is built by the constructor from validated inputs, so a Base value bypassed every check that makes it trustworthy",
+			kind)
+	}
+	record.NativeBinding = nil
 
 	switch kind {
 	case recoveryTransitionKindRedeliver:
 		// This path holds no assessment. Presence of a pause generation here is evidence that
 		// someone derived one locally, so it refuses rather than storing it.
-		if pause != "" {
-			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transitions must NOT carry a pause generation: this path holds no assessment, so a value here was recomputed or invented (got %q)", pause)
+		// BOTH RAW ROUTES, and this guard is where the Supervisor bug came from: I used it as the
+		// template, so it propagated its own defect into the new field. `record := in.Base` above copies
+		// Base.PauseGeneration, and `pause` derives from in.PauseGeneration only -- so a value arriving
+		// through Base was returned and PERSISTED on a redeliver record, making pause-generation presence
+		// an unreliable native-origin signal exactly as it did for the supervisor.
+		//
+		// RAW, not trimmed, for the reason dev-2 gave on the supervisor: `omitempty` does not omit a
+		// whitespace-only string, so a trimmed guard would serialise a present-but-meaningless value.
+		// Redeliver has no assessment, so it has no exact binding to persist.
+		if in.NativeBinding != nil {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transitions must NOT carry a native binding: that block is the assessment's exact binding and this path holds no assessment")
+		}
+		if in.PauseGeneration != "" || record.PauseGeneration != "" {
+			route, carried := "input", in.PauseGeneration
+			if in.PauseGeneration == "" {
+				route, carried = "Base record", record.PauseGeneration
+			}
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transitions must NOT carry a pause generation: this path holds no assessment, so a value here was recomputed or invented (arrived via %s as %q)", route, carried)
 		}
 		if strings.TrimSpace(in.BindingDigest) == "" {
 			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transition requires the binding digest its identity is derived from")
+		}
+		// Same asymmetry as the pause generation above: this path holds no assessment and no supervisor,
+		// so a supervisor here was invented. Refusing is what keeps "supervisor present" a reliable
+		// signal that a record came from the supervised path.
+		//
+		// BOTH ROUTES, and my first version only guarded ONE. `record := in.Base` above copies
+		// Base.Supervisor, so a value arriving through Base was returned and PERSISTED while
+		// in.Supervisor was empty -- defeating the asymmetry through the door I left open. I had applied
+		// the Base-route guard correctly for NewAttemptID in the native branch twenty lines below and
+		// did not apply it here, which is the same-pattern-half-applied failure.
+		//
+		// RAW COMPARISON, NOT TRIMMED, and dev-2's reason is sharper than my own: a whitespace-only value
+		// survives `omitempty` because the raw string is nonempty, so it would serialise into the record
+		// as a present-but-meaningless supervisor. Trimming before the check would let exactly that
+		// through. Trimming is right for the NATIVE branch, which stores a validated identity; here the
+		// question is only whether ANYTHING is present.
+		if in.Supervisor != "" || record.Supervisor != "" {
+			route := "input"
+			carried := in.Supervisor
+			if in.Supervisor == "" {
+				route, carried = "Base record", record.Supervisor
+			}
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("redeliver transitions must NOT carry a supervisor: this path holds no assessment and no supervising actor, so a value here was invented (arrived via %s as %q)", route, carried)
 		}
 		// The canonical redeliver identity is unchanged, so redelivery's own readers are
 		// untouched -- PR5 does not refactor that read side. It is now emitted HERE, which is
 		// what makes "no write bypasses the one constructor" true in meaning.
 		record.TransitionID = resumeGoalTransitionID(attemptID, in.BindingDigest)
 		record.PreclaimFingerprint = fingerprint // optional evidence on this path
+		// THE SHARED DURABLE CONTRACT, on what this branch just built. Everything above is
+		// CONSTRUCTOR-ONLY work -- route disagreement and Base smuggling, which a finished record cannot
+		// testify about. Everything observable IN the record is decided by the one validator, so the
+		// publisher cannot hold a different opinion about what a valid redeliver record is.
+		//
+		// This closes dev-2's blocker 2 at its root: this branch used to return a record with a BLANK
+		// NewAttemptID, which publication then unconditionally refused. The constructor accepted what the
+		// publisher rejected, and my own anti-vacuity test asserted the accepted case and could never pass.
+		if err := validateRecoveryTransitionRecordContract(record); err != nil {
+			return resumeGoalTransitionRecord{}, "", err
+		}
 		// Derived through resumeGoalTransitionPath so redelivery's EXISTING readers are
 		// untouched: the path they already compute is the path this constructor emits.
 		path, err := resumeGoalTransitionPath(in.Base.Project, in.Base.Profile, in.Base.Session, record.TransitionID)
@@ -277,11 +393,12 @@ func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransiti
 		return record, path, nil
 
 	case recoveryTransitionKindNativeGoalResume:
-		// Scope consistency: the record's own triple must match what the caller claims, or the
-		// path and the record would describe different namespaces.
-		if strings.TrimSpace(in.Base.Project) == "" || strings.TrimSpace(in.Base.Profile) == "" || strings.TrimSpace(in.Base.Session) == "" {
-			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires an exact project/profile/session triple")
-		}
+		// THE SCOPE-TRIPLE REQUIREMENT LIVED HERE AND IS DELETED. It is a completed-record content check, so
+		// the shared contract owns it (recovery_transition_contract.go), and keeping a copy here was the
+		// ruled shape half-applied: I added the one decider and did not remove what it replaced. A second
+		// list is not redundancy, it is co-drift waiting to happen -- deleting a row from the shared contract
+		// would have left these constructor tests green while publication silently regressed.
+		//
 		// NamespaceID must equal the canonical id for this profile/session, or a correct hash
 		// could be written under a namespace it does not belong to -- present on disk and
 		// invisible to the scanner that would look for it.
@@ -299,6 +416,36 @@ func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransiti
 		if fingerprint == "" {
 			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires the preclaim fingerprint as staleness evidence")
 		}
+		// THE FLAT LAUNCH GENERATION requirement lived here and is DELETED for the same reason as the scope
+		// triple: it is completed-record content, so the shared contract is its sole owner. Note what does
+		// NOT move with it -- these fields arrive via Base, and Base is their LEGITIMATE route because they
+		// have no explicit input counterpart and no derived value to disagree with. That is a provenance
+		// fact, but it is a fact about what the constructor must NOT refuse, so it needs no check at all.
+		//
+		// SUPERVISOR IS REQUIRED AND VALIDATED HERE TOO, not only at the gate. The gate protects the
+		// delivering path; this protects the RECORD, and any future caller of the constructor that
+		// skips the gate would otherwise write an unattributable claim. A durable identity field whose
+		// only guard lives in one caller is guarded by convention rather than by construction.
+		supervisor := strings.TrimSpace(in.Supervisor)
+		if supervisor == "" {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires the supervisor identity: a claim nobody is recorded as authorising cannot be audited after the fact")
+		}
+		if supervisor == supervisorIdentityPlaceholder {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume supervisor is still the literal placeholder %s: recording it would durably attribute the resume to nobody while looking like an answer", supervisorIdentityPlaceholder)
+		}
+		// AND THE BASE ROUTE HERE TOO, by the same rule I applied to NewAttemptID twenty lines below.
+		// Assigning the validated value would OVERWRITE a disagreeing Base.Supervisor silently: the
+		// persisted attribution would be correct, so nothing breaks -- which is exactly why it is worth
+		// refusing. A caller passing a different supervisor through Base believes something false about
+		// what this record will say, and silently correcting them hides a caller bug that will surface
+		// somewhere less observable. Same reasoning as the attempt id: a record whose identity fields
+		// disagree is ambiguous evidence, not a tie to break.
+		if supplied := strings.TrimSpace(record.Supervisor); supplied != "" && supplied != supervisor {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"supervision resume supervisor %q disagrees with the Base-supplied %q: the record would attribute the resume to one actor while the caller believes another",
+				supervisor, supplied)
+		}
+		record.Supervisor = supervisor
 		key, err := supervisionClaimKey(in.NamespaceID, pause, attemptID)
 		if err != nil {
 			return resumeGoalTransitionRecord{}, "", err
@@ -308,8 +455,102 @@ func newRecoveryTransitionRecord(in recoveryTransitionInput) (resumeGoalTransiti
 		// under the wrong key -- unmatched on read, therefore absent, therefore a second
 		// delivery.
 		record.TransitionID = key
+		// Same rule as Supervisor and NewAttemptID: a DISAGREEING Base value refuses rather than being
+		// silently corrected. See the posture note above the constructor for why TransitionID is the one
+		// deliberate exception.
+		if supplied := strings.TrimSpace(record.PauseGeneration); supplied != "" && supplied != pause {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"supervision resume pause generation %q disagrees with the Base-supplied %q: two sources for one derived identity is the one-identity-two-owners shape whose symptom is double delivery",
+				pause, supplied)
+		}
 		record.PauseGeneration = pause
+		if supplied := strings.TrimSpace(record.PreclaimFingerprint); supplied != "" && supplied != fingerprint {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"supervision resume preclaim fingerprint %q disagrees with the Base-supplied %q: the record would carry staleness evidence the caller did not intend",
+				fingerprint, supplied)
+		}
 		record.PreclaimFingerprint = fingerprint
+
+		// THE U7 EXACT BINDING. Required, every field validated, and assembled as a FRESH VALUE field by
+		// field rather than by assigning the caller's pointer: a pointer assignment would leave the record
+		// ALIASING memory the caller still holds, so a later mutation by the caller would silently change a
+		// record we validated. Validation of aliased data expires the moment the caller touches it again.
+		if in.NativeBinding == nil {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf("supervision resume requires the native exact binding: the record IS the recovery contract, and recovery cannot revalidate fields the record never persists")
+		}
+		nb := *in.NativeBinding
+		// THE NINE-INTERIOR REQUIRED LIST AND THE PolicyRevision CHECK LIVED HERE AND ARE DELETED. They were
+		// the third and largest duplicate of the shared contract, and the most dangerous one to keep: the
+		// all-zero-interiors record dev-2 found was refused by THIS list while publication accepted it, so
+		// two lists meant the constructor path and the publication path disagreed about the same record.
+		//
+		// WHAT SURVIVES ABOVE IS THE nil CHECK ONLY, and it survives as a ROUTE/MECHANICAL fact rather than a
+		// content requirement: the dereference on the next line needs it, and "the caller supplied no block"
+		// is knowledge the finished record cannot carry (a nil block and a caller who passed nothing are
+		// indistinguishable once the record exists). Per the ruling, it keeps the nil fact and NOT the
+		// interior list.
+		//
+		// THE INTENTIONAL DUAL, with its invariant ENFORCED rather than assumed. GoalAttemptID is the
+		// authorized assessment identity; the flat NewAttemptID is the ruled lifecycle identity used
+		// through bound/consumed. Two fields carrying one value is only legitimate because this equality
+		// is checked -- that is exactly what distinguishes it from the five duplicate fields dev-2
+		// rejected from my draft.
+		if strings.TrimSpace(nb.GoalAttemptID) != attemptID {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"native binding goal attempt id %q disagrees with the reservation attempt %q: the authorized identity and the lifecycle identity must be the same attempt",
+				nb.GoalAttemptID, attemptID)
+		}
+		if strings.TrimSpace(nb.NamespaceID) != strings.TrimSpace(in.NamespaceID) {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"native binding namespace id %q disagrees with the claim namespace %q: a record filed under one namespace claiming another is invisible to the scanner that would find it",
+				nb.NamespaceID, in.NamespaceID)
+		}
+		record.NativeBinding = &resumeGoalNativeBinding{
+			NamespaceID:             strings.TrimSpace(nb.NamespaceID),
+			PaneID:                  strings.TrimSpace(nb.PaneID),
+			GoalMode:                strings.TrimSpace(nb.GoalMode),
+			GoalAttemptID:           strings.TrimSpace(nb.GoalAttemptID),
+			GoalBindingDigest:       strings.TrimSpace(nb.GoalBindingDigest),
+			GoalCommandDigest:       strings.TrimSpace(nb.GoalCommandDigest),
+			BlockerID:               strings.TrimSpace(nb.BlockerID),
+			BlockerResolutionDigest: strings.TrimSpace(nb.BlockerResolutionDigest),
+			PolicyMode:              strings.TrimSpace(nb.PolicyMode),
+			PolicyRevision:          nb.PolicyRevision,
+		}
+		// NEWATTEMPTID, ruled for native reservations (#498, U7 slice, cto 2026-07-28T09:25): the
+		// persisted record must carry an attempt identity a reader can MATCH on. Without it the
+		// cross-kind mutex's "proves a different pause" escape keys on fields native records never
+		// set, so it can never open -- an escape unreachable by construction, which is worse than no
+		// escape because the surrounding code reads as conditional while behaving unconditionally.
+		//
+		// DERIVED from the validated attemptID, never accepted from Base, for the same reason
+		// TransitionID is: a caller-supplied value could disagree with the key this record is filed
+		// under, and a record whose identity fields disagree is ambiguous evidence rather than a tie
+		// to break.
+		//
+		// THE FIELD IS SEMANTICALLY OVERLOADED ACROSS KINDS, AND THAT IS A HAZARD RATHER THAN A
+		// DESIGN. For REDELIVER, NewAttemptID is the NEW attempt being created, and two validators
+		// require it to DIFFER from OriginalAttemptID (validateResumeGoalTransitionPlan, and the
+		// explicit-CAS branch of validateResumeGoalTransitionForDelivery: "transition reuses the
+		// original attempt id"). For NATIVE it is the SAME attempt being resumed, so that invariant is
+		// INVERTED. Both validators are redelivery-scoped today, so nothing breaks now -- but Unit B
+		// is deliberately building KIND-AGNOSTIC readers, and the first kind-agnostic validator that
+		// applies the differs-invariant to a native record will reject every native reservation. Any
+		// such reader MUST scope that check to recoveryTransitionKindRedeliver.
+		if supplied := strings.TrimSpace(record.NewAttemptID); supplied != "" && supplied != attemptID {
+			return resumeGoalTransitionRecord{}, "", fmt.Errorf(
+				"supervision resume new attempt id %q disagrees with the attempt being resumed %q: the record would be filed under one attempt and claim another",
+				supplied, attemptID)
+		}
+		record.NewAttemptID = attemptID
+		// THE SHARED DURABLE CONTRACT, on what this branch just built -- the same function publication calls.
+		// The per-field requirements above that duplicate it are now the CONSTRUCTOR-ONLY half: they refuse a
+		// disagreeing INPUT ROUTE (Base versus explicit) and name the input that was wrong, which is a better
+		// error for a caller than a refusal about the finished record. The contract is what guarantees the
+		// record is valid regardless of how it was assembled.
+		if err := validateRecoveryTransitionRecordContract(record); err != nil {
+			return resumeGoalTransitionRecord{}, "", err
+		}
 		// The DIRECTORY is derived from the same validated triple, inside the constructor. A
 		// caller joining a basename could place a namespace-A claim in namespace-B's directory,
 		// where neither scanner would find it.
@@ -331,4 +572,11 @@ type recoveryTransitionInput struct {
 	BindingDigest       string
 	PauseGeneration     string
 	PreclaimFingerprint string
+	Supervisor          string
+
+	// NativeBinding is the U7 exact-binding block, supplied EXPLICITLY and never through Base.
+	// dev-2 owns the type; this is the only route the constructor accepts it by, because
+	// Base.NativeBinding is a refused side door on BOTH kinds -- see the posture note above the
+	// constructor. Non-nil exactly for native goal-resume; must be nil for redeliver.
+	NativeBinding *resumeGoalNativeBinding
 }

--- a/internal/cli/recovery_transition_cas.go
+++ b/internal/cli/recovery_transition_cas.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// PR5 / #498 CAS layer. Three durable publications -- RESERVE, BIND, CONSUME -- each going
+// through publishGoalJSON, the one CAS owner (goal_attempt.go:152). There is no new store and no
+// new primitive here; this file only decides WHAT is published and WHAT a lost race means.
+//
+// THE PUBLICATION PRIMITIVE IS link(2), NOT O_EXCL. publishGoalJSON writes a same-directory
+// candidate, fsyncs it, and link(2)s it into the canonical path: losers see ErrExist and can never
+// observe a partial file. I had assumed O_EXCL and written an enforcement test against that
+// assumption; it would have detected nothing here. Recorded so the next reader does not repeat it.
+//
+// THE THREE PUBLICATIONS DO NOT SHARE LOST-RACE SEMANTICS, and that asymmetry is the whole reason
+// this is not one generic helper. Read from the existing redelivery code before writing this:
+//
+//	RESERVE  !published -> REFUSE. Another actor holds the claim. This is claim-once.
+//	BIND     !published -> RE-READ AND VALIDATE, not refuse. A binding may legitimately already
+//	         exist from this same actor's earlier attempt; what matters is that the existing one
+//	         AGREES about the launch generation. Refusing here would break the idempotent retry
+//	         that ensureResumeGoalTransitionBinding relies on (resume_goal.go:954-967).
+//	CONSUME  !published -> REFUSE. A concurrent consumption means someone else completed the
+//	         delivery, and two consumptions of one claim is the double-delivery signature.
+//
+// A single "publish or fail" helper across all three would look like a simplification and would
+// silently convert bind's legitimate idempotence into a hard failure on every retry. The
+// uniformity is the bug, not the duplication.
+
+// recoveryReservation pairs the record with the EXACT path it was published to.
+//
+// The path comes from newRecoveryTransitionRecord and is never recomputed here. A reserver that
+// derived its own path would be a second path owner, and a claim written where no scanner looks
+// exists on disk while blocking nothing -- the r6 failure at the container level.
+type recoveryReservation struct {
+	Record resumeGoalTransitionRecord
+	Path   string
+}
+
+// reserveRecoveryTransition publishes the reservation. First writer wins; a loser REFUSES.
+func reserveRecoveryTransition(record resumeGoalTransitionRecord, path string) (recoveryReservation, error) {
+	payload, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return recoveryReservation{}, fmt.Errorf("marshal recovery transition reservation: %w", err)
+	}
+	published, err := publishGoalJSON(path, append(payload, '\n'))
+	if err != nil {
+		return recoveryReservation{}, fmt.Errorf("publish recovery transition reservation: %w", err)
+	}
+	if !published {
+		// NOT an overwrite and NOT a retry. Another actor reserved this pause first, and the
+		// contract prefers a refusal with a recovery step over a second audited resume.
+		return recoveryReservation{}, fmt.Errorf(
+			"recovery transition %s already exists at %s: another actor holds this pause's claim, so a second delivery is refused",
+			record.TransitionID, path)
+	}
+	return recoveryReservation{Record: record, Path: path}, nil
+}
+
+// bindRecoveryTransitionGeneration pins the launch generation the claim was made against, so a
+// generation change between reservation and delivery is DETECTED rather than assumed away.
+//
+// This mirrors ensureResumeGoalTransitionBinding deliberately, including its lost-race handling.
+func bindRecoveryTransitionGeneration(res recoveryReservation, launchDigest string, launchModTime int64) error {
+	boundPath := resumeGoalTransitionBoundPath(res.Path)
+	bound := resumeGoalTransitionBound{
+		SchemaVersion:       resumeGoalTransitionSchemaVersion,
+		TransitionID:        res.Record.TransitionID,
+		NewAttemptID:        res.Record.NewAttemptID,
+		LaunchRecordDigest:  launchDigest,
+		LaunchRecordModTime: launchModTime,
+		BoundAt:             time.Now().UTC(),
+	}
+	payload, err := json.MarshalIndent(bound, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal recovery transition binding: %w", err)
+	}
+	published, err := publishGoalJSON(boundPath, append(payload, '\n'))
+	if err != nil {
+		return fmt.Errorf("publish recovery transition binding: %w", err)
+	}
+	if published {
+		return nil
+	}
+	// A binding already exists. That is NOT a failure by itself -- see the asymmetry note above.
+	// What must hold is that it AGREES; a binding recorded against a different launch generation
+	// means the runtime moved under us and the claim no longer describes the world it was made in.
+	existingBytes, readErr := os.ReadFile(boundPath)
+	if readErr != nil {
+		// Cannot read the thing that beat us: unknown, therefore refused. An unreadable binding is
+		// not an absent one.
+		return fmt.Errorf("read concurrent recovery transition binding: %w", readErr)
+	}
+	var existing resumeGoalTransitionBound
+	if err := json.Unmarshal(existingBytes, &existing); err != nil {
+		return fmt.Errorf("parse concurrent recovery transition binding: %w", err)
+	}
+	if err := validateResumeGoalTransitionBound(existing, res.Record, launchDigest, launchModTime); err != nil {
+		return fmt.Errorf("launch generation changed after this claim was reserved: %w", err)
+	}
+	return nil
+}
+
+// consumeRecoveryTransition records that the delivery completed. A concurrent consumption REFUSES.
+//
+// Called ONLY after a successful delivery. On a failed delivery the reservation is deliberately
+// left UNCONSUMED, so the pause reads as indeterminate and the next scan refuses rather than
+// risking a second audited resume.
+// It takes the identity EXPLICITLY rather than a recoveryReservation, and the reason is worth
+// stating: the legacy consume path holds only an id and a path, never a record. A
+// reservation-shaped parameter would have forced that caller to fabricate a populated
+// resumeGoalTransitionRecord literal purely to satisfy the signature -- precisely the literal the
+// AST pin forbids, manufactured to feed the pin's own neighbour. A signature that makes a correct
+// caller write forbidden code is the wrong signature; I wrote it that way first and the wiring
+// caught it.
+func consumeRecoveryTransition(transitionID, newAttemptID, path string) error {
+	consumed := resumeGoalTransitionConsumed{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  transitionID,
+		NewAttemptID:  newAttemptID,
+		ConsumedAt:    time.Now().UTC(),
+	}
+	payload, err := json.MarshalIndent(consumed, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal recovery transition consumption: %w", err)
+	}
+	published, err := publishGoalJSON(resumeGoalTransitionConsumedPath(path), append(payload, '\n'))
+	if err != nil {
+		return fmt.Errorf("publish recovery transition consumption: %w", err)
+	}
+	if !published {
+		return fmt.Errorf(
+			"recovery transition %s was concurrently consumed: two consumptions of one claim is the double-delivery signature, so this is reported rather than ignored",
+			transitionID)
+	}
+	return nil
+}

--- a/internal/cli/recovery_transition_cas.go
+++ b/internal/cli/recovery_transition_cas.go
@@ -43,6 +43,11 @@ type recoveryReservation struct {
 
 // reserveRecoveryTransition publishes the reservation. First writer wins; a loser REFUSES.
 func reserveRecoveryTransition(record resumeGoalTransitionRecord, path string) (recoveryReservation, error) {
+	// PUBLICATION CONTRACT, before marshal. Every constructor guard is bypassable by a caller that builds a
+	// record itself and calls this directly, so the last step must re-decide rather than trust.
+	if err := validateRecoveryTransitionPublication(record, path); err != nil {
+		return recoveryReservation{}, err
+	}
 	payload, err := json.MarshalIndent(record, "", "  ")
 	if err != nil {
 		return recoveryReservation{}, fmt.Errorf("marshal recovery transition reservation: %w", err)

--- a/internal/cli/recovery_transition_cas_test.go
+++ b/internal/cli/recovery_transition_cas_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These three proofs exist because MUTATION TESTING FOUND THEM MISSING, not because I reasoned my
+// way to them. W4, W6 and W2 all SURVIVED the first mutation run: the corresponding properties
+// were asserted in prose, in file headers and in commit messages, and nowhere in a test.
+//
+// W4 is the one worth remembering. Bind's re-read-and-validate on a lost race is the finding I
+// called the most consequential of the milestone; I wrote three paragraphs on why collapsing the
+// three publications into one uniform helper would break it -- and making bind refuse on
+// !published failed nothing. I documented the property and never pinned it. A comment is not a
+// test, and being pleased with an insight is not evidence for it.
+
+// W4: bind is the ONE publication of the three where a lost race is NOT a failure.
+//
+// BOTH DIRECTIONS, deliberately: a bind that refused everything would satisfy a
+// refuses-on-change test alone, and a bind that accepted everything would satisfy an
+// idempotent-retry test alone. Only the pair pins the actual contract.
+func TestBindIsIdempotentForTheSameGenerationAndRefusesADifferentOne(t *testing.T) {
+	const digest = "launch-digest-1"
+	const modTime int64 = 1700000000
+
+	newReservation := func(t *testing.T) recoveryReservation {
+		t.Helper()
+		dir := t.TempDir()
+		return recoveryReservation{
+			Record: resumeGoalTransitionRecord{
+				SchemaVersion: resumeGoalTransitionSchemaVersion,
+				TransitionID:  strings.Repeat("a", 64),
+				NewAttemptID:  "attempt-new",
+			},
+			Path: filepath.Join(dir, ".resume-redelivery-"+strings.Repeat("a", 64)+".json"),
+		}
+	}
+
+	t.Run("same generation binds twice", func(t *testing.T) {
+		res := newReservation(t)
+		if err := bindRecoveryTransitionGeneration(res, digest, modTime); err != nil {
+			t.Fatalf("first bind must succeed: %v", err)
+		}
+		// THE LEGITIMATE RETRY. A prior attempt by this same actor already published the binding;
+		// the second call loses the CAS race and must still succeed, because the existing binding
+		// AGREES. Refusing here would break every resumed delivery that had already bound.
+		if err := bindRecoveryTransitionGeneration(res, digest, modTime); err != nil {
+			t.Errorf("re-binding the SAME launch generation must SUCCEED -- a lost race here is a "+
+				"legitimate retry, not a failure. This is the one publication of the three where "+
+				"!published is not an error: %v", err)
+		}
+	})
+
+	t.Run("different generation refuses", func(t *testing.T) {
+		res := newReservation(t)
+		if err := bindRecoveryTransitionGeneration(res, digest, modTime); err != nil {
+			t.Fatalf("first bind must succeed: %v", err)
+		}
+		// The runtime moved under us: the claim no longer describes the world it was made in.
+		err := bindRecoveryTransitionGeneration(res, "launch-digest-CHANGED", modTime)
+		if err == nil {
+			t.Fatal("binding against a DIFFERENT launch generation must REFUSE: the reservation was " +
+				"made against a generation that no longer exists, so proceeding would deliver into a " +
+				"runtime the claim never authorised")
+		}
+		if !strings.Contains(err.Error(), "generation") {
+			t.Errorf("the refusal must name the generation change: %v", err)
+		}
+	})
+}
+
+// W6: the omitempty tags are a COMPATIBILITY REQUIREMENT, not formatting.
+//
+// I claimed this in the struct comment and in the commit message. Dropping the tags failed
+// nothing, because the round-trip proof goes through validateResumeGoalTransitionPlan, which never
+// looks at serialised bytes. This asserts the on-disk SHAPE, which is the thing the claim is about.
+//
+// Both directions again: absent when unset, present when set. Without the second half, a record
+// that dropped the fields entirely would pass.
+func TestLegacyShapedRecordsSerialiseWithoutThePR5Keys(t *testing.T) {
+	const kindKey = `"recovery_kind"`
+	const pauseKey = `"pause_generation"`
+	const fingerprintKey = `"preclaim_fingerprint"`
+
+	legacy := resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  strings.Repeat("b", 64),
+		CreatedAt:     time.Now().UTC(),
+	}
+	encoded, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{kindKey, pauseKey, fingerprintKey} {
+		if strings.Contains(string(encoded), key) {
+			t.Errorf("a legacy-shaped record must not emit %s.\nA record on disk written before PR5 "+
+				"carries no such key; emitting it as an empty string makes an ABSENT value "+
+				"indistinguishable from a deliberately-blank one, which is exactly the read/write "+
+				"asymmetry this design depends on.\ngot: %s", key, encoded)
+		}
+	}
+
+	// The companion direction: when the fields ARE set they must serialise, or omitempty would be
+	// "correct" by never writing them at all.
+	populated := legacy
+	populated.RecoveryKind = string(recoveryTransitionKindNativeGoalResume)
+	populated.PauseGeneration = "pause-gen-1"
+	populated.PreclaimFingerprint = "fingerprint-1"
+	encoded, err = json.Marshal(populated)
+	if err != nil {
+		t.Fatalf("marshal populated: %v", err)
+	}
+	for _, key := range []string{kindKey, pauseKey, fingerprintKey} {
+		if !strings.Contains(string(encoded), key) {
+			t.Errorf("a populated record MUST emit %s; without this the absence test above would be "+
+				"satisfied by never writing the field at all\ngot: %s", key, encoded)
+		}
+	}
+}
+
+// W2, THE REAL ONE: a caller must not be able to SMUGGLE a transition id.
+//
+// I got this wrong twice and dev-2 caught both. First I claimed the behavioural mutation was
+// INERT -- "no caller sets that field, so the branch never fires". Then I claimed the property was
+// purely structural and pinned it with a reflection check on recoveryTransitionInput's DIRECT
+// field names.
+//
+// BOTH CLAIMS WERE FALSE, for the same reason. recoveryTransitionInput.Base is a
+// resumeGoalTransitionRecord, and that type HAS a TransitionID field. So the smuggling channel
+// exists TODAY as Base.TransitionID; the direct-field pin sees only "Base" and never descends, so
+// it passed while the hole it named was open. The old test's own NAME asserted something untrue.
+//
+// And the mutation was never inert: it is inert only for the production callers I happened to
+// look at. A test is a caller, and future production callers are exactly what a pin is for. "No
+// input can express this" was a conclusion I reached without trying to construct one.
+//
+// So the property gets its BEHAVIOURAL proof below, with the input dev-2 named: a valid, foreign,
+// 64-char id in Base.TransitionID. The constructor must overwrite it with the derived identity.
+func TestConstructorOverwritesASmuggledTransitionID(t *testing.T) {
+	const attemptID = "attempt-abc"
+	const bindingDigest = "digest-def"
+	// A WELL-FORMED id belonging to someone else -- not garbage. Garbage would be rejected by any
+	// shape check and would prove only that malformed input fails; this one is exactly as valid as
+	// the right answer and differs only in being wrong.
+	foreign := strings.Repeat("9", 64)
+	canonical := resumeGoalTransitionID(attemptID, bindingDigest)
+	if foreign == canonical {
+		t.Fatal("fixture is void: the foreign id equals the canonical one")
+	}
+
+	project := t.TempDir()
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base: resumeGoalTransitionRecord{
+			Project: project, Profile: "squad", Session: "v2-25-0",
+			TransitionID: foreign, // the smuggling channel
+		},
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     attemptID,
+		BindingDigest: bindingDigest,
+	})
+	if err != nil {
+		t.Fatalf("constructor refused a well-formed input: %v", err)
+	}
+
+	if record.TransitionID == foreign {
+		t.Errorf("the constructor HONOURED a caller-supplied transition id (%q).\nIdentity is derived "+
+			"per kind precisely so there is nothing to smuggle: a supplied id could be a legacy value "+
+			"or one byte wrong, writing a current-looking record under the wrong key -- unmatched on "+
+			"read, therefore treated as absent, therefore a SECOND DELIVERY.", foreign)
+	}
+	if record.TransitionID != canonical {
+		t.Errorf("TransitionID = %q, want the derived %q", record.TransitionID, canonical)
+	}
+	// The PATH must follow the derived id too. Overwriting the id while deriving the path from the
+	// smuggled one would put a correct record where no scanner looks.
+	wantPath, pathErr := resumeGoalTransitionPath(project, "squad", "v2-25-0", canonical)
+	if pathErr != nil {
+		t.Fatalf("canonical path: %v", pathErr)
+	}
+	if path != wantPath {
+		t.Errorf("path = %q, want %q -- the path must follow the DERIVED identity, not the supplied one",
+			path, wantPath)
+	}
+}
+
+// The structural pin survives as an ADDITIONAL API guard, with an honest name. It proves only that
+// no DIRECT TransitionID field is added to the input -- a second, easier smuggling channel. It
+// does NOT prove the nested one is closed; that is the behavioural test above. Kept because the
+// two catch different edits, stated because the previous version claimed the stronger thing.
+func TestRecoveryTransitionInputGainsNoDirectTransitionIDField(t *testing.T) {
+	typ := reflect.TypeOf(recoveryTransitionInput{})
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		if strings.Contains(strings.ToLower(name), "transitionid") {
+			t.Errorf("recoveryTransitionInput.%s adds a DIRECT channel for a caller-supplied "+
+				"transition id. The nested Base.TransitionID route is covered behaviourally by "+
+				"TestConstructorOverwritesASmuggledTransitionID; this guards the easier one.", name)
+		}
+	}
+	if typ.NumField() == 0 {
+		t.Fatal("recoveryTransitionInput has no fields; this pin is enforcing nothing")
+	}
+	// Anti-vacuity with teeth: Base must still be present and must still be the record type, or
+	// the nested channel this test explicitly does NOT cover has moved somewhere unexamined.
+	base, ok := typ.FieldByName("Base")
+	if !ok || base.Type != reflect.TypeOf(resumeGoalTransitionRecord{}) {
+		t.Fatal("recoveryTransitionInput.Base is missing or retyped; the nested-id analysis above no " +
+			"longer describes this struct and must be redone")
+	}
+}
+
+// Kept honest: the reservation and consumption publications DO refuse on a lost race, which is the
+// other half of the three-way asymmetry. Without this, "bind is the exception" is a claim about
+// bind alone rather than a contrast that could be wrong.
+func TestReserveAndConsumeBothRefuseALostRace(t *testing.T) {
+	dir := t.TempDir()
+	record := resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  strings.Repeat("c", 64),
+		NewAttemptID:  "attempt-new",
+	}
+	path := filepath.Join(dir, ".resume-redelivery-"+record.TransitionID+".json")
+
+	if _, err := reserveRecoveryTransition(record, path); err != nil {
+		t.Fatalf("first reserve must succeed: %v", err)
+	}
+	if _, err := reserveRecoveryTransition(record, path); err == nil {
+		t.Error("a second reserve must REFUSE: another actor holds this pause's claim, and " +
+			"overwriting it is the double-delivery path")
+	}
+
+	if err := consumeRecoveryTransition(record.TransitionID, record.NewAttemptID, path); err != nil {
+		t.Fatalf("first consume must succeed: %v", err)
+	}
+	if err := consumeRecoveryTransition(record.TransitionID, record.NewAttemptID, path); err == nil {
+		t.Error("a second consume must REFUSE: two consumptions of one claim is the double-delivery " +
+			"signature and must be reported, not absorbed")
+	}
+	// Prove the consumption actually landed on disk rather than the calls merely returning nil.
+	if _, err := os.Stat(resumeGoalTransitionConsumedPath(path)); err != nil {
+		t.Errorf("consumption record must exist at the companion path: %v", err)
+	}
+}

--- a/internal/cli/recovery_transition_cas_test.go
+++ b/internal/cli/recovery_transition_cas_test.go
@@ -155,11 +155,13 @@ func TestConstructorOverwritesASmuggledTransitionID(t *testing.T) {
 	}
 
 	project := t.TempDir()
+	smuggling := redeliverTransitionBase(project, "squad", "v2-25-0", attemptID, bindingDigest)
+	// THE SMUGGLING CHANNEL, applied to an otherwise complete Base so the supplied id is the row's only
+	// defect. With an incomplete Base this row would now refuse on the redeliver contract and prove nothing
+	// about smuggling.
+	smuggling.TransitionID = foreign
 	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
-		Base: resumeGoalTransitionRecord{
-			Project: project, Profile: "squad", Session: "v2-25-0",
-			TransitionID: foreign, // the smuggling channel
-		},
+		Base:          smuggling,
 		Kind:          recoveryTransitionKindRedeliver,
 		AttemptID:     attemptID,
 		BindingDigest: bindingDigest,
@@ -219,13 +221,29 @@ func TestRecoveryTransitionInputGainsNoDirectTransitionIDField(t *testing.T) {
 // other half of the three-way asymmetry. Without this, "bind is the exception" is a claim about
 // bind alone rather than a contrast that could be wrong.
 func TestReserveAndConsumeBothRefuseALostRace(t *testing.T) {
-	dir := t.TempDir()
-	record := resumeGoalTransitionRecord{
-		SchemaVersion: resumeGoalTransitionSchemaVersion,
-		TransitionID:  strings.Repeat("c", 64),
-		NewAttemptID:  "attempt-new",
+	// THE FIXTURE NOW COMES FROM THE CONSTRUCTOR, and that change is the point rather than a tidy-up.
+	//
+	// It used to be a hand-built record carrying only SchemaVersion/TransitionID/NewAttemptID at a
+	// hand-joined path. The publication contract correctly refuses that -- it has no kind and no scope --
+	// so this test broke the moment publication started validating, and it broke for a reason that had
+	// NOTHING to do with lost races. That is the fixture failure mode dev-2 keeps finding: a row whose
+	// setup encodes only what its author was thinking about, which silently becomes a row about something
+	// else as soon as the contract grows.
+	//
+	// Built from the one constructor, the fixture cannot drift out of validity without the constructor
+	// itself changing, and this row stays a row about CAS semantics.
+	const profile = "squad"
+	const session = "v2-25-0"
+	project := t.TempDir()
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:          redeliverTransitionBase(project, profile, session, "attempt-abc", "binding-digest-1"),
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     "attempt-abc",
+		BindingDigest: "binding-digest-1",
+	})
+	if err != nil {
+		t.Fatalf("a complete redeliver input must be accepted: %v", err)
 	}
-	path := filepath.Join(dir, ".resume-redelivery-"+record.TransitionID+".json")
 
 	if _, err := reserveRecoveryTransition(record, path); err != nil {
 		t.Fatalf("first reserve must succeed: %v", err)

--- a/internal/cli/recovery_transition_contract.go
+++ b/internal/cli/recovery_transition_contract.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+// #498 U7 / HOLD 2: THE ONE DURABLE-RECORD CONTRACT.
+//
+// WHY THIS FILE EXISTS. I wrote the publication validator as its OWN list of checks, and dev-2 found by
+// source trace that it accepted records the constructor would refuse -- exactly:
+//
+//	a current-schema native record with scope, supervisor, pause generation, an arbitrary 64-hex
+//	TransitionID, and NativeBinding = &resumeGoalNativeBinding{} with all ten interiors ZERO,
+//	published at the canonical path derived from that arbitrary id.
+//
+// Publication accepted it. Nothing durable about that record is usable: no scanner derives that id, so the
+// claim is present on disk and reads as ABSENT for the real pause, which is the double delivery claim-once
+// exists to prevent -- reached through the writer I added to prevent it.
+//
+// THE RULED SHAPE IS ONE DECIDER, TWO CALL SITES, not a second hand-maintained list inside publication. Two
+// lists of record requirements must co-evolve forever, and their drift IS the constructor-versus-publisher
+// disagreement this milestone has been closing all day. With one function, a field added to the contract is
+// automatically required at publication and the co-drift is structurally impossible.
+//
+// THE BOUNDARY (dev-2's refinement, ruled binding) is what makes the split principled rather than arbitrary:
+//
+//	SHARED (here)      every invariant OBSERVABLE IN THE COMPLETED RECORD: per-kind required fields, and
+//	                   derived-identity RECOMPUTATION from the record's own durable source fields.
+//	CONSTRUCTOR ONLY   what a finished record cannot testify about: which INPUT ROUTE a value arrived by,
+//	                   Base smuggling, and fresh-copy/non-aliasing. A record on disk cannot tell you whether
+//	                   its supervisor came through the explicit input or through Base.
+//	PUBLICATION        this validator, then exact path/name agreement, which is about the record's LOCATION
+//	                   rather than its content.
+//
+// IDENTITY IS RECOMPUTED, NOT COMPARED TO ITSELF. This is the sharpest part of dev-2's finding and the reason
+// path-equality alone was not closure: my canonical path derivation took record.TransitionID as INPUT, so
+// checking the path against it proved only that the record agreed with itself. A self-referential invariant
+// binds nothing -- the same defect class as U10's runtime-resolved baseline_head, which cto rejected for
+// binding the run to whatever tree it found. The identity must be derived from the fields that GENERATE it.
+func validateRecoveryTransitionRecordContract(record resumeGoalTransitionRecord) error {
+	kind := recoveryTransitionKind(strings.TrimSpace(record.RecoveryKind))
+	if kind == "" {
+		return fmt.Errorf("recovery transition record carries no recovery kind, so it is neither a valid redeliver nor a valid native reservation")
+	}
+	if !knownRecoveryTransitionKind(kind) {
+		return fmt.Errorf("recovery transition record has unknown recovery kind %q", kind)
+	}
+	if record.SchemaVersion != resumeGoalTransitionSchemaVersion {
+		return fmt.Errorf(
+			"recovery transition record schema version %d is not the current %d: its own readers validate this, so a record written under a version they reject is undiscoverable evidence",
+			record.SchemaVersion, resumeGoalTransitionSchemaVersion)
+	}
+	// THE SCOPE TRIPLE MUST ALREADY BE IN CANONICAL FORM -- stored trimmed, not merely trimmable.
+	//
+	// dev-2's static counterexample: a Project of "<tmpdir> " (trailing space) is nonblank under a TrimSpace
+	// check, so the contract accepted it; the constructor then derived its path from the RAW value while
+	// canonicalRecoveryTransitionPath re-derived from the TRIMMED one. Publication refused the constructor's
+	// own output. goalAttemptDir trims session and normalizes profile but joins project verbatim, so project
+	// was the live vector -- all three are checked because a normalization difference is not something to
+	// re-audit per field every time goalAttemptDir changes.
+	//
+	// RULED FIX: canonicalize AT THE DATA rather than aligning two consumers of ambiguous data. One canonical
+	// form in the record, everything derives from it. Refusing is chosen over silently rewriting the value
+	// because a caller holding "<tmpdir> " believes something false about where its claim will live, and
+	// silent correction defers that discovery to somewhere less observable -- the same posture rule the
+	// constructor applies to disagreeing Base values.
+	for _, f := range [][2]string{{"project", record.Project}, {"profile", record.Profile}, {"session", record.Session}} {
+		if f[1] != strings.TrimSpace(f[1]) {
+			return fmt.Errorf(
+				"recovery transition (%s) %s %q is not stored in canonical form: the record must hold the exact value every path derivation uses, or the writer and the publisher compute different locations for the same claim",
+				kind, f[0], f[1])
+		}
+	}
+	// THE SCOPE TRIPLE, both kinds. Without it there is no canonical location and no namespace identity, and
+	// goalAttemptDir would build a RELATIVE path from blanks -- a claim published relative to whatever
+	// directory the process happens to be in, unfindable by every scanner including the one that wrote it.
+	if err := requireRecoveryFields(kind, [][2]string{
+		{"project", record.Project},
+		{"profile", record.Profile},
+		{"session", record.Session},
+		// NewAttemptID is required for BOTH kinds, and the reason differs per kind rather than being one
+		// rule: for redeliver it is the new attempt being created, for native it is the attempt being
+		// resumed. Both need a reader to be able to MATCH on it -- the cross-kind mutex's
+		// proves-a-different-pause escape keys on it, and a blank one makes that escape unreachable.
+		{"new attempt id", record.NewAttemptID},
+	}); err != nil {
+		return err
+	}
+
+	switch kind {
+	case recoveryTransitionKindNativeGoalResume:
+		return validateNativeRecoveryRecordContract(record)
+	case recoveryTransitionKindRedeliver:
+		return validateRedeliverRecoveryRecordContract(record)
+	}
+	// Unreachable via knownRecoveryTransitionKind above. Stated as a refusal rather than a fallthrough so a
+	// future kind that adds a constructor branch and forgets a contract branch FAILS here instead of
+	// publishing an unvalidated record.
+	return fmt.Errorf("recovery transition record kind %q has no durable contract", kind)
+}
+
+// validateNativeRecoveryRecordContract is the RATIFIED U7 SET, checked against the finished record.
+func validateNativeRecoveryRecordContract(record resumeGoalTransitionRecord) error {
+	kind := recoveryTransitionKindNativeGoalResume
+	if err := requireRecoveryFields(kind, [][2]string{
+		// ROLE AND HANDLE. dev-2's blocker 3: the ratified contract requires these, the production caller
+		// supplies them, and revalidation compares them -- but nothing REQUIRED them, so a blank record
+		// revalidated against a blank assessment passed BY MUTUAL ABSENCE. That was the third
+		// pass-by-mutual-absence of the day. A comparison is not a requirement.
+		{"lead role", record.Role},
+		{"lead handle", record.Handle},
+		// WHO AUTHORISED IT. Accountability that exists only in a live process cannot be audited after it.
+		{"supervisor", record.Supervisor},
+		{"pause generation", record.PauseGeneration},
+		{"preclaim fingerprint", record.PreclaimFingerprint},
+		// THE FLAT LAUNCH GENERATION. Recovery cannot revalidate a generation the record never persisted,
+		// and a relaunch is the one drift the U5 liveness gates cannot see: the pane can be live, managed
+		// and idle while belonging to a process this claim never authorized.
+		{"launch id", record.LaunchID},
+		{"launch record digest", record.LaunchRecordDigest},
+	}); err != nil {
+		return err
+	}
+	if strings.TrimSpace(record.Supervisor) == supervisorIdentityPlaceholder {
+		return fmt.Errorf(
+			"recovery transition (%s) supervisor is still the literal placeholder %s: recording it would durably attribute the resume to nobody while LOOKING like an answer, which is worse than a blank",
+			kind, supervisorIdentityPlaceholder)
+	}
+	// <= 0 rather than == 0: a negative modtime is not a plausible observation either, and accepting one
+	// would persist a generation no stat call could reproduce.
+	if record.LaunchRecordModTime <= 0 {
+		return fmt.Errorf(
+			"recovery transition (%s) requires a positive launch record mod time, got %d: zero is indistinguishable from an unset field, so drift against it can never be detected",
+			kind, record.LaunchRecordModTime)
+	}
+	if record.NativeBinding == nil {
+		return fmt.Errorf("recovery transition (%s) requires its exact binding: the record IS the recovery contract, and delivery cannot revalidate fields the record never persists", kind)
+	}
+	nb := record.NativeBinding
+	// EVERY INTERIOR, because dev-2's counterexample was an all-zero block that passed a nil check. A
+	// pointer-presence sentinel tests that someone allocated a struct, not that the binding says anything.
+	if err := requireRecoveryFields(kind, [][2]string{
+		{"native binding namespace id", nb.NamespaceID},
+		{"native binding pane id", nb.PaneID},
+		{"native binding goal mode", nb.GoalMode},
+		{"native binding goal attempt id", nb.GoalAttemptID},
+		{"native binding goal binding digest", nb.GoalBindingDigest},
+		{"native binding goal command digest", nb.GoalCommandDigest},
+		// Blocker fields are REQUIRED, not optional: eligibility (goal_supervision.go:341-342) requires
+		// Known + nonblank ID + Resolved + nonblank ResolutionDigest, so an authorized native resume ALWAYS
+		// carries both. Accepting empty would let a gate-skipping caller write a record the executor could
+		// never have authorized.
+		{"native binding blocker id", nb.BlockerID},
+		{"native binding blocker resolution digest", nb.BlockerResolutionDigest},
+		{"native binding policy mode", nb.PolicyMode},
+	}); err != nil {
+		return err
+	}
+	if nb.PolicyRevision <= 0 {
+		return fmt.Errorf("recovery transition (%s) requires a positive native binding policy revision, got %d: revision zero is indistinguishable from an unset field", kind, nb.PolicyRevision)
+	}
+	// THE NAMESPACE MUST BE THE CANONICAL ONE FOR THIS RECORD'S OWN PROFILE/SESSION. Checked here rather
+	// than only at construction because it is fully observable in the record: a correct hash filed under a
+	// foreign namespace is invisible to the scanner that would look for it.
+	if want := squadnamespace.ID(record.Profile, record.Session); strings.TrimSpace(nb.NamespaceID) != want {
+		return fmt.Errorf(
+			"recovery transition (%s) native binding namespace id %q is not the canonical id %q for its own profile/session: a claim filed under a foreign namespace is invisible to the scanner that would find it",
+			kind, nb.NamespaceID, want)
+	}
+	// THE INTENTIONAL DUAL'S INVARIANT, re-checked on the finished record. Two fields carrying one value is
+	// legitimate ONLY while something enforces that they do; construction-time enforcement says nothing
+	// about a record read back from disk or hand-built by a direct caller.
+	if strings.TrimSpace(nb.GoalAttemptID) != strings.TrimSpace(record.NewAttemptID) {
+		return fmt.Errorf(
+			"recovery transition (%s) native binding goal attempt id %q disagrees with the record's lifecycle attempt %q: a record whose two attempt identities differ is ambiguous evidence about which attempt was authorized",
+			kind, nb.GoalAttemptID, record.NewAttemptID)
+	}
+	// THE DERIVED IDENTITY, RECOMPUTED FROM THE RECORD'S OWN SOURCE FIELDS. This is dev-2's central finding:
+	// an arbitrary 64-hex id that merely AGREES with its filename and path is not an identity, because no
+	// pause scanner derives it. The claim key is what a scanner computes from namespace + pause generation +
+	// attempt, so that is what the record must carry.
+	wantID, err := supervisionClaimKey(nb.NamespaceID, record.PauseGeneration, record.NewAttemptID)
+	if err != nil {
+		return fmt.Errorf("recovery transition (%s) cannot derive its own claim key: %w", kind, err)
+	}
+	if strings.TrimSpace(record.TransitionID) != wantID {
+		return fmt.Errorf(
+			"recovery transition (%s) transition id %q is not the claim key %q derived from its own namespace/pause/attempt: an id no scanner computes is unmatchable on read, therefore treated as ABSENT, therefore a second delivery",
+			kind, record.TransitionID, wantID)
+	}
+	return nil
+}
+
+// validateRedeliverRecoveryRecordContract is the complete redeliver contract dev-2's blocker 2 required be
+// DEFINED rather than assumed.
+//
+// It was previously undefined, and the cost was concrete: the constructor accepted an input carrying only a
+// scope triple and returned a record with a blank NewAttemptID, which publication then unconditionally
+// refused. The constructor and the publisher disagreed about what a valid redeliver record is, and my own
+// anti-vacuity test asserted the accepted case and could never pass.
+func validateRedeliverRecoveryRecordContract(record resumeGoalTransitionRecord) error {
+	kind := recoveryTransitionKindRedeliver
+	if err := requireRecoveryFields(kind, [][2]string{
+		// THE IDENTITY SOURCE FIELDS. Required because the identity is recomputed from them below: a record
+		// that does not carry what generates its own id cannot have that id verified, and an unverifiable
+		// id is exactly the arbitrary-64-hex hole in the native branch wearing different field names.
+		{"original attempt id", record.OriginalAttemptID},
+		{"original binding digest", record.OriginalBindingDigest},
+	}); err != nil {
+		return err
+	}
+	// THE NEW ATTEMPT MUST DIFFER FROM THE ORIGINAL. Both peer-owned readers already refuse equality
+	// (validateResumeGoalTransitionPlan at resume_goal.go:458-459, and the explicit-CAS branch of
+	// validateResumeGoalTransitionForDelivery at :1173-1174), so without this the writer could make DURABLE a
+	// record its own readers reject -- the writer/reader disagreement class, with the ledger left holding
+	// evidence nothing can consume.
+	//
+	// SCOPED TO REDELIVER ONLY, deliberately. For native, NewAttemptID EQUALS the resumed attempt by ruling:
+	// the same field means "the new attempt being created" here and "the attempt being resumed" there. That
+	// overload is a known hazard rather than a design, which is exactly why the invariant has to live in the
+	// per-kind contract instead of the shared preamble -- a kind-agnostic version of this check would reject
+	// every native reservation.
+	if strings.TrimSpace(record.NewAttemptID) == strings.TrimSpace(record.OriginalAttemptID) {
+		return fmt.Errorf(
+			"recovery transition (%s) new attempt id %q must differ from the original attempt id it replaces: its own readers refuse a transition that reuses the original attempt, so this record would be durable evidence nothing can consume",
+			kind, record.NewAttemptID)
+	}
+	// THE ABSENCES ARE PART OF THE CONTRACT, and they are compared RAW rather than trimmed: `omitempty` does
+	// not omit a whitespace-only string, so a trimmed guard would let a present-but-meaningless value
+	// serialise. This path holds no assessment, so a value in either field was recomputed or invented, and
+	// refusing is what keeps their PRESENCE a reliable signal that a record came from the supervised path.
+	if record.NativeBinding != nil {
+		return fmt.Errorf("recovery transition (%s) must not carry a native exact binding: that block is the assessment's binding and this path holds no assessment", kind)
+	}
+	if record.PauseGeneration != "" {
+		return fmt.Errorf("recovery transition (%s) must not carry a pause generation (got %q): this path holds no assessment, so the value was recomputed or invented", kind, record.PauseGeneration)
+	}
+	if record.Supervisor != "" {
+		return fmt.Errorf("recovery transition (%s) must not carry a supervisor (got %q): this path holds no assessment and no supervising actor, so the value was invented", kind, record.Supervisor)
+	}
+	// RECOMPUTED from the record's own durable source fields, exactly as the native branch recomputes its
+	// claim key. resumeGoalTransitionID is the derivation redelivery's EXISTING readers use, so this proves
+	// the record is filed under the id those readers will look for.
+	wantID := resumeGoalTransitionID(record.OriginalAttemptID, record.OriginalBindingDigest)
+	if strings.TrimSpace(record.TransitionID) != wantID {
+		return fmt.Errorf(
+			"recovery transition (%s) transition id %q is not the id %q derived from its own original attempt and binding digest: redelivery's readers compute that value, so a record under any other id is invisible to them",
+			kind, record.TransitionID, wantID)
+	}
+	return nil
+}
+
+// requireRecoveryFields refuses the FIRST blank field and names it.
+//
+// A table rather than a run of ifs so that adding a required field is one line and cannot silently skip the
+// refusal, and so every message has the same shape for an operator reading a refusal they have not seen.
+func requireRecoveryFields(kind recoveryTransitionKind, fields [][2]string) error {
+	for _, f := range fields {
+		if strings.TrimSpace(f[1]) == "" {
+			return fmt.Errorf("recovery transition (%s) requires a %s", kind, f[0])
+		}
+	}
+	return nil
+}

--- a/internal/cli/recovery_transition_contract.go
+++ b/internal/cli/recovery_transition_contract.go
@@ -89,6 +89,36 @@ func validateRecoveryTransitionRecordContract(record resumeGoalTransitionRecord)
 	}); err != nil {
 		return err
 	}
+	// NONBLANK IS NOT READER-ACCEPTED (codex finding 4). The requirement above proves the field is present;
+	// it says nothing about whether the value can ever be USED. "../new" is nonblank, and for redeliver it is
+	// also different from the original attempt, so it satisfied every writer-side check and published --
+	// while the delivery path refuses it at resume_goal.go:1176 via goalAttemptPath. The result is durable
+	// evidence NOTHING CAN CONSUME: the claim blocks at the claim-once gate permanently, and no code path
+	// deletes reservations.
+	//
+	// VALIDATED THROUGH THE READER'S OWN OWNER, never re-implemented. goalAttemptPath (goal_attempt.go:105)
+	// holds the shape rule -- empty, ".", "..", non-basename, or containing a separator -- and re-stating
+	// those characters here would be a SECOND OPINION about attempt-id shape, which is the exact defect this
+	// file exists to make structurally impossible. Calling the reader's function is what makes writer and
+	// reader agree by construction instead of by maintenance.
+	//
+	// IN THE SHARED PREAMBLE, so it covers BOTH KINDS. The native branch derives its claim key by HASHING
+	// NewAttemptID (validateNativeRecoveryRecordContract below), and a hash accepts any string, so native
+	// carried the identical hole under a different derivation. Placing this in the redeliver branch alone --
+	// where the finding was reported -- would have closed one of two doors.
+	//
+	// It also closes the READ-BACK TAMPER PATH: this contract runs against the record re-read from disk
+	// (goal_supervision_resume.go:416), where catching a tampered value is the entire purpose of the call.
+	//
+	// MY OWN COMMENT CONVICTED ME. The redeliver branch below cites "the explicit-CAS branch of
+	// validateResumeGoalTransitionForDelivery at :1173-1174" as the reason for its equality check. I was
+	// reading that region and mirrored the refusal at :1173 while not mirroring the one THREE LINES LATER at
+	// :1176. Reading the adjacent line and not this one is how a writer/reader disagreement survives review.
+	if _, err := goalAttemptPath(record.Project, record.Profile, record.Session, record.NewAttemptID); err != nil {
+		return fmt.Errorf(
+			"recovery transition (%s) new attempt id %q is not a value its own delivery reader accepts (%w): the delivery path refuses it, so this record would be durable evidence nothing can consume and the pause would block forever",
+			kind, record.NewAttemptID, err)
+	}
 
 	switch kind {
 	case recoveryTransitionKindNativeGoalResume:

--- a/internal/cli/recovery_transition_fixtures_test.go
+++ b/internal/cli/recovery_transition_fixtures_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+// ONE COMPLETE NATIVE FIXTURE, shared, because the alternative produced two defect classes in one day.
+//
+// dev-2's cross-gate found five native fixtures carrying an INCOMPLETE exact binding and two carrying a
+// GoalMode that production can never emit. Both are the same root failure: each fixture was written by
+// hand next to the row that needed it, so each one encoded whatever the author was thinking about at that
+// moment, and a row meant to prove ONE defect could refuse for an unrelated missing field instead.
+//
+// THE SINGLE-DEFECT PROPERTY IS THE POINT. A falsifier proves what it names only if everything EXCEPT the
+// named defect is valid. Hand-built fixtures cannot maintain that as the constructor's requirements grow:
+// every new required field silently converts some existing rows into rows that refuse for the new reason.
+// With one complete fixture, a row states its defect as a single explicit override of a known-good value,
+// and adding a required field updates every row at once.
+//
+// USE: take the complete input, then break EXACTLY ONE thing.
+//
+//	in := completeNativeTransitionInput(project, profile, session, attemptID)
+//	in.Supervisor = ""  // the single defect this row is about
+
+// fixtureNativeGoalMode is the mode a blocked native goal ACTUALLY carries.
+//
+// PINNED TO PRODUCTION, and stated as a citation rather than a constant import because THERE IS NO
+// EXPORTED CONSTANT: goal_supervision.go:334 compares b.Goal.Mode against the bare literal
+// "native_goal_blocked" inside the goal_attempt eligibility reason. Two fixtures previously used "native",
+// which no production path emits -- so they pinned behaviour for a state the system cannot reach, and a
+// test asserting an unreachable state actively defends whatever the real state does instead.
+//
+// This is a latent drift risk I am NOT fixing here (the speed directive scopes me to the four blockers):
+// production owns this value as a literal, so nothing mechanically ties this fixture to it. Flagged in the
+// delivery as a follow-up rather than silently absorbed.
+const fixtureNativeGoalMode = "native_goal_blocked"
+
+// The launch generation the claim is written against.
+//
+// THE VALUES DELIBERATELY MATCH the u6 assessment fixture's launch generation
+// (goal_supervision_u6_falsifiers_test.go:62-64) rather than introducing a second vocabulary. A record
+// built from these constants and revalidated against that assessment must AGREE; had I invented
+// "launch-record-digest-1" here while the assessment said "launch-digest-1", every such row would refuse
+// on launch drift and I would have manufactured a fixture disagreement that looks like a real finding.
+const (
+	fixtureLaunchID              = "launch-1"
+	fixtureLaunchDigest          = "launch-digest-1"
+	fixtureLaunchModTime   int64 = 1700000000
+	fixturePauseGeneration       = "pause-gen-1"
+	fixtureFingerprint           = "fingerprint-1"
+	fixtureSupervisor            = "supervisor-1"
+)
+
+// nativeTransitionBase is the Base a native reservation legitimately carries.
+//
+// It exists because the flat launch generation is now REQUIRED for native, and eleven call sites shared
+// the identical three-field Base literal. Adding the fields inline at each site would have made the next
+// required field an eleven-site edit again -- and the fixture-drift defects dev-2 found are exactly what
+// happens when N hand-maintained copies of one fixture fall out of step.
+func nativeTransitionBase(project, profile, session string) resumeGoalTransitionRecord {
+	return resumeGoalTransitionRecord{
+		Project: project, Profile: profile, Session: session,
+		// LEAD IDENTITY. Required by the shared contract as of HOLD 2 blocker 3: they were compared by
+		// revalidation but required by nothing, so a blank record and a blank assessment agreed BY MUTUAL
+		// ABSENCE. Adding them here rather than at eleven call sites is the whole reason this helper exists.
+		Role: "cto", Handle: "cto",
+		LaunchID:            fixtureLaunchID,
+		LaunchRecordDigest:  fixtureLaunchDigest,
+		LaunchRecordModTime: fixtureLaunchModTime,
+	}
+}
+
+// redeliverTransitionBase is the Base a redeliver reservation legitimately carries.
+//
+// It exists because HOLD 2 blocker 2 required the redeliver contract to be DEFINED: the record must carry the
+// fields its own identity is derived from (OriginalAttemptID + OriginalBindingDigest) so publication can
+// RECOMPUTE that identity instead of comparing it to itself, plus the NewAttemptID the constructor never set.
+//
+// The identity sources are taken as parameters and must be the SAME values passed as the input's
+// AttemptID/BindingDigest -- the contract recomputes resumeGoalTransitionID from the record's copies, so a
+// fixture whose Base disagreed with its input would refuse on the identity check rather than on whatever the
+// row is about.
+func redeliverTransitionBase(project, profile, session, originalAttemptID, bindingDigest string) resumeGoalTransitionRecord {
+	return resumeGoalTransitionRecord{
+		Project: project, Profile: profile, Session: session,
+		Role: "cto", Handle: "cto",
+		OriginalAttemptID:     originalAttemptID,
+		OriginalBindingDigest: bindingDigest,
+		// The NEW attempt being created -- deliberately DIFFERENT from the original, because two redelivery
+		// validators require exactly that (validateResumeGoalTransitionPlan and the explicit-CAS branch of
+		// validateResumeGoalTransitionForDelivery: "transition reuses the original attempt id").
+		NewAttemptID: "attempt-new",
+	}
+}
+
+// completeNativeTransitionInput returns an input the constructor MUST accept.
+//
+// The NamespaceID is derived with squadnamespace.ID from the same profile/session pair, because the
+// constructor requires that exact equality -- a hand-written namespace string would make every row using
+// this fixture refuse on the namespace check instead of the thing it is testing.
+// It reuses validNativeBinding (goal_supervision_u6_falsifiers_test.go:874) for the nested block rather
+// than defining a second all-valid binding. A duplicate would be a second owner of one fixture, and the
+// two would disagree the first time either was extended -- which is the same one-fact-two-owners shape
+// that produces double delivery in production, demoted to test scaffolding.
+func completeNativeTransitionInput(project, profile, session, attemptID string) recoveryTransitionInput {
+	namespaceID := squadnamespace.ID(profile, session)
+	base := nativeTransitionBase(project, profile, session)
+	base.Role, base.Handle = "lead", "cto"
+	return recoveryTransitionInput{
+		Base:                base,
+		Kind:                recoveryTransitionKindNativeGoalResume,
+		NamespaceID:         namespaceID,
+		AttemptID:           attemptID,
+		PauseGeneration:     fixturePauseGeneration,
+		PreclaimFingerprint: fixtureFingerprint,
+		Supervisor:          fixtureSupervisor,
+		NativeBinding:       validNativeBinding(namespaceID, attemptID),
+	}
+}

--- a/internal/cli/recovery_transition_legacy_test.go
+++ b/internal/cli/recovery_transition_legacy_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// COMPATIBILITY PROOF (1) of the two dev-2 ruled must both exist and neither substitute for the
+// other:
+//
+//	(1) HERE: a legacy fixture built THROUGH resumeGoalTransitionID, proving the CURRENT code
+//	    recognises and blocks the reservations the old code wrote. This is about the reader.
+//	(2) pr5-roundtrip: a fixed hard-coded golden AttemptID+BindingDigest -> exact id/path vector,
+//	    proving the ALGORITHM has not moved. This is about persisted records on disk.
+//
+// Why (1) cannot be a hard-coded name: the fixture must be what the writer WOULD produce, so if
+// the legacy derivation is ever changed this fixture changes with it and the recognition test
+// keeps passing -- correctly, because recognition tracks the writer. Why (2) cannot be built by a
+// helper: a helper that drifts with the implementation proves nothing about records already
+// written. Each covers exactly the failure the other cannot see, which is why one is not
+// redundant with the other.
+
+// legacyReservationFor builds the filename the PRE-PR5 writer would have produced, through the
+// production helper rather than by string assembly. String assembly here would be a second
+// derivation owner inside the test -- the very defect PR5 exists to remove.
+func legacyReservationFor(t *testing.T, dir, attemptID, bindingDigest string) (string, string) {
+	t.Helper()
+	id := resumeGoalTransitionID(attemptID, bindingDigest)
+	name := legacyRecoveryTransitionPrefix + id + ".json"
+	path := filepath.Join(dir, name)
+	// A legacy body carries NO recovery_kind: that field did not exist when these were written.
+	// Its absence is the whole point of the read/write asymmetry -- absent means legacy on READ,
+	// and refuses on WRITE.
+	if err := os.WriteFile(path, []byte(`{"transition_id":"`+id+`"}`), 0o644); err != nil {
+		t.Fatalf("write legacy fixture: %v", err)
+	}
+	return name, id
+}
+
+func TestLegacyReservationsAreRecognisedAndBlockTheirOwnPause(t *testing.T) {
+	dir := t.TempDir()
+	const attemptID = "attempt-abc"
+	const bindingDigest = "digest-def"
+
+	name, id := legacyReservationFor(t, dir, attemptID, bindingDigest)
+
+	// RECOGNITION. A legacy name carries no kind, so recognition must SUPPLY redeliver. If it
+	// returned NotATransition instead, a live redelivery claim would be invisible to supervision
+	// resume -- one delivered resume authorising another, the forbidden case.
+	parsed, recognition := recognizeRecoveryTransitionName(name)
+	if recognition != recoveryNameRecognized {
+		t.Fatalf("a legacy reservation must be RECOGNISED, got %v for %q", recognition, name)
+	}
+	if !parsed.Legacy {
+		t.Error("a legacy-named reservation must be classified Legacy, or it will be matched against the current key and missed")
+	}
+	if parsed.Kind != recoveryTransitionKindRedeliver {
+		t.Errorf("kind = %q, want redeliver: legacy names carry no kind, so recognition supplies it", parsed.Kind)
+	}
+	if parsed.ClaimKey != id {
+		t.Errorf("claim key = %q, want %q", parsed.ClaimKey, id)
+	}
+
+	// BLOCKING, for its OWN pause. Reserved-and-not-consumed is indeterminate, and indeterminate
+	// refuses.
+	scan, err := scanRecoveryTransitionsForPause(dir, strings.Repeat("f", 64), id)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	blocker := scan.blocking()
+	if blocker == nil {
+		t.Fatal("a legacy reservation for THIS pause must block: the old writer's claims are " +
+			"authoritative, and PR5 removes their writer path, not their standing")
+	}
+	if strings.TrimSpace(blocker.recovery()) == "" {
+		t.Error("the blocker must carry a runnable next step")
+	}
+}
+
+// The other half, and the one that turns the property above from "blocks" into "blocks the RIGHT
+// pause". Without it, blocking would be satisfied by a scan that blocked on any legacy file
+// anywhere -- which would wedge every future pause behind any historical record in the directory.
+//
+// THE FALSIFYING INPUT: a legacy reservation for a DIFFERENT attempt, in the SAME directory. It
+// is byte-for-byte the same KIND of artifact; only the identity differs.
+func TestALegacyReservationForADifferentAttemptDoesNotBlockThisPause(t *testing.T) {
+	dir := t.TempDir()
+
+	_, otherID := legacyReservationFor(t, dir, "attempt-SOMEONE-ELSE", "digest-other")
+	ourID := resumeGoalTransitionID("attempt-abc", "digest-def")
+	if otherID == ourID {
+		t.Fatal("fixture is void: both attempts hash to the same legacy id")
+	}
+
+	scan, err := scanRecoveryTransitionsForPause(dir, strings.Repeat("f", 64), ourID)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if blocker := scan.blocking(); blocker != nil {
+		t.Errorf("a legacy reservation for a DIFFERENT attempt must NOT block this pause (%s).\n"+
+			"Directory-wide legacy blocking would wedge every future pause behind any historical "+
+			"record, which is an outage dressed as caution.", blocker.describe())
+	}
+}
+
+// CONSUMED STILL BLOCKS, on the legacy derivation too. This is the ruled semantics and it is
+// counter-intuitive enough to be worth pinning: a COMPLETED redelivery means a delivery may have
+// reached the pane, so it is terminal ownership evidence about this pause -- never permission for
+// a second automatic action.
+//
+// My first scan treated proven-consumed as ignorable. It contradicted two ratified texts and would
+// have made a completed redelivery INVISIBLE to supervision resume.
+func TestAConsumedLegacyReservationStillBlocks(t *testing.T) {
+	dir := t.TempDir()
+	name, id := legacyReservationFor(t, dir, "attempt-abc", "digest-def")
+
+	consumed := resumeGoalTransitionConsumedPath(filepath.Join(dir, name))
+	if err := os.WriteFile(consumed, []byte(`{"consumed":true}`), 0o644); err != nil {
+		t.Fatalf("write consumption record: %v", err)
+	}
+
+	scan, err := scanRecoveryTransitionsForPause(dir, strings.Repeat("f", 64), id)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	blocker := scan.blocking()
+	if blocker == nil {
+		t.Fatal("a CONSUMED reservation must still block: a delivery may have reached the pane, so " +
+			"a second automatic delivery is refused. There is no non-blocking lifecycle state for " +
+			"a matching key.")
+	}
+	if !strings.Contains(blocker.Reason, "CONSUMED") {
+		t.Errorf("the blocker must say the claim was consumed, so the operator knows a delivery may "+
+			"already have landed rather than thinking it stalled; got %q", blocker.Reason)
+	}
+}

--- a/internal/cli/recovery_transition_publication.go
+++ b/internal/cli/recovery_transition_publication.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// #498 U7 / BLOCKER 1: THE PUBLICATION CONTRACT.
+//
+// This validator was ASSIGNED, listed as owed in my own checkpoint, and then reported as delivered without
+// existing. Recording that here because the absence had a shape: reserveRecoveryTransition marshalled and
+// published whatever record and path it was handed, so every guard the constructor enforces could be
+// bypassed by any caller that built a record itself and called the publisher directly. A perfect constructor
+// feeding an unvalidating publisher is the one-decider principle broken at the last step -- the decider is
+// only the decider if nothing downstream accepts un-decided input.
+//
+// WHY VALIDATE AT PUBLICATION AND NOT ONLY AT CONSTRUCTION: they are different threats. Construction
+// validates what a caller ASKS FOR; publication validates what is about to become DURABLE EVIDENCE. A record
+// can be perfectly constructed and then paired with a path it does not belong at, and the filesystem will
+// happily hold it there -- present on disk and invisible to the scanner that computes the canonical name.
+// supervisionReservedClaimLoader reads a RESERVED claim back from disk at its canonical path.
+//
+// #498 U7, ruled option (d) after I reported that the delivery-time revalidation was a TAUTOLOGY at its only
+// call site: the executor built the record's exact binding field-by-field from the assessment and then
+// revalidated that record against the same assessment, so every comparison reduced to assessment.X ==
+// assessment.X and could not fail.
+//
+// THE FIX IS A GENUINELY SECOND OBSERVATION: disk versus memory. The record goes out through marshal and comes
+// back through unmarshal, and THAT is what gets compared to the in-memory assessment. What it really catches,
+// stated precisely so the comment cannot outlive the behaviour:
+//   - serialization defects in the new schema -- a field that marshals under the wrong key, or drops entirely
+//     (every U7 field now has its persist->read->compare loop exercised on the live path);
+//   - a write that landed incomplete, or at a path other than the one the reader derives;
+//   - concurrent mutation of the record between reserve and delivery.
+//
+// What it does NOT do is re-observe the WORLD -- that is the U5 delivery-time gates' job (generation, pane,
+// freshness), and duplicating it here under U7's name would be the two-deciders shape again.
+type supervisionReservedClaimLoader func(path string) (resumeGoalTransitionRecord, error)
+
+// readReservedRecoveryTransition is the production loader: the real file, the real unmarshal.
+//
+// It deliberately does NOT validate or repair what it reads. Its whole value is being a faithful mirror of
+// what is on disk, because the caller's comparison is the check. A loader that "fixed up" a drifted field
+// would hide exactly the defect this exists to surface.
+func readReservedRecoveryTransition(path string) (resumeGoalTransitionRecord, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return resumeGoalTransitionRecord{}, fmt.Errorf("read reserved recovery transition %s: %w", path, err)
+	}
+	var record resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return resumeGoalTransitionRecord{}, fmt.Errorf("parse reserved recovery transition %s: %w", path, err)
+	}
+	return record, nil
+}
+
+// canonicalRecoveryTransitionPath derives the ONE full path the constructor emits for this record's
+// kind and identity, from the record's OWN scope triple.
+//
+// It deliberately CALLS the same derivations the constructor calls -- resumeGoalTransitionPath for
+// redeliver, goalAttemptDir + currentRecoveryTransitionName for native -- rather than re-implementing
+// the join. Re-deriving it here would make publication a SECOND path owner, and two owners of one
+// identity that can disagree is the defect whose symptom is double delivery; a validator that disagreed
+// with the constructor would refuse every legitimate write instead.
+//
+// The kinds do NOT share a naming vocabulary, and that asymmetry is load-bearing rather than historical:
+// redeliver's canonical name is the LEGACY prefix, because redelivery's existing readers already compute
+// it and PR5 does not refactor that read side. Native uses the kind-carrying current prefix. So a
+// redeliver record under a current-prefix name is not "also fine" -- it is a name no writer emits and no
+// redelivery reader looks for.
+func canonicalRecoveryTransitionPath(record resumeGoalTransitionRecord, kind recoveryTransitionKind) (string, error) {
+	project := strings.TrimSpace(record.Project)
+	profile := strings.TrimSpace(record.Profile)
+	session := strings.TrimSpace(record.Session)
+	// A record with no scope has no canonical location, so there is nothing to compare a path against.
+	// Refusing is not pedantry: goalAttemptDir would happily build a RELATIVE path from blanks, and a
+	// claim published relative to whatever directory the process happens to be in is unfindable by every
+	// scanner including the one that wrote it.
+	if project == "" || profile == "" || session == "" {
+		return "", fmt.Errorf(
+			"recovery transition publication refused: the record carries no exact project/profile/session triple (%q/%q/%q), so it has no canonical location to be verified against",
+			record.Project, record.Profile, record.Session)
+	}
+	transitionID := strings.TrimSpace(record.TransitionID)
+	switch kind {
+	case recoveryTransitionKindRedeliver:
+		// This validates the 64-hex identity shape itself, so a malformed id cannot reach a join.
+		return resumeGoalTransitionPath(project, profile, session, transitionID)
+	case recoveryTransitionKindNativeGoalResume:
+		if !isRecoveryClaimKey(transitionID) {
+			return "", fmt.Errorf(
+				"recovery transition publication refused: transition id %q is not a claim-key-shaped identity, so no canonical native name derives from it",
+				transitionID)
+		}
+		return filepath.Join(goalAttemptDir(project, profile, session), currentRecoveryTransitionName(kind, transitionID)), nil
+	}
+	// Unreachable through the validator, which checks knownRecoveryTransitionKind first. Stated as a
+	// refusal rather than a fallthrough so a future kind that adds a constructor branch and forgets a
+	// path derivation FAILS here instead of silently publishing wherever it was told to.
+	return "", fmt.Errorf("recovery transition publication refused: no canonical path derivation for kind %q", kind)
+}
+
+func validateRecoveryTransitionPublication(record resumeGoalTransitionRecord, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("recovery transition publication requires a path")
+	}
+	// THE ONE DURABLE-RECORD CONTRACT, not a second list of publication's own.
+	//
+	// This single call replaces the schema/kind/id/per-kind-shape checks this function used to own. dev-2's
+	// finding was that those checks were a SUBSET of the constructor's, so publication accepted records the
+	// constructor would refuse -- most sharply a NativeBinding with all ten interiors zero, which satisfied a
+	// nil check and said nothing. The fix is not a longer list here; two lists of record requirements must
+	// co-evolve forever and their drift is the constructor-versus-publisher disagreement itself. One decider,
+	// two call sites: a field added to the contract is now required at publication automatically.
+	//
+	// IT ALSO RECOMPUTES THE DERIVED IDENTITY, which is what makes the path check below meaningful. Before,
+	// canonicalRecoveryTransitionPath took record.TransitionID as INPUT, so comparing the path against it
+	// proved only that the record agreed with itself -- an arbitrary 64-hex id passed. The contract now
+	// derives the id from the fields that generate it, so by the time the path is compared, the identity is
+	// established rather than assumed.
+	if err := validateRecoveryTransitionRecordContract(record); err != nil {
+		return fmt.Errorf("recovery transition publication refused: %w", err)
+	}
+	kind := recoveryTransitionKind(strings.TrimSpace(record.RecoveryKind))
+
+	// THE FILENAME MUST BE THE ONE THE READERS COMPUTE.
+	//
+	// THESE THREE NAME CHECKS ARE DIAGNOSTICS, NOT THE CLOSURE, and saying so is the correction: the
+	// version dev-2 gated presented them as the load-bearing check while they read only the basename.
+	// The full-path equality below SUBSUMES all three -- if the path equals the constructor's output then
+	// its name is canonical by construction, so nothing can fail here and pass there. They are kept
+	// because they run FIRST and name the specific disagreement (wrong key, wrong kind, legacy-vs-current),
+	// which a single "not the canonical path" refusal cannot tell an operator apart. They are reachable,
+	// not decorative: each one fires on a real input before equality is ever evaluated.
+	parsed, recognition := recognizeRecoveryTransitionName(filepath.Base(path))
+	if recognition != recoveryNameRecognized {
+		return fmt.Errorf(
+			"recovery transition publication refused: %q is not a recognized recovery-transition filename, so the scanner that looks for this claim would never see it",
+			filepath.Base(path))
+	}
+	if parsed.ClaimKey != strings.TrimSpace(record.TransitionID) {
+		return fmt.Errorf(
+			"recovery transition publication refused: filename claim key %q disagrees with the record transition id %q -- the same filename/body disagreement the scanner treats as ambiguous evidence, manufactured at write time instead of by corruption",
+			parsed.ClaimKey, record.TransitionID)
+	}
+	// Legacy names carry no kind in the filename, so only current-derivation names are compared -- the same
+	// asymmetry reservationBlocker applies on the read side.
+	if !parsed.Legacy && parsed.Kind != kind {
+		return fmt.Errorf(
+			"recovery transition publication refused: filename kind %q disagrees with record kind %q",
+			parsed.Kind, kind)
+	}
+
+	// THE FULL PATH, NOT THE BASENAME. dev-2 found this hole in the version above: every check to this
+	// point reads filepath.Base, so a PERFECTLY CANONICAL FILENAME IN AN ARBITRARY DIRECTORY passed.
+	//
+	// This is the r6 failure class the constructor's own comment names -- "I closed the name and left the
+	// container" -- and I reproduced it one file later, which is defect heredity at the level of a habit
+	// rather than a copied guard: I was thinking about names because the checks I was writing were about
+	// names. A namespace-A claim sitting in namespace-B's directory is invisible to BOTH scanners, so it
+	// blocks nothing while existing, and absent means "no prior claim", which means a second delivery.
+	//
+	// EQUALITY AGAINST THE ONE CONSTRUCTOR'S OUTPUT, per kind, derived from the record's OWN validated
+	// scope -- not a directory-prefix test. A prefix test would accept a claim one level deep in the right
+	// tree, and it would also let publication permit kind/path combinations the constructor never emits
+	// (a redeliver record under a current-prefix name parses and agrees, but no writer produces it).
+	// Accepting only the writer's own vocabulary is what makes this a re-decision rather than a
+	// second, laxer opinion about where claims may live.
+	canonical, canonicalErr := canonicalRecoveryTransitionPath(record, kind)
+	if canonicalErr != nil {
+		return canonicalErr
+	}
+	if path != canonical {
+		return fmt.Errorf(
+			"recovery transition publication refused: path %q is not the canonical location %q for this %s record -- a claim written where no scanner looks exists on disk while blocking nothing, which reads as ABSENT and therefore permits a second delivery",
+			path, canonical, kind)
+	}
+
+	// THE ONE CHECK THAT IS GENUINELY PUBLICATION'S OWN AND NOT THE RECORD CONTRACT'S: a native reservation
+	// must not be published under a LEGACY filename. It survives here rather than moving into the shared
+	// contract because it is a property of the record's LOCATION, not of the record -- the same record is
+	// perfectly valid at its current-prefix path. The kind must be derivable from the name the scanner parses.
+	//
+	// It is also strictly subsumed by the path equality above (the canonical native path is current-prefix by
+	// construction, so a legacy path cannot equal it). Kept as a named diagnostic for the same reason as the
+	// three name checks: "not the canonical path" does not tell an operator that the problem is the naming
+	// GENERATION rather than the directory.
+	if kind == recoveryTransitionKindNativeGoalResume && parsed.Legacy {
+		return fmt.Errorf("recovery transition publication refused: a native reservation must not be published under a legacy filename; the kind must be derivable from the name the scanner parses")
+	}
+	return nil
+}

--- a/internal/cli/recovery_transition_publication_test.go
+++ b/internal/cli/recovery_transition_publication_test.go
@@ -1,0 +1,755 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+)
+
+// #498 U7 / BLOCKER 1 FALSIFIERS: the publication contract.
+//
+// THE VALIDATOR SHIPPED WITHOUT THESE, and that is the finding worth recording. I wrote
+// validateRecoveryTransitionPublication, wired it in, and reported it as delivered -- a guard whose own
+// correctness rested on nothing but my reading of it. dev-2 then found, by reading it, that every check
+// examined filepath.Base and a canonical filename in an ARBITRARY DIRECTORY passed. An unverified guard is
+// not a weaker version of a verified one; it is a claim, and this milestone's whole retro is about claims
+// outrunning artifacts.
+//
+// EVERY ROW DRIVES reserveRecoveryTransition, NOT THE VALIDATOR DIRECTLY. That is deliberate and it is the
+// M-U5h lesson applied before the fact: a mutation that DELETES THE VALIDATOR CALL from the publisher
+// leaves the validator itself perfectly intact and perfectly unit-tested, so rows that call the validator
+// directly all stay green while the production path validates nothing. Only rows that go through the
+// publisher can kill that mutation. The wiring is part of the contract.
+
+// ANTI-VACUITY FIRST, and for both kinds. Every refusal row below is worthless if the publisher refuses
+// everything -- a validator that always errored would satisfy all four falsifiers and break production.
+//
+// This row also pins the property that matters most in practice: THE PUBLISHER ACCEPTS THE ONE
+// CONSTRUCTOR'S OWN OUTPUT. Publication re-decides rather than trusting, so it necessarily holds a second
+// opinion about where a claim belongs -- and if that opinion ever diverges from the constructor's, every
+// legitimate write fails closed. Pinning agreement is what makes the duplication safe.
+func TestPublicationAcceptsTheConstructorsOwnOutputForBothKinds(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	t.Run("native", func(t *testing.T) {
+		project := t.TempDir()
+		record, path, err := newRecoveryTransitionRecord(
+			completeNativeTransitionInput(project, profile, session, attemptID))
+		if err != nil {
+			t.Fatalf("the complete native fixture must be accepted by the constructor: %v", err)
+		}
+		if _, err := reserveRecoveryTransition(record, path); err != nil {
+			t.Fatalf("the publisher REFUSED the constructor's own output: %v\nThe two derive the canonical "+
+				"path independently; a disagreement between them fails every legitimate native resume "+
+				"closed, so this is a production outage rather than a test failure.", err)
+		}
+	})
+
+	t.Run("redeliver", func(t *testing.T) {
+		project := t.TempDir()
+		// BUILT FROM THE COMPLETE REDELIVER BASE. The first version of this row passed a Base carrying only
+		// the scope triple, and dev-2 proved statically that it could never pass: the constructor returned a
+		// blank NewAttemptID and publication unconditionally refused it. The row asserted the ACCEPTED case
+		// against an input the publisher rejects -- an anti-vacuity control that was itself vacuous.
+		record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+			Base:          redeliverTransitionBase(project, profile, session, attemptID, "binding-digest-1"),
+			Kind:          recoveryTransitionKindRedeliver,
+			AttemptID:     attemptID,
+			BindingDigest: "binding-digest-1",
+		})
+		if err != nil {
+			t.Fatalf("a complete redeliver input must be accepted by the constructor: %v", err)
+		}
+		if _, err := reserveRecoveryTransition(record, path); err != nil {
+			t.Fatalf("the publisher REFUSED the constructor's own redeliver output: %v\nRedeliver's "+
+				"canonical name is the LEGACY prefix, so a publisher that assumed the current prefix for "+
+				"every kind would fail exactly here -- and redelivery is the shipped path.", err)
+		}
+	})
+}
+
+// dev-2's FINDING, as a falsifier: a correct basename in the wrong directory.
+//
+// THE FALSIFYING INPUT IS THE CONSTRUCTOR'S OWN RECORD AND ITS OWN FILENAME, relocated. Nothing about the
+// record or the name is wrong; only the container is. That is what makes it the right input -- a
+// hand-damaged record would be refused by some earlier shape check and would prove nothing about the
+// directory. The record here is byte-for-byte one the publisher accepts at its canonical path, as the
+// anti-vacuity row above proves.
+//
+// WHY IT MATTERS: a namespace-A claim published into namespace-B's directory is invisible to BOTH
+// scanners. It exists on disk and blocks nothing. Absent means "no prior claim", and "no prior claim"
+// means a SECOND DELIVERY -- the exact failure claim-once exists to prevent, reached by a write that
+// passed every name-shaped check.
+func TestPublicationRefusesACanonicalNameInTheWrongDirectory(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	record, canonicalPath, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, attemptID))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+
+	// Same basename, foreign directory. Using a second TempDir rather than a subdirectory of the first,
+	// so this cannot be mistaken for a test about path depth: it is a different namespace container.
+	foreign := filepath.Join(t.TempDir(), filepath.Base(canonicalPath))
+	if foreign == canonicalPath {
+		t.Fatal("fixture is void: the foreign path equals the canonical one")
+	}
+
+	_, err = reserveRecoveryTransition(record, foreign)
+	if err == nil {
+		t.Fatalf("publishing a CANONICALLY NAMED record into a foreign directory was ACCEPTED (%q).\n"+
+			"Every check that reads only filepath.Base passes here, which is precisely why this row "+
+			"exists: the claim would sit on disk where no scanner looks, read as ABSENT, and permit a "+
+			"second delivery.", foreign)
+	}
+	// The refusal must name the CANONICAL LOCATION, not merely report a bad path. An operator holding
+	// this error needs to know where the claim should have gone; "invalid path" sends them to read code.
+	if !strings.Contains(err.Error(), canonicalPath) {
+		t.Errorf("the refusal must name the canonical location %q so an operator can see the "+
+			"disagreement; got: %v", canonicalPath, err)
+	}
+}
+
+// A MINIMAL RECORD MUST NOT BECOME DURABLE EVIDENCE, even at a perfectly canonical path.
+//
+// This is the shape the unvalidated publisher accepted: a record carrying just enough to be filed. It is
+// placed at its OWN canonical path deliberately, so the path checks all pass and the row isolates the
+// per-kind shape contract. A native claim without its exact binding cannot be revalidated at delivery --
+// so it can never be safely acted on, and writing it creates a claim that blocks recovery without being
+// able to authorize it.
+func TestPublicationRefusesAMinimalNativeRecordAtItsCanonicalPath(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	namespaceID := squadnamespace.ID(profile, session)
+	key, err := supervisionClaimKey(namespaceID, fixturePauseGeneration, attemptID)
+	if err != nil {
+		t.Fatalf("canonical claim key: %v", err)
+	}
+
+	minimal := resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		Project:       project, Profile: profile, Session: session,
+		RecoveryKind: string(recoveryTransitionKindNativeGoalResume),
+		TransitionID: key,
+	}
+	path := filepath.Join(goalAttemptDir(project, profile, session),
+		currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key))
+
+	if _, err := reserveRecoveryTransition(minimal, path); err == nil {
+		t.Fatal("a MINIMAL native record at its canonical path was published.\nIt carries no exact " +
+			"binding, no supervisor and no pause generation, so delivery could never revalidate it -- " +
+			"the claim would block recovery while being unable to authorize it.")
+	}
+}
+
+// A BLANK KIND must refuse. It is neither a valid redeliver nor a valid native record, and the scanner's
+// tri-state parser cannot classify what it finds.
+//
+// The record is otherwise COMPLETE and sits at a canonical native path, so the only defect is the missing
+// kind -- the single-defect property. A record that was also missing other fields would refuse for
+// whichever check ran first and would prove nothing about the kind requirement.
+func TestPublicationRefusesABlankKindRecord(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	record, path, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, attemptID))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+
+	// The ONE defect, applied to an otherwise valid record at its own canonical path.
+	record.RecoveryKind = ""
+
+	if _, err := reserveRecoveryTransition(record, path); err == nil {
+		t.Fatal("a record with NO recovery kind was published.\nOn read, a blank kind is " +
+			"indistinguishable from a legacy record, so a lenient writer silently enrols new native " +
+			"claims into the legacy population where native validation never runs.")
+	}
+}
+
+// PUBLICATION ACCEPTS ONLY THE WRITER VOCABULARY THE CONSTRUCTOR EMITS.
+//
+// A redeliver record under the CURRENT kind-carrying prefix parses cleanly, carries the right kind, and
+// agrees with its own claim key -- it passes every name-shaped check. No writer produces it, and no
+// redelivery reader looks for it: those readers compute the LEGACY name. So this is a claim that would be
+// invisible to the very population it belongs to, published under a name that looks more modern than the
+// correct one.
+//
+// This row is what makes the contract "the one canonical path" rather than "any recognized path". Without
+// it, a publisher could independently permit a second naming vocabulary per kind and every name check
+// would still pass.
+func TestPublicationRefusesARedeliverRecordUnderTheNativeNamingVocabulary(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	record, canonicalPath, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:          redeliverTransitionBase(project, profile, session, attemptID, "binding-digest-1"),
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     attemptID,
+		BindingDigest: "binding-digest-1",
+	})
+	if err != nil {
+		t.Fatalf("a complete redeliver input must be accepted: %v", err)
+	}
+
+	// Same directory, same claim key, same kind in the name -- only the VOCABULARY differs.
+	alternate := filepath.Join(filepath.Dir(canonicalPath),
+		currentRecoveryTransitionName(recoveryTransitionKindRedeliver, record.TransitionID))
+	if alternate == canonicalPath {
+		t.Fatal("fixture is void: the alternate name equals the canonical one, so redeliver's canonical " +
+			"vocabulary is no longer the legacy prefix and this row must be rewritten")
+	}
+
+	if _, err := reserveRecoveryTransition(record, alternate); err == nil {
+		t.Fatalf("a redeliver record was published under the current-prefix name %q.\nIt parses, its kind "+
+			"agrees and its claim key agrees -- but redelivery's readers compute the LEGACY name, so this "+
+			"claim is invisible to the population it belongs to.", filepath.Base(alternate))
+	}
+}
+
+// THE SHARED CONTRACT, EXERCISED THROUGH THE PUBLISHER, one field at a time.
+//
+// dev-2's HOLD-2 blocker 1 was that publication owned a SUBSET of the constructor's requirements, so it
+// accepted records the constructor would refuse -- most sharply a NativeBinding whose ten interiors were all
+// ZERO, which satisfied a nil check and testified to nothing. These rows are the falsifiers for the shared
+// contract that replaced that subset, and they run through reserveRecoveryTransition so they also pin the
+// WIRING: a mutation deleting the contract call from publication must kill every row here.
+//
+// EACH ROW BLANKS EXACTLY ONE FIELD ON AN OTHERWISE VALID RECORD, at its own canonical path. Blanking on the
+// RECORD rather than the input is deliberate: the input route is the constructor's concern, and what
+// publication must refuse is a finished record handed to it directly by any caller.
+func TestPublicationRefusesEveryMissingNativeContractField(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	for _, row := range []struct {
+		name    string
+		blank   func(*resumeGoalTransitionRecord)
+		wantErr string
+	}{
+		// THE FLAT SET. Role and Handle are here because blocker 3 found them compared by revalidation and
+		// required by nothing -- a blank record and a blank assessment agreed by mutual absence.
+		{"lead role", func(r *resumeGoalTransitionRecord) { r.Role = "" }, "lead role"},
+		{"lead handle", func(r *resumeGoalTransitionRecord) { r.Handle = "" }, "lead handle"},
+		{"supervisor", func(r *resumeGoalTransitionRecord) { r.Supervisor = "" }, "supervisor"},
+		{"pause generation", func(r *resumeGoalTransitionRecord) { r.PauseGeneration = "" }, "pause generation"},
+		{"preclaim fingerprint", func(r *resumeGoalTransitionRecord) { r.PreclaimFingerprint = "" }, "preclaim fingerprint"},
+		{"launch id", func(r *resumeGoalTransitionRecord) { r.LaunchID = "" }, "launch id"},
+		{"launch record digest", func(r *resumeGoalTransitionRecord) { r.LaunchRecordDigest = "" }, "launch record digest"},
+		{"launch record mod time", func(r *resumeGoalTransitionRecord) { r.LaunchRecordModTime = 0 }, "launch record mod time"},
+		{"new attempt id", func(r *resumeGoalTransitionRecord) { r.NewAttemptID = "" }, "new attempt id"},
+		// THE PLACEHOLDER, which is sharper than a blank: it LOOKS like an answer while attributing the
+		// resume to nobody.
+		{"placeholder supervisor", func(r *resumeGoalTransitionRecord) { r.Supervisor = supervisorIdentityPlaceholder },
+			"placeholder"},
+
+		// THE TEN INTERIORS -- dev-2's exact counterexample, decomposed. A pointer-presence check passes for
+		// every one of these.
+		{"binding namespace id", func(r *resumeGoalTransitionRecord) { r.NativeBinding.NamespaceID = "" },
+			"native binding namespace id"},
+		{"binding pane id", func(r *resumeGoalTransitionRecord) { r.NativeBinding.PaneID = "" },
+			"native binding pane id"},
+		{"binding goal mode", func(r *resumeGoalTransitionRecord) { r.NativeBinding.GoalMode = "" },
+			"native binding goal mode"},
+		{"binding goal attempt id", func(r *resumeGoalTransitionRecord) { r.NativeBinding.GoalAttemptID = "" },
+			"native binding goal attempt id"},
+		{"binding goal binding digest", func(r *resumeGoalTransitionRecord) { r.NativeBinding.GoalBindingDigest = "" },
+			"native binding goal binding digest"},
+		{"binding goal command digest", func(r *resumeGoalTransitionRecord) { r.NativeBinding.GoalCommandDigest = "" },
+			"native binding goal command digest"},
+		{"binding blocker id", func(r *resumeGoalTransitionRecord) { r.NativeBinding.BlockerID = "" },
+			"native binding blocker id"},
+		{"binding blocker resolution digest", func(r *resumeGoalTransitionRecord) { r.NativeBinding.BlockerResolutionDigest = "" },
+			"native binding blocker resolution digest"},
+		{"binding policy mode", func(r *resumeGoalTransitionRecord) { r.NativeBinding.PolicyMode = "" },
+			"native binding policy mode"},
+		{"binding policy revision", func(r *resumeGoalTransitionRecord) { r.NativeBinding.PolicyRevision = 0 },
+			"positive native binding policy revision"},
+		// THE WHOLE BLOCK, kept as its own row: the nil case and the all-zero case are different defects and
+		// a check for one does not catch the other.
+		{"binding block absent", func(r *resumeGoalTransitionRecord) { r.NativeBinding = nil },
+			"requires its exact binding"},
+		// THE DUAL'S INVARIANT: two attempt identities in one record that differ is ambiguous evidence about
+		// which attempt was authorized. Set on the binding side so NewAttemptID stays nonblank and the row
+		// cannot be satisfied by the blank check above.
+		{"dual attempt identities disagree",
+			func(r *resumeGoalTransitionRecord) { r.NativeBinding.GoalAttemptID = "attempt-somebody-elses" },
+			"disagrees with the record's lifecycle attempt"},
+	} {
+		project := t.TempDir()
+		record, path, err := newRecoveryTransitionRecord(
+			completeNativeTransitionInput(project, profile, session, attemptID))
+		if err != nil {
+			t.Fatalf("%s: the complete native fixture must be accepted: %v", row.name, err)
+		}
+		row.blank(&record)
+		_, err = reserveRecoveryTransition(record, path)
+		if err == nil {
+			t.Errorf("%s: publication accepted a record missing a required field. Publication is the last "+
+				"step before the record becomes durable evidence, so anything it accepts is what recovery "+
+				"has to work with.", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the field (want %q), got: %v", row.name, row.wantErr, err)
+		}
+	}
+}
+
+// THE DERIVED IDENTITY, for BOTH kinds. This is the row that closes the self-reference.
+//
+// The record here is COMPLETELY VALID in shape, and its path is the canonical path FOR THE ID IT CARRIES --
+// so the filename agrees with the body, the body agrees with the filename, and the full-path equality check
+// passes. Only recomputation catches it: the id is not the one that the record's own source fields generate,
+// so no scanner will ever compute it, and the claim is present on disk while reading as ABSENT for the real
+// pause. That is the double delivery, reached through a record that agrees with itself in every direction.
+//
+// My previous round's path-equality check took record.TransitionID as INPUT, which is why it could not see
+// this: an invariant that derives its expectation from the thing it is checking binds nothing. Same defect
+// class as U10's runtime-resolved baseline_head.
+func TestPublicationRefusesARecordWhoseDerivedIdentityIsWrong(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	t.Run("native", func(t *testing.T) {
+		project := t.TempDir()
+		record, _, err := newRecoveryTransitionRecord(
+			completeNativeTransitionInput(project, profile, session, attemptID))
+		if err != nil {
+			t.Fatalf("the complete native fixture must be accepted: %v", err)
+		}
+		// A WELL-FORMED CLAIM KEY FOR A DIFFERENT PAUSE -- not garbage. Garbage would be caught by any shape
+		// check and would prove only that malformed input fails; this is exactly as valid as the right answer
+		// and differs only in being wrong.
+		foreign, keyErr := supervisionClaimKey(
+			squadnamespace.ID(profile, session), "a-different-pause-generation", attemptID)
+		if keyErr != nil {
+			t.Fatalf("foreign claim key: %v", keyErr)
+		}
+		if foreign == record.TransitionID {
+			t.Fatal("fixture is void: the foreign claim key equals the canonical one")
+		}
+		record.TransitionID = foreign
+		// The path is rebuilt FOR THE FOREIGN ID, so body, filename and full path are mutually consistent.
+		foreignPath := filepath.Join(goalAttemptDir(project, profile, session),
+			currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, foreign))
+
+		_, err = reserveRecoveryTransition(record, foreignPath)
+		if err == nil {
+			t.Fatal("publication accepted a native record whose transition id is not the claim key derived " +
+				"from its own namespace/pause/attempt. Body and filename agree, the path is canonical for " +
+				"that id, and no pause scanner will ever compute it.")
+		}
+		if !strings.Contains(err.Error(), "is not the claim key") {
+			t.Errorf("the refusal must name the derived-identity disagreement, got: %v", err)
+		}
+	})
+
+	t.Run("redeliver", func(t *testing.T) {
+		project := t.TempDir()
+		record, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+			Base:          redeliverTransitionBase(project, profile, session, attemptID, "binding-digest-1"),
+			Kind:          recoveryTransitionKindRedeliver,
+			AttemptID:     attemptID,
+			BindingDigest: "binding-digest-1",
+		})
+		if err != nil {
+			t.Fatalf("a complete redeliver input must be accepted: %v", err)
+		}
+		// The id redelivery's readers would compute for a DIFFERENT attempt.
+		foreign := resumeGoalTransitionID("attempt-somebody-elses", "binding-digest-1")
+		if foreign == record.TransitionID {
+			t.Fatal("fixture is void: the foreign id equals the canonical one")
+		}
+		record.TransitionID = foreign
+		foreignPath, pathErr := resumeGoalTransitionPath(project, profile, session, foreign)
+		if pathErr != nil {
+			t.Fatalf("foreign redeliver path: %v", pathErr)
+		}
+
+		_, err = reserveRecoveryTransition(record, foreignPath)
+		if err == nil {
+			t.Fatal("publication accepted a redeliver record whose transition id is not derived from its " +
+				"own original attempt and binding digest -- invisible to the readers that compute it.")
+		}
+		if !strings.Contains(err.Error(), "is not the id") {
+			t.Errorf("the refusal must name the derived-identity disagreement, got: %v", err)
+		}
+	})
+}
+
+// THE REDELIVER CONTRACT'S REQUIRED FIELDS AND REQUIRED ABSENCES.
+//
+// Blocker 2 was that this contract had never been DEFINED: the constructor accepted a scope-triple-only Base
+// and returned a blank NewAttemptID that publication then unconditionally refused. Both halves are pinned
+// here -- the fields it must carry, and the fields whose PRESENCE means someone recomputed or invented a
+// value this path cannot honestly hold.
+func TestPublicationRefusesAnIncompleteRedeliverRecord(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	for _, row := range []struct {
+		name    string
+		break1  func(*resumeGoalTransitionRecord)
+		wantErr string
+	}{
+		{"missing new attempt id", func(r *resumeGoalTransitionRecord) { r.NewAttemptID = "" }, "new attempt id"},
+		{"missing original attempt id", func(r *resumeGoalTransitionRecord) { r.OriginalAttemptID = "" },
+			"original attempt id"},
+		{"missing original binding digest", func(r *resumeGoalTransitionRecord) { r.OriginalBindingDigest = "" },
+			"original binding digest"},
+		// THE INEQUALITY. Both peer-owned readers already refuse a transition that reuses the original
+		// attempt, so accepting it here would make durable a record nothing can consume. Set on the
+		// NewAttemptID side so the identity recomputation (which keys on OriginalAttemptID and
+		// OriginalBindingDigest) is untouched and this row can only fail on the inequality.
+		{"new attempt reuses the original", func(r *resumeGoalTransitionRecord) { r.NewAttemptID = r.OriginalAttemptID },
+			"must differ from the original attempt id"},
+		// THE REQUIRED ABSENCES, compared RAW: omitempty does not omit a whitespace-only string, so a trimmed
+		// guard would let a present-but-meaningless value serialise.
+		{"carries a pause generation", func(r *resumeGoalTransitionRecord) { r.PauseGeneration = "pause-gen-1" },
+			"must not carry a pause generation"},
+		{"carries a supervisor", func(r *resumeGoalTransitionRecord) { r.Supervisor = "cto" },
+			"must not carry a supervisor"},
+		{"carries a whitespace-only supervisor", func(r *resumeGoalTransitionRecord) { r.Supervisor = "   " },
+			"must not carry a supervisor"},
+	} {
+		project := t.TempDir()
+		record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+			Base:          redeliverTransitionBase(project, profile, session, attemptID, "binding-digest-1"),
+			Kind:          recoveryTransitionKindRedeliver,
+			AttemptID:     attemptID,
+			BindingDigest: "binding-digest-1",
+		})
+		if err != nil {
+			t.Fatalf("%s: a complete redeliver input must be accepted: %v", row.name, err)
+		}
+		row.break1(&record)
+		_, err = reserveRecoveryTransition(record, path)
+		if err == nil {
+			t.Errorf("%s: publication accepted an invalid redeliver record", row.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), row.wantErr) {
+			t.Errorf("%s: refusal must name the cause (want %q), got: %v", row.name, row.wantErr, err)
+		}
+	}
+}
+
+// NON-CANONICAL SCOPE IS REFUSED AT CONSTRUCTION, so no constructor-accepted pair can be publisher-refused.
+//
+// THE PROPERTY THIS PROTECTS: every record/path pair the constructor returns must be accepted by the
+// publisher. dev-2 broke it statically with one character -- a Project of "<tmpdir> " passed the nonblank
+// check, the constructor derived its path from the RAW value, and canonicalRecoveryTransitionPath re-derived
+// from the TRIMMED one, so publication refused the constructor's own output. goalAttemptDir trims session and
+// normalizes profile but joins project verbatim, which is why project was the live vector.
+//
+// The fix is at the DATA (the record must already hold the canonical value) rather than aligning two
+// consumers of an ambiguous one, so this row asserts REFUSAL AT CONSTRUCTION -- the drifting pair cannot be
+// built at all. The second half proves the canonical form still works end to end, or this would be a test
+// that "fixed" the edge by rejecting the whole feature.
+func TestNonCanonicalScopeIsRefusedAtConstructionSoPathsCannotDrift(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	t.Run("trailing space in project refuses", func(t *testing.T) {
+		project := t.TempDir()
+		in := completeNativeTransitionInput(project+" ", profile, session, attemptID)
+		_, _, err := newRecoveryTransitionRecord(in)
+		if err == nil {
+			t.Fatal("a Project carrying a trailing space was ACCEPTED. It is nonblank, so every TrimSpace " +
+				"check passes -- and the constructor derives its path from the raw value while publication " +
+				"derives from the trimmed one, so the record and its own publisher disagree about where the " +
+				"claim belongs.")
+		}
+		if !strings.Contains(err.Error(), "canonical form") {
+			t.Errorf("the refusal must name the canonicalization requirement, got: %v", err)
+		}
+	})
+
+	// ANTI-VACUITY: the same input with a canonical project must construct AND publish. Without this, the row
+	// above would be satisfied by a contract that refused every project.
+	t.Run("canonical project constructs and publishes", func(t *testing.T) {
+		project := t.TempDir()
+		record, path, err := newRecoveryTransitionRecord(
+			completeNativeTransitionInput(project, profile, session, attemptID))
+		if err != nil {
+			t.Fatalf("the canonical form must be accepted at construction: %v", err)
+		}
+		if _, err := reserveRecoveryTransition(record, path); err != nil {
+			t.Fatalf("the publisher must accept the constructor's own output: %v", err)
+		}
+	})
+}
+
+// GAP A: a correct basename in a SUBDIRECTORY of its own canonical directory must refuse.
+//
+// I found this gap by designing the mutation set rather than by review: a weakening of `path != canonical` to
+// `!strings.HasPrefix(path, goalAttemptDir(...))` SURVIVES every other row here, because my wrong-directory row
+// places the file in a separate TempDir, which fails a prefix test too. So a prefix relaxation would look
+// tested while actually accepting a claim nested one level deeper inside the right namespace — invisible to the
+// scanner for exactly the same reason a foreign directory is.
+//
+// This row is the one that kills that relaxation: the path is INSIDE the canonical directory, so a prefix check
+// passes it and only full equality refuses it.
+func TestPublicationRefusesACanonicalNameInASubdirectoryOfItsOwnDirectory(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	record, canonicalPath, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, attemptID))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+
+	nested := filepath.Join(filepath.Dir(canonicalPath), "nested", filepath.Base(canonicalPath))
+	if !strings.HasPrefix(nested, filepath.Dir(canonicalPath)) {
+		t.Fatal("fixture is void: the nested path is not inside the canonical directory, so it would also " +
+			"fail a prefix check and this row would not distinguish equality from prefix")
+	}
+
+	if _, err := reserveRecoveryTransition(record, nested); err == nil {
+		t.Fatalf("publication accepted a canonically-named record in %q, a SUBDIRECTORY of its own canonical "+
+			"directory. A directory-prefix check passes this; only exact path equality refuses it, and the "+
+			"scanner reads the canonical directory only -- so this claim would exist and block nothing.", nested)
+	}
+}
+
+// GAP B: the executor must REFUSE, with ZERO pane input, when the PERSISTED claim disagrees with the assessment.
+//
+// THIS ROW IS ONLY HONEST BECAUSE OF THE RULED READ-BACK. Before it, the executor revalidated the record it had
+// just built from the assessment against that same assessment, so the comparison was a tautology and no input
+// could make it fail. Writing this test then would have required contriving a disagreement production cannot
+// produce — the unreachable-state fixture class. With the read-back, the loader is the seam, and a drifted
+// persisted record is a state the world genuinely reaches (a bad marshal, a partial write, a concurrent edit).
+//
+// It also kills the call-site-deletion mutation legitimately: deleting the revalidation call from the executor
+// makes this row deliver, and the zero-input assertion catches it.
+func TestExecutorRefusesADriftedPersistedClaimWithoutDelivering(t *testing.T) {
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loadPayload := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	delivered := 0
+	// THE ONE DEFECT: the persisted claim comes back with a single drifted field. Read the real file first and
+	// mutate ONE field of it, rather than fabricating a record — fabricating would risk failing for a missing
+	// field instead of for the drift, which is the single-defect rule applied to the seam itself.
+	drifting := func(path string) (resumeGoalTransitionRecord, error) {
+		record, err := readReservedRecoveryTransition(path)
+		if err != nil {
+			return resumeGoalTransitionRecord{}, err
+		}
+		if record.NativeBinding == nil {
+			t.Fatal("the persisted native claim carries no exact binding, so this row cannot drift one field of it")
+		}
+		record.NativeBinding.PaneID = "%999"
+		return record, nil
+	}
+
+	outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loadPayload,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		drifting,
+		func(string) error { delivered++; return nil })
+
+	if err == nil {
+		t.Fatal("the executor DELIVERED against a persisted claim that disagrees with the assessment. The " +
+			"claim on disk is the recovery contract; if it does not describe the assessment being acted on, " +
+			"the delivery is authorized by something other than what was reserved.")
+	}
+	if delivered != 0 || outcome.Delivered {
+		t.Errorf("delivered=%d Delivered=%t; a claim/assessment disagreement must refuse BEFORE pane input -- "+
+			"a gate that refuses after delivering has already caused the harm it exists to prevent",
+			delivered, outcome.Delivered)
+	}
+	if !strings.Contains(err.Error(), "pane id") {
+		t.Errorf("the refusal must name the disagreeing field, got: %v", err)
+	}
+}
+
+// dev-2's TWO COUNTEREXAMPLES to the first read-back, as executor-driven rows.
+//
+// The PaneID row above kills deletion of the revalidation call, but it did NOT kill either of these, and the
+// reason is worth stating: revalidateNativeBindingAgainstAssessment deliberately excludes TransitionID because
+// "publication already proves name+path agree" -- true at its old call site, FALSE once I added a read-back
+// after publication. I moved a validator across a boundary without re-deriving what its exclusions rest on.
+//
+// Both rows read the REAL persisted record and change exactly ONE field, so neither can pass or fail for a
+// missing field instead of the drift it names.
+func TestExecutorRefusesAPersistedClaimWithADriftedDurableIdentity(t *testing.T) {
+	for _, row := range []struct {
+		name    string
+		drift   func(*resumeGoalTransitionRecord)
+		wantErr string
+	}{
+		{
+			// A well-shaped 64-hex id that is simply not this claim's. The body no longer matches its own
+			// filename or its derived claim key, so no scanner would ever find it -- the absent-means-no-claim
+			// path to a second delivery, reached through a record that passed every binding comparison.
+			name:    "transition id",
+			drift:   func(r *resumeGoalTransitionRecord) { r.TransitionID = strings.Repeat("d", 64) },
+			wantErr: "durable-record contract",
+		},
+		{
+			// A DIFFERENT NONBLANK supervisor. The validator checks presence only, so this passed and delivery
+			// would proceed under a claim attributing authorization to someone else. A wrong attribution is
+			// worse than a missing one because it looks like an answer.
+			name:    "supervisor identity",
+			drift:   func(r *resumeGoalTransitionRecord) { r.Supervisor = "somebody-else" },
+			wantErr: "authorized by",
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			assessment, action, payload, _, now := u6DeliveringFixture(t)
+			u6StubSeams(t,
+				func(GoalSupervisionAssessment, string, string) error { return nil },
+				func(GoalSupervisionAssessment) error { return nil },
+			)
+			loadPayload := func(GoalSupervisionAssessment) (string, string, error) {
+				return payload, digestGoalSupervisionString(payload), nil
+			}
+
+			delivered := 0
+			drifting := func(path string) (resumeGoalTransitionRecord, error) {
+				record, err := readReservedRecoveryTransition(path)
+				if err != nil {
+					return resumeGoalTransitionRecord{}, err
+				}
+				row.drift(&record)
+				return record, nil
+			}
+
+			outcome, err := executeSupervisionResume(assessment, action, "supervisor-1",
+				func() time.Time { return now }, loadPayload,
+				passingGenerationReader(assessment), passingPaneReader(assessment),
+				drifting,
+				func(string) error { delivered++; return nil })
+
+			if err == nil {
+				t.Fatalf("the executor DELIVERED against a persisted claim whose %s had drifted. The claim on "+
+					"disk is the durable evidence; if its identity or its recorded authorizer is not what was "+
+					"reserved, the delivery rests on something other than the reservation.", row.name)
+			}
+			if delivered != 0 || outcome.Delivered {
+				t.Errorf("%s: delivered=%d Delivered=%t; this must refuse BEFORE pane input",
+					row.name, delivered, outcome.Delivered)
+			}
+			if !strings.Contains(err.Error(), row.wantErr) {
+				t.Errorf("%s: refusal must name the cause (want %q), got: %v", row.name, row.wantErr, err)
+			}
+		})
+	}
+}
+
+// AND THE NIL-LOADER POSTURE: a missing read-back loader REFUSES rather than skipping.
+//
+// The M-U5g rule, applied to the new seam. Without this row, deleting the nil check turns a missing check into
+// a passing one, and every test above stays green because they all supply a loader.
+func TestExecutorRefusesANilReservedClaimLoaderRatherThanSkipping(t *testing.T) {
+	assessment, action, payload, _, now := u6DeliveringFixture(t)
+	u6StubSeams(t,
+		func(GoalSupervisionAssessment, string, string) error { return nil },
+		func(GoalSupervisionAssessment) error { return nil },
+	)
+	loadPayload := func(GoalSupervisionAssessment) (string, string, error) {
+		return payload, digestGoalSupervisionString(payload), nil
+	}
+
+	delivered := 0
+	_, err := executeSupervisionResume(assessment, action, "supervisor-1",
+		func() time.Time { return now }, loadPayload,
+		passingGenerationReader(assessment), passingPaneReader(assessment),
+		nil,
+		func(string) error { delivered++; return nil })
+
+	if err == nil {
+		t.Fatal("a nil reserved-claim loader was treated as a SKIP. A missing verification that becomes a " +
+			"passing verification is the authorization-seam defect: production would deliver having proven " +
+			"nothing about what it persisted.")
+	}
+	if delivered != 0 {
+		t.Errorf("delivered %d time(s) with no loader supplied", delivered)
+	}
+}
+
+// A STALE SCHEMA VERSION must refuse at publication, even at a perfectly canonical path.
+//
+// The record is otherwise complete and correctly located; only the version is wrong. Its own readers
+// validate nonzero-and-current (resume_goal.go:351, :403, :1131, :1210), so a record written under a
+// version they reject is undiscoverable evidence: present on disk, unreadable by the code that looks for
+// it, and therefore ABSENT -- which permits a second delivery.
+//
+// This row exists because the audit table would otherwise read NONE for this cell. The check was in the
+// validator from the start and nothing proved it fired.
+func TestPublicationRefusesAStaleSchemaVersion(t *testing.T) {
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+
+	project := t.TempDir()
+	record, path, err := newRecoveryTransitionRecord(
+		completeNativeTransitionInput(project, profile, session, attemptID))
+	if err != nil {
+		t.Fatalf("the complete native fixture must be accepted: %v", err)
+	}
+
+	// The ONE defect. Zero specifically, because that is what a record written by a caller that never set
+	// the field carries -- the reachable failure rather than an invented one.
+	record.SchemaVersion = 0
+
+	if _, err := reserveRecoveryTransition(record, path); err == nil {
+		t.Fatal("a record with schema version 0 was published at its canonical path.\nIts own readers " +
+			"validate nonzero, so they would reject it -- the claim would exist while reading as absent.")
+	}
+}
+
+// A RECORD WITH NO SCOPE has no canonical location, so there is nothing to verify a path against.
+//
+// This is the fixture the old lost-race test used, and it is worth pinning as a refusal rather than
+// merely fixing that test: goalAttemptDir builds a RELATIVE path from blanks, so a claim published from
+// such a record lands relative to whatever directory the process happens to be in -- unfindable by every
+// scanner including the one that wrote it.
+func TestPublicationRefusesARecordWithNoScopeTriple(t *testing.T) {
+	dir := t.TempDir()
+	record := resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		RecoveryKind:  string(recoveryTransitionKindRedeliver),
+		TransitionID:  strings.Repeat("c", 64),
+		NewAttemptID:  "attempt-new",
+	}
+	path := filepath.Join(dir, legacyRecoveryTransitionPrefix+record.TransitionID+".json")
+
+	if _, err := reserveRecoveryTransition(record, path); err == nil {
+		t.Fatal("a record with NO project/profile/session was published.\nIt has no canonical location, " +
+			"so no path can be verified against it and the claim cannot be found by the scanner that " +
+			"would look for it.")
+	}
+}

--- a/internal/cli/recovery_transition_roundtrip_test.go
+++ b/internal/cli/recovery_transition_roundtrip_test.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	// ALIAS IS NOT DIRECTORY. There is no internal/runwizard: runwizard is the alias
+	// resume_goal.go:21 gives to internal/wizard. I made this exact mistake with squadnamespace
+	// earlier, wrote the lesson into recovery_transition.go, and then repeated it here. go vet
+	// caught it; go build could not, because this is a _test.go file.
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// PR5 requirement 3, written BEFORE the wiring on purpose.
+//
+// PR5 routes resume_goal.go's existing redelivery reservation through the new shared constructor.
+// That touches another PR's writer, and this test is the thing that makes the touch safe: it
+// proves a redeliver reservation built the NEW way is indistinguishable, to redelivery's OWN
+// readers, from one built the old way.
+//
+// Tests-before-the-change is deliberate. Written afterwards, this test would be shaped by
+// whatever the wiring happened to produce -- which is how a regression test comes to certify the
+// bug it was meant to catch. Written first, the wiring has to satisfy it.
+func TestRedeliverReservationRoundTripsThroughItsExistingReaders(t *testing.T) {
+	project := t.TempDir()
+	const profile = "squad"
+	const session = "v2-25-0"
+	const attemptID = "attempt-abc"
+	const bindingDigest = "digest-def"
+
+	// The record the OLD code built as a struct literal, populated with EVERY field
+	// validateResumeGoalTransitionPlan requires. A minimal record would decode fine and fail
+	// validation, which is exactly the gap the JSON-only draft had.
+	const goalText = "ship it"
+	base := resumeGoalTransitionRecord{
+		SchemaVersion:         resumeGoalTransitionSchemaVersion,
+		Project:               project,
+		Profile:               profile,
+		Session:               session,
+		Role:                  "cto",
+		Handle:                "cto",
+		MemberSession:         session,
+		MemberCWD:             project,
+		MemberBinary:          "codex",
+		GoalDigest:            digestBytes([]byte(goalText)),
+		OriginalAttemptID:     attemptID,
+		OriginalBindingDigest: bindingDigest,
+		OriginalAttemptDigest: "attempt-digest",
+		OriginalClaimDigest:   "claim-digest",
+		NewAttemptID:          "attempt-xyz",
+		LaunchID:              "launch-1",
+		LaunchStartedAt:       time.Now().UTC(),
+		TeamRecordDigest:      "team-digest",
+		TeamRecordModTime:     1,
+		LaunchRecordDigest:    "launch-digest",
+		LaunchRecordModTime:   1,
+		CreatedAt:             time.Now().UTC(),
+	}
+
+	record, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:          base,
+		Kind:          recoveryTransitionKindRedeliver,
+		AttemptID:     attemptID,
+		BindingDigest: bindingDigest,
+	})
+	if err != nil {
+		t.Fatalf("constructor refused a well-formed redeliver input: %v", err)
+	}
+
+	// PROPERTY 1a: the constructor and redelivery's derivation agree -- ONE DERIVATION OWNER.
+	// This is what the same-helper assertion proves, and no more. My earlier claim that it also
+	// proved formula stability was BACKWARDS: if the constructor and the helper drifted together,
+	// this comparison would still pass.
+	wantID := resumeGoalTransitionID(attemptID, bindingDigest)
+	if record.TransitionID != wantID {
+		t.Errorf("redeliver identity changed: got %q, want the canonical %q.\n"+
+			"Redelivery's readers compute this id independently; a different one makes every "+
+			"existing reservation unfindable.", record.TransitionID, wantID)
+	}
+
+	// PROPERTY 1b: the GOLDEN COMPATIBILITY VECTOR -- a fixed literal, computed once out of band
+	// and never at runtime. THIS is what catches sha/input-order/separator drift, and that drift
+	// is the failure that would strand every persisted legacy record: reservations already on disk
+	// become unfindable while every same-helper assertion keeps passing.
+	//
+	// sha256("attempt-abc" + NUL + "digest-def"), matching resumeGoalTransitionID's formula.
+	// If this literal is wrong, the test fails on its first run -- which is the point. A wrong
+	// golden vector announces itself; a missing one hides a migration break.
+	const goldenID = "663df61cf81c30cb48238b02b058d9225af2a7d7cb867edec2128db813f46af3"
+	if wantID != goldenID {
+		t.Errorf("the legacy id derivation CHANGED: %q != golden %q.\n"+
+			"Every reservation already on disk was written under the golden value and is now "+
+			"unfindable. This is a migration, not a refactor.", wantID, goldenID)
+	}
+
+	// PROPERTY 2: the PATH is the one redelivery's readers compute. Same reasoning -- derived
+	// through resumeGoalTransitionPath, not assembled here, so a change in either place fails.
+	wantPath, pathErr := resumeGoalTransitionPath(project, profile, session, wantID)
+	if pathErr != nil {
+		t.Fatalf("canonical redeliver path: %v", pathErr)
+	}
+	if path != wantPath {
+		t.Errorf("redeliver path changed: got %q, want %q.\nA reservation written elsewhere is "+
+			"invisible to the readers that look for it -- present on disk and undiscoverable.", path, wantPath)
+	}
+
+	// PROPERTY 3: it must NOT acquire PR5's supervision fields. The per-kind contract says this
+	// path cannot honestly have a pause generation, and a record carrying one would be
+	// indistinguishable from a supervision claim to anything keyed on that field.
+	if strings.TrimSpace(record.PauseGeneration) != "" {
+		t.Errorf("redeliver record acquired a pause generation (%q); this path holds no assessment, "+
+			"so any value here was recomputed or invented", record.PauseGeneration)
+	}
+	if record.RecoveryKind != string(recoveryTransitionKindRedeliver) {
+		t.Errorf("redeliver record kind = %q, want %q -- the kind must be explicit in the body even "+
+			"though the filename is the legacy one", record.RecoveryKind, recoveryTransitionKindRedeliver)
+	}
+
+	// PROPERTY 4: it passes redelivery's ACTUAL production validator.
+	//
+	// My first draft marshalled and unmarshalled JSON and called that a round trip. dev-2 was
+	// right that it proves nothing: Go IGNORES unknown fields, so a constructor-built record can
+	// decode cleanly while violating delivery validation. Checking against the real validator
+	// found that immediately -- validateResumeGoalTransitionPlan requires NewAttemptID, LaunchID,
+	// LaunchStartedAt, CreatedAt, MemberCWD, MemberBinary, both record digests and both mod-times,
+	// and requires NewAttemptID != OriginalAttemptID. My minimal record set NONE of them, so the
+	// JSON test would have certified a record production REFUSES.
+	//
+	// The validator is called directly rather than reimplemented, so it cannot drift from the one
+	// redelivery uses.
+	plan := runwizard.ResumeGoalPlan{
+		TransitionID:      record.TransitionID,
+		LeadRole:          base.Role,
+		LeadHandle:        base.Handle,
+		Goal:              goalText,
+		OriginalAttemptID: attemptID,
+		BindingDigest:     bindingDigest,
+		AttemptDigest:     base.OriginalAttemptDigest,
+		ClaimDigest:       base.OriginalClaimDigest,
+	}
+	if err := validateResumeGoalTransitionPlan(record, project, profile, session, plan); err != nil {
+		t.Errorf("a constructor-built redeliver record must satisfy redelivery's OWN validator: %v.\n"+
+			"If this fails, the wiring changed what redelivery records, not merely how it builds them.", err)
+	}
+
+	// PROPERTY 5: the scan recognises it, with the kind the FILENAME implies. The legacy filename
+	// carries no kind, so recognition must supply redeliver -- and if it did not, a redelivery
+	// reservation would be invisible to supervision, which is the forbidden case.
+	parsed, recognition := recognizeRecoveryTransitionName(filepath.Base(path))
+	if recognition != recoveryNameRecognized {
+		t.Fatalf("the scan does not recognise a canonical redeliver reservation (%v)", recognition)
+	}
+	if !parsed.Legacy || parsed.Kind != recoveryTransitionKindRedeliver {
+		t.Errorf("recognition = %+v; a legacy-named reservation must be classified redeliver, or "+
+			"supervision resume would not see a live redelivery claim", parsed)
+	}
+}
+
+// The negative half of the per-kind contract, in the same file because it is the same invariant
+// seen from the other side: a redeliver input carrying a pause generation is REFUSED.
+//
+// Without this, "redeliver must not carry a pause generation" is a property of the inputs I chose
+// to test rather than of the constructor.
+func TestRedeliverInputCarryingAPauseGenerationIsRefused(t *testing.T) {
+	_, _, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+		Base:            resumeGoalTransitionRecord{Project: t.TempDir(), Profile: "squad", Session: "v2-25-0"},
+		Kind:            recoveryTransitionKindRedeliver,
+		AttemptID:       "attempt-abc",
+		BindingDigest:   "digest-def",
+		PauseGeneration: "pause-gen-from-somewhere",
+	})
+	if err == nil {
+		t.Fatal("a redeliver input carrying a pause generation must be refused: this path holds no " +
+			"assessment, so the value was recomputed or invented")
+	}
+	if !strings.Contains(err.Error(), "must NOT carry a pause generation") {
+		t.Errorf("refusal must name the reason: %v", err)
+	}
+}

--- a/internal/cli/recovery_transition_scan.go
+++ b/internal/cli/recovery_transition_scan.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// recoveryTransitionBlocker is one reason this pause cannot be claimed. It always carries an
+// operator-runnable next step: a refusal without one is a dead end, and #498's whole complaint
+// was a lifecycle step that stalled on a human who did not know what to type.
+type recoveryTransitionBlocker struct {
+	Path   string
+	Reason string
+}
+
+func (b recoveryTransitionBlocker) describe() string {
+	return b.Reason + " (" + b.Path + ")"
+}
+
+func (b recoveryTransitionBlocker) recovery() string {
+	return "inspect " + b.Path + " and either consume or clear that transition deliberately; automatic resume will not retry an indeterminate pause"
+}
+
+// pauseLedgerScan is the kind-agnostic result for ONE pause.
+type pauseLedgerScan struct {
+	Blockers []recoveryTransitionBlocker
+	// Ours is the exact path of this executor's own reservation, set only by the post-reserve
+	// rescan so step 6.5 can exclude it by EXACT PATH EQUALITY and nothing looser.
+	Ours string
+}
+
+func (s pauseLedgerScan) blocking() *recoveryTransitionBlocker {
+	for i := range s.Blockers {
+		if s.Blockers[i].Path != s.Ours {
+			return &s.Blockers[i]
+		}
+	}
+	return nil
+}
+
+func (s pauseLedgerScan) competingWith(ourPath string) *recoveryTransitionBlocker {
+	s.Ours = ourPath
+	return s.blocking()
+}
+
+// scanRecoveryTransitionsForPause enumerates every recovery transition for ONE pause, across
+// BOTH derivations and ALL kinds, and reports what blocks.
+//
+// No prefix literal appears here. Today's kind-blindness exists because the scan carried its own
+// prefix filter (resume_goal.go:790) separate from the path builder (:345) -- two filters, one of
+// which nobody updated when a kind was added. Everything goes through the one parser.
+//
+// FAILS CLOSED EVERYWHERE. The ledger is the only thing standing between one audited /goal
+// resume and two, so every ambiguity blocks:
+//   - a reservation with no .consumed.json     -> indeterminate
+//   - a companion that cannot be read/parsed   -> cannot prove consumption
+//   - a name that fails to parse               -> a reservation we cannot understand
+//   - a body whose kind disagrees with its name -> ambiguous evidence
+//   - an ORPHAN companion for this pause       -> a reservation existed and is gone
+//   - any stat error other than not-exist      -> cannot prove anything
+//   - a reservation that IS consumed            -> a delivery may have reached the pane
+//
+// THERE IS NO NON-BLOCKING LIFECYCLE STATE for a matching current or exact-matching legacy key.
+// Reserved, bound and consumed all refuse. An earlier version of this comment said consumed was
+// the one ignorable state, which contradicted the ratified checklist AND the confirmed sequence,
+// and would have made a COMPLETED redelivery invisible to supervision resume -- one delivered
+// resume authorising another. Only records proven to belong to a DIFFERENT current claim key or a
+// different legacy attempt+binding are outside this pause.
+func scanRecoveryTransitionsForPause(dir, claimKey, legacyKey string) (pauseLedgerScan, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Refusal, INCLUDING not-exist. An absent directory is the normal fresh case, but it is
+		// also exactly what a wrong project/profile/session triple produces, and the error
+		// cannot distinguish them. Unlike #577's fresh-workstream case there is no successful
+		// observation to prove absence with, so none is manufactured. The resolved path is named
+		// so the operator can see which namespace was inspected.
+		return pauseLedgerScan{}, fmt.Errorf("cannot read the recovery transition directory %s: %w", dir, err)
+	}
+
+	var scan pauseLedgerScan
+	// Companions are collected first so orphan detection can ask "does a reservation exist for
+	// this companion?" after every name is known. Doing it in one pass would depend on
+	// directory order, which is not guaranteed.
+	reservations := map[string]string{} // claimKey+kind -> path
+	companions := map[string]string{}   // reservation base name -> companion path
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if base, ok := companionReservationBase(name); ok {
+			if companionBelongsToPause(base, claimKey, legacyKey) {
+				companions[base] = filepath.Join(dir, name)
+			}
+			continue
+		}
+		parsed, recognition := recognizeRecoveryTransitionName(name)
+		switch recognition {
+		case recoveryNameNotATransition:
+			// Ordinary <attempt>.json and <attempt>.claim.json live in this directory too.
+			// Blocking on those would let normal attempt files wedge all recovery permanently --
+			// amendment 1 overcorrected into an outage.
+			continue
+		case recoveryNameMalformed:
+			// TRANSITION-LIKE but malformed, unknown-kind or missing structure. This blocks
+			// WITHOUT requiring a key match, and my earlier key-match heuristic was FAIL-OPEN:
+			// if corruption destroyed the key, requiring the key to be present proves nothing
+			// about ownership while quietly permitting delivery. Ambiguous ledger integrity is
+			// an operator recovery condition, and it may wedge the namespace -- accepted, per
+			// ruling, because the alternative is delivering against evidence we cannot read.
+			scan.Blockers = append(scan.Blockers, recoveryTransitionBlocker{
+				Path:   filepath.Join(dir, name),
+				Reason: "a recovery-transition-like file is malformed, unknown-kind or missing structure, so no claim here can be honoured or dismissed",
+			})
+			continue
+		}
+		if !parsedBelongsToPause(parsed, claimKey, legacyKey) {
+			continue
+		}
+		reservations[string(parsed.Kind)+":"+parsed.ClaimKey] = filepath.Join(dir, name)
+	}
+
+	// AMENDMENT 1: orphan companions block. A .consumed.json or .bound.json whose reservation is
+	// ABSENT is evidence that a reservation existed and something removed it -- and nothing in
+	// any code path deletes a reservation. That is tampering or partial state, not vacancy.
+	for base, companionPath := range companions {
+		if _, err := os.Stat(filepath.Join(dir, base+".json")); err != nil {
+			if !os.IsNotExist(err) {
+				scan.Blockers = append(scan.Blockers, recoveryTransitionBlocker{
+					Path:   companionPath,
+					Reason: "cannot stat the reservation this companion belongs to, so consumption cannot be proven",
+				})
+				continue
+			}
+			scan.Blockers = append(scan.Blockers, recoveryTransitionBlocker{
+				Path:   companionPath,
+				Reason: "ORPHAN companion: a transition companion exists for this pause but its reservation is gone, and nothing in this system deletes reservations",
+			})
+		}
+	}
+
+	for _, path := range reservations {
+		if blocker := reservationBlocker(path); blocker != nil {
+			scan.Blockers = append(scan.Blockers, *blocker)
+		}
+	}
+	return scan, nil
+}
+
+// reservationBlocker decides whether ONE reservation blocks, reading its body and companion.
+//
+// AMENDMENT 2 / ruling (B): the body IS read. A name-trusting scan is shape-not-proof at exactly
+// the spot this milestone keeps getting burned, and the cost is 0-3 file reads for one pause.
+func reservationBlocker(path string) *recoveryTransitionBlocker {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return &recoveryTransitionBlocker{Path: path, Reason: "cannot read this pause's reservation, so its claim state is unknown"}
+	}
+	var record struct {
+		Kind         string `json:"recovery_kind"`
+		TransitionID string `json:"transition_id"`
+	}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return &recoveryTransitionBlocker{Path: path, Reason: "this pause's reservation does not parse, so its claim state is unknown"}
+	}
+	parsed, ok := parseRecoveryTransitionName(filepath.Base(path))
+	if !ok {
+		return &recoveryTransitionBlocker{Path: path, Reason: "reservation name no longer parses"}
+	}
+	// PREFIX-KIND vs RECORD-KIND must AGREE. A renamed file would otherwise silently change what
+	// a reservation means, and disagreement is ambiguous evidence rather than a tie to break.
+	// Legacy names carry no kind in the filename, so only current-derivation names are compared.
+	if !parsed.Legacy && strings.TrimSpace(record.Kind) != string(parsed.Kind) {
+		return &recoveryTransitionBlocker{
+			Path:   path,
+			Reason: fmt.Sprintf("reservation kind disagrees: filename says %q, record says %q", parsed.Kind, record.Kind),
+		}
+	}
+
+	// RULED (#498 checklist section 2 + confirmed sequence step 3a): a matching reservation
+	// BLOCKS in EVERY lifecycle state. There is no ignored state for this pause.
+	//
+	// My first version treated proven-consumed as non-blocking and called that "ignoring". It
+	// was wrong against two ratified texts, and the semantics matter more than the wording: a
+	// COMPLETED redelivery would have been INVISIBLE to supervision resume, which is exactly the
+	// forbidden case -- one delivered resume authorising another. Consumed means a delivery may
+	// have reached the pane. That is terminal ownership evidence about this pause, never
+	// permission for a second automatic action.
+	consumedPath := resumeGoalTransitionConsumedPath(path)
+	if _, err := os.Stat(consumedPath); err == nil {
+		return &recoveryTransitionBlocker{
+			Path:   consumedPath,
+			Reason: "a recovery transition for this pause is already CONSUMED: a delivery may have reached the pane, so a second automatic delivery is refused",
+		}
+	} else if !os.IsNotExist(err) {
+		return &recoveryTransitionBlocker{Path: consumedPath, Reason: "cannot stat the consumption record, so delivery cannot be proven"}
+	}
+	return &recoveryTransitionBlocker{
+		Path:   path,
+		Reason: "a recovery transition for this pause is reserved and NOT consumed: delivery is indeterminate, so a second delivery is refused",
+	}
+}
+
+// companionReservationBase maps a companion filename to the reservation base name it belongs to.
+func companionReservationBase(name string) (string, bool) {
+	for _, suffix := range []string{".consumed.json", ".bound.json"} {
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix), true
+		}
+	}
+	return "", false
+}
+
+func companionBelongsToPause(base, claimKey, legacyKey string) bool {
+	return strings.Contains(base, claimKey) || (legacyKey != "" && strings.Contains(base, legacyKey))
+}
+
+func parsedBelongsToPause(parsed parsedRecoveryTransitionName, claimKey, legacyKey string) bool {
+	if parsed.Legacy {
+		// A legacy record for a DIFFERENT attempt is someone else's claim: directory-wide legacy
+		// blocking would wedge every future pause behind any historical record.
+		return legacyKey != "" && parsed.ClaimKey == legacyKey
+	}
+	return parsed.ClaimKey == claimKey
+}

--- a/internal/cli/recovery_transition_writer_pin_test.go
+++ b/internal/cli/recovery_transition_writer_pin_test.go
@@ -1,0 +1,310 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// PR5 / #498: one ledger owns every recovery action for a pause. The half of that which
+// survives as a comment and dies in code is "legacy transitions remain READABLE but must not
+// remain an alternate WRITER path". A convention cannot enforce that; this does.
+//
+// The rule: exactly ONE production function may construct a transition record, and exactly ONE
+// may create a reservation file. Every other site reads. A second writer is not a style
+// problem -- two writers with two notions of the key is double delivery of an audited
+// /goal resume, which is the worst outcome the #498 contract names.
+//
+// Structural, not textual, because this milestone has now produced five checks that accepted a
+// shape where they needed a proof. The enforcement is over the AST: which functions contain a
+// call that creates a reservation, not which files mention one.
+func TestOnlyOneProductionSiteReservesARecoveryTransition(t *testing.T) {
+	// THE SANCTIONED PUBLISHERS: THREE. Ratified, after a round trip worth recording.
+	//
+	// dev-2 counted FOUR and was describing the TRANSITIONAL state correctly: under a
+	// constructor-only wiring, resume_goal.go's reserveResumeGoalTransition keeps its direct
+	// publishGoalJSON at :770 and is a genuine fourth publisher. The ruling resolved it the other
+	// way -- the wiring DELEGATES, so the three legacy transition functions hand their
+	// publication to these three and no direct publishGoalJSON remains inside any transition
+	// publisher. The set stays three because the end state has three, and the pin then forces the
+	// full migration instead of blessing a half-done one.
+	//
+	// Enumerated rather than reasoned about. publishGoalJSON has five call sites; exactly three
+	// touch a transition path (resume_goal.go:770 reserve, :950 bind, :981 consume). The other
+	// two, goal_attempt.go:139 and :227, publish ATTEMPT and CLAIM paths and are not this rule's
+	// business -- see the explicit non-transition allowlist below, which exists so that
+	// "not our business" is a decision on the record rather than a gap.
+	sanctioned := map[string]bool{
+		"reserveRecoveryTransition":        true,
+		"bindRecoveryTransitionGeneration": true,
+		"consumeRecoveryTransition":        true,
+	}
+
+	// EXPLICIT NON-TRANSITION PUBLISHERS. Naming them is what lets the detector below be
+	// DEFAULT-DENY: every function that publishes must be classified, so a new publisher added
+	// tomorrow fails this test until someone decides which list it belongs in. Silence is not a
+	// classification.
+	// Names read from the tree, not guessed: I had written publishGoalAttempt/publishGoalClaim
+	// from memory and both were wrong.
+	nonTransition := map[string]bool{
+		"createGoalAttempt": true, // goal_attempt.go:115, publishes at :139 -- attempt record
+		"claimGoalAttempt":  true, // goal_attempt.go:209, publishes at :227 -- claim record
+	}
+
+	// THE PUBLICATION PRIMITIVE IS publishGoalJSON, NOT O_EXCL.
+	//
+	// The first version of this test looked for os.O_EXCL, citing briefs.go:185. That citation is
+	// real and the idiom is real, but it is NOT the idiom this domain uses: publishGoalJSON
+	// (goal_attempt.go:152) publishes by writing a same-directory candidate, fsyncing it, and
+	// link(2)-ing it into place -- link is the atomic no-replace primitive, and losers see
+	// ErrExist. grep confirms O_EXCL appears nowhere in the recovery-transition path.
+	//
+	// So the original detector would have found ZERO writers and fired its own
+	// detection-is-broken guard. That guard working is the only reason this was noisy rather than
+	// silent, and it is exactly the shape-not-proof failure again: I wrote the detector from an
+	// idiom I assumed instead of from the CAS owner I could have read. An enforcement test keyed
+	// on the wrong primitive enforces nothing about the thing it names.
+	const publicationPrimitive = "publishGoalJSON"
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	// DEFAULT-DENY, and this is the second correction to this detector.
+	//
+	// The previous version classified a function as a writer only if it ALSO mentioned an
+	// identifier containing "transitionPath". That has a hole big enough to drive the whole rule
+	// through: reserveRecoveryTransition RECEIVES its path as a parameter -- deliberately, so it
+	// cannot be a second path owner -- and therefore mentions no such identifier. The single most
+	// important writer in the design would have been INVISIBLE to the test guarding it, while the
+	// legacy functions that derive their own paths stayed visible. Keying on "derives a path"
+	// instead of "publishes" is the same shape-not-proof substitution as keying on O_EXCL.
+	//
+	// So: EVERY function that calls publishGoalJSON is collected, and every one must be
+	// classified as either a sanctioned transition publisher or an explicit non-transition
+	// publisher. An unclassified publisher FAILS. Silence is not a classification, and a new
+	// publisher added tomorrow cannot slip in by simply not looking like the ones here.
+	publishers := map[string]string{} // func name -> file
+	found := map[string]bool{}
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Body == nil {
+				continue
+			}
+			found[fn.Name.Name] = true
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, isCall := n.(*ast.CallExpr)
+				if !isCall {
+					return true
+				}
+				// The primitive is called bare within package cli; the SelectorExpr arm catches a
+				// qualified or aliased reference so a move to another package cannot evade this.
+				switch fun := call.Fun.(type) {
+				case *ast.Ident:
+					if fun.Name == publicationPrimitive {
+						publishers[fn.Name.Name] = filepath.Base(path)
+					}
+				case *ast.SelectorExpr:
+					if fun.Sel != nil && fun.Sel.Name == publicationPrimitive {
+						publishers[fn.Name.Name] = filepath.Base(path)
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	// ANTI-VACUITY, three ways. Each guards a different way this test could quietly stop meaning
+	// anything, and the O_EXCL episode is why there are three rather than one: that mistake was
+	// caught ONLY because a floor fired.
+	if len(publishers) == 0 {
+		t.Fatalf("no function calls %s; the detection is broken, not the tree clean", publicationPrimitive)
+	}
+	for name := range sanctioned {
+		if !found[name] {
+			t.Fatalf("sanctioned publisher %q does not exist in the tree; this test is enforcing a "+
+				"rule about a function that is not there", name)
+		}
+		if publishers[name] == "" {
+			t.Errorf("sanctioned publisher %q exists but never calls %s.\nAfter the ruled delegation "+
+				"the CAS layer is the ONLY thing that publishes; a sanctioned publisher that does not "+
+				"publish means the delegation did not land.", name, publicationPrimitive)
+		}
+	}
+
+	for name, file := range publishers {
+		if sanctioned[name] || nonTransition[name] {
+			continue
+		}
+		t.Errorf("%s (%s) calls %s but is neither a sanctioned transition publisher nor a declared "+
+			"non-transition publisher.\nEvery publisher must be classified deliberately. If this is a "+
+			"transition writer, it is an ALTERNATE WRITER: two writers means two notions of the claim "+
+			"key, and for /goal resume that is DOUBLE DELIVERY of an audited action (#498). If it is "+
+			"not, add it to nonTransition with a reason.", name, file, publicationPrimitive)
+	}
+}
+
+// The companion: every transition record must be built by one constructor, so no site can
+// assemble a record that skips the fields the key depends on.
+//
+// This is the #572 lesson applied before the fact rather than after. There, two struct
+// literals bypassed bootstrapack.NewExpectation and recorded an empty LaunchID; here a literal
+// that omits PauseGeneration or PreclaimFingerprint would produce a record the key derivation
+// cannot reproduce -- unmatched on read, so treated as absent, so a second delivery.
+func TestNoProductionCodeBuildsRecoveryTransitionLiterals(t *testing.T) {
+	const recordType = "resumeGoalTransitionRecord"
+	const constructor = "newRecoveryTransitionRecord"
+
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	var offenders []string
+	constructorFound := false
+	inspected := 0
+	// Calls to the constructor from production, NOT counting its own declaration. See the floor
+	// below for why the count and not merely the existence.
+	constructorCalls := 0
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		inspected++
+		for _, decl := range parsed.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name == nil {
+				continue
+			}
+			if fn.Name.Name == constructor {
+				constructorFound = true
+				// The constructor is the one place allowed to build the literal.
+				continue
+			}
+			if fn.Body == nil {
+				continue
+			}
+			// SANCTIONED-INPUT PASS, first: a literal supplied as the Base field of a
+			// recoveryTransitionInput is the constructor's INPUT, not a bypass of it.
+			//
+			// The wiring exposed this and it is worth stating plainly, because the pin was
+			// UNSATISFIABLE as first written: the constructor's signature takes
+			// `Base resumeGoalTransitionRecord`, so every correct caller must build a populated
+			// literal to hand it. A rule forbidding all populated literals therefore forbade the
+			// only correct way to call the thing it was protecting. Nothing detected this until
+			// real production code had to satisfy both at once -- an enforcement test can be
+			// self-consistent and still describe a world no caller can live in.
+			sanctionedLit := map[token.Pos]bool{}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				lit, isLit := n.(*ast.CompositeLit)
+				if !isLit {
+					return true
+				}
+				if id, ok := lit.Type.(*ast.Ident); !ok || id.Name != "recoveryTransitionInput" {
+					return true
+				}
+				for _, elt := range lit.Elts {
+					kv, isKV := elt.(*ast.KeyValueExpr)
+					if !isKV {
+						continue
+					}
+					key, isKey := kv.Key.(*ast.Ident)
+					if !isKey || key.Name != "Base" {
+						continue
+					}
+					if inner, ok := kv.Value.(*ast.CompositeLit); ok {
+						sanctionedLit[inner.Pos()] = true
+					}
+					// A Base supplied as a bare identifier (base := ...; Base: base) is the
+					// common shape; the assignment's literal is caught by position below only if
+					// it is inline, so identifier-valued Base is handled by the assignment scan.
+					if ident, ok := kv.Value.(*ast.Ident); ok && ident.Obj != nil {
+						if assign, ok := ident.Obj.Decl.(*ast.AssignStmt); ok {
+							for _, rhs := range assign.Rhs {
+								if inner, ok := rhs.(*ast.CompositeLit); ok {
+									sanctionedLit[inner.Pos()] = true
+								}
+							}
+						}
+					}
+				}
+				return true
+			})
+
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if call, isCall := n.(*ast.CallExpr); isCall {
+					if id, ok := call.Fun.(*ast.Ident); ok && id.Name == constructor {
+						constructorCalls++
+					}
+				}
+				lit, isLit := n.(*ast.CompositeLit)
+				if !isLit {
+					return true
+				}
+				id, isID := lit.Type.(*ast.Ident)
+				if !isID || id.Name != recordType {
+					return true
+				}
+				// An EMPTY literal is a zero value for a read target, not a constructed
+				// record; only a populated one bypasses the constructor.
+				if len(lit.Elts) == 0 {
+					return true
+				}
+				if sanctionedLit[lit.Pos()] {
+					return true
+				}
+				offenders = append(offenders, fset.Position(lit.Pos()).String())
+				return true
+			})
+		}
+	}
+
+	if !constructorFound {
+		t.Fatalf("constructor %q does not exist; this test would permit every literal", constructor)
+	}
+	if inspected < 50 {
+		t.Fatalf("parsed only %d non-test files; the walk is broken", inspected)
+	}
+	// THE FLOOR THAT MATTERS, and the one the first draft was missing. `inspected` proves the
+	// WALK ran; it says nothing about whether the rule has any subject. If no production code
+	// calls the constructor, then "no literal bypasses the constructor" is true the way it is true
+	// of a function nobody uses -- vacuously -- and this test would sit green through exactly the
+	// regression it exists to prevent: a wiring reverted, a call replaced by a literal that the
+	// literal-walk happened to miss, or a PR5 that never landed its writer at all.
+	//
+	// Counting FILES was the same shape as counting the string instead of the thing. The subject
+	// of the rule is the constructor's use, so that is what the floor counts.
+	//
+	// NOTE FOR THE INTERIM: until resume_goal.go's redelivery writer is routed through the
+	// constructor, this floor FAILS. That is intended and is the point of writing the pin before
+	// the wiring -- the pin goes green when the wiring lands, so it cannot be shaped to fit
+	// whatever the wiring happened to produce.
+	if constructorCalls < 1 {
+		t.Fatalf("no production code calls %s; the no-literal rule has no subject and this test is "+
+			"vacuously green. Either the wiring has not landed yet, or it was reverted.", constructor)
+	}
+	if len(offenders) != 0 {
+		t.Errorf("production code builds a populated %s literal at %v; use %s so PauseGeneration and "+
+			"PreclaimFingerprint are always recorded. A record missing them cannot be matched by the key "+
+			"derivation, reads as ABSENT, and permits a second delivery.", recordType, offenders, constructor)
+	}
+}

--- a/internal/cli/resume_goal.go
+++ b/internal/cli/resume_goal.go
@@ -25,6 +25,31 @@ const resumeGoalPlanSchemaVersion = 1
 
 const resumeGoalTransitionSchemaVersion = 1
 
+// resumeGoalNativeBinding is the exact assessment binding authorized by a native goal-resume
+// reservation that is not already represented by the transition record's shared flat fields.
+//
+// Every field is required for native reservations and deliberately lacks omitempty. The containing
+// pointer is the compatibility boundary: it is absent for legacy/redeliver records, while a broken
+// native writer leaves visibly invalid evidence that readers refuse instead of silently omitting
+// the missing identity.
+//
+// GoalAttemptID intentionally duplicates the VALUE in the flat NewAttemptID under a different
+// semantic contract. GoalAttemptID is the assessment identity that authorized the reservation;
+// NewAttemptID is the lifecycle identity carried through bound/consumed artifacts. Native
+// construction and recovery require them to agree.
+type resumeGoalNativeBinding struct {
+	NamespaceID             string `json:"namespace_id"`
+	PaneID                  string `json:"pane_id"`
+	GoalMode                string `json:"goal_mode"`
+	GoalAttemptID           string `json:"goal_attempt_id"`
+	GoalBindingDigest       string `json:"goal_binding_digest"`
+	GoalCommandDigest       string `json:"goal_command_digest"`
+	BlockerID               string `json:"blocker_id"`
+	BlockerResolutionDigest string `json:"blocker_resolution_digest"`
+	PolicyMode              string `json:"policy_mode"`
+	PolicyRevision          int    `json:"policy_revision"`
+}
+
 type resumeGoalTransitionRecord struct {
 	SchemaVersion         int       `json:"schema_version"`
 	TransitionID          string    `json:"transition_id"`
@@ -50,11 +75,12 @@ type resumeGoalTransitionRecord struct {
 	LaunchRecordModTime   int64     `json:"launch_record_mod_time_unix_nano"`
 	CreatedAt             time.Time `json:"created_at"`
 
-	// PR5 / #498. Three ADDITIVE fields that let this record serve every recovery kind rather
-	// than redelivery alone. All three are omitempty, and that is a compatibility REQUIREMENT,
-	// not a style choice: a legacy record on disk carries none of them, so they must stay absent
-	// from its round trip instead of appearing as empty strings a reader could mistake for
-	// deliberate values.
+	// PR5 / #498. ADDITIVE top-level fields that let this record serve every recovery kind rather
+	// than redelivery alone. Every top-level addition is omitempty, and that is a compatibility
+	// REQUIREMENT, not a style choice: a legacy record on disk carries none of them, so they must
+	// stay absent from its round trip instead of appearing as empty values a reader could mistake
+	// for deliberate evidence. NativeBinding's required interior fields are the intentional inverse:
+	// once the pointer is present, an empty field stays visible so native validation can refuse it.
 	//
 	// READ/WRITE ASYMMETRY (ruled): on READ, absence means legacy/redeliver, identified by the
 	// legacy key. On WRITE, absence of a field the kind requires REFUSES -- a defaulted identity
@@ -79,6 +105,31 @@ type resumeGoalTransitionRecord struct {
 	// fingerprint-keyed claim would rotate its own identity at the moment of being recorded and
 	// become unmatchable on read.
 	PreclaimFingerprint string `json:"preclaim_fingerprint,omitempty"`
+
+	// Supervisor is WHO AUTHORISED this resume, recorded because accountability that exists only in a
+	// live process cannot be audited after it. The pre-mutation gates already refuse a blank or
+	// placeholder supervisor, so the value is validated before it gets here -- but validating an
+	// identity and then discarding it means the claim on disk cannot answer the one question an
+	// operator asks about an unexpected resume.
+	//
+	// NEVER INFERRED FROM Role/Handle. The lead and the supervisor are two different actors with two
+	// different accountabilities; deriving one from the other would durably record the wrong actor,
+	// and a wrong attribution is worse than a missing one because it looks like an answer.
+	//
+	// REDELIVER MUST NOT CARRY ONE, same asymmetry as PauseGeneration: that path holds no assessment
+	// and no supervisor, so a value there was invented rather than observed.
+	Supervisor string `json:"supervisor,omitempty"`
+
+	// NativeBinding is nil for legacy/redeliver and non-nil exactly for native goal-resume
+	// reservations. The constructor owns this entire block: Base.NativeBinding is never a valid
+	// source (even when its values would agree), and accepted native input is copied into a fresh
+	// value rather than retaining a caller or Base pointer.
+	//
+	// Existing shared identities deliberately stay flat: Project/Profile/Session, Role/Handle,
+	// LaunchID and launch generation, SchemaVersion, transition/kind, pause/fingerprint,
+	// Supervisor, and NewAttemptID. Duplicating them here would create permanent disagreement
+	// states between two durable owners of the same fact.
+	NativeBinding *resumeGoalNativeBinding `json:"native_binding,omitempty"`
 
 	// BindingReserved is runtime-only recovery state. It records that a prior
 	// process durably published this transition's exact new binding before it
@@ -733,6 +784,182 @@ func resumeGoalDeliveryErrorState(err error) (state, attemptID, attemptPath stri
 	return "", "", ""
 }
 
+// resumeGoalRecoveryScanOptions carries the delivery identity used to decide
+// whether CONSUMED recovery evidence belongs to this pause. UNCONSUMED evidence
+// is directory-wide and always blocks; unlike consumed audit history it is
+// transient, operator-recoverable evidence that another delivery may still be
+// in flight.
+type resumeGoalRecoveryScanOptions struct {
+	LegacyKey       string
+	TargetNamespace string
+	TargetAttemptID string
+	OwnPath         string
+	OwnTransitionID string
+}
+
+type resumeGoalRecoveryCompanion struct {
+	Base string
+	Path string
+}
+
+// scanResumeGoalRecoveryTransitions is the redelivery-side reader for both
+// recovery-transition derivations. Recognition always goes through the shared
+// tri-state parser: ordinary attempt files are ignored, transition-like malformed
+// names block, and recognized legacy/current reservations are inspected.
+func scanResumeGoalRecoveryTransitions(dir string, opts resumeGoalRecoveryScanOptions) (*recoveryTransitionBlocker, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read recovery transition directory %s: %w", dir, err)
+	}
+
+	reservations := make(map[string]struct{})
+	var companions []resumeGoalRecoveryCompanion
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if base, ok := companionReservationBase(name); ok {
+			_, recognition := recognizeRecoveryTransitionName(base + ".json")
+			switch recognition {
+			case recoveryNameNotATransition:
+				continue
+			case recoveryNameMalformed:
+				return &recoveryTransitionBlocker{
+					Path:   filepath.Join(dir, name),
+					Reason: "a recovery-transition companion has a malformed, unknown-kind or damaged reservation name",
+				}, nil
+			}
+			companions = append(companions, resumeGoalRecoveryCompanion{
+				Base: base,
+				Path: filepath.Join(dir, name),
+			})
+			continue
+		}
+
+		parsed, recognition := recognizeRecoveryTransitionName(name)
+		switch recognition {
+		case recoveryNameNotATransition:
+			continue
+		case recoveryNameMalformed:
+			return &recoveryTransitionBlocker{
+				Path:   filepath.Join(dir, name),
+				Reason: "a recovery-transition-like file is malformed, unknown-kind or missing structure",
+			}, nil
+		}
+		path := filepath.Join(dir, name)
+		reservations[name] = struct{}{}
+		record, identityErr := readResumeGoalRecoveryIdentity(path, parsed)
+		if identityErr != nil {
+			return &recoveryTransitionBlocker{Path: path, Reason: identityErr.Error()}, nil
+		}
+		if path == opts.OwnPath &&
+			record.TransitionID == opts.OwnTransitionID &&
+			strings.TrimSpace(record.RecoveryKind) == string(recoveryTransitionKindRedeliver) {
+			// Exact path is not enough. Only the body identity of the reservation
+			// this redelivery wrote permits self-exclusion; a replaced or renamed
+			// record remains a blocker.
+			continue
+		}
+
+		consumedPath := resumeGoalTransitionConsumedPath(path)
+		if _, statErr := os.Stat(consumedPath); statErr == nil {
+			matches, matchErr := resumeGoalConsumedRecoveryMatchesDelivery(parsed, record, opts)
+			if matchErr != nil {
+				return &recoveryTransitionBlocker{
+					Path:   consumedPath,
+					Reason: "consumed recovery-transition identity is indeterminate: " + matchErr.Error(),
+				}, nil
+			}
+			if !matches {
+				// A consumed transition proven to belong to a different pause is
+				// durable audit history, not a poison pill for all future delivery.
+				continue
+			}
+		} else if !os.IsNotExist(statErr) {
+			return &recoveryTransitionBlocker{
+				Path:   consumedPath,
+				Reason: "cannot stat the consumption record, so recovery-transition identity is indeterminate",
+			}, nil
+		}
+
+		// Unconsumed evidence blocks directory-wide; consumed evidence reaches
+		// here only after exact delivery-identity matching.
+		if blocker := reservationBlocker(path); blocker != nil {
+			return blocker, nil
+		}
+	}
+
+	for _, companion := range companions {
+		if _, ok := reservations[companion.Base+".json"]; ok {
+			continue
+		}
+		return &recoveryTransitionBlocker{
+			Path:   companion.Path,
+			Reason: "ORPHAN recovery-transition companion: its reservation is absent, so prior delivery cannot be disproved",
+		}, nil
+	}
+	return nil, nil
+}
+
+func readResumeGoalRecoveryIdentity(path string, parsed parsedRecoveryTransitionName) (resumeGoalTransitionRecord, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return resumeGoalTransitionRecord{}, fmt.Errorf("cannot read recovery reservation identity: %w", err)
+	}
+	var record resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return resumeGoalTransitionRecord{}, fmt.Errorf("recovery reservation identity does not parse: %w", err)
+	}
+	if strings.TrimSpace(record.TransitionID) != parsed.ClaimKey {
+		return resumeGoalTransitionRecord{}, fmt.Errorf(
+			"recovery reservation filename key %q disagrees with record transition id %q",
+			parsed.ClaimKey, record.TransitionID,
+		)
+	}
+	recordKind := recoveryTransitionKind(strings.TrimSpace(record.RecoveryKind))
+	if parsed.Legacy {
+		// Pre-PR5 legacy records have no kind field; current redelivery writes
+		// carry the explicit redeliver kind while retaining the legacy filename.
+		if recordKind != "" && recordKind != recoveryTransitionKindRedeliver {
+			return resumeGoalTransitionRecord{}, fmt.Errorf(
+				"legacy redelivery reservation record carries incompatible kind %q", record.RecoveryKind,
+			)
+		}
+	} else if recordKind != parsed.Kind {
+		return resumeGoalTransitionRecord{}, fmt.Errorf(
+			"recovery reservation filename kind %q disagrees with record kind %q",
+			parsed.Kind, record.RecoveryKind,
+		)
+	}
+	return record, nil
+}
+
+func resumeGoalConsumedRecoveryMatchesDelivery(
+	parsed parsedRecoveryTransitionName,
+	record resumeGoalTransitionRecord,
+	opts resumeGoalRecoveryScanOptions,
+) (bool, error) {
+	if parsed.Legacy {
+		if strings.TrimSpace(opts.LegacyKey) == "" {
+			return false, fmt.Errorf("delivery has no exact legacy attempt+binding key")
+		}
+		return parsed.ClaimKey == opts.LegacyKey, nil
+	}
+	expected, err := supervisionClaimKey(
+		opts.TargetNamespace,
+		record.PauseGeneration,
+		opts.TargetAttemptID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("recompute current claim key from delivery namespace, record pause generation, and delivery attempt: %w", err)
+	}
+	return parsed.ClaimKey == expected, nil
+}
+
 func reserveResumeGoalTransition(t team.Team, profile, workstream string, verified resumeExecLaunchResult, plan runwizard.ResumeGoalPlan) error {
 	check := verified.Check
 	opts := goalDeliveryOptions{Project: t.Project, Profile: profile, Session: workstream, Role: plan.LeadRole}
@@ -778,6 +1005,18 @@ func reserveResumeGoalTransition(t team.Team, profile, workstream string, verifi
 		launchDigest, launchMod, err := readGoalFileGeneration(launch.ExistingPath(check.AgentDir))
 		if err != nil {
 			return fmt.Errorf("capture launch generation: %w", err)
+		}
+		if blocker, err := scanResumeGoalRecoveryTransitions(
+			goalAttemptDir(t.Project, profile, workstream),
+			resumeGoalRecoveryScanOptions{
+				LegacyKey:       plan.TransitionID,
+				TargetNamespace: squadnamespace.ID(profile, workstream),
+				TargetAttemptID: plan.OriginalAttemptID,
+			},
+		); err != nil {
+			return fmt.Errorf("inspect recovery transitions before redelivery reserve: %w", err)
+		} else if blocker != nil {
+			return fmt.Errorf("redelivery claim-once refusal before reserve: %s", blocker.describe())
 		}
 		// PR5 / #498. This site no longer derives a path, no longer stamps a TransitionID, and no
 		// longer publishes: the CONSTRUCTOR owns identity and path, and the RESERVER owns
@@ -825,23 +1064,51 @@ func reserveResumeGoalTransition(t team.Team, profile, workstream string, verifi
 	})
 }
 
+func resumeGoalDeliveryLegacyKey(opts goalDeliveryOptions, mr memberRuntime) (string, error) {
+	attemptID := strings.TrimSpace(opts.AttemptID)
+	if attemptID == "" {
+		return "", fmt.Errorf("delivery attempt id is blank")
+	}
+	contract, err := goalDeliveryContractForBinary(opts.Member.Binary)
+	if err != nil {
+		return "", err
+	}
+	if mr.HasRecord && mr.Record.GoalBinding != nil {
+		if _, boundAttempt, bindingErr := goalBindingPayload(mr.Record.GoalBinding, contract); bindingErr == nil && boundAttempt == attemptID {
+			return resumeGoalTransitionID(attemptID, digestJSON(*mr.Record.GoalBinding)), nil
+		}
+	}
+	prompt := contract.prompt(opts.Goal, opts.Team, opts.Profile, opts.Session, opts.Role, attemptID)
+	binding := contract.binding(
+		opts.Goal,
+		attemptID,
+		prompt,
+		"goal-control",
+		contract.Label+" reserved as a claim-once control action",
+	)
+	return resumeGoalTransitionID(attemptID, digestJSON(*binding)), nil
+}
+
 func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr memberRuntime) (*resumeGoalTransitionRecord, error) {
 	dir := goalAttemptDir(opts.Project, opts.Profile, opts.Session)
 	if opts.ResumeTransitionID == "" {
-		entries, err := os.ReadDir(dir)
-		if err != nil && !os.IsNotExist(err) {
-			return nil, fmt.Errorf("inspect goal redelivery transitions: %w", err)
+		legacyKey, err := resumeGoalDeliveryLegacyKey(opts, mr)
+		if err != nil {
+			return nil, fmt.Errorf("derive goal delivery recovery identity: %w", err)
 		}
-		for _, entry := range entries {
-			name := entry.Name()
-			if !strings.HasPrefix(name, ".resume-redelivery-") || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".consumed.json") || strings.HasSuffix(name, ".bound.json") {
-				continue
-			}
-			path := filepath.Join(dir, name)
-			if _, err := os.Stat(resumeGoalTransitionConsumedPath(path)); err == nil {
-				continue
-			}
-			return nil, fmt.Errorf("goal delivery refused: an unconsumed durable resume-goal transition already exists at %s", path)
+		blocker, err := scanResumeGoalRecoveryTransitions(
+			dir,
+			resumeGoalRecoveryScanOptions{
+				LegacyKey:       legacyKey,
+				TargetNamespace: squadnamespace.ID(opts.Profile, opts.Session),
+				TargetAttemptID: opts.AttemptID,
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("inspect goal recovery transitions: %w", err)
+		}
+		if blocker != nil {
+			return nil, fmt.Errorf("goal delivery refused: %s", blocker.describe())
 		}
 		return nil, nil
 	}
@@ -861,6 +1128,22 @@ func validateResumeGoalTransitionForDelivery(opts goalDeliveryOptions, mr member
 	var tr resumeGoalTransitionRecord
 	if err := json.Unmarshal(payload, &tr); err != nil {
 		return nil, fmt.Errorf("goal delivery refused: durable resume-goal transition is corrupt: %w", err)
+	}
+	blocker, err := scanResumeGoalRecoveryTransitions(
+		dir,
+		resumeGoalRecoveryScanOptions{
+			LegacyKey:       opts.ResumeTransitionID,
+			TargetNamespace: squadnamespace.ID(opts.Profile, opts.Session),
+			TargetAttemptID: tr.OriginalAttemptID,
+			OwnPath:         path,
+			OwnTransitionID: tr.TransitionID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("goal delivery refused: inspect recovery-transition mutex: %w", err)
+	}
+	if blocker != nil {
+		return nil, fmt.Errorf("goal delivery refused by cross-kind claim-once mutex: %s", blocker.describe())
 	}
 	currentTeam, err := team.ReadProfile(opts.Project, opts.Profile)
 	if err != nil {

--- a/internal/cli/resume_goal.go
+++ b/internal/cli/resume_goal.go
@@ -49,6 +49,37 @@ type resumeGoalTransitionRecord struct {
 	LaunchRecordDigest    string    `json:"launch_record_digest"`
 	LaunchRecordModTime   int64     `json:"launch_record_mod_time_unix_nano"`
 	CreatedAt             time.Time `json:"created_at"`
+
+	// PR5 / #498. Three ADDITIVE fields that let this record serve every recovery kind rather
+	// than redelivery alone. All three are omitempty, and that is a compatibility REQUIREMENT,
+	// not a style choice: a legacy record on disk carries none of them, so they must stay absent
+	// from its round trip instead of appearing as empty strings a reader could mistake for
+	// deliberate values.
+	//
+	// READ/WRITE ASYMMETRY (ruled): on READ, absence means legacy/redeliver, identified by the
+	// legacy key. On WRITE, absence of a field the kind requires REFUSES -- a defaulted identity
+	// field is indistinguishable on disk from a legacy record, so a lenient writer would silently
+	// enrol new records into the legacy population.
+
+	// RecoveryKind is what this reservation is FOR. It lives here AND in the filename prefix, and
+	// the scan requires the two to AGREE: the prefix keeps the kind-agnostic scan cheap and the
+	// directory readable, the body makes the kind durable evidence rather than a naming
+	// convention, and disagreement is ambiguous evidence that refuses rather than a tie to break.
+	RecoveryKind string `json:"recovery_kind,omitempty"`
+
+	// PauseGeneration is CONSUMED from the assessment, never recomputed here. PR4 derives it from
+	// captured LaunchID + Goal.BindingDigest + Goal.AttemptID + Goal.Mode; a second derivation
+	// owner reading a different snapshot is the one-identity-two-owners failure whose symptom is
+	// DOUBLE DELIVERY. Redeliver transitions must NOT carry one: that path holds no assessment,
+	// so any value here would have been recomputed or invented.
+	PauseGeneration string `json:"pause_generation,omitempty"`
+
+	// PreclaimFingerprint is staleness EVIDENCE and deliberately NOT part of the claim key. It
+	// rotates when claim evidence changes, and writing the claim is itself such a change, so a
+	// fingerprint-keyed claim would rotate its own identity at the moment of being recorded and
+	// become unmatchable on read.
+	PreclaimFingerprint string `json:"preclaim_fingerprint,omitempty"`
+
 	// BindingReserved is runtime-only recovery state. It records that a prior
 	// process durably published this transition's exact new binding before it
 	// crashed, so continuation must reuse the same attempt rather than require
@@ -748,13 +779,19 @@ func reserveResumeGoalTransition(t team.Team, profile, workstream string, verifi
 		if err != nil {
 			return fmt.Errorf("capture launch generation: %w", err)
 		}
-		path, err := resumeGoalTransitionPath(t.Project, profile, workstream, plan.TransitionID)
-		if err != nil {
-			return err
-		}
-		tr := resumeGoalTransitionRecord{
-			SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: plan.TransitionID,
-			Project: t.Project, Profile: squadnamespace.NormalizeProfile(profile), Session: workstream,
+		// PR5 / #498. This site no longer derives a path, no longer stamps a TransitionID, and no
+		// longer publishes: the CONSTRUCTOR owns identity and path, and the RESERVER owns
+		// publication. What redelivery records is unchanged -- every field below is exactly what
+		// this function already captured -- which is what makes the migration additive rather
+		// than a rewrite of another PR's writer.
+		//
+		// TransitionID is deliberately ABSENT from this literal. It is derived inside the
+		// constructor from AttemptID + BindingDigest, so there is nothing here for a caller to
+		// get wrong or to smuggle, and the equality check below pins it to what the plan's own
+		// readers compute.
+		base := resumeGoalTransitionRecord{
+			SchemaVersion: resumeGoalTransitionSchemaVersion,
+			Project:       t.Project, Profile: squadnamespace.NormalizeProfile(profile), Session: workstream,
 			Role: plan.LeadRole, Handle: plan.LeadHandle, MemberSession: member.Session, MemberCWD: member.EffectiveCWD(currentTeam.Project), MemberBinary: member.Binary, GoalDigest: digestBytes([]byte(plan.Goal)),
 			OriginalAttemptID: plan.OriginalAttemptID, OriginalBindingDigest: plan.BindingDigest,
 			OriginalAttemptDigest: plan.AttemptDigest, OriginalClaimDigest: plan.ClaimDigest,
@@ -763,16 +800,26 @@ func reserveResumeGoalTransition(t team.Team, profile, workstream string, verifi
 			TeamRecordDigest: teamDigest, TeamRecordModTime: teamMod, LaunchRecordDigest: launchDigest, LaunchRecordModTime: launchMod,
 			CreatedAt: time.Now().UTC(),
 		}
-		payload, err := json.MarshalIndent(tr, "", "  ")
+		tr, path, err := newRecoveryTransitionRecord(recoveryTransitionInput{
+			Base:          base,
+			Kind:          recoveryTransitionKindRedeliver,
+			AttemptID:     plan.OriginalAttemptID,
+			BindingDigest: plan.BindingDigest,
+		})
 		if err != nil {
-			return err
+			return fmt.Errorf("construct durable goal redelivery transition: %w", err)
 		}
-		published, err := publishGoalJSON(path, append(payload, '\n'))
-		if err != nil {
+		// IDENTITY PIN, at the seam rather than in a test. plan.TransitionID is what this
+		// function's own callers and every existing reader compute independently; the constructor
+		// derives its own. If those ever diverge, the reservation is written where nobody looks --
+		// present on disk and undiscoverable -- so a mismatch refuses instead of proceeding.
+		if tr.TransitionID != plan.TransitionID {
+			return fmt.Errorf("constructed redelivery transition id %q does not match the plan's %q: "+
+				"a reservation under a divergent id is invisible to the readers that look for it",
+				tr.TransitionID, plan.TransitionID)
+		}
+		if _, err := reserveRecoveryTransition(tr, path); err != nil {
 			return fmt.Errorf("publish durable goal redelivery transition: %w", err)
-		}
-		if !published {
-			return fmt.Errorf("durable goal redelivery transition %s already exists; duplicate/ABA redelivery refused", plan.TransitionID)
 		}
 		return nil
 	})
@@ -938,34 +985,14 @@ func ensureResumeGoalTransitionBinding(opts goalDeliveryOptions, tr *resumeGoalT
 	if err != nil {
 		return fmt.Errorf("capture reserved launch generation: %w", err)
 	}
-	boundPath := resumeGoalTransitionBoundPath(transitionPath)
-	bound := resumeGoalTransitionBound{
-		SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: tr.TransitionID, NewAttemptID: tr.NewAttemptID,
-		LaunchRecordDigest: digest, LaunchRecordModTime: modTime, BoundAt: time.Now().UTC(),
-	}
-	payload, err := json.MarshalIndent(bound, "", "  ")
-	if err != nil {
-		return err
-	}
-	published, err := publishGoalJSON(boundPath, append(payload, '\n'))
-	if err != nil {
-		return fmt.Errorf("publish reserved launch binding generation: %w", err)
-	}
-	if published {
-		return nil
-	}
-	existingBytes, err := os.ReadFile(boundPath)
-	if err != nil {
-		return fmt.Errorf("read concurrent reserved launch binding generation: %w", err)
-	}
-	var existing resumeGoalTransitionBound
-	if err := json.Unmarshal(existingBytes, &existing); err != nil {
-		return fmt.Errorf("parse concurrent reserved launch binding generation: %w", err)
-	}
-	if err := validateResumeGoalTransitionBound(existing, *tr, digest, modTime); err != nil {
-		return fmt.Errorf("reserved launch binding generation changed: %w", err)
-	}
-	return nil
+	// PR5 / #498: DELEGATED. The lost-race handling that used to live here -- publish, and on
+	// ErrExist re-read and validate rather than refuse -- now lives in
+	// bindRecoveryTransitionGeneration, unchanged in behaviour. It is load-bearing and easy to
+	// mistake for boilerplate: a binding may legitimately already exist from this same actor's
+	// earlier attempt, so bind is the ONE publication of the three where !published is not a
+	// failure. Reserve and consume both refuse.
+	return bindRecoveryTransitionGeneration(
+		recoveryReservation{Record: *tr, Path: transitionPath}, digest, modTime)
 }
 
 func consumeResumeGoalTransition(opts goalDeliveryOptions, newAttemptID string) error {
@@ -973,19 +1000,10 @@ func consumeResumeGoalTransition(opts goalDeliveryOptions, newAttemptID string) 
 	if err != nil {
 		return err
 	}
-	consumed := resumeGoalTransitionConsumed{SchemaVersion: resumeGoalTransitionSchemaVersion, TransitionID: opts.ResumeTransitionID, NewAttemptID: newAttemptID, ConsumedAt: time.Now().UTC()}
-	payload, err := json.MarshalIndent(consumed, "", "  ")
-	if err != nil {
-		return err
-	}
-	published, err := publishGoalJSON(resumeGoalTransitionConsumedPath(path), append(payload, '\n'))
-	if err != nil {
-		return fmt.Errorf("publish resume-goal transition completion: %w", err)
-	}
-	if !published {
-		return fmt.Errorf("resume-goal transition %s was concurrently consumed", opts.ResumeTransitionID)
-	}
-	return nil
+	// PR5 / #498: DELEGATED. Identity passed explicitly -- this path holds no record, and
+	// fabricating one just to satisfy a signature would have created the very literal the AST pin
+	// forbids.
+	return consumeRecoveryTransition(opts.ResumeTransitionID, newAttemptID, path)
 }
 
 func captureResumeGoalSendSnapshot(opts goalDeliveryOptions, tr *resumeGoalTransitionRecord, prompt, attemptID string) (memberRuntime, resumeGoalSendSnapshot, error) {

--- a/internal/cli/resume_goal.go
+++ b/internal/cli/resume_goal.go
@@ -935,6 +935,18 @@ func readResumeGoalRecoveryIdentity(path string, parsed parsedRecoveryTransition
 			parsed.Kind, record.RecoveryKind,
 		)
 	}
+	if !parsed.Legacy {
+		// A current record may be classified as belonging to a different pause
+		// only after its own durable identity is proved. In particular, using an
+		// unvalidated PauseGeneration to recompute the delivery-side match would
+		// turn a body/filename identity mismatch into "different" and hide prior
+		// consumption evidence.
+		if err := validateRecoveryTransitionRecordContract(record); err != nil {
+			return resumeGoalTransitionRecord{}, fmt.Errorf(
+				"current recovery reservation violates the durable record contract: %w", err,
+			)
+		}
+	}
 	return record, nil
 }
 

--- a/internal/cli/resume_goal_mutex_test.go
+++ b/internal/cli/resume_goal_mutex_test.go
@@ -40,31 +40,21 @@ func writeNativeResumeMutexReservationForAttempt(
 	attemptID string,
 ) (string, string) {
 	t.Helper()
-	key, err := supervisionClaimKey(
-		squadnamespace.ID(team.DefaultProfile, session),
-		pause,
+	in := completeNativeTransitionInput(
+		tm.Project,
+		team.DefaultProfile,
+		session,
 		attemptID,
 	)
+	in.Base.Role = plan.LeadRole
+	in.Base.Handle = plan.LeadHandle
+	in.PauseGeneration = pause
+	record, path, err := newRecoveryTransitionRecord(in)
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(
-		goalAttemptDir(tm.Project, team.DefaultProfile, session),
-		currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key),
-	)
-	writeTestJSON(t, path, resumeGoalTransitionRecord{
-		SchemaVersion:   resumeGoalTransitionSchemaVersion,
-		TransitionID:    key,
-		Project:         tm.Project,
-		Profile:         team.DefaultProfile,
-		Session:         session,
-		Role:            plan.LeadRole,
-		Handle:          plan.LeadHandle,
-		NewAttemptID:    attemptID,
-		RecoveryKind:    string(recoveryTransitionKindNativeGoalResume),
-		PauseGeneration: pause,
-	})
-	return path, key
+	writeTestJSON(t, path, record)
+	return path, record.TransitionID
 }
 
 func resumeGoalMutexOptions(
@@ -191,25 +181,86 @@ func TestRedeliveryConsumedNativeUsesRecomputedDeliveryIdentity(t *testing.T) {
 	}
 }
 
+// The consumed filename and TransitionID still describe the original claim,
+// but the body has been damaged after publication. Without read-side contract
+// validation, the scanner uses the tampered nonblank PauseGeneration to derive
+// a different key, ignores the prior-consumption evidence, and this production
+// redelivery reaches one pane send.
+func TestRedeliveryConsumedNativePauseGenerationTamperBlocksProductionDelivery(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	path, key := writeNativeResumeMutexReservation(
+		t,
+		tm,
+		session,
+		plan,
+		"pause-native-consumed-original",
+	)
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRecoveryTransitionRecordContract(record); err != nil {
+		t.Fatalf("native reservation was not valid before the one-field tamper: %v", err)
+	}
+	record.PauseGeneration = "pause-native-consumed-tampered"
+	writeTestJSON(t, path, record)
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(path), map[string]string{
+		"transition_id": key,
+	})
+
+	oldLister, oldSend := statusPaneLister, sendPromptToPane
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+		return []tmuxpane.TmuxPane{{
+			PaneID:  "%447",
+			CWD:     tm.Project,
+			Command: tm.Members[0].Binary,
+			Title:   paneTitleToken(session, plan.LeadRole),
+		}}, nil
+	}
+	sends := 0
+	sendPromptToPane = func(_ string, _ string) error {
+		sends++
+		return nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister, sendPromptToPane = oldLister, oldSend
+	})
+
+	_, err = executeGoalDelivery(resumeGoalMutexOptions(tm, session, plan))
+	if err == nil || sends != 0 ||
+		!strings.Contains(err.Error(), "cross-kind claim-once mutex") ||
+		!strings.Contains(err.Error(), "not the claim key") {
+		t.Fatalf("damaged consumed native identity did not fail closed before pane input: err=%v sends=%d", err, sends)
+	}
+}
+
 func TestRedeliveryConsumedNativeWithBlankPauseGenerationBlocks(t *testing.T) {
 	tm, session, _, plan, _ := freshResumeTransitionFixture(t)
 	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
-	key := strings.Repeat("b", 64)
-	path := filepath.Join(
-		dir,
-		currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key),
+	path, key := writeNativeResumeMutexReservation(
+		t,
+		tm,
+		session,
+		plan,
+		"pause-native-consumed-blank",
 	)
-	writeTestJSON(t, path, resumeGoalTransitionRecord{
-		SchemaVersion: resumeGoalTransitionSchemaVersion,
-		TransitionID:  key,
-		Project:       tm.Project,
-		Profile:       team.DefaultProfile,
-		Session:       session,
-		Role:          plan.LeadRole,
-		Handle:        plan.LeadHandle,
-		NewAttemptID:  plan.OriginalAttemptID,
-		RecoveryKind:  string(recoveryTransitionKindNativeGoalResume),
-	})
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	record.PauseGeneration = ""
+	writeTestJSON(t, path, record)
 	writeTestJSON(t, resumeGoalTransitionConsumedPath(path), map[string]string{
 		"transition_id": key,
 	})
@@ -220,8 +271,8 @@ func TestRedeliveryConsumedNativeWithBlankPauseGenerationBlocks(t *testing.T) {
 		TargetAttemptID: plan.OriginalAttemptID,
 	})
 	if err != nil || blocker == nil ||
-		!strings.Contains(blocker.Reason, "requires namespace, pause generation and attempt id") ||
-		blocker.Path != resumeGoalTransitionConsumedPath(path) {
+		!strings.Contains(blocker.Reason, "requires a pause generation") ||
+		blocker.Path != path {
 		t.Fatalf("blank consumed pause generation did not fail closed with cause: blocker=%+v err=%v", blocker, err)
 	}
 }

--- a/internal/cli/resume_goal_mutex_test.go
+++ b/internal/cli/resume_goal_mutex_test.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+func writeNativeResumeMutexReservation(
+	t *testing.T,
+	tm team.Team,
+	session string,
+	plan runwizard.ResumeGoalPlan,
+	pause string,
+) (string, string) {
+	t.Helper()
+	return writeNativeResumeMutexReservationForAttempt(
+		t,
+		tm,
+		session,
+		plan,
+		pause,
+		plan.OriginalAttemptID,
+	)
+}
+
+func writeNativeResumeMutexReservationForAttempt(
+	t *testing.T,
+	tm team.Team,
+	session string,
+	plan runwizard.ResumeGoalPlan,
+	pause string,
+	attemptID string,
+) (string, string) {
+	t.Helper()
+	key, err := supervisionClaimKey(
+		squadnamespace.ID(team.DefaultProfile, session),
+		pause,
+		attemptID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(
+		goalAttemptDir(tm.Project, team.DefaultProfile, session),
+		currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key),
+	)
+	writeTestJSON(t, path, resumeGoalTransitionRecord{
+		SchemaVersion:   resumeGoalTransitionSchemaVersion,
+		TransitionID:    key,
+		Project:         tm.Project,
+		Profile:         team.DefaultProfile,
+		Session:         session,
+		Role:            plan.LeadRole,
+		Handle:          plan.LeadHandle,
+		NewAttemptID:    attemptID,
+		RecoveryKind:    string(recoveryTransitionKindNativeGoalResume),
+		PauseGeneration: pause,
+	})
+	return path, key
+}
+
+func resumeGoalMutexOptions(
+	tm team.Team,
+	session string,
+	plan runwizard.ResumeGoalPlan,
+) goalDeliveryOptions {
+	return goalDeliveryOptions{
+		Project:            tm.Project,
+		Profile:            team.DefaultProfile,
+		Session:            session,
+		Role:               plan.LeadRole,
+		Goal:               plan.Goal,
+		Team:               tm,
+		Member:             tm.Members[0],
+		Namespace:          squadnamespace.Resolve(tm.Project, team.DefaultProfile, session),
+		Mode:               executionModeProjectLead,
+		ResumeTransitionID: plan.TransitionID,
+	}
+}
+
+// The old reader filtered only ".resume-redelivery-" and skipped consumed
+// records. Either mutation makes this current native consumed reservation
+// invisible and turns the expected refusal into nil.
+func TestGoalDeliveryDiscoveryUsesTheSharedParserForCurrentConsumedTransitions(t *testing.T) {
+	tm, session, _, plan, _ := freshResumeTransitionFixture(t)
+	path, key := writeNativeResumeMutexReservation(t, tm, session, plan, "pause-current-consumed")
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(path), map[string]string{
+		"transition_id": key,
+	})
+
+	opts := resumeGoalMutexOptions(tm, session, plan)
+	opts.ResumeTransitionID = ""
+	opts.AttemptID = plan.OriginalAttemptID
+	_, err := validateResumeGoalTransitionForDelivery(opts, memberRuntime{})
+	if err == nil || !strings.Contains(err.Error(), "CONSUMED") ||
+		!strings.Contains(err.Error(), filepath.Base(resumeGoalTransitionConsumedPath(path))) {
+		t.Fatalf("current consumed native transition was not discovered through the shared parser: %v", err)
+	}
+}
+
+// Unconsumed recovery evidence blocks directory-wide because it may still
+// authorize delivery. Once consumed, the same durable record is history and
+// blocks only the exact legacy attempt+binding identity.
+func TestRedeliveryScanUsesExactLegacyMatching(t *testing.T) {
+	tm, session, _, plan, _ := freshResumeTransitionFixture(t)
+	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
+	otherID := strings.Repeat("f", 64)
+	otherPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, otherID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestJSON(t, otherPath, resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  otherID,
+		RecoveryKind:  string(recoveryTransitionKindRedeliver),
+	})
+
+	blocker, err := scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+	})
+	if err != nil || blocker == nil || blocker.Path != otherPath {
+		t.Fatalf("different unconsumed legacy evidence did not block directory-wide: blocker=%+v err=%v", blocker, err)
+	}
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(otherPath), map[string]string{
+		"transition_id": otherID,
+	})
+	blocker, err = scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+	})
+	if err != nil || blocker != nil {
+		t.Fatalf("different consumed legacy key poisoned this delivery: blocker=%+v err=%v", blocker, err)
+	}
+
+	ownPath, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestJSON(t, ownPath, resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  plan.TransitionID,
+		RecoveryKind:  string(recoveryTransitionKindRedeliver),
+	})
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(ownPath), map[string]string{
+		"transition_id": plan.TransitionID,
+	})
+	blocker, err = scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+	})
+	if err != nil || blocker == nil || blocker.Path != resumeGoalTransitionConsumedPath(ownPath) {
+		t.Fatalf("matching consumed legacy key did not block: blocker=%+v err=%v", blocker, err)
+	}
+}
+
+func TestRedeliveryConsumedNativeUsesRecomputedDeliveryIdentity(t *testing.T) {
+	tm, session, _, plan, _ := freshResumeTransitionFixture(t)
+	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
+	otherAttempt := "different-native-attempt"
+	path, key := writeNativeResumeMutexReservationForAttempt(
+		t,
+		tm,
+		session,
+		plan,
+		"pause-native-consumed-other",
+		otherAttempt,
+	)
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(path), map[string]string{
+		"transition_id": key,
+	})
+
+	blocker, err := scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+	})
+	if err != nil || blocker != nil {
+		t.Fatalf("different consumed native attempt poisoned this delivery: blocker=%+v err=%v", blocker, err)
+	}
+}
+
+func TestRedeliveryConsumedNativeWithBlankPauseGenerationBlocks(t *testing.T) {
+	tm, session, _, plan, _ := freshResumeTransitionFixture(t)
+	dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
+	key := strings.Repeat("b", 64)
+	path := filepath.Join(
+		dir,
+		currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key),
+	)
+	writeTestJSON(t, path, resumeGoalTransitionRecord{
+		SchemaVersion: resumeGoalTransitionSchemaVersion,
+		TransitionID:  key,
+		Project:       tm.Project,
+		Profile:       team.DefaultProfile,
+		Session:       session,
+		Role:          plan.LeadRole,
+		Handle:        plan.LeadHandle,
+		NewAttemptID:  plan.OriginalAttemptID,
+		RecoveryKind:  string(recoveryTransitionKindNativeGoalResume),
+	})
+	writeTestJSON(t, resumeGoalTransitionConsumedPath(path), map[string]string{
+		"transition_id": key,
+	})
+
+	blocker, err := scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+	})
+	if err != nil || blocker == nil ||
+		!strings.Contains(blocker.Reason, "requires namespace, pause generation and attempt id") ||
+		blocker.Path != resumeGoalTransitionConsumedPath(path) {
+		t.Fatalf("blank consumed pause generation did not fail closed with cause: blocker=%+v err=%v", blocker, err)
+	}
+}
+
+// Removing reserveResumeGoalTransition's pre-scan makes this call publish the
+// legacy redelivery path despite the existing native reservation.
+func TestRedeliveryPreReserveScanBlocksNativeWithoutPublishing(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	nativePath, _ := writeNativeResumeMutexReservation(t, tm, session, plan, "pause-pre-reserve")
+
+	err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan)
+	if err == nil || !strings.Contains(err.Error(), "before reserve") ||
+		!strings.Contains(err.Error(), filepath.Base(nativePath)) {
+		t.Fatalf("native reservation did not block before redelivery reserve: %v", err)
+	}
+	redeliveryPath, pathErr := resumeGoalTransitionPath(
+		tm.Project,
+		team.DefaultProfile,
+		session,
+		plan.TransitionID,
+	)
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(redeliveryPath); !os.IsNotExist(statErr) {
+		t.Fatalf("pre-reserve refusal still published redelivery reservation: %v", statErr)
+	}
+}
+
+// A pathname is not proof of ownership. The first scan excludes the exact
+// path only because its body carries the same redelivery kind and transition
+// id; changing the body at that path must turn it back into a blocker.
+func TestRedeliverySelfExclusionRequiresPathAndBodyIdentity(t *testing.T) {
+	tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+		t.Fatal(err)
+	}
+	path, err := resumeGoalTransitionPath(tm.Project, team.DefaultProfile, session, plan.TransitionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := resumeGoalRecoveryScanOptions{
+		LegacyKey:       plan.TransitionID,
+		TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+		TargetAttemptID: plan.OriginalAttemptID,
+		OwnPath:         path,
+		OwnTransitionID: plan.TransitionID,
+	}
+	if blocker, scanErr := scanResumeGoalRecoveryTransitions(filepath.Dir(path), opts); scanErr != nil || blocker != nil {
+		t.Fatalf("content-proven own reservation was not excluded: blocker=%+v err=%v", blocker, scanErr)
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record resumeGoalTransitionRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatal(err)
+	}
+	record.TransitionID = strings.Repeat("e", 64)
+	writeTestJSON(t, path, record)
+	blocker, scanErr := scanResumeGoalRecoveryTransitions(filepath.Dir(path), opts)
+	if scanErr != nil || blocker == nil ||
+		!strings.Contains(blocker.Reason, "disagrees with record transition id") {
+		t.Fatalf("changed body at own path was self-excluded: blocker=%+v err=%v", blocker, scanErr)
+	}
+}
+
+func TestRedeliveryScanBlocksMalformedAndOrphanCurrentEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(*testing.T, string)
+	}{
+		{
+			name: "malformed current reservation name",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				writeTestJSON(t, filepath.Join(dir, currentRecoveryTransitionPrefix+"bad-key.json"), map[string]string{})
+			},
+		},
+		{
+			name: "orphan current bound companion",
+			write: func(t *testing.T, dir string) {
+				t.Helper()
+				key := strings.Repeat("a", 64)
+				reservation := filepath.Join(
+					dir,
+					currentRecoveryTransitionName(recoveryTransitionKindNativeGoalResume, key),
+				)
+				writeTestJSON(t, resumeGoalTransitionBoundPath(reservation), map[string]string{
+					"transition_id": key,
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tm, session, _, plan, _ := freshResumeTransitionFixture(t)
+			dir := goalAttemptDir(tm.Project, team.DefaultProfile, session)
+			tc.write(t, dir)
+			blocker, err := scanResumeGoalRecoveryTransitions(dir, resumeGoalRecoveryScanOptions{
+				LegacyKey:       plan.TransitionID,
+				TargetNamespace: squadnamespace.ID(team.DefaultProfile, session),
+				TargetAttemptID: plan.OriginalAttemptID,
+			})
+			if err != nil || blocker == nil {
+				t.Fatalf("ambiguous current evidence did not block: blocker=%+v err=%v", blocker, err)
+			}
+		})
+	}
+}
+
+// This companion prevents an always-refuse implementation from satisfying the
+// race row: without a native competitor the production redelivery must reach
+// one pane send; with both reservations present its final validation must send
+// zero. Removing the redelivery-side rescan changes the second count to one.
+func TestRedeliveryNativeRaceChangesProductionDeliveryFromOneToZero(t *testing.T) {
+	for _, competitor := range []bool{false, true} {
+		name := "without native competitor"
+		if competitor {
+			name = "with native competitor"
+		}
+		t.Run(name, func(t *testing.T) {
+			tm, session, _, plan, verified := freshResumeTransitionFixture(t)
+			if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
+				t.Fatal(err)
+			}
+			var nativePath string
+			if competitor {
+				nativePath, _ = writeNativeResumeMutexReservation(t, tm, session, plan, "pause-race")
+			}
+
+			oldLister, oldSend := statusPaneLister, sendPromptToPane
+			statusPaneLister = func() ([]tmuxpane.TmuxPane, error) {
+				return []tmuxpane.TmuxPane{{
+					PaneID:  "%447",
+					CWD:     tm.Project,
+					Command: tm.Members[0].Binary,
+					Title:   paneTitleToken(session, plan.LeadRole),
+				}}, nil
+			}
+			sends := 0
+			sendPromptToPane = func(_ string, _ string) error {
+				sends++
+				return nil
+			}
+			t.Cleanup(func() {
+				statusPaneLister, sendPromptToPane = oldLister, oldSend
+			})
+
+			_, err := executeGoalDelivery(resumeGoalMutexOptions(tm, session, plan))
+			if !competitor {
+				if err != nil || sends != 1 {
+					t.Fatalf("anti-vacuity delivery failed: err=%v sends=%d", err, sends)
+				}
+				return
+			}
+			if err == nil || sends != 0 ||
+				!strings.Contains(err.Error(), "cross-kind claim-once mutex") {
+				t.Fatalf("both reservations did not suppress redelivery: err=%v sends=%d", err, sends)
+			}
+
+			nativeKey := strings.TrimSuffix(
+				strings.TrimPrefix(filepath.Base(nativePath), currentRecoveryTransitionPrefix+string(recoveryTransitionKindNativeGoalResume)+"-"),
+				".json",
+			)
+			nativeScan, scanErr := scanRecoveryTransitionsForPause(
+				goalAttemptDir(tm.Project, team.DefaultProfile, session),
+				nativeKey,
+				plan.TransitionID,
+			)
+			if scanErr != nil {
+				t.Fatal(scanErr)
+			}
+			if other := nativeScan.competingWith(nativePath); other == nil {
+				t.Fatal("native side did not refuse the concurrently reserved redelivery")
+			}
+			redeliveryPath, pathErr := resumeGoalTransitionPath(
+				tm.Project,
+				team.DefaultProfile,
+				session,
+				plan.TransitionID,
+			)
+			if pathErr != nil {
+				t.Fatal(pathErr)
+			}
+			for _, path := range []string{nativePath, redeliveryPath} {
+				if _, statErr := os.Stat(path); statErr != nil {
+					t.Fatalf("race refusal removed reservation %s: %v", path, statErr)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/resume_goal_test.go
+++ b/internal/cli/resume_goal_test.go
@@ -119,14 +119,51 @@ func freshResumeTransitionFixtureForBinary(t *testing.T, binary string) (team.Te
 	return tm, session, plans, plan, result
 }
 
+// The duplicate loser may be refused by the pre-reserve scan or by the atomic
+// link publication. The safety property is the same under either interleaving:
+// one successful caller leaves exactly one reservation at the expected identity.
+func assertExactlyOneResumeGoalTransitionReservation(t *testing.T, project, profile, session, transitionID string) {
+	t.Helper()
+	expectedPath, err := resumeGoalTransitionPath(project, profile, session, transitionID)
+	if err != nil {
+		t.Fatalf("derive expected transition path: %v", err)
+	}
+	entries, err := os.ReadDir(goalAttemptDir(project, profile, session))
+	if err != nil {
+		t.Fatalf("read transition directory: %v", err)
+	}
+	var reservations []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		switch _, recognition := recognizeRecoveryTransitionName(entry.Name()); recognition {
+		case recoveryNameRecognized:
+			reservations = append(reservations, entry.Name())
+		case recoveryNameMalformed:
+			// UNKNOWN IS NOT ABSENT. A transition-LIKE name we cannot classify might be a second reservation,
+			// and the production scanner treats it as BLOCKING evidence. Counting only recognized names would
+			// let this helper report "exactly one" while an unclassifiable artifact sat beside it -- the helper
+			// claiming more than it checks. Same rule the pause scan, the migration guard, and the read-back
+			// refusal all apply.
+			t.Fatalf("unclassifiable recovery-transition artifact %s beside the reservation: it cannot be shown "+
+				"NOT to be a second claim, so exactly-one cannot be established", entry.Name())
+		}
+	}
+	if len(reservations) != 1 || reservations[0] != filepath.Base(expectedPath) {
+		t.Fatalf("durable transition reservations = %v, want exactly [%s]", reservations, filepath.Base(expectedPath))
+	}
+}
+
 func TestResumeGoalTransitionNoReplaceAndPlannerFingerprint(t *testing.T) {
 	tm, session, plans, plan, verified := freshResumeTransitionFixture(t)
 	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err != nil {
 		t.Fatalf("reserve transition: %v", err)
 	}
-	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err == nil || !strings.Contains(err.Error(), "already exists") {
-		t.Fatalf("duplicate transition accepted: %v", err)
+	if err := reserveResumeGoalTransition(tm, team.DefaultProfile, session, verified, plan); err == nil {
+		t.Fatal("duplicate transition accepted")
 	}
+	assertExactlyOneResumeGoalTransitionReservation(t, tm.Project, team.DefaultProfile, session, plan.TransitionID)
 	blocked := buildResumeGoalPlan(tm, team.DefaultProfile, session, plans, false, false)
 	if blocked.Eligible || blocked.Action != "continue" || blocked.TransitionID != plan.TransitionID || blocked.TransitionState != "reserved" || blocked.TransitionDigest == "" || blocked.RecoveryAttemptID == "" || !strings.Contains(blocked.RecoveryCommand, "--resume-transition "+plan.TransitionID) || blocked.EvidenceDigest == plan.EvidenceDigest {
 		t.Fatalf("transition not included in read-only plan/fingerprint: %+v", blocked)
@@ -178,15 +215,14 @@ func TestResumeGoalTransitionConcurrentReservationHasOneWinner(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		if err := <-errs; err == nil {
 			success++
-		} else if strings.Contains(err.Error(), "already exists") {
-			refused++
 		} else {
-			t.Fatalf("unexpected concurrent reservation result: %v", err)
+			refused++
 		}
 	}
 	if success != 1 || refused != 1 {
 		t.Fatalf("concurrent reservation success=%d refused=%d", success, refused)
 	}
+	assertExactlyOneResumeGoalTransitionReservation(t, tm.Project, team.DefaultProfile, session, plan.TransitionID)
 }
 
 func TestResumeGoalTransitionRejectsLaunchRecordABA(t *testing.T) {


### PR DESCRIPTION
**Part of #498** (PR5 of the claim-once native `/goal resume` series).

Extends the recovery-transition ledger to serve **every** recovery kind rather than redelivery alone, routes redelivery's existing writer through the same constructor and publishers, and — new in round 2 — adds the **production caller** that makes an eligible live resume actually occur, a **shared record contract** with one owner, **read-back revalidation** against disk, and a **migration guard** over native claims.

Round 3 closes the five findings from an independent **codex convergence review**, which read this branch source-only and returned FAIL. All five were adjudicated at source, all five confirmed, none refuted.

## Round 2 corrects the residual that dominated round 1

Round 1's leading residual said the supervision executor was **dead code with no production caller**, so #498's eligible live resume could not occur from this branch at all. **That is no longer true, and this section replaces it rather than leaving it to be discovered.** `goal_supervise_resume.go` is the production surface; `executeSupervisionResume` is reached from it at line 365.

Why a *new* surface instead of wiring into an existing one: there was nothing to wire into. All three production consumers of `buildGoalSupervisionAssessment` (`status_board.go`, `status.go`, `doctor.go`) are **read-only reporters**, and no sweep, autonomy loop, or operator loop exists in `internal/cli` or `internal/autonomy`. Confirmed by grep before proposing, because "wire it into the existing actor" is the obvious answer and it was not available.

`--dry-run` is the inspection path an operator uses *before* enabling SafeAuto, and it is truly side-effect-free: no reservation, no bind, no consume, no directive publication, nothing written to disk, no pane input.

## Round 3: the codex convergence findings

An independent review found five defects the two-reviewer process had passed. Three were P1. They are listed with what actually failed, because the pattern matters more than the count: **every one of them is a defect class this milestone had already named somewhere else.**

- **[P1] A damaged consumed claim read as "another pause".** The scan recomputed the delivery-side match from an *unvalidated* `PauseGeneration`, so tampering with that one nonblank field — filename and `TransitionID` left intact — produced a different key, the prior consumption was classified as somebody else's pause, and redelivery proceeded. A body/filename identity mismatch is corruption, and corruption must block. This is *unknown is not absent* at the consumed-record seam.
- **[P1] Migration silently dropped consumption evidence.** The native-claim guard mirrored only one of the pause scan's **two** recognition steps, so `.consumed.json` companions classified as `NotATransition` and raised no blocker. The adapter copies them content-unchanged with basenames preserved, carrying the old namespace-derived claim key into the new namespace — where neither the consumed-state blocker nor the orphan-companion blocker can match it. Prior delivery becomes invisible to claim-once. The guard's own comment claimed it *could not* drift from the scanner; that claim was false, and it is what stopped a reader from looking.
- **[P1] The gates did not run immediately before pane input.** A durable directive — an `amq send` subprocess plus a receipt persist, of unbounded duration — sat between the last world-check and the bytes. `FreshUntil` could pass, the launch generation could change, the pane could go busy, with no re-check. The ratified text requires *both* directive-before-input and gates-immediately-before-**pane input**; the only order satisfying both is directive → gates → input, which is now what the boundary does. The diagnosis is worth more than the fix: the spec states this requirement twice with different wording ("immediately before delivery" vs "immediately before pane input") and I had coded to the looser phrasing while writing the tighter one in my own comment.
- **[P2] The contract accepted a `NewAttemptID` its own reader rejects.** `"../new"` is nonblank and differs from the original attempt, so it published — and then `goalAttemptPath` refuses it at delivery, leaving durable evidence nothing can consume and a pause blocked forever. Now validated through the reader's own owner, in the **shared** preamble so it covers both kinds and the read-back tamper path. Writer/reader disagreement, in the file whose header says it exists to prevent exactly that.
- **[P2] Proven non-delivery was reported as UNKNOWN.** Every error out of the delivery boundary set `DeliveryOutcomeUnknown`, including directive failures that provably produced zero pane input — contradicting the field's own documentation, which said it is set "ONLY on the pane-input error path". A typed marker now distinguishes proven non-delivery, with **unknown as the fail-closed default and a definite verdict requiring proof**. Reporting only: nothing releases, clears or deletes a reservation, because a self-deleting claim would manufacture the orphan-companion state of the finding above.

Two of these landed on my own fix work rather than on the original code, and both are recorded here because they are the more useful half of the review:

- The typed distinction in finding 5 was created for callers to branch on and **had zero readers and zero tests**. My first fix added the branch but left the type itself untested, so the batch preserved the exact defect it was closing. The cross-gate caught it.
- My first falsifier for that fix **fabricated the typed error inside a fake callback**, pinning the consumer while merely asserting the producer: reverting the boundary to a plain `fmt.Errorf` would have left the test green. Both halves are now driven through the real boundary.

## One decider, N call sites

The failure class this milestone kept hitting is **two places computing one thing and disagreeing**. Round 2 removes the remaining instances:

- **Shared record contract** (`recovery_transition_contract.go`) — a single per-kind validator called by the constructor, by publication, and by the disk read-back. Publication was previously a *subset* of the constructor's checks, so a record with all-zero binding interiors passed it. Three hand-maintained field lists were deleted in favour of the one validator.
- **Recomputed identity, not compared strings** — the contract recomputes `supervisionClaimKey(namespace, pauseGeneration, newAttemptID)` and requires the record's `TransitionID` to equal it. The earlier check derived the expected path *from* `record.TransitionID`, which is a tautology: it could not fail.
- **Read-back revalidation** (disk vs memory) — after publication the executor re-reads the persisted claim and runs the **full** publication contract on it, then compares `Supervisor` by equality. This is what gives the comparison two independent sides. A nil loader **refuses** rather than skipping, and an unreadable or malformed record refuses rather than reading as "nothing here".
- **Migration guard** (`namespace_migration_native_claims.go`) — the namespace planner refuses to migrate a source holding a native recovery claim, including one whose name it **cannot classify**. Unknown is not absent: an unclassifiable file might *be* a native claim, and migrating it corrupts the record we failed to read.

## The three publications do not share lost-race semantics

| publication | `!published` means |
|---|---|
| reserve | **refuse** — another actor holds the claim. This is claim-once. |
| bind | **re-read and validate**, not refuse. A binding may legitimately exist from this actor's earlier attempt; what matters is that it *agrees* about the launch generation. |
| consume | **refuse** — two consumptions of one claim is the double-delivery signature. |

A single publish-or-fail helper would read as a simplification and would convert bind's legitimate retry into a hard failure on every resumed delivery that had already bound. The uniformity would have been the bug, not the duplication.

## Consumed, never recomputed

`PauseGeneration` arrives from the assessment; PR4 owns its derivation. A second derivation owner reading a different snapshot is one identity with two owners, and the symptom is double delivery. The same applies to the launch generation `bind` consumes — re-reading it would bind the claim to a different moment than the one that authorised it.

`PreclaimFingerprint` is evidence and deliberately **not** part of the key: it rotates when claim evidence changes, and writing the claim is itself such a change, so a fingerprint-keyed claim would rotate its own identity as it was recorded and become unmatchable.

## Compatibility

The new record fields are `omitempty` because a legacy record carries none of them, so they must stay **absent** from its serialisation rather than appear as empty strings a reader could mistake for deliberate values. On read, absence means legacy/redeliver. On write, absence of a field the kind requires refuses.

Two independent compatibility proofs, neither substituting for the other:
- a legacy fixture built **through** `resumeGoalTransitionID`, proving the current reader recognises and blocks what the old writer produced (tracks the writer if it ever changes);
- a **fixed golden vector**, computed out of band, proving the persisted algorithm has not moved (catches the drift that would strand records already on disk while every same-helper assertion kept passing).

## Evidence

**Integration, round 3 head `3d7f5be`.** `make ci` exit 0 with the changed package proven **uncached** (`internal/cli` at 345.257s), so the green is an execution rather than a replay. Scoped by-name run: **237/237 top-level rows passed**, 0 failed, 0 skipped, 412 rows including subtests, `-count=1`. The filter was **regenerated from the tree** — `internal/cli` holds 2518 tests, so the prior "223" was always a scoped subset — and carries **zero phantoms**: every name resolves to a declaration, verified by set difference rather than assumed.

**Mutation, round 2: U10 36/36 KILLED, zero survivors.** 35 rows in the main window plus M-M2r; restore byte-identical, HEAD unchanged, 26-file manifest clean at both ends.

**Mutation, round 3: 6/6 KILLED, zero survivors**, one row per finding plus a second row for the ordering property. Every row's *named* expected killer fired. Preflight bound the run to the exact commit and a 166-file manifest, clean at both ends; restore byte-identical; 0 phantoms; harness pinned by hash.

- **M-W2 is the decisive row.** It was written to be *structurally unkillable* under the old code — the self-referential path check could not fail — and it died to the executor read-back drift test. Its death is evidence the tautology fix is real, not cosmetic.
- **M-M1** exists only because review rejected helper-only coverage; it kills through the planner, proving the guard is *wired* and not merely unit-tested. A guard connected to nothing survives call-site deletion, and the through-the-caller rule applies per guard, not per file.
- **M-M2 BUILD FAILED in the main window and was not counted as a kill.** My replacement was a string case against the int-based `recoveryNameRecognition`, so the row never compiled and tested nothing — a spec defect, reported as itself. Re-specified as **M-M2r** with a same-type substitution and re-run in a one-row window: KILLED, with the property-owning subtest `…/malformed_transition-like_name_refuses` firing by name.

**Remote CI on the fix commit.** [Run 30390330110](https://github.com/omriariav/amq-squad/actions/runs/30390330110) at head `3d7f5be` — the commit this description describes. Per lane:

| lane | result |
|---|---|
| `make ci` | **success** |
| real AMQ compatibility `v0.49.0` (pinned floor) | success |
| real AMQ compatibility `v0.49.1` (pinned floor) | success |
| real AMQ wake compatibility `v0.49.0` / `v0.49.1` / `latest` | success |
| real AMQ compatibility `latest` | **failure** — deferred, see below |

**The run's overall conclusion is `failure`, and that is stated rather than smoothed over**: it is attributable solely to the `latest` compatibility lane. Every merge-blocking lane — `make ci` and both pinned floors, plus all three wake lanes — is green.

The `latest` lane's signature was read **from the log**, not inferred from the lane name: its only failing subtest is `TestRealAMQCompatibility/doctor_repairs_malformed_configured_mailbox` against upstream **v0.49.9**. That is the exact known **#581** signature rather than a new failure shape introduced by the 0.49.8/0.49.9 releases — a distinction worth recording, because "the canary went red after an upstream bump" and "the one known canary failure recurred on a newer upstream" call for different follow-ups. Verification against 0.49.8/0.49.9 is postponed to **v2.25.1 / #584** by explicit operator decision, so this lane is a recorded deferral and not a finding against these fixes.

Round 2's evidence remains [run 30383436605](https://github.com/omriariav/amq-squad/actions/runs/30383436605) at the pre-fix head `5daf94ec`, retained as the record for that round only.

Every mutation asserts its anchor is present and unique before replacement, so a row that fails to apply reports a harness error rather than a survival.

## Residuals — please scope review to these

**Follow-ups for v2.26.0** (adopted as the tracked set; #583 is the umbrella):

1. **Migration claim-key recompute — a correctness bug, ranked above #583.** The migration path does not recompute the claim key under the destination namespace, so a migrated claim can carry an identity that no longer derives from its own scope.
2. **Empty-roster typed-gate defect.** `status --json` returns an empty members list, so no requester can validate a gate in this session. This is what parked the push behind a gate that could not be satisfied.
3. **`LaunchStartedAt` is not persisted**, so it cannot participate in any durable freshness comparison.
4. **Relative-project cwd coupling in `goalAttemptDir`** — the path resolves against the process working directory rather than the frozen project root.
5. **M-M2r minimality note.** The M-M2r mutation is a **swap, not a pure deletion**: substituting `recoveryNameMalformed` → `recoveryNameNotATransition` removes malformed handling *and* routes ordinary non-transition files into the blocker branch, which is why `TestHelperAllowsANamespaceWithOnlyLegacyRedeliveryRecords` also failed. The kill is valid — the named killer and its property-owning subtest both fired — but the row does not *isolate* the removal from the inversion it also introduces. Recorded as a precision limitation, not missing evidence.

6. **D-3a/D-3b do not isolate presence from ordering.** Both round-3 rows for the gate — deleting it, and moving it above the directive — kill *both* the presence test and the sequence test. The ordering property is genuinely pinned, since D-3b leaves the gate present and still refusing yet dies to the sequence assertion, which no presence-only suite could catch. But it is pinned by two tests rather than one, because the fixture-integrity assertions double as order checks. Redundancy, not a gap; recorded as a precision limitation.

**Dependency.** Depends on PR4 (#580); base `27584d2` contains it, verified by ancestry rather than by pairing two claims.

**Binding acceptance specification.** Round 2 is authored against the unified acceptance specification U1–U11 as amended, identified by hash so it is verifiable rather than described:

- `pr582-r2-unified-acceptance.md`, 353 lines, `sha256 ac22784a8b38e45c8d211a29000589766aaa3c0b348f53e36451a7b33ec43a42` (supersedes the 254-line `c5932eb5…` copy cited in the round-1 body)
- **A1** — operator-authorized easing of *non-safety* evidence breadth. The safety bar did not move: everything guarding double-delivery, wrong-target delivery, stale delivery, or claim-once bypass stays at full depth.
- **A2** — U1 invocation/payload split and the strong dry-run contract.
- **A3** — Executable Actions template and complete metadata binding: the canonical `goal supervise-resume` invocation carries `--attempt-id` and `--assessment-fingerprint`, both validated against a freshly rebuilt assessment, and `--supervisor` as an explicit operator-owned placeholder following the #579 never-invent precedent. A literal, blank, or omitted placeholder refuses. A3 **strengthens** A2 and eases nothing.

A3's payload-loader note is worth a reviewer's attention: injection is what makes loader substitution *possible* and is not itself the security boundary. Security comes from both loader equalities agreeing with the independent durable `Binding.Goal.CommandDigest`. The comments and tests state this directly rather than claiming an injected dependency is inherently non-substitutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


