### PR TITLE
Fix fresh-namespace launch bricking (#598)

### DIFF
--- a/internal/cli/bootstrap_drift_evidence_598.go
+++ b/internal/cli/bootstrap_drift_evidence_598.go
@@ -1,0 +1,49 @@
+package cli
+
+import "fmt"
+
+// Bootstrap drift evidence for the readiness row (#598 root cause 4).
+//
+// The row used to read:
+//
+//	evidence: generated bootstrap differs from accepted preview
+//	fix:      review the bootstrap diff and approve preparation again
+//
+// and no flag, artifact, or verbose mode printed that diff. That is not a
+// missing print statement. The accepted bootstrap TEXT is never persisted:
+// preparation records only manifest.BootstrapDigests[role] and discards the
+// prompt. There is nothing on disk to diff against, so the remedy named an
+// action that is impossible rather than merely unimplemented -- and the same
+// gap rules out the "at minimum the differing field names" fallback, which
+// needs the identical accepted render.
+//
+// Persisting the accepted preview per role is the real fix and it belongs with
+// the other preparation-surface work in #597, because it has to be declared in
+// the preparation proposal's MutationPaths and covered by the transaction's
+// rollback. What is fixed HERE is the lie: the row now states everything that
+// is actually known, and names a remedy the CLI can actually perform.
+
+// preparedBootstrapDriftFix is the remedy for a drifted bootstrap row.
+//
+// It deliberately does NOT promise a diff. Re-running preparation is an action
+// that exists today and does resolve the drift; the field-level comparison
+// arrives with the persisted preview in #597. A remedy that overstates what the
+// tool can do is the defect this row is being fixed for, so it must not be
+// reintroduced in the fix text itself.
+const preparedBootstrapDriftFix = "re-run preparation for this exact namespace and accept it again (`amq-squad run start ... --prepare`); a field-level accepted-vs-generated diff is not available yet because the accepted preview is not persisted (#597)"
+
+// preparedBootstrapDriftEvidence states everything known about a bootstrap
+// digest mismatch at the moment it is detected.
+//
+// Naming the namespace, role, generation and BOTH digests is what makes the row
+// actionable without source access: the operator can tell which member drifted,
+// in which accepted generation, and can compare the recorded digest against a
+// re-rendered one after re-preparing. Reporting only "differs" forced the
+// operator to reproduce the pane command by hand to learn anything at all,
+// which is exactly how the fresh-namespace brick stayed undiagnosed.
+func preparedBootstrapDriftEvidence(profile, session, role, generation, accepted, generated string) string {
+	return fmt.Sprintf(
+		"generated bootstrap differs from the accepted preview: namespace=%s/%s role=%s generation=%s accepted_sha256=%s generated_sha256=%s",
+		profile, session, role, generation, accepted, generated,
+	)
+}

--- a/internal/cli/bootstrap_drift_evidence_598.go
+++ b/internal/cli/bootstrap_drift_evidence_598.go
@@ -18,7 +18,7 @@ import "fmt"
 // needs the identical accepted render.
 //
 // Persisting the accepted preview per role is the real fix and it belongs with
-// the other preparation-surface work in #597, because it has to be declared in
+// the other preparation-surface work in #609, because it has to be declared in
 // the preparation proposal's MutationPaths and covered by the transaction's
 // rollback. What is fixed HERE is the lie: the row now states everything that
 // is actually known, and names a remedy the CLI can actually perform.
@@ -27,10 +27,10 @@ import "fmt"
 //
 // It deliberately does NOT promise a diff. Re-running preparation is an action
 // that exists today and does resolve the drift; the field-level comparison
-// arrives with the persisted preview in #597. A remedy that overstates what the
+// arrives with the persisted preview in #609. A remedy that overstates what the
 // tool can do is the defect this row is being fixed for, so it must not be
 // reintroduced in the fix text itself.
-const preparedBootstrapDriftFix = "re-run preparation for this exact namespace and accept it again (`amq-squad run start ... --prepare`); a field-level accepted-vs-generated diff is not available yet because the accepted preview is not persisted (#597)"
+const preparedBootstrapDriftFix = "re-run preparation for this exact namespace and accept it again (`amq-squad run start ... --prepare`); a field-level accepted-vs-generated diff is not available yet because the accepted preview is not persisted (#609)"
 
 // preparedBootstrapDriftEvidence states everything known about a bootstrap
 // digest mismatch at the moment it is detected.

--- a/internal/cli/bootstrap_drift_evidence_598_test.go
+++ b/internal/cli/bootstrap_drift_evidence_598_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPreparedBootstrapDriftEvidenceNamesEveryKnownFact is the #598 root cause 4
+// regression.
+//
+// The row used to say only "generated bootstrap differs from accepted preview",
+// which forced the operator to reproduce the pane command by hand to learn
+// anything at all. That is how the fresh-namespace brick stayed undiagnosed. The
+// evidence must carry every fact known at detection time.
+func TestPreparedBootstrapDriftEvidenceNamesEveryKnownFact(t *testing.T) {
+	got := preparedBootstrapDriftEvidence("squad", "v2-26-0", "cto", "gen0001", "sha256:accepted", "sha256:generated")
+	for _, want := range []string{
+		"squad/v2-26-0",      // namespace
+		"role=cto",           // which member drifted
+		"generation=gen0001", // which accepted generation
+		"sha256:accepted",    // what was accepted
+		"sha256:generated",   // what was rendered now
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("drift evidence omits %q\n  evidence: %s", want, got)
+		}
+	}
+}
+
+// TestPreparedBootstrapDriftFixPromisesOnlyWhatExists guards the fix text
+// against reintroducing the exact defect it replaces.
+//
+// The old remedy said "review the bootstrap diff", an action the CLI cannot
+// perform: the accepted bootstrap text is never persisted, so there is nothing
+// to diff against. A fix text that overstates the tool's capability is the RC4
+// defect itself, so the replacement must name a real action and must be honest
+// that the diff does not exist yet.
+func TestPreparedBootstrapDriftFixPromisesOnlyWhatExists(t *testing.T) {
+	// It must name an action that exists today.
+	for _, want := range []string{"--prepare", "re-run preparation"} {
+		if !strings.Contains(preparedBootstrapDriftFix, want) {
+			t.Errorf("fix text does not name a performable action (%q missing): %s", want, preparedBootstrapDriftFix)
+		}
+	}
+	// It must be explicit that the diff is not available, and say where it is
+	// coming from, so the gap is tracked rather than merely unmentioned.
+	for _, want := range []string{"not available", "#597"} {
+		if !strings.Contains(preparedBootstrapDriftFix, want) {
+			t.Errorf("fix text does not disclose the missing diff capability (%q missing): %s", want, preparedBootstrapDriftFix)
+		}
+	}
+	// It must NOT instruct the operator to review a diff, which is what the
+	// defect said. Guarding the literal phrasing is deliberate: this is a
+	// message-honesty regression, and the message is the whole artifact.
+	if strings.Contains(preparedBootstrapDriftFix, "review the bootstrap diff") {
+		t.Errorf("fix text still instructs an impossible action: %s", preparedBootstrapDriftFix)
+	}
+}

--- a/internal/cli/bootstrap_drift_evidence_598_test.go
+++ b/internal/cli/bootstrap_drift_evidence_598_test.go
@@ -44,7 +44,7 @@ func TestPreparedBootstrapDriftFixPromisesOnlyWhatExists(t *testing.T) {
 	}
 	// It must be explicit that the diff is not available, and say where it is
 	// coming from, so the gap is tracked rather than merely unmentioned.
-	for _, want := range []string{"not available", "#597"} {
+	for _, want := range []string{"not available", "#609"} {
 		if !strings.Contains(preparedBootstrapDriftFix, want) {
 			t.Errorf("fix text does not disclose the missing diff capability (%q missing): %s", want, preparedBootstrapDriftFix)
 		}

--- a/internal/cli/bootstrap_failure.go
+++ b/internal/cli/bootstrap_failure.go
@@ -276,6 +276,36 @@ func tmuxBootstrapProbes(panes []teamLaunchPane, paneIDs []string) []bootstrapPr
 	return probes
 }
 
+// livePaneIDs reports the set of pane ids tmux currently knows about, and
+// whether tmux could be asked at all.
+//
+// This exists because #540's per-pane probes cannot tell "this pane is gone"
+// from "I could not look" (#598). `display-message -t <missing>` silently
+// resolves to the client's current pane, so the per-pane probe deliberately
+// treats every inspection error as inconclusive. Asking tmux to enumerate every
+// pane it has answers the question the per-pane probe structurally cannot: a
+// successful enumeration that omits a pane is positive proof of absence, while
+// a failed enumeration stays inconclusive exactly as before.
+var livePaneIDs = func() (map[string]bool, bool) {
+	out, err := tmuxOutputCommand("tmux", "list-panes", "-a", "-F", "#{pane_id}")
+	if err != nil {
+		return nil, false
+	}
+	ids := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		if id := strings.TrimSpace(line); id != "" {
+			ids[id] = true
+		}
+	}
+	return ids, true
+}
+
+// vanishedPaneBootstrapError is the failure text for an agent whose pane no
+// longer exists. There is no pane content to quote, so the message says what is
+// known and why nothing more specific is available, instead of implying the
+// diagnostic was retrievable and merely omitted.
+const vanishedPaneBootstrapError = "pane no longer exists: the agent exited and its pane closed before bootstrap completed, taking its error output with it (run with a pane that stays on exit to capture it, e.g. tmux set-option -g remain-on-exit on)"
+
 // waitForPaneBootstrap polls the spawned panes until every agent is confirmed
 // running or one is confirmed dead, and returns the members that died.
 //
@@ -297,9 +327,30 @@ func waitForPaneBootstrap(probes []bootstrapProbe) []memberPaneBootstrapFailure 
 		var failures []memberPaneBootstrapFailure
 		running := 0
 		inspectable := 0
+		// Resolved lazily and at most once per poll, and only when some pane
+		// fails to inspect: a healthy launch never asks tmux for the pane list
+		// at all.
+		var present map[string]bool
+		var presentKnown, presentAsked bool
 		for _, p := range probes {
 			command, ok := paneBootstrapProbe(p.PaneID)
 			if !ok {
+				// #598: every caller of this function has already proved this
+				// pane existed, via verifyPaneProcessLaunched at dispatch. So
+				// an uninspectable pane is not automatically inconclusive; if
+				// tmux can still enumerate its panes and this one is absent,
+				// the agent died and took its pane with it. That is the case
+				// #540's detector structurally could not see, and it is the one
+				// that let a bricked launch print "Added N team pane(s)" and
+				// exit 0.
+				if !presentAsked {
+					present, presentKnown = livePaneIDs()
+					presentAsked = true
+				}
+				if presentKnown && !present[p.PaneID] {
+					inspectable++
+					failures = append(failures, memberPaneBootstrapFailure{Role: p.Role, PaneID: p.PaneID, Error: vanishedPaneBootstrapError})
+				}
 				continue
 			}
 			inspectable++

--- a/internal/cli/bootstrap_failure_test.go
+++ b/internal/cli/bootstrap_failure_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -22,12 +23,32 @@ func withFakePanes(t *testing.T, panes map[string]fakePane) {
 	origTail := paneTailForBootstrap
 	origBudget := paneBootstrapProbeBudget
 	origInterval := paneBootstrapProbeInterval
+	origTmux := tmuxOutputCommand
 	t.Cleanup(func() {
 		paneBootstrapProbe = origProbe
 		paneTailForBootstrap = origTail
 		paneBootstrapProbeBudget = origBudget
 		paneBootstrapProbeInterval = origInterval
+		tmuxOutputCommand = origTmux
 	})
+	// #598 added a pane-ENUMERATION fallback to waitForPaneBootstrap. These
+	// fixtures stub the per-pane probes but historically left tmuxOutputCommand
+	// alone, so without this the enumeration would reach the REAL shared tmux
+	// server (the one the squad itself runs in) from tests that were hermetic.
+	// That is both a wrong answer and a shared-state violation, so the fake owns
+	// the seam too.
+	//
+	// It reports tmux as UNREACHABLE, which preserves these fixtures' meaning
+	// exactly: "cannot inspect the pane AND cannot enumerate" is the
+	// inconclusive case that must stay fail-open. The enumerable-but-absent
+	// case, where absence is positive proof, is covered separately in
+	// bootstrap_failure_vanished_598_test.go.
+	tmuxOutputCommand = func(name string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "list-panes" {
+			return "", fmt.Errorf("tmux: no server running (fake)")
+		}
+		return "", fmt.Errorf("unexpected tmux call in fake pane fixture: %s %v", name, args)
+	}
 	paneBootstrapProbe = func(paneID string) (string, bool) {
 		p, ok := panes[paneID]
 		if !ok {

--- a/internal/cli/bootstrap_failure_vanished_598_test.go
+++ b/internal/cli/bootstrap_failure_vanished_598_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubVanishedPaneProbes wires the seams waitForPaneBootstrap depends on: the
+// per-pane command probe, the underlying tmux command runner, and the clock.
+// Nothing here touches a real tmux server.
+//
+// It deliberately stubs tmuxOutputCommand rather than the pane-list helper
+// directly, so these tests compile and run unchanged against the pre-fix code.
+// A regression test that only fails to COMPILE without the fix proves nothing
+// about behavior.
+func stubVanishedPaneProbes(t *testing.T, commands map[string]string, livePanes []string, tmuxReachable bool) *int {
+	t.Helper()
+	origProbe, origTmux := paneBootstrapProbe, tmuxOutputCommand
+	origNow, origSleep := runStartLeadReadyNow, runStartLeadReadySleep
+	t.Cleanup(func() {
+		paneBootstrapProbe, tmuxOutputCommand = origProbe, origTmux
+		runStartLeadReadyNow, runStartLeadReadySleep = origNow, origSleep
+	})
+	paneBootstrapProbe = func(paneID string) (string, bool) {
+		cmd, ok := commands[paneID]
+		return cmd, ok
+	}
+	listCalls := 0
+	tmuxOutputCommand = func(name string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "list-panes" {
+			listCalls++
+			if !tmuxReachable {
+				return "", fmt.Errorf("tmux: no server running")
+			}
+			return strings.Join(livePanes, "\n") + "\n", nil
+		}
+		return "", fmt.Errorf("unexpected tmux call: %s %v", name, args)
+	}
+	now := time.Unix(0, 0).UTC()
+	runStartLeadReadyNow = func() time.Time { return now }
+	runStartLeadReadySleep = func(d time.Duration) { now = now.Add(d) }
+	return &listCalls
+}
+
+// TestVanishedPaneIsALaunchFailureNotSilentSuccess is the #598 root cause 3
+// regression for the launcher half.
+//
+// #540 taught the launcher to read a dead agent's pane. It cannot read a pane
+// that no longer exists, and its per-pane probe treats every inspection failure
+// as inconclusive, so an agent that exited and took its pane with it produced
+// NO signal at all: the launcher printed "Added N team pane(s)", exited 0, and
+// the only symptom was a later 45s goal-delivery timeout blamed on lead
+// readiness. That is exactly how the fresh-namespace brick stayed invisible.
+func TestVanishedPaneIsALaunchFailureNotSilentSuccess(t *testing.T) {
+	// tmux answers, and it does not list %2: that pane is gone.
+	stubVanishedPaneProbes(t, map[string]string{"%1": "claude"}, []string{"%1"}, true)
+
+	failures := waitForPaneBootstrap([]bootstrapProbe{
+		{Role: "cto", PaneID: "%1", Engine: "claude"},
+		{Role: "amq-dev-1", PaneID: "%2", Engine: "claude"},
+	})
+	if len(failures) != 1 {
+		t.Fatalf("a vanished pane must be reported as a launch failure; got %d failures: %+v", len(failures), failures)
+	}
+	if failures[0].Role != "amq-dev-1" || failures[0].PaneID != "%2" {
+		t.Errorf("failure must name the member and pane; got role=%q pane=%q", failures[0].Role, failures[0].PaneID)
+	}
+	if !strings.Contains(failures[0].Error, "no longer exists") {
+		t.Errorf("failure text must say the pane is gone, not imply a readable error was omitted; got %q", failures[0].Error)
+	}
+	// The launch verdict the caller actually uses must be non-nil and must name
+	// the member, since "which agent died" was the missing information.
+	err := bootstrapFailureError(failures)
+	if err == nil {
+		t.Fatal("bootstrapFailureError must turn a vanished pane into a launch error")
+	}
+	if !strings.Contains(err.Error(), "amq-dev-1") {
+		t.Errorf("launch error must name the member; got %q", err.Error())
+	}
+}
+
+// TestUninspectablePanesStayInconclusiveWhenTmuxCannotBeAsked is the guard on
+// the fix above. Absence of a pane is only evidence when tmux successfully
+// enumerated its panes. If tmux itself cannot be reached, every pane is
+// uninspectable for reasons that say nothing about the agent, and inventing a
+// launch failure there would break healthy launches in sandboxed or stubbed
+// environments. This is the false-positive direction the #540 comment is
+// explicit about protecting, and this fix must not erode it.
+func TestUninspectablePanesStayInconclusiveWhenTmuxCannotBeAsked(t *testing.T) {
+	stubVanishedPaneProbes(t, map[string]string{}, nil, false)
+
+	failures := waitForPaneBootstrap([]bootstrapProbe{
+		{Role: "cto", PaneID: "%1", Engine: "claude"},
+		{Role: "amq-dev-1", PaneID: "%2", Engine: "claude"},
+	})
+	if len(failures) != 0 {
+		t.Fatalf("an unreachable tmux must stay inconclusive, not fail the launch; got %+v", failures)
+	}
+}
+
+// TestHealthyLaunchNeverConsultsThePaneList keeps the fix off the happy path.
+// Enumerating panes is an extra tmux round trip, and a launch where every agent
+// reports its engine has nothing to diagnose.
+func TestHealthyLaunchNeverConsultsThePaneList(t *testing.T) {
+	listCalls := stubVanishedPaneProbes(t,
+		map[string]string{"%1": "claude", "%2": "codex"},
+		[]string{"%1", "%2"}, true)
+
+	failures := waitForPaneBootstrap([]bootstrapProbe{
+		{Role: "cto", PaneID: "%1", Engine: "claude"},
+		{Role: "amq-dev-2", PaneID: "%2", Engine: "codex"},
+	})
+	if len(failures) != 0 {
+		t.Fatalf("healthy launch reported failures: %+v", failures)
+	}
+	if *listCalls != 0 {
+		t.Errorf("healthy launch enumerated panes %d times; it must not be asked at all", *listCalls)
+	}
+}

--- a/internal/cli/bootstrap_launch_evidence_598.go
+++ b/internal/cli/bootstrap_launch_evidence_598.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+)
+
+// Launch-attempt evidence for the doctor bootstrap row (#598 root cause 3).
+//
+// doctor reported `bootstrap/<role>: no launch record; skipped` as OK even when
+// a launch had just been attempted for that role and the agent had died. During
+// the fresh-namespace brick that made doctor report every row ok while the
+// namespace was unusable, so no sanctioned diagnostic surfaced the cause.
+//
+// Turning that row into a failure needs a predicate, because plenty of members
+// legitimately have no launch record: never launched, staged but not started,
+// an external lead adopted in a pane amq-squad did not spawn. Failing those
+// would make doctor noisy for people who did nothing wrong, which is its own
+// way of hiding a real problem.
+//
+// The predicate is the prepared launch RESERVATION. A reservation is durable,
+// positive proof that a launch was reserved for this exact namespace and
+// generation. No reservation means nothing was attempted and silence is honest.
+// A reservation means silence is a lie.
+
+// preparedLaunchAttemptEvidence is the proof that a launch was reserved for a
+// namespace, and where that proof lives so the operator can go look at it.
+type preparedLaunchAttemptEvidence struct {
+	Generation string
+	Path       string
+}
+
+// findPreparedLaunchAttempt reports the most recent generation of this
+// namespace that recorded a launch reservation.
+//
+// It is deliberately read-only and failure-tolerant: any unreadable prepared
+// tree yields "no evidence", which keeps the bootstrap row at its historical
+// skip rather than inventing a failure out of a directory listing error. The
+// escalation this feeds must only ever fire on positive proof.
+func findPreparedLaunchAttempt(project, profile, session string) (preparedLaunchAttemptEvidence, bool) {
+	generationsRoot := preparedRunGenerationsPath(project, profile, session)
+	entries, err := os.ReadDir(generationsRoot)
+	if err != nil {
+		return preparedLaunchAttemptEvidence{}, false
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	// Newest-looking generation first, so a namespace relaunched several times
+	// reports the reservation an operator is most likely to be looking at.
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+	for _, generation := range names {
+		path := preparedRunReservationPath(project, profile, session, generation)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return preparedLaunchAttemptEvidence{Generation: generation, Path: path}, true
+		}
+	}
+	return preparedLaunchAttemptEvidence{}, false
+}
+
+// preparedInitialRosterRoles reports the accepted initial roster of the
+// generation that reserved the launch. A member outside it was never part of
+// that accepted launch, so the reservation says nothing about whether that
+// member should have a record.
+//
+// This reads the generation's own manifest directly rather than going through
+// readPreparedRunManifest, and that is deliberate rather than a shortcut.
+// readPreparedRunManifest resolves the CURRENT pointer and validates manifest
+// and state digests, so it fails whenever preparation has drifted -- which is
+// precisely the #598 situation this row exists to report. Depending on it would
+// make the escalation go silent exactly when it matters most, reintroducing the
+// defect one layer down. The roster is only used to SCOPE the failure to
+// accepted members, never as authority, so an unvalidated read is the right
+// tool: it answers "was this member part of the launch that was reserved" from
+// the launch that was actually reserved.
+//
+// An unreadable generation manifest yields no roles, which collapses the
+// escalation to the historical skip.
+func preparedInitialRosterRoles(project, profile, session, generation string) map[string]bool {
+	data, err := os.ReadFile(preparedRunGenerationManifestPath(project, profile, session, generation))
+	if err != nil {
+		return nil
+	}
+	var manifest struct {
+		InitialRoster []string `json:"initial_roster"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil
+	}
+	roles := make(map[string]bool, len(manifest.InitialRoster))
+	for _, role := range manifest.InitialRoster {
+		roles[role] = true
+	}
+	return roles
+}
+
+// bootstrapRecordAbsence distinguishes a launch record that is missing from one
+// that is present but unreadable. Absence after a reserved launch means the
+// agent died before writing its record; a malformed record means it wrote one
+// and something corrupted it. Both are failures once a launch was reserved, and
+// they need different remedies, so they must not share a message.
+func bootstrapRecordAbsence(agentDir string) string {
+	if launch.HasRecord(agentDir) {
+		return "malformed"
+	}
+	return "absent"
+}
+
+// bootstrapLaunchRecordPath names where the record was expected, so a failure
+// tells the operator the exact path to inspect instead of implying they should
+// go read the source.
+func bootstrapLaunchRecordPath(agentDir string) string {
+	return filepath.Clean(launch.Path(agentDir))
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1130,9 +1130,19 @@ func doctorCheckBootstrap(d doctorExecution) []doctorCheck {
 		return []doctorCheck{{Name: "bootstrap", Status: doctorOK, Detail: "workstream unresolved; skipped"}}
 	}
 	now := d.Probe.Now()
+	// #598: a launch reservation is durable proof that a launch was attempted
+	// for this namespace. Resolved once, outside the member loop, and used to
+	// decide whether a missing launch record is honest silence or a swallowed
+	// failure.
+	attempt, attempted := findPreparedLaunchAttempt(d.ProjectDir, profile, workstream)
+	acceptedRoster := preparedInitialRosterRoles(d.ProjectDir, profile, workstream, attempt.Generation)
 	out := make([]doctorCheck, 0, len(t.Members))
 	for _, m := range orderedTeamMembers(t.Members) {
 		handle := memberHandle(m)
+		// Escalation requires BOTH a reserved launch and membership of the
+		// accepted initial roster. A member outside that roster was never part
+		// of the accepted launch, so the reservation says nothing about it.
+		launchWasReserved := attempted && acceptedRoster[m.Role]
 		env, err := resolveAMQEnvForTeamProfile(m.EffectiveCWD(t.Project), profile, workstream, handle)
 		if err != nil {
 			out = append(out, doctorCheck{Name: "bootstrap/" + m.Role, Status: doctorOK, Detail: "AMQ root unresolved; skipped"})
@@ -1141,18 +1151,57 @@ func doctorCheckBootstrap(d doctorExecution) []doctorCheck {
 		agentDir := filepath.Join(absoluteAMQRoot(m.EffectiveCWD(t.Project), env.Root), "agents", handle)
 		rec, err := launch.Read(agentDir)
 		if err != nil {
+			if launchWasReserved {
+				// The row an operator needed during the fresh-namespace brick.
+				// It names the evidence and the exact path to inspect, because
+				// a remedy the CLI cannot perform is not a remedy (#598 RC4).
+				out = append(out, doctorCheck{
+					Name:   "bootstrap/" + m.Role,
+					Status: doctorFail,
+					Detail: fmt.Sprintf("launch reserved for %s in generation %s (%s) but the launch record is %s at %s: the agent did not complete bootstrap; inspect the pane error or relaunch the namespace",
+						m.Role, attempt.Generation, attempt.Path, bootstrapRecordAbsence(agentDir), bootstrapLaunchRecordPath(agentDir)),
+				})
+				continue
+			}
+			if launch.HasRecord(agentDir) {
+				// No reservation, so this is not a swallowed launch failure,
+				// but a record that exists and cannot be parsed is still not
+				// something to report as ok.
+				out = append(out, doctorCheck{
+					Name:   "bootstrap/" + m.Role,
+					Status: doctorWarn,
+					Detail: "launch record present but unreadable at " + bootstrapLaunchRecordPath(agentDir) + ": " + err.Error(),
+				})
+				continue
+			}
 			out = append(out, doctorCheck{Name: "bootstrap/" + m.Role, Status: doctorOK, Detail: "no launch record; skipped"})
 			continue
 		}
 		result := bootstrapack.Evaluate(rec.BootstrapExpectation, bootstrapack.Identity{Handle: rec.Handle, Role: rec.Role, Profile: rec.TeamProfile, Session: rec.Session, Root: rec.Root}, agentDir, now)
-		status := doctorBootstrapStatus(result)
+		status := doctorBootstrapStatus(result, launchWasReserved)
 		out = append(out, doctorCheck{Name: "bootstrap/" + m.Role, Status: status, Detail: result.State + ": " + result.Detail})
 	}
 	return out
 }
 
-func doctorBootstrapStatus(result bootstrapack.Result) doctorStatus {
-	if result.State == "unverified" || result.State == "mismatch" || result.State == "malformed" {
+// doctorBootstrapStatus maps a bootstrap acknowledgement result to a doctor
+// status.
+//
+// launchWasReserved lifts the historical WARN cap (#598). A mismatched or
+// malformed acknowledgement is ambiguous on its own: it can mean the agent is
+// still starting. Once a launch was positively reserved for this member it is
+// not ambiguous, it is a launch that did not complete, and a warning is too
+// quiet for the one signal that would have explained a bricked namespace.
+// `unverified` stays a warning either way: a launch can be reserved and the
+// agent legitimately still on its way to acknowledging.
+func doctorBootstrapStatus(result bootstrapack.Result, launchWasReserved bool) doctorStatus {
+	switch result.State {
+	case "mismatch", "malformed":
+		if launchWasReserved {
+			return doctorFail
+		}
+		return doctorWarn
+	case "unverified":
 		return doctorWarn
 	}
 	return doctorOK

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1178,7 +1178,7 @@ func doctorCheckBootstrap(d doctorExecution) []doctorCheck {
 			continue
 		}
 		result := bootstrapack.Evaluate(rec.BootstrapExpectation, bootstrapack.Identity{Handle: rec.Handle, Role: rec.Role, Profile: rec.TeamProfile, Session: rec.Session, Root: rec.Root}, agentDir, now)
-		status := doctorBootstrapStatus(result, launchWasReserved)
+		status := doctorBootstrapStatus(result, launchWasReserved, now)
 		out = append(out, doctorCheck{Name: "bootstrap/" + m.Role, Status: status, Detail: result.State + ": " + result.Detail})
 	}
 	return out
@@ -1189,15 +1189,28 @@ func doctorCheckBootstrap(d doctorExecution) []doctorCheck {
 //
 // launchWasReserved lifts the historical WARN cap (#598). A mismatched or
 // malformed acknowledgement is ambiguous on its own: it can mean the agent is
-// still starting. Once a launch was positively reserved for this member it is
-// not ambiguous, it is a launch that did not complete, and a warning is too
-// quiet for the one signal that would have explained a bricked namespace.
-// `unverified` stays a warning either way: a launch can be reserved and the
-// agent legitimately still on its way to acknowledging.
-func doctorBootstrapStatus(result bootstrapack.Result, launchWasReserved bool) doctorStatus {
+// still starting. Once a launch was positively reserved for this member and the
+// acknowledgement grace period has EXPIRED it is not ambiguous, it is a launch
+// that did not complete, and a warning is too quiet for the one signal that
+// would have explained a bricked namespace.
+//
+// The grace gate is load-bearing, and it closes a false positive found in
+// review rather than by these tests. bootstrapack.Evaluate consults the grace
+// period ONLY when the marker is missing; a marker that exists but belongs to a
+// previous launch returns "mismatch" immediately. Ordinary relaunch never
+// removes the old marker -- launch.go touches bootstrapack state nowhere, and
+// the only removals live in the staged-launch rollback path. So a healthy agent
+// that was just relaunched has a stale marker, a fresh expectation, and a
+// reservation, and without this gate doctor would report FAIL for a member that
+// is starting normally and simply has not re-acknowledged yet.
+//
+// `unverified` stays a warning either way. It already means the grace period
+// expired with no marker at all, and escalating it would widen this beyond the
+// case #598 is about.
+func doctorBootstrapStatus(result bootstrapack.Result, launchWasReserved bool, now time.Time) doctorStatus {
 	switch result.State {
 	case "mismatch", "malformed":
-		if launchWasReserved {
+		if launchWasReserved && !withinBootstrapAckGrace(result, now) {
 			return doctorFail
 		}
 		return doctorWarn
@@ -1205,6 +1218,20 @@ func doctorBootstrapStatus(result bootstrapack.Result, launchWasReserved bool) d
 		return doctorWarn
 	}
 	return doctorOK
+}
+
+// withinBootstrapAckGrace reports whether this launch is still inside the
+// acknowledgement grace window, during which a not-yet-acknowledged agent is
+// indistinguishable from a failed one.
+//
+// An expectation with no issue time cannot prove it is inside the window, so it
+// is treated as outside. That is the conservative direction for a grace check:
+// a missing timestamp must not become an indefinite amnesty.
+func withinBootstrapAckGrace(result bootstrapack.Result, now time.Time) bool {
+	if result.IssuedAt == nil || result.IssuedAt.IsZero() {
+		return false
+	}
+	return now.Before(result.IssuedAt.Add(bootstrapack.GracePeriod))
 }
 
 func defaultDoctorAMQOps(projectDir string, env amqEnv) ([]byte, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1231,6 +1231,15 @@ func withinBootstrapAckGrace(result bootstrapack.Result, now time.Time) bool {
 	if result.IssuedAt == nil || result.IssuedAt.IsZero() {
 		return false
 	}
+	// A FUTURE issue time is the same indefinite-amnesty class as a missing
+	// one. A bad clock at launch, or a hand-edited record, would otherwise hold
+	// a genuinely dead agent at WARN for as long as that timestamp stays ahead
+	// of now. The window only means anything measured forward from a real
+	// launch, so an expectation claiming to be issued later than now cannot
+	// prove it is inside it.
+	if result.IssuedAt.After(now) {
+		return false
+	}
 	return now.Before(result.IssuedAt.Add(bootstrapack.GracePeriod))
 }
 

--- a/internal/cli/doctor_bootstrap_row_598_test.go
+++ b/internal/cli/doctor_bootstrap_row_598_test.go
@@ -256,4 +256,14 @@ func TestDoctorBootstrapReservedRelaunchInsideGraceIsNotFailed(t *testing.T) {
 	if got := doctorBootstrapStatus(noIssue, true, issued); got != doctorFail {
 		t.Errorf("reserved mismatch with no issue time = %s, want fail (cannot prove it is inside the window)", got)
 	}
+	// Nor must a FUTURE one. Found by Reviewer B on the third pass over this
+	// function: a bad clock at launch or a hand-edited record would otherwise
+	// hold a dead agent at WARN for as long as the timestamp stays ahead. Same
+	// class as the missing-timestamp case directly above, so it fails closed
+	// the same way.
+	future := issued.Add(24 * time.Hour)
+	futureIssue := bootstrapack.Result{State: "mismatch", Required: true, IssuedAt: &future}
+	if got := doctorBootstrapStatus(futureIssue, true, issued); got != doctorFail {
+		t.Errorf("reserved mismatch with a FUTURE issue time = %s, want fail (a future stamp must not extend the window)", got)
+	}
 }

--- a/internal/cli/doctor_bootstrap_row_598_test.go
+++ b/internal/cli/doctor_bootstrap_row_598_test.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// seedLaunchReservation writes a launch reservation for a namespace generation,
+// which is the durable proof that a launch was attempted.
+func seedLaunchReservation(t *testing.T, project, profile, session, generation string) string {
+	t.Helper()
+	path := preparedRunReservationPath(project, profile, session, generation)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"kind":"launch_reservation"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// seedAcceptedRoster writes the GENERATION manifest naming the accepted initial
+// roster, so the escalation can tell an accepted member from a bystander.
+//
+// This writes the generation's own manifest, not the pointer at
+// preparedRunPath: the row reads the roster of the generation that reserved the
+// launch, deliberately bypassing pointer/digest validation so a drifted
+// preparation cannot silence the failure.
+func seedAcceptedRoster(t *testing.T, project, profile, session, generation string, roles ...string) {
+	t.Helper()
+	path := preparedRunGenerationManifestPath(project, profile, session, generation)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(preparedRunManifest{
+		Project: project, Profile: profile, Session: session,
+		InitialRoster: roles,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFindPreparedLaunchAttemptRequiresPositiveProof pins the predicate's
+// fail-closed direction. Everything that is not a readable reservation must
+// report "no evidence", because the escalation it feeds turns a skip into a
+// hard failure and must never fire on a directory listing error.
+func TestFindPreparedLaunchAttemptRequiresPositiveProof(t *testing.T) {
+	project := t.TempDir()
+	profile, session := team.DefaultProfile, "ns"
+
+	if _, ok := findPreparedLaunchAttempt(project, profile, session); ok {
+		t.Error("a namespace with no prepared tree at all reported a launch attempt")
+	}
+
+	// A generation directory with no reservation is preparation without a
+	// launch, which is exactly the case that must stay silent.
+	if err := os.MkdirAll(preparedRunGenerationDir(project, profile, session, "aaa111"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findPreparedLaunchAttempt(project, profile, session); ok {
+		t.Error("a prepared generation with no reservation reported a launch attempt")
+	}
+
+	want := seedLaunchReservation(t, project, profile, session, "aaa111")
+	got, ok := findPreparedLaunchAttempt(project, profile, session)
+	if !ok {
+		t.Fatal("a real reservation was not recognized as proof of a launch attempt")
+	}
+	if got.Generation != "aaa111" || got.Path != want {
+		t.Errorf("evidence = %+v, want generation aaa111 at %s", got, want)
+	}
+}
+
+// doctorBootstrapRowFixture builds a single-member team whose AMQ root exists
+// but whose agent has no launch record, and returns the doctor execution plus
+// the agent directory.
+func doctorBootstrapRowFixture(t *testing.T, project, profile, session, role string) (doctorExecution, string) {
+	t.Helper()
+	root := filepath.Join(project, ".agent-mail", session)
+	agentDir := filepath.Join(root, "agents", role)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := team.WriteProfile(project, profile, team.Team{
+		Project: project,
+		Members: []team.Member{{Role: role, Handle: role, Binary: "claude", Session: session, CWD: project}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	d := newDoctorExec(t, project)
+	d.ProjectDir = project
+	d.Profile = profile
+	d.WorkstreamHint = session
+	return d, agentDir
+}
+
+func bootstrapRowFor(t *testing.T, checks []doctorCheck, role string) doctorCheck {
+	t.Helper()
+	for _, c := range checks {
+		if c.Name == "bootstrap/"+role {
+			return c
+		}
+	}
+	t.Fatalf("no bootstrap row for %q in %+v", role, checks)
+	return doctorCheck{}
+}
+
+// TestDoctorBootstrapRowFailsWhenAReservedLaunchLeftNoRecord is the #598 root
+// cause 3 regression for the doctor half.
+//
+// During the fresh-namespace brick, doctor reported EVERY row ok, including
+// `bootstrap/<role>: no launch record; skipped`, while the namespace was
+// unusable and the agents had died seconds after spawning. A launch was
+// reserved for those exact roles, so "no launch record" was not honest silence,
+// it was the missing diagnostic.
+func TestDoctorBootstrapRowFailsWhenAReservedLaunchLeftNoRecord(t *testing.T) {
+	project := t.TempDir()
+	profile, session, role := team.DefaultProfile, "bricked", "cto"
+	d, agentDir := doctorBootstrapRowFixture(t, project, profile, session, role)
+
+	reservation := seedLaunchReservation(t, project, profile, session, "gen0001")
+	seedAcceptedRoster(t, project, profile, session, "gen0001", role)
+
+	row := bootstrapRowFor(t, doctorCheckBootstrap(d), role)
+	if row.Status != doctorFail {
+		t.Fatalf("a reserved launch that left no record must FAIL, got %s: %s", row.Status, row.Detail)
+	}
+	// Actionability: the operator must be able to act without reading source.
+	for _, want := range []string{role, "gen0001", reservation, "absent", bootstrapLaunchRecordPath(agentDir)} {
+		if !strings.Contains(row.Detail, want) {
+			t.Errorf("failure detail omits %q\n  detail: %s", want, row.Detail)
+		}
+	}
+}
+
+// TestDoctorBootstrapRowDistinguishesMalformedFromAbsent keeps the two failures
+// from sharing a message. An agent that died before writing a record and one
+// that wrote a corrupt record need different remedies.
+func TestDoctorBootstrapRowDistinguishesMalformedFromAbsent(t *testing.T) {
+	project := t.TempDir()
+	profile, session, role := team.DefaultProfile, "corrupt", "cto"
+	d, agentDir := doctorBootstrapRowFixture(t, project, profile, session, role)
+
+	seedLaunchReservation(t, project, profile, session, "gen0001")
+	seedAcceptedRoster(t, project, profile, session, "gen0001", role)
+	if err := os.MkdirAll(filepath.Dir(launch.Path(agentDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(launch.Path(agentDir), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	row := bootstrapRowFor(t, doctorCheckBootstrap(d), role)
+	if row.Status != doctorFail {
+		t.Fatalf("a reserved launch with a malformed record must FAIL, got %s: %s", row.Status, row.Detail)
+	}
+	if !strings.Contains(row.Detail, "malformed") {
+		t.Errorf("detail must say malformed, not absent: %s", row.Detail)
+	}
+}
+
+// TestDoctorBootstrapRowStaysSilentWithoutAReservation is the false-positive
+// guard, and it is the reason the predicate exists at all. Members legitimately
+// have no launch record: never launched, staged but not started, an external
+// lead adopted in a pane amq-squad did not spawn. Failing those would make
+// doctor noisy for people who did nothing wrong, which is its own way of hiding
+// a real problem.
+func TestDoctorBootstrapRowStaysSilentWithoutAReservation(t *testing.T) {
+	project := t.TempDir()
+	profile, session, role := team.DefaultProfile, "never-launched", "cto"
+	d, _ := doctorBootstrapRowFixture(t, project, profile, session, role)
+
+	// Preparation exists and names the roster, but no launch was ever reserved.
+	seedAcceptedRoster(t, project, profile, session, "gen0001", role)
+
+	row := bootstrapRowFor(t, doctorCheckBootstrap(d), role)
+	if row.Status != doctorOK {
+		t.Fatalf("no reservation means nothing was attempted and silence is honest; got %s: %s", row.Status, row.Detail)
+	}
+}
+
+// TestDoctorBootstrapRowStaysSilentForAMemberOutsideTheAcceptedRoster is the
+// second half of the predicate. A reservation proves a launch was attempted for
+// the ACCEPTED roster, and says nothing about a member who was not part of it.
+func TestDoctorBootstrapRowStaysSilentForAMemberOutsideTheAcceptedRoster(t *testing.T) {
+	project := t.TempDir()
+	profile, session, role := team.DefaultProfile, "bystander", "cto"
+	d, _ := doctorBootstrapRowFixture(t, project, profile, session, role)
+
+	seedLaunchReservation(t, project, profile, session, "gen0001")
+	// The accepted roster names a DIFFERENT role.
+	seedAcceptedRoster(t, project, profile, session, "gen0001", "someone-else")
+
+	row := bootstrapRowFor(t, doctorCheckBootstrap(d), role)
+	if row.Status != doctorOK {
+		t.Fatalf("a member outside the accepted initial roster must not be failed by another member's reservation; got %s: %s", row.Status, row.Detail)
+	}
+}

--- a/internal/cli/doctor_bootstrap_row_598_test.go
+++ b/internal/cli/doctor_bootstrap_row_598_test.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/bootstrapack"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
@@ -204,5 +206,54 @@ func TestDoctorBootstrapRowStaysSilentForAMemberOutsideTheAcceptedRoster(t *test
 	row := bootstrapRowFor(t, doctorCheckBootstrap(d), role)
 	if row.Status != doctorOK {
 		t.Fatalf("a member outside the accepted initial roster must not be failed by another member's reservation; got %s: %s", row.Status, row.Detail)
+	}
+}
+
+// TestDoctorBootstrapReservedRelaunchInsideGraceIsNotFailed is Reviewer A's
+// false-positive, reproduced and closed.
+//
+// bootstrapack.Evaluate consults the grace period ONLY when the marker is
+// missing. A marker that exists but belongs to a PREVIOUS launch returns
+// "mismatch" immediately, and ordinary relaunch never removes the old marker:
+// launch.go touches bootstrapack state nowhere, and the only removals live in
+// the staged-launch rollback path. So a healthy agent that was just relaunched
+// has a stale marker, a fresh expectation, and a reservation.
+//
+// Without the grace gate, doctor reported FAIL for a member that was starting
+// normally and simply had not re-acknowledged yet. That is exactly the
+// "failed while having done nothing wrong" case the predicate is supposed to
+// exclude.
+func TestDoctorBootstrapReservedRelaunchInsideGraceIsNotFailed(t *testing.T) {
+	issued := time.Now().UTC()
+	mismatch := bootstrapack.Result{
+		State:    "mismatch",
+		Required: true,
+		IssuedAt: &issued,
+		Detail:   "bootstrap acknowledgement does not match the current launch identity",
+	}
+
+	// Inside the window: still starting, must not be failed even with a
+	// reservation.
+	if got := doctorBootstrapStatus(mismatch, true, issued.Add(bootstrapack.GracePeriod/2)); got != doctorWarn {
+		t.Errorf("reserved relaunch INSIDE the ack grace period = %s, want warn (the agent is still starting)", got)
+	}
+	// Boundary: exactly at expiry is outside the window.
+	if got := doctorBootstrapStatus(mismatch, true, issued.Add(bootstrapack.GracePeriod)); got != doctorFail {
+		t.Errorf("reserved mismatch AT grace expiry = %s, want fail", got)
+	}
+	// Past the window: the launch genuinely did not complete.
+	if got := doctorBootstrapStatus(mismatch, true, issued.Add(2*bootstrapack.GracePeriod)); got != doctorFail {
+		t.Errorf("reserved mismatch AFTER the grace period = %s, want fail", got)
+	}
+	// No reservation: unchanged historical behavior in and out of the window.
+	for _, at := range []time.Time{issued.Add(bootstrapack.GracePeriod / 2), issued.Add(2 * bootstrapack.GracePeriod)} {
+		if got := doctorBootstrapStatus(mismatch, false, at); got != doctorWarn {
+			t.Errorf("unreserved mismatch = %s, want warn", got)
+		}
+	}
+	// A missing issue time must not become an indefinite amnesty.
+	noIssue := bootstrapack.Result{State: "mismatch", Required: true}
+	if got := doctorBootstrapStatus(noIssue, true, issued); got != doctorFail {
+		t.Errorf("reserved mismatch with no issue time = %s, want fail (cannot prove it is inside the window)", got)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -168,17 +168,44 @@ func TestDoctorStoppedUnplannedSharedIndexDoesNotFail(t *testing.T) {
 }
 
 func TestDoctorBootstrapGraceIsInfoAndOverdueIsWarn(t *testing.T) {
-	if got := doctorBootstrapStatus(bootstrapack.Result{State: "pending", Required: true}); got != doctorOK {
+	// No launch reservation: the historical mapping, unchanged. A mismatched or
+	// malformed acknowledgement is ambiguous without evidence that a launch was
+	// actually attempted, so it stays a warning.
+	if got := doctorBootstrapStatus(bootstrapack.Result{State: "pending", Required: true}, false); got != doctorOK {
 		t.Fatalf("pending=%s", got)
 	}
 	for _, state := range []string{"unverified", "mismatch", "malformed"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}); got != doctorWarn {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, false); got != doctorWarn {
 			t.Fatalf("%s=%s", state, got)
 		}
 	}
 	for _, state := range []string{"verified", "not_required", "legacy_unknown"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}); got != doctorOK {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, false); got != doctorOK {
 			t.Fatalf("%s=%s", state, got)
+		}
+	}
+}
+
+// TestDoctorBootstrapReservedLaunchEscalatesMismatchToFail covers the #598
+// root cause 3 lift of the WARN cap. Once a launch was positively reserved for
+// a member, a mismatched or malformed acknowledgement is no longer "the agent
+// might still be starting"; it is a launch that did not complete, and a warning
+// is too quiet for the one signal that explains a bricked namespace.
+func TestDoctorBootstrapReservedLaunchEscalatesMismatchToFail(t *testing.T) {
+	for _, state := range []string{"mismatch", "malformed"} {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, true); got != doctorFail {
+			t.Errorf("reserved launch with %s acknowledgement = %s, want fail", state, got)
+		}
+	}
+	// unverified stays a warning even with a reservation: a launch can be
+	// reserved and the agent legitimately still on its way to acknowledging.
+	if got := doctorBootstrapStatus(bootstrapack.Result{State: "unverified", Required: true}, true); got != doctorWarn {
+		t.Errorf("reserved launch with unverified acknowledgement = %s, want warn", got)
+	}
+	// A healthy agent must not be failed just because its launch was reserved.
+	for _, state := range []string{"verified", "not_required", "legacy_unknown", "pending"} {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, true); got != doctorOK {
+			t.Errorf("reserved launch with %s = %s, want ok", state, got)
 		}
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -171,16 +171,16 @@ func TestDoctorBootstrapGraceIsInfoAndOverdueIsWarn(t *testing.T) {
 	// No launch reservation: the historical mapping, unchanged. A mismatched or
 	// malformed acknowledgement is ambiguous without evidence that a launch was
 	// actually attempted, so it stays a warning.
-	if got := doctorBootstrapStatus(bootstrapack.Result{State: "pending", Required: true}, false); got != doctorOK {
+	if got := doctorBootstrapStatus(bootstrapack.Result{State: "pending", Required: true}, false, time.Now()); got != doctorOK {
 		t.Fatalf("pending=%s", got)
 	}
 	for _, state := range []string{"unverified", "mismatch", "malformed"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, false); got != doctorWarn {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, false, time.Now()); got != doctorWarn {
 			t.Fatalf("%s=%s", state, got)
 		}
 	}
 	for _, state := range []string{"verified", "not_required", "legacy_unknown"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, false); got != doctorOK {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, false, time.Now()); got != doctorOK {
 			t.Fatalf("%s=%s", state, got)
 		}
 	}
@@ -193,18 +193,18 @@ func TestDoctorBootstrapGraceIsInfoAndOverdueIsWarn(t *testing.T) {
 // is too quiet for the one signal that explains a bricked namespace.
 func TestDoctorBootstrapReservedLaunchEscalatesMismatchToFail(t *testing.T) {
 	for _, state := range []string{"mismatch", "malformed"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, true); got != doctorFail {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state, Required: true}, true, time.Now()); got != doctorFail {
 			t.Errorf("reserved launch with %s acknowledgement = %s, want fail", state, got)
 		}
 	}
 	// unverified stays a warning even with a reservation: a launch can be
 	// reserved and the agent legitimately still on its way to acknowledging.
-	if got := doctorBootstrapStatus(bootstrapack.Result{State: "unverified", Required: true}, true); got != doctorWarn {
+	if got := doctorBootstrapStatus(bootstrapack.Result{State: "unverified", Required: true}, true, time.Now()); got != doctorWarn {
 		t.Errorf("reserved launch with unverified acknowledgement = %s, want warn", got)
 	}
 	// A healthy agent must not be failed just because its launch was reserved.
 	for _, state := range []string{"verified", "not_required", "legacy_unknown", "pending"} {
-		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, true); got != doctorOK {
+		if got := doctorBootstrapStatus(bootstrapack.Result{State: state}, true, time.Now()); got != doctorOK {
 			t.Errorf("reserved launch with %s = %s, want ok", state, got)
 		}
 	}

--- a/internal/cli/fresh_namespace_launch_598_test.go
+++ b/internal/cli/fresh_namespace_launch_598_test.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/role"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// materializeSpawnState reproduces what spawning actually writes into a fresh
+// namespace: the agent mailbox directory, the extension layer, role.md, and
+// launch.json. Readiness is calculated before and after so any field whose
+// value depends on that state shows up as drift.
+func materializeSpawnState(t *testing.T, project, profile, session, handle, roleID string) string {
+	t.Helper()
+	agentDir := filepath.Join(squadnamespace.AMQRoot(project, profile, session), "agents", handle)
+	if err := os.MkdirAll(role.ExtensionDir(agentDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(role.Path(agentDir), []byte("---\nid: "+roleID+"\n---\n\n# Role\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rec := launch.Record{
+		Role: roleID, Handle: handle, Session: session,
+		CWD: project, TeamHome: project, TeamProfile: profile,
+		StartedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(launch.Path(agentDir), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return agentDir
+}
+
+func readinessRowsByArtifact(res runReadinessResult) map[string]runReadinessRow {
+	out := make(map[string]runReadinessRow, len(res.Rows))
+	for _, row := range res.Rows {
+		out[row.Artifact] = row
+	}
+	return out
+}
+
+// TestPreparedBootstrapRenderIsDeterministicWithoutStateChange settles whether
+// the accept-time stamp inside preparedBootstrap (bootstrapack.NewExpectation,
+// which calls time.Now()) reaches the digested prompt text. If it does, EVERY
+// re-render drifts and #598 root cause 1 is a far broader bug than the issue
+// describes. This test changes nothing between the two renders, so a mismatch
+// here can only come from a non-deterministic input.
+func TestPreparedBootstrapRenderIsDeterministicWithoutStateChange(t *testing.T) {
+	project := prepareRunStartFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	profile, session := team.DefaultProfile, "prepared"
+
+	manifest, err := readPreparedRunManifest(project, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(project, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	for _, member := range tm.Members {
+		first, err := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if err != nil {
+			t.Fatalf("first render for %s: %v", member.Role, err)
+		}
+		time.Sleep(1100 * time.Millisecond) // cross a whole-second boundary
+		second, err := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if err != nil {
+			t.Fatalf("second render for %s: %v", member.Role, err)
+		}
+		if digestRunArtifactBytes([]byte(first)) != digestRunArtifactBytes([]byte(second)) {
+			t.Errorf("preparedBootstrap for %s is NOT deterministic across renders with zero state change; a timestamp or other non-deterministic input reaches the digested prompt", member.Role)
+			for i, line := range diffPromptLines(first, second) {
+				if i > 20 {
+					t.Errorf("  ... further differences truncated")
+					break
+				}
+				t.Errorf("  %s", line)
+			}
+			continue
+		}
+		if digestRunArtifactBytes([]byte(first)) != manifest.BootstrapDigests[member.Role] {
+			t.Errorf("preparedBootstrap for %s is deterministic but does NOT match the accepted digest recorded at preparation time; the accepted preview was captured from a different render path", member.Role)
+			continue
+		}
+		t.Logf("preparedBootstrap for %s is deterministic and matches the accepted digest", member.Role)
+	}
+}
+
+// diffPromptLines reports the first differing lines between two renders so a
+// drift names the field that moved instead of only asserting inequality. This
+// is the surface #598 root cause 4 says the CLI is missing.
+func diffPromptLines(a, b string) []string {
+	linesA, linesB := strings.Split(a, "\n"), strings.Split(b, "\n")
+	out := []string{}
+	max := len(linesA)
+	if len(linesB) > max {
+		max = len(linesB)
+	}
+	for i := 0; i < max; i++ {
+		var la, lb string
+		if i < len(linesA) {
+			la = linesA[i]
+		}
+		if i < len(linesB) {
+			lb = linesB[i]
+		}
+		if la != lb {
+			out = append(out, "line "+strconv.Itoa(i+1)+":\n    accepted:  "+la+"\n    generated: "+lb)
+		}
+	}
+	return out
+}
+
+// TestFreshNamespaceReadinessSurvivesSpawnMaterialization is the #598 root
+// cause 1 repro. run start --go validates the bootstrap rows as ready and
+// spawns; each agent up then re-validates the SAME rows against a world that
+// spawning itself just changed. If the two disagree, a fresh namespace is
+// bricked on first launch: the panes die on drift and the accepted preview can
+// never be satisfied again.
+func TestFreshNamespaceReadinessSurvivesSpawnMaterialization(t *testing.T) {
+	project := prepareRunStartFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	profile, session := team.DefaultProfile, "prepared"
+
+	manifest, err := readPreparedRunManifest(project, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	before := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if !before.Ready {
+		for _, row := range before.Rows {
+			if row.Status != "ready" {
+				t.Logf("pre-spawn row %s/%s: %s", row.Artifact, row.Status, row.Evidence)
+			}
+		}
+		t.Fatalf("fixture must be ready before spawn; readiness=%v", before.Ready)
+	}
+
+	for _, roleID := range manifest.InitialRoster {
+		materializeSpawnState(t, project, profile, session, roleID, roleID)
+	}
+
+	after := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if after.Ready {
+		return
+	}
+	beforeRows := readinessRowsByArtifact(before)
+	for _, row := range after.Rows {
+		if row.Status == "ready" {
+			continue
+		}
+		t.Errorf("row %q flipped %q -> %q after spawn materialized state it validates against\n  evidence: %s\n  fix text: %s",
+			row.Artifact, beforeRows[row.Artifact].Status, row.Status, row.Evidence, row.Fix)
+	}
+	t.Fatalf("fresh namespace bricks: readiness passed pre-spawn and failed post-spawn (#598 RC1)")
+}

--- a/internal/cli/prepared_teardown_598_test.go
+++ b/internal/cli/prepared_teardown_598_test.go
@@ -212,8 +212,11 @@ func TestPreparedTeardownRefusesSymlinkedPreparedParentEscapingTheProject(t *tes
 	if err == nil {
 		t.Fatalf("teardown accepted a prepared parent that resolves outside the project; target=%+v", target)
 	}
-	if !strings.Contains(err.Error(), "outside the project") {
-		t.Errorf("refusal must name the escape, got: %v", err)
+	// The refusal reason tightened with blocker 3: escaping the project is now
+	// a special case of failing the canonical-namespace identity check, so that
+	// is the message. Still a refusal, on a strictly stronger rule.
+	if !strings.Contains(err.Error(), "canonical prepared namespace") {
+		t.Errorf("refusal must name the canonical-namespace requirement, got: %v", err)
 	}
 	if target.PreparedHas || target.GenerationsHas {
 		t.Errorf("escaping paths must never be marked removable: %+v", target)
@@ -259,5 +262,93 @@ func TestPathWithinResolvedRootRejectsSiblingPrefix(t *testing.T) {
 		if got := pathWithinResolvedRoot(root, path); got != want {
 			t.Errorf("pathWithinResolvedRoot(%q, %q) = %v, want %v", root, path, got, want)
 		}
+	}
+}
+
+// TestPreparedTeardownRefusesInProjectPreparedRedirects is Reviewer A's blocker
+// 3, both variants, reproduced and closed.
+//
+// The previous containment proved only that a redirected prepared directory
+// stayed somewhere inside the project. That is ancestry, and the invariant this
+// function needs is identity: the directory IS this profile's prepared
+// namespace, or teardown does not touch it. Redirecting at the project root or
+// at any unrelated in-project directory passed the old check and made
+// same-named artifacts belonging to something else removable.
+func TestPreparedTeardownRefusesInProjectPreparedRedirects(t *testing.T) {
+	for name, redirect := range map[string]func(project string) string{
+		// The project root itself. pathWithinResolvedRoot allows equality, so
+		// this variant passed the old check most explicitly of all.
+		"project root": func(project string) string { return project },
+		// Any unrelated in-project directory.
+		"unrelated in-project dir": func(project string) string {
+			dir := filepath.Join(project, "unrelated")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			return dir
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			project := t.TempDir()
+			profile, session := team.DefaultProfile, "victim"
+			victimDir := redirect(project)
+
+			// State that belongs to something else and must survive.
+			victimManifest := filepath.Join(victimDir, session+".json")
+			victimGenerations := filepath.Join(victimDir, session+".generations")
+			if err := os.WriteFile(victimManifest, []byte(`{"schema":3}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(victimGenerations, "gen0001"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			preparedParent := filepath.Dir(preparedRunPath(project, profile, session))
+			if err := os.MkdirAll(filepath.Dir(preparedParent), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(victimDir, preparedParent); err != nil {
+				t.Skipf("symlinks unavailable on this platform: %v", err)
+			}
+
+			var target rmTarget
+			err := resolvePreparedRunTeardown(&target, "rm", project, profile, session)
+			if err == nil {
+				t.Fatalf("teardown accepted an in-project prepared redirect; target=%+v", target)
+			}
+			if !strings.Contains(err.Error(), "canonical prepared namespace") {
+				t.Errorf("refusal must name the canonical-namespace requirement, got: %v", err)
+			}
+			if target.PreparedHas || target.GenerationsHas {
+				t.Errorf("redirected paths must never be marked removable: %+v", target)
+			}
+			if _, statErr := os.Stat(victimManifest); statErr != nil {
+				t.Errorf("unrelated in-project manifest was destroyed: %v", statErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(victimGenerations, "gen0001")); statErr != nil {
+				t.Errorf("unrelated in-project generation state was destroyed: %v", statErr)
+			}
+		})
+	}
+}
+
+// TestPreparedTeardownAcceptsTheCanonicalPreparedDirectory is the companion
+// property, proved directly rather than inferred from the refusals above: the
+// tightened rule must still accept ordinary, unredirected prepared state, or it
+// would have broken teardown for every real namespace.
+func TestPreparedTeardownAcceptsTheCanonicalPreparedDirectory(t *testing.T) {
+	project := t.TempDir()
+	profile, session := team.DefaultProfile, "ordinary"
+	manifest, generations := seedPreparedTeardownFixture(t, project, profile, session)
+
+	var target rmTarget
+	if err := resolvePreparedRunTeardown(&target, "rm", project, profile, session); err != nil {
+		t.Fatalf("canonical prepared state must be accepted: %v", err)
+	}
+	if !target.PreparedHas || !target.GenerationsHas {
+		t.Fatalf("canonical prepared state must be marked removable: %+v", target)
+	}
+	if target.Prepared != manifest || target.Generations != generations {
+		t.Errorf("target paths = %q,%q want %q,%q", target.Prepared, target.Generations, manifest, generations)
 	}
 }

--- a/internal/cli/prepared_teardown_598_test.go
+++ b/internal/cli/prepared_teardown_598_test.go
@@ -170,3 +170,94 @@ func TestRmPreviewNamesPreparedStateBeforeRemoving(t *testing.T) {
 		t.Errorf("preview must not delete anything, but the generation state is gone: %v", statErr)
 	}
 }
+
+// TestPreparedTeardownRefusesSymlinkedPreparedParentEscapingTheProject is
+// Reviewer A's blocker 2, reproduced and closed.
+//
+// The original containment compared filepath.Dir(path) against
+// filepath.Dir(manifest) -- the same value by construction -- so it was
+// tautological and proved nothing. Making .amq-squad/prepared/<profile> a
+// symlink to an external directory left the lexical paths looking
+// project-local while the real files sat outside, and deleteSession would have
+// RemoveAll'd state belonging to another project entirely.
+//
+// This is the destructive-cross-boundary direction, so the assertion is not
+// merely "returns an error": the victim files must still exist afterwards.
+func TestPreparedTeardownRefusesSymlinkedPreparedParentEscapingTheProject(t *testing.T) {
+	project := t.TempDir()
+	external := t.TempDir()
+	profile, session := team.DefaultProfile, "victim"
+
+	// The external state that must survive.
+	victimManifest := filepath.Join(external, session+".json")
+	victimGenerations := filepath.Join(external, session+".generations")
+	if err := os.WriteFile(victimManifest, []byte(`{"schema":3}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(victimGenerations, "gen0001"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// .amq-squad/prepared/<profile> -> external
+	preparedParent := filepath.Dir(preparedRunPath(project, profile, session))
+	if err := os.MkdirAll(filepath.Dir(preparedParent), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, preparedParent); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	var target rmTarget
+	err := resolvePreparedRunTeardown(&target, "rm", project, profile, session)
+	if err == nil {
+		t.Fatalf("teardown accepted a prepared parent that resolves outside the project; target=%+v", target)
+	}
+	if !strings.Contains(err.Error(), "outside the project") {
+		t.Errorf("refusal must name the escape, got: %v", err)
+	}
+	if target.PreparedHas || target.GenerationsHas {
+		t.Errorf("escaping paths must never be marked removable: %+v", target)
+	}
+
+	// The point of the whole check: the external state is untouched.
+	if _, statErr := os.Stat(victimManifest); statErr != nil {
+		t.Errorf("external manifest was destroyed: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(victimGenerations, "gen0001")); statErr != nil {
+		t.Errorf("external generation state was destroyed: %v", statErr)
+	}
+}
+
+// TestPreparedTeardownRefusesWhenContainmentCannotBeResolved pins the
+// fail-closed direction. A teardown that cannot PROVE what it is about to
+// delete must not delete it, which matches this verb's existing conservative
+// posture everywhere else.
+func TestPreparedTeardownRefusesWhenContainmentCannotBeResolved(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "does-not-exist")
+	var target rmTarget
+	err := resolvePreparedRunTeardown(&target, "rm", project, team.DefaultProfile, "s")
+	if err == nil {
+		t.Fatalf("an unresolvable project must refuse, got target=%+v", target)
+	}
+	if !strings.Contains(err.Error(), "cannot resolve project directory") {
+		t.Errorf("refusal must name what could not be resolved, got: %v", err)
+	}
+}
+
+// TestPathWithinResolvedRootRejectsSiblingPrefix guards the separator rule. A
+// plain string prefix would accept "/tmp/project-evil" as inside "/tmp/project".
+func TestPathWithinResolvedRootRejectsSiblingPrefix(t *testing.T) {
+	root := filepath.Join("/tmp", "project")
+	for path, want := range map[string]bool{
+		root:                                  true,
+		filepath.Join(root, "child"):          true,
+		filepath.Join(root, "a", "b"):         true,
+		filepath.Join("/tmp", "project-evil"): false,
+		filepath.Join("/tmp", "other"):        false,
+		filepath.Join("/tmp"):                 false,
+	} {
+		if got := pathWithinResolvedRoot(root, path); got != want {
+			t.Errorf("pathWithinResolvedRoot(%q, %q) = %v, want %v", root, path, got, want)
+		}
+	}
+}

--- a/internal/cli/prepared_teardown_598_test.go
+++ b/internal/cli/prepared_teardown_598_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// seedPreparedTeardownFixture creates the prepared-state footprint teardown is
+// supposed to clear: the accepted manifest and its generation directory, plus
+// the AMQ root and brief that rm already knew about.
+func seedPreparedTeardownFixture(t *testing.T, project, profile, session string) (manifest, generations string) {
+	t.Helper()
+	manifest = preparedRunPath(project, profile, session)
+	generations = preparedRunGenerationsPath(project, profile, session)
+	if err := os.MkdirAll(filepath.Dir(manifest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest, []byte(`{"schema":3,"session":"`+session+`"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(generations, "abc123"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(generations, "abc123", "manifest.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return manifest, generations
+}
+
+func seedRmSessionRoot(t *testing.T, baseRoot, session string) string {
+	t.Helper()
+	root := filepath.Join(baseRoot, session)
+	if err := os.MkdirAll(filepath.Join(root, "agents", "cto"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestRmRemovesPreparedManifestAndGenerationState is the #598 root cause 2
+// regression. rm printed "session removed" while leaving
+// .amq-squad/prepared/<profile>/<session>.json and <session>.generations on
+// disk. Every later launch then loaded that stale accepted preview and drifted
+// permanently, which is what turned a failed launch into a bricked namespace.
+func TestRmRemovesPreparedManifestAndGenerationState(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(project, ".agent-mail")
+	profile, session := team.DefaultProfile, "bricked"
+
+	seedRmSessionRoot(t, baseRoot, session)
+	manifest, generations := seedPreparedTeardownFixture(t, project, profile, session)
+
+	out, err := runRmExec(t, rmExecution{
+		ProjectDir: project, BaseRoot: baseRoot, Session: session,
+		Profile: profile, Yes: true,
+	})
+	if err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if _, statErr := os.Stat(manifest); !os.IsNotExist(statErr) {
+		t.Errorf("prepared manifest survived rm: %s (stat err %v)", manifest, statErr)
+	}
+	if _, statErr := os.Stat(generations); !os.IsNotExist(statErr) {
+		t.Errorf("prepared generation state survived rm: %s (stat err %v)", generations, statErr)
+	}
+	// The print must be true, not merely reassuring: a verb that claims to have
+	// removed the session while leaving the state that bricks it is worse than
+	// one that refuses.
+	for _, want := range []string{manifest, generations} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rm output does not name the removed path %q\noutput:\n%s", want, out)
+		}
+	}
+}
+
+// TestRmOfOneSessionLeavesAnotherSessionsPreparedStateIntact is the scoping
+// negative. The prepared tree is shared by every session in a profile, so a
+// teardown that reached one directory too far would be a cross-session
+// data-loss bug rather than a local one.
+func TestRmOfOneSessionLeavesAnotherSessionsPreparedStateIntact(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(project, ".agent-mail")
+	profile := team.DefaultProfile
+
+	seedRmSessionRoot(t, baseRoot, "alpha")
+	seedRmSessionRoot(t, baseRoot, "beta")
+	_, _ = seedPreparedTeardownFixture(t, project, profile, "alpha")
+	betaManifest, betaGenerations := seedPreparedTeardownFixture(t, project, profile, "beta")
+
+	if _, err := runRmExec(t, rmExecution{
+		ProjectDir: project, BaseRoot: baseRoot, Session: "alpha",
+		Profile: profile, Yes: true,
+	}); err != nil {
+		t.Fatalf("rm alpha: %v", err)
+	}
+
+	if _, err := os.Stat(betaManifest); err != nil {
+		t.Errorf("rm of session alpha destroyed session beta's prepared manifest: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(betaGenerations, "abc123", "manifest.json")); err != nil {
+		t.Errorf("rm of session alpha destroyed session beta's generation state: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(baseRoot, "beta")); err != nil {
+		t.Errorf("rm of session alpha destroyed session beta's AMQ root: %v", err)
+	}
+}
+
+// TestRmClearsAnOrphanedPreparedManifestWithNoRootOrBrief closes the recovery
+// deadlock. After a failed launch the AMQ root and brief can already be gone
+// while the prepared manifest survives -- the exact bricked state. rm used to
+// refuse that with "nothing to remove", so the one verb able to clear the
+// orphan was the one that declined to look at it.
+func TestRmClearsAnOrphanedPreparedManifestWithNoRootOrBrief(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(project, ".agent-mail")
+	profile, session := team.DefaultProfile, "orphaned"
+	if err := os.MkdirAll(baseRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, generations := seedPreparedTeardownFixture(t, project, profile, session)
+
+	_, err := runRmExec(t, rmExecution{
+		ProjectDir: project, BaseRoot: baseRoot, Session: session,
+		Profile: profile, Yes: true,
+	})
+	if err != nil {
+		t.Fatalf("rm must clear an orphaned prepared manifest instead of refusing: %v", err)
+	}
+	if _, statErr := os.Stat(manifest); !os.IsNotExist(statErr) {
+		t.Errorf("orphaned prepared manifest survived: %s", manifest)
+	}
+	if _, statErr := os.Stat(generations); !os.IsNotExist(statErr) {
+		t.Errorf("orphaned generation state survived: %s", generations)
+	}
+}
+
+// TestRmPreviewNamesPreparedStateBeforeRemoving keeps the confirm gate honest.
+// The operator approves what the preview lists, so prepared state must appear
+// there before rm is allowed to delete it.
+func TestRmPreviewNamesPreparedStateBeforeRemoving(t *testing.T) {
+	project := t.TempDir()
+	baseRoot := filepath.Join(project, ".agent-mail")
+	profile, session := team.DefaultProfile, "previewed"
+
+	seedRmSessionRoot(t, baseRoot, session)
+	manifest, generations := seedPreparedTeardownFixture(t, project, profile, session)
+
+	// A declined confirmation renders the full preview and makes zero
+	// filesystem changes, which is exactly the observation this needs.
+	out, err := runRmExec(t, rmExecution{
+		ProjectDir: project, BaseRoot: baseRoot, Session: session,
+		Profile: profile, Confirm: strings.NewReader("n\n"),
+	})
+	if err != nil {
+		t.Fatalf("declined rm must not error: %v", err)
+	}
+	for _, want := range []string{manifest, generations} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview omits prepared path %q\noutput:\n%s", want, out)
+		}
+	}
+	if _, statErr := os.Stat(manifest); statErr != nil {
+		t.Errorf("preview must not delete anything, but the manifest is gone: %v", statErr)
+	}
+	if _, statErr := os.Stat(generations); statErr != nil {
+		t.Errorf("preview must not delete anything, but the generation state is gone: %v", statErr)
+	}
+}

--- a/internal/cli/rc1_bisect_598_test.go
+++ b/internal/cli/rc1_bisect_598_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// RC1 bisect (#598 root cause 1).
+//
+// The issue's stated mechanism is already FALSIFIED: preparing a fresh
+// namespace, materializing exactly what spawn writes, and recalculating leaves
+// readiness ready (see TestFreshNamespaceReadinessSurvivesSpawnMaterialization),
+// and the render is deterministic so no timestamp reaches the digest.
+//
+// What remains is to find which condition of the LIVE brick the passing fixture
+// does not reproduce. The live run differed in four ways, bisected one at a
+// time rather than all at once. This file is delta 1: the namespace was created
+// with --from-profile, cloning an existing roster, instead of being built
+// directly from --roles.
+//
+// The fixture asserts the same invariant either way. If it stays ready, delta 1
+// is excluded and the bisect moves on; if it drifts, the failure names the row
+// and the differing lines, which is the mechanism.
+
+// prepareRunStartClonedFixture prepares a namespace whose profile was CLONED
+// from another profile, mirroring the live `--from-profile OLD --profile NEW`
+// launch rather than the direct `--roles` construction used elsewhere.
+func prepareRunStartClonedFixture(t *testing.T, shape string) (project, profile, session string) {
+	t.Helper()
+	project = t.TempDir()
+	profile, session = "squad-clone-target", "prepared"
+
+	// The source roster the live run cloned from, pinned to a DIFFERENT session
+	// so the clone has to restamp it, exactly as the live path did.
+	if err := team.WriteProfile(project, "squad-source", team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Trust:        "approve-for-me",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "earlier"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", project, "--profile", profile, "--session", session,
+			"--from-profile", "squad-source", "--lead", "cto",
+			"--launch-shape", shape, "--goal", "Execute the accepted RC1 bisect fixture",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	})
+	if err != nil {
+		t.Fatalf("prepare cloned-profile fixture: %v", err)
+	}
+	return project, profile, session
+}
+
+// TestRC1Delta1ClonedProfileReadinessSurvivesSpawnMaterialization is delta 1 of
+// the bisect: does creating the namespace via --from-profile reproduce the
+// drift that a directly-constructed namespace does not?
+func TestRC1Delta1ClonedProfileReadinessSurvivesSpawnMaterialization(t *testing.T) {
+	project, profile, session := prepareRunStartClonedFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+
+	manifest, err := readPreparedRunManifest(project, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	before := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if !before.Ready {
+		for _, row := range before.Rows {
+			if row.Status != "ready" {
+				t.Logf("pre-spawn row %s/%s: %s", row.Artifact, row.Status, row.Evidence)
+			}
+		}
+		t.Fatalf("cloned-profile fixture must be ready before spawn")
+	}
+
+	// Capture the accepted render per role BEFORE spawn, in memory. The
+	// persisted preview is #597 operator tooling; the investigation does not
+	// need it and must not wait for it.
+	tm, err := team.ReadProfile(project, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	acceptedRender := map[string]string{}
+	for _, member := range tm.Members {
+		prompt, renderErr := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if renderErr != nil {
+			t.Fatalf("accepted render for %s: %v", member.Role, renderErr)
+		}
+		acceptedRender[member.Role] = prompt
+	}
+
+	for _, roleID := range manifest.InitialRoster {
+		materializeSpawnState(t, project, profile, session, roleID, roleID)
+	}
+
+	after := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if after.Ready {
+		t.Log("DELTA 1 EXCLUDED: --from-profile cloning does not reproduce the RC1 drift; readiness survives spawn materialization on a cloned profile too")
+		return
+	}
+
+	beforeRows := readinessRowsByArtifact(before)
+	for _, row := range after.Rows {
+		if row.Status == "ready" {
+			continue
+		}
+		t.Errorf("row %q flipped %q -> %q after spawn\n  evidence: %s", row.Artifact, beforeRows[row.Artifact].Status, row.Status, row.Evidence)
+	}
+	// Name the mechanism rather than only asserting a drift: re-render each role
+	// post-spawn and diff it against the accepted render captured above.
+	for _, member := range tm.Members {
+		post, renderErr := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if renderErr != nil {
+			t.Errorf("post-spawn render for %s failed: %v", member.Role, renderErr)
+			continue
+		}
+		diff := diffPromptLines(acceptedRender[member.Role], post)
+		if len(diff) == 0 {
+			continue
+		}
+		t.Errorf("DELTA 1 REPRODUCES: bootstrap render for %s changed across spawn; %d differing line(s):", member.Role, len(diff))
+		for i, line := range diff {
+			if i >= 10 {
+				t.Errorf("  ... %d more", len(diff)-10)
+				break
+			}
+			t.Errorf("  %s", line)
+		}
+	}
+	t.Fatalf("cloned-profile namespace bricks: readiness passed pre-spawn and failed post-spawn (#598 RC1 delta 1)")
+}

--- a/internal/cli/rc1_bisect_delta23_598_test.go
+++ b/internal/cli/rc1_bisect_delta23_598_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// RC1 bisect deltas 2 and 3 (#598 root cause 1).
+//
+// Delta 1 (--from-profile cloning) is excluded. Remaining differences between
+// the passing fixture and the live brick:
+//
+//	delta 2  three members with mixed binaries (claude lead + claude + codex)
+//	         vs a single-member cto fixture. The bootstrap embeds the current-team
+//	         routing block, which lists EVERY member, so a multi-member mixed
+//	         roster is materially more render surface.
+//	delta 3  AMQ root resolution answering differently once
+//	         .agent-mail/<profile>/<session> exists.
+//
+// Delta 3 carries a trap I need to disarm first. My earlier fixtures called
+// materializeSpawnState, which creates the agent mailbox directory and thereby
+// the AMQ root as a side effect. If preparation ALREADY created that root, then
+// "before" and "after" both ran with the root present and the absent-to-present
+// transition was never exercised at all -- meaning delta 3 is untested rather
+// than excluded. TestRC1Delta3PreparationRootMaterializationIsObserved settles
+// that explicitly instead of leaving it as an assumption.
+
+// prepareRunStartMixedRosterFixture prepares a namespace with the live squad's
+// actual shape: a claude lead and two workers, one claude and one codex.
+func prepareRunStartMixedRosterFixture(t *testing.T, shape string) (project, profile, session string) {
+	t.Helper()
+	project = t.TempDir()
+	profile, session = team.DefaultProfile, "prepared"
+
+	// The live squad used CUSTOM roles (amq-dev-1, amq-dev-2), which must be
+	// staged under .amq-squad/roles/<id>.md before preparation will accept
+	// them. Seeding them is closer to the live shape than substituting catalog
+	// roles would be.
+	rolesDir := filepath.Join(project, ".amq-squad", "roles")
+	if err := os.MkdirAll(rolesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, roleID := range []string{"amq-dev-1", "amq-dev-2"} {
+		doc := "---\nid: " + roleID + "\nlabel: " + roleID + "\n---\n\n# Role: " + roleID + "\n\nImplement assigned work.\n"
+		if err := os.WriteFile(filepath.Join(rolesDir, roleID+".md"), []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", project, "--profile", profile, "--session", session,
+			"--roles", "cto,amq-dev-1,amq-dev-2",
+			"--binary", "cto=claude", "--binary", "amq-dev-1=claude", "--binary", "amq-dev-2=codex",
+			"--lead", "cto",
+			// The live squad had all three members in ONE working directory,
+			// which readiness fails closed on without a recorded exception.
+			// Reproducing that shape is the point of this delta.
+			"--shared-cwd-exception", "rc1 bisect fixture reproduces the live single-checkout squad",
+			"--launch-shape", shape, "--goal", "Execute the accepted mixed-roster fixture",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	})
+	if err != nil {
+		t.Fatalf("prepare mixed-roster fixture: %v", err)
+	}
+	return project, profile, session
+}
+
+// TestRC1Delta3PreparationRootMaterializationIsObserved records whether
+// preparation creates the AMQ session root, because that determines whether the
+// other bisect fixtures ever exercised the root absent-to-present transition at
+// all. It asserts nothing about which answer is correct; it exists so the bisect
+// cannot quietly rest on an untested assumption.
+func TestRC1Delta3PreparationRootMaterializationIsObserved(t *testing.T) {
+	project, profile, session := prepareRunStartMixedRosterFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+	root := squadnamespace.AMQRoot(project, profile, session)
+
+	_, err := os.Stat(root)
+	switch {
+	case err == nil:
+		t.Logf("DELTA 3 NOTE: preparation ALREADY materializes the AMQ root at %s. Every fixture that calls materializeSpawnState therefore ran both readiness passes with the root PRESENT, so the absent-to-present transition is NOT covered by them and delta 3 remains open.", root)
+	case os.IsNotExist(err):
+		t.Logf("DELTA 3 NOTE: preparation does NOT create the AMQ root; it first appears when spawn state is materialized. The existing fixtures therefore DO cover the absent-to-present transition, and delta 3 is excluded by them.")
+	default:
+		t.Fatalf("stat AMQ root %s: %v", root, err)
+	}
+
+	// Whether or not the root exists, record what the per-agent directories look
+	// like, since those feed RolePath/LaunchPath in the bootstrap render.
+	for _, handle := range []string{"cto", "amq-dev-1", "amq-dev-2"} {
+		agentDir := filepath.Join(root, "agents", handle)
+		if _, statErr := os.Stat(agentDir); statErr == nil {
+			t.Logf("  agent dir already present after preparation: %s", agentDir)
+		}
+	}
+}
+
+// TestRC1Delta2MixedBinaryRosterReadinessSurvivesSpawnMaterialization is delta
+// 2: does a three-member mixed-binary roster reproduce the drift that a
+// single-member fixture does not?
+func TestRC1Delta2MixedBinaryRosterReadinessSurvivesSpawnMaterialization(t *testing.T) {
+	project, profile, session := prepareRunStartMixedRosterFixture(t, runwizard.LaunchShapeWorkingTeamTogether)
+
+	manifest, err := readPreparedRunManifest(project, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	before := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if !before.Ready {
+		for _, row := range before.Rows {
+			if row.Status != "ready" {
+				t.Logf("pre-spawn row %s/%s: %s", row.Artifact, row.Status, row.Evidence)
+			}
+		}
+		t.Fatalf("mixed-roster fixture must be ready before spawn")
+	}
+
+	tm, err := team.ReadProfile(project, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	acceptedRender := map[string]string{}
+	for _, member := range tm.Members {
+		prompt, renderErr := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if renderErr != nil {
+			t.Fatalf("accepted render for %s: %v", member.Role, renderErr)
+		}
+		acceptedRender[member.Role] = prompt
+	}
+
+	for _, roleID := range manifest.InitialRoster {
+		materializeSpawnState(t, project, profile, session, roleID, roleID)
+	}
+
+	after := calculateRunReadinessWithContext(project, profile, session, accepted)
+	if after.Ready {
+		t.Log("DELTA 2 EXCLUDED: a three-member mixed-binary roster does not reproduce the RC1 drift either")
+		return
+	}
+
+	beforeRows := readinessRowsByArtifact(before)
+	for _, row := range after.Rows {
+		if row.Status == "ready" {
+			continue
+		}
+		t.Errorf("row %q flipped %q -> %q after spawn\n  evidence: %s", row.Artifact, beforeRows[row.Artifact].Status, row.Status, row.Evidence)
+	}
+	for _, member := range tm.Members {
+		post, renderErr := preparedBootstrap(project, profile, session, binding, tm, member, accepted)
+		if renderErr != nil {
+			t.Errorf("post-spawn render for %s failed: %v", member.Role, renderErr)
+			continue
+		}
+		diff := diffPromptLines(acceptedRender[member.Role], post)
+		if len(diff) == 0 {
+			continue
+		}
+		t.Errorf("DELTA 2 REPRODUCES: bootstrap render for %s changed across spawn; %d differing line(s):", member.Role, len(diff))
+		for i, line := range diff {
+			if i >= 10 {
+				t.Errorf("  ... %d more", len(diff)-10)
+				break
+			}
+			t.Errorf("  %s", line)
+		}
+	}
+	t.Fatalf("mixed-binary roster bricks: readiness passed pre-spawn and failed post-spawn (#598 RC1 delta 2)")
+}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -286,6 +286,25 @@ type rmTarget struct {
 	Brief      string // brief path; "" when none could be resolved
 	BriefHas   bool
 	Agents     int // count of agent mailboxes under <root>/agents
+	// Prepared and Generations are the accepted-preparation state for this
+	// namespace (#598). Teardown used to leave both behind while printing
+	// "session removed", so the next launch loaded a stale accepted preview,
+	// compared it against a brief that no longer existed, and drifted
+	// permanently. That is what turned a failed launch into a bricked
+	// namespace, so removing them is part of removing the session.
+	Prepared       string // .amq-squad/prepared/<profile>/<session>.json
+	PreparedHas    bool
+	Generations    string // .amq-squad/prepared/<profile>/<session>.generations
+	GenerationsHas bool
+}
+
+// hasPreparedState reports whether any accepted-preparation artifact survives
+// for this namespace. Teardown must treat these as removable state in their own
+// right: after a failed launch the AMQ root and brief can already be gone while
+// the prepared manifest remains, and that orphan alone is enough to brick every
+// subsequent launch.
+func (t rmTarget) hasPreparedState() bool {
+	return t.PreparedHas || t.GenerationsHas
 }
 
 func executeRm(e rmExecution) error {
@@ -399,10 +418,18 @@ func executeRmReportDeclined(e rmExecution) (bool, error) {
 			target.BriefHas = true
 		}
 	}
+	if err := resolvePreparedRunTeardown(&target, verb, e.ProjectDir, profile, session); err != nil {
+		return false, err
+	}
 
 	// SAFETY 5: nothing to remove is a clean error, never a panic.
-	if !target.RootExists && !target.BriefHas {
-		return false, fmt.Errorf("%s: session %q has no AMQ root or brief under %s; nothing to remove", verb, session, baseRoot)
+	//
+	// Prepared state counts (#598). An orphaned prepared manifest with no root
+	// and no brief is exactly the bricked state operators land in, and the old
+	// check refused it as "nothing to remove" -- a refusal that pointed at
+	// nothing, from the one verb able to clear it.
+	if !target.RootExists && !target.BriefHas && !target.hasPreparedState() {
+		return false, fmt.Errorf("%s: session %q has no AMQ root, brief, or prepared launch state under %s; nothing to remove", verb, session, baseRoot)
 	}
 
 	// SAFETY 3: refuse a running session unless --force. Reuse the repo's
@@ -719,6 +746,50 @@ func countAgentMailboxes(root string) int {
 	return n
 }
 
+// resolvePreparedRunTeardown fills in the prepared-manifest paths for a
+// teardown target and proves each one is confined to this exact
+// profile/session before teardown is allowed to touch it.
+//
+// The containment check mirrors SAFETY 2 on the AMQ root rather than trusting
+// name validation alone: removing session X must be provably incapable of
+// touching session Y's accepted preparation, and the prepared tree is shared
+// by every session in the profile, so a single bad join here would be a
+// cross-session data-loss bug rather than a local one.
+func resolvePreparedRunTeardown(target *rmTarget, verb, project, profile, session string) error {
+	manifest := preparedRunPath(project, profile, session)
+	generations := preparedRunGenerationsPath(project, profile, session)
+	preparedDir := filepath.Dir(manifest)
+	for label, path := range map[string]string{
+		"prepared manifest":         manifest,
+		"prepared generation state": generations,
+	} {
+		if filepath.Dir(path) != preparedDir {
+			return fmt.Errorf("refusing to %s: resolved %s path %q is not a direct child of %q", verb, label, path, preparedDir)
+		}
+	}
+	if filepath.Base(manifest) != session+".json" {
+		return fmt.Errorf("refusing to %s: resolved prepared manifest %q does not belong to session %q", verb, manifest, session)
+	}
+	if filepath.Base(generations) != session+".generations" {
+		return fmt.Errorf("refusing to %s: resolved prepared generation state %q does not belong to session %q", verb, generations, session)
+	}
+	target.Prepared = manifest
+	target.Generations = generations
+	if fi, err := os.Stat(manifest); err == nil {
+		if fi.IsDir() {
+			return fmt.Errorf("refusing to %s: %q exists but is a directory", verb, manifest)
+		}
+		target.PreparedHas = true
+	}
+	if fi, err := os.Stat(generations); err == nil {
+		if !fi.IsDir() {
+			return fmt.Errorf("refusing to %s: %q exists but is not a directory", verb, generations)
+		}
+		target.GenerationsHas = true
+	}
+	return nil
+}
+
 func renderRmPreview(out io.Writer, mode rmMode, t rmTarget) {
 	if mode == rmModeArchive {
 		fmt.Fprintf(out, "# amq-squad archive — preview\n")
@@ -740,6 +811,14 @@ func renderRmPreview(out io.Writer, mode rmMode, t rmTarget) {
 			fmt.Fprintf(out, "  %s  %s\n", action, t.Brief)
 			fmt.Fprintf(out, "      -> %s\n", filepath.Join(dest, t.Session+".md"))
 		}
+		if t.PreparedHas {
+			fmt.Fprintf(out, "  %s  %s\n", action, t.Prepared)
+			fmt.Fprintf(out, "      -> %s\n", filepath.Join(dest, filepath.Base(t.Prepared)))
+		}
+		if t.GenerationsHas {
+			fmt.Fprintf(out, "  %s  %s\n", action, t.Generations)
+			fmt.Fprintf(out, "      -> %s\n", filepath.Join(dest, filepath.Base(t.Generations)))
+		}
 		return
 	}
 	if t.RootExists {
@@ -747,6 +826,12 @@ func renderRmPreview(out io.Writer, mode rmMode, t rmTarget) {
 	}
 	if t.BriefHas {
 		fmt.Fprintf(out, "  %s  %s\n", action, t.Brief)
+	}
+	if t.PreparedHas {
+		fmt.Fprintf(out, "  %s  %s\n", action, t.Prepared)
+	}
+	if t.GenerationsHas {
+		fmt.Fprintf(out, "  %s  %s\n", action, t.Generations)
 	}
 }
 
@@ -780,6 +865,21 @@ func deleteSession(out io.Writer, t rmTarget) error {
 		}
 		fmt.Fprintf(out, "removed %s\n", t.Brief)
 	}
+	// #598: the accepted preparation is part of the session. Leaving it behind
+	// while printing "session removed" is what made a failed launch
+	// unrecoverable instead of merely annoying.
+	if t.PreparedHas {
+		if err := os.Remove(t.Prepared); err != nil {
+			return fmt.Errorf("remove prepared manifest %q: %w", t.Prepared, err)
+		}
+		fmt.Fprintf(out, "removed %s\n", t.Prepared)
+	}
+	if t.GenerationsHas {
+		if err := os.RemoveAll(t.Generations); err != nil {
+			return fmt.Errorf("remove prepared generation state %q: %w", t.Generations, err)
+		}
+		fmt.Fprintf(out, "removed %s\n", t.Generations)
+	}
 	fmt.Fprintf(out, "rm: session %s removed.\n", t.Session)
 	return nil
 }
@@ -809,6 +909,30 @@ func archiveSession(out io.Writer, t rmTarget) error {
 			return fmt.Errorf("archive brief %q: %w", t.Brief, err)
 		}
 		fmt.Fprintf(out, "moved %s -> %s\n", t.Brief, briefDest)
+	}
+	// #598: archive moves the same prepared state rm deletes. Leaving it in
+	// place would archive a session while keeping the accepted preview that
+	// bricks the next launch under the same name -- the identical defect, just
+	// reached by the other verb.
+	for _, item := range []struct {
+		has   bool
+		src   string
+		label string
+	}{
+		{t.PreparedHas, t.Prepared, "prepared manifest"},
+		{t.GenerationsHas, t.Generations, "prepared generation state"},
+	} {
+		if !item.has {
+			continue
+		}
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			return fmt.Errorf("create archive dir: %w", err)
+		}
+		itemDest := filepath.Join(dest, filepath.Base(item.src))
+		if err := os.Rename(item.src, itemDest); err != nil {
+			return fmt.Errorf("archive %s %q: %w", item.label, item.src, err)
+		}
+		fmt.Fprintf(out, "moved %s -> %s\n", item.src, itemDest)
 	}
 	fmt.Fprintf(out, "archive: session %s moved to %s.\n", t.Session, dest)
 	return nil

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -759,19 +759,59 @@ func resolvePreparedRunTeardown(target *rmTarget, verb, project, profile, sessio
 	manifest := preparedRunPath(project, profile, session)
 	generations := preparedRunGenerationsPath(project, profile, session)
 	preparedDir := filepath.Dir(manifest)
+
+	// Lexical shape first. These are a cheap gate, NOT the containment proof.
+	//
+	// The previous version of this function stopped here and compared
+	// filepath.Dir(path) against filepath.Dir(manifest), which is the same
+	// value by construction, so the check was tautological and proved nothing.
+	// A reviewer built the case that breaks it: make
+	// .amq-squad/prepared/<profile> a symlink to an external directory and the
+	// lexical paths still look project-local while the real files are outside.
+	// deleteSession would then RemoveAll state that does not belong to this
+	// project. Containment is therefore proven on RESOLVED paths below.
+	if filepath.Base(manifest) != session+".json" {
+		return fmt.Errorf("refusing to %s: prepared manifest %q does not belong to session %q", verb, manifest, session)
+	}
+	if filepath.Base(generations) != session+".generations" {
+		return fmt.Errorf("refusing to %s: prepared generation state %q does not belong to session %q", verb, generations, session)
+	}
+
+	// Resolved containment. Every failure direction refuses, matching this
+	// verb's existing conservative posture: a teardown that cannot PROVE what
+	// it is about to delete must not delete it.
+	resolvedProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		return fmt.Errorf("refusing to %s: cannot resolve project directory %q: %w", verb, project, err)
+	}
+	resolvedPrepared, err := filepath.EvalSymlinks(preparedDir)
+	switch {
+	case os.IsNotExist(err):
+		// No prepared tree at all. Nothing to contain and nothing to remove;
+		// the stat probes below will simply find neither artifact.
+		target.Prepared = manifest
+		target.Generations = generations
+		return nil
+	case err != nil:
+		return fmt.Errorf("refusing to %s: cannot resolve prepared directory %q: %w", verb, preparedDir, err)
+	}
+	if !pathWithinResolvedRoot(resolvedProject, resolvedPrepared) {
+		return fmt.Errorf("refusing to %s: prepared directory %q resolves to %q, which is outside the project at %q; refusing to remove state that does not belong to this project", verb, preparedDir, resolvedPrepared, resolvedProject)
+	}
 	for label, path := range map[string]string{
 		"prepared manifest":         manifest,
 		"prepared generation state": generations,
 	} {
-		if filepath.Dir(path) != preparedDir {
-			return fmt.Errorf("refusing to %s: resolved %s path %q is not a direct child of %q", verb, label, path, preparedDir)
+		resolved, resolveErr := filepath.EvalSymlinks(path)
+		if os.IsNotExist(resolveErr) {
+			continue // absent artifacts are handled by the stat probes below
 		}
-	}
-	if filepath.Base(manifest) != session+".json" {
-		return fmt.Errorf("refusing to %s: resolved prepared manifest %q does not belong to session %q", verb, manifest, session)
-	}
-	if filepath.Base(generations) != session+".generations" {
-		return fmt.Errorf("refusing to %s: resolved prepared generation state %q does not belong to session %q", verb, generations, session)
+		if resolveErr != nil {
+			return fmt.Errorf("refusing to %s: cannot resolve %s %q: %w", verb, label, path, resolveErr)
+		}
+		if !pathWithinResolvedRoot(resolvedPrepared, resolved) {
+			return fmt.Errorf("refusing to %s: %s %q resolves to %q, which escapes the prepared directory %q", verb, label, path, resolved, resolvedPrepared)
+		}
 	}
 	target.Prepared = manifest
 	target.Generations = generations
@@ -936,4 +976,22 @@ func archiveSession(out io.Writer, t rmTarget) error {
 	}
 	fmt.Fprintf(out, "archive: session %s moved to %s.\n", t.Session, dest)
 	return nil
+}
+
+// pathWithinResolvedRoot reports whether an ALREADY-RESOLVED path is the
+// resolved root or lies beneath it.
+//
+// Both arguments must have been through filepath.EvalSymlinks. Passing lexical
+// paths here would reintroduce exactly the defect this exists to prevent, which
+// is why the parameter names say resolved.
+//
+// The separator suffix matters: a plain strings.HasPrefix would accept
+// "/tmp/project-evil" as being inside "/tmp/project".
+func pathWithinResolvedRoot(resolvedRoot, resolvedPath string) bool {
+	resolvedRoot = filepath.Clean(resolvedRoot)
+	resolvedPath = filepath.Clean(resolvedPath)
+	if resolvedPath == resolvedRoot {
+		return true
+	}
+	return strings.HasPrefix(resolvedPath, resolvedRoot+string(os.PathSeparator))
 }

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -391,12 +391,25 @@ func executeRmReportDeclined(e rmExecution) (bool, error) {
 	baseRoot = filepath.Clean(baseRoot)
 
 	root := filepath.Join(baseRoot, session)
-	// SAFETY 2 (highest-risk property): the target MUST resolve to a direct
-	// child of the base root. A validated session name already forbids
-	// separators, but we re-derive and compare independently so a future change
-	// to validation can never silently re-open an escape. Deleting session X
-	// must be provably incapable of touching session Y or anything outside
-	// <baseRoot>/<session>/.
+	// SAFETY 2: the target must be a direct LEXICAL child of the base root.
+	//
+	// Read what this actually provides, because the previous comment here
+	// claimed more than the code delivers and that overclaim is itself the
+	// defect class this release is about. Dir(Join(baseRoot, session)) IS
+	// baseRoot whenever session contains no separator, which
+	// validateWorkstreamName already guarantees, so both clauses below are
+	// vacuous. They are a cheap restatement of validation, NOT an independent
+	// check, and they would not catch a future change that let a separator
+	// through in a form Join collapses.
+	//
+	// They also prove nothing about SYMLINKS. If baseRoot or an intermediate
+	// component resolves outside the project, the RemoveAll and Rename below
+	// follow it, and the blast radius here is the whole AMQ root: every agent
+	// mailbox for the session. That hole is tracked in #606 and is NOT fixed
+	// here; see resolvePreparedRunTeardown in this file for the resolved-path
+	// containment it needs, applied to the prepared tree.
+	//
+	// Comment corrected only. Behavior is unchanged.
 	if filepath.Dir(root) != baseRoot || filepath.Base(root) != session {
 		return false, fmt.Errorf("refusing to %s: resolved path %q is not a direct child of base root %q", verb, root, baseRoot)
 	}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -808,8 +808,26 @@ func resolvePreparedRunTeardown(target *rmTarget, verb, project, profile, sessio
 	case err != nil:
 		return fmt.Errorf("refusing to %s: cannot resolve prepared directory %q: %w", verb, preparedDir, err)
 	}
-	if !pathWithinResolvedRoot(resolvedProject, resolvedPrepared) {
-		return fmt.Errorf("refusing to %s: prepared directory %q resolves to %q, which is outside the project at %q; refusing to remove state that does not belong to this project", verb, preparedDir, resolvedPrepared, resolvedProject)
+	// The prepared directory must resolve to its CANONICAL location, not merely
+	// to somewhere inside the project.
+	//
+	// "Inside the project" was the second wrong question here. A reviewer
+	// redirected .amq-squad/prepared/<profile> at the project ROOT and at an
+	// unrelated in-project directory; both stayed within the project and both
+	// made same-named victim.json / victim.generations belonging to something
+	// else removable. Containment by ancestry cannot express the actual
+	// invariant, which is identity: this directory IS the prepared namespace
+	// for this profile, or teardown does not touch it.
+	//
+	// Equality against the canonical path rejects every redirect in one rule
+	// rather than enumerating bad destinations, and it means a symlinked
+	// prepared directory is refused even when the target looks harmless. That
+	// is deliberate: the operator can move real state into place, and a
+	// destructive verb should not be the thing that follows an indirection it
+	// cannot justify.
+	canonicalPrepared := filepath.Join(resolvedProject, team.DirName, "prepared", squadnamespace.NormalizeProfile(profile))
+	if resolvedPrepared != filepath.Clean(canonicalPrepared) {
+		return fmt.Errorf("refusing to %s: prepared directory %q resolves to %q, which is not the canonical prepared namespace %q; refusing to remove state that is not this namespace's prepared state", verb, preparedDir, resolvedPrepared, filepath.Clean(canonicalPrepared))
 	}
 	for label, path := range map[string]string{
 		"prepared manifest":         manifest,

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1705,8 +1705,8 @@ func calculateRunReadinessWithContext(project, profile, session string, context 
 			prompt, err := preparedBootstrap(project, profile, session, binding, tm, member, acceptedRunContext{Version: context.Version, Topology: manifest.Topology})
 			if err != nil {
 				add(artifact, "drifted", err.Error(), "repair the referenced artifact and approve preparation again")
-			} else if digestRunArtifactBytes([]byte(prompt)) != manifest.BootstrapDigests[member.Role] {
-				add(artifact, "drifted", "generated bootstrap differs from accepted preview", "review the bootstrap diff and approve preparation again")
+			} else if generated := digestRunArtifactBytes([]byte(prompt)); generated != manifest.BootstrapDigests[member.Role] {
+				add(artifact, "drifted", preparedBootstrapDriftEvidence(profile, session, member.Role, manifest.Generation, manifest.BootstrapDigests[member.Role], generated), preparedBootstrapDriftFix)
 			} else {
 				goalMode := strings.TrimPrefix(expectedBinding, "Goal binding: ")
 				add(artifact, "ready", fmt.Sprintf("namespace=%s/%s role=%s lead=%s brief=%s rules=%s role_path=%s goal_mode=%s goal_digest=%s routing=durable-amq gates=operator-contract sha256=%s",
@@ -1729,8 +1729,10 @@ func calculateRunReadinessWithContext(project, profile, session string, context 
 				continue
 			}
 			prompt, promptErr := preparedBootstrap(project, profile, session, binding, fullTeam, member, acceptedRunContext{Version: context.Version, Topology: manifest.Topology})
-			if promptErr != nil || digestRunArtifactBytes([]byte(prompt)) != manifest.BootstrapDigests[member.Role] {
-				add(artifact, "drifted", "staged generated bootstrap differs from accepted preparation", "review the staged bootstrap diff and approve preparation again")
+			if promptErr != nil {
+				add(artifact, "drifted", "staged bootstrap could not be generated: "+promptErr.Error(), "repair the referenced artifact and approve preparation again")
+			} else if generated := digestRunArtifactBytes([]byte(prompt)); generated != manifest.BootstrapDigests[member.Role] {
+				add(artifact, "drifted", "staged "+preparedBootstrapDriftEvidence(profile, session, member.Role, manifest.Generation, manifest.BootstrapDigests[member.Role], generated), preparedBootstrapDriftFix)
 			} else {
 				add(artifact, "ready", fmt.Sprintf("staged role=%s handle=%s sha256=%s", member.Role, memberHandle(member), manifest.BootstrapDigests[member.Role]), "")
 			}


### PR DESCRIPTION
# Fix fresh-namespace launch bricking (#598)

Closes #598 (partially — see **Root cause 1** and **Root cause 4** below for what is
deliberately not closed here).

A fresh namespace was bricked permanently on first launch. Panes spawned and died
within seconds, `status` reported both members `missing / no_record`, and `doctor`
reported **every row `ok`**. No sanctioned diagnostic surfaced the cause, and all
three documented recovery verbs delegated to each other in a closed loop.

This is a correctness fix. **No guard is relaxed.** Guard relaxation is #597 and is
out of scope; where a fix looked like it needed a weaker guard, it was raised rather
than taken.

## Two corrections to the issue text

Review should happen against reality, not the original guess. Two of the issue's
stated mechanisms did not survive investigation:

**Root cause 1's mechanism is falsified, not merely unproven.** The issue says
spawning "materializes the AMQ root and the per-agent `role.md`, which feed the
bootstrap render", so accepted preview and spawn-time render can never agree. A
repro that prepares a fresh namespace, materializes exactly what spawn writes (agent
mailbox dir, extension layer, `role.md`, `launch.json`) and recalculates readiness
shows readiness **stays ready**. Both `role.ExistingPath` and `launch.ExistingPath`
fall back to the same extension path when nothing exists, so they return an identical
string before and after spawn. A second test also excludes the obvious alternative:
`preparedBootstrap` is deterministic across renders 1.1s apart and its digest matches
the accepted digest, so the `bootstrapack.NewExpectation(time.Now())` stamp does not
reach the digested prompt. RC1 therefore has **no proven mechanism** and no fix is
attempted here. Writing one against a guess is how the next #598 gets built, and one
of the issue's two suggested directions ("have `agent up` trust its generation token")
would skip a re-validation, which is guard relaxation wearing a correctness costume.

**Root cause 3 is a blind spot, not a regression.** The issue says #540 "has regressed
or is incomplete". It has not regressed. Its detector must *read the pane* to report an
error, and `tmux display-message -t <missing>` silently resolves to the client's current
pane, so its per-pane probe deliberately treats every inspection error as inconclusive.
An agent that dies *and* whose pane closes therefore produces no signal at all. #540
could never have caught this.

## What is fixed

### Root cause 2 — teardown orphaned the prepared manifest

`rm` and `archive` printed `session removed` while leaving
`.amq-squad/prepared/<profile>/<session>.json` and `<session>.generations` on disk.
Every later launch loaded that stale accepted preview, compared it against a brief
that no longer existed, and drifted permanently. **This orphan is what made a failed
launch unrecoverable rather than merely annoying.**

Teardown now treats accepted preparation as part of the session: it removes both
artifacts and names each removed path, so the print is true rather than reassuring.
An orphaned manifest with no root and no brief is now removable — previously that hit
`nothing to remove`, so the one verb able to clear the orphan was the one that declined
to look at it. That is the concrete half of the recovery-deadlock fix. The preview lists
prepared state before the confirm gate, because the operator can only approve what they
were shown.

Path resolution is proven confined to the exact profile/session on **resolved** paths
before teardown touches anything. The prepared tree is shared by every session in a
profile, so a bad join here would be cross-session data loss rather than a local bug,
and there is a negative test for exactly that.

An earlier revision of this section said the check "mirrors the existing SAFETY 2 check
on the AMQ root". That claim is withdrawn: review established that SAFETY 2 is itself
tautological (see **Blocker 2** below and #606), so mirroring it would have been
mirroring nothing. Containment here is proven on resolved paths instead.

**Scoped addition beyond the issue text:** the issue names `rm` and `up --reset`.
`archive` is extended too. Leaving it would archive a session while keeping the accepted
preview that bricks the next launch under the same name — the identical defect through
another verb. Shipping with a known second door open was the worse trade. `up --reset`
needed no separate change; it calls the same teardown.

### Root cause 3 — the launcher swallowed the failure

Enumerating tmux's panes answers what the per-pane probe structurally cannot: a
successful enumeration that omits a pane is positive proof of absence, and every caller
has already proved that pane existed via `verifyPaneProcessLaunched` at dispatch, so
absence means the agent died.

The conservative direction is preserved. A **failed** enumeration stays inconclusive
exactly as before, so an unreachable or stubbed tmux still cannot invent a launch
failure. The probe is lazy — at most once per poll, only when some pane fails to
inspect — so a healthy launch never asks for the pane list at all, and there is a test
asserting that so it cannot creep onto the happy path.

### Root cause 3 (doctor half) — `no launch record; skipped` reported as `ok`

`doctor` reported every row `ok` during the brick, including
`bootstrap/<role>: no launch record; skipped`, while the namespace was unusable.

Escalating that row needs a predicate, because plenty of members legitimately have no
launch record: never launched, staged but not started, an external lead adopted in a
pane amq-squad did not spawn. Failing those would make `doctor` noisy for people who did
nothing wrong, which is its own way of hiding a real problem.

The predicate is the prepared **launch reservation** — durable, positive proof that a
launch was reserved for this exact namespace and generation. No reservation means
nothing was attempted and silence is honest; a reservation means silence is a lie. The
row fails only when a reservation exists **and** the member is in that generation's
accepted initial roster **and** no launch record is readable. Every other path keeps its
historical skip, and any unreadable prepared state collapses to that skip so a listing
error can never manufacture a failure.

**Design rationale worth preserving against a future refactor.** The roster is read from
the reserving generation's own manifest, *unvalidated*, rather than through
`readPreparedRunManifest`. That looks like a shortcut and is not. `readPreparedRunManifest`
resolves the current pointer and validates manifest and state digests, so it fails
whenever preparation has drifted — which is **precisely the condition this row exists to
report**. Depending on it would make the escalation go silent exactly when it matters,
reintroducing the swallowed-failure defect one layer down. The roster only *scopes* the
failure to accepted members and is never authority, so an unvalidated read is the correct
tool for the question being asked. This was caught by the fail-closed test, not by review.

The failure names the reservation path, the generation, whether the record is absent or
malformed, and the exact expected record path, so the remedy is something an operator can
act on. `doctorBootstrapStatus` takes `launchWasReserved` and lifts the WARN cap for
mismatch/malformed once a launch was reserved; `unverified` stays a warning either way,
because a launch can be reserved and the agent legitimately still on its way to
acknowledging.

**Second scoped addition:** a launch record that exists but cannot be parsed is now a
WARN instead of `ok, no launch record; skipped`, even with no reservation. That report
was the same category of lie, just quieter. WARN rather than FAIL because without a
reservation nothing proves a launch happened.

`doctorCheckAMQRootAuthority` also reports a skip as `ok` and is deliberately **not**
touched. It has no launch-attempt evidence available to it, so its skip is honest.

### Root cause 4 — the readiness row is unactionable (partially fixed here, split with #597)

The row emitted `generated bootstrap differs from accepted preview` with fix text
`review the bootstrap diff and approve preparation again`, and nothing printed that diff.

This is not a missing print statement: **the accepted bootstrap text is never persisted.**
Preparation records only `manifest.BootstrapDigests[role]` and discards the prompt, so
there is nothing on disk to diff against. The remedy named an action that is *impossible*
rather than merely unimplemented — and the same gap rules out the issue's "at minimum the
differing field names" fallback, which needs the identical accepted render.

**Fixed here — the lie.** The row now states everything actually known:

```
generated bootstrap differs from the accepted preview: namespace=<profile>/<session>
role=<role> generation=<gen> accepted_sha256=<...> generated_sha256=<...>
```

and its fix text names an action that exists (re-run preparation and accept again), with
an explicit note that the field-level diff is not yet available. The fix text deliberately
does **not** promise a diff: a remedy that overstates what the tool can do is the exact
defect this row is being fixed for, so it must not be reintroduced inside the fix itself.

**Moved to #597 — the capability.** Persisting the accepted preview per role (sibling
artifact `<generation>/bootstrap/<role>.txt`, no digest-model change, declared in the
preparation proposal's `MutationPaths` and covered by transaction rollback) and the
resulting real diff. It lands there because #597 already carries the other
preparation-surface change, so there is one review focus, one rebase surface, and one
transaction-invariant discussion instead of two. Acceptance criteria are recorded on #597.

**Third scoped addition:** the staged-roster branch collapsed two different failures into
one message — `promptErr != nil || digest != accepted` both reported `staged generated
bootstrap differs from accepted preparation`. A render *error* is not a digest *mismatch*,
and reporting a failed render as a drift sends the operator to compare digests that were
never produced. They are now split, mirroring the initial-roster branch which already drew
that line. Same misdiagnosis class RC4 exists to kill, and symmetry between the two
branches is itself a correctness property.

## Live evidence

This squad's own session is post-brick fallout. The workers were hand-spawned after the
orphaned prepared manifest was moved aside, so their launch records carry no goal binding
(present only on the lead record), and typed task-store events consequently reject with
`generation_ref.goal_digest must be non-empty`. That is a reproducible consequence chain
of the swallowed launch failure plus the manual recovery path.

Orphaned prepared manifests from **completed** past sessions were still on disk during
this work (`.amq-squad/prepared/squad/v2-25-0.json`, `v2-25-0.generations`,
`v2-25-1.json`, `v2-25-1.generations`, mtimes Jul 26 and Jul 28). Orphans surviving two
release cycles is field proof for the teardown omission.

## Testing

Every fix has a regression test that **fails behaviourally** at the parent commit, not
merely fails to compile. That distinction cost one rework: a first attempt at the RC3
launcher test stubbed the new helper and so only failed to build at base, which proves
nothing about behaviour. Rewritten against a seam that already exists at base, it fails
with `got 0 failures: []` — the silent success itself.

- RC2 at parent: `rm: session bricked removed.` printed while manifest and generations
  survive; `nothing to remove` refusal on the orphan; preview omits both paths.
- RC3 launcher at parent: `a vanished pane must be reported as a launch failure; got 0 failures: []`.
- RC3 doctor at parent: `got ok: no launch record; skipped`.
- False-positive guards pass at **both** commits, which is what a guard test is for.

Also green: existing `rm`/`archive` suites, the existing #540 suite, the full doctor
suite, `go build ./...`, `go vet ./internal/cli/`, `gofmt -l`.

## Three scoped additions beyond the issue text

Called out so review meets them deliberately rather than by surprise. Each is defect
completion in the same class the issue names, not opportunistic scope growth:

1. **`archive` teardown** (RC2). The issue names `rm` and `up --reset`. Leaving `archive`
   would archive a session while keeping the accepted preview that bricks the next launch
   under the same name — the identical defect through another verb.
2. **Malformed-record WARN** (RC3 doctor). A launch record that exists but cannot be parsed
   was reported as `ok, no launch record; skipped`. Same category of lie, just quieter.
   WARN rather than FAIL because without a reservation nothing proves a launch happened.
3. **Render-error / digest-mismatch split** (RC4). A render error reported as a drift is the
   same misdiagnosis class RC4 exists to kill.

## Notes for review

- `b1e4aa3f` (the #600 doctor floor commit) is cherry-picked here so the bootstrap-row
  changes layer on the interface they will merge onto. It did not layer cleanly alone —
  it raises the floor to 0.51.1 while the fake-AMQ fixtures live elsewhere in #602 — so
  those fixture bumps are duplicated in a separate commit. Both dissolve on the
  post-#602 rebase.
- Merge chain: #602 → #603 → this. A rebase invalidates the reviewed head.

## Three blockers found in review, all fixed here

Recorded because the provenance matters: all three were found by Reviewer A constructing the failing case,
not by the tests in this PR, and two of them had already been approved as sound by Reviewer B. The
containment fix took three attempts — tautological, then ancestry, then identity — and its own history is
now the best evidence in this PR that "the check looks right" is not proof.

**Blocker 1 — a reserved relaunch was failed during the ack grace period** (`aa8fc3d`).
`bootstrapack.Evaluate` consults the grace period *only* when the marker is missing; a marker belonging to a
previous launch returns `mismatch` immediately. Ordinary relaunch never removes the old marker —
`launch.go` touches bootstrapack state nowhere, and the only removals live in the staged-launch rollback
path. So a healthy just-relaunched agent had a stale marker, a fresh expectation, and a reservation, and the
escalation reported FAIL for a member that was starting normally. The escalation is now gated on the grace
window having expired. A missing issue time counts as *outside* the window: a missing timestamp must not
become an indefinite amnesty.

**Blocker 3 — containment proved ancestry when the invariant is identity** (`cc102a7`).
After blocker 2, containment required the resolved prepared directory to be *inside* the project.
Redirecting `.amq-squad/prepared/<profile>` at the project **root**, or at any unrelated in-project
directory, satisfied that and made same-named artifacts belonging to something else removable. "Somewhere
under the project" is not what makes a directory safe to delete from; the property is identity. The resolved
prepared directory must now **equal** the canonical path, computed from the resolved project without
resolving the expected path itself — resolving both sides would make the redirect tautological again. This
also refuses a symlinked prepared directory whose target looks harmless, deliberately: an operator can move
real state into place, and a destructive verb should not follow an indirection it cannot justify. A positive
test proves ordinary unredirected layouts still work, because a rule this strict could otherwise have broken
teardown for every real namespace while every refusal test still passed.

**Blocker 2 — teardown containment was tautological** (`a727489`).
The check compared `filepath.Dir(path)` against `filepath.Dir(manifest)` — the same value by construction —
so it proved nothing. A symlinked `.amq-squad/prepared/<profile>` left the lexical paths looking
project-local while the real files sat outside, and `deleteSession` would have `RemoveAll`'d another
project's state. Containment is now proven on **resolved** paths, with a separator-suffix comparison so
`/tmp/project-evil` cannot pass as inside `/tmp/project`, and fail-closed on resolution errors. The
regression asserts the external victim files **still exist** after the refusal, rather than merely that an
error was returned.

## Residual risk

- **TOCTOU between path resolution and removal is real and accepted.** `EvalSymlinks` and `RemoveAll` are
  separate syscalls, and an attacker able to swap a path component in that window defeats any check of this
  shape. Closing it properly requires handle-based traversal (`openat2` / `O_NOFOLLOW`), which is out of
  scope here and equally absent from every sibling teardown path.
  Be precise about what bounds it, because an earlier revision of this note overstated it. Retaining the
  **unresolved** target paths helps only for a **final-entry** swap: `os.Remove`/`os.RemoveAll`/`os.Rename`
  do not follow a symlink in the last path component, so they act on the link rather than its target. It
  does **not** help if a **parent** component — the prepared directory itself — is swapped to a symlink
  after resolution: traversal then goes through that parent and the entry acted on is external.
  **Parent-component replacement is the explicitly accepted cross-boundary residual here.** The remaining
  bound is operational, not structural: the verb is a local CLI operation behind an operator confirmation
  gate.
- **A symlinked `.amq-squad`, `prepared/`, or `prepared/<profile>` directory is refused**, for example when
  squad state is parked on another volume. The failure is a refusal naming both the resolved and canonical
  paths, not data loss, and a symlinked *project* path (the common macOS `/tmp` → `/private/tmp` shape) is
  unaffected because both sides resolve identically — the positive test covers that. This is the deliberate
  trade for a destructive verb: refusing to follow an indirection it cannot justify beats deleting through
  one.
- **Above-project symlinks and hardlinks are not escapes.** `EvalSymlinks` resolves the whole chain on both
  sides, so root and artifact are compared in one resolved namespace. Directory hardlinks are prohibited on
  both supported platforms, and unlinking a hardlinked file inside the prepared directory removes that entry
  only, leaving external data intact.
- **`SAFETY 2` on the AMQ root has the same tautological shape and is NOT fixed here** — pre-existing,
  tracked in #606, with only a comment correction in this PR. The AMQ root may legitimately live outside the
  project, so that fix needs a boundary decision rather than a mechanical change.
- **A future ack issue time no longer extends the grace window** (`aeab9bc`, found by Reviewer B on a third
  pass). A bad clock at launch or a hand-edited record previously held the row at WARN for as long as the
  timestamp stayed ahead of now, hiding a genuinely dead agent. It now fails closed exactly like a missing
  timestamp: failing closed on a missing stamp while trusting an impossible one would have been an
  inconsistency inside the same three lines.
- **RC1 is documented, not fixed**, per the operator-approved scope gate. The real-AMQ probe runs after
  #602 merges and before any release tag.
- **A forward constraint this PR creates:** if anything ever writes a launch reservation at *preparation*
  time rather than at launch time, prepare-time orphans would begin satisfying the RC3 doctor predicate and
  doctor would fail bootstrap rows for launches that never happened.


## Post-#602 rebase and review coverage

The post-#602 rebase dropped only the two compatibility commits now carried by main and replayed all 11 surviving #598 commits without conflict; range-diff marks every survivor as patch-identical. #609 now supersedes the earlier #597 RC4 capability-tracking references in this body because #597 deferred that capability.

Reviewer A coverage is waived by lead decision for the rebased head because the only new semantic delta is the narrowly scoped RC4 issue-reference correction from #597 to #609 plus its existing regression assertion. The cto provides the single substantive review at the new exact head.
