### PR TITLE
Make real-AMQ fixtures hermetic to managed context

### DIFF
--- a/internal/act/control.go
+++ b/internal/act/control.go
@@ -325,7 +325,9 @@ func decodeControlReceipt(raw []byte) (Receipt, error) {
 func envWithoutAMQIdentity(env []string) []string {
 	remove := map[string]bool{
 		"AM_ROOT":         true,
+		"AM_ROOT_ID":      true,
 		"AM_BASE_ROOT":    true,
+		"AM_BASE_ROOT_ID": true,
 		"AM_SESSION":      true,
 		"AM_ME":           true,
 		"AMQ_GLOBAL_ROOT": true,
@@ -333,9 +335,12 @@ func envWithoutAMQIdentity(env []string) []string {
 	out := make([]string, 0, len(env))
 	for _, entry := range env {
 		key, _, ok := strings.Cut(entry, "=")
-		if !ok || !remove[key] {
-			out = append(out, entry)
+		// Owner tokens and private wake descriptors belong to the parent
+		// context and must never authorize the receipted child action.
+		if ok && (remove[key] || strings.HasPrefix(key, "AMQ_WAKE_")) {
+			continue
 		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/act/control_test.go
+++ b/internal/act/control_test.go
@@ -3,6 +3,7 @@ package act
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -122,9 +123,15 @@ func TestSendUsesExactPreviewArgvAndReturnsDurableReceipt(t *testing.T) {
 	}
 	t.Cleanup(func() { controlExec = previous })
 	t.Setenv("AM_ROOT", "/stale")
+	t.Setenv("AM_ROOT_ID", "v1:stale:root")
 	t.Setenv("AM_BASE_ROOT", "/stale-base")
+	t.Setenv("AM_BASE_ROOT_ID", "v1:stale:base")
 	t.Setenv("AM_SESSION", "stale")
 	t.Setenv("AM_ME", "stale")
+	t.Setenv("AMQ_GLOBAL_ROOT", "/stale-global")
+	t.Setenv("AMQ_WAKE_OWNER", "stale-owner-token")
+	t.Setenv("AMQ_WAKE_PRIVATE_STOP_FD", "998")
+	t.Setenv("AMQ_WAKE_FUTURE_PRIVATE_STATE", "stale")
 
 	receipt, err := Send(action)
 	if err != nil {
@@ -137,10 +144,14 @@ func TestSendUsesExactPreviewArgvAndReturnsDurableReceipt(t *testing.T) {
 		t.Fatalf("executed args\n got: %#v\nwant: %#v", gotArgs, want)
 	}
 	for _, entry := range gotEnv {
-		for _, key := range []string{"AM_ROOT=", "AM_BASE_ROOT=", "AM_SESSION=", "AM_ME="} {
-			if strings.HasPrefix(entry, key) {
-				t.Fatalf("stale identity leaked to child: %q", entry)
-			}
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(key, "AMQ_WAKE_") || slices.Contains([]string{
+			"AM_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT", "AM_BASE_ROOT_ID", "AM_SESSION", "AM_ME", "AMQ_GLOBAL_ROOT",
+		}, key) {
+			t.Fatalf("stale identity leaked to child: %q", entry)
 		}
 	}
 }

--- a/internal/cli/amq_env.go
+++ b/internal/cli/amq_env.go
@@ -197,9 +197,13 @@ func envWithoutAMQIdentity(env []string) []string {
 	out := make([]string, 0, len(env))
 	for _, entry := range env {
 		key, _, ok := strings.Cut(entry, "=")
-		if !ok || (!remove[key] && !strings.HasPrefix(key, "AMQ_SQUAD_TERMINAL_")) {
-			out = append(out, entry)
+		// AMQ v0.51.1 exports both the owner token and private descriptor
+		// state under AMQ_WAKE_. Scrub the namespace so new wake internals
+		// cannot silently reintroduce live managed-agent authority.
+		if ok && (remove[key] || strings.HasPrefix(key, "AMQ_WAKE_") || strings.HasPrefix(key, "AMQ_SQUAD_TERMINAL_")) {
+			continue
 		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/internal/cli/amq_env_test.go
+++ b/internal/cli/amq_env_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -81,6 +82,7 @@ func TestResolveAMQEnvInDirClearsInheritedAMQIdentity(t *testing.T) {
 func TestEnvWithoutAMQIdentityRemovesCompleteTuple(t *testing.T) {
 	got := envWithoutAMQIdentity([]string{
 		"KEEP=value",
+		"AMQ_NO_UPDATE_CHECK=0",
 		"AM_ROOT=/root",
 		"AM_ROOT_ID=v1:test:root",
 		"AM_BASE_ROOT=/base",
@@ -88,10 +90,15 @@ func TestEnvWithoutAMQIdentityRemovesCompleteTuple(t *testing.T) {
 		"AM_SESSION=",
 		"AM_ME=cto",
 		"AMQ_GLOBAL_ROOT=/global",
+		"AMQ_WAKE_OWNER=live-owner-token",
+		"AMQ_WAKE_ATTENTION_FD=997",
+		"AMQ_WAKE_PRIVATE_STOP_FD=998",
+		"AMQ_WAKE_FUTURE_PRIVATE_STATE=live",
 		"AMQ_SQUAD_TERMINAL_TITLE=test",
 	})
-	if len(got) != 1 || got[0] != "KEEP=value" {
-		t.Fatalf("sanitized env = %#v, want only KEEP=value", got)
+	want := []string{"KEEP=value", "AMQ_NO_UPDATE_CHECK=0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sanitized env = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -98,6 +98,7 @@ func TestRealAMQCompatibility(t *testing.T) {
 	if binary == "" {
 		t.Skip("set AMQ_SQUAD_REAL_AMQ to run disposable real-AMQ compatibility checks")
 	}
+	isolateRealAMQManagedContext(t)
 	info, err := os.Stat(binary)
 	if err != nil {
 		t.Fatalf("stat AMQ_SQUAD_REAL_AMQ %q: %v", binary, err)

--- a/internal/cli/real_amq_env_test.go
+++ b/internal/cli/real_amq_env_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/amqexec"
+)
+
+// realAMQManagedContextPoison mirrors the context exported by a live managed
+// agent and includes private wake state observed in AMQ v0.51.1. The AMQ_WAKE_
+// sentinel makes the regression cover future wake-owned descriptors too.
+var realAMQManagedContextPoison = []string{
+	"AM_ROOT=/hostile/live/root",
+	"AM_ROOT_ID=v1:hostile:root",
+	"AM_BASE_ROOT=/hostile/live/base",
+	"AM_BASE_ROOT_ID=v1:hostile:base",
+	"AM_ME=hostile-live-agent",
+	"AM_SESSION=hostile-live-session",
+	"AMQ_GLOBAL_ROOT=/hostile/global/root",
+	"AMQ_WAKE_OWNER=hostile-live-owner-token",
+	"AMQ_WAKE_ATTENTION_FD=997",
+	"AMQ_WAKE_PRIVATE_STOP_FD=998",
+	"AMQ_WAKE_FUTURE_PRIVATE_STATE=hostile",
+}
+
+func isolateRealAMQManagedContext(t *testing.T) {
+	t.Helper()
+	for _, entry := range realAMQManagedContextPoison {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			t.Fatalf("invalid real-AMQ managed context poison %q", entry)
+		}
+		t.Setenv(key, value)
+	}
+
+	current := os.Environ()
+	kept := make(map[string]bool)
+	for _, entry := range envWithoutAMQIdentity(current) {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			kept[key] = true
+		}
+	}
+	for _, entry := range current {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if kept[key] {
+			continue
+		}
+		t.Cleanup(func() {
+			if err := os.Setenv(key, value); err != nil {
+				t.Errorf("restore sanitized real-AMQ managed context %s: %v", key, err)
+			}
+		})
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset sanitized real-AMQ managed context %s: %v", key, err)
+		}
+	}
+}
+
+func TestRealAMQFixtureEnvSanitizesManagedContext(t *testing.T) {
+	clean := []string{
+		"PATH=/fixture/bin",
+		"AMQ_NO_UPDATE_CHECK=0",
+		"AMQ_SQUAD_REAL_AMQ=/fixture/amq",
+		"AMQ_SQUAD_REAL_AMQ_VERSION=v0.51.1",
+	}
+	poisoned := append(append([]string(nil), clean...), realAMQManagedContextPoison...)
+	want := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(clean))
+	got := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(poisoned))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("poisoned fixture env = %#v, want clean env %#v", got, want)
+	}
+}
+
+func TestRealAMQProcessEnvSanitizesManagedContext(t *testing.T) {
+	isolateRealAMQManagedContext(t)
+	for _, entry := range realAMQManagedContextPoison {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, ok := os.LookupEnv(key); ok {
+			t.Fatalf("process fixture env retained %s", key)
+		}
+	}
+}

--- a/internal/cli/real_amq_root_authority_compatibility_test.go
+++ b/internal/cli/real_amq_root_authority_compatibility_test.go
@@ -198,15 +198,7 @@ func realAMQRootAuthorityCompatibilityContract(t *testing.T, binary string) {
 }
 
 func realAMQRootAuthorityCleanEnv(env []string) []string {
-	clean := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(env))
-	out := clean[:0]
-	for _, entry := range clean {
-		if strings.HasPrefix(entry, "AMQ_WAKE_OWNER=") {
-			continue
-		}
-		out = append(out, entry)
-	}
-	return out
+	return amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(env))
 }
 
 func realAMQRootAuthorityTry(binary, dir string, env []string, args ...string) (string, error) {

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -33,6 +33,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 	if amq == "" {
 		t.Skip("set AMQ_SQUAD_REAL_AMQ to run disposable real-AMQ wake checks")
 	}
+	isolateRealAMQManagedContext(t)
 	requireExecutable(t, amq, "AMQ_SQUAD_REAL_AMQ")
 	tmux, err := exec.LookPath("tmux")
 	if err != nil {


### PR DESCRIPTION
Closes #587

Rebased onto `main` after #602 merged at `6a34984db6ff9813b872c7a1fb4e8cc0c64ff2b6`.

## Summary

- scrub the full `AMQ_WAKE_` namespace wherever inherited AMQ identity is removed
- remove both root identity tokens from the duplicate `internal/act` subprocess sanitizer
- make both real-AMQ entrypoints self-poison with live-like identity, global-root, owner-token, and private wake-FD values
- sanitize the test process and every subprocess fixture by construction
- remove the root-authority lane's one-off `AMQ_WAKE_OWNER` workaround in favor of the shared boundary
- retain fixture controls such as `AMQ_SQUAD_REAL_AMQ` and `AMQ_NO_UPDATE_CHECK`

## Regression evidence

The CLI sanitizer test-first proof failed at the stacked parent because `AMQ_WAKE_OWNER`, current private `AMQ_WAKE_*_FD` values, and a future-prefix sentinel survived. The identical focused suite passes after the namespace scrub.

Reviewer B identified the duplicate `internal/act` sanitizer. Its expected-red execution-path test failed on leaked `AM_ROOT_ID`; after aligning both identity tokens and the `AMQ_WAKE_` prefix, the identical test passes.

The durable AMQ coordination thread `p2p/amq-dev-2__cto` at 17:41Z records the live workaround: the v0.51.1 lanes had to be invoked with explicit identity unsets. The final lanes below use no caller-side `env -u`.

## Rebase evidence

- old exact head: `1fe8bbb61a555805f3142de66ac32de5206086d7`
- rebased exact head: `07cc3976b86a3c8c357d247bf9097d7c4017eb86`
- `git range-diff` reports both branch commits exact-equivalent
- `git diff` between old and rebased tips is empty; the tip trees are byte-identical
- no conflicts or semantic conflict resolution occurred

## Validation

- `make ci` — PASS at rebased head
- self-poisoning pinned AMQ v0.51.1 `TestRealAMQCompatibility` — PASS, all 15 subtests
- self-poisoning pinned AMQ v0.51.1 `TestRealAMQWakeCompatibility` — PASS, all wake subtests
- focused CLI fixture/process sanitizer suite — PASS
- focused `internal/act` subprocess sanitizer suite — PASS

### Transparent flake record

The first sandboxed real-AMQ attempt is excluded because wake operations were denied by the sandbox. On the first unsandboxed compatibility run, 14 of 15 subtests passed and `production_cleanup_recovers_owner-bound_managed_wake` hit `cooperative authoritative wake stop unavailable: no such file or directory` for PID 83362. This exact signature is the known open timing race in #590. PID 83362 was gone afterward; no ambient pinned-AMQ wake/coop process or fixture directory remained. The isolated subtest then passed 3/3, and one lead-authorized clean full retry passed both real-AMQ lanes plus `make ci`. Because the old and rebased tip trees are byte-identical, this is classified as a diff-independent environmental flake rather than a rebase regression.
