### PR TITLE
Release v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 > [v2.21.0](docs/v2.21.0-release-notes.md),
 > [v2.22.0](docs/v2.22.0-release-notes.md),
 > [v2.23.0](docs/v2.23.0-release-notes.md),
-> [v2.23.1](docs/v2.23.1-release-notes.md), and
-> [v2.24.0](docs/v2.24.0-release-notes.md).
+> [v2.23.1](docs/v2.23.1-release-notes.md),
+> [v2.24.0](docs/v2.24.0-release-notes.md), and
+> [v2.25.0](docs/v2.25.0-release-notes.md).
 >
 > **v2.23.1 reconciliation index:** the canonical note records the exact Go
 > 1.25.12 requirement; lead-only staged admission/replacement; exact-authorizer,

--- a/GOAL.md
+++ b/GOAL.md
@@ -80,9 +80,9 @@ acceptance boundary. Canonical release detail remains in `docs/vX.Y.Z-release-no
   become the pane's own process instead of typed input, previews consult the
   predicate admission enforces, and launch identity is stamped at capture so
   incomplete records stop reading as mismatches.
-- Raise the AMQ floor to 0.49.0 as the sole supported series, collapse the CI
-  matrices onto it, and let the skills leverage the CLI instead of re-deriving
-  it in prose.
+- Adopt AMQ 0.49.x as the supported series with 0.49.0 as the minimum supported
+  release and compatibility tested through 0.49.1, collapse the CI matrices onto
+  it, and let the skills leverage the CLI instead of re-deriving it in prose.
 - Definition of done: every implementation slice is reviewed at an exact commit,
   the full compatibility/CI matrix passes, safety-critical guards carry mutation
   evidence with zero survivors, and merge/tag/release remain separate verified

--- a/GOAL.md
+++ b/GOAL.md
@@ -27,7 +27,7 @@ from one place.**
   (isolated tmux `-L`, never the default socket) — not just `Update`-level unit tests.
   (Lesson from the NOC nav bug that passed unit tests 4x while broken on screen.)
 
-## Version ladder (current as of v2.23.1)
+## Version ladder (current as of v2.24.0)
 
 The old 2.1.0–2.3.0 roadmap mixed aspirations with release claims long after the
 product had moved on. The ladder now separates shipped foundations from the next
@@ -54,21 +54,41 @@ acceptance boundary. Canonical release detail remains in `docs/vX.Y.Z-release-no
   closed the major split-brain paths between CLI state and the AMQ bus.
 - Prepared launches, staged admission, exact runtime identity, terminal recovery,
   and bound command evidence made launch and review outcomes reproducible.
-- v2.23.1 is the current released baseline. Its exact claims and compatibility
-  floor are recorded in `docs/v2.23.1-release-notes.md`.
+- v2.23.1 closed this band. Its exact claims and compatibility floor are
+  recorded in `docs/v2.23.1-release-notes.md`.
 
-### 2.24.0 — Current target: control, scale, and squad reuse
-- Complete the human control loop: preview and explicitly confirm console replies,
-  gate approvals/denials, arbitrary-agent messages, and squad broadcasts; every
-  AMQ write must expose a stable message id and durable receipt.
-- Harden delivery against AMQ 0.46 behavior, add deterministic isolated-worktree
-  ownership, improve reusable squad/roster flows, and make model economics
-  visible without weakening actor-relative policy.
+### 2.24.0 — Shipped: control, scale, and squad reuse
+- The human control loop is explicit: console replies, gate approvals/denials,
+  arbitrary-agent messages and squad broadcasts are previewed and confirmed, and
+  every AMQ write exposes a stable message id and a durable receipt.
+- Delivery was hardened against AMQ 0.46 behavior, isolated-worktree ownership
+  became deterministic and enforced, reusable squad/roster flows landed, and
+  model economics became visible advisory data without weakening actor-relative
+  policy.
+- v2.24.0 is the previous released baseline; its exact claims and compatibility
+  floor are recorded in `docs/v2.24.0-release-notes.md`.
+
+### 2.25.0 — Current target: delivery safety and exact identity at the pane
+- Make automatic recovery of a paused native `/goal` run safe enough to run
+  unattended: one owner for the recovery-transition record and its path, one CAS
+  layer for publication, one shared contract validated at construction, at
+  publication and on read-back, and delivery-time revalidation of launch
+  generation, exact pane state and assessment freshness immediately before pane
+  input. Claim-once must be structural rather than procedural, and an unknown
+  delivery result must remain indeterminate rather than be retried.
+- Remove the delivery paths that could report partial success: worker commands
+  become the pane's own process instead of typed input, previews consult the
+  predicate admission enforces, and launch identity is stamped at capture so
+  incomplete records stop reading as mismatches.
+- Raise the AMQ floor to 0.49.0 as the sole supported series, collapse the CI
+  matrices onto it, and let the skills leverage the CLI instead of re-deriving
+  it in prose.
 - Definition of done: every implementation slice is reviewed at an exact commit,
-  the full compatibility/CI matrix passes, and merge/tag/release remain separate
-  verified operator-gated actions.
+  the full compatibility/CI matrix passes, safety-critical guards carry mutation
+  evidence with zero survivors, and merge/tag/release remain separate verified
+  operator-gated actions.
 
-**Multi-root console feasibility (not a 2.24.0 implementation claim):** the console
+**Multi-root console feasibility (not an implementation claim in any release to date):** the console
 currently owns one canonical project/profile/base-root context, and its action
 confirmations deliberately re-resolve inside that boundary. A trustworthy
 multi-root NOC needs an explicit neutral-root discovery model plus a per-row

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,39 @@ session state does **not** need to be migrated.
 
 This guide covers everything you have to change.
 
+## What's new in 2.25.0: claim-once goal resume, AMQ 0.49.0 floor
+
+**Action required if you pin AMQ below 0.49.0.** 2.25.0 raises the floor: AMQ
+0.49.0 is the minimum supported release and compatibility is tested through
+0.49.1. Releases older than 0.49.0 are rejected rather than degraded, so
+upgrade `amq` before upgrading amq-squad. `latest` is exercised in CI as a
+forward-compatibility canary and is not a support claim.
+
+**No schema migration.** `team.json` and the goal-attempt record schema are
+unchanged. The recovery-transition record's new fields are `omitempty`, so a
+record written by an earlier version continues to serialise without them and
+continues to be read as a legacy redelivery record — absence means legacy, and
+a field a kind requires is refused on write rather than defaulted.
+
+**One new refusal to be aware of.** A namespace holding a native recovery
+claim now refuses to migrate until that claim is consumed, because the claim
+key is derived from the namespace and rewriting profile/session without
+recomputing it would leave a record that reads as absent — and absent means
+"no prior claim", which is a second delivery. This replaces silent corruption
+with an explicit refusal; consume or resolve the claim, then migrate.
+
+Paused native `/goal` runs can now be resumed automatically under `SafeAuto`
+policy via `goal supervise-resume`, with `--dry-run` as a side-effect-free
+inspection path. Worker commands are delivered as the pane's own process
+instead of being typed, so a long command can no longer be truncated into a
+partial launch reported as success. `resume` previews now consult the
+predicate admission enforces. Launch ids are stamped at capture so incomplete
+records are distinguished from genuine identity mismatches.
+
+See [the v2.25.0 release notes](docs/v2.25.0-release-notes.md) for the
+complete issue-to-behavior map, the safety-evidence summary, and residual
+risks.
+
 ## What's new in 2.24.0: squad reuse, enforced worktree isolation, advisory model routing
 
 2.24.0 keeps the AMQ 0.42.1 compatibility floor; AMQ 0.46 delivery-model

--- a/README.html
+++ b/README.html
@@ -374,10 +374,11 @@ rejects.</li>
 <li><strong>Launch id stamped at capture (#572).</strong> Incomplete
 launch records are distinguished from genuine mismatches, so an identity
 refusal stops obscuring an earlier partial-launch failure.</li>
-<li><strong>AMQ 0.49.0 is the sole supported series (#557,
-#533).</strong> The floor is raised, the CI matrices collapse, and the
-0.47–0.49 trace/doctor additions can be relied on. Releases older than
-0.49.0 are rejected.</li>
+<li><strong>AMQ 0.49.x is the supported series, minimum 0.49.0 (#557,
+#533).</strong> The floor is raised and compatibility is tested through
+0.49.1, the CI matrices collapse, and the 0.47–0.49 trace/doctor
+additions can be relied on. Releases older than 0.49.0 are
+rejected.</li>
 <li><strong>Skills leverage the CLI (#534).</strong> The authoritative
 skills were rewritten to reach for the binary instead of re-deriving it
 in prose, identity moved to frontmatter, <code>docs/skills.md</code>

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2240" id="toc-whats-new-in-v2240">What's new
-in v2.24.0</a></li>
+<li><a href="#whats-new-in-v2250" id="toc-whats-new-in-v2250">What's new
+in v2.25.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2240">What's new in v2.24.0</a></li>
+<li><a href="#whats-new-in-v2250">What's new in v2.25.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,71 +342,74 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2240">What's new in v2.24.0</h2>
-<p>v2.24.0 focuses on squad reuse, enforced worktree isolation, and
-advisory model economics across the lead-orchestrated lifecycle:</p>
+<h2 id="whats-new-in-v2250">What's new in v2.25.0</h2>
+<p>v2.25.0 is a delivery-safety and identity release, headlined by
+claim-once automatic resume for paused native <code>/goal</code>
+runs:</p>
 <ul>
-<li><strong>Squad reuse (#523, #451).</strong>
-<code>run start --from-profile</code> clones an existing profile's
-roster into a new session-pinned profile instead of dead-ending on the
-pinned-session refusal; <code>--no-session-pin</code> creates
-first-class unpinned template profiles launchable for any workstream;
-<code>team member update</code> maintains members (including the lead)
-in place; the wizard offers the clone path and presents templates in
-both adapters.</li>
-<li><strong>AMQ 0.46 delivery model (#524).</strong> The durable inbox
-is the contract, wake injection is an optimization. Resume goal
-redelivery is an explicit post-baseline re-send with fail-closed lead
-readiness verification; lead register/register-orchestrator adopt
-version-gated <code>wake --baseline-existing</code> (floor 0.42.1
-unchanged).</li>
-<li><strong>Enforced isolated worktrees (#497).</strong> A durable
-WorktreePlan store backs a deterministic <code>worktree</code>
-plan/materialize/activate/handoff/cleanup CLI with refusal-first safety
-(never overwrite, never delete unknown, git-registered cleanup only); a
-planning-level fail-closed readiness gate blocks squads where 2+
-mutation-capable developers would otherwise share one working directory,
-with an explicit
-<code>team shared-cwd-exception set "&lt;reason&gt;"</code> escape
-hatch; generated team-rules policy and actor-relative bootstrap
-worktree-identity blocks make the posture visible to every agent; the
-wizard surfaces a composition-time advisory.</li>
-<li><strong>NOC control plane (#515).</strong> The console action
-palette (Reply/Approve/Deny/Message/Broadcast) is wired through
-<code>internal/act</code> with staged preview and dedicated
-confirmation; first-class preview-by-default <code>operator send</code>
-and <code>broadcast</code> verbs (<code>--yes</code> to mutate, durable
-receipts); generic sends refuse <code>gate/*</code> so gate authority
-stays on the typed operator-answer path.</li>
-<li><strong>Model economics (#496).</strong> Advisory task-aware
-model/effort routing: six work classes as data, per-role recommendations
-with rationale/source/ confidence in the wizard (both adapters) and
-preparation review rows; planner-lead recommendation for multi-worker
-squads. Advisory only — the operator always overrides.</li>
-<li><strong>Tree-equivalence review rebinding (#418).</strong>
-<code>verify rebind</code> proves tree identity or conservative scoped
-patch identity between a reviewed head and a rebuilt head, records an
-immutable tamper-evident artifact, and <code>verify merge</code> accepts
-the carried review only after re-proving from Git objects; semantic
-deltas fail closed.</li>
-<li><strong>Pane keyboard-loss fix (#525).</strong> Every scheduled
-<code>tmux run-shell -b</code> helper (Claude session rename, layout
-finalization) is now silent and zero-exit by construction; a target pane
-that is already gone is a benign no-op. Diagnostics land in
-<code>.amq-squad/run-shell.log</code> instead of a view-mode overlay
-that made panes appear keyboard-dead.</li>
+<li><strong>Goal supervisor claim-once resume (#498).</strong> An
+eligible paused native <code>/goal</code> run can be resumed
+automatically under <code>SafeAuto</code> policy via
+<code>goal supervise-resume</code>, with a genuinely side-effect-free
+<code>--dry-run</code> inspection path. One constructor owns the
+recovery-transition record and its path, one CAS layer owns publication,
+and one shared per-kind contract validates the record at construction,
+at publication, and again on read-back from disk. Record identity is
+recomputed from the fields that generate it rather than compared against
+itself. <code>reserve</code> and <code>consume</code> refuse a lost race
+while <code>bind</code> re-reads and validates, because those three do
+not share lost-race semantics. Delivery re-checks launch generation,
+exact pane state and assessment freshness immediately before pane input;
+any drift produces zero pane input and leaves the claim indeterminate
+rather than retried. Unknown pane input is a first-class third outcome
+that is never auto-retried, and every automatic delivery leaves a
+durable audit record written before the pane is touched.</li>
+<li><strong>Worker commands are the pane process (#571).</strong> Long
+commands are no longer typed via <code>send-keys</code>, where
+truncation could report a partial team launch as a success.</li>
+<li><strong>Resume preview matches admission (#573).</strong> The
+preview now consults the same predicate admission enforces, so the
+<code>agent up</code> commands it offers are not ones admission always
+rejects.</li>
+<li><strong>Launch id stamped at capture (#572).</strong> Incomplete
+launch records are distinguished from genuine mismatches, so an identity
+refusal stops obscuring an earlier partial-launch failure.</li>
+<li><strong>AMQ 0.49.0 is the sole supported series (#557,
+#533).</strong> The floor is raised, the CI matrices collapse, and the
+0.47–0.49 trace/doctor additions can be relied on. Releases older than
+0.49.0 are rejected.</li>
+<li><strong>Skills leverage the CLI (#534).</strong> The authoritative
+skills were rewritten to reach for the binary instead of re-deriving it
+in prose, identity moved to frontmatter, <code>docs/skills.md</code>
+became per-skill references, and a <code>check-skill-commands</code>
+drift gate is wired into <code>make ci</code>.</li>
+<li><strong>Deterministic global/NOC mode (#454, #455).</strong> The
+wake-registered orchestrator pattern is a deterministic bootstrap rather
+than a pasted directive, with managed notification watch, a read-only
+global status board, and a wizard scope flow carrying trust posture and
+a wake-first contract.</li>
+<li><strong>Launch, profile and config robustness (#535, #536, #537,
+#538, #539, #540, #513, #560).</strong> Stale launch records no longer
+poison profile resolution, path representation is normalized at one
+choke point, repeated role-map flags stop dropping earlier values, Codex
+MCP subtables parse, and <code>GO_FILES</code> no longer descends into
+<code>.worktrees/</code>.</li>
 </ul>
-<p>AMQ floor remains 0.42.1; AMQ 0.46 features are version-gated.
-team.json schema is unchanged (additive optional fields only).</p>
-<p>See <a href="docs/v2.24.0-release-notes.md">the v2.24.0 release
-notes</a> for the complete issue-to-behavior map and residual risks.</p>
+<p><strong>Breaking:</strong> AMQ 0.49.0 is the minimum supported
+release; compatibility is tested through 0.49.1. team.json and the
+goal-attempt schema remain backward compatible, and the new
+recovery-transition fields are <code>omitempty</code> so legacy records
+still read as legacy.</p>
+<p>See <a href="docs/v2.25.0-release-notes.md">the v2.25.0 release
+notes</a> for the complete issue-to-behavior map, the safety-evidence
+summary, and residual risks.</p>
 <h2 id="install">Install</h2>
 <p>Install the v2 module path:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@latest</span>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.24.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -1111,9 +1114,9 @@ implicit default. Two or more <code>full</code> members duplicate
 MCP/plugin context and increase memory and concurrency pressure, so the
 review screen warns before that configuration proceeds.</p>
 <p>Model guidance is intentionally skill-owned because it changes faster
-than the binary. For v2.24.0, use the current model family and per-role
-model/effort recommendations in the installed v2.24.0 skills; confirm
-the startup marker <code>amq-squad skill v2.24.0</code> matches
+than the binary. For v2.25.0, use the current model family and per-role
+model/effort recommendations in the installed v2.25.0 skills; confirm
+the startup marker <code>amq-squad skill v2.25.0</code> matches
 <code>amq-squad version</code>. Treat cost as a tie-breaker after output
 quality for shippable work, and prefer installed-skill guidance over
 copying model examples from this README.</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.24.0](#whats-new-in-v2240)
+- [What's new in v2.25.0](#whats-new-in-v2250)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,58 +38,60 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.24.0
+## What's new in v2.25.0
 
-v2.24.0 focuses on squad reuse, enforced worktree isolation, and advisory
-model economics across the lead-orchestrated lifecycle:
+v2.25.0 is a delivery-safety and identity release, headlined by claim-once
+automatic resume for paused native `/goal` runs:
 
-- **Squad reuse (#523, #451).** `run start --from-profile` clones an existing
-  profile's roster into a new session-pinned profile instead of dead-ending on
-  the pinned-session refusal; `--no-session-pin` creates first-class unpinned
-  template profiles launchable for any workstream; `team member update`
-  maintains members (including the lead) in place; the wizard offers the clone
-  path and presents templates in both adapters.
-- **AMQ 0.46 delivery model (#524).** The durable inbox is the contract, wake
-  injection is an optimization. Resume goal redelivery is an explicit
-  post-baseline re-send with fail-closed lead readiness verification; lead
-  register/register-orchestrator adopt version-gated `wake --baseline-existing`
-  (floor 0.42.1 unchanged).
-- **Enforced isolated worktrees (#497).** A durable WorktreePlan store backs a
-  deterministic `worktree` plan/materialize/activate/handoff/cleanup CLI with
-  refusal-first safety (never overwrite, never delete unknown, git-registered
-  cleanup only); a planning-level fail-closed readiness gate blocks squads
-  where 2+ mutation-capable developers would otherwise share one working
-  directory, with an explicit `team shared-cwd-exception set "<reason>"`
-  escape hatch; generated team-rules policy and actor-relative bootstrap
-  worktree-identity blocks make the posture visible to every agent; the wizard
-  surfaces a composition-time advisory.
-- **NOC control plane (#515).** The console action palette
-  (Reply/Approve/Deny/Message/Broadcast) is wired through `internal/act` with
-  staged preview and dedicated confirmation; first-class preview-by-default
-  `operator send` and `broadcast` verbs (`--yes` to mutate, durable receipts);
-  generic sends refuse `gate/*` so gate authority stays on the typed
-  operator-answer path.
-- **Model economics (#496).** Advisory task-aware model/effort routing: six
-  work classes as data, per-role recommendations with rationale/source/
-  confidence in the wizard (both adapters) and preparation review rows;
-  planner-lead recommendation for multi-worker squads. Advisory only — the
-  operator always overrides.
-- **Tree-equivalence review rebinding (#418).** `verify rebind` proves tree
-  identity or conservative scoped patch identity between a reviewed head and a
-  rebuilt head, records an immutable tamper-evident artifact, and `verify
-  merge` accepts the carried review only after re-proving from Git objects;
-  semantic deltas fail closed.
-- **Pane keyboard-loss fix (#525).** Every scheduled `tmux run-shell -b` helper
-  (Claude session rename, layout finalization) is now silent and zero-exit by
-  construction; a target pane that is already gone is a benign no-op.
-  Diagnostics land in `.amq-squad/run-shell.log` instead of a view-mode overlay
-  that made panes appear keyboard-dead.
+- **Goal supervisor claim-once resume (#498).** An eligible paused native
+  `/goal` run can be resumed automatically under `SafeAuto` policy via `goal
+  supervise-resume`, with a genuinely side-effect-free `--dry-run` inspection
+  path. One constructor owns the recovery-transition record and its path, one
+  CAS layer owns publication, and one shared per-kind contract validates the
+  record at construction, at publication, and again on read-back from disk.
+  Record identity is recomputed from the fields that generate it rather than
+  compared against itself. `reserve` and `consume` refuse a lost race while
+  `bind` re-reads and validates, because those three do not share lost-race
+  semantics. Delivery re-checks launch generation, exact pane state and
+  assessment freshness immediately before pane input; any drift produces zero
+  pane input and leaves the claim indeterminate rather than retried. Unknown
+  pane input is a first-class third outcome that is never auto-retried, and
+  every automatic delivery leaves a durable audit record written before the
+  pane is touched.
+- **Worker commands are the pane process (#571).** Long commands are no longer
+  typed via `send-keys`, where truncation could report a partial team launch as
+  a success.
+- **Resume preview matches admission (#573).** The preview now consults the
+  same predicate admission enforces, so the `agent up` commands it offers are
+  not ones admission always rejects.
+- **Launch id stamped at capture (#572).** Incomplete launch records are
+  distinguished from genuine mismatches, so an identity refusal stops
+  obscuring an earlier partial-launch failure.
+- **AMQ 0.49.0 is the sole supported series (#557, #533).** The floor is
+  raised, the CI matrices collapse, and the 0.47–0.49 trace/doctor additions
+  can be relied on. Releases older than 0.49.0 are rejected.
+- **Skills leverage the CLI (#534).** The authoritative skills were rewritten
+  to reach for the binary instead of re-deriving it in prose, identity moved to
+  frontmatter, `docs/skills.md` became per-skill references, and a
+  `check-skill-commands` drift gate is wired into `make ci`.
+- **Deterministic global/NOC mode (#454, #455).** The wake-registered
+  orchestrator pattern is a deterministic bootstrap rather than a pasted
+  directive, with managed notification watch, a read-only global status board,
+  and a wizard scope flow carrying trust posture and a wake-first contract.
+- **Launch, profile and config robustness (#535, #536, #537, #538, #539, #540,
+  #513, #560).** Stale launch records no longer poison profile resolution, path
+  representation is normalized at one choke point, repeated role-map flags stop
+  dropping earlier values, Codex MCP subtables parse, and `GO_FILES` no longer
+  descends into `.worktrees/`.
 
-AMQ floor remains 0.42.1; AMQ 0.46 features are version-gated. team.json
-schema is unchanged (additive optional fields only).
+**Breaking:** AMQ 0.49.0 is the minimum supported release; compatibility is
+tested through 0.49.1. team.json and the goal-attempt schema remain backward
+compatible, and the new recovery-transition fields are `omitempty` so legacy
+records still read as legacy.
 
-See [the v2.24.0 release notes](docs/v2.24.0-release-notes.md) for the
-complete issue-to-behavior map and residual risks.
+See [the v2.25.0 release notes](docs/v2.25.0-release-notes.md) for the
+complete issue-to-behavior map, the safety-evidence summary, and residual
+risks.
 
 ## Install
 
@@ -103,7 +105,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.24.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -635,9 +637,9 @@ broad and assigns each built-in worker its catalog-minimum profile. Choosing
 pressure, so the review screen warns before that configuration proceeds.
 
 Model guidance is intentionally skill-owned because it changes faster than the
-binary. For v2.24.0, use the current model family and per-role model/effort
-recommendations in the installed v2.24.0 skills; confirm the startup marker
-`amq-squad skill v2.24.0` matches `amq-squad version`. Treat cost as a
+binary. For v2.25.0, use the current model family and per-role model/effort
+recommendations in the installed v2.25.0 skills; confirm the startup marker
+`amq-squad skill v2.25.0` matches `amq-squad version`. Treat cost as a
 tie-breaker after output quality for shippable work, and prefer installed-skill
 guidance over copying model examples from this README.
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ automatic resume for paused native `/goal` runs:
 - **Launch id stamped at capture (#572).** Incomplete launch records are
   distinguished from genuine mismatches, so an identity refusal stops
   obscuring an earlier partial-launch failure.
-- **AMQ 0.49.0 is the sole supported series (#557, #533).** The floor is
-  raised, the CI matrices collapse, and the 0.47–0.49 trace/doctor additions
-  can be relied on. Releases older than 0.49.0 are rejected.
+- **AMQ 0.49.x is the supported series, minimum 0.49.0 (#557, #533).** The
+  floor is raised and compatibility is tested through 0.49.1, the CI matrices
+  collapse, and the 0.47–0.49 trace/doctor additions can be relied on. Releases
+  older than 0.49.0 are rejected.
 - **Skills leverage the CLI (#534).** The authoritative skills were rewritten
   to reach for the binary instead of re-deriving it in prose, identity moved to
   frontmatter, `docs/skills.md` became per-skill references, and a

--- a/docs/v2.25.0-release-notes.md
+++ b/docs/v2.25.0-release-notes.md
@@ -9,9 +9,9 @@ that one audited resume can never become two. Around that, worker commands are
 delivered as the pane's own process instead of being typed into it, the resume
 preview now consults the predicate admission actually enforces, launch identity
 is stamped at capture so incomplete records stop masquerading as mismatches,
-and AMQ 0.49.0 becomes the sole supported series. The plugin skills were
-rewritten to leverage the CLI rather than re-derive it, and global/NOC mode
-became a deterministic bootstrap instead of a pasted directive.
+and AMQ 0.49.x becomes the supported series with 0.49.0 as the minimum. The
+plugin skills were rewritten to leverage the CLI rather than re-derive it, and
+global/NOC mode became a deterministic bootstrap instead of a pasted directive.
 
 This release also carries an unusually thorough verification record for #498 —
 including an independent third review that found five defects two reviewers had
@@ -32,6 +32,29 @@ passed — which is summarized under **Safety evidence** below.
   record's identity is *recomputed* from the fields that generate it rather
   than compared against itself, so an id no scanner would derive is refused
   instead of being silently unmatchable.
+- **The record IS the recovery contract, so the schema is exhaustive rather than
+  convenient.** A native reservation must be sufficient to revalidate the exact
+  observation that authorized it, not merely to derive a filename. The current
+  native record carries: `SchemaVersion`; `TransitionID`;
+  `RecoveryKind = native_goal_resume`; the scope and namespace
+  (`Binding.Project`, `Binding.Profile`, `Binding.Session`,
+  `Binding.NamespaceID`); the lead identity (`LeadRole`, `LeadHandle`);
+  `LaunchID`; the exact pane (`Binding.Pane.PaneID`); the goal binding
+  (`Binding.Goal.Mode`, `Binding.Goal.BindingDigest`,
+  `Binding.Goal.AttemptID`, `Binding.Goal.CommandDigest`); the blocker
+  (`Blocker.ID`, `Blocker.ResolutionDigest`); the policy (`Policy.Mode`,
+  `Policy.Revision`); the assessment-captured `PauseGeneration`; the
+  assessment's own `Fingerprint` recorded as `PreclaimFingerprint`; an explicit
+  `Supervisor`; and a native `NewAttemptID` equal to the same nonblank
+  `Binding.Goal.AttemptID`. None of these is recomputed — each is consumed
+  from the single observation that authorized the claim, because a second
+  derivation owner reading a different snapshot is one identity with two
+  owners, and the symptom is double delivery.
+- The **bound companion** stores the assessment-captured launch digest and
+  modtime, which is what delivery-time revalidation compares against. Per-kind
+  validation runs over this exact schema at construction, at publication, and
+  again on read-back from disk, so a record that satisfies one call site cannot
+  fail another.
 - The three publications deliberately do **not** share lost-race semantics:
   `reserve` refuses (another actor holds the claim), `bind` re-reads and
   validates (a binding may legitimately exist from this actor's earlier
@@ -81,9 +104,9 @@ failure. The launch id is now stamped when the record is captured, and
 incomplete records are distinguished from genuine mismatches so the reported
 error names the real problem.
 
-## AMQ 0.49.0 is the sole supported series (#557 and #533, PRs #558 and #555)
+## AMQ 0.49.x is the supported series (#557 and #533, PRs #558 and #555)
 
-The compatibility floor is raised: 0.49.0 is the minimum supported release and
+AMQ 0.49.x is the supported series: 0.49.0 is the minimum supported release and
 compatibility is tested through 0.49.1. The CI matrices collapse accordingly,
 and the trace/doctor additions in the 0.47–0.49 line are now available to be
 relied on rather than feature-detected. **This is a breaking change for
@@ -97,12 +120,13 @@ moved into frontmatter, `docs/skills.md` was split into per-skill references
 with the pointer reversed, and a `check-skill-commands` drift gate is wired
 into `make ci` so a skill cannot document a command the binary does not expose.
 
-## Global / NOC mode is deterministic (#454 and #455, PRs #556, #576, #574 and #568)
+## Global / NOC mode is deterministic (#454 and #455)
 
 The wake-registered orchestrator pattern became a deterministic bootstrap
-rather than a pasted directive, with managed AMQ notification watch, a
-read-only global NOC status board, and a wizard scope flow that adds a trust
-posture step, a wake-first contract, and a window hint.
+rather than a pasted directive (PR #556), with managed AMQ notification watch
+(PR #576), a read-only global NOC status board (PR #574), and a wizard scope
+flow that adds a trust posture step, a wake-first contract, and a window hint
+(PR #568).
 
 ## Launch, profile and configuration robustness
 
@@ -131,9 +155,10 @@ failure mode is a second audited resume against a live agent.
   replay. A scoped by-name run covering the #498 surface and its neighbours
   passed 237/237 top-level rows, with the filter regenerated from the test
   tree and verified to contain zero phantom names.
-- **Mutation testing: 42/42 killed, zero survivors.** 36 rows in the main
-  window plus a re-specified row, and 6 more in a delta window covering the
-  fixes below. Every row asserts its anchor is present and unique before
+- **Mutation testing: 42/42 killed, zero survivors.** The decomposition is 35
+  kills in the main window, plus one re-specified row replacing a row that
+  failed to compile (36 for that round), plus 6 in a delta window covering
+  the fixes below. Every row asserts its anchor is present and unique before
   replacement and verifies a byte-identical restore afterwards, so a row that
   fails to apply reports a harness error rather than a survival. One row that
   failed to compile was recorded as a specification defect and explicitly not

--- a/docs/v2.25.0-release-notes.md
+++ b/docs/v2.25.0-release-notes.md
@@ -1,0 +1,203 @@
+# amq-squad v2.25.0
+
+## Summary
+
+v2.25.0 is a delivery-safety and identity release. Its headline is the goal
+supervisor's **claim-once native resume**: an eligible paused `/goal` run can
+now be resumed automatically, and the ledger that authorizes it is built so
+that one audited resume can never become two. Around that, worker commands are
+delivered as the pane's own process instead of being typed into it, the resume
+preview now consults the predicate admission actually enforces, launch identity
+is stamped at capture so incomplete records stop masquerading as mismatches,
+and AMQ 0.49.0 becomes the sole supported series. The plugin skills were
+rewritten to leverage the CLI rather than re-derive it, and global/NOC mode
+became a deterministic bootstrap instead of a pasted directive.
+
+This release also carries an unusually thorough verification record for #498 —
+including an independent third review that found five defects two reviewers had
+passed — which is summarized under **Safety evidence** below.
+
+## Goal supervisor: claim-once native resume (#498, PRs #580 and #582)
+
+- A paused native `/goal` run that is eligible for resume can be resumed
+  automatically under `SafeAuto` policy. `goal supervise-resume` is the
+  production surface; `--dry-run` is the inspection path an operator uses
+  before enabling it, and it is genuinely side-effect-free: no reservation, no
+  bind, no consume, no directive publication, nothing written to disk, no pane
+  input.
+- **Claim-once is structural, not procedural.** One constructor owns the
+  recovery-transition record and the path that holds it, one CAS layer owns
+  publication, and a single shared per-kind contract validates the record — at
+  construction, at publication, and again when it is read back from disk. The
+  record's identity is *recomputed* from the fields that generate it rather
+  than compared against itself, so an id no scanner would derive is refused
+  instead of being silently unmatchable.
+- The three publications deliberately do **not** share lost-race semantics:
+  `reserve` refuses (another actor holds the claim), `bind` re-reads and
+  validates (a binding may legitimately exist from this actor's earlier
+  attempt), and `consume` refuses (two consumptions of one claim is the
+  double-delivery signature). Collapsing them into one helper would have read
+  as a simplification and converted bind's legitimate retry into a hard
+  failure.
+- Delivery is gated immediately before pane input: the current launch
+  generation is compared against the bound generation, the exact pane is
+  revalidated by id for managed/alive/idle with a live PID, and assessment
+  freshness is re-checked on an injected clock. Any drift produces **zero**
+  pane input and leaves the claim indeterminate rather than retried.
+- An unknown pane-input result is a first-class third outcome. Input that was
+  queued or typed-but-unconfirmed is neither success nor failure: it leaves the
+  reservation unconsumed so no automatic path retries, because treating it as
+  failure could deliver twice and treating it as success would hide a lost
+  resume.
+- Every automatic delivery leaves a durable audit directive recorded *before*
+  the pane is touched, and a second record after known success. The pre-input
+  record states that a resume is being attempted and explicitly does not claim
+  it was delivered.
+- Namespace migration now refuses to migrate a source holding a native
+  recovery claim — including a companion whose reservation is absent and a
+  transition-like file it cannot classify. A claim key is derived from the
+  namespace, so rewriting profile/session without recomputing it would leave a
+  record that reads as *absent*, and absent means "no prior claim".
+
+## Worker commands are delivered as the pane process (#571, PR #577)
+
+Long worker commands were typed into the pane with `send-keys` and could be
+truncated, which reported a partial team launch as a success. The command is
+now the pane's own process, so a command that cannot be delivered fails
+visibly instead of arriving half-written.
+
+## Resume preview consults the predicate admission enforces (#573, PR #579)
+
+`resume` advertised copy-ready `agent up` commands that admission then always
+rejected, because the preview and the admission check disagreed about the
+reserved generation token. The preview now consults the same predicate, so a
+command it offers is one that can actually run.
+
+## Launch identity is stamped at capture (#572, PR #575)
+
+An external-lead status promotion refused with `managed launch record has no
+exact launch id`, an identity refusal that obscured an earlier partial-launch
+failure. The launch id is now stamped when the record is captured, and
+incomplete records are distinguished from genuine mismatches so the reported
+error names the real problem.
+
+## AMQ 0.49.0 is the sole supported series (#557 and #533, PRs #558 and #555)
+
+The compatibility floor is raised: 0.49.0 is the minimum supported release and
+compatibility is tested through 0.49.1. The CI matrices collapse accordingly,
+and the trace/doctor additions in the 0.47–0.49 line are now available to be
+relied on rather than feature-detected. **This is a breaking change for
+deployments pinned below 0.49.0** — see Compatibility.
+
+## Plugin skills leverage the CLI (#534, PRs #567, #569 and #553)
+
+The authoritative skills were rewritten so an agent reaches for the CLI
+instead of re-deriving behaviour in prose, cutting model turns. Skill identity
+moved into frontmatter, `docs/skills.md` was split into per-skill references
+with the pointer reversed, and a `check-skill-commands` drift gate is wired
+into `make ci` so a skill cannot document a command the binary does not expose.
+
+## Global / NOC mode is deterministic (#454 and #455, PRs #556, #576, #574 and #568)
+
+The wake-registered orchestrator pattern became a deterministic bootstrap
+rather than a pasted directive, with managed AMQ notification watch, a
+read-only global NOC status board, and a wizard scope flow that adds a trust
+posture step, a wake-first contract, and a window hint.
+
+## Launch, profile and configuration robustness
+
+- Stale launch records from stopped sessions no longer poison profile
+  resolution, and `doctor` severity is corrected (#535 and #537, PR #551).
+- `worktree_isolation` readiness now names remedies that actually exist and are
+  discoverable (#538, PR #552).
+- Path representation is normalized at a single choke point, fixing bootstrap
+  death under a relative `--project` and the prepare/spawn relative-vs-absolute
+  capability comparison that made launch impossible for a Claude member with a
+  generated tool policy (#539 and #540, PR #544).
+- Repeated `--binary`/`--model`/`--effort`/`--tool-profile` flags no longer
+  silently drop earlier values, and Codex `[mcp_servers.X.env]` subtables
+  materialize correctly (#536 and #513, PR #541).
+- `GO_FILES` no longer descends into `.worktrees/`, so `fmt-check` stops
+  failing on peer worktrees and `make fmt` stops writing into them; offenders
+  are named (#560, PR #563).
+
+## Safety evidence
+
+The #498 work was verified more heavily than a normal feature, because its
+failure mode is a second audited resume against a live agent.
+
+- **Integration.** `make ci` green on the release candidate with the changed
+  package proven *uncached*, so the result is an execution rather than a
+  replay. A scoped by-name run covering the #498 surface and its neighbours
+  passed 237/237 top-level rows, with the filter regenerated from the test
+  tree and verified to contain zero phantom names.
+- **Mutation testing: 42/42 killed, zero survivors.** 36 rows in the main
+  window plus a re-specified row, and 6 more in a delta window covering the
+  fixes below. Every row asserts its anchor is present and unique before
+  replacement and verifies a byte-identical restore afterwards, so a row that
+  fails to apply reports a harness error rather than a survival. One row that
+  failed to compile was recorded as a specification defect and explicitly not
+  counted as a kill.
+- **Three-reviewer convergence.** After two reviewers passed the branch, an
+  independent codex review read it source-only and returned five findings —
+  three of them P1, all five confirmed at source, none refuted. Two further
+  defects were then found in the *fixes* by cross-review: a typed distinction
+  that was created for callers to branch on but shipped with no readers and no
+  tests, and a falsifier that pinned the consumer of a boundary while merely
+  asserting its producer. Both were closed before merge. The full narrative is
+  in PR #582.
+
+## Compatibility
+
+- **Breaking: AMQ 0.49.0 is now the minimum supported release.** Releases
+  older than 0.49.0 are rejected rather than degraded. Compatibility is tested
+  against pinned 0.49.0 and 0.49.1; `latest` remains a forward-compatibility
+  canary and is not a support claim.
+- `team.json` and the goal-attempt record schema remain backward compatible.
+  The recovery-transition record's new fields are `omitempty`, so a legacy
+  record continues to serialise without them and continues to be read as a
+  legacy redelivery record. A fixed golden vector pins the persisted id
+  algorithm, and a legacy fixture built through the original writer proves the
+  current reader still recognises what the old writer produced.
+- Existing profiles need no migration. A namespace holding a native recovery
+  claim will, by design, refuse to migrate until that claim is consumed; this
+  is a new refusal, and it replaces silent corruption.
+
+## Known issues and residual risks
+
+- **`compat-latest` is red under AMQ 0.49.8/0.49.9, deferred to v2.25.1
+  (#584).** The failure is exactly the previously recorded #581 signature
+  (`TestRealAMQCompatibility/doctor_repairs_malformed_configured_mailbox`) —
+  the known canary failure recurring on a newer upstream, not a new failure
+  shape introduced by those releases. Verification against 0.49.8/0.49.9 is
+  postponed by explicit decision. Both pinned floors and every wake lane are
+  green.
+- **Migration does not recompute the claim key under the destination
+  namespace.** This is a correctness bug rather than missing breadth, and it
+  is the highest-ranked v2.26.0 follow-up. The guard above prevents the
+  corrupting case by refusing outright, so the risk is a refused migration
+  rather than a corrupted claim.
+- **`status --json` returns an empty members list**, so a typed gate cannot be
+  validated by a requester in that session.
+- **`LaunchStartedAt` is not persisted**, so it cannot participate in a
+  durable freshness comparison.
+- **`goalAttemptDir` resolves a relative project against the process working
+  directory** rather than a frozen project root.
+- **Two mutation rows are not minimal.** One is a swap rather than a pure
+  deletion, and the pair covering the delivery-gate ordering kills both the
+  presence test and the ordering test rather than isolating them. The
+  properties are pinned; the rows do not separate them. Recorded as precision
+  limitations rather than missing evidence.
+
+## v2.26.0 follow-ups
+
+The residuals above are tracked as the v2.26.0 follow-up set, ranked with the
+migration claim-key recompute first because it is the only correctness bug
+among them.
+
+## Release boundary
+
+This document prepares the v2.25.0 candidate. It does not merge protected
+main, push a commit or tag, publish a GitHub release, close issues or the
+milestone, or authorize any provider action. Those actions remain separately
+gated and verified against the final candidate.

--- a/docs/v2.25.0-release-notes.md
+++ b/docs/v2.25.0-release-notes.md
@@ -46,10 +46,18 @@ passed — which is summarized under **Safety evidence** below.
   `Policy.Revision`); the assessment-captured `PauseGeneration`; the
   assessment's own `Fingerprint` recorded as `PreclaimFingerprint`; an explicit
   `Supervisor`; and a native `NewAttemptID` equal to the same nonblank
-  `Binding.Goal.AttemptID`. None of these is recomputed — each is consumed
-  from the single observation that authorized the claim, because a second
-  derivation owner reading a different snapshot is one identity with two
-  owners, and the symptom is double delivery.
+  `Binding.Goal.AttemptID`.
+- **Which of those are consumed and which are derived is itself the contract.**
+  The observation-bound authorization fields are consumed from the single
+  assessment rather than re-observed, because a second derivation owner reading
+  a different snapshot is one identity with two owners and the symptom is
+  double delivery. `TransitionID` is the deliberate exception: it is *derived*
+  from the canonical namespace, pause generation and attempt components and
+  recomputed by the shared validator, never accepted from a caller — a
+  caller-supplied id would file a current-looking record under the wrong key,
+  where it reads as absent. `SchemaVersion` and `RecoveryKind` are
+  constructor-owned, and `Supervisor` is explicit operator-provided input
+  rather than an assessment field.
 - The **bound companion** stores the assessment-captured launch digest and
   modtime, which is what delivery-time revalidation compares against. Per-kind
   validation runs over this exact schema at construction, at publication, and

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | console | up | focus | send | resume | fork | rm | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | activity | gate | resume | stop | archive | context | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | stage goal|brief|rules|roles|profile|readiness|launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` and its roles stage. Role authoring is part of the reviewed goal-to-launch preparation flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, preparation, readiness, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.24.0"  # x-release-please-version
+version: "2.25.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Prepares the **v2.25.0** candidate. Docs and release metadata only — **the diff contains no `.go` files.**

Milestone: [v2.25.0](https://github.com/omriariav/amq-squad/milestone/32) — 17 closed, 0 open.

## What this PR contains

- **`docs/v2.25.0-release-notes.md`** (new) — the canonical notes. Headline is
  #498's claim-once native `/goal` resume, including the enumerated U7 native
  reservation schema, with the other 16 closed milestone issues grouped by theme
  and each mapped to the PR that closed it.
- **`README.md`** — new "What's new in v2.25.0" section, the `@v2.25.0` install
  line, and the skill-marker paragraph. `README.html` regenerated by
  `make readme-html`.
- **`CHANGELOG.md`** — the pointer-index paragraph only, per the file's own
  policy that it is retired as a release source.
- **`GOAL.md`** — the version ladder moves its baseline to v2.24.0, converts
  that section from target to shipped, and adds 2.25.0 as the current target.
- **`MIGRATION.md`** — a new 2.25.0 section above the 2.24.0 one, leading with
  the single action-required item.
- **`plugins/{claude,codex}` manifests → 2.25.0**, with the 14 mirror
  `SKILL.md` frontmatter versions regenerated by `make skills-generate`.

## Two scope items that do not exist, verified rather than assumed

- **There is no version constant to bump.** The Makefile derives
  `VERSION ?= $(shell git describe --tags ...)`, so the released version comes
  from the tag at build time.
- **There is no per-skill version to hand-edit.** #567 moved skill identity into
  generated frontmatter, so each mirror's `plugin.json` is the single source and
  the 14 `SKILL.md` versions are generated from it. Two manifest edits plus a
  regenerate cannot drift; 21 hand-edits can.

The version-reference set was derived from **`scripts/check-release-version.py`**
— the contract `make release-check` actually enforces — rather than by mimicking
the previous release's bundled diff.

## Breaking change

**AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported
release and compatibility tested through 0.49.1.** Releases older than 0.49.0
are rejected rather than degraded, so `amq` must be upgraded before amq-squad.
`latest` is exercised in CI as a forward-compatibility canary and is not a
support claim.

`team.json` and the goal-attempt schema remain backward compatible. The
recovery-transition record's new fields are `omitempty`, so legacy records still
serialise without them and still read as legacy redelivery records.

## Evidence at this head

- `make ci` **exit 0**, with the exit code captured directly rather than through
  a pipe. `internal/cli` proven **uncached** at 344.346s, so the result is an
  execution rather than a replayed one.
- `scripts/check-release-version.py v2.25.0` → **`release metadata matches
  v2.25.0`**.
- `README.html is in sync with README.md` and `docs/skills.html is in sync with
  docs/skills.md`, both reported by their own drift gates in `make ci`.
- All **19** post-boundary merged PRs and all **17** closed milestone issues are
  cited in the notes, verified by set membership rather than by eye. The notes
  deliberately assert **no aggregate PR total** — a total nobody consumes is a
  number that can only rot.

## Preflight review found four defects, all fixed here

Review caught four documentation-accuracy defects across two rounds, recorded
because the corrections are part of the candidate's history:

1. The U7 schema was described abstractly when the record *is* the recovery
   contract. It is now enumerated field by field.
2. The mutation arithmetic did not reconcile with its own headline — the text
   described 36 + 1 + 6 = 43 under a 42/42 claim. The correct decomposition is
   35 main-window kills + one re-specified row replacing a compile-failed row
   (36 that round) + 6 delta = 42, with the compile-failed original excluded
   rather than counted.
3. `0.49.0` was called a "series" in four places; all four now match the
   checker's wording.
4. The schema enumeration added by fix 1 then ended with a blanket claim that
   none of the enumerated fields is recomputed and each is consumed from the
   authorizing observation. That was false for `TransitionID` — which is
   *derived* via `supervisionClaimKey` and recomputed by the shared validator,
   never accepted from a caller — for `SchemaVersion` and `RecoveryKind`, which
   are constructor-owned, and for `Supervisor`, which is explicit operator
   input. It also contradicted a sentence earlier in the same document, and it
   contradicted the exact mechanism these notes credit for closing the
   unmatchable-id defect. The paragraph now states which fields are consumed and
   which are derived instead of asserting one rule over all of them.

Fix 4 is worth naming rather than folding into fix 1: it was introduced *by* a
correction, which is why the notes now separate the two properties structurally
instead of appending a qualifier.

## Release boundary

This PR prepares the candidate. It does not tag, publish a GitHub release, or
close the milestone. Those remain separately gated operator actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


