### PR TITLE
Relax two happy-path session-reuse guards (#597)

### DIFF
--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -42,7 +42,10 @@ func validateEffortOverrideKeys(overrides map[string]string, selected map[string
 		return nil
 	}
 	sort.Strings(unknown)
-	return fmt.Errorf("--effort names role(s) not selected by --roles: %s", strings.Join(unknown, ", "))
+	// Source-neutral wording (#597 guard 4). Under --from-profile the selected
+	// roster comes from the clone and no --roles flag was ever passed, so
+	// naming --roles sent the operator to a flag they had not used.
+	return fmt.Errorf("--effort names role(s) not in the selected roster: %s", strings.Join(unknown, ", "))
 }
 
 func effortArgsForBinary(binary, effort string) ([]string, error) {

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -31,7 +31,7 @@ func parseEffortOverrides(raw string) (map[string]string, error) {
 	return overrides, nil
 }
 
-func validateEffortOverrideKeys(overrides map[string]string, selected map[string]bool) error {
+func validateEffortOverrideKeys(overrides map[string]string, selected map[string]bool, selectionSource string) error {
 	var unknown []string
 	for role := range overrides {
 		if !selected[role] {
@@ -42,10 +42,13 @@ func validateEffortOverrideKeys(overrides map[string]string, selected map[string
 		return nil
 	}
 	sort.Strings(unknown)
-	// Source-neutral wording (#597 guard 4). Under --from-profile the selected
-	// roster comes from the clone and no --roles flag was ever passed, so
-	// naming --roles sent the operator to a flag they had not used.
-	return fmt.Errorf("--effort names role(s) not in the selected roster: %s", strings.Join(unknown, ", "))
+	// The message names the ACTUAL selection source (#597 guard 4). Under
+	// --from-profile the roster comes from the clone and no --roles flag was
+	// ever passed, so naming --roles sent the operator to a flag they had not
+	// used. Where --roles genuinely IS the source, saying so is more useful
+	// than a generic phrase, which is why this is parameterized rather than
+	// flattened to one wording.
+	return fmt.Errorf("--effort names role(s) not selected by %s: %s", selectionSource, strings.Join(unknown, ", "))
 }
 
 func effortArgsForBinary(binary, effort string) ([]string, error) {

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -781,6 +781,16 @@ func runRunStart(args []string, version string) error {
 			if err != nil {
 				return err
 			}
+			// #597 guard 4: the clone must carry the requested effort, or the
+			// proposal shows a roster the launch will not produce. Relaxing
+			// preflight to ACCEPT --effort here without applying it would make
+			// the command succeed while silently dropping operator input, which
+			// is worse than the refusal it replaced. CloneRosterForSession is a
+			// JSON round-trip, so this mutates the clone only and the SOURCE
+			// profile is untouched.
+			if proposalTeam.Members, err = applyRunStartCloneEffort(project, proposalTeam.Members, *effortFlag); err != nil {
+				return err
+			}
 			// A cloned roster keeps the source's own lead/lead-mode (part of the
 			// cloned "launch shape") unless the operator explicitly overrides them.
 			if explicitLead != "" {
@@ -1009,7 +1019,7 @@ func runRunStart(args []string, version string) error {
 		result, err := executeRunPreparationTransaction(project, profile, session, preparationProposal.MutationPaths, preparedRunPath(project, profile, session), func() (runReadinessResult, error) {
 			if freshRoster {
 				quietNotice("preparing accepted roster; no panes will launch...\n")
-				if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, newTeamArgs); err != nil {
+				if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
 					return runReadinessResult{}, err
 				}
 			} else if len(newTeamArgs) > 0 {
@@ -1088,7 +1098,7 @@ func runRunStart(args []string, version string) error {
 		}
 		if freshRoster {
 			quietNotice("creating roster...\n")
-			if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, newTeamArgs); err != nil {
+			if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
 				return err
 			}
 		} else if len(newTeamArgs) > 0 {
@@ -1164,7 +1174,7 @@ func runRunStart(args []string, version string) error {
 	// 1) roster
 	if freshRoster {
 		quietNotice("creating roster...\n")
-		if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, newTeamArgs); err != nil {
+		if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
 			return err
 		}
 		if err := applyRunStartToolProfiles(project, profile, *toolProfileFlag); err != nil {
@@ -1658,9 +1668,9 @@ func runStartRolesFixArg(roles string) string {
 // and explicitLeadMode override the cloned source's own lead/lead-mode only
 // when the operator passed --lead / --lead-mode; otherwise the clone keeps
 // the source roster's lead as part of its cloned launch shape.
-func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, explicitLeadMode string, newTeamArgs []string) error {
+func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, explicitLeadMode, effort string, newTeamArgs []string) error {
 	if strings.TrimSpace(fromProfile) != "" {
-		return runStartCloneRosterProfile(project, profile, fromProfile, session, explicitLead, explicitLeadMode)
+		return runStartCloneRosterProfile(project, profile, fromProfile, session, explicitLead, explicitLeadMode, effort)
 	}
 	return runNew(newTeamArgs)
 }
@@ -1669,7 +1679,7 @@ func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitL
 // the source profile's roster shape and write it under targetProfile, pinned
 // to session. Goal binding, brief, prepared generations, and launch records
 // are never part of team.Team and are therefore never touched here.
-func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, explicitLead, explicitLeadMode string) error {
+func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, explicitLead, explicitLeadMode, effort string) error {
 	source, err := team.ReadProfile(project, sourceProfile)
 	if err != nil {
 		return fmt.Errorf("read source profile %q: %w", sourceProfile, err)
@@ -1683,6 +1693,13 @@ func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, 
 	}
 	if strings.TrimSpace(explicitLeadMode) != "" {
 		cloned.LeadMode = explicitLeadMode
+	}
+	// #597 guard 4: apply the requested effort to the CLONE before persisting
+	// it, so the materialized roster matches the accepted proposal. The source
+	// profile is never written here, which is the no-rewrite condition:
+	// --from-profile must not mutate what it clones from.
+	if cloned.Members, err = applyRunStartCloneEffort(project, cloned.Members, effort); err != nil {
+		return err
 	}
 	if err := team.WriteProfile(project, targetProfile, cloned); err != nil {
 		return fmt.Errorf("write cloned profile %q: %w", targetProfile, err)
@@ -2004,4 +2021,23 @@ func checkNOCDispatchLineBound(command, promptPath string) error {
 	}
 	return fmt.Errorf("NOC dispatch line is %d bytes, over the %d-byte safe bound (tty MAX_CANON is 1024 and an over-length line is dropped SILENTLY): shorten the control root or the model/passthrough args. Payload path %s is %d bytes of that",
 		len(command), nocDispatchLineBound, promptPath, len(promptPath))
+}
+
+// applyRunStartCloneEffort normalizes --effort into the cloned roster's native
+// member args.
+//
+// It exists so the proposal and the materialization apply the SAME override to
+// the SAME effective roster. #597 guard 4 relaxed preflight to accept --effort
+// alongside --from-profile; without this the command would accept the flag and
+// then persist a clone that never received it, reporting success while
+// discarding operator input.
+func applyRunStartCloneEffort(project string, members []team.Member, effort string) ([]team.Member, error) {
+	if strings.TrimSpace(effort) == "" {
+		return members, nil
+	}
+	overrides, err := parseEffortOverrides(effort)
+	if err != nil {
+		return nil, err
+	}
+	return applyLaunchEffortOverridesCatalogMode(members, overrides, loadAgentCatalogAndWarn(project), false)
 }

--- a/internal/cli/run_start_effort_from_profile_597_test.go
+++ b/internal/cli/run_start_effort_from_profile_597_test.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
 // #597 guard 4: --effort was unusable with --from-profile.
@@ -16,9 +19,23 @@ import (
 
 func seedEffortSourceProfile(t *testing.T, project string) {
 	t.Helper()
+	// "challenger" is a custom role, so preparation requires it staged under
+	// .amq-squad/roles/ before it will accept the roster.
+	rolesDir := filepath.Join(project, ".amq-squad", "roles")
+	if err := os.MkdirAll(rolesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := "---\nid: challenger\nlabel: challenger\n---\n\n# Role: challenger\n\nChallenge the plan.\n"
+	if err := os.WriteFile(filepath.Join(rolesDir, "challenger.md"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := team.WriteProfile(project, "source-squad", team.Team{
 		Orchestrated: true,
 		Lead:         "cto",
+		// Two mutation-capable members in one checkout, recorded on the SOURCE
+		// so the clone inherits it. The run-start flag only reaches a profile
+		// created via `new team`, which the --from-profile path does not use.
+		SharedCwdException: "597 guard 4 regression fixture",
 		Members: []team.Member{
 			{Role: "cto", Binary: "codex", Handle: "cto", Session: "earlier"},
 			{Role: "challenger", Binary: "claude", Handle: "challenger", Session: "earlier"},
@@ -97,53 +114,54 @@ func TestRunStartEffortMissingSourceProfileDefersToItsOwnRefusal(t *testing.T) {
 }
 
 // TestRunStartEffortIsActuallyAppliedToTheClonedRoster is the blocker
-// regression, and it exists because the first version of this fix was a no-op.
+// regression, and it goes through the OPERATOR ENTRY POINT deliberately.
 //
-// Relaxing preflight made the command ACCEPT --effort with --from-profile and
-// nothing applied it: the proposal cloned without effort, the materialized
-// clone was persisted unchanged, and upArgs forwards --effort only when a team
-// already exists, which a fresh clone does not. The command stopped refusing
-// and started lying, which is strictly worse than the refusal it replaced.
+// Two things it has to survive that earlier attempts did not. It must assert
+// the PRESENCE OF THE EFFECT rather than the absence of a refusal, because the
+// first version of this fix was a silent no-op that a refusal-absence test
+// passed. And it must call only stable signatures, because the fix changes
+// runStartCloneRosterProfile's arity: a test calling that helper directly
+// cannot compile at either parent, so it can prove nothing about them without
+// being hand-edited per commit, which is not evidence.
 //
-// The original test asserted the ABSENCE OF A REFUSAL and passed against that
-// broken state. This one asserts the PRESENCE OF THE EFFECT, so it fails at the
-// base commit for the refusal AND fails at the no-op commit for the missing
-// effort. Distinguishing base from HEAD was not enough; it has to distinguish
-// base, the no-op, and the fix.
+// runRunStart's signature is stable across all three states, so this exact
+// checked-in test compiles and runs at 08d03da, at 883df06, and here.
 func TestRunStartEffortIsActuallyAppliedToTheClonedRoster(t *testing.T) {
 	project := t.TempDir()
 	seedEffortSourceProfile(t, project)
 
-	if err := runStartCloneRosterProfile(project, "target-squad", "source-squad", "tonight", "", "", "cto=xhigh"); err != nil {
-		t.Fatalf("clone with effort: %v", err)
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", project, "--profile", "target-squad", "--session", "tonight",
+			"--from-profile", "source-squad", "--lead", "cto",
+			"--effort", "cto=xhigh",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Execute the guard 4 effort fixture",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	})
+	if err != nil {
+		t.Fatalf("run start --from-profile --effort --prepare: %v", err)
 	}
 
 	cloned, err := team.ReadProfile(project, "target-squad")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var cto *team.Member
-	for i := range cloned.Members {
-		if cloned.Members[i].Role == "cto" {
-			cto = &cloned.Members[i]
-		}
-	}
-	if cto == nil {
-		t.Fatalf("cloned roster lost the cto member: %+v", cloned.Members)
-	}
-	// The effect: the requested effort reached the cloned member's native args.
-	native := strings.Join(append(append([]string{}, cto.CodexArgs...), cto.ClaudeArgs...), " ")
-	if !strings.Contains(native, "xhigh") {
-		t.Errorf("--effort cto=xhigh was accepted but never applied to the clone; native args = %q", native)
-	}
-	// Members not named keep their identity.
+	native := map[string]string{}
 	for _, m := range cloned.Members {
-		if m.Role == "challenger" && strings.Contains(strings.Join(append(append([]string{}, m.CodexArgs...), m.ClaudeArgs...), " "), "xhigh") {
-			t.Errorf("effort leaked onto an unnamed member: %+v", m)
-		}
+		native[m.Role] = strings.Join(append(append([]string{}, m.CodexArgs...), m.ClaudeArgs...), " ")
+	}
+	// THE EFFECT: the requested effort reached the cloned member's native args.
+	if !strings.Contains(native["cto"], "xhigh") {
+		t.Errorf("--effort cto=xhigh was accepted but never applied to the clone; cto native args = %q", native["cto"])
+	}
+	// And did not leak onto a member it did not name.
+	if strings.Contains(native["challenger"], "xhigh") {
+		t.Errorf("effort leaked onto an unnamed member; challenger native args = %q", native["challenger"])
 	}
 
-	// THE NO-REWRITE CONDITION: --from-profile must not mutate its source.
+	// NO-REWRITE: --from-profile must not mutate what it clones from.
 	source, err := team.ReadProfile(project, "source-squad")
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +169,7 @@ func TestRunStartEffortIsActuallyAppliedToTheClonedRoster(t *testing.T) {
 	for _, m := range source.Members {
 		joined := strings.Join(append(append([]string{}, m.CodexArgs...), m.ClaudeArgs...), " ")
 		if strings.Contains(joined, "xhigh") {
-			t.Errorf("cloning mutated the SOURCE profile member %q: %q", m.Role, joined)
+			t.Errorf("cloning mutated the SOURCE member %q: %q", m.Role, joined)
 		}
 		if m.Session != "earlier" {
 			t.Errorf("cloning re-pinned the SOURCE member %q to %q", m.Role, m.Session)

--- a/internal/cli/run_start_effort_from_profile_597_test.go
+++ b/internal/cli/run_start_effort_from_profile_597_test.go
@@ -92,8 +92,8 @@ func TestRunStartEffortStillRefusesRolesInNeitherSource(t *testing.T) {
 	if detail == "" {
 		t.Fatal("an --effort key naming a role in neither --roles nor the cloned roster must still be refused")
 	}
-	if !strings.Contains(detail, "ctoo") {
-		t.Errorf("refusal must name the unknown role, got: %s", detail)
+	if !strings.Contains(detail, "ctoo") || !strings.Contains(detail, "--from-profile") {
+		t.Errorf("refusal must name the unknown role AND the real selection source, got: %s", detail)
 	}
 
 	// And the pre-existing --roles path is untouched.

--- a/internal/cli/run_start_effort_from_profile_597_test.go
+++ b/internal/cli/run_start_effort_from_profile_597_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// #597 guard 4: --effort was unusable with --from-profile.
+//
+// --roles and --from-profile are mutually exclusive roster sources, so under
+// --from-profile the --roles-derived selection is empty and every --effort key
+// read as "not selected by --roles". The guard was not wrong about its own
+// predicate; it was being asked the wrong question.
+
+func seedEffortSourceProfile(t *testing.T, project string) {
+	t.Helper()
+	if err := team.WriteProfile(project, "source-squad", team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "earlier"},
+			{Role: "challenger", Binary: "claude", Handle: "challenger", Session: "earlier"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// preflightEffortIssue runs the real preflight entry point and returns any
+// invalid-effort issue.
+//
+// It goes through runStartPreflight rather than calling the validator directly
+// ON PURPOSE. The fix changes the validator's signature, so a direct unit test
+// cannot compile at the parent commit, and a test that only fails to BUILD
+// proves nothing about behavior. runStartPreflight's signature is stable, so
+// these cases compile at the parent and fail there for the right reason.
+func preflightEffortIssue(project, roles, fromProfile, effort string) string {
+	res := runStartPreflight(runStartPreflightInput{
+		Project: project, Profile: "target-squad", Session: "tonight",
+		Roles: roles, FromProfile: fromProfile, FromProfileSet: fromProfile != "",
+		Effort: effort, EffortSet: effort != "",
+	})
+	for _, issue := range res.Issues {
+		if issue.Code == runStartPreflightInvalidEffort {
+			return issue.Detail
+		}
+	}
+	return ""
+}
+
+// TestRunStartEffortAcceptsRolesFromClonedProfile is the relaxation: an effort
+// key naming a role that exists in the cloned roster is now accepted.
+func TestRunStartEffortAcceptsRolesFromClonedProfile(t *testing.T) {
+	project := t.TempDir()
+	seedEffortSourceProfile(t, project)
+
+	for _, effort := range []string{"cto=xhigh", "challenger=high", "cto=xhigh,challenger=low"} {
+		if detail := preflightEffortIssue(project, "", "source-squad", effort); detail != "" {
+			t.Errorf("--effort %q with --from-profile must be accepted, got: %s", effort, detail)
+		}
+	}
+}
+
+// TestRunStartEffortStillRefusesRolesInNeitherSource is the protection that had
+// to survive the relaxation. Relaxing a guard is not deleting it: a typo'd role
+// silently doing nothing is the failure this check exists to prevent, and it is
+// still refused.
+func TestRunStartEffortStillRefusesRolesInNeitherSource(t *testing.T) {
+	project := t.TempDir()
+	seedEffortSourceProfile(t, project)
+
+	detail := preflightEffortIssue(project, "", "source-squad", "ctoo=xhigh")
+	if detail == "" {
+		t.Fatal("an --effort key naming a role in neither --roles nor the cloned roster must still be refused")
+	}
+	if !strings.Contains(detail, "ctoo") {
+		t.Errorf("refusal must name the unknown role, got: %s", detail)
+	}
+
+	// And the pre-existing --roles path is untouched.
+	if detail := preflightEffortIssue(project, "cto", "", "nope=high"); detail == "" {
+		t.Error("--effort naming a role outside --roles must still be refused")
+	}
+}
+
+// TestRunStartEffortMissingSourceProfileDefersToItsOwnRefusal keeps this check
+// from burying a better error. A --from-profile that cannot be read has a
+// dedicated refusal that says so; reporting it here as an effort problem would
+// point the operator at the wrong flag.
+func TestRunStartEffortMissingSourceProfileDefersToItsOwnRefusal(t *testing.T) {
+	project := t.TempDir()
+	if detail := preflightEffortIssue(project, "", "does-not-exist", "cto=xhigh"); detail != "" {
+		t.Errorf("a missing source profile must not surface as an effort error: %s", detail)
+	}
+}

--- a/internal/cli/run_start_effort_from_profile_597_test.go
+++ b/internal/cli/run_start_effort_from_profile_597_test.go
@@ -95,3 +95,66 @@ func TestRunStartEffortMissingSourceProfileDefersToItsOwnRefusal(t *testing.T) {
 		t.Errorf("a missing source profile must not surface as an effort error: %s", detail)
 	}
 }
+
+// TestRunStartEffortIsActuallyAppliedToTheClonedRoster is the blocker
+// regression, and it exists because the first version of this fix was a no-op.
+//
+// Relaxing preflight made the command ACCEPT --effort with --from-profile and
+// nothing applied it: the proposal cloned without effort, the materialized
+// clone was persisted unchanged, and upArgs forwards --effort only when a team
+// already exists, which a fresh clone does not. The command stopped refusing
+// and started lying, which is strictly worse than the refusal it replaced.
+//
+// The original test asserted the ABSENCE OF A REFUSAL and passed against that
+// broken state. This one asserts the PRESENCE OF THE EFFECT, so it fails at the
+// base commit for the refusal AND fails at the no-op commit for the missing
+// effort. Distinguishing base from HEAD was not enough; it has to distinguish
+// base, the no-op, and the fix.
+func TestRunStartEffortIsActuallyAppliedToTheClonedRoster(t *testing.T) {
+	project := t.TempDir()
+	seedEffortSourceProfile(t, project)
+
+	if err := runStartCloneRosterProfile(project, "target-squad", "source-squad", "tonight", "", "", "cto=xhigh"); err != nil {
+		t.Fatalf("clone with effort: %v", err)
+	}
+
+	cloned, err := team.ReadProfile(project, "target-squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cto *team.Member
+	for i := range cloned.Members {
+		if cloned.Members[i].Role == "cto" {
+			cto = &cloned.Members[i]
+		}
+	}
+	if cto == nil {
+		t.Fatalf("cloned roster lost the cto member: %+v", cloned.Members)
+	}
+	// The effect: the requested effort reached the cloned member's native args.
+	native := strings.Join(append(append([]string{}, cto.CodexArgs...), cto.ClaudeArgs...), " ")
+	if !strings.Contains(native, "xhigh") {
+		t.Errorf("--effort cto=xhigh was accepted but never applied to the clone; native args = %q", native)
+	}
+	// Members not named keep their identity.
+	for _, m := range cloned.Members {
+		if m.Role == "challenger" && strings.Contains(strings.Join(append(append([]string{}, m.CodexArgs...), m.ClaudeArgs...), " "), "xhigh") {
+			t.Errorf("effort leaked onto an unnamed member: %+v", m)
+		}
+	}
+
+	// THE NO-REWRITE CONDITION: --from-profile must not mutate its source.
+	source, err := team.ReadProfile(project, "source-squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range source.Members {
+		joined := strings.Join(append(append([]string{}, m.CodexArgs...), m.ClaudeArgs...), " ")
+		if strings.Contains(joined, "xhigh") {
+			t.Errorf("cloning mutated the SOURCE profile member %q: %q", m.Role, joined)
+		}
+		if m.Session != "earlier" {
+			t.Errorf("cloning re-pinned the SOURCE member %q to %q", m.Role, m.Session)
+		}
+	}
+}

--- a/internal/cli/run_start_from_profile_test.go
+++ b/internal/cli/run_start_from_profile_test.go
@@ -23,7 +23,7 @@ func TestRunStartCloneRosterProfileWritesRestampedRoster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "", ""); err != nil {
+	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "", "", ""); err != nil {
 		t.Fatalf("runStartCloneRosterProfile: %v", err)
 	}
 
@@ -66,7 +66,7 @@ func TestRunStartCloneRosterProfileHonorsExplicitLeadOverride(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "qa", ""); err != nil {
+	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "qa", "", ""); err != nil {
 		t.Fatalf("runStartCloneRosterProfile: %v", err)
 	}
 	cloned, err := team.ReadProfile(dir, "release-squad-v2")

--- a/internal/cli/run_start_plan_seed_597_test.go
+++ b/internal/cli/run_start_plan_seed_597_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// #597 guard 3: --prepare-plan is the READ-ONLY proposal stage, but the
+// accepted-brief goal binding resolved against a brief path that only --prepare
+// creates. On a fresh namespace it refused even though --seed-from named the
+// content on the same command line.
+//
+// Tests drive runRunStart, the stable operator entry point, so the same
+// unmodified file runs at the parent commit.
+
+func seedPlanStageFixture(t *testing.T) (project, seedRef string) {
+	t.Helper()
+	project = t.TempDir()
+	seedPath := filepath.Join(project, "seed-brief.md")
+	if err := os.WriteFile(seedPath, []byte("# Tonight\n\nReal seeded brief content.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return project, "file:" + seedPath
+}
+
+func runPlanStage(t *testing.T, project, seedRef, goal string) (string, error) {
+	t.Helper()
+	args := []string{
+		"--project", project, "--profile", team.DefaultProfile, "--session", "tonight",
+		"--roles", "cto", "--binary", "cto=codex", "--lead", "cto",
+		"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+		"--visibility", "detached", "--prepare-plan",
+	}
+	if seedRef != "" {
+		args = append(args, "--seed-from", seedRef)
+	}
+	if goal != "" {
+		args = append(args, "--goal", goal)
+	}
+	out, _, err := captureOutput(t, func() error { return runRunStart(args, "test") })
+	return out, err
+}
+
+// TestPlanStageBindsTheSeededGoal is the relaxation, and it asserts the EFFECT:
+// the plan stage produces a goal binding, not merely that the old refusal
+// stopped firing.
+func TestPlanStageBindsTheSeededGoal(t *testing.T) {
+	project, seedRef := seedPlanStageFixture(t)
+
+	out, err := runPlanStage(t, project, seedRef, "")
+	if err != nil {
+		t.Fatalf("--prepare-plan with --seed-from must not refuse on a fresh namespace: %v", err)
+	}
+	// The observable outcome: the proposal reports a ready goal_binding row
+	// carrying the accepted-brief source and a computed digest.
+	if !strings.Contains(out, "goal_binding") {
+		t.Fatalf("plan output has no goal_binding row:\n%s", out)
+	}
+	for _, want := range []string{runwizard.GoalBindingSourceAcceptedBrief, "digest="} {
+		if !strings.Contains(out, want) {
+			t.Errorf("goal binding does not carry %q; the plan stage must BIND the goal, not just stop refusing\n%s", want, out)
+		}
+	}
+	// Read-only really is read-only: the plan stage must not have written the
+	// brief it bound against.
+	if _, statErr := os.Stat(briefPathForProfile(project, team.DefaultProfile, "tonight")); !os.IsNotExist(statErr) {
+		t.Errorf("--prepare-plan wrote the brief; it must stay read-only (stat err %v)", statErr)
+	}
+}
+
+// TestPlanStageStillRefusesWithNoGoalSource is what the guard still refuses.
+// Relaxing it is not deleting it: a plan stage with no brief, no seed and no
+// explicit goal has nothing to bind and must still say so.
+func TestPlanStageStillRefusesWithNoGoalSource(t *testing.T) {
+	project, _ := seedPlanStageFixture(t)
+
+	_, err := runPlanStage(t, project, "", "")
+	if err == nil {
+		t.Fatal("a plan stage with no brief, no --seed-from and no --goal must still be refused")
+	}
+	// And the refusal must name BOTH escape hatches. Naming one is how the next
+	// operator files the same issue.
+	for _, want := range []string{"--seed-from", "--goal"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal must name %s; got: %v", want, err)
+		}
+	}
+}
+
+// TestPlanStageExplicitGoalStillWorks pins the pre-existing escape hatch, so
+// the relaxation cannot quietly become the only way through.
+func TestPlanStageExplicitGoalStillWorks(t *testing.T) {
+	project, _ := seedPlanStageFixture(t)
+	if _, err := runPlanStage(t, project, "", "Execute the explicit goal"); err != nil {
+		t.Fatalf("--prepare-plan with an explicit --goal must work: %v", err)
+	}
+}

--- a/internal/cli/run_start_plan_seed_597_test.go
+++ b/internal/cli/run_start_plan_seed_597_test.go
@@ -193,3 +193,39 @@ func extractGoalBindingDigest(t *testing.T, out string) string {
 	t.Fatalf("no goal_binding digest in plan output:\n%s", out)
 	return ""
 }
+
+// TestPlanStageRefusesAnUnresolvableSeed is the second guard 3 blocker.
+//
+// The first repair derived "a seed is pending" from the FLAG BEING NONEMPTY,
+// so any garbage bypassed the missing-brief refusal and produced a ready plan
+// while the later prepare resolved the reference for real and failed. Plan and
+// prepare diverged again, just for a different input class. Flag presence is a
+// string; resolution is evidence.
+func TestPlanStageRefusesAnUnresolvableSeed(t *testing.T) {
+	project, _ := seedPlanStageFixture(t)
+
+	for name, ref := range map[string]string{
+		"missing file":     "file:/definitely/not/here/brief.md",
+		"unknown scheme":   "nonsense:whatever",
+		"no scheme at all": "just-a-string",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := runPlanStage(t, project, ref, ""); err == nil {
+				t.Fatalf("--prepare-plan must refuse an unresolvable --seed-from %q instead of producing a ready plan", ref)
+			}
+		})
+	}
+}
+
+// TestPrepareRefusesAnUnresolvableSeedBeforeBinding holds a DIRECT prepare, with
+// no plan stage first, to the identical standard.
+func TestPrepareRefusesAnUnresolvableSeedBeforeBinding(t *testing.T) {
+	project, _ := seedPlanStageFixture(t)
+	if _, err := runPrepareStage(t, project, "file:/definitely/not/here/brief.md", ""); err == nil {
+		t.Fatal("--prepare must refuse an unresolvable --seed-from")
+	}
+	// And it must not have written a brief on the way to refusing.
+	if _, statErr := os.Stat(briefPathForProfile(project, team.DefaultProfile, "tonight")); !os.IsNotExist(statErr) {
+		t.Errorf("a refused prepare must leave no brief behind (stat err %v)", statErr)
+	}
+}

--- a/internal/cli/run_start_plan_seed_597_test.go
+++ b/internal/cli/run_start_plan_seed_597_test.go
@@ -210,9 +210,14 @@ func TestPlanStageRefusesAnUnresolvableSeed(t *testing.T) {
 		"no scheme at all": "just-a-string",
 	} {
 		t.Run(name, func(t *testing.T) {
-			if _, err := runPlanStage(t, project, ref, ""); err == nil {
+			_, err := runPlanStage(t, project, ref, "")
+			if err == nil {
 				t.Fatalf("--prepare-plan must refuse an unresolvable --seed-from %q instead of producing a ready plan", ref)
 			}
+			// PIN THE GUARD. Asserting only err != nil would pass on an
+			// unrelated environment, roster, or missing-brief refusal, so it
+			// would not prove the surviving guard is the one claimed.
+			assertSeedResolutionRefusal(t, err, ref)
 		})
 	}
 }
@@ -221,11 +226,34 @@ func TestPlanStageRefusesAnUnresolvableSeed(t *testing.T) {
 // no plan stage first, to the identical standard.
 func TestPrepareRefusesAnUnresolvableSeedBeforeBinding(t *testing.T) {
 	project, _ := seedPlanStageFixture(t)
-	if _, err := runPrepareStage(t, project, "file:/definitely/not/here/brief.md", ""); err == nil {
+	const ref = "file:/definitely/not/here/brief.md"
+	_, err := runPrepareStage(t, project, ref, "")
+	if err == nil {
 		t.Fatal("--prepare must refuse an unresolvable --seed-from")
 	}
+	assertSeedResolutionRefusal(t, err, ref)
 	// And it must not have written a brief on the way to refusing.
 	if _, statErr := os.Stat(briefPathForProfile(project, team.DefaultProfile, "tonight")); !os.IsNotExist(statErr) {
 		t.Errorf("a refused prepare must leave no brief behind (stat err %v)", statErr)
+	}
+}
+
+// assertSeedResolutionRefusal pins WHICH guard refused.
+//
+// A bare err != nil proves only that something objected, and several unrelated
+// refusals (environment, roster, missing brief) reach the same call. The claim
+// under test is specifically that the seed reference failed to resolve, so the
+// message must name that and the offending reference.
+func assertSeedResolutionRefusal(t *testing.T, err error, ref string) {
+	t.Helper()
+	if !strings.Contains(err.Error(), "--seed-from cannot be resolved") {
+		t.Errorf("refusal does not name the seed-resolution guard; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), ref) {
+		t.Errorf("refusal does not name the offending reference %q; got: %v", ref, err)
+	}
+	// It must NOT be the missing-brief refusal wearing a different hat.
+	if strings.Contains(err.Error(), "accepted brief goal binding") {
+		t.Errorf("refusal came from the missing-brief guard, not seed resolution; got: %v", err)
 	}
 }

--- a/internal/cli/run_start_plan_seed_597_test.go
+++ b/internal/cli/run_start_plan_seed_597_test.go
@@ -100,3 +100,96 @@ func TestPlanStageExplicitGoalStillWorks(t *testing.T) {
 		t.Fatalf("--prepare-plan with an explicit --goal must work: %v", err)
 	}
 }
+
+// runPrepareStage drives the MATERIALIZING stage on the same namespace.
+func runPrepareStage(t *testing.T, project, seedRef, goal string) (string, error) {
+	t.Helper()
+	args := []string{
+		"--project", project, "--profile", team.DefaultProfile, "--session", "tonight",
+		"--roles", "cto", "--binary", "cto=codex", "--lead", "cto",
+		"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+		"--visibility", "detached", "--prepare",
+	}
+	if seedRef != "" {
+		args = append(args, "--seed-from", seedRef)
+	}
+	if goal != "" {
+		args = append(args, "--goal", goal)
+	}
+	out, _, err := captureOutput(t, func() error { return runRunStart(args, "test") })
+	return out, err
+}
+
+// TestSeededPlanAndPrepareConvergeEndToEnd is the guard 3 end-to-end proof.
+//
+// The first guard 3 attempt relaxed the PROPOSAL only. Preparation resolves the
+// same binding BEFORE it writes the seeded brief, so --prepare-plan started
+// succeeding while the matching --prepare still refused: the relaxation moved
+// the failure later instead of removing it, and no test called prepare, so
+// nothing caught it.
+//
+// A relaxation is not done when the refusal stops firing; it is done when the
+// operator's whole workflow succeeds. This drives plan THEN prepare on one
+// fresh namespace and asserts the final state, including the equality the
+// design rests on: the accepted binding after prepare must equal the
+// plan-stage binding, or plan and prepare silently disagree.
+func TestSeededPlanAndPrepareConvergeEndToEnd(t *testing.T) {
+	project, seedRef := seedPlanStageFixture(t)
+
+	planOut, err := runPlanStage(t, project, seedRef, "")
+	if err != nil {
+		t.Fatalf("plan stage refused: %v", err)
+	}
+	planDigest := extractGoalBindingDigest(t, planOut)
+
+	if _, err := runPrepareStage(t, project, seedRef, ""); err != nil {
+		t.Fatalf("prepare refused after the plan stage accepted the same inputs; the relaxation moved the failure instead of removing it: %v", err)
+	}
+
+	// The brief the binding named must now exist and carry the seeded content.
+	briefPath := briefPathForProfile(project, team.DefaultProfile, "tonight")
+	data, readErr := os.ReadFile(briefPath)
+	if readErr != nil {
+		t.Fatalf("prepare must create the seeded brief at %s: %v", briefPath, readErr)
+	}
+	if !strings.Contains(string(data), "Real seeded brief content") {
+		t.Errorf("brief does not carry the seeded content:\n%s", data)
+	}
+
+	// THE EQUALITY THE DESIGN RESTS ON.
+	manifest, err := readPreparedRunManifest(project, team.DefaultProfile, "tonight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.GoalDigest != planDigest {
+		t.Errorf("accepted goal digest after prepare (%s) differs from the plan stage (%s); plan and prepare must bind the SAME goal", manifest.GoalDigest, planDigest)
+	}
+	if strings.TrimSpace(manifest.GoalText) == "" {
+		t.Error("accepted goal text is empty after prepare")
+	}
+}
+
+// TestPrepareWithNoSeedAndNoGoalStaysRefused keeps the materializing refusal.
+// Relaxing the seeded path must not open an unseeded one.
+func TestPrepareWithNoSeedAndNoGoalStaysRefused(t *testing.T) {
+	project, _ := seedPlanStageFixture(t)
+	if _, err := runPrepareStage(t, project, "", ""); err == nil {
+		t.Fatal("prepare with no brief, no --seed-from and no --goal must still be refused")
+	}
+}
+
+func extractGoalBindingDigest(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "goal_binding") {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			if strings.HasPrefix(field, "digest=") {
+				return strings.TrimPrefix(field, "digest=")
+			}
+		}
+	}
+	t.Fatalf("no goal_binding digest in plan output:\n%s", out)
+	return ""
+}

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -289,7 +289,7 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 				_, effortErr = applyLaunchEffortOverridesCatalogMode(existing.Members, efforts, agentCatalog, false)
 			}
 		} else {
-			effortErr = validateRunStartFreshEffort(input.Roles, input.Binary, input.Effort, agentCatalog)
+			effortErr = validateRunStartFreshEffort(r.Project, input.Roles, input.FromProfile, input.Binary, input.Effort, agentCatalog)
 		}
 		if effortErr != nil {
 			return add(runStartPreflightInvalidEffort, effortErr.Error(), "use role=automatic|low|medium|high|xhigh|max assignments")
@@ -298,7 +298,19 @@ func runStartPreflight(input runStartPreflightInput) runStartPreflightResult {
 	return r
 }
 
-func validateRunStartFreshEffort(rolesRaw, binaryRaw, effortRaw string, agentCatalog agentcatalog.Catalog) error {
+// validateRunStartFreshEffort checks --effort against the roster this run will
+// actually create.
+//
+// fromProfile matters (#597 guard 4). --roles and --from-profile are mutually
+// exclusive roster sources, so under --from-profile the --roles-derived
+// selection is EMPTY and every --effort key read as "not selected by --roles".
+// The guard was not wrong about its own predicate; it was being asked the wrong
+// question, because the roster came from the clone rather than from --roles.
+//
+// The protection that matters is unchanged: an --effort key naming a role that
+// is in NEITHER source is still refused, because silently doing nothing with a
+// typo'd role is the failure this exists to prevent.
+func validateRunStartFreshEffort(project, rolesRaw, fromProfile, binaryRaw, effortRaw string, agentCatalog agentcatalog.Catalog) error {
 	efforts, err := parseEffortOverrides(effortRaw)
 	if err != nil {
 		return err
@@ -320,6 +332,21 @@ func validateRunStartFreshEffort(rolesRaw, binaryRaw, effortRaw string, agentCat
 		}
 		if role != "" {
 			selected[role] = true
+		}
+	}
+	// Seed the selection from the cloned roster when one is named. A source
+	// profile that cannot be read is left to the dedicated missing-source
+	// refusal, which says something useful; re-reporting it here as an effort
+	// error would bury the real cause.
+	if strings.TrimSpace(fromProfile) != "" {
+		if source, err := team.ReadProfile(project, strings.TrimSpace(fromProfile)); err == nil {
+			for _, member := range source.Members {
+				if role := strings.ToLower(strings.TrimSpace(member.Role)); role != "" {
+					selected[role] = true
+				}
+			}
+		} else {
+			specialSelection = true
 		}
 	}
 	if !specialSelection {

--- a/internal/cli/run_start_preflight.go
+++ b/internal/cli/run_start_preflight.go
@@ -350,7 +350,11 @@ func validateRunStartFreshEffort(project, rolesRaw, fromProfile, binaryRaw, effo
 		}
 	}
 	if !specialSelection {
-		if err := validateEffortOverrideKeys(efforts, selected); err != nil {
+		source := "--roles"
+		if strings.TrimSpace(fromProfile) != "" {
+			source = "the roster cloned from --from-profile"
+		}
+		if err := validateEffortOverrideKeys(efforts, selected, source); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/run_start_preparation.go
+++ b/internal/cli/run_start_preparation.go
@@ -235,6 +235,13 @@ func buildRunPreparationProposal(in runPreparationProposalInput) (runPreparation
 			return proposal, fmt.Errorf("staged role %q overlaps the initial roster", staged)
 		}
 	}
+	// A pending seed only counts once it RESOLVES. Treating flag presence as
+	// proof let invalid references produce a ready plan that prepare then
+	// refused (#597 guard 3). Resolving is read-only; the brief is still not
+	// written here.
+	if seedErr := pendingSeedIsUsable(in.Seed); seedErr != nil {
+		return proposal, fmt.Errorf("--seed-from cannot be resolved: %w", seedErr)
+	}
 	binding, err := resolveAcceptedGoalBinding(in.Project, in.Profile, in.Session, in.Goal, in.GoalSource, in.GoalDigest, strings.TrimSpace(in.Seed) != "")
 	if err != nil {
 		return proposal, err

--- a/internal/cli/run_start_preparation.go
+++ b/internal/cli/run_start_preparation.go
@@ -235,7 +235,7 @@ func buildRunPreparationProposal(in runPreparationProposalInput) (runPreparation
 			return proposal, fmt.Errorf("staged role %q overlaps the initial roster", staged)
 		}
 	}
-	binding, err := resolveAcceptedGoalBinding(in.Project, in.Profile, in.Session, in.Goal, in.GoalSource, in.GoalDigest)
+	binding, err := resolveAcceptedGoalBinding(in.Project, in.Profile, in.Session, in.Goal, in.GoalSource, in.GoalDigest, strings.TrimSpace(in.Seed) != "")
 	if err != nil {
 		return proposal, err
 	}

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1365,7 +1365,14 @@ func validateAcceptedGoalBinding(binding acceptedGoalBinding) error {
 	return nil
 }
 
-func resolveAcceptedGoalBinding(project, profile, session, goal, source, claimedDigest string) (acceptedGoalBinding, error) {
+// resolveAcceptedGoalBinding resolves the accepted goal binding for a
+// namespace.
+//
+// pendingSeed reports that a --seed-from reference was supplied and the brief
+// it will produce has not been written yet. It is set by the read-only
+// proposal stage only; the materializing stages resolve after the brief exists
+// and must keep refusing a missing one.
+func resolveAcceptedGoalBinding(project, profile, session, goal, source, claimedDigest string, pendingSeed bool) (acceptedGoalBinding, error) {
 	profile = squadnamespace.NormalizeProfile(profile)
 	namespace := profile + "/" + session
 	goal = strings.TrimSpace(goal)
@@ -1380,11 +1387,25 @@ func resolveAcceptedGoalBinding(project, profile, session, goal, source, claimed
 	if source == runwizard.GoalBindingSourceAcceptedBrief {
 		briefPath := briefPathForProfile(project, profile, session)
 		data, err := os.ReadFile(briefPath)
-		if err != nil {
-			return acceptedGoalBinding{}, fmt.Errorf("accepted brief goal binding: %w", err)
-		}
-		if strings.TrimSpace(string(data)) == "" || strings.Contains(string(data), briefStubFirstLine) {
-			return acceptedGoalBinding{}, fmt.Errorf("accepted brief goal binding requires a real non-stub brief at %s", briefPath)
+		switch {
+		case err == nil:
+			if strings.TrimSpace(string(data)) == "" || strings.Contains(string(data), briefStubFirstLine) {
+				return acceptedGoalBinding{}, preparedGoalBindingSourceError(briefPath, "the brief at %s is empty or still the generated stub", briefPath)
+			}
+		case os.IsNotExist(err) && pendingSeed:
+			// #597 guard 3: the read-only plan stage runs BEFORE --prepare
+			// writes the brief, so on a fresh namespace the accepted-brief
+			// binding resolved against a path that cannot exist yet and
+			// refused, even though --seed-from named the content on the same
+			// command line.
+			//
+			// The synthesized goal text below depends only on the namespace and
+			// the brief PATH, never on the brief's bytes, so the binding this
+			// produces is identical to the one --prepare computes once the seed
+			// has been written. Honoring the seed here changes when the same
+			// answer is available, not what it is.
+		default:
+			return acceptedGoalBinding{}, preparedGoalBindingSourceError(briefPath, "accepted brief goal binding: %v", err)
 		}
 		if goal == "" {
 			goal = fmt.Sprintf("Execute the accepted brief for namespace %s at %s.", namespace, briefPath)
@@ -1959,7 +1980,7 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 	if shape != runwizard.LaunchShapeWorkingTeamTogether && shape != runwizard.LaunchShapeLeadOnlyStaged {
 		return runReadinessResult{}, fmt.Errorf("preparation requires explicit --launch-shape working-team-together or lead-only-staged")
 	}
-	binding, err := resolveAcceptedGoalBinding(project, profile, session, goal, goalSource, goalDigest)
+	binding, err := resolveAcceptedGoalBinding(project, profile, session, goal, goalSource, goalDigest, false)
 	if err != nil {
 		return runReadinessResult{}, err
 	}
@@ -2139,4 +2160,16 @@ func parseRoleAssignments(raw string) map[string]string {
 		}
 	}
 	return values
+}
+
+// preparedGoalBindingSourceError refuses a goal binding that has no usable
+// source, naming BOTH escape hatches.
+//
+// The original message pointed only at the missing brief path, so an operator
+// on a fresh namespace was told about a file that cannot exist yet and nothing
+// about what to pass instead. Naming one hatch would just move the problem, so
+// it names both (#597 guard 3).
+func preparedGoalBindingSourceError(briefPath, format string, args ...any) error {
+	return fmt.Errorf("%s; supply a goal source: --seed-from <ref> to seed the brief at %s, or --goal \"<text>\" to bind an explicit goal",
+		fmt.Sprintf(format, args...), briefPath)
 }

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1369,9 +1369,10 @@ func validateAcceptedGoalBinding(binding acceptedGoalBinding) error {
 // namespace.
 //
 // pendingSeed reports that a --seed-from reference was supplied and the brief
-// it will produce has not been written yet. It is set by the read-only
-// proposal stage only; the materializing stages resolve after the brief exists
-// and must keep refusing a missing one.
+// it will produce has not been written yet. BOTH the read-only proposal and the
+// materializing preparation set it, because preparation also resolves the
+// binding before it writes the seeded brief. A stage with no seed keeps
+// refusing a missing brief.
 func resolveAcceptedGoalBinding(project, profile, session, goal, source, claimedDigest string, pendingSeed bool) (acceptedGoalBinding, error) {
 	profile = squadnamespace.NormalizeProfile(profile)
 	namespace := profile + "/" + session
@@ -1980,7 +1981,23 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 	if shape != runwizard.LaunchShapeWorkingTeamTogether && shape != runwizard.LaunchShapeLeadOnlyStaged {
 		return runReadinessResult{}, fmt.Errorf("preparation requires explicit --launch-shape working-team-together or lead-only-staged")
 	}
-	binding, err := resolveAcceptedGoalBinding(project, profile, session, goal, goalSource, goalDigest, false)
+	// #597 guard 3: account for the seed promised in THIS transaction.
+	//
+	// The brief is written further down, inside the rollback-protected region,
+	// and this resolution happens before that region is armed. An earlier
+	// revision claimed materialization resolves after the brief exists; the
+	// execution order says otherwise, which is why --prepare-plan started
+	// succeeding while the matching --prepare still refused.
+	//
+	// Of the two available repairs this is the one that preserves the
+	// transaction. Reordering the brief write ahead of this call would move a
+	// write OUTSIDE the rollback-protected region, so a later failure would
+	// leave the brief behind -- trading a wrong answer for a durable side
+	// effect on failure. Telling the resolver a seed is pending changes no
+	// write ordering at all, and the binding is identical either way because
+	// the synthesized text depends on the namespace and brief PATH, never on
+	// the brief's bytes.
+	binding, err := resolveAcceptedGoalBinding(project, profile, session, goal, goalSource, goalDigest, strings.TrimSpace(seed) != "")
 	if err != nil {
 		return runReadinessResult{}, err
 	}

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1997,6 +1997,12 @@ func prepareRunArtifacts(project, profile, session, shape, stagedRaw, goal, goal
 	// write ordering at all, and the binding is identical either way because
 	// the synthesized text depends on the namespace and brief PATH, never on
 	// the brief's bytes.
+	// Same proof the proposal applies, so a direct --prepare (no plan stage
+	// first) is held to the identical standard rather than binding against a
+	// seed that will fail to resolve a few lines later.
+	if seedErr := pendingSeedIsUsable(seed); seedErr != nil {
+		return runReadinessResult{}, fmt.Errorf("--seed-from cannot be resolved: %w", seedErr)
+	}
 	binding, err := resolveAcceptedGoalBinding(project, profile, session, goal, goalSource, goalDigest, strings.TrimSpace(seed) != "")
 	if err != nil {
 		return runReadinessResult{}, err
@@ -2177,6 +2183,23 @@ func parseRoleAssignments(raw string) map[string]string {
 		}
 	}
 	return values
+}
+
+// pendingSeedIsUsable reports whether a --seed-from reference actually
+// resolves, and is the difference between evidence and a string.
+//
+// #597 guard 3 first derived "a seed is pending" from the FLAG BEING NONEMPTY.
+// Any garbage then bypassed the missing-brief refusal and produced a ready
+// plan, while the later prepare resolved the reference for real and failed --
+// so plan and prepare diverged again, just for a different input class.
+// Resolving the reference is read-only, so the proposal can afford the same
+// proof the materializing stage relies on.
+func pendingSeedIsUsable(seed string) error {
+	if strings.TrimSpace(seed) == "" {
+		return nil
+	}
+	_, err := resolveSeed(seed)
+	return err
 }
 
 // preparedGoalBindingSourceError refuses a goal binding that has no usable

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -433,7 +433,7 @@ Examples:
 	if err := validateModelOverrideKeys(modelOverrides, pickedSet); err != nil {
 		return err
 	}
-	if err := validateEffortOverrideKeys(effortOverrides, pickedSet); err != nil {
+	if err := validateEffortOverrideKeys(effortOverrides, pickedSet, "--roles"); err != nil {
 		return err
 	}
 	for label, values := range map[string]map[string]string{"--tool-profile": toolProfiles, "--tool-config": toolConfigs, "--actor-mode": actorModes} {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -465,7 +465,7 @@ func executeResume(r resumeExecution) error {
 	if err := validateModelOverrideKeys(modelOverrides, memberRoles); err != nil {
 		return err
 	}
-	if err := validateEffortOverrideKeys(effortOverrides, memberRoles); err != nil {
+	if err := validateEffortOverrideKeys(effortOverrides, memberRoles, "the team roster"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Relax two happy-path session-reuse guards (#597)

Delivers **two of #597's five items**. Three are deferred with design records rather than attempted. Stated
up front because the issue lists five and a reader should not have to count commits to find that out.

| Item | Outcome |
|---|---|
| 4 — `--effort` composes with `--from-profile` | **Shipped** |
| 3 — plan-stage brief binding honors `--seed-from` | **Shipped** |
| 1 — profile reusable across sessions | **Deferred** → #608 |
| 2 — profile/session naming collision | **Deferred**, namespace-layout migration |
| 5 — persist-and-diff | **Deferred** → #609 |

## Rebased onto v2.26.0 for the v2.27.0 milestone

Rebased from `08d03da` onto **`f8b0911`** (`Release v2.26.0`). All 8 commits replayed with no conflicts and
the diffstat is unchanged at 10 files, +613/−23, so nothing was dropped in replay. The unsquashed sequence is
preserved deliberately (see below); only the SHAs moved.

Two commits that landed on `main` in the meantime touch files this branch also edits, so each was checked on
the **merged tree** rather than inferred from the clean replay:

- **#598 (`de28a61`)** edits `internal/cli/run_start_readiness.go`, which this branch extends. #598 *hardens*
  drift reporting while guard 3 here *relaxes* a plan-stage refusal, and #597 says explicitly that #598 must
  not be fixed by relaxing a guard. Both of #598's `preparedBootstrapDriftEvidence` call sites survive intact
  (`run_start_readiness.go:1731` and `:1757`). Git replayed guard 3's hunks into different regions of the
  file; **nothing #598 added is weakened here.**
- **#604 (`67c4969`)** edits `internal/cli/run_start_preflight.go`, which guard 4 also edits. See the delta
  note in the guard 4 section.

## Guard 4 — `--effort` was unusable with `--from-profile`

`--roles` and `--from-profile` are mutually exclusive roster sources, so under `--from-profile` the
`--roles`-derived selection was empty and every `--effort` key was rejected. The operator's report is two
refusals in sequence: `--effort` alone is refused for naming unselected roles, and adding `--roles` to select
them is refused because both name a roster source.

The guard was not wrong about its predicate — it was being asked the wrong question. The selection is now
seeded from the effective roster, and the override is applied to the cloned roster in **both** the proposal
and the materialization through one shared helper, so the accepted proposal and the persisted roster cannot
disagree. The **source profile is never written**: `--from-profile` must not mutate what it clones from, and
the regression asserts the source's member args and session pins are unchanged.

**Still refuses:** an `--effort` key naming a role in neither source, with the unknown role named — and now
also naming the real selection source rather than always saying `--roles`.

### Delta vs #604, which landed first

#597's guard 4 has a **secondary** ask: the fix text said `use role=automatic|low|medium|high assignments`
and omitted `xhigh`, which `team member update --effort` accepts fine. **#604 already shipped that**, as the
one-line change to `run_start_preflight.go:295` (`…|high|xhigh|max assignments`). This PR does **not** claim
it. The rebase kept #604's newer string: this branch carried the older text but never edited that line, so
there was nothing to conflict and nothing was reverted — verified by reading the merged line, not assumed
from the clean replay.

The **primary** ask is untouched by #604 and is delivered only here: seeding the effort selection from the
roster cloned by `--from-profile`, so a clone and a per-member effort adjustment compose in **one** command.

Adjacent and complementary, not competing: #604 also added `team_member_prepared.go`, refreshing prepared
runs after roster edits. That shortens the four-command workaround #597 complains about
(`--prepare` → `team member update` → readiness drift → `--prepare` again). #604 makes the *workaround* one
step; guard 4 removes the need for the workaround at all.

## Guard 3 — `--prepare-plan` refused on a fresh namespace

The read-only proposal stage resolved the accepted-brief goal binding against a brief path that only
`--prepare` creates, so it refused even when `--seed-from` named the content on the same command line.

The key property, checked before writing rather than assumed: **the synthesized goal text depends on the
namespace and the brief PATH, never on the brief's BYTES.** So the plan-stage binding is identical to what
prepare computes once the seed lands. This changes *when* the same answer is available, not what it is. Had
it gone the other way, plan and prepare digests would have diverged silently. A future refactor must not
"simplify" this into a content-dependent binding.

A `--seed-from` reference must **resolve**, not merely be non-empty. Flag presence is a string; resolution is
evidence. Both readers of the predicate apply that proof, so a direct `--prepare` with no plan stage is held
to the same standard.

**Still refuses:** a stage with no brief, no `--seed-from` and no `--goal`, with a message naming **both**
escape hatches. Naming one would move the problem rather than fix it.

## What "still refuses" means here

Each relaxation ships a test proving the surviving refusal, because relaxing a guard is not deleting it.
Those tests name the specific refusal rather than asserting that an error occurred — a refusal test that does
not name the refusal is the negative-space version of asserting the absence of an obstacle.

## Deferrals

**Guard 1 (#608).** Not a guard relaxation. `filterMembersBySession` is read at 16 sites and answers two
different questions under one name: "which members belong to this run" (10 readers) and "who is running right
now" (4 readers). Two more cannot be classified without first deciding whether reuse is a property of the
**run** or the **session**. Granting AMQ root authority or building routing blocks for members that are not
running would be a bad outcome from a change meant to make setup friendlier. The issue carries the full
classification and a proposed seam: reuse as a prepared-run property carried by an exact accepted generation,
bound to the launch token rather than a mutable pointer.

**Guard 2.** Left intact. The overlap is structural — named `X/X` stays nested under legacy `X` even with no
durable state, and creating it creates the ancestor a later default-profile write can target. A
state-dependent relaxation would neither fulfil the issue's ask nor preserve stable command semantics. This
PR carries a **comment-only** correction where the code overclaimed what its check proves; see #606.

**Item 5 (#609).** Its acceptance criteria were unsatisfiable: `MutationPaths` holds concrete paths built at
proposal time, but the generation id is minted inside `mutate()`, so a path under `<generation>/` cannot be
declared before the generation naming it exists. The replacement design was also wrong — co-locating the
preview beside `manifest.json` does **not** put it inside the digest-validated generation, because the
digests cover those files' contents and a sibling is covered by nothing. That turns it into a
publication-integrity design, which #609 specifies.

## Testing

Every behavior change ships a regression that fails **behaviourally** at its parent with the unmodified test
file, driven through `runRunStart` so the seam is stable across states.

Guard 4 needed three states to be honest, because the first attempt shipped as a silent no-op: base fails on
the refusal, `f613ac6` fails on the missing effect, HEAD passes. Checking base against HEAD alone would have
gone green against the no-op.

Guard 3's proof drives the **whole workflow** — plan then prepare on one fresh namespace — and asserts the
accepted goal digest after prepare **equals** the plan-stage digest. That equality is the property the design
rests on and nothing before it proved.

All 11 regressions re-verified on the rebased head `2fcbe2b`, including both surviving-refusal tests — the
point being that the relaxations did not become deletions:

```
go test ./internal/cli/ -run 'TestRunStartEffort|TestPlanStage|TestSeededPlanAndPrepareConverge|TestPrepareWithNoSeedAndNoGoalStaysRefused|TestPrepareRefusesAnUnresolvableSeedBeforeBinding' -count=1 -v
ok  github.com/omriariav/amq-squad/v2/internal/cli  1.693s   (11/11 pass)
```

### The red CI leg, and what actually fixed it

At `e7eed94` the **`real AMQ compatibility (latest)`** leg was **FAILURE** while every other leg was green.
It was not debugged and not worked around: rebasing onto `f8b0911` put #602 (`6a34984`, AMQ 0.51.1 as the
supported floor) and #603 (`5311ea4`, real-AMQ fixtures hermetic to managed context) underneath this branch,
and the leg is **green at `2fcbe2b`**. The matrix leg also renames `v0.49.9` → `v0.51.1` for the same reason.

## Commit sequence, deliberately unsquashed

`f613ac6` shipped a no-op, `1b4d482` fixed the code, `a496be7` fixed the proof. The history records that a
relaxation shipped silently broken and what caught it; squashing would show a clean change that was never
clean. (Pre-rebase these were `883df06` / `f609414` / `2691d53`; the rebase preserved the sequence and moved
only the SHAs.)

## Testing standard this PR was held to

Recorded as a standard the next contributor can apply, not as contrition. Five failures tonight shared one
root — asserting a proxy for the outcome instead of the outcome:

- a test that only fails to **compile** at the parent proves nothing about behavior
- `ok ... [no tests to run]` is a failure, not a pass
- a green line from the **wrong working tree** is not evidence
- asserting the **absence of a refusal** passes against a no-op that silently drops the input
- a refusal test that does not **name the refusal** can pass on an unrelated error

**State what observable thing should now be different, then assert that thing.** And: evidence must be
reproducible from the committed artifacts — if demonstrating before/after requires modifying the test, the
test is on the wrong seam, and the modification is the signal.

