### PR TITLE
Fix path-case identity on case-insensitive filesystems

### DIFF
--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -783,29 +783,12 @@ func profileSessionFromComparableRoots(base, root string) (string, string, bool)
 	}
 }
 
-// canonicalContextComparisonPath resolves symlinks in the longest existing
-// prefix while preserving a not-yet-created suffix. macOS commonly reports
-// cwd under /private/var while test/process environment paths use /var; those
-// spellings must compare as one project without requiring a fresh AMQ root to
-// exist. The original spelling remains in command output and diagnostics.
+// canonicalContextComparisonPath keeps context-root comparison on the shared
+// pathnorm seam. That seam resolves symlinks and on-disk case in the longest
+// existing prefix while preserving a not-yet-created suffix. The original
+// spelling remains in command output and diagnostics.
 func canonicalContextComparisonPath(path string) string {
-	path = filepath.Clean(path)
-	current := path
-	var suffix []string
-	for {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
-			for i := len(suffix) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, suffix[i])
-			}
-			return filepath.Clean(resolved)
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return path
-		}
-		suffix = append(suffix, filepath.Base(current))
-		current = parent
-	}
+	return canonicalFilesystemPath(path)
 }
 
 func matchingLiveLaunchContexts(projectDir string, opts contextResolveOptions, env injectedContext) ([]launchContext, error) {

--- a/internal/cli/identity_drift_test.go
+++ b/internal/cli/identity_drift_test.go
@@ -118,6 +118,27 @@ func TestPreparedLaunchIdentityAcceptsEquivalentProjectRepresentations(t *testin
 	}
 }
 
+func TestPreparedLaunchIdentityAcceptsDifferentlyCasedProjectOnCaseInsensitiveFilesystem(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "PreparedProject")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	variant, ok := differentlyCasedExistingPath(project)
+	if !ok {
+		t.Skip("test filesystem is case-sensitive")
+	}
+
+	manifest := preparedRunManifest{
+		Project:   variant,
+		Profile:   "squad-v2-27-0",
+		Session:   "v2-27-0",
+		Namespace: "squad-v2-27-0/v2-27-0",
+	}
+	if err := preparedLaunchIdentityDrift(manifest, project, manifest.Profile, manifest.Session); err != nil {
+		t.Fatalf("differently-cased aliases of one prepared project reported drift: %v", err)
+	}
+}
+
 // A genuine profile or session mismatch must still fail closed. The fix makes
 // the message honest; it must not make the check permissive.
 func TestPreparedLaunchIdentityStillRejectsRealNamespaceDrift(t *testing.T) {

--- a/internal/cli/pathnorm.go
+++ b/internal/cli/pathnorm.go
@@ -103,8 +103,9 @@ func absoluteFilesystemPath(p string) string {
 }
 
 // canonicalFilesystemPath is the COMPARISON normalization: absoluteFilesystemPath
-// plus symlink resolution. Two paths naming the same location canonicalize to
-// the same string regardless of how either was written or recorded.
+// plus symlink resolution and the platform's on-disk case for existing paths.
+// Two paths naming the same location canonicalize to the same string regardless
+// of how either was written or recorded.
 //
 // Symlink resolution is best effort, because comparators must be able to
 // canonicalize a location that does not exist -- a recorded worktree that has
@@ -121,8 +122,8 @@ func canonicalFilesystemPath(p string) string {
 	if p == "" {
 		return ""
 	}
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
-		return filepath.Clean(resolved)
+	if resolved, err := resolveExistingFilesystemPath(p); err == nil {
+		return resolved
 	}
 	remainder := ""
 	dir := p
@@ -135,10 +136,22 @@ func canonicalFilesystemPath(p string) string {
 		}
 		remainder = filepath.Join(filepath.Base(dir), remainder)
 		dir = parent
-		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		if resolved, err := resolveExistingFilesystemPath(dir); err == nil {
 			return filepath.Clean(filepath.Join(resolved, remainder))
 		}
 	}
+}
+
+// resolveExistingFilesystemPath is the shared existing-path comparison seam.
+// EvalSymlinks normalizes symlink representation but, on a case-insensitive
+// macOS filesystem, preserves the caller's input case. canonicalPathCase asks
+// the OS for the on-disk spelling so differently-cased aliases converge too.
+func resolveExistingFilesystemPath(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(canonicalPathCase(resolved)), nil
 }
 
 // absoluteFilesystemPathIn is the RECORDING normalization for a path that may be

--- a/internal/cli/pathnorm_case_darwin.go
+++ b/internal/cli/pathnorm_case_darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package cli
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// canonicalPathCase returns the filesystem's spelling for an existing path.
+// Darwin's filepath.EvalSymlinks preserves input case even when APFS resolves a
+// differently-cased alias. F_GETPATH returns the canonical path attached to the
+// opened object without changing the process working directory.
+func canonicalPathCase(path string) string {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return canonicalPathCasePortable(path)
+	}
+	defer unix.Close(fd)
+
+	var buf [unix.PathMax]byte
+	_, _, errno := unix.Syscall(unix.SYS_FCNTL, uintptr(fd), unix.F_GETPATH, uintptr(unsafe.Pointer(&buf[0])))
+	if errno != 0 {
+		return canonicalPathCasePortable(path)
+	}
+	canonical := unix.ByteSliceToString(buf[:])
+	if canonical == "" {
+		return canonicalPathCasePortable(path)
+	}
+	return canonical
+}

--- a/internal/cli/pathnorm_case_other.go
+++ b/internal/cli/pathnorm_case_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package cli
+
+// canonicalPathCase uses the portable entry/inode walk when the platform has no
+// cheaper API for retrieving an existing path's on-disk spelling.
+func canonicalPathCase(path string) string {
+	return canonicalPathCasePortable(path)
+}

--- a/internal/cli/pathnorm_case_portable.go
+++ b/internal/cli/pathnorm_case_portable.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// canonicalPathCasePortable reconstructs an existing absolute path using the
+// names returned by its parent directories. Exact spellings take the cheap
+// path. When a case-insensitive filesystem accepted another spelling, SameFile
+// identifies the actual directory entry without treating an entire OS as
+// case-insensitive or conflating distinct names on a case-sensitive volume.
+func canonicalPathCasePortable(path string) string {
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return path
+	}
+
+	rawVolume := filepath.VolumeName(path)
+	volume := canonicalPathVolume(rawVolume)
+	remainder := strings.TrimPrefix(path, rawVolume)
+	remainder = strings.TrimLeftFunc(remainder, func(r rune) bool {
+		return r <= 0xff && os.IsPathSeparator(uint8(r))
+	})
+	parts := strings.FieldsFunc(remainder, func(r rune) bool {
+		return r <= 0xff && os.IsPathSeparator(uint8(r))
+	})
+	current := volume + string(filepath.Separator)
+	for i, part := range parts {
+		entries, err := os.ReadDir(current)
+		if err != nil {
+			return filepath.Join(append([]string{current}, parts[i:]...)...)
+		}
+
+		actual := part
+		exact := false
+		for _, entry := range entries {
+			if entry.Name() == part {
+				exact = true
+				break
+			}
+		}
+		if !exact {
+			candidateInfo, statErr := os.Stat(filepath.Join(current, part))
+			if statErr == nil {
+				fallback := ""
+				for _, entry := range entries {
+					entryInfo, infoErr := entry.Info()
+					if infoErr != nil || !os.SameFile(candidateInfo, entryInfo) {
+						continue
+					}
+					if strings.EqualFold(entry.Name(), part) {
+						actual = entry.Name()
+						fallback = ""
+						break
+					}
+					if fallback == "" {
+						fallback = entry.Name()
+					}
+				}
+				if fallback != "" {
+					actual = fallback
+				}
+			}
+		}
+		current = filepath.Join(current, actual)
+	}
+	return current
+}

--- a/internal/cli/pathnorm_test.go
+++ b/internal/cli/pathnorm_test.go
@@ -149,6 +149,98 @@ func TestRecordingKeepsSymlinkAndComparisonResolvesIt(t *testing.T) {
 	}
 }
 
+// #617: macOS can resolve two differently-cased path spellings to the same
+// directory while filepath.EvalSymlinks preserves the spelling it was given.
+// Every comparison seam must converge on the on-disk spelling so pane CWD,
+// launch-record, and prepared-run identity checks agree.
+func TestCanonicalPathUsesOnDiskCaseOnCaseInsensitiveFilesystem(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "CaseProbe")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	variant, ok := differentlyCasedExistingPath(project)
+	if !ok {
+		t.Skip("test filesystem is case-sensitive")
+	}
+
+	want := canonicalFilesystemPath(project)
+	if got := canonicalFilesystemPath(variant); got != want {
+		t.Fatalf("same directory canonicalized with different case:\n canonical: %q\n variant:   %q\n got:       %q", project, variant, got)
+	}
+	if !sameFilesystemPath(project, variant) {
+		t.Fatal("sameFilesystemPath rejected differently-cased aliases of one directory")
+	}
+	if !sameResolvedDir(project, variant) {
+		t.Fatal("sameResolvedDir rejected differently-cased aliases of one directory")
+	}
+	canonicalDirProject, err := canonicalDir(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalDirVariant, err := canonicalDir(variant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonicalDirProject != canonicalDirVariant {
+		t.Fatalf("canonicalDir preserved input case: %q != %q", canonicalDirProject, canonicalDirVariant)
+	}
+	if canonicalPath(project) != canonicalPath(variant) {
+		t.Fatal("launch/resume canonicalPath rejected differently-cased aliases")
+	}
+	if canonicalContextComparisonPath(project) != canonicalContextComparisonPath(variant) {
+		t.Fatal("context comparison rejected differently-cased aliases")
+	}
+	if !rootsMatch(filepath.Join(project, ".agent-mail"), filepath.Join(variant, ".agent-mail")) {
+		t.Fatal("AMQ root comparison rejected differently-cased aliases")
+	}
+	if got := canonicalFilesystemPaths([]string{project, variant}); len(got) != 1 {
+		t.Fatalf("one directory produced %d canonical set entries: %v", len(got), got)
+	}
+	missing := filepath.Join("future", "worktree")
+	if canonicalFilesystemPath(filepath.Join(project, missing)) != canonicalFilesystemPath(filepath.Join(variant, missing)) {
+		t.Fatal("differently-cased existing ancestors diverged for the same missing descendant")
+	}
+}
+
+func TestPortableCanonicalPathCasePreservesOnDiskSpelling(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "MixedCaseProject")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := canonicalPathCasePortable(project); got != project {
+		t.Fatalf("portable path-case fallback rewrote exact on-disk spelling: got %q want %q", got, project)
+	}
+	if variant, ok := differentlyCasedExistingPath(project); ok {
+		if got := canonicalPathCasePortable(variant); got != project {
+			t.Fatalf("portable path-case fallback did not recover on-disk spelling: got %q want %q", got, project)
+		}
+	}
+}
+
+func differentlyCasedExistingPath(path string) (string, bool) {
+	want, err := os.Stat(path)
+	if err != nil {
+		return "", false
+	}
+	for i := len(path) - 1; i >= 0; i-- {
+		var replacement byte
+		switch {
+		case path[i] >= 'a' && path[i] <= 'z':
+			replacement = path[i] - ('a' - 'A')
+		case path[i] >= 'A' && path[i] <= 'Z':
+			replacement = path[i] + ('a' - 'A')
+		default:
+			continue
+		}
+		candidate := path[:i] + string(replacement) + path[i+1:]
+		got, statErr := os.Stat(candidate)
+		if statErr == nil && os.SameFile(got, want) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
 // canonicalFilesystemPath must be total: a comparator has to canonicalize a
 // recorded location that no longer exists (a removed worktree) without failing.
 func TestCanonicalPathHandlesMissingLocation(t *testing.T) {

--- a/internal/cli/pathnorm_volume_other.go
+++ b/internal/cli/pathnorm_volume_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package cli
+
+func canonicalPathVolume(volume string) string {
+	return volume
+}

--- a/internal/cli/pathnorm_volume_windows.go
+++ b/internal/cli/pathnorm_volume_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package cli
+
+import "strings"
+
+// Windows drive and UNC volume names are case-insensitive but have no parent
+// directory whose entry spelling the portable walker can inspect. Fold only
+// that volume prefix; directory components are still proven with SameFile.
+func canonicalPathVolume(volume string) string {
+	return strings.ToLower(volume)
+}

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -575,13 +575,7 @@ func rootsMatch(actual, expected string) bool {
 }
 
 func canonicalRootForMatch(root string) string {
-	if root == "" {
-		return ""
-	}
-	if resolved, err := filepath.EvalSymlinks(root); err == nil {
-		return resolved
-	}
-	return filepath.Clean(root)
+	return canonicalFilesystemPath(root)
 }
 
 func relativeRootMatchesAbsolute(a, b string) bool {

--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -193,9 +193,10 @@ func resolveControlTarget(mr memberRuntime, workstream string, panes []tmuxpane.
 }
 
 // sameResolvedDir reports whether two paths refer to the same directory after
-// resolving symlinks, so a member cwd under a symlinked path (e.g. macOS
-// /var -> /private/var TMPDIR) matches tmux's resolved #{pane_current_path}.
-// Falls back to a plain absolute comparison when a side cannot be resolved.
+// comparison canonicalization, so symlinked paths (e.g. macOS /var ->
+// /private/var TMPDIR) and differently-cased APFS aliases both match tmux's
+// resolved #{pane_current_path}. Falls back to a plain absolute comparison when
+// a side cannot be resolved.
 func sameResolvedDir(a, b string) bool {
 	if strings.TrimSpace(a) == "" || strings.TrimSpace(b) == "" {
 		return false
@@ -204,14 +205,7 @@ func sameResolvedDir(a, b string) bool {
 }
 
 func resolveDir(dir string) string {
-	abs := dir
-	if a, err := filepath.Abs(dir); err == nil {
-		abs = a
-	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
-	}
-	return filepath.Clean(abs)
+	return canonicalFilesystemPath(dir)
 }
 
 // paneTitledForDifferentAgent reports whether a pane carries an amq title token

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -37,6 +37,32 @@ func TestResolveControlTargetSymlinkedCWD(t *testing.T) {
 	}
 }
 
+func TestResolveControlTargetDifferentlyCasedCWDOnCaseInsensitiveFilesystem(t *testing.T) {
+	project := filepath.Join(t.TempDir(), "PaneProject")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	variant, ok := differentlyCasedExistingPath(project)
+	if !ok {
+		t.Skip("test filesystem is case-sensitive")
+	}
+
+	mr := memberRuntime{
+		Member:    team.Member{Role: "cto", Binary: "codex"},
+		Handle:    "cto",
+		CWD:       variant,
+		HasRecord: true,
+		Record:    launch.Record{Tmux: &launch.TmuxInfo{PaneID: "%617"}},
+	}
+	panes := []tmuxpane.TmuxPane{{
+		PaneID: "%617", Session: "v2-27-0", Window: "0", Pane: "0", CWD: project, Command: "codex",
+	}}
+	id, _, found := resolveControlTarget(mr, "v2-27-0", panes)
+	if !found || id != "%617" {
+		t.Fatalf("differently-cased pane CWD must preserve recorded-pane identity, got id=%q found=%v", id, found)
+	}
+}
+
 func TestSameResolvedDir(t *testing.T) {
 	real, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -2387,7 +2387,7 @@ func canonicalDir(path string) (string, error) {
 	if !info.IsDir() {
 		return "", fmt.Errorf("%s is not a directory", abs)
 	}
-	resolved, err := filepath.EvalSymlinks(abs)
+	resolved, err := resolveExistingFilesystemPath(abs)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -1746,21 +1746,10 @@ func findMemberRestoreRecord(baseRoot, projectDir, memberCWD, profile, workstrea
 	return launch.Record{}, false
 }
 
-// canonicalPath returns a normalized absolute path or "" when input is
-// empty. Symlink resolution is best effort: when EvalSymlinks fails (e.g.
-// the path no longer exists) the absolute clean form is returned.
+// canonicalPath keeps launch/resume identity comparisons on the shared pathnorm
+// seam, including symlink and on-disk case normalization for existing paths.
 func canonicalPath(p string) string {
-	if strings.TrimSpace(p) == "" {
-		return ""
-	}
-	abs, err := filepath.Abs(p)
-	if err != nil {
-		return filepath.Clean(p)
-	}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved
-	}
-	return abs
+	return canonicalFilesystemPath(p)
 }
 
 // wakeHealthForMember returns the wake-health label for a member, using


### PR DESCRIPTION
## Summary

- canonicalize existing filesystem paths to their on-disk case at the shared comparison seam
- use Darwin F_GETPATH as the fast path with a portable directory-entry and inode fallback
- route pane, context-root, launch/resume, prepared identity, and AMQ-root helper comparisons through that seam
- normalize Windows drive and UNC volume prefixes while proving directory components with SameFile

## Regression coverage

- TestCanonicalPathUsesOnDiskCaseOnCaseInsensitiveFilesystem
- TestPortableCanonicalPathCasePreservesOnDiskSpelling
- TestResolveControlTargetDifferentlyCasedCWDOnCaseInsensitiveFilesystem
- TestPreparedLaunchIdentityAcceptsDifferentlyCasedProjectOnCaseInsensitiveFilesystem

The case-insensitive assertions run on supported volumes and explicitly skip with reason on case-sensitive filesystems. The portable fallback test still runs meaningfully on case-sensitive CI.

## Verification

- make ci: PASS
- focused four-test regression run: PASS
- GOOS=linux package compile: PASS
- isolated GOOS=windows compile for the new portable and Windows-tagged pathnorm files: PASS
- full GOOS=windows internal/cli package compile: baseline failure in unrelated existing Unix-only sources, including namespace_migration_plan.go and team_lead.go; it does not reach the t14 files
- go test -race ./internal/cli/ -count=1: PENDING serialized Tier 1 evidence run; result will be appended at this exact PR head

Fixes #617
- `go test -race ./internal/cli/ -count=1 -timeout 30m` — PASS at exact head `0f4fd5e2461a838f900a605b6dc29661a51a67d6` (`497.587s`; no race warning or timeout).
