### PR TITLE
Adapt #581 doctor-repair canary and raise AMQ floor to 0.49.9 (#584)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.49.0, v0.49.1, latest]
+        amq-version: [v0.49.9, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.49.0, v0.49.1, latest]
+        amq-version: [v0.49.9, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,32 @@ session state does **not** need to be migrated.
 
 This guide covers everything you have to change.
 
+## What's new in 2.25.1: AMQ 0.49.9 floor
+
+**Action required if you pin AMQ below 0.49.9.** 2.25.1 raises the floor again:
+AMQ 0.49.9 is now the minimum supported release, and the whole 0.49.0 through
+0.49.8 range is no longer supported. Releases below 0.49.9 are rejected rather
+than degraded, so upgrade `amq` before upgrading amq-squad. Run `amq upgrade`,
+then `amq-squad doctor` to confirm the version check passes.
+
+**The pinned CI lanes changed with it.** Both real-AMQ matrices now exercise
+pinned `v0.49.9` and `latest` only; the `v0.49.0` and `v0.49.1` lanes are
+retired along with the floor they proved. `latest` remains a
+forward-compatibility canary and is not a support claim. The pinned lane is the
+one that records what was actually proved: the version assertion is skipped when
+the requested version is literally `latest`.
+
+**Why the jump.** AMQ 0.49.7 (upstream `fab4c76`) changed `doctor` to audit the
+reserved operator handle implicitly, so a mailbox repair now reports created
+paths for the `user` roster entry alongside the mailbox you actually repaired.
+Verification against 0.49.8 and 0.49.9 found the two releases indistinguishable
+for this behaviour. Supporting a single current release instead of a floor plus
+a tested range is what the raised floor buys.
+
+**No schema migration.** `team.json`, the goal-attempt record, and on-disk
+session artifacts are unchanged. This is a support-policy and compatibility
+change only.
+
 ## What's new in 2.25.0: claim-once goal resume, AMQ 0.49.0 floor
 
 **Action required if you pin AMQ below 0.49.0.** 2.25.0 raises the floor: AMQ

--- a/README.html
+++ b/README.html
@@ -1318,7 +1318,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.49.0 on <code>PATH</code></li>
+<li><code>amq</code> 0.49.9 on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>
@@ -1328,11 +1328,14 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>AMQ 0.49.x is the supported series, with 0.49.0 as the minimum
-supported release and compatibility tested through 0.49.1. Both real-AMQ
-matrices validate pinned v0.49.0, pinned v0.49.1, and
+<p>AMQ 0.49.x is the supported series, with 0.49.9 as the minimum
+supported release. The 0.49.0 through 0.49.8 range is no longer
+supported. Both real-AMQ matrices validate pinned v0.49.9 and
 <code>latest</code>; <code>latest</code> remains a forward-compatibility
-canary. Releases older than 0.49.0 are rejected fail-closed.</p>
+canary and is not a support claim, and because the version assertion is
+skipped for <code>latest</code>, the pinned lane is the one that records
+what was proved. Releases older than 0.49.9 are rejected
+fail-closed.</p>
 <table>
 <thead>
 <tr>
@@ -1345,12 +1348,12 @@ canary. Releases older than 0.49.0 are rejected fail-closed.</p>
 <tr>
 <td>Queue, routing, receipts, doctor, lifecycle</td>
 <td>Ubuntu</td>
-<td><code>v0.49.0</code>, <code>v0.49.1</code>, <code>latest</code></td>
+<td><code>v0.49.9</code>, <code>latest</code></td>
 </tr>
 <tr>
 <td>Native real-PTY wake and teardown</td>
 <td>macOS</td>
-<td><code>v0.49.0</code>, <code>v0.49.1</code>, <code>latest</code></td>
+<td><code>v0.49.9</code>, <code>latest</code></td>
 </tr>
 </tbody>
 </table>
@@ -1360,10 +1363,10 @@ headers or subjects, managed coop wakes submit the fixed, shell-inert
 doorbell
 <code>: AMQ doorbell run amq drain --include-body then act on it</code>.
 AMQ 0.49.1 extended that fixed doorbell to standalone/default wake
-injection; 0.49.0 standalone wakes still emit the post-baseline subject.
-The compatibility lane pins that historical boundary while all managed
-coop lanes require the fixed doorbell. Agents must drain the durable
-mailbox to discover the sender, subject, and body.</p>
+injection, and every supported release is now above that boundary, so
+the lane that used to pin it is retired along with the sub-0.49.9
+floors. All managed coop lanes require the fixed doorbell. Agents must
+drain the durable mailbox to discover the sender, subject, and body.</p>
 <p>AMQ 0.49.1 also hardens wake delivery without changing amq-squad
 production branches: transient foreground-process-group handoffs retry
 pending notices, active input through max hold demotes to out-of-band
@@ -1397,7 +1400,7 @@ authorization authority for amq-squad evidence/receipt flows. See the <a
 href="docs/amq-0.49.x-assessment.md">AMQ 0.49.x support
 assessment</a>.</p>
 <p>AMQ 0.42.1 historically introduced the complete injected identity
-contract; 0.49.0 is the supported floor for the 0.49.x series. After
+contract; 0.49.9 is the supported floor for the 0.49.x series. After
 upgrading AMQ, stop and resume/relaunch agents so their parent shells
 refresh the complete identity tuple; a child command cannot repair stale
 parent environment variables. Default-profile sessions use

--- a/README.html
+++ b/README.html
@@ -1329,13 +1329,13 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb20-1"><a href="#
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
 <p>AMQ 0.49.x is the supported series, with 0.49.9 as the minimum
-supported release. The 0.49.0 through 0.49.8 range is no longer
-supported. Both real-AMQ matrices validate pinned v0.49.9 and
+supported release. Both real-AMQ matrices validate pinned v0.49.9 and
 <code>latest</code>; <code>latest</code> remains a forward-compatibility
-canary and is not a support claim, and because the version assertion is
-skipped for <code>latest</code>, the pinned lane is the one that records
-what was proved. Releases older than 0.49.9 are rejected
-fail-closed.</p>
+canary and is not a support claim. The 0.49.0 through 0.49.8 range is no
+longer supported, and releases older than 0.49.9 are rejected
+fail-closed. Because the version assertion is skipped for
+<code>latest</code>, the pinned lane is the one that records what was
+proved.</p>
 <table>
 <thead>
 <tr>

--- a/README.md
+++ b/README.md
@@ -825,11 +825,11 @@ sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
 AMQ 0.49.x is the supported series, with 0.49.9 as the minimum supported
-release. The 0.49.0 through 0.49.8 range is no longer supported. Both real-AMQ
-matrices validate pinned v0.49.9 and `latest`; `latest` remains a
-forward-compatibility canary and is not a support claim, and because the
-version assertion is skipped for `latest`, the pinned lane is the one that
-records what was proved. Releases older than 0.49.9 are rejected fail-closed.
+release. Both real-AMQ matrices validate pinned v0.49.9 and `latest`; `latest`
+remains a forward-compatibility canary and is not a support claim. The 0.49.0
+through 0.49.8 range is no longer supported, and releases older than 0.49.9 are
+rejected fail-closed. Because the version assertion is skipped for `latest`,
+the pinned lane is the one that records what was proved.
 
 | Real-AMQ lane | Runner | Versions |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.49.0 on `PATH`
+- `amq` 0.49.9 on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend
@@ -824,25 +824,26 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported release
-and compatibility tested through 0.49.1. Both real-AMQ matrices validate pinned
-v0.49.0, pinned v0.49.1, and `latest`; `latest` remains a
-forward-compatibility canary. Releases older than 0.49.0 are rejected
-fail-closed.
+AMQ 0.49.x is the supported series, with 0.49.9 as the minimum supported
+release. The 0.49.0 through 0.49.8 range is no longer supported. Both real-AMQ
+matrices validate pinned v0.49.9 and `latest`; `latest` remains a
+forward-compatibility canary and is not a support claim, and because the
+version assertion is skipped for `latest`, the pinned lane is the one that
+records what was proved. Releases older than 0.49.9 are rejected fail-closed.
 
 | Real-AMQ lane | Runner | Versions |
 | --- | --- | --- |
-| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.49.0`, `v0.49.1`, `latest` |
-| Native real-PTY wake and teardown | macOS | `v0.49.0`, `v0.49.1`, `latest` |
+| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.49.9`, `latest` |
+| Native real-PTY wake and teardown | macOS | `v0.49.9`, `latest` |
 
 AMQ 0.47.1 introduced the supervised `coop exec` wake contract used by every
 supported release: instead of injecting message headers or subjects, managed
 coop wakes submit the fixed, shell-inert doorbell
 `: AMQ doorbell run amq drain --include-body then act on it`. AMQ 0.49.1
-extended that fixed doorbell to standalone/default wake injection; 0.49.0
-standalone wakes still emit the post-baseline subject. The compatibility lane
-pins that historical boundary while all managed coop lanes require the fixed
-doorbell. Agents must drain the durable mailbox to discover the sender,
+extended that fixed doorbell to standalone/default wake injection, and every
+supported release is now above that boundary, so the lane that used to pin it
+is retired along with the sub-0.49.9 floors. All managed coop lanes require the
+fixed doorbell. Agents must drain the durable mailbox to discover the sender,
 subject, and body.
 
 AMQ 0.49.1 also hardens wake delivery without changing amq-squad production
@@ -877,7 +878,7 @@ for amq-squad evidence/receipt flows. See the
 [AMQ 0.49.x support assessment](docs/amq-0.49.x-assessment.md).
 
 AMQ 0.42.1 historically introduced the complete injected identity contract;
-0.49.0 is the supported floor for the 0.49.x series. After upgrading AMQ, stop and
+0.49.9 is the supported floor for the 0.49.x series. After upgrading AMQ, stop and
 resume/relaunch agents so their parent shells refresh the complete identity
 tuple; a child command cannot repair stale parent environment variables.
 Default-profile sessions use

--- a/docs/amq-0.49.x-assessment.md
+++ b/docs/amq-0.49.x-assessment.md
@@ -1,9 +1,11 @@
 # AMQ 0.49.x support and leverage assessment
 
 AMQ 0.49.x is the supported series for amq-squad. The minimum supported release
-is 0.49.0 and compatibility is tested through 0.49.1. Both real-AMQ CI matrices
-run pinned `v0.49.0`, pinned `v0.49.1`, and `latest`; `latest` remains a
-forward-compatibility canary. Older AMQ versions fail doctor diagnostics and
+is 0.49.9; the 0.49.0 through 0.49.8 range is no longer supported. Both
+real-AMQ CI matrices run pinned `v0.49.9` and `latest`; `latest` remains a
+forward-compatibility canary and is not a support claim. Because the harness
+skips its version assertion when the requested version is literally `latest`,
+the pinned `v0.49.9` lane is the one that records which version was proved. Older AMQ versions fail doctor diagnostics and
 the child `agent up` gate before launch-record or process side effects. Parent
 team launch, `resume --exec`, and `up --reset` also validate every selected
 member's resolved AMQ version before creating roots, briefs, watchers, or
@@ -20,6 +22,7 @@ Historical capability boundaries remain named in code for archaeology:
 | Fixed shell-inert `coop exec` doorbell | 0.47.1 |
 | Configured-mailbox repair | 0.48.0 |
 | Fixed shell-inert standalone/default wake doorbell | 0.49.1 |
+| Implicit reserved-`user` roster audit in doctor | 0.49.7 |
 
 They are not compatibility lanes or reasons to preserve below-floor branches.
 
@@ -43,6 +46,34 @@ No local follow-up is filed for Phase A. Re-evaluate integration only when
 upstream trace gains durable notification-attempt evidence or another new
 artifact that can strengthen, rather than project, amq-squad's existing
 receipts.
+
+## Implicit reserved-user roster audit (0.49.7+)
+
+Upstream `fab4c76`, first released in 0.49.7, made `amq doctor` audit the
+reserved `user` roster entry implicitly rather than only the handles a caller
+configured. A repair therefore reports created paths for the reserved operator
+mailbox alongside the mailbox that was actually broken. A single-mailbox repair
+of `alpha` now returns a global `mailbox_repair.created_paths` list like:
+
+```
+agents/alpha/inbox/cur
+agents/user  agents/user/inbox  agents/user/inbox/{tmp,new,cur}
+agents/user/outbox  agents/user/outbox/sent
+agents/user/dlq  agents/user/dlq/{tmp,new,cur}
+agents/user/receipts
+```
+
+Verified against v0.49.8 and v0.49.9 (#584): the two releases produce a
+byte-identical list, and the per-mailbox report for `alpha` is unchanged
+(`ok`, no issues, not repair eligible, created exactly `inbox/cur`). The
+pre-repair inspection is also unchanged: the reserved mailbox does not add to
+the error count, which stays at 1 for the one broken mailbox.
+
+The compatibility contract is bounded rather than exact (#581): the repaired
+mailbox must appear exactly once, and every other created path must lie inside
+the reserved `agents/user` subtree. An arbitrary extra creation is still a
+contract break. Prefix matching alone is not sufficient, since `agents/username`
+must not be accepted as the reserved subtree.
 
 ## Doctor discovered-mailbox remedies
 

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -20,10 +20,10 @@ verbs are the source of truth.
   Hidden spawns (`run start --visibility detached --go`) do not require a
   visible pane.
 - `amq-squad` + `amq` on `PATH`; AMQ **0.49.x is the supported series**, with
-  0.49.0 as the minimum supported release and compatibility tested through
-  0.49.1. Both real-AMQ matrices validate pinned v0.49.0, pinned v0.49.1, and
-  `latest`; `latest` remains a forward-compatibility canary. Releases older
-  than 0.49.0 are rejected fail-closed; upgrade to v0.49.0 or newer and
+  0.49.9 as the minimum supported release. Both real-AMQ matrices validate
+  pinned v0.49.9 and `latest`; `latest` remains a forward-compatibility canary
+  and is not a support claim. Releases older
+  than 0.49.9 are rejected fail-closed; upgrade to v0.49.9 or newer and
   stop/resume agents so the parent shell refreshes the complete AMQ identity
   tuple. A child command cannot repair stale injected environment.
   `amq-squad doctor` reports legacy/inconsistent pins and version skew

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -732,13 +732,13 @@ only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
 <code>--settings</code> file is missing. AMQ 0.49.x is the supported
-series, with 0.49.0 as the minimum supported release and compatibility
-tested through 0.49.1. Both real-AMQ matrices validate pinned v0.49.0,
-pinned v0.49.1, and <code>latest</code>; <code>latest</code> remains a
-forward-compatibility canary. Releases older than 0.49.0 are rejected
-fail-closed; upgrade to v0.49.0 or newer and stop/resume agents so their
-parent shells refresh the complete identity tuple. A child command
-cannot repair stale injected environment. Default profiles use
+series, with 0.49.9 as the minimum supported release. Both real-AMQ
+matrices validate pinned v0.49.9 and <code>latest</code>;
+<code>latest</code> remains a forward-compatibility canary and is not a
+support claim. Releases older than 0.49.9 are rejected fail-closed;
+upgrade to v0.49.9 or newer and stop/resume agents so their parent
+shells refresh the complete identity tuple. A child command cannot
+repair stale injected environment. Default profiles use
 <code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty
 <code>AM_SESSION</code>; named profiles use an exact root with
 <code>AM_ROOT=AM_BASE_ROOT</code> and omit <code>AM_SESSION</code>. Run

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -267,13 +267,12 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ 0.49.x is the supported series, with 0.49.0 as the minimum
-supported release and compatibility tested through 0.49.1. Both real-AMQ
-matrices validate pinned v0.49.0, pinned v0.49.1, and `latest`; `latest`
-remains a forward-compatibility canary. Releases older than 0.49.0 are rejected
-fail-closed; upgrade to v0.49.0 or newer and stop/resume agents so their parent
-shells refresh the complete identity tuple. A child command cannot repair stale
-injected environment.
+missing. AMQ 0.49.x is the supported series, with 0.49.9 as the minimum
+supported release. Both real-AMQ matrices validate pinned v0.49.9 and `latest`;
+`latest` remains a forward-compatibility canary and is not a support claim.
+Releases older than 0.49.9 are rejected fail-closed; upgrade to v0.49.9 or
+newer and stop/resume agents so their parent shells refresh the complete
+identity tuple. A child command cannot repair stale injected environment.
 Default profiles use `AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty
 `AM_SESSION`; named profiles use an exact root with `AM_ROOT=AM_BASE_ROOT` and
 omit `AM_SESSION`. Run

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -96,7 +96,7 @@ if [ "$1" = "env" ]; then
     echo "unexpected cwd: $actual" >&2
     exit 17
   fi
-  printf '{"root":"%s","amq_version":"0.49.0"}\n' "$AMQ_FAKE_ROOT"
+  printf '{"root":"%s","amq_version":"0.49.9"}\n' "$AMQ_FAKE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2
@@ -262,7 +262,7 @@ if [ "$1" = "env" ]; then
     echo "session should not be passed to amq env when named-profile root is explicit: $saw_session" >&2
     exit 18
   fi
-  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.49.0"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
+  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.49.9"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -27,7 +27,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.49.0"
+const doctorMinAMQVersion = "0.49.9"
 
 type doctorStatus string
 
@@ -88,7 +88,7 @@ type doctorExecution struct {
 	Getenv func(name string) string
 	// LookupEnv preserves the distinction between an absent value and an
 	// explicitly empty AM_SESSION. AMQ 0.42.1 introduced that distinction as
-	// part of the injected identity contract; 0.49.0 is the supported floor.
+	// part of the injected identity contract; 0.49.9 is the supported floor.
 	LookupEnv func(name string) (string, bool)
 	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
 	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
@@ -1085,7 +1085,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy exact-root/sessionless pin (AM_ROOT=AM_BASE_ROOT; AM_SESSION omitted; AM_ME set)"}
 		}
 		if sessionOK && session == "" {
-			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.49.0; a child command cannot repair its parent shell"}
+			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.49.9; a child command cannot repair its parent shell"}
 		}
 		if session != "" && sameResolvedDir(root, filepath.Join(base, session)) {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy sessionful pin (AM_ROOT=AM_BASE_ROOT/AM_SESSION; AM_ME set)"}
@@ -1102,7 +1102,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 	return doctorCheck{
 		Name:   "amq identity pin",
 		Status: doctorWarn,
-		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.49.0; a child command cannot repair its parent shell",
+		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.49.9; a child command cannot repair its parent shell",
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -447,13 +447,13 @@ if [ -n "$AM_ROOT_ID$AM_BASE_ROOT_ID" ]; then
   echo "inherited AMQ root identity metadata leaked" >&2
   exit 92
 fi
-printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.49.0"}'
+printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.49.9"}'
 `)
 
 	d := defaultDoctorExecution(t.TempDir())
 	check := doctorCheckAMQVersion(d)
-	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.49.0") {
-		t.Fatalf("doctor amq version check = %+v, want ok 0.49.0", check)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.49.9") {
+		t.Fatalf("doctor amq version check = %+v, want ok 0.49.9", check)
 	}
 	if got := os.Getenv("AMQ_NO_UPDATE_CHECK"); got != "0" {
 		t.Fatalf("parent AMQ_NO_UPDATE_CHECK = %q, want unchanged 0", got)
@@ -509,9 +509,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts0490AndNewerCanary(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0499AndNewerCanary(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.49.0", "v0.49.1-rc1", "0.50.0", "1.0.0+build49"} {
+	for _, v := range []string{"0.49.9", "v0.50.0-rc1", "0.50.0", "1.0.0+build49"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -529,8 +529,11 @@ func TestExecuteDoctorAMQVersionAccepts0490AndNewerCanary(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionRejectsOlderThan0490(t *testing.T) {
-	for _, version := range []string{"0.42.1", "0.47.2", "0.48.0", "0.49.0-rc1"} {
+// The v2.25.1 floor raise to 0.49.9 makes the whole 0.49.0-0.49.8 range
+// unsupported, so the previously-supported floor and the immediately-preceding
+// release are now the cases that matter most here.
+func TestExecuteDoctorAMQVersionRejectsOlderThan0499(t *testing.T) {
+	for _, version := range []string{"0.42.1", "0.47.2", "0.48.0", "0.49.0-rc1", "0.49.0", "0.49.1", "0.49.8", "0.49.9-rc1"} {
 		t.Run(version, func(t *testing.T) {
 			dir := t.TempDir()
 			d := newDoctorExec(t, dir)
@@ -540,10 +543,10 @@ func TestExecuteDoctorAMQVersionRejectsOlderThan0490(t *testing.T) {
 			var buf bytes.Buffer
 			d.Out = &buf
 			if err := executeDoctor(d); err == nil {
-				t.Fatalf("doctor should fail when amq %s is below the 0.49.0 floor", version)
+				t.Fatalf("doctor should fail when amq %s is below the 0.49.9 floor", version)
 			}
 			amqLine := firstLineWith(buf.String(), "amq version")
-			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.49.0") {
+			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.49.9") {
 				t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 			}
 			if !strings.Contains(amqLine, "amq upgrade") {

--- a/internal/cli/fresh_amq_bootstrap_test.go
+++ b/internal/cli/fresh_amq_bootstrap_test.go
@@ -86,7 +86,7 @@ else
   root="$base"
   if [ -n "$session" ]; then root="$base/$session"; fi
 fi
-printf '{"schema_version":1,"amq_version":"0.49.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","root_source":"%s"}\n' "$root" "$base" "$session" "$me" "$source"
+printf '{"schema_version":1,"amq_version":"0.49.9","root":"%s","base_root":"%s","session_name":"%s","me":"%s","root_source":"%s"}\n' "$root" "$base" "$session" "$me" "$source"
 `
 	path := filepath.Join(binDir, "amq")
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -354,10 +354,11 @@ func realAMQDoctorMailboxRepairContract(t *testing.T, binary string) {
 	repaired := runDoctor("--fix-mailboxes", "--json")
 	status, issues, created, eligible := findAlpha(repaired)
 	if status != "ok" || len(issues) != 0 || eligible || len(created) != 1 || created[0] != "inbox/cur" ||
-		repaired.Summary.Error != 0 || repaired.MailboxRepair == nil || repaired.MailboxRepair.Status != "repaired" ||
-		len(repaired.MailboxRepair.CreatedPaths) != 1 || repaired.MailboxRepair.CreatedPaths[0] != "agents/alpha/inbox/cur" {
+		repaired.Summary.Error != 0 || repaired.MailboxRepair == nil || repaired.MailboxRepair.Status != "repaired" {
 		t.Fatalf("mailbox repair = status:%q issues:%v created:%v eligible:%t errors:%d repair:%+v", status, issues, created, eligible, repaired.Summary.Error, repaired.MailboxRepair)
 	}
+	assertRealAMQDoctorGlobalRepairScope(t, repaired.MailboxRepair.CreatedPaths, "agents/alpha/inbox/cur")
+	assertRealAMQDoctorReservedUserMailboxHealthy(t, repaired)
 	if info, err := os.Stat(missingPath); err != nil || !info.IsDir() {
 		t.Fatalf("repaired mailbox directory = %v, info=%v", err, info)
 	}
@@ -371,6 +372,107 @@ func realAMQDoctorMailboxRepairContract(t *testing.T, binary string) {
 		t.Fatalf("idempotent mailbox repair = status:%q issues:%v created:%v eligible:%t errors:%d repair:%+v", status, issues, created, eligible, idempotent.Summary.Error, idempotent.MailboxRepair)
 	}
 	assertRealAMQDoctorSentinelUnchanged(t, sentinelPath, sentinelBefore)
+}
+
+// realAMQDoctorReservedUserSubtree is the one roster entry doctor is allowed to
+// materialize on its own initiative. AMQ 0.49.7 (upstream fab4c76) made doctor
+// audit the reserved operator handle implicitly, so the global repair list is no
+// longer alpha-only.
+const realAMQDoctorReservedUserSubtree = "agents/user"
+
+// assertRealAMQDoctorGlobalRepairScope holds upstream to the public repair
+// contract without assuming the global audit list is alpha-only. The bounded
+// claim is: the mailbox we actually broke is repaired exactly once, and every
+// other created path lives inside the reserved user subtree. An arbitrary extra
+// creation is still a contract break, so relaxing the shape must not relax the
+// boundary.
+// The boundary logic is a pure function so the relaxed assertion can be proven
+// to still kill an out-of-scope creation without needing a real AMQ binary.
+func realAMQDoctorGlobalRepairScopeViolation(created []string, wantRepaired string) error {
+	repairedCount := 0
+	var unexpected []string
+	for _, path := range created {
+		switch {
+		case path == wantRepaired:
+			repairedCount++
+		case path == realAMQDoctorReservedUserSubtree || strings.HasPrefix(path, realAMQDoctorReservedUserSubtree+"/"):
+		default:
+			unexpected = append(unexpected, path)
+		}
+	}
+	if repairedCount != 1 || len(unexpected) > 0 {
+		return fmt.Errorf("global mailbox repair scope = %v; want %q exactly once (saw %d) and every other path under %q (unexpected: %v)",
+			created, wantRepaired, repairedCount, realAMQDoctorReservedUserSubtree, unexpected)
+	}
+	return nil
+}
+
+func assertRealAMQDoctorGlobalRepairScope(t *testing.T, created []string, wantRepaired string) {
+	t.Helper()
+	if err := realAMQDoctorGlobalRepairScopeViolation(created, wantRepaired); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRealAMQDoctorGlobalRepairScope is the mutation evidence for the relaxed
+// doctor-repair assertion (#581). Relaxing an exact-equality check is only safe
+// if the replacement still kills what the original killed, so the accept case
+// is the real 13-path list measured from AMQ v0.49.8 and v0.49.9, and every
+// reject case is a mutation that must not survive. This test is hermetic: no
+// AMQ binary, no tmux, no shared external state.
+func TestRealAMQDoctorGlobalRepairScope(t *testing.T) {
+	const alpha = "agents/alpha/inbox/cur"
+	measured := []string{
+		alpha,
+		"agents/user", "agents/user/inbox", "agents/user/inbox/tmp", "agents/user/inbox/new", "agents/user/inbox/cur",
+		"agents/user/outbox", "agents/user/outbox/sent",
+		"agents/user/dlq", "agents/user/dlq/tmp", "agents/user/dlq/new", "agents/user/dlq/cur",
+		"agents/user/receipts",
+	}
+
+	for _, tc := range []struct {
+		name    string
+		created []string
+		wantErr bool
+	}{
+		{name: "measured 0.49.8/0.49.9 roster", created: measured},
+		{name: "pre-0.49.7 alpha only", created: []string{alpha}},
+		{name: "unrelated extra mailbox", created: append(append([]string{}, measured...), "agents/beta/inbox/cur"), wantErr: true},
+		{name: "unrelated extra outside agents", created: append(append([]string{}, measured...), "config.json"), wantErr: true},
+		{name: "user subtree prefix impostor", created: append(append([]string{}, measured...), "agents/username/inbox/cur"), wantErr: true},
+		{name: "target repair missing", created: measured[1:], wantErr: true},
+		{name: "target repair duplicated", created: append(append([]string{}, measured...), alpha), wantErr: true},
+		{name: "no creations at all", created: nil, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := realAMQDoctorGlobalRepairScopeViolation(tc.created, alpha)
+			if tc.wantErr && err == nil {
+				t.Fatalf("relaxed scope accepted a creation it must reject: %v", tc.created)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("relaxed scope rejected a legitimate roster: %v", err)
+			}
+		})
+	}
+}
+
+// assertRealAMQDoctorReservedUserMailboxHealthy checks that when doctor does
+// surface the reserved user mailbox, it hands back a complete and healthy one
+// rather than a partial skeleton. A doctor that does not report the handle at
+// all is the pre-0.49.7 shape and stays acceptable, so this must not assert
+// presence.
+func assertRealAMQDoctorReservedUserMailboxHealthy(t *testing.T, report realAMQDoctorReport) {
+	t.Helper()
+	for _, mailbox := range report.Mailboxes {
+		if mailbox.Handle != "user" {
+			continue
+		}
+		if mailbox.Status != "ok" || len(mailbox.Issues) != 0 || mailbox.RepairEligible {
+			t.Fatalf("reserved user mailbox after repair = status:%q issues:%v eligible:%t, want a complete healthy mailbox",
+				mailbox.Status, mailbox.Issues, mailbox.RepairEligible)
+		}
+		return
+	}
 }
 
 func assertRealAMQDoctorSentinelUnchanged(t *testing.T, path string, before os.FileInfo) {

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -104,7 +104,7 @@ if [ "$1" = "env" ]; then
   if [ -n "$session" ]; then
     base_root=$(dirname "$root")
   fi
-  printf '{"schema_version":1,"amq_version":"0.49.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
+  printf '{"schema_version":1,"amq_version":"0.49.9","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
   exit 0
 fi
 if [ "$1" = "route" ] && [ "$2" = "explain" ]; then

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -22,11 +22,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported release and
-compatibility tested through 0.49.1. Both real-AMQ matrices validate pinned v0.49.0,
-pinned v0.49.1, and latest; latest remains a forward-compatibility canary.
+AMQ 0.49.x is the supported series, with 0.49.9 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.49.9 and latest; latest remains a
+forward-compatibility canary and is not a support claim.
 
-Releases older than 0.49.0 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.49.9 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported release and
-compatibility tested through 0.49.1. Both real-AMQ matrices validate pinned v0.49.0,
-pinned v0.49.1, and latest; latest remains a forward-compatibility canary.
+AMQ 0.49.x is the supported series, with 0.49.9 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.49.9 and latest; latest remains a
+forward-compatibility canary and is not a support claim.
 
-Releases older than 0.49.0 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.49.9 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/skills-src/cli/SKILL.md
+++ b/plugins/skills-src/cli/SKILL.md
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.49.x is the supported series, with 0.49.0 as the minimum supported release and
-compatibility tested through 0.49.1. Both real-AMQ matrices validate pinned v0.49.0,
-pinned v0.49.1, and latest; latest remains a forward-compatibility canary.
+AMQ 0.49.x is the supported series, with 0.49.9 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.49.9 and latest; latest remains a
+forward-compatibility canary and is not a support claim.
 
-Releases older than 0.49.0 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.49.9 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -22,14 +22,12 @@ SKILL_FRONTMATTER_VERSION_RE = re.compile(
     r'^version:[ \t]*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
     re.MULTILINE,
 )
-AMQ_MIN_VERSION = "0.49.0"
-AMQ_TESTED_CURRENT_VERSION = "0.49.1"
+AMQ_MIN_VERSION = "0.49.9"
 AMQ_COMPATIBILITY_POLICY = (
     f"AMQ 0.49.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
-    f"supported release and compatibility tested through {AMQ_TESTED_CURRENT_VERSION}. "
-    f"Both real-AMQ matrices validate pinned v{AMQ_MIN_VERSION}, pinned "
-    f"v{AMQ_TESTED_CURRENT_VERSION}, and latest; latest remains a "
-    "forward-compatibility canary."
+    f"supported release. Both real-AMQ matrices validate pinned "
+    f"v{AMQ_MIN_VERSION} and latest; latest remains a forward-compatibility "
+    "canary and is not a support claim."
 )
 
 


### PR DESCRIPTION
Closes #584.

## What this does

Verification against AMQ **v0.49.8** and **v0.49.9** confirmed the real-AMQ compat lane fails on exactly one subtest, `doctor_repairs_malformed_configured_mailbox`, with a **byte-identical** global created-path list on both versions. Upstream 0.49.7 (`fab4c76`) made `doctor` audit the reserved `user` roster entry implicitly, so `mailbox_repair.created_paths` is no longer alpha-only:

```
agents/alpha/inbox/cur
agents/user  agents/user/inbox  agents/user/inbox/{tmp,new,cur}
agents/user/outbox  agents/user/outbox/sent
agents/user/dlq  agents/user/dlq/{tmp,new,cur}
agents/user/receipts
```

The canary (#581) now asserts **bounded public repair semantics** instead of exact equality on the global list: the repaired mailbox appears exactly once, every other created path must lie inside the reserved `agents/user` subtree, and a surfaced `user` mailbox must be complete and healthy. Per-mailbox `alpha` assertions stay exact and unchanged. The pre-repair inspection was **measured**, not assumed — its error count stayed at 1 — so that assertion is untouched.

Per operator policy, **AMQ 0.49.9 becomes the minimum supported release** and both real-AMQ CI matrices collapse to `[v0.49.9, latest]`.

## Mutation evidence

Relaxing an exact-equality check needs proof it still kills. The boundary logic is a pure function covered by a hermetic table test (no AMQ binary, no tmux). Rejected: an unrelated mailbox, a path outside `agents`, an `agents/username` prefix impostor, a missing target, a duplicated target, an empty list. Accepted: the real measured 13-path roster and the pre-0.49.7 alpha-only list.

## Evidence (sha256, pinned)

| Run | Result | Digest |
| --- | --- | --- |
| compat v0.49.8 (pre-adapt) | 1 red, #581 signature | `508580c8b01141a7bc388423bb6bda6eff67cd0026b2c5d190111f0ecc76009e` |
| compat v0.49.9 (pre-adapt) | 1 red, #581 signature | `d3bbd54cb9b2704f52330047b23a818c98208cc905504c43e17f900609b25e8a` |
| mutation evidence | 8/8 PASS | `212fcd4bb502fcf6a0088af9553b54685e8db4a4280aa766d699693193002372` |
| compat v0.49.9 (post-adapt) | **fully green** | `0d761000f8b62f5d9e094f6ae24a8ef1dcddfbb81143f5143d8ee9fc5fbae4ce` |
| compat latest (post-adapt) | **fully green** | `d97513bb37f394415d6b78a391f58ab665c16c253cd796484222c9bd757b36fc` |
| `make ci` | exit 0, zero FAIL | `8fcb3db2df2da8507878c54d0d8b2b5e2a91726cc3207b25fa427567d8e19b8d` |

`latest` currently resolves to v0.49.9. Note the harness skips its version assertion when the requested version is literally `latest`, so the pinned lane is the one that records what was proved.

## Known reds, disclosed

- **Wake lane is red locally at every version**, including the v0.49.1 floor that CI reports green. Proven **version-independent** by control, and identified as the #577/#586 pane-identity regression (agent PID *is* the pane PID; the ancestry guard refuses). Not an AMQ 0.49.x issue. CI is the authority for wake-green here.
- **`production_cleanup_recovers_owner-bound_managed_wake` flaked once in 7 observations** on a subtest this diff does not touch (race, not assertion). Filed as #590, not release-gating.

## Merge gating

**Merge is sequenced behind #586 and #588.** This branch raises the floor to 0.49.9, which is the version that fails closed on real session roots (#588). Merging before #588 lands would ship that outage. Release order: #586 → #584 → #588.
