### PR TITLE
Release v2.25.1

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -40,11 +40,11 @@ amq-squad doctor --fix-amq-root
 ```
 
 The repair writes the configured member roster plus the enabled operator
-handle atomically, then asks AMQ to materialize missing mailboxes. `team resume
---exec` performs the same repair automatically before restarting watchers or
-agents and reports every created or written path. `team.json` and goal-attempt
-schemas remain unchanged; only the AMQ session root gains its authority config
-and any missing mailbox directories.
+handle atomically, then asks AMQ to materialize missing mailboxes.
+`amq-squad resume --exec` performs the same repair automatically before
+restarting watchers or agents and reports every created or written path.
+`team.json` and goal-attempt schemas remain unchanged; only the AMQ session
+root gains its authority config and any missing mailbox directories.
 
 **Known upstream doorbell limitation.** AMQ owns the fixed coop-wake doorbell
 text, which still says to run bare `amq drain --include-body`. From a repository

--- a/README.html
+++ b/README.html
@@ -272,6 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
+<li><a href="#whats-new-in-v2251" id="toc-whats-new-in-v2251">What's new
+in v2.25.1</a></li>
 <li><a href="#whats-new-in-v2250" id="toc-whats-new-in-v2250">What's new
 in v2.25.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
@@ -342,6 +344,44 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
+<h2 id="whats-new-in-v2251">What's new in v2.25.1</h2>
+<p>v2.25.1 is a compatibility and identity-repair release, produced by
+verifying amq-squad against upstream AMQ 0.49.8 and 0.49.9:</p>
+<ul>
+<li><strong>Pane-process identity acceptance (#586).</strong> PR #577
+delivers the worker as the pane's own process, so the agent PID IS the
+pane PID. The v2.25.0 verifiers still demanded strict descendance and
+refused every launch and every <code>stop --close-panes</code>. One
+shared predicate now accepts equality or a strict descendant at both
+call sites; <code>strictDescendant</code> stays strict.</li>
+<li><strong>AMQ 0.49.9 floor and adapted doctor canary (#584, retires
+#581).</strong> 0.49.9 is the minimum supported release and both
+real-AMQ matrices collapse to pinned <code>v0.49.9</code> and
+<code>latest</code>. AMQ 0.49.7 made doctor audit the reserved
+<code>user</code> roster implicitly, so the repair canary now asserts
+bounded public semantics instead of an alpha-only created-path
+list.</li>
+<li><strong>Session-root authority under AMQ 0.49.8+ (#588).</strong>
+0.49.8 made bare verbs refuse when a repo-local <code>.amqrc</code>
+conflicts with the env-pinned root, and made exact-root writes demand
+<code>meta/config.json</code> that session roots never carried. Session
+roots are now self-sufficient and every amq-squad-issued invocation and
+printed command pins <code>--root</code>.</li>
+</ul>
+<p><strong>Breaking:</strong> AMQ 0.49.9 is the minimum supported
+release; the 0.49.0 through 0.49.8 range is no longer supported and
+releases below the floor are rejected fail-closed. Upgrade
+<code>amq</code> before upgrading amq-squad, then stop and
+resume/relaunch agents so parent shells refresh the injected identity
+tuple.</p>
+<p><strong>Known limitation:</strong> under AMQ 0.49.8+ the upstream
+coop-wake doorbell's bare <code>amq drain --include-body</code> still
+refuses from a repo-root cwd with a conflicting <code>.amqrc</code>. The
+refusal names the exact <code>--root</code> recovery command and the
+bootstrap routing block is authoritative; tracked upstream.</p>
+<p>See <a href="docs/v2.25.1-release-notes.md">the v2.25.1 release
+notes</a> for the complete issue-to-behavior map, the safety-evidence
+summary, and residual risks.</p>
 <h2 id="whats-new-in-v2250">What's new in v2.25.0</h2>
 <p>v2.25.0 is a delivery-safety and identity release, headlined by
 claim-once automatic resume for paused native <code>/goal</code>
@@ -410,7 +450,7 @@ summary, and residual risks.</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.1</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.html
+++ b/README.html
@@ -365,8 +365,9 @@ list.</li>
 0.49.8 made bare verbs refuse when a repo-local <code>.amqrc</code>
 conflicts with the env-pinned root, and made exact-root writes demand
 <code>meta/config.json</code> that session roots never carried. Session
-roots are now self-sufficient and every amq-squad-issued invocation and
-printed command pins <code>--root</code>.</li>
+roots are now self-sufficient, and affected coop, dispatch and
+wake-sidecar invocations plus generated bootstrap/routing commands use
+the resolved exact root.</li>
 </ul>
 <p><strong>Breaking:</strong> AMQ 0.49.9 is the minimum supported
 release; the 0.49.0 through 0.49.8 range is no longer supported and

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ amq-squad against upstream AMQ 0.49.8 and 0.49.9:
 - **Session-root authority under AMQ 0.49.8+ (#588).** 0.49.8 made bare verbs
   refuse when a repo-local `.amqrc` conflicts with the env-pinned root, and
   made exact-root writes demand `meta/config.json` that session roots never
-  carried. Session roots are now self-sufficient and every amq-squad-issued
-  invocation and printed command pins `--root`.
+  carried. Session roots are now self-sufficient, and affected coop, dispatch
+  and wake-sidecar invocations plus generated bootstrap/routing commands use
+  the resolved exact root.
 
 **Breaking:** AMQ 0.49.9 is the minimum supported release; the 0.49.0 through
 0.49.8 range is no longer supported and releases below the floor are rejected

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
+## What's new in v2.25.1
+
+v2.25.1 is a compatibility and identity-repair release, produced by verifying
+amq-squad against upstream AMQ 0.49.8 and 0.49.9:
+
+- **Pane-process identity acceptance (#586).** PR #577 delivers the worker as
+  the pane's own process, so the agent PID IS the pane PID. The v2.25.0
+  verifiers still demanded strict descendance and refused every launch and
+  every `stop --close-panes`. One shared predicate now accepts equality or a
+  strict descendant at both call sites; `strictDescendant` stays strict.
+- **AMQ 0.49.9 floor and adapted doctor canary (#584, retires #581).** 0.49.9
+  is the minimum supported release and both real-AMQ matrices collapse to
+  pinned `v0.49.9` and `latest`. AMQ 0.49.7 made doctor audit the reserved
+  `user` roster implicitly, so the repair canary now asserts bounded public
+  semantics instead of an alpha-only created-path list.
+- **Session-root authority under AMQ 0.49.8+ (#588).** 0.49.8 made bare verbs
+  refuse when a repo-local `.amqrc` conflicts with the env-pinned root, and
+  made exact-root writes demand `meta/config.json` that session roots never
+  carried. Session roots are now self-sufficient and every amq-squad-issued
+  invocation and printed command pins `--root`.
+
+**Breaking:** AMQ 0.49.9 is the minimum supported release; the 0.49.0 through
+0.49.8 range is no longer supported and releases below the floor are rejected
+fail-closed. Upgrade `amq` before upgrading amq-squad, then stop and
+resume/relaunch agents so parent shells refresh the injected identity tuple.
+
+**Known limitation:** under AMQ 0.49.8+ the upstream coop-wake doorbell's bare
+`amq drain --include-body` still refuses from a repo-root cwd with a
+conflicting `.amqrc`. The refusal names the exact `--root` recovery command and
+the bootstrap routing block is authoritative; tracked upstream.
+
+See [the v2.25.1 release notes](docs/v2.25.1-release-notes.md) for the
+complete issue-to-behavior map, the safety-evidence summary, and residual
+risks.
+
 ## What's new in v2.25.0
 
 v2.25.0 is a delivery-safety and identity release, headlined by claim-once
@@ -106,7 +141,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.1
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.25.1-release-notes.md
+++ b/docs/v2.25.1-release-notes.md
@@ -1,0 +1,106 @@
+# amq-squad v2.25.1
+
+## Summary
+
+v2.25.1 is a compatibility and identity-repair release, produced by verifying
+amq-squad against upstream AMQ 0.49.8 and 0.49.9. It fixes the v2.25.0
+regression that left every managed launch unpromotable (#586), raises the
+supported AMQ floor to 0.49.9 with an adapted doctor-repair canary (#584,
+retiring #581), and restores durable coordination under AMQ 0.49.8+'s
+canonical-root authority, which a live upgrade proved could take down a running
+squad's mailboxes (#588). All three fixes shipped with adversarial two-reviewer
+verification at content-addressed frozen artifacts, CI proofs at exact head
+SHAs, and named mutation killers.
+
+## Pane-process identity acceptance (#586, PR #592)
+
+- PR #577 (v2.25.0) delivers the worker command as the pane's own process, so
+  the agent PID IS the pane PID. The v2.25.0 identity verifiers still required
+  strict descendance, refusing every launch ("verified agent PID N is not a
+  descendant of recorded pane PID N" with N == N) and refusing
+  `stop --close-panes` cleanup.
+- One shared predicate (`paneProcessOrDescendant`: equality OR strict
+  descendant, positive-PID guarded) now backs both call sites:
+  `verifyAgentPaneLineage` (status promotion / goal delivery) and
+  `PreparePaneCleanup` (pane cleanup). `strictDescendant` itself remains
+  byte-for-byte strict for its deliberate semantics.
+- Regression tests anchor through the real #577 delivery seams
+  (`deliverPaneCommand` respawn-pane path, `verifyPaneProcessLaunched`), not
+  synthetic equal integers; mutation killers cover equality removal,
+  strictness relaxation, accept-everything, and the non-positive PID boundary.
+- Live verification: the fixed predicate accepts all three of the discovering
+  session's real launch records (agent PID == pane PID) where the shipped
+  binary refused them.
+
+## AMQ 0.49.9 floor and doctor-repair canary (#584, PR #591; retires #581)
+
+- AMQ 0.49.9 is the minimum supported release. The 0.49.0 through 0.49.8 range
+  is no longer supported; releases below the floor are rejected fail-closed.
+  Both real-AMQ CI matrices collapse to pinned `v0.49.9` and `latest`.
+- The #581 canary is adapted: since AMQ 0.49.7 (upstream fab4c76), doctor
+  audits the reserved `user` roster entry implicitly, so a single-mailbox
+  repair also materializes the reserved operator mailbox. The compatibility
+  assertion now checks bounded public semantics: the repaired path exactly
+  once, every other created path inside the reserved `agents/user` subtree
+  (prefix-impostor-proof), reserved mailbox healthy when surfaced, pre-0.49.7
+  alpha-only shape still accepted, with a hermetic 8-case mutation table
+  proving the relaxed boundary still kills unrelated creations, duplicates,
+  and prefix impostors.
+- Verification record: compat lanes at 0.49.8 and 0.49.9 fail on exactly the
+  #581 signature pre-adaptation (byte-identical created-paths lists) and are
+  fully green post-adaptation; the wake lane's local red was proven
+  version-independent by a v0.49.1 control and green in CI at three versions;
+  the local failure is the same #577 pane-identity class as #586 and is
+  machine-specific, never reproduced in CI. The `latest` lane's version guard
+  skips its own assertion, so the pinned lane is the one that records what was
+  proved. That is now documented.
+- The release validator (`scripts/check-release-version.py`) and every live
+  policy surface (README, skills, runbook, generated mirrors) normalize to the
+  single-pinned-lane policy.
+
+## Session-root authority under AMQ 0.49.8+ (#588, PR #593)
+
+- AMQ 0.49.8 introduced canonical root authority: bare verbs refuse when a
+  repo-local `.amqrc` conflicts with the env-pinned root from cwd, and
+  exact-root writes demand `meta/config.json`, which amq-squad session roots
+  never carried. A live `amq upgrade` to 0.49.9 mid-session proved this takes
+  down a running squad's durable coordination (both failure modes hit within a
+  minute).
+- Session roots are now self-sufficient: root creation writes
+  `meta/config.json` with the exact configured roster (reserved operator
+  handle included), kept in sync across member add/update/rm with atomic
+  writes; `team resume` auto-repairs configless legacy roots (visibly);
+  `doctor --fix-amq-root` is the explicit manual repair.
+- Every AMQ invocation amq-squad issues, and every printed bootstrap/routing
+  command, pins `--root` (and sender where applicable). The upstream
+  coop-wake doorbell string is untouched; it is AMQ's contract.
+- A real-AMQ compatibility fixture now reproduces the exact production tuple
+  (repo-local base `.amqrc` + exact named sub-root + repo cwd + full injected
+  identity) and asserts both refusals and the repair path, closing the class
+  of defects CI structurally could not see.
+- KNOWN LIMITATION: under 0.49.8+, the upstream doorbell's bare
+  `amq drain --include-body` still refuses from a repo-root cwd with a
+  conflicting `.amqrc`. The refusal message names the exact `--root` recovery
+  command, and the bootstrap routing block is authoritative. Tracked upstream
+  (injected-tuple authority over cwd discovery).
+
+## Also in this release
+
+- #587 (filed): the real-AMQ compat lane leaks `AMQ_WAKE_OWNER` from live
+  managed-agent environments into disposable fixtures.
+- #589 (filed): `amq-squad amq send` writes an `ambiguous_unknown` receipt for
+  a send that failed closed.
+- #590 (filed): wake-harness timing fragility across two independent
+  subtests: a ~1-in-7 local race in
+  `production_cleanup_recovers_owner-bound_managed_wake`, and consecutive
+  recorder-readiness timeouts in
+  `dispatch_force_durable_plus_prompt_fallback` under load.
+
+## Upgrade notes
+
+Upgrade `amq` to 0.49.9 (`amq upgrade`) before upgrading amq-squad; releases
+below the floor are rejected rather than degraded. After upgrading, stop and
+resume/relaunch agents so parent shells refresh the injected identity tuple.
+Existing sessions with configless roots are repaired automatically on resume,
+or manually with `amq-squad doctor --fix-amq-root`. See MIGRATION.md
+("What's new in 2.25.1").

--- a/docs/v2.25.1-release-notes.md
+++ b/docs/v2.25.1-release-notes.md
@@ -69,11 +69,12 @@ SHAs, and named mutation killers.
 - Session roots are now self-sufficient: root creation writes
   `meta/config.json` with the exact configured roster (reserved operator
   handle included), kept in sync across member add/update/rm with atomic
-  writes; `team resume` auto-repairs configless legacy roots (visibly);
-  `doctor --fix-amq-root` is the explicit manual repair.
-- Every AMQ invocation amq-squad issues, and every printed bootstrap/routing
-  command, pins `--root` (and sender where applicable). The upstream
-  coop-wake doorbell string is untouched; it is AMQ's contract.
+  writes; `amq-squad resume --exec` auto-repairs configless legacy roots and
+  reports its writes; `doctor --fix-amq-root` is the explicit manual repair.
+- Affected coop, dispatch, and wake-sidecar invocations, plus generated
+  bootstrap/routing/gate/READY commands, now use the resolved exact root (and
+  sender where applicable). The upstream coop-wake doorbell string is
+  untouched; it is AMQ's contract.
 - A real-AMQ compatibility fixture now reproduces the exact production tuple
   (repo-local base `.amqrc` + exact named sub-root + repo cwd + full injected
   identity) and asserts both refusals and the repair path, closing the class
@@ -101,6 +102,7 @@ SHAs, and named mutation killers.
 Upgrade `amq` to 0.49.9 (`amq upgrade`) before upgrading amq-squad; releases
 below the floor are rejected rather than degraded. After upgrading, stop and
 resume/relaunch agents so parent shells refresh the injected identity tuple.
-Existing sessions with configless roots are repaired automatically on resume,
-or manually with `amq-squad doctor --fix-amq-root`. See MIGRATION.md
+Existing sessions with configless roots are repaired automatically by
+`amq-squad resume --exec`, or manually with
+`amq-squad doctor --fix-amq-root`. See MIGRATION.md
 ("What's new in 2.25.1").

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | console | up | focus | send | resume | fork | rm | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | activity | gate | resume | stop | archive | context | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | stage goal|brief|rules|roles|profile|readiness|launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.25.0",
+  "version": "2.25.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` and its roles stage. Role authoring is part of the reviewed goal-to-launch preparation flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, preparation, readiness, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.25.0"  # x-release-please-version
+version: "2.25.1"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release v2.25.1.

**DRAFT until #593 lands.** This branch is based on `cb6551be` (post-#592 main). Once #593 merges it rebases onto the new main; the rebase is file-disjoint (version bumps, docs and generated skill mirrors versus #593's `internal/cli` changes), so the patch should carry forward content-addressed with no conflicts.

## Contents

- `docs/v2.25.1-release-notes.md` (new) — full issue-to-behavior map for #584, #586 and #588, the evidence summary, and residual risks.
- `README.md` — "What's new in v2.25.1" block, `go install` tag bump, plus the **Breaking** floor note and the **Known limitation** on the upstream coop-wake doorbell.
- `plugins/{claude,codex}` manifests → `2.25.1`.
- 14 generated `SKILL.md` frontmatters → `2.25.1`, produced by `make skills-generate`. These are **generated**: the generator reads each mirror's `plugin.json`, so the manifests are the only authored edit. Hand-editing them would fail `skills-check` or be silently overwritten.
- `README.html` regenerated by `make readme-html`.

## Gate evidence

| Check | Result |
| --- | --- |
| `VERSION=v2.25.1 make release-check` | **exit 0** — "release metadata matches v2.25.1" |
| `make skills-generate` / `make readme-html` | exit 0 |
| `make skills-check skill-routing-check skill-command-check readme-html-check docs-html-check` | exit 0 |
| `make ci` | **not run locally** — CI is the arbiter per the expedite ruling |

The release-check gate is the meaningful one here: at 22:00 it failed with 19 items (missing release notes, both manifests, 14 frontmatters, the `go install` line). All 19 are now closed.

## Known limitation carried into the notes

Under AMQ 0.49.8+ the upstream coop-wake doorbell's bare `amq drain --include-body` still refuses from a repo-root cwd with a conflicting `.amqrc`. amq-squad cannot edit that string; it is AMQ's contract. The refusal names the exact `--root` recovery command and the bootstrap routing block is authoritative. Tracked upstream.

## Merge gating

Merges after #593, and after CI green at the rebased head. The tag and publish are operator-executed.
