### PR TITLE
Fix pane-process identity checks for managed launches (#586)

### DIFF
--- a/internal/cli/live_identity.go
+++ b/internal/cli/live_identity.go
@@ -413,7 +413,16 @@ func observeManagedLiveActor(scope liveIdentityScope, managed managedLiveLaunch,
 }
 
 func verifyAgentPaneLineage(panePID, agentPID int, childrenIndex func() (func(int) []int, error)) error {
-	if panePID <= 0 || agentPID <= 0 || childrenIndex == nil {
+	if panePID <= 0 || agentPID <= 0 {
+		return fmt.Errorf("%w: pane/agent process lineage is incomplete", errIncompleteLaunchRecord)
+	}
+	// #577 delivers the agent command with respawn-pane, making the agent the
+	// pane process itself. Equality is therefore positive identity evidence and
+	// does not require a process-tree snapshot.
+	if paneProcessOrDescendant(nil, panePID, agentPID) {
+		return nil
+	}
+	if childrenIndex == nil {
 		return fmt.Errorf("%w: pane/agent process lineage is incomplete", errIncompleteLaunchRecord)
 	}
 	children, err := childrenIndex()
@@ -423,10 +432,19 @@ func verifyAgentPaneLineage(panePID, agentPID int, childrenIndex func() (func(in
 		}
 		return fmt.Errorf("process lineage snapshot unavailable")
 	}
-	if !strictDescendant(children, panePID, agentPID) {
-		return fmt.Errorf("verified agent PID %d is not a descendant of recorded pane PID %d", agentPID, panePID)
+	if !paneProcessOrDescendant(children, panePID, agentPID) {
+		return fmt.Errorf("verified agent PID %d is neither recorded pane process %d nor its descendant", agentPID, panePID)
 	}
 	return nil
+}
+
+// paneProcessOrDescendant is the process-shape contract for managed panes:
+// #577 makes the agent the pane process, while older/adopted launches can still
+// put the agent below a shell. Keep strictDescendant strict for callers that
+// require a child rather than the pane process itself.
+func paneProcessOrDescendant(children func(int) []int, panePID, agentPID int) bool {
+	return panePID > 0 && agentPID > 0 &&
+		(panePID == agentPID || strictDescendant(children, panePID, agentPID))
 }
 
 func observeExactWakeConsumers(root, handle, target, launchID string, probe duplicateLaunchProbe) ([]liveidentity.WakeConsumer, error) {

--- a/internal/cli/live_identity_test.go
+++ b/internal/cli/live_identity_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -390,10 +391,216 @@ func TestLiveIdentityResolverRejectsScopeLaunchAndProcessFailures(t *testing.T) 
 	}
 }
 
-func TestVerifyAgentPaneLineageRejectsReusedAndSiblingPID(t *testing.T) {
+func verifiedPaneProcessPIDFromDeliveryPath(t *testing.T) int {
+	t.Helper()
+	const paneID = "%7"
+
+	previousRun, previousInspect, previousOutput := tmuxRunCommand, inspectPaneExact, tmuxOutputCommand
+	t.Cleanup(func() {
+		tmuxRunCommand, inspectPaneExact, tmuxOutputCommand = previousRun, previousInspect, previousOutput
+	})
+
+	var delivered []string
+	tmuxRunCommand = func(name string, args ...string) error {
+		delivered = append([]string{name}, args...)
+		return nil
+	}
+	if err := deliverPaneCommand(paneID, "codex --model gpt-5"); err != nil {
+		t.Fatalf("deliver pane-process command: %v", err)
+	}
+	if got, want := strings.Join(delivered, " "), "tmux respawn-pane -k -t %7 codex --model gpt-5"; got != want {
+		t.Fatalf("delivery path = %q, want #577 pane-process path %q", got, want)
+	}
+
+	inspectPaneExact = func(id string) tmuxpane.PaneInspection {
+		return tmuxpane.PaneInspection{
+			State: tmuxpane.PaneInspectionFound,
+			Pane:  tmuxpane.TmuxPane{Pane: id, PaneID: id, PID: 4242},
+		}
+	}
+	tmuxOutputCommand = func(string, ...string) (string, error) {
+		return paneID + "\t0\n", nil
+	}
+	panePIDText, err := verifyPaneProcessLaunched(paneID)
+	if err != nil {
+		t.Fatalf("verify pane-process delivery: %v", err)
+	}
+	panePID, err := strconv.Atoi(panePIDText)
+	if err != nil {
+		t.Fatalf("parse verified pane pid %q: %v", panePIDText, err)
+	}
+	return panePID
+}
+
+func TestObserveManagedLiveActorAcceptsPaneProcessRecordFromDeliveryPath(t *testing.T) {
+	const paneID = "%7"
+	panePID := verifiedPaneProcessPIDFromDeliveryPath(t)
+
+	previousStatusInspect := statusPaneInspector
+	t.Cleanup(func() { statusPaneInspector = previousStatusInspect })
+
+	project := t.TempDir()
+	root := filepath.Join(project, ".agent-mail", "review", "s")
+	agentDir := filepath.Join(root, "agents", "dev")
+	terminal := &launch.TerminalInfo{
+		Backend: "tmux", Target: "new-window", Session: "tmux-s",
+		WindowID: "@1", PaneID: paneID,
+	}
+	rec := launch.Record{
+		CWD: project, Root: root, Role: "dev", Handle: "dev", Binary: "codex", Model: "gpt-5",
+		AgentPID: panePID, Session: "s", TeamProfile: "review",
+		PreparedRunGeneration: "generation", PreparedRunDigest: "digest",
+		NoWakeReason: "test fixture", Terminal: terminal,
+		Tmux:                 &launch.TmuxInfo{Target: "new-window", Session: "tmux-s", WindowID: "@1", PaneID: paneID},
+		BootstrapExpectation: &bootstrapack.Expectation{LaunchID: "launch-1"},
+	}
+	// Persist and read the same launch.json shape that agent up writes. The PID
+	// comes from #577's delivery/verification seam above rather than an invented
+	// equal pair in a hand-built live-identity fixture.
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatalf("write pane-process launch record: %v", err)
+	}
+	readRecord, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatalf("read pane-process launch record: %v", err)
+	}
+	rec = readRecord
+
+	statusPaneInspector = func(id string) (tmuxpane.TmuxPane, bool) {
+		return tmuxpane.TmuxPane{Pane: id, PaneID: id, PID: panePID, CWD: project}, id == paneID
+	}
+	childrenSnapshotCalled := false
+	observed, err := observeManagedLiveActor(
+		liveIdentityScope{Project: project, Profile: "review", Session: "s", Handle: "dev"},
+		managedLiveLaunch{Record: rec, AgentDir: agentDir, Root: root},
+		duplicateLaunchProbe{
+			PIDAlive: func(pid int) bool { return pid == panePID },
+			ProcessMatch: func(pid int, predicate func(string) bool) bool {
+				return pid == panePID && predicate("codex --model gpt-5")
+			},
+			Now: time.Now,
+		},
+		func() (func(int) []int, error) {
+			childrenSnapshotCalled = true
+			return nil, fmt.Errorf("pane-process equality must not need a process snapshot")
+		},
+	)
+	if err != nil {
+		t.Fatalf("observe #577 pane-process launch record: %v", err)
+	}
+	if observed.Identity.PID != panePID {
+		t.Fatalf("observed pid = %d, want verified pane-process pid %d", observed.Identity.PID, panePID)
+	}
+	if childrenSnapshotCalled {
+		t.Fatal("pane-process equality called the descendant snapshot")
+	}
+}
+
+func TestStopClosePanesAcceptsPaneProcessRecordFromDeliveryPath(t *testing.T) {
+	panePID := verifiedPaneProcessPIDFromDeliveryPath(t)
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.AgentPID = panePID
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatalf("write #577 pane-process launch record: %v", err)
+	}
+	pane.PID = panePID
+
+	var events []string
+	deps := PaneCleanupDependencies{
+		Inspect: func(string) tmuxpane.PaneInspection {
+			events = append(events, "inspect")
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+		},
+		ChildrenIndex: func() (func(int) []int, error) {
+			t.Fatal("#577 pane-process equality must not require a process snapshot")
+			return nil, fmt.Errorf("unreachable")
+		},
+		Close: func(string) error {
+			events = append(events, "close")
+			return nil
+		},
+	}
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, "issue-465",
+		eventTerminator{events: &events},
+		downFakeProbe(map[int]bool{panePID: true}, map[int]bool{panePID: true}),
+		nil, true, deps,
+	)
+	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupClosed {
+		t.Fatalf("stop --close-panes report=%+v, want stopped and pane closed", report)
+	}
+	if got, want := strings.Join(events, ","), "inspect,signal,inspect,close"; got != want {
+		t.Fatalf("stop --close-panes events=%q, want %q", got, want)
+	}
+}
+
+func TestPaneCleanupRejectsUnrelatedPaneProcessPID(t *testing.T) {
+	panePID := verifiedPaneProcessPIDFromDeliveryPath(t)
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.AgentPID = panePID + 1
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatalf("write unrelated agent launch record: %v", err)
+	}
+	pane.PID = panePID
+
+	closeCalls := 0
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, "issue-465",
+		eventTerminator{events: &[]string{}},
+		downFakeProbe(map[int]bool{record.AgentPID: true}, map[int]bool{record.AgentPID: true}),
+		nil, true, PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(int) []int { return nil }, nil
+			},
+			Close: func(string) error {
+				closeCalls++
+				return nil
+			},
+		},
+	)
+	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupPreservedIdentityUnconfirmed {
+		t.Fatalf("unrelated cleanup report=%+v, want signaled with pane preserved", report)
+	}
+	if closeCalls != 0 {
+		t.Fatalf("unrelated pane-process cleanup closed pane %d times", closeCalls)
+	}
+	if len(report.Pane.Mismatches) != 1 || report.Pane.Mismatches[0].Field != "agent_pid_ancestry" {
+		t.Fatalf("unrelated pane-process mismatch=%+v", report.Pane.Mismatches)
+	}
+}
+
+func TestStrictDescendantRemainsStrictForPaneCleanup(t *testing.T) {
+	if strictDescendant(func(int) []int { return nil }, 10, 10) {
+		t.Fatal("strictDescendant accepted equality; pane-cleanup semantics must remain strict")
+	}
+}
+
+func TestPaneProcessOrDescendantRejectsNonPositivePIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		panePID  int
+		agentPID int
+	}{
+		{name: "zero equality", panePID: 0, agentPID: 0},
+		{name: "negative equality", panePID: -1, agentPID: -1},
+		{name: "missing pane pid", panePID: 0, agentPID: 1},
+		{name: "missing agent pid", panePID: 1, agentPID: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if paneProcessOrDescendant(nil, tc.panePID, tc.agentPID) {
+				t.Fatalf("paneProcessOrDescendant(nil, %d, %d) accepted a non-positive PID", tc.panePID, tc.agentPID)
+			}
+		})
+	}
+}
+
+func TestVerifyAgentPaneLineageRejectsUnrelatedAndAcceptsDescendantPID(t *testing.T) {
 	tree := map[int][]int{10: {20}, 20: {30}, 40: {101}}
 	children := func() (func(int) []int, error) { return func(pid int) []int { return tree[pid] }, nil }
-	if err := verifyAgentPaneLineage(10, 101, children); err == nil || !strings.Contains(err.Error(), "not a descendant") {
+	if err := verifyAgentPaneLineage(10, 101, children); err == nil || !strings.Contains(err.Error(), "neither recorded pane process") {
 		t.Fatalf("unexpected lineage result: %v", err)
 	}
 	if err := verifyAgentPaneLineage(10, 30, children); err != nil {

--- a/internal/cli/pane_cleanup.go
+++ b/internal/cli/pane_cleanup.go
@@ -175,18 +175,20 @@ func PreparePaneCleanup(req PaneCleanupRequest, deps PaneCleanupDependencies) Pa
 	if len(paneMismatches) > 0 {
 		return finish(PaneCleanupPreservedIdentityUnconfirmed, "inspected pane identity is not fully confirmed", paneMismatches...)
 	}
-	children, err := deps.ChildrenIndex()
-	if err != nil || children == nil {
-		detail := "process table snapshot unavailable"
-		if err != nil {
-			detail += ": " + err.Error()
+	if !paneProcessOrDescendant(nil, initial.PanePID, req.Attestation.PID) {
+		children, err := deps.ChildrenIndex()
+		if err != nil || children == nil {
+			detail := "process table snapshot unavailable"
+			if err != nil {
+				detail += ": " + err.Error()
+			}
+			return finish(PaneCleanupPreservedIdentityUnconfirmed, detail,
+				PaneCleanupMismatch{Field: "process_snapshot", Expected: "available", Actual: "unavailable"})
 		}
-		return finish(PaneCleanupPreservedIdentityUnconfirmed, detail,
-			PaneCleanupMismatch{Field: "process_snapshot", Expected: "available", Actual: "unavailable"})
-	}
-	if !strictDescendant(children, initial.PanePID, req.Attestation.PID) {
-		return finish(PaneCleanupPreservedIdentityUnconfirmed, "verified agent PID is not a descendant of the inspected pane PID",
-			PaneCleanupMismatch{Field: "agent_pid_ancestry", Expected: fmt.Sprintf("descendant of %d", initial.PanePID), Actual: fmt.Sprintf("pid %d", req.Attestation.PID)})
+		if !paneProcessOrDescendant(children, initial.PanePID, req.Attestation.PID) {
+			return finish(PaneCleanupPreservedIdentityUnconfirmed, "verified agent PID is neither the inspected pane process nor its descendant",
+				PaneCleanupMismatch{Field: "agent_pid_ancestry", Expected: fmt.Sprintf("pane process %d or descendant", initial.PanePID), Actual: fmt.Sprintf("pid %d", req.Attestation.PID)})
+		}
 	}
 
 	return PaneCleanupPreparation{Ready: true, Identity: identity, Initial: initial}


### PR DESCRIPTION
## Summary

- Accept the managed agent when `respawn-pane` makes it the tmux pane process itself.
- Apply the same process-shape rule to live-status promotion and `stop --close-panes` cleanup.
- Keep legacy/adopted launches working through strict descendant validation.
- Keep non-positive and unrelated PIDs fail-closed.

## Root cause

#577 changed pane delivery to `tmux respawn-pane -k`. The launched agent is therefore the pane process, so the recorded `agent_pid` can equal `pane_pid`. The existing strict-descendant-only checks rejected that valid equality at both lineage call sites.

This change introduces one shared `paneProcessOrDescendant` predicate:

- positive PID equality is accepted without a process-tree snapshot;
- unequal PIDs still require `strictDescendant`;
- `strictDescendant` itself remains strict and unchanged;
- zero, negative, and unrelated PIDs remain rejected.

The positive regressions are anchored through the real `deliverPaneCommand` / `verifyPaneProcessLaunched` seams rather than invented equal integers.

## Validation and mutation evidence

- Focused pre-mutation regressions: PASS (`3380bd26233cac5757975307cb1218d2a484a4dc0459768680d7506bd1fb14aa`).
- M1, equality removed: both live-status and cleanup positive tests fail (`6bece585b2afbcff38efc054d4656faa9344f0832adb7b16e957c90685e492e7`).
- M2, strict descendant relaxed to accept equality: strictness guard fails (`cf249352ded92919b51401ad4249b2fddebdf228447f1c7b50e5c5c5372e40aa`).
- M3, all positive PID pairs accepted: both unrelated-PID negative tests fail (`e63c3440cce3abb7e91454be0aec77422a2f052167dd74e7755da17a517c85ec`).
- Real v2-25-1 records: cto `73060 == 73060`, amq-dev-1 `73767 == 73767`, and amq-dev-2 `74139 == 74139`; all three pass the fixed lineage verifier without requesting a descendant snapshot (`ca1e78bb42fa0469afa9b5db48f05192e2d532d2190c144f8978c4f36bd7db63`).
- Non-positive boundary table: four cases pass; removing the positive-PID guard makes `(0,0)` and `(-1,-1)` fail (`315ca2383000f463d989db2893609a3d194a63dbb9d30aa94db5293933668f81`).
- Final six-test focused set: PASS (`ebed00d816e5b9c9bdcab4e91d02f8f729efd57be3aa00f5d53524e009bf5ccf`).
- Candidate binary build: PASS (`478115608d379832a6343c142b6efb32da851b43b885881c8b869fcdbd48c948`).
- Every temporary mutation and real-record proof was restored byte-exactly; every post-restore `git diff --check` artifact was empty.
- Two independent reviewers passed frozen patch `c651927017c3f4342e41f0c8985f2add3811df7b9e16bca38952789b88f93229`.
- Commit `7253635f4fcab8cee0f7900c3e2d88e7a816cfe2` independently re-derived that exact patch from base `a9625ce8777b4f11f2d05608316322c77f8253e8`, with no extra files.

Full CI is intentionally not claimed here; the PR checks are the suite-wide authority.

## Live-session caveat

The current v2-25-1 tmux session was manually rearranged during earlier recovery. Two launch records now have stale window metadata (`amq-dev-1 @43 -> @42`, `amq-dev-2 @44 -> @42`), so end-to-end status promotion rejects that independent pane-metadata mismatch before reaching lineage. The real-record proof above isolates and verifies the original equality refusal. A clean operator relaunch is expected to supply fresh pane metadata for the end-to-end check.

## Merge gates

- #586 lands first in the v2.25.1 train.
- Merge requires full CI green on this PR.
- Merge remains operator-gated at the exact PR/head, requires merge preflight, and must be performed by a non-author.

Fixes #586
