### PR TITLE
feat: make roster edits one-step

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -1058,6 +1058,16 @@ and launch it through the managed resume/up path so stop, resume, focus,
 and status retain a stable runtime identity. The durable roster and task
 store must rebuild the team the lead created, not merely the initial
 seed.</p>
+<p>For a session-pinned roster with an existing ready accepted
+preparation, <code>team member add</code>,
+<code>team member update</code> (including <code>--binary</code>,
+<code>--model</code>, and <code>--effort</code>), and
+<code>team member rm</code> are one-step roster edits: the command
+publishes a replacement accepted generation while holding the prepared
+writer admission. The accepted goal, launch shape, topology, and
+environment contract stay unchanged. An unprepared or already-drifted
+session is not implicitly accepted; run the normal preparation workflow
+for that case.</p>
 <p>Autonomous mode is never inferred. It requires positive
 <code>max-agents</code>, <code>max-total-spawns</code>, and
 <code>budget-turns</code>, plus an allowed-role or allowed-role-class

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -513,6 +513,14 @@ the managed resume/up path so stop, resume, focus, and status retain a stable
 runtime identity. The durable roster and task store must rebuild the team the
 lead created, not merely the initial seed.
 
+For a session-pinned roster with an existing ready accepted preparation,
+`team member add`, `team member update` (including `--binary`, `--model`, and
+`--effort`), and `team member rm` are one-step roster edits: the
+command publishes a replacement accepted generation while holding the prepared
+writer admission. The accepted goal, launch shape, topology, and environment
+contract stay unchanged. An unprepared or already-drifted session is not
+implicitly accepted; run the normal preparation workflow for that case.
+
 Autonomous mode is never inferred. It requires positive `max-agents`,
 `max-total-spawns`, and `budget-turns`, plus an allowed-role or
 allowed-role-class boundary; `idle-reap-minutes` constrains pruning. Before an

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -292,7 +292,7 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 			effortErr = validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort, agentCatalog)
 		}
 		if effortErr != nil {
-			return add(runStartPreflightInvalidEffort, effortErr.Error(), "use role=automatic|low|medium|high assignments")
+			return add(runStartPreflightInvalidEffort, effortErr.Error(), "use role=automatic|low|medium|high|xhigh|max assignments")
 		}
 	}
 	return r

--- a/internal/cli/run_start_preflight_test.go
+++ b/internal/cli/run_start_preflight_test.go
@@ -116,3 +116,15 @@ func TestRunStartPreflightAcceptsCurrentAndCustomEffortForSupportedBinary(t *tes
 		}
 	}
 }
+
+func TestRunStartPreflightInvalidEffortFixIncludesXHigh(t *testing.T) {
+	result := runStartPreflight(runStartPreflightInput{
+		Project: t.TempDir(), Session: "sess", Roles: "qa", Binary: "qa=claude", Visibility: "sibling-tabs", Effort: "high", EffortSet: true,
+	})
+	if len(result.Issues) != 1 || result.Issues[0].Code != runStartPreflightInvalidEffort {
+		t.Fatalf("preflight = %+v", result)
+	}
+	if fixes := strings.Join(result.Issues[0].SuggestedFixes, " "); !strings.Contains(fixes, "xhigh") {
+		t.Fatalf("invalid effort fix omits xhigh: %q", fixes)
+	}
+}

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -40,7 +40,8 @@ Usage:
       [--session S] [--project DIR] [--profile NAME] [--json]
   amq-squad team member status <role> [--session S] [--project DIR] [--profile NAME] [--json]
   amq-squad team member history <role> [--session S] [--project DIR] [--profile NAME] [--json]
-  amq-squad team member update <role> [--handle H] [--session S | --no-session-pin]
+  amq-squad team member update <role> [--binary <claude|codex>] [--handle H]
+      [--session S | --no-session-pin]
       [--model M] [--effort E] [--claude-args "…"] [--codex-args "…"]
       [--actor-mode review|implementation] [--project DIR] [--profile NAME]
       [--dry-run] [--json]
@@ -50,11 +51,15 @@ Usage:
 
 Mutates the persisted team profile (team.json) atomically and under an
 exclusive lock, then re-validates it (orchestration constraints included).
+When an edit keeps one affected session pin and that session already has a
+valid, ready accepted preparation, add/update/rm also publishes its replacement
+generation before returning, so the roster edit does not require a separate
+prepare/accept round trip.
 The new member is NOT launched; 'add' prints how to start it (a managed pane
 via 'resume --exec --target new-window', or 'agent up' for an unmanaged one-off).
 
-'update' changes an existing member in place (session pin, model, effort,
-native args, handle, actor-mode) without the remove-then-add dance — the only
+'update' changes an existing member in place (binary, session pin, model,
+effort, native args, handle, actor-mode) without the remove-then-add dance; the only
 way today to adjust the orchestration lead, since 'rm' refuses to remove it.
 Only the flags you pass are changed; the rest of the member is untouched.
 Changing a self_operator lead's --session does NOT reconfigure its exact-session
@@ -341,28 +346,47 @@ func runTeamMemberAdd(args []string) error {
 		}
 		return nil
 	}
-	if err := withProfileLock(projectDir, profile, func() error {
-		t, err := team.ReadProfile(projectDir, profile)
-		if err != nil {
-			return fmt.Errorf("read team: %w", err)
-		}
-		oldTeam := t
-		oldTeam.Members = append([]team.Member(nil), t.Members...)
-		added, err = buildAdded(t)
-		if err != nil {
-			return err
-		}
-		t.Members = append(t.Members, added)
-		// WriteProfileUnderLock re-validates the whole team (orchestration, per-member
-		// binary-match, duplicate handles) before the atomic rename, so an
-		// invalid add never persists.
-		if err := writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, t, resolveAMQEnvForTeamProfile); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+	currentTeam, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	predictedSession := strings.ToLower(strings.TrimSpace(*sessionFlag))
+	if predictedSession == "" {
+		predictedSession = inheritedSession(currentTeam)
+	}
+	mutation := func(expectedProfileDigest string) error {
+		return withProfileLock(projectDir, profile, func() error {
+			if err := verifyAcceptedProfileDigestBeforeRosterMutation(team.ProfilePath(projectDir, profile), expectedProfileDigest); err != nil {
+				return err
+			}
+			t, err := team.ReadProfile(projectDir, profile)
+			if err != nil {
+				return fmt.Errorf("read team: %w", err)
+			}
+			oldTeam := t
+			oldTeam.Members = append([]team.Member(nil), t.Members...)
+			added, err = buildAdded(t)
+			if err != nil {
+				return err
+			}
+			if added.Session != predictedSession {
+				return fmt.Errorf("team profile changed concurrently while adding %q; retry", role)
+			}
+			t.Members = append(t.Members, added)
+			// WriteProfileUnderLock re-validates the whole team (orchestration, per-member
+			// binary-match, duplicate handles) before the atomic rename, so an
+			// invalid add never persists.
+			if err := writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, t, resolveAMQEnvForTeamProfile); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	preparedAcceptance, err := mutateRosterWithPreparedAcceptance(projectDir, profile, predictedSession, mutation)
+	if err != nil {
 		return err
 	}
+	printRosterPreparedAcceptance(preparedAcceptance, profile, predictedSession, *jsonOut)
 
 	if *jsonOut {
 		return printJSONEnvelope("team_member_add", mutationResult{
@@ -448,6 +472,7 @@ func runTeamMemberUpdate(args []string) error {
 	}
 	role = strings.ToLower(strings.TrimSpace(role))
 	fs := flag.NewFlagSet("team member update", flag.ContinueOnError)
+	binaryFlag := fs.String("binary", "", "new agent CLI for this member: claude or codex")
 	handleFlag := fs.String("handle", "", "new AMQ handle for this member")
 	sessionFlag := fs.String("session", "", "new AMQ workstream session pin for this member")
 	noSessionPinFlag := fs.Bool("no-session-pin", false, "clear this member's session pin instead of setting one")
@@ -470,7 +495,7 @@ func runTeamMemberUpdate(args []string) error {
 	if *noSessionPinFlag && flagWasSet(fs, "session") {
 		return usageErrorf("use either --session or --no-session-pin, not both")
 	}
-	changing := []string{"handle", "session", "no-session-pin", "model", "effort", "claude-args", "codex-args", "actor-mode", "cwd"}
+	changing := []string{"binary", "handle", "session", "no-session-pin", "model", "effort", "claude-args", "codex-args", "actor-mode", "cwd"}
 	changed := false
 	for _, name := range changing {
 		if flagWasSet(fs, name) {
@@ -479,7 +504,13 @@ func runTeamMemberUpdate(args []string) error {
 		}
 	}
 	if !changed {
-		return usageErrorf("no changes given; pass at least one of --handle, --session, --no-session-pin, --model, --effort, --claude-args, --codex-args, --actor-mode")
+		return usageErrorf("no changes given; pass at least one of --binary, --handle, --session, --no-session-pin, --model, --effort, --claude-args, --codex-args, --actor-mode")
+	}
+	if flagWasSet(fs, "binary") {
+		binary := normalizedAgentBinary(*binaryFlag)
+		if binary != "claude" && binary != "codex" {
+			return usageErrorf("--binary must be claude or codex (got %q)", *binaryFlag)
+		}
 	}
 	if flagWasSet(fs, "actor-mode") {
 		mode := strings.ToLower(strings.TrimSpace(*actorModeFlag))
@@ -506,6 +537,17 @@ func runTeamMemberUpdate(args []string) error {
 			return team.Member{}, team.Team{}, fmt.Errorf("role %q is not a team member", role)
 		}
 		m := t.Members[idx]
+		if flagWasSet(fs, "binary") {
+			binary := normalizedAgentBinary(*binaryFlag)
+			if binary != m.Binary {
+				m.Binary = binary
+				if binary == "claude" {
+					m.CodexArgs = nil
+				} else {
+					m.ClaudeArgs = nil
+				}
+			}
+		}
 		if flagWasSet(fs, "handle") {
 			handle := strings.ToLower(strings.TrimSpace(*handleFlag))
 			if handle == "" {
@@ -589,26 +631,60 @@ func runTeamMemberUpdate(args []string) error {
 		return nil
 	}
 
-	var updated team.Member
-	if err := withProfileLock(projectDir, profile, func() error {
-		t, err := team.ReadProfile(projectDir, profile)
-		if err != nil {
-			return fmt.Errorf("read team: %w", err)
-		}
-		oldTeam := t
-		oldTeam.Members = append([]team.Member(nil), t.Members...)
-		var newTeam team.Team
-		updated, newTeam, err = buildUpdated(t)
-		if err != nil {
-			return err
-		}
-		// WriteProfileUnderLock re-validates the whole team (orchestration,
-		// per-member binary-match, duplicate handles) before the atomic
-		// rename, so an invalid update never persists.
-		return writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, newTeam, resolveAMQEnvForTeamProfile)
-	}); err != nil {
+	currentTeam, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return fmt.Errorf("read team: %w", err)
+	}
+	currentMember, ok := teamMemberByRole(currentTeam, role)
+	if !ok {
+		return fmt.Errorf("role %q is not a team member", role)
+	}
+	predicted, _, err := buildUpdated(currentTeam)
+	if err != nil {
 		return err
 	}
+	preparedSession := currentMember.Session
+	if predicted.Session != currentMember.Session {
+		preparedSession = ""
+	}
+
+	var updated team.Member
+	mutation := func(expectedProfileDigest string) error {
+		return withProfileLock(projectDir, profile, func() error {
+			if err := verifyAcceptedProfileDigestBeforeRosterMutation(team.ProfilePath(projectDir, profile), expectedProfileDigest); err != nil {
+				return err
+			}
+			t, err := team.ReadProfile(projectDir, profile)
+			if err != nil {
+				return fmt.Errorf("read team: %w", err)
+			}
+			oldTeam := t
+			oldTeam.Members = append([]team.Member(nil), t.Members...)
+			if preparedSession != "" {
+				current, exists := teamMemberByRole(t, role)
+				if !exists || current.Session != preparedSession {
+					return fmt.Errorf("team profile changed concurrently while updating %q; retry", role)
+				}
+			}
+			var newTeam team.Team
+			updated, newTeam, err = buildUpdated(t)
+			if err != nil {
+				return err
+			}
+			if preparedSession != "" && updated.Session != preparedSession {
+				return fmt.Errorf("team profile changed concurrently while updating %q; retry", role)
+			}
+			// WriteProfileUnderLock re-validates the whole team (orchestration,
+			// per-member binary-match, duplicate handles) before the atomic
+			// rename, so an invalid update never persists.
+			return writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, newTeam, resolveAMQEnvForTeamProfile)
+		})
+	}
+	preparedAcceptance, err := mutateRosterWithPreparedAcceptance(projectDir, profile, preparedSession, mutation)
+	if err != nil {
+		return err
+	}
+	printRosterPreparedAcceptance(preparedAcceptance, profile, preparedSession, *jsonOut)
 
 	if *jsonOut {
 		return printJSONEnvelope("team_member_update", mutationResult{
@@ -674,37 +750,48 @@ func runTeamMemberRemove(args []string) error {
 	}
 
 	var removed bool
-	if err := withProfileLock(projectDir, profile, func() error {
-		t, err := team.ReadProfile(projectDir, profile)
-		if err != nil {
-			return fmt.Errorf("read team: %w", err)
-		}
-		oldTeam := t
-		oldTeam.Members = append([]team.Member(nil), t.Members...)
-		// Removing the lead of an orchestrated team would leave a dangling
-		// lead reference that fails validation; refuse with a clear pointer.
-		if t.Orchestrated && t.Lead == role {
-			return fmt.Errorf("role %q is the orchestration lead; reassign the lead before removing it", role)
-		}
-		kept := t.Members[:0:0]
-		for _, m := range t.Members {
-			if m.Role == role {
-				removed = true
-				continue
+	mutation := func(expectedProfileDigest string) error {
+		return withProfileLock(projectDir, profile, func() error {
+			if err := verifyAcceptedProfileDigestBeforeRosterMutation(team.ProfilePath(projectDir, profile), expectedProfileDigest); err != nil {
+				return err
 			}
-			kept = append(kept, m)
-		}
-		if !removed {
-			return fmt.Errorf("role %q is not a team member", role)
-		}
-		t.Members = kept
-		if err := writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, t, resolveAMQEnvForTeamProfile); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+			t, err := team.ReadProfile(projectDir, profile)
+			if err != nil {
+				return fmt.Errorf("read team: %w", err)
+			}
+			oldTeam := t
+			oldTeam.Members = append([]team.Member(nil), t.Members...)
+			// Removing the lead of an orchestrated team would leave a dangling
+			// lead reference that fails validation; refuse with a clear pointer.
+			if t.Orchestrated && t.Lead == role {
+				return fmt.Errorf("role %q is the orchestration lead; reassign the lead before removing it", role)
+			}
+			kept := t.Members[:0:0]
+			for _, m := range t.Members {
+				if m.Role == role {
+					if m.Session != removedMember.Session {
+						return fmt.Errorf("team profile changed concurrently while removing %q; retry", role)
+					}
+					removed = true
+					continue
+				}
+				kept = append(kept, m)
+			}
+			if !removed {
+				return fmt.Errorf("role %q is not a team member", role)
+			}
+			t.Members = kept
+			if err := writeTeamProfileWithAMQRosterSyncUnderLock(projectDir, profile, oldTeam, t, resolveAMQEnvForTeamProfile); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	preparedAcceptance, err := mutateRosterWithPreparedAcceptance(projectDir, profile, removedMember.Session, mutation)
+	if err != nil {
 		return err
 	}
+	printRosterPreparedAcceptance(preparedAcceptance, profile, removedMember.Session, *jsonOut)
 
 	if *jsonOut {
 		return printJSONEnvelope("team_member_rm", mutationResult{

--- a/internal/cli/team_member_prepared.go
+++ b/internal/cli/team_member_prepared.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// rosterPreparedAcceptance reports whether a roster mutation replaced an
+// already-ready prepared generation. Warning is non-nil when the roster write
+// succeeded but the replacement generation could not be prepared; callers
+// retain the historical successful-mutation behavior and surface the recovery
+// guidance instead of silently claiming readiness.
+type rosterPreparedAcceptance struct {
+	Refreshed bool
+	Warning   error
+}
+
+var rosterPreparedBeforeMutation = func() {}
+
+// mutateRosterWithPreparedAcceptance serializes a one-step roster mutation
+// against live prepared launches. When the affected namespace has a valid,
+// ready accepted generation before the mutation, the same goal, launch shape,
+// topology, and environment contract are republished against the new roster
+// before the admission locks are released.
+//
+// This deliberately does not create accepted state for an unprepared or
+// already-drifted namespace. In those cases the roster command keeps its
+// historical behavior and the existing preparation workflow remains the
+// authority boundary.
+func mutateRosterWithPreparedAcceptance(project, profile, session string, mutate func(expectedProfileDigest string) error) (rosterPreparedAcceptance, error) {
+	session = strings.TrimSpace(session)
+	if session == "" {
+		return rosterPreparedAcceptance{}, mutate("")
+	}
+	manifestPath := preparedRunPath(project, profile, session)
+	var outcome rosterPreparedAcceptance
+	_, err := executeRunPreparationTransaction(project, profile, session, []string{manifestPath}, manifestPath, func() (runReadinessResult, error) {
+		if _, statErr := os.Stat(manifestPath); statErr != nil {
+			if os.IsNotExist(statErr) {
+				return runReadinessResult{}, mutate("")
+			}
+			return runReadinessResult{}, fmt.Errorf("inspect accepted preparation before roster mutation: %w", statErr)
+		}
+
+		manifest, _, readErr := readPreparedRunManifestSnapshot(project, profile, session)
+		eligible := false
+		context := acceptedRunContext{}
+		if readErr == nil {
+			context = acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+			eligible = calculateRunReadinessWithContext(project, profile, session, context).Ready
+		} else {
+			outcome.Warning = fmt.Errorf("inspect current accepted preparation: %w", readErr)
+		}
+		expectedProfileDigest := ""
+		if eligible {
+			expectedProfileDigest = manifest.ArtifactDigests["profile"]
+		}
+		rosterPreparedBeforeMutation()
+		if err := mutate(expectedProfileDigest); err != nil {
+			return runReadinessResult{}, err
+		}
+		if !eligible {
+			return runReadinessResult{}, nil
+		}
+
+		staged := append([]string(nil), manifest.StagedRoster...)
+		if manifest.LaunchShape == runwizard.LaunchShapeLeadOnlyStaged {
+			current, err := team.ReadProfile(project, profile)
+			if err != nil {
+				outcome.Warning = fmt.Errorf("refresh accepted preparation after roster mutation: read team: %w", err)
+				return runReadinessResult{}, nil
+			}
+			staged = staged[:0]
+			for _, member := range current.Members {
+				if (member.Session == "" || member.Session == session) && member.Role != current.Lead {
+					staged = append(staged, member.Role)
+				}
+			}
+		}
+
+		result, prepareErr := prepareRunArtifacts(
+			project,
+			profile,
+			session,
+			manifest.LaunchShape,
+			strings.Join(staged, ","),
+			manifest.GoalText,
+			manifest.GoalSource,
+			manifest.GoalDigest,
+			"",
+			context,
+			true,
+		)
+		if prepareErr != nil {
+			outcome.Warning = fmt.Errorf("refresh accepted preparation after roster mutation: %w", prepareErr)
+			return runReadinessResult{}, nil
+		}
+		outcome.Refreshed = true
+		return result, nil
+	})
+	return outcome, err
+}
+
+func verifyAcceptedProfileDigestBeforeRosterMutation(profilePath, expected string) error {
+	if strings.TrimSpace(expected) == "" {
+		return nil
+	}
+	current, err := digestFile(profilePath)
+	if err != nil {
+		return fmt.Errorf("verify team profile before roster mutation: %w", err)
+	}
+	if current != expected {
+		return fmt.Errorf("team profile changed after accepted-readiness verification; retry the roster edit")
+	}
+	return nil
+}
+
+func printRosterPreparedAcceptance(outcome rosterPreparedAcceptance, profile, session string, jsonOut bool) {
+	if outcome.Refreshed && !jsonOut {
+		fmt.Printf("accepted preparation refreshed for %s/%s; no separate prepare/accept round trip is required.\n", profile, session)
+	}
+	if outcome.Warning != nil {
+		fmt.Fprintf(os.Stderr, "warning: roster changed, but its accepted preparation was not refreshed: %v\n", outcome.Warning)
+		fmt.Fprintf(os.Stderr, "run preparation again before launching %s/%s.\n", profile, session)
+	}
+}

--- a/internal/cli/team_member_prepared_test.go
+++ b/internal/cli/team_member_prepared_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+func prepareRosterMutationFixture(t *testing.T, shape string) string {
+	t.Helper()
+	dir := t.TempDir()
+	args := []string{
+		"--project", dir,
+		"--profile", team.DefaultProfile,
+		"--session", "prepared",
+		"--roles", "cto,qa",
+		"--binary", "cto=codex,qa=codex",
+		"--lead", "cto",
+		"--launch-shape", shape,
+		"--goal", "Keep roster mutations one-step",
+		"--visibility", "detached",
+		"--prepare",
+		"--shared-cwd-exception", "test fixture: roster acceptance only",
+	}
+	if shape == runwizard.LaunchShapeLeadOnlyStaged {
+		args = append(args, "--staged-roles", "qa")
+	}
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart(args, "test")
+	})
+	if err != nil {
+		t.Fatalf("prepare roster fixture: %v", err)
+	}
+	return dir
+}
+
+func assertPreparedRosterReady(t *testing.T, dir string, beforeGeneration string) preparedRunManifest {
+	t.Helper()
+	manifest, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatalf("read refreshed preparation: %v", err)
+	}
+	if manifest.Generation == beforeGeneration {
+		t.Fatalf("prepared generation was not refreshed: %s", manifest.Generation)
+	}
+	result := calculateRunReadinessWithContext(dir, team.DefaultProfile, "prepared", acceptedRunContext{
+		Version:  manifest.Environment.BinaryVersion,
+		Topology: manifest.Topology,
+	})
+	if !result.Ready {
+		t.Fatalf("refreshed preparation is not ready: %+v", result.Rows)
+	}
+	return manifest
+}
+
+func TestTeamMemberUpdateRefreshesReadyPreparedGeneration(t *testing.T) {
+	dir := prepareRosterMutationFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "qa", "--project", dir, "--effort", "xhigh"})
+	})
+	if err != nil {
+		t.Fatalf("one-step member update: %v", err)
+	}
+	if !strings.Contains(out, "no separate prepare/accept round trip") {
+		t.Fatalf("update did not report refreshed preparation:\n%s", out)
+	}
+	after := assertPreparedRosterReady(t, dir, before.Generation)
+	if got := after.Members["qa"].Effort; got != "xhigh" {
+		t.Fatalf("accepted qa effort = %q, want xhigh", got)
+	}
+}
+
+func TestTeamMemberBinaryUpdateRefreshesReadyPreparedGeneration(t *testing.T) {
+	dir := prepareRosterMutationFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runTeamMember([]string{"update", "qa", "--project", dir, "--binary", "claude", "--effort", "xhigh"}); err != nil {
+		t.Fatalf("one-step member binary update: %v", err)
+	}
+	after := assertPreparedRosterReady(t, dir, before.Generation)
+	qa := after.Members["qa"]
+	if qa.Binary != "claude" || qa.Effort != "xhigh" {
+		t.Fatalf("accepted qa identity = %+v, want claude/xhigh", qa)
+	}
+	stored := teamMembers(t, dir)[1]
+	if stored.Binary != "claude" || len(stored.CodexArgs) != 0 {
+		t.Fatalf("stored binary switch retained incompatible args: %+v", stored)
+	}
+}
+
+func TestTeamMemberUpdateDoesNotAcceptAlreadyDriftedPreparation(t *testing.T) {
+	dir := prepareRosterMutationFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(briefPathForProfile(dir, team.DefaultProfile, "prepared"), []byte("# unrelated drift\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "qa", "--project", dir, "--model", "new-model"})
+	})
+	if err != nil {
+		t.Fatalf("member update on drifted preparation: %v", err)
+	}
+	after, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Generation != before.Generation {
+		t.Fatalf("already-drifted preparation was implicitly accepted: before=%s after=%s", before.Generation, after.Generation)
+	}
+	if strings.Contains(out, "no separate prepare/accept round trip") {
+		t.Fatalf("drifted preparation reported a refresh:\n%s", out)
+	}
+	if got := teamMembers(t, dir)[1].Model; got != "new-model" {
+		t.Fatalf("roster update was not preserved: model=%q", got)
+	}
+	result := calculateRunReadinessWithContext(dir, team.DefaultProfile, "prepared", acceptedRunContext{
+		Version: before.Environment.BinaryVersion, Topology: before.Topology,
+	})
+	if result.Ready {
+		t.Fatal("unrelated brief drift was erased by the roster update")
+	}
+}
+
+func TestTeamMemberUpdateRejectsConcurrentProfileChangeWithoutOverwritingIt(t *testing.T) {
+	dir := prepareRosterMutationFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousHook := rosterPreparedBeforeMutation
+	rosterPreparedBeforeMutation = func() {
+		current, readErr := team.ReadProfile(dir, team.DefaultProfile)
+		if readErr != nil {
+			t.Fatalf("read concurrent team: %v", readErr)
+		}
+		current.Members[1].Model = "concurrent-model"
+		if writeErr := team.WriteProfile(dir, team.DefaultProfile, current); writeErr != nil {
+			t.Fatalf("write concurrent team: %v", writeErr)
+		}
+	}
+	t.Cleanup(func() { rosterPreparedBeforeMutation = previousHook })
+
+	err = runTeamMember([]string{"update", "qa", "--project", dir, "--effort", "xhigh"})
+	if err == nil || !strings.Contains(err.Error(), "changed after accepted-readiness verification") {
+		t.Fatalf("concurrent profile update error = %v", err)
+	}
+	if got := teamMembers(t, dir)[1].Model; got != "concurrent-model" {
+		t.Fatalf("concurrent profile update was overwritten: model=%q", got)
+	}
+	after, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Generation != before.Generation {
+		t.Fatalf("rejected concurrent update changed accepted generation: before=%s after=%s", before.Generation, after.Generation)
+	}
+}
+
+func TestTeamMemberAddPreservesRosterWhenPreparedRefreshCannotValidateNewRole(t *testing.T) {
+	dir := prepareRosterMutationFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"add", "new-role", "--project", dir, "--binary", "codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member add with missing role contract: %v", err)
+	}
+	if !strings.Contains(stderr, "roster changed, but its accepted preparation was not refreshed") {
+		t.Fatalf("missing refresh recovery warning:\n%s", stderr)
+	}
+	members := teamMembers(t, dir)
+	if got := members[len(members)-1].Role; got != "new-role" {
+		t.Fatalf("successful roster add was rolled back: %+v", members)
+	}
+	after, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Generation != before.Generation {
+		t.Fatalf("invalid new role contract was accepted: before=%s after=%s", before.Generation, after.Generation)
+	}
+}
+
+func TestTeamMemberRemoveAndAddRefreshReadyPreparedGeneration(t *testing.T) {
+	for _, shape := range []string{runwizard.LaunchShapeWorkingTeamTogether, runwizard.LaunchShapeLeadOnlyStaged} {
+		t.Run(shape, func(t *testing.T) {
+			dir := prepareRosterMutationFixture(t, shape)
+			before, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := runTeamMember([]string{"rm", "qa", "--project", dir}); err != nil {
+				t.Fatalf("one-step member remove: %v", err)
+			}
+			afterRemove := assertPreparedRosterReady(t, dir, before.Generation)
+			if _, exists := afterRemove.Members["qa"]; exists || len(afterRemove.StagedRoster) != 0 {
+				t.Fatalf("removed qa remains accepted: members=%v staged=%v", afterRemove.Members, afterRemove.StagedRoster)
+			}
+
+			if err := runTeamMember([]string{"add", "qa", "--project", dir, "--binary", "codex"}); err != nil {
+				t.Fatalf("one-step member add: %v", err)
+			}
+			afterAdd := assertPreparedRosterReady(t, dir, afterRemove.Generation)
+			if shape == runwizard.LaunchShapeLeadOnlyStaged {
+				if got := strings.Join(afterAdd.StagedRoster, ","); got != "qa" {
+					t.Fatalf("lead-only staged roster = %q, want qa", got)
+				}
+				if _, exists := afterAdd.StagedMembers["qa"]; !exists {
+					t.Fatalf("lead-only re-added qa is not accepted as staged: %+v", afterAdd.StagedMembers)
+				}
+			} else if _, exists := afterAdd.Members["qa"]; !exists {
+				t.Fatalf("working-team re-added qa is not accepted: %+v", afterAdd.Members)
+			}
+		})
+	}
+}

--- a/internal/cli/team_member_update_test.go
+++ b/internal/cli/team_member_update_test.go
@@ -95,6 +95,16 @@ func TestTeamMemberUpdateRejectsCrossBinaryArgs(t *testing.T) {
 	}
 }
 
+func TestTeamMemberUpdateRejectsInvalidBinary(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-96"}},
+	})
+	err := runTeamMember([]string{"update", "qa", "--binary", "unknown"})
+	if err == nil || !strings.Contains(err.Error(), "must be claude or codex") {
+		t.Fatalf("expected an invalid-binary error, got %v", err)
+	}
+}
+
 // The recorded #451 friction: `rm` refuses to remove the orchestration lead,
 // so today the only way to touch its session/model is remove-then-add, which
 // is impossible for the lead. `update` must work directly on the lead role.


### PR DESCRIPTION
## Summary

- make session-pinned `team member add`, `update`, and `rm` refresh an existing ready accepted preparation before releasing namespace admission
- preserve the accepted goal, launch shape, topology, and environment contract while publishing a new immutable generation
- add one-step `team member update --binary claude|codex`, clearing only incompatible native args
- refuse to auto-accept already-drifted or concurrently changed profiles, while preserving a successful roster mutation when the replacement generation cannot validate
- include `xhigh` and `max` in invalid effort recovery text

## Verification

- exact pinned roster, binary-switch, drift, concurrency, fallback, and effort-text proof — PASS at `644e69523547ad422c268c57857f115c9ae72a37`
- `make ci` — PASS at the same exact head
  - `go vet ./...`
  - `go test ./...` (`internal/cli` 374.841s)
  - generated documentation freshness
  - skill routing and command coverage
  - release-validator and Go file-scope gates

## Rebase and generated-artifact evidence

- retargeted to `main` after #602 merged at `6a34984db6ff9813b872c7a1fb4e8cc0c64ff2b6`
- old exact head: `2bd4f3ddf804cefb449775363d5313422604143a`
- rebased exact head: `644e69523547ad422c268c57857f115c9ae72a37`
- source/tests/docs commit: `41f9da3e3aaeacdf8c6f7132429291aa841041e5` became `933505f698477d809a524a928f91df878cb12670`
- stale generated-only commit `2bd4f3d` was dropped; `make docs-html` was rerun on the rebased source and committed as `644e695`
- `git range-diff` marks both old/new commits exact-equivalent
- `git diff` between old and rebased tips is empty; the complete trees are byte-identical
- no conflicts or semantic conflict resolution occurred

PR #603 merged afterward at main `5311ee4`. Per the lead ruling, #604 does not rebase again: the two PRs touch disjoint files, GitHub reports the combination conflict-free, and the ordinary residual is that the exact squashed combination is first exercised by post-merge main CI.

## Boundaries

- no profile export/import or cross-project portability
- no goal-digest, generation-token, session-reuse, or naming guard relaxation
- unprepared, already-drifted, unpinned, or session-changing edits retain the normal explicit preparation path

Closes #601
