### PR TITLE
Release v2.26.0

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,6 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
+<li><a href="#whats-new-in-v2260" id="toc-whats-new-in-v2260">What's new
+in v2.26.0</a></li>
 <li><a href="#whats-new-in-v2251" id="toc-whats-new-in-v2251">What's new
 in v2.25.1</a></li>
 <li><a href="#whats-new-in-v2250" id="toc-whats-new-in-v2250">What's new
@@ -326,7 +328,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2250">What's new in v2.25.0</a></li>
+<li><a href="#whats-new-in-v2260">What's new in v2.26.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -344,6 +346,45 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
+<h2 id="whats-new-in-v2260">What's new in v2.26.0</h2>
+<p>v2.26.0 is an AMQ-compatibility, launch-reliability, and
+team-management release. Four of the milestone's five issues ship:</p>
+<ul>
+<li><strong>AMQ 0.51.1 supported floor (#600, PR #602).</strong> Both
+real-AMQ matrices now test pinned <code>v0.51.1</code> and
+<code>latest</code>; pre-0.51 compatibility branches are removed, and
+supported launches use canonical exact-root authority and the current
+wake flags.</li>
+<li><strong>Hermetic real-AMQ fixtures (#587, PR #603).</strong> Test
+boundaries scrub the complete <code>AMQ_WAKE_</code> namespace plus the
+full injected identity tuple, and the entry points self-poison so
+isolation is proved rather than supplied by the caller.</li>
+<li><strong>One-step roster edits (#601, PR #604).</strong>
+Session-pinned member add, update, remove, effort, model, and binary
+changes can refresh a ready accepted preparation as one operation while
+preserving the accepted launch contract.</li>
+<li><strong>Fresh-namespace recovery and diagnostics (#598, PR
+#605).</strong> Three of four root causes are fixed: teardown removes
+orphaned prepared state, vanished panes and attempted-launch record
+failures surface, and bootstrap-drift evidence is honest and actionable.
+The proposed RC1 bootstrap-drift mechanism was falsified, documented,
+and instrumented—not fixed. A post-merge real-AMQ probe at
+<code>de28a619</code> kept the raw root and all three bootstrap digests
+byte-identical while only non-rendered <code>root_source</code> metadata
+moved, satisfying the pre-tag requirement without a production fix.</li>
+</ul>
+<p><strong>Breaking:</strong> AMQ 0.51.1 is the minimum supported
+release. Every 0.49.x and 0.50.x release plus 0.51.0 is unsupported and
+rejected fail-closed; upgrade AMQ before upgrading amq-squad, then stop
+and resume/relaunch agents so parent shells refresh their injected
+identity and wake environment.</p>
+<p><strong>Deferred:</strong> #597 moves entirely to v2.27.0. Its two
+implemented guards remain on draft PR #610, which is parked with two
+open blockers and is not included in this release.</p>
+<p>See <a href="docs/v2.26.0-release-notes.md">the v2.26.0 release
+notes</a> for the complete issue-to-behavior map, verification record,
+accepted teardown residuals, and known issues including unverified #606
+and the pre-existing #590 wake-owner cleanup flake.</p>
 <h2 id="whats-new-in-v2251">What's new in v2.25.1</h2>
 <p>v2.25.1 is a compatibility and identity-repair release, produced by
 verifying amq-squad against upstream AMQ 0.49.8 and 0.49.9:</p>
@@ -451,7 +492,7 @@ summary, and residual risks.</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.1</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.26.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.25.0](#whats-new-in-v2250)
+- [What's new in v2.26.0](#whats-new-in-v2260)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -37,6 +37,45 @@ The 30-second mental model:
 - [Cross-project teams](#cross-project-teams)
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
+
+## What's new in v2.26.0
+
+v2.26.0 is an AMQ-compatibility, launch-reliability, and team-management
+release. Four of the milestone's five issues ship:
+
+- **AMQ 0.51.1 supported floor (#600, PR #602).** Both real-AMQ matrices now
+  test pinned `v0.51.1` and `latest`; pre-0.51 compatibility branches are
+  removed, and supported launches use canonical exact-root authority and the
+  current wake flags.
+- **Hermetic real-AMQ fixtures (#587, PR #603).** Test boundaries scrub the
+  complete `AMQ_WAKE_` namespace plus the full injected identity tuple, and
+  the entry points self-poison so isolation is proved rather than supplied by
+  the caller.
+- **One-step roster edits (#601, PR #604).** Session-pinned member add, update,
+  remove, effort, model, and binary changes can refresh a ready accepted
+  preparation as one operation while preserving the accepted launch contract.
+- **Fresh-namespace recovery and diagnostics (#598, PR #605).** Three of four
+  root causes are fixed: teardown removes orphaned prepared state, vanished
+  panes and attempted-launch record failures surface, and bootstrap-drift
+  evidence is honest and actionable. The proposed RC1 bootstrap-drift
+  mechanism was falsified, documented, and instrumented—not fixed. A
+  post-merge real-AMQ probe at `de28a619` kept the raw root and all three
+  bootstrap digests byte-identical while only non-rendered `root_source`
+  metadata moved, satisfying the pre-tag requirement without a production fix.
+
+**Breaking:** AMQ 0.51.1 is the minimum supported release. Every 0.49.x and
+0.50.x release plus 0.51.0 is unsupported and rejected fail-closed; upgrade
+AMQ before upgrading amq-squad, then stop and resume/relaunch agents so parent
+shells refresh their injected identity and wake environment.
+
+**Deferred:** #597 moves entirely to v2.27.0. Its two implemented guards remain
+on draft PR #610, which is parked with two open blockers and is not included in
+this release.
+
+See [the v2.26.0 release notes](docs/v2.26.0-release-notes.md) for the complete
+issue-to-behavior map, verification record, accepted teardown residuals, and
+known issues including unverified #606 and the pre-existing #590 wake-owner
+cleanup flake.
 
 ## What's new in v2.25.1
 
@@ -142,7 +181,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.25.1
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.26.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.26.0-release-notes.md
+++ b/docs/v2.26.0-release-notes.md
@@ -1,0 +1,194 @@
+# amq-squad v2.26.0
+
+## Summary
+
+v2.26.0 is an AMQ-compatibility, launch-reliability, and team-management
+release. Four of the milestone's five issues ship: AMQ 0.51.1 becomes the
+supported floor (#600), real-AMQ fixtures stop inheriting live managed-agent
+state (#587), routine roster edits become one-step operations (#601), and
+three of the four investigated fresh-namespace failure root causes are fixed
+(#598).
+
+#597 is deferred entirely to v2.27.0. Its `--effort`/`--from-profile` and
+plan-stage `--seed-from` guards are implemented on draft PR #610, but that PR
+remains parked with two open blockers and is not part of this release.
+
+## AMQ 0.51.1 supported floor (#600, PR #602)
+
+- AMQ 0.51.1 is the minimum supported release. Every 0.49.x and 0.50.x
+  release, plus 0.51.0, is below the floor and is rejected fail-closed with an
+  actionable upgrade message.
+- Both real-AMQ matrices now exercise pinned `v0.51.1` and `latest` only.
+  `latest` remains a forward-compatibility canary; the pinned lane records the
+  supported floor.
+- Pre-0.51 capability and root/session compatibility branches are removed.
+  Supported launches always use canonical exact-root authority and the current
+  wake flags.
+- Version enforcement is covered at launch, lead registration,
+  goal-orchestrator registration, doctor, and release validation rather than
+  by one isolated version check.
+- The AMQ 0.49.11-through-0.51.1 changes, including the versioned
+  `amq wake check` capability, are mapped in
+  [the AMQ 0.51.x assessment](amq-0.51.x-assessment.md). Capabilities not
+  adopted in this release are ruled explicitly rather than implied by the
+  floor bump.
+
+## Hermetic real-AMQ fixtures (#587, PR #603)
+
+- Real-AMQ compatibility and wake fixtures now scrub the complete
+  `AMQ_WAKE_` namespace wherever inherited AMQ identity is removed, including
+  private wake descriptors and future prefix additions.
+- Both root identity tokens are removed from the CLI and `internal/act`
+  subprocess boundaries. The duplicated sanitizer was found during review and
+  brought under the same contract.
+- Both real-AMQ entry points self-poison with live-like root, sender, session,
+  owner-token, and private wake-descriptor values. Tests therefore prove their
+  own isolation instead of relying on a caller to remember `env -u` flags.
+- Fixture controls such as `AMQ_SQUAD_REAL_AMQ` and
+  `AMQ_NO_UPDATE_CHECK` remain available; the production identity and wake
+  namespaces are what get scrubbed.
+
+## One-step roster edits (#601, PR #604)
+
+- Session-pinned `team member add`, `update`, and `rm` refresh an existing
+  ready accepted preparation before releasing namespace admission. Routine
+  roster edits no longer require an edit, failed-readiness observation,
+  re-prepare, and second acceptance.
+- Refresh publishes a new immutable generation while preserving the accepted
+  goal, launch shape, topology, and environment contract.
+- `team member update --binary claude|codex` is supported as a one-step edit
+  and clears only arguments incompatible with the selected runtime.
+- Already-drifted, unprepared, unpinned, session-changing, and concurrently
+  modified profiles retain the explicit preparation path. If the roster edit
+  succeeds but the replacement generation cannot validate, the successful
+  roster mutation is preserved and the error names the required recovery.
+- Invalid effort recovery text now includes `xhigh` and `max`.
+
+## Fresh-namespace recovery and diagnostics (#598, PR #605)
+
+#598 fixes three of four root causes. Root cause 1, the reported bootstrap
+drift mechanism, was falsified rather than fixed: preparation remains ready
+after materializing exactly the state spawn writes, and repeated bootstrap
+renders remain deterministic. That path is documented and instrumented, but
+bootstrap drift itself is not claimed fixed. The required post-merge real-AMQ
+probe ran at `de28a619`: the raw root and all three bootstrap digests stayed
+byte-identical while only non-rendered `root_source` metadata moved, satisfying
+the pre-tag requirement without a production fix.
+
+### Root cause 2: teardown orphaned prepared state
+
+- `rm`, `archive`, and the shared `up --reset` teardown now remove the accepted
+  prepared manifest and generation state they previously orphaned. An orphan
+  with no session root or brief is removable, and the confirmation preview
+  names the prepared paths before deletion.
+- Prepared-state teardown proves the resolved prepared directory is exactly
+  the canonical directory for the resolved project/profile before touching
+  artifacts. It refuses redirects and fails closed when identity cannot be
+  established.
+
+### Root cause 3: launch failure was swallowed
+
+- When a pane was verified at dispatch and then disappears from a successful
+  tmux enumeration, the launcher reports that member's launch failure instead
+  of timing out later on missing readiness. Failed enumeration remains
+  inconclusive, and healthy launches do not pay for pane enumeration.
+- `doctor` now fails a missing or malformed bootstrap record only when a launch
+  reservation proves this exact accepted generation attempted that roster
+  member. Never-launched, outside-roster, unreadable-preparation, and in-grace
+  cases retain their conservative skip/warn behavior; a missing issue time is
+  outside the grace window rather than an indefinite amnesty.
+
+### Root cause 4: the drift row promised an unavailable action
+
+- Bootstrap drift evidence now names the namespace, role, generation,
+  accepted digest, and generated digest. Its recovery text offers an action
+  that exists—re-run preparation—and states that a field-level diff is not
+  available because the accepted preview is not persisted.
+- The missing persist-and-diff capability is tracked by #609. The staged-roster
+  path also distinguishes a render error from a digest mismatch instead of
+  misdiagnosing both as drift.
+
+## Also in this release
+
+- #597 is deferred as a whole. Draft PR #610 preserves the implemented guard
+  4 and guard 3 work as a starting point, but its two open blockers must be
+  resolved in v2.27.0; it must not be treated as nearly shipped.
+- #607 records a clone-path flag-composition defect found while testing the
+  deferred guard work. #608 records the run-versus-session decision required
+  before roster reuse can be made coherent across all readers. #609 records
+  the publication and integrity design required before persisted bootstrap
+  previews can support a real diff.
+- #606 records the broader session-root containment question discovered while
+  proving the narrower prepared-state teardown boundary. It is a separate,
+  unverified follow-up, not a behavior change in this release.
+
+## Verification and process
+
+- PR #602 passed `make ci`, the pinned AMQ 0.51.1 compatibility and native-wake
+  lanes, and focused version-floor/shim proofs.
+- PR #603 passed poisoned-environment sanitizer proofs, both real-AMQ lanes,
+  and `make ci`; its post-#602 rebase was patch-equivalent.
+- PR #604 passed focused roster, binary-switch, drift, concurrency, fallback,
+  and effort-text proofs plus `make ci`; its regenerated documentation was
+  rebuilt after the post-#602 rebase.
+- PR #605 passed focused RC1/RC2/RC3/RC4 proofs, local `make ci`, and all five
+  hosted lanes at its rebased exact head.
+
+Every #598 behavior change was required to fail behaviorally at its parent
+with the committed test unchanged; compile failures, no-test runs, and
+test-only rewrites did not count. That standard kept the proofs on stable
+operator-facing seams and required negative controls to stay green at both the
+parent and fixed heads.
+
+Cross-review found three release-blocking code defects in #605 and one
+additional sanitizer gap in #603; two of the #605 defects had already passed
+an earlier reviewer approval for the affected revision. All four were fixed
+and re-pinned before their final approvals, while draft PR #610 remains parked
+with its two open blockers rather than being counted in the release.
+
+The final release branch must pass `make release-check VERSION=2.26.0` and
+`make ci` after #604 and #605 merge. The separate real-AMQ RC1 probe ran
+against post-merge `main` at `de28a619` with pinned AMQ v0.51.1; it kept the raw
+root and all three bootstrap digests byte-identical, moved only non-rendered
+`root_source` metadata, and satisfied the pre-tag requirement without changing
+production code. The reproducible evidence and disposable instrument source
+are recorded on [#598](https://github.com/omriariav/amq-squad/issues/598#issuecomment-5155126646).
+
+## Known issues
+
+- **#606 is unverified.** The existing AMQ session-root `SAFETY 2` containment
+  check is tautological by code inspection and does not establish a resolved
+  symlink boundary, but no live reproduction has verified the exposure. Its
+  boundary must be designed and proved before a fix is claimed.
+- **Prepared-state teardown retains a parent-component TOCTOU residual.** Path
+  resolution and removal are separate syscalls. Acting on unresolved target
+  paths prevents following a final-entry symlink, but replacement of a parent
+  component after validation can still redirect traversal across the proven
+  boundary; that risk is accepted for this local, confirmation-gated command.
+- **Symlinked state directories are refused.** A symlinked `.amq-squad`,
+  `prepared`, or `prepared/<profile>` directory—for example state parked on
+  another volume—fails with both resolved and canonical paths named. A
+  symlinked project path such as macOS `/tmp` to `/private/tmp` is unaffected
+  because both sides resolve identically.
+- **#590 remains a pre-existing timing flake.** The owner-bound managed-wake
+  cleanup subtest can race the wake-owner file lifecycle at roughly one in
+  seven local observations and fail with
+  `cooperative authoritative wake stop unavailable: no such file or directory`.
+  It passed isolated reruns and a clean full retry during #603 verification.
+
+## Upgrade notes
+
+Upgrade AMQ to 0.51.1 or newer before upgrading amq-squad; older releases are
+rejected rather than degraded. Run `amq upgrade`, then stop and
+resume/relaunch agents so parent shells receive the current AMQ identity and
+wake environment, and confirm the result with `amq-squad doctor`.
+
+Install the pinned release with:
+
+```sh
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.26.0
+```
+
+No team/profile schema migration is required. See
+[MIGRATION.md](../MIGRATION.md) ("What's new in 2.26.0") for the AMQ floor and
+compatibility-path changes.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | console | up | focus | send | resume | fork | rm | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | activity | gate | resume | stop | archive | context | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | stage goal|brief|rules|roles|profile|readiness|launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` and its roles stage. Role authoring is part of the reviewed goal-to-launch preparation flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, preparation, readiness, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.25.1"  # x-release-please-version
+version: "2.26.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release v2.26.0.

This release ships four of the five v2.26.0 milestone issues. #597 is deferred entirely to v2.27.0; its two implemented guards remain on parked draft PR #610 with two open blockers and are not included here.

## Contents

- `docs/v2.26.0-release-notes.md` (new) — full issue-to-behavior map for #600, #587, #601 and #598, verification record, accepted residuals, known issues, and upgrade notes.
- `README.md` — "What's new in v2.26.0", the breaking AMQ 0.51.1 floor, pinned `go install` tag, #597 deferral, and the post-merge RC1 probe result.
- `plugins/{claude,codex}` manifests → `2.26.0`.
- 14 generated `SKILL.md` frontmatters → `2.26.0`, produced by `make skills-generate` from the two manifests.
- `README.html` regenerated by `make readme-html`.
- `MIGRATION.md` was audited against the merged behavior and remains accurate, so it is intentionally unchanged.

## Shipped milestone work

- #600 via #602: AMQ 0.51.1 becomes the supported floor; pinned-floor/latest matrices and canonical root/wake behavior replace pre-0.51 shims.
- #587 via #603: real-AMQ fixtures scrub the complete managed identity and `AMQ_WAKE_` namespace and prove their own isolation with poisoned environments.
- #601 via #604: session-pinned roster edits can refresh a ready accepted preparation in one operation while preserving the accepted launch contract.
- #598 via #605: three of four root causes are fixed across teardown, vanished-pane/attempt diagnostics, and honest bootstrap-drift evidence. RC1 was investigated and falsified rather than claimed fixed.

## RC1 pre-tag probe

The required disposable real-AMQ probe ran against post-merge `main` at `de28a619a59998798cfe9df53e3acd510baf14a3` with pinned AMQ v0.51.1 before this branch was pushed.

- Accepted preparation left the fresh session root absent.
- Production `prepareSelectedAMQRoots` materialized the exact root used before backend spawn.
- The raw returned root was byte-identical before/after for `cto`, `amq-dev-1`, and `amq-dev-2`.
- Only non-rendered `root_source` metadata moved from `fresh_project_default` to `flag`.
- All three bootstrap digests were byte-identical and no prompt diff lines existed.
- No production fix was made; the disposable probe intentionally stopped and was removed after its source was preserved.

The pre-tag probe requirement is satisfied. Reproducible raw evidence and the full instrument source are on [#598](https://github.com/omriariav/amq-squad/issues/598#issuecomment-5155126646).

## Gate evidence

Exact release commit: `19dddcdba1e91bf526749796b6e184400bb3230b` on base `de28a619a59998798cfe9df53e3acd510baf14a3`.

| Check | Result |
| --- | --- |
| `git diff --check` | **exit 0** |
| `make release-check VERSION=2.26.0` at clean commit head | **exit 0** — `release metadata matches v2.26.0` |
| `make ci` at clean commit head | **exit 0** — `internal/cli` 372.350s; generated docs, all 14 skill mirrors, build, command coverage, and auxiliary suites green |
| `README.html` / `docs/skills.html` sync | **pass** |
| Skill mirror validation | **pass** — all 14 frontmatters valid and version markers match manifests |

## Known issues carried into the notes

- #606 remains unverified.
- Prepared-state teardown retains the accepted parent-component TOCTOU residual.
- Symlinked `.amq-squad` state directories are refused.
- #590 remains a pre-existing owner-cleanup timing flake observed at roughly one in seven local runs.

## Merge gating

This branch is based on merged #602/#603/#604/#605 and the release gates are green at its exact commit. PR merge remains an operator action. Tag creation and release publication remain separately operator-gated; no tag or release action is part of this PR.
