### PR TITLE
Render prepared launches from accepted state (#618)

### DIFF
--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -527,11 +527,15 @@ func memberHandle(m team.Member) string {
 	return m.Binary
 }
 
+// sameLaunchTarget decides which roster row is marked "(you)". Its cwd clause
+// compares canonical forms for the same reason samePath does (#618): raw string
+// equality made the accepted render mark NOBODY as "(you)" while the pane render
+// marked the right row -- same directory, two spellings, two different prompts.
 func sameLaunchTarget(rec launch.Record, cwd, handle string, m team.Member) bool {
 	return rec.Role == m.Role &&
 		rec.Handle == handle &&
 		rec.Session == routingSessionForMember(rec, m) &&
-		rec.CWD == cwd
+		samePath(rec.CWD, cwd)
 }
 
 type projectIdentity struct {
@@ -670,16 +674,33 @@ func projectIdentityForCWD(cwd string) projectIdentity {
 	return projectIdentity{}
 }
 
+// samePath reports whether two paths name the same directory, COMPARING
+// canonical forms rather than recorded spellings (#618).
+//
+// filepath.Abs alone is not enough, because the spellings reaching this function
+// come from sources that normalize differently:
+//
+//	accepted render  rec.CWD = canonicalDir(member.EffectiveCWD(...))  RESOLVED
+//	pane render      rec.CWD = os.Getwd() (launch.go:339)              RAW
+//	both             cwd     = m.EffectiveCWD(t.Project)               RAW, from team.json
+//
+// os.Getwd honours $PWD when it stats to the same file, so it returns the
+// spelling the operator's shell was carrying. One symlinked or differently-cased
+// component and an Abs-only comparison calls two spellings of ONE directory two
+// directories. routeCommandFor then takes its !sameCWD branch, project identity
+// reads unknown, and every peer's send: line degrades to "unavailable" -- an
+// accepted prompt telling every agent its peers are unreachable.
+//
+// canonicalFilesystemPath is the project's established comparison seam and where
+// #617/#621 put on-disk case normalization, so this composes with that work
+// instead of duplicating it.
+//
+// Deliberately NOT fixed at the recording sites: the recorded spelling is
+// diagnostic information an operator should still see, recorded paths feed
+// comparisons outside this file that have not been audited, and rewriting what
+// gets stored is a far wider blast radius than making one comparison honest.
 func samePath(a, b string) bool {
-	aa, err := filepath.Abs(a)
-	if err != nil {
-		aa = filepath.Clean(a)
-	}
-	bb, err := filepath.Abs(b)
-	if err != nil {
-		bb = filepath.Clean(b)
-	}
-	return aa == bb
+	return canonicalFilesystemPath(a) == canonicalFilesystemPath(b)
 }
 
 func findProjectName(start string) (string, string) {

--- a/internal/cli/bootstrap_routing_canonical_618_test.go
+++ b/internal/cli/bootstrap_routing_canonical_618_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// GUARD ON AN ADJACENT PROPERTY — NOT EVIDENCE FOR THIS PR'S FIX.
+//
+// Both tests in this file PASS at this PR's parent. They do not bisect anything
+// here and are not offered as evidence. They are kept because #622's fix DEPENDS
+// on the property they assert: rendering from accepted state is only correct if
+// the accepted state's routing block is itself correct, and that rests on the
+// path canonicalization #617/#621 landed. Nothing else asserts it.
+//
+// A defensive samePath/sameLaunchTarget change originally shipped alongside
+// these. It was dropped: #621 canonicalizes the profile path and run start
+// restamps recorded member CWDs on ingestion, so both operands are already
+// canonical by the time the comparison runs and the defensive change had no
+// reachable failing state. Hardening with no failing test does not ship.
+//
+// TestAcceptedPromptNeverRendersUnroutablePeers asserts a property worth stating
+// independently of digest equality.
+//
+// The digest tests would catch a REGRESSION of this, but only as "the two
+// prompts differ". They would not catch both renders collapsing together, which
+// is a strictly worse outcome: agreeing prompts that both tell every agent its
+// peers are unreachable would pass a byte-equality test while shipping a squad
+// that cannot coordinate.
+//
+// The failure this pins is real and was live at f8b0911: samePath compared
+// rec.CWD (resolved via canonicalDir) against m.EffectiveCWD (raw from
+// team.json). Under a symlinked or differently-cased path those are two
+// spellings of one directory, the comparison failed, routeCommandFor took the
+// !sameCWD branch, project identity read as unknown, and EVERY peer line became
+// "send: unavailable (AMQ project identity is missing ...)".
+//
+// The fixture runs under t.TempDir(), which on macOS lives beneath the
+// /var -> /private/var symlink, so it exercises the resolved-vs-raw divergence
+// naturally rather than by contriving one.
+func TestAcceptedPromptNeverRendersUnroutablePeers(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		SharedCwdException: "probe fixture: single-directory squad matching the #618 field-hit profile",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Accepted prompts must route to peers sharing the launch cwd",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare fixture: %v", err)
+	}
+
+	profile, session := team.DefaultProfile, "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(tm.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Members = initial
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+
+	for _, member := range initial {
+		prompt, err := preparedBootstrap(dir, profile, session, binding, tm, member,
+			acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology})
+		if err != nil {
+			t.Fatalf("accepted render for %s: %v", member.Role, err)
+		}
+		if !strings.Contains(prompt, "Current team routing:") {
+			t.Fatalf("role %s: accepted prompt has no routing block at all", member.Role)
+		}
+		if strings.Contains(prompt, "send: unavailable") {
+			t.Errorf("role %s: ACCEPTED prompt reports peers as unroutable while every member"+
+				" shares the launch cwd; the routing comparison is trusting a recorded"+
+				" spelling instead of a canonical one (#618)", member.Role)
+			for _, line := range strings.Split(prompt, "\n") {
+				if strings.Contains(line, "send:") {
+					t.Errorf("  %s", strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+}
+
+// TestAcceptedPromptRoutesPeersWithExplicitlyRecordedCWD is the bisecting
+// regression for the canonical-comparison fix, and it exists because the
+// ORIGINAL one stopped bisecting.
+//
+// The first version of this regression used members with no explicit CWD, so
+// both operands of the samePath comparison derived from the profile's Project
+// path. #617/#621 then canonicalized that path, which made both sides agree and
+// fixed the routing collapse from the other side of the same seam. The test kept
+// passing at its parent and therefore proved nothing about THIS change.
+//
+// A member with an EXPLICITLY RECORDED CWD is the case #621 does not reach. The
+// recorded spelling comes straight from team.json and is compared against a
+// canonicalDir-resolved rec.CWD, so a member whose recorded path is the
+// symlinked spelling of the same directory still compares unequal without this
+// fix. On macOS t.TempDir() lives under /var -> /private/var, so recording the
+// unresolved spelling exercises it without contriving anything.
+func TestAcceptedPromptRoutesPeersWithExplicitlyRecordedCWD(t *testing.T) {
+	dir := t.TempDir()
+	// Record the UNRESOLVED spelling deliberately: this is what an operator's
+	// shell hands the tool, and what os.Getwd reports when $PWD carries it.
+	if err := team.Write(dir, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		SharedCwdException: "regression fixture: one checkout, recorded unresolved",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: dir},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: dir},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: dir, ToolProfile: team.ToolProfileFull},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Peers sharing an explicitly recorded cwd must stay routable",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare fixture: %v", err)
+	}
+
+	profile, session := team.DefaultProfile, "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(tm.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Members = initial
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	for _, member := range initial {
+		prompt, err := preparedBootstrap(dir, profile, session, binding, tm, member,
+			acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology})
+		if err != nil {
+			t.Fatalf("accepted render for %s: %v", member.Role, err)
+		}
+		if strings.Contains(prompt, "send: unavailable") {
+			t.Errorf("role %s: peers reported unroutable although every member records the SAME"+
+				" directory; the comparison is trusting the recorded spelling (#618)", member.Role)
+			for _, line := range strings.Split(prompt, "\n") {
+				if strings.Contains(line, "send:") {
+					t.Errorf("  %s", strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+}

--- a/internal/cli/bootstrap_routing_canonical_618_test.go
+++ b/internal/cli/bootstrap_routing_canonical_618_test.go
@@ -8,39 +8,24 @@ import (
 	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
-// GUARD ON AN ADJACENT PROPERTY — NOT EVIDENCE FOR THIS PR'S FIX.
+// BEHAVIOURAL BISECT FOR THIS PR. Both tests here FAIL at this PR's parent and
+// PASS with the fix, reporting the real defect: every peer line reading
+// "send: unavailable (AMQ project identity is missing...)" in a squad where all
+// members share one checkout.
 //
-// Both tests in this file PASS at this PR's parent. They do not bisect anything
-// here and are not offered as evidence. They are kept because #622's fix DEPENDS
-// on the property they assert: rendering from accepted state is only correct if
-// the accepted state's routing block is itself correct, and that rests on the
-// path canonicalization #617/#621 landed. Nothing else asserts it.
+// They assert the routing PROPERTY rather than digest equality, deliberately.
+// Two identically-broken prompts would satisfy every digest-equality check in
+// this PR while shipping a squad that cannot coordinate, so equality is
+// necessary and not sufficient.
 //
-// A defensive samePath/sameLaunchTarget change originally shipped alongside
-// these. It was dropped: #621 canonicalizes the profile path and run start
-// restamps recorded member CWDs on ingestion, so both operands are already
-// canonical by the time the comparison runs and the defensive change had no
-// reachable failing state. Hardening with no failing test does not ship.
-//
-// TestAcceptedPromptNeverRendersUnroutablePeers asserts a property worth stating
-// independently of digest equality.
-//
-// The digest tests would catch a REGRESSION of this, but only as "the two
-// prompts differ". They would not catch both renders collapsing together, which
-// is a strictly worse outcome: agreeing prompts that both tell every agent its
-// peers are unreachable would pass a byte-equality test while shipping a squad
-// that cannot coordinate.
-//
-// The failure this pins is real and was live at f8b0911: samePath compared
-// rec.CWD (resolved via canonicalDir) against m.EffectiveCWD (raw from
-// team.json). Under a symlinked or differently-cased path those are two
-// spellings of one directory, the comparison failed, routeCommandFor took the
-// !sameCWD branch, project identity read as unknown, and EVERY peer line became
-// "send: unavailable (AMQ project identity is missing ...)".
-//
-// The fixture runs under t.TempDir(), which on macOS lives beneath the
-// /var -> /private/var symlink, so it exercises the resolved-vs-raw divergence
-// naturally rather than by contriving one.
+// HISTORY, because these comments previously said the opposite and a reader
+// deserves to know why. The canonicalization these tests cover was briefly
+// dropped from this PR on the strength of a bisect that measured the wrong tree
+// -- a git stash did not apply as assumed, so the run that "passed at the
+// parent" was almost certainly measuring the tree WITH the fix. A full-package
+// -race run failed both tests and reversed the decision; the fix is restored.
+// The lesson is worth more than the incident: a bisect conclusion is only as
+// good as the proof of which tree it measured.
 func TestAcceptedPromptNeverRendersUnroutablePeers(t *testing.T) {
 	dir := seedTeam(t, team.Team{
 		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1457,12 +1457,16 @@ func launchBootstrapPrompt(rec launch.Record, agentDir, teamHome string, prepare
 	if project == "" {
 		project = strings.TrimSpace(rec.CWD)
 	}
+	roster, err := acceptedRenderRoster(prepared, rec.Session)
+	if err != nil {
+		return "", err
+	}
 	return preparedBootstrap(
 		project,
 		squadnamespace.NormalizeProfile(rec.TeamProfile),
 		rec.Session,
 		prepared.Binding,
-		acceptedRenderRoster(prepared, rec.Session),
+		roster,
 		prepared.Member,
 		acceptedRunContext{
 			Version:  prepared.Manifest.Environment.BinaryVersion,
@@ -1507,13 +1511,20 @@ func stagedRenderIsForked(prepared *preparedLaunchRecordContext, role string) bo
 // Keep this in step with buildPreparedRunManifest; when they disagree the
 // symptom is a digest drift that reads like corruption rather than like a roster
 // disagreement, which is what made #618 expensive to find.
-func acceptedRenderRoster(prepared *preparedLaunchRecordContext, session string) team.Team {
+func acceptedRenderRoster(prepared *preparedLaunchRecordContext, session string) (team.Team, error) {
 	roster := prepared.Team
 	initial, _, err := partitionPreparedRunMembers(roster.Members, session, prepared.Manifest.StagedRoster)
 	if err != nil {
-		return roster
+		// Propagate rather than falling back to the un-narrowed roster. Returning
+		// `roster` here would silently render initial members against a roster
+		// still containing staged roles -- reproducing the exact divergence this
+		// function exists to prevent, and surfacing later as a digest-drift
+		// refusal that reads like corruption rather than like a roster
+		// disagreement. That failure mode is what made #618 expensive to find;
+		// a loud error at the point of failure is strictly better than a quiet
+		// wrong answer that fails closed somewhere else.
+		return team.Team{}, fmt.Errorf("partition accepted roster for %s: %w", session, err)
 	}
 	roster.Members = initial
-	return roster
+	return roster, nil
 }
-

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -694,11 +694,7 @@ Examples:
 	}
 	rec.BootstrapExpectation = &expectation
 	if bootstrapAppended {
-		bootstrapContext := bootstrapContextFor(rec, agentDir, *teamHome)
-		if preparedLaunchContext != nil {
-			bootstrapContext.CurrentTeam, bootstrapContext.Warnings = bootstrapCurrentTeamWithRoster(rec, *teamHome, true)
-		}
-		prompt, err := buildBootstrapPrompt(bootstrapContext)
+		prompt, err := launchBootstrapPrompt(rec, agentDir, *teamHome, preparedLaunchContext)
 		if err != nil {
 			return err
 		}
@@ -1422,3 +1418,102 @@ func splitDashDash(args []string) ([]string, []string) {
 	}
 	return args, nil
 }
+
+// launchBootstrapPrompt renders the pane's bootstrap prompt.
+//
+// #618. A PREPARED launch renders through preparedBootstrap -- the SAME function
+// that produced the digest preparation accepted -- so the pane prompt and the
+// accepted preview are byte-identical by construction rather than by two call
+// sites agreeing to stay in step.
+//
+// They did not stay in step, and that is the bug. The old code here built the
+// context with bootstrapContextFor and overrode exactly ONE thing
+// (CurrentTeam+Warnings), while preparedBootstrap overrode FIVE (adding
+// Execution, ActorExecution, PlannerLead, MutationCapable) and derived rec.CWD
+// and rec.Root from ACCEPTED state instead of from the live process. So four
+// context fields plus two rendered record fields reached the pane prompt from
+// live state that preparation never saw:
+//
+//	accepted   rec.CWD = canonicalDir(member.EffectiveCWD(...))   resolved
+//	pane       rec.CWD = os.Getwd() (launch.go:339)               the operator's spelling
+//
+// Equalizing the COMPARISONS (samePath, #618 fix (a)) cannot reconcile prompts
+// that PRINT different bytes, because rendering and comparison are different
+// surfaces. The only durable fix is one renderer with one input set: the render
+// becomes a function of what was accepted, and live process state contributes
+// nothing to the prompt text.
+//
+// An UNPREPARED launch has no accepted state to render from and keeps the
+// original path unchanged. bootstrapContextFor's live-state reads are correct
+// there -- there is no accepted preview for them to contradict.
+func launchBootstrapPrompt(rec launch.Record, agentDir, teamHome string, prepared *preparedLaunchRecordContext) (string, error) {
+	if prepared == nil || stagedRenderIsForked(prepared, rec.Role) {
+		return buildBootstrapPrompt(bootstrapContextFor(rec, agentDir, teamHome))
+	}
+	project := strings.TrimSpace(rec.TeamHome)
+	if project == "" {
+		project = strings.TrimSpace(teamHome)
+	}
+	if project == "" {
+		project = strings.TrimSpace(rec.CWD)
+	}
+	return preparedBootstrap(
+		project,
+		squadnamespace.NormalizeProfile(rec.TeamProfile),
+		rec.Session,
+		prepared.Binding,
+		acceptedRenderRoster(prepared, rec.Session),
+		prepared.Member,
+		acceptedRunContext{
+			Version:  prepared.Manifest.Environment.BinaryVersion,
+			Topology: prepared.Manifest.Topology,
+		},
+	)
+}
+
+// stagedRenderIsForked marks the one case this fix deliberately does NOT change.
+//
+// #618's fix renders prepared launches from accepted state so the pane prompt
+// reproduces the accepted digest by construction. That is proven for INITIAL
+// roster members and is what the 2026-08-02 field hit exercised.
+//
+// STAGED members are excluded and keep the original bootstrapContextFor path.
+// Rendering them from accepted state alone does not currently reproduce their
+// accepted digest: the accepted preview pins a staged member's ActorMode to
+// review, the profile on disk carries no ActorMode (which resolves to
+// implementation), and the old path only agreed with the digest because it
+// projected the staged CLAIM -- runtime admission state that cannot exist at
+// preparation time and therefore must not be what a digest-checked body depends
+// on. Reconciling that is a design question about what the accepted preview
+// means for staged spawns, not a roster-selection bug, and it is forked rather
+// than guessed at under a release deadline.
+//
+// Excluding them is not a half-fix: it leaves the staged path EXACTLY as it
+// shipped, so this change cannot regress it.
+func stagedRenderIsForked(prepared *preparedLaunchRecordContext, role string) bool {
+	return containsRole(prepared.Manifest.StagedRoster, role)
+}
+
+// acceptedRenderRoster returns the roster the ACCEPTED digest for an INITIAL
+// member was computed with: partitionPreparedRunMembers, i.e. the session filter
+// MINUS staged roles (buildPreparedRunManifest).
+//
+// preparedLaunchRecordContext.Team does not already match that. Its initial
+// branch carries a merely session-filtered roster with staged roles still in it,
+// so passing it straight through would render initial members against a roster
+// containing members preparation excluded -- the original #618 divergence
+// reappearing one layer in.
+//
+// Keep this in step with buildPreparedRunManifest; when they disagree the
+// symptom is a digest drift that reads like corruption rather than like a roster
+// disagreement, which is what made #618 expensive to find.
+func acceptedRenderRoster(prepared *preparedLaunchRecordContext, session string) team.Team {
+	roster := prepared.Team
+	initial, _, err := partitionPreparedRunMembers(roster.Members, session, prepared.Manifest.StagedRoster)
+	if err != nil {
+		return roster
+	}
+	roster.Members = initial
+	return roster
+}
+

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1457,12 +1457,16 @@ func launchBootstrapPrompt(rec launch.Record, agentDir, teamHome string, prepare
 	if project == "" {
 		project = strings.TrimSpace(rec.CWD)
 	}
+	roster, err := acceptedRenderRoster(prepared)
+	if err != nil {
+		return "", err
+	}
 	return preparedBootstrap(
 		project,
 		squadnamespace.NormalizeProfile(rec.TeamProfile),
 		rec.Session,
 		prepared.Binding,
-		acceptedRenderRoster(prepared),
+		roster,
 		prepared.Member,
 		acceptedRunContext{
 			Version:  prepared.Manifest.Environment.BinaryVersion,
@@ -1511,19 +1515,30 @@ func stagedRenderIsForked(prepared *preparedLaunchRecordContext, role string) bo
 // explicitly accepted (proved by
 // TestPreparedRunMixedSessionRosterIsExactAcrossDefaultAndNamedProfiles).
 //
-// Note what that means for error handling: this function no longer has a failure
-// mode to propagate or swallow. The earlier version returned an error, which was
-// an improvement over silently returning the un-narrowed roster, but the better
-// answer was to stop asking a question that could fail. A total function beats a
-// correct error path.
-func acceptedRenderRoster(prepared *preparedLaunchRecordContext) team.Team {
+// The remaining error is deliberately narrow and means something different from
+// the one it replaced. A staged role missing from the narrowed Team is NORMAL
+// (it belongs to another session). An INITIAL role missing is corruption: the
+// accepted manifest names a member the launch context cannot supply, so the
+// render could not reproduce the accepted digest even if it tried. That refuses
+// loudly rather than rendering a quietly short roster, because a silently
+// missing peer produces a prompt that looks fine and routes to nobody.
+func acceptedRenderRoster(prepared *preparedLaunchRecordContext) (team.Team, error) {
 	roster := prepared.Team
+	present := make(map[string]bool, len(roster.Members))
 	initial := make([]team.Member, 0, len(roster.Members))
 	for _, member := range roster.Members {
 		if containsRole(prepared.Manifest.InitialRoster, member.Role) {
+			present[member.Role] = true
 			initial = append(initial, member)
 		}
 	}
+	for _, role := range prepared.Manifest.InitialRoster {
+		if !present[role] {
+			return team.Team{}, fmt.Errorf(
+				"accepted initial roster names role %q, absent from the prepared launch context;"+
+					" the accepted preview cannot be reproduced", role)
+		}
+	}
 	roster.Members = initial
-	return roster
+	return roster, nil
 }

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1457,16 +1457,12 @@ func launchBootstrapPrompt(rec launch.Record, agentDir, teamHome string, prepare
 	if project == "" {
 		project = strings.TrimSpace(rec.CWD)
 	}
-	roster, err := acceptedRenderRoster(prepared, rec.Session)
-	if err != nil {
-		return "", err
-	}
 	return preparedBootstrap(
 		project,
 		squadnamespace.NormalizeProfile(rec.TeamProfile),
 		rec.Session,
 		prepared.Binding,
-		roster,
+		acceptedRenderRoster(prepared),
 		prepared.Member,
 		acceptedRunContext{
 			Version:  prepared.Manifest.Environment.BinaryVersion,
@@ -1499,32 +1495,35 @@ func stagedRenderIsForked(prepared *preparedLaunchRecordContext, role string) bo
 }
 
 // acceptedRenderRoster returns the roster the ACCEPTED digest for an INITIAL
-// member was computed with: partitionPreparedRunMembers, i.e. the session filter
-// MINUS staged roles (buildPreparedRunManifest).
+// member was computed with.
 //
-// preparedLaunchRecordContext.Team does not already match that. Its initial
-// branch carries a merely session-filtered roster with staged roles still in it,
-// so passing it straight through would render initial members against a roster
-// containing members preparation excluded -- the original #618 divergence
-// reappearing one layer in.
+// It REPRODUCES manifest.InitialRoster rather than re-deriving it. Preparation
+// already recorded exactly which roles it rendered as initial
+// (buildPreparedRunManifest), so reading that record is both simpler and
+// strictly more faithful than re-running the partition and hoping it lands on
+// the same answer from different inputs.
 //
-// Keep this in step with buildPreparedRunManifest; when they disagree the
-// symptom is a digest drift that reads like corruption rather than like a roster
-// disagreement, which is what made #618 expensive to find.
-func acceptedRenderRoster(prepared *preparedLaunchRecordContext, session string) (team.Team, error) {
+// Re-deriving was wrong, not merely redundant. partitionPreparedRunMembers
+// requires every role in the staged roster to be present in the members slice it
+// is handed, and preparedLaunchRecordContext.Team is already session-filtered --
+// so a staged role pinned to ANOTHER session is in manifest.StagedRoster but
+// absent from those members, and the partition refused a launch preparation had
+// explicitly accepted (proved by
+// TestPreparedRunMixedSessionRosterIsExactAcrossDefaultAndNamedProfiles).
+//
+// Note what that means for error handling: this function no longer has a failure
+// mode to propagate or swallow. The earlier version returned an error, which was
+// an improvement over silently returning the un-narrowed roster, but the better
+// answer was to stop asking a question that could fail. A total function beats a
+// correct error path.
+func acceptedRenderRoster(prepared *preparedLaunchRecordContext) team.Team {
 	roster := prepared.Team
-	initial, _, err := partitionPreparedRunMembers(roster.Members, session, prepared.Manifest.StagedRoster)
-	if err != nil {
-		// Propagate rather than falling back to the un-narrowed roster. Returning
-		// `roster` here would silently render initial members against a roster
-		// still containing staged roles -- reproducing the exact divergence this
-		// function exists to prevent, and surfacing later as a digest-drift
-		// refusal that reads like corruption rather than like a roster
-		// disagreement. That failure mode is what made #618 expensive to find;
-		// a loud error at the point of failure is strictly better than a quiet
-		// wrong answer that fails closed somewhere else.
-		return team.Team{}, fmt.Errorf("partition accepted roster for %s: %w", session, err)
+	initial := make([]team.Member, 0, len(roster.Members))
+	for _, member := range roster.Members {
+		if containsRole(prepared.Manifest.InitialRoster, member.Role) {
+			initial = append(initial, member)
+		}
 	}
 	roster.Members = initial
-	return roster, nil
+	return roster
 }

--- a/internal/cli/prepared_render_identity_618_test.go
+++ b/internal/cli/prepared_render_identity_618_test.go
@@ -12,33 +12,6 @@ import (
 	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
 )
 
-// TestPrepareAndPaneRenderTheSameRoster is the #618 probe.
-//
-// THE DEFECT UNDER TEST. The bootstrap prompt's "Current team routing:" block is
-// produced by two different call sites that each choose the roster themselves,
-// with two different functions:
-//
-//	prepare-time  run_start_readiness.go:1148  bootstrapCurrentTeamForTeam(rec, tm)
-//	              where tm.Members was narrowed at :1571-1573 by
-//	              partitionPreparedRunMembers = filterMembersBySession MINUS staged roles
-//	pane-time     launch.go:699-700            bootstrapCurrentTeamWithRoster(rec, teamHome, true)
-//	              = team.ReadProfile + filterMembersBySession, staged roles NOT removed
-//
-// So with a non-empty staged roster the pane render contains members the prepare
-// render does not, the prompts differ, the digests differ, and every bootstrap
-// row drifts at once. That is #618's reported signature.
-//
-// WHY NOTHING IN THE EXISTING SUITE CATCHES THIS. Every current fixture renders
-// through preparedBootstrap on BOTH sides of its comparison, so it compares the
-// prepare path against itself. No test renders the pane path and the prepare
-// path and compares them. This test does exactly that, at the seam where they
-// diverge, so it does not have to reconstruct all of launch.go to be honest.
-//
-// A NOTE ON WHAT THIS IS NOT. An earlier version of this probe hid the prepared
-// manifest to flip bootstrapContextFor's exactSessionRoster. That was wrong:
-// all three prepared render paths overwrite CurrentTeam immediately after
-// calling bootstrapContextFor, so the os.Stat result never reaches the prompt
-// and that probe would have reported "insensitive" while proving nothing.
 // TestPrepareAndPaneRenderTheSameRoster is the #618 staged-roster regression.
 //
 // THE ORIGINAL DEFECT. The routing block was produced by two call sites that each

--- a/internal/cli/prepared_render_identity_618_test.go
+++ b/internal/cli/prepared_render_identity_618_test.go
@@ -701,7 +701,10 @@ func TestCrossSessionStagedRoleDoesNotBlockInitialRender(t *testing.T) {
 		},
 	}
 
-	roster := acceptedRenderRoster(prepared)
+	roster, err := acceptedRenderRoster(prepared)
+	if err != nil {
+		t.Fatalf("cross-session staged role must not block an initial render: %v", err)
+	}
 
 	if got := len(roster.Members); got != 1 {
 		t.Fatalf("accepted render roster has %d members, want exactly the accepted initial roster [cto]", got)
@@ -716,5 +719,32 @@ func TestCrossSessionStagedRoleDoesNotBlockInitialRender(t *testing.T) {
 		if member.Role == "qa" {
 			t.Fatalf("staged role qa leaked into the initial render roster")
 		}
+	}
+}
+
+// TestAcceptedInitialRoleMissingFromContextRefuses pins the OTHER half of the
+// distinction. A staged role absent from the narrowed Team is normal -- it
+// belongs to another session. An INITIAL role absent is corruption: the accepted
+// manifest names a member the launch context cannot supply, so the accepted
+// digest could not be reproduced even in principle. Refusing loudly beats
+// rendering a quietly short roster, because a prompt missing a peer looks
+// perfectly well-formed and routes to nobody.
+func TestAcceptedInitialRoleMissingFromContextRefuses(t *testing.T) {
+	prepared := &preparedLaunchRecordContext{
+		Manifest: preparedRunManifest{
+			InitialRoster: []string{"cto", "senior-dev"},
+			StagedRoster:  []string{"qa"},
+		},
+		Team: team.Team{
+			Lead: "cto",
+			Members: []team.Member{
+				{Role: "cto", Handle: "cto", Binary: "claude", Session: "focus"},
+			},
+		},
+	}
+	if _, err := acceptedRenderRoster(prepared); err == nil {
+		t.Fatal("an accepted initial role absent from the launch context must refuse, not render short")
+	} else if !strings.Contains(err.Error(), "senior-dev") {
+		t.Fatalf("refusal must name the missing role, got: %v", err)
 	}
 }

--- a/internal/cli/prepared_render_identity_618_test.go
+++ b/internal/cli/prepared_render_identity_618_test.go
@@ -662,3 +662,59 @@ func stagedRolesForShape618(shape string) string {
 	}
 	return "qa"
 }
+
+// TestCrossSessionStagedRoleDoesNotBlockInitialRender is amq-dev-2's review
+// finding, turned into a regression.
+//
+// A profile may legitimately pin a staged role to a DIFFERENT session than the
+// one being launched; preparation accepts that shape deliberately (see
+// TestPreparedRunMixedSessionRosterIsExactAcrossDefaultAndNamedProfiles), and
+// preparedContextForLaunchRecord then hands the render a roster containing only
+// the ACTIVE session's members.
+//
+// An earlier version of acceptedRenderRoster re-derived the initial roster by
+// re-running partitionPreparedRunMembers over that already-filtered slice while
+// supplying the complete manifest.StagedRoster. The helper requires every staged
+// role to be present in the members it is given, so the cross-session staged
+// role -- correctly absent -- made it refuse, and a valid prepared launch failed
+// with "staged role %q has no complete profile member definition".
+//
+// Worth recording precisely because the intermediate state was WORSE than the
+// original: before that, the error was swallowed and the un-narrowed roster
+// returned (wrong roster, launch proceeds); propagating it turned a silent wrong
+// answer into a refused launch. The real fix was to stop re-deriving and read
+// manifest.InitialRoster, which preparation already recorded.
+func TestCrossSessionStagedRoleDoesNotBlockInitialRender(t *testing.T) {
+	const activeSession = "focus"
+	prepared := &preparedLaunchRecordContext{
+		Manifest: preparedRunManifest{
+			InitialRoster: []string{"cto"},
+			StagedRoster:  []string{"qa"},
+		},
+		// As preparedContextForLaunchRecord builds it: the cross-session staged
+		// member is already gone.
+		Team: team.Team{
+			Lead: "cto",
+			Members: []team.Member{
+				{Role: "cto", Handle: "cto", Binary: "claude", Session: activeSession},
+			},
+		},
+	}
+
+	roster := acceptedRenderRoster(prepared)
+
+	if got := len(roster.Members); got != 1 {
+		t.Fatalf("accepted render roster has %d members, want exactly the accepted initial roster [cto]", got)
+	}
+	if roster.Members[0].Role != "cto" {
+		t.Fatalf("accepted render roster = %q, want cto", roster.Members[0].Role)
+	}
+
+	// And the staged role must not be reintroduced: reproducing InitialRoster
+	// means the render sees what preparation accepted, no more and no less.
+	for _, member := range roster.Members {
+		if member.Role == "qa" {
+			t.Fatalf("staged role qa leaked into the initial render roster")
+		}
+	}
+}

--- a/internal/cli/prepared_render_identity_618_test.go
+++ b/internal/cli/prepared_render_identity_618_test.go
@@ -1,0 +1,691 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	runwizard "github.com/omriariav/amq-squad/v2/internal/wizard"
+)
+
+// TestPrepareAndPaneRenderTheSameRoster is the #618 probe.
+//
+// THE DEFECT UNDER TEST. The bootstrap prompt's "Current team routing:" block is
+// produced by two different call sites that each choose the roster themselves,
+// with two different functions:
+//
+//	prepare-time  run_start_readiness.go:1148  bootstrapCurrentTeamForTeam(rec, tm)
+//	              where tm.Members was narrowed at :1571-1573 by
+//	              partitionPreparedRunMembers = filterMembersBySession MINUS staged roles
+//	pane-time     launch.go:699-700            bootstrapCurrentTeamWithRoster(rec, teamHome, true)
+//	              = team.ReadProfile + filterMembersBySession, staged roles NOT removed
+//
+// So with a non-empty staged roster the pane render contains members the prepare
+// render does not, the prompts differ, the digests differ, and every bootstrap
+// row drifts at once. That is #618's reported signature.
+//
+// WHY NOTHING IN THE EXISTING SUITE CATCHES THIS. Every current fixture renders
+// through preparedBootstrap on BOTH sides of its comparison, so it compares the
+// prepare path against itself. No test renders the pane path and the prepare
+// path and compares them. This test does exactly that, at the seam where they
+// diverge, so it does not have to reconstruct all of launch.go to be honest.
+//
+// A NOTE ON WHAT THIS IS NOT. An earlier version of this probe hid the prepared
+// manifest to flip bootstrapContextFor's exactSessionRoster. That was wrong:
+// all three prepared render paths overwrite CurrentTeam immediately after
+// calling bootstrapContextFor, so the os.Stat result never reaches the prompt
+// and that probe would have reported "insensitive" while proving nothing.
+// TestPrepareAndPaneRenderTheSameRoster is the #618 staged-roster regression.
+//
+// THE ORIGINAL DEFECT. The routing block was produced by two call sites that each
+// chose the roster themselves, with two different functions:
+//
+//	prepare-time  run_start_readiness.go  bootstrapCurrentTeamForTeam(rec, tm)
+//	              where tm was narrowed by partitionPreparedRunMembers
+//	              = filterMembersBySession MINUS staged roles
+//	pane-time     launch.go               bootstrapCurrentTeamWithRoster(rec, teamHome, true)
+//	              = team.ReadProfile + filterMembersBySession, staged roles NOT removed
+//
+// With a non-empty staged roster the pane render carried members the accepted
+// render did not, so every bootstrap row drifted at once.
+//
+// WHY THIS TEST ASSERTS AT THE RENDERER, NOT AT THOSE TWO FUNCTIONS. It first
+// compared bootstrapCurrentTeamForTeam against bootstrapCurrentTeamWithRoster
+// directly. After the fix, the pane no longer CALLS the second one for a prepared
+// launch, so that comparison would have kept failing while the shipped behaviour
+// was correct -- a test asserting a proxy for the outcome instead of the outcome.
+// It now drives launchBootstrapPrompt, the renderer the pane actually uses, and
+// asserts the property that matters: with staged members present, the pane prompt
+// must digest to exactly what preparation accepted.
+func TestPrepareAndPaneRenderTheSameRoster(t *testing.T) {
+	for _, shape := range []string{runwizard.LaunchShapeWorkingTeamTogether, runwizard.LaunchShapeLeadOnlyStaged} {
+		t.Run(shape, func(t *testing.T) { assertPreparedRenderIdentity618(t, shape) })
+	}
+}
+
+func assertPreparedRenderIdentity618(t *testing.T, shape string) {
+	project := prepareStagedRosterFixture618Shape(t, shape)
+	profile, session := team.DefaultProfile, "prepared"
+
+	manifest, err := readPreparedRunManifest(project, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.StagedRoster) == 0 {
+		t.Fatalf("fixture cannot express the defect: staged roster is empty, so the two"+
+			" selectors agree trivially and a pass here would prove nothing"+
+			" (initial=%v staged=%v)", manifest.InitialRoster, manifest.StagedRoster)
+	}
+
+	full, err := team.ReadProfile(project, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, staged, err := partitionPreparedRunMembers(full.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatalf("partition accepted roster: %v", err)
+	}
+	if len(staged) == 0 {
+		t.Fatalf("fixture partitioned no staged members; initial=%d", len(initial))
+	}
+	acceptedRoster := full
+	acceptedRoster.Members = initial
+
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	root := squadnamespace.AMQRoot(project, profile, session)
+
+	for _, member := range initial {
+		handle := memberHandle(member)
+		agentDir := filepath.Join(root, "agents", handle)
+		rec := launch.Record{
+			Role: member.Role, Handle: handle, Binary: member.Binary,
+			ToolProfile: member.EffectiveToolProfile(), ToolConfig: member.ToolConfig,
+			Session: session, CWD: project, Root: root,
+			TeamHome: project, TeamProfile: profile, SharedWorkstream: true,
+		}
+		// Feed the roster the LAUNCH CONTEXT actually carries for an initial
+		// member -- session-filtered with staged roles still present -- not a
+		// roster this test narrowed itself. Narrowing here would test the helper
+		// with inputs production never supplies, which is how the staged-spawn
+		// regression reached a full-suite run instead of this one.
+		sessionFiltered := full
+		sessionFiltered.Members, _ = filterMembersBySession(full.Members, session)
+		panePrompt, err := launchBootstrapPrompt(rec, agentDir, project, &preparedLaunchRecordContext{
+			Manifest: manifest, Team: sessionFiltered, Member: member, Binding: binding,
+		})
+		if err != nil {
+			t.Fatalf("pane render for %s: %v", member.Role, err)
+		}
+		got := digestRunArtifactBytes([]byte(panePrompt))
+		want := manifest.BootstrapDigests[member.Role]
+		if got == want {
+			t.Logf("staged roster present, role %s: pane render matches the accepted digest", member.Role)
+			continue
+		}
+		t.Errorf("#618 STAGED-ROSTER DIVERGENCE: role %s pane render does not match the accepted digest", member.Role)
+		t.Errorf("  accepted=%s pane=%s", want, got)
+		t.Errorf("  accepted initial roster: %v", manifest.InitialRoster)
+		t.Errorf("  accepted staged roster:  %v", manifest.StagedRoster)
+		acceptedPrompt, renderErr := preparedBootstrap(project, profile, session, binding, acceptedRoster, member,
+			acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology})
+		if renderErr != nil {
+			continue
+		}
+		for i, line := range diffPromptLines(acceptedPrompt, panePrompt) {
+			if i > 15 {
+				t.Errorf("  ... truncated")
+				break
+			}
+			t.Errorf("  %s", line)
+		}
+	}
+
+	// STAGED MEMBERS ARE OUT OF SCOPE FOR THIS PR AND DELIBERATELY NOT ASSERTED.
+	// launchBootstrapPrompt forks them back to the original bootstrapContextFor
+	// path (see stagedRenderIsForked), because rendering a staged member from
+	// accepted state alone does not reproduce its accepted digest: the accepted
+	// preview pins ActorMode to review while the on-disk profile carries none.
+	// Asserting byte-identity here would fail against behaviour this PR
+	// intentionally leaves untouched. Forked to its own task with the findings.
+}
+
+// prepareStagedRosterFixture618 prepares a run whose accepted manifest carries a
+// non-empty staged roster. The staged split is what makes the two selectors
+// disagree, so a fixture without one cannot express the defect at all.
+func prepareStagedRosterFixture618(t *testing.T) string {
+	t.Helper()
+	return prepareStagedRosterFixture618Shape(t, runwizard.LaunchShapeWorkingTeamTogether)
+}
+
+// prepareStagedRosterFixture618Shape parameterizes over launch shape because the
+// shape changes the accepted TOPOLOGY, and topology feeds the execution contract
+// that decides "Implementation allowed for you". A staged member under
+// lead-only-staged is not the same subject as a staged member under
+// working-team-together, and testing only the latter is how the staged-spawn
+// regression survived a suite that already had staged coverage.
+func prepareStagedRosterFixture618Shape(t *testing.T, shape string) string {
+	t.Helper()
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "codex", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "codex", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "claude", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	})
+	_, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			// lead-only-staged requires the initial roster to be exactly the lead,
+			// so every non-lead member must be staged under that shape. Under
+			// working-team-together only qa is staged, which leaves a mixed
+			// initial/staged roster -- the two shapes exercise genuinely different
+			// partitions and that is the point of running both.
+			"--launch-shape", shape, "--staged-roles", stagedRolesForShape618(shape),
+			"--goal", "Reproduce #618 render-path roster divergence",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	})
+	if err != nil {
+		t.Fatalf("prepare staged fixture: %v", err)
+	}
+	return dir
+}
+
+// routingHandles618 renders the routing roster as a stable comparable string so
+// a failure names WHICH members differ rather than only that a count moved.
+func routingHandles618(members []bootstrapTeamMember) string {
+	out := make([]string, 0, len(members))
+	for _, m := range members {
+		out = append(out, m.Role+"/"+m.Handle)
+	}
+	return strings.Join(out, ",")
+}
+
+// TestFieldShapeRosterAgreesWhenNothingIsStaged is probe (b): does the
+// CONFIRMED staged-roster divergence explain the 2026-08-02 field hit?
+//
+// The field-hit prepared tree is gone (#598's teardown fix correctly deleted it
+// on reset) and the team profile has been edited since, so neither settles it.
+// The issue transcript does: profile squad-v2-27-0 had three members and
+// --readiness-json reported "all three bootstrap rows drifted". Three members,
+// three initial-roster bootstrap rows, therefore nothing was staged.
+//
+// This reproduces that SHAPE -- three members, all session-matched, no staged
+// roles -- and asks whether the two render paths still disagree.
+//
+//	They AGREE  -> mechanism 1 cannot explain the field hit. A second
+//	               contributor exists and #618 must stay open past the
+//	               staged-roster fix.
+//	They DIFFER -> mechanism 1 explains it after all and my reading of the
+//	               transcript is wrong.
+//
+// Either answer is worth having before a PR body is written, which is why this
+// runs before the fix rather than after it.
+func TestFieldShapeRosterAgreesWhenNothingIsStaged(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{
+			// Built-in roles, deliberately. The field hit used custom roles
+			// (amq-dev-1/amq-dev-2) which require .amq-squad/roles/<role>.md to
+			// exist; staging those files would add a variable this probe is not
+			// testing. What must match the field hit is the SHAPE -- three
+			// members, all session-matched, nothing staged -- not the names.
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Reproduce the #618 field-hit roster shape",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare field-shape fixture: %v", err)
+	}
+
+	profile, session := team.DefaultProfile, "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.StagedRoster) != 0 {
+		t.Fatalf("fixture does not match the field shape: staged roster is %v, want empty", manifest.StagedRoster)
+	}
+	if len(manifest.InitialRoster) != 3 {
+		t.Fatalf("fixture does not match the field shape: initial roster %v, want 3 members", manifest.InitialRoster)
+	}
+
+	full, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(full.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatalf("partition accepted roster: %v", err)
+	}
+	prepareRoster := full
+	prepareRoster.Members = initial
+
+	member := initial[0]
+	rec := launch.Record{
+		Role: member.Role, Handle: memberHandle(member), Binary: member.Binary,
+		Session: session, CWD: dir, TeamHome: dir, TeamProfile: profile,
+		SharedWorkstream: true,
+	}
+	prepareTeam, _ := bootstrapCurrentTeamForTeam(rec, prepareRoster)
+	paneTeam, _ := bootstrapCurrentTeamWithRoster(rec, dir, true)
+
+	prepareHandles := routingHandles618(prepareTeam)
+	paneHandles := routingHandles618(paneTeam)
+	if prepareHandles != paneHandles {
+		t.Errorf("UNEXPECTED: the paths diverge even with nothing staged, so mechanism 1 may explain the field hit after all")
+		t.Errorf("  prepare-time: %s", prepareHandles)
+		t.Errorf("  pane-time:    %s", paneHandles)
+		return
+	}
+	t.Logf("field shape: both render paths agree on the routing roster (%s)", prepareHandles)
+	t.Logf("CONCLUSION: the confirmed staged-roster divergence does NOT explain the 2026-08-02 field hit;" +
+		" a second contributor exists and #618 must stay open past that fix")
+}
+
+// TestPromptTextAcrossNamespaceCreation is the mechanism-2 hunt.
+//
+// WHAT EVERY PRIOR PROBE EXCLUDED, so this one is aimed rather than hopeful:
+// the routing roster (proved identical in the field shape), bootstrapContextFor's
+// exactSessionRoster stat (dead on all three prepared paths), role/launch
+// ExistingPath (same string in both reachable cases), timestamps (#598's
+// determinism test passes and a clock input would drift EVERY render), the
+// amq env root_id/base_root_id delta (real, but discarded by the amqEnv
+// unmarshal), and the staged projection plus execution-contract roster width
+// (both no-ops when nothing is staged).
+//
+// WHAT SURVIVES: routeExplainCommand (bootstrap.go:595-603) shells out to
+// `amq route explain --json` ONCE PER PEER and splices the result verbatim into
+// that peer's send: line. Its answer depends on the AMQ root and the peer
+// mailboxes actually existing. Preparation runs before they do; `agent up`
+// re-renders after. That is the last live-state input inside the render.
+//
+// WHY THIS IS NOT rc1_bisect's EXCLUDED DELTA 3: that fixture materializes the
+// agent extension directory, role.md and launch.json, but never initializes AMQ
+// MAILBOXES. `amq route explain` does not care about role.md; it cares about
+// mailbox structure under the root. So delta 3 crossed a different boundary than
+// the one the send: lines actually depend on, and its exclusion does not cover
+// this. Stated explicitly so this is not read as re-deriving settled evidence.
+//
+// Reports the diff rather than asserting a shape: if the differing lines are
+// send: lines, mechanism 2 is found. If the diff is EMPTY, mechanism 2 is not a
+// render input at all and the fix design has to look at what "accepted" bytes
+// were persisted versus re-derived, which is decisive either way.
+func TestPromptTextAcrossNamespaceCreation(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Hunt #618 mechanism 2 across namespace creation",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare fixture: %v", err)
+	}
+
+	profile, session := team.DefaultProfile, "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(tm.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Members = initial
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	member := initial[0]
+	before, err := preparedBootstrap(dir, profile, session, binding, tm, member, accepted)
+	if err != nil {
+		t.Fatalf("render before namespace creation: %v", err)
+	}
+
+	// Create what a real launch creates and the existing fixtures do not: the AMQ
+	// root with a real mailbox for every peer. This is the state `amq route
+	// explain` answers against.
+	root := squadnamespace.AMQRoot(dir, profile, session)
+	for _, m := range tm.Members {
+		handle := memberHandle(m)
+		for _, sub := range []string{"inbox/cur", "inbox/new", "inbox/tmp", "outbox"} {
+			if err := os.MkdirAll(filepath.Join(root, "agents", handle, sub), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	after, err := preparedBootstrap(dir, profile, session, binding, tm, member, accepted)
+	if err != nil {
+		t.Fatalf("render after namespace creation: %v", err)
+	}
+
+	if digestRunArtifactBytes([]byte(before)) == digestRunArtifactBytes([]byte(after)) {
+		t.Logf("render is STABLE across namespace creation for role %s", member.Role)
+		t.Logf("mechanism 2 is NOT a render input across this boundary; look at persisted-vs-rederived accepted bytes")
+		return
+	}
+
+	lines := diffPromptLines(before, after)
+	sendLines := 0
+	for _, line := range lines {
+		if strings.Contains(line, "send:") || strings.Contains(line, "amq send") {
+			sendLines++
+		}
+	}
+	t.Errorf("MECHANISM 2 CANDIDATE: prompt text for role %s CHANGES across namespace creation", member.Role)
+	t.Errorf("  before sha256=%s", digestRunArtifactBytes([]byte(before)))
+	t.Errorf("  after  sha256=%s", digestRunArtifactBytes([]byte(after)))
+	t.Errorf("  %d differing line(s), %d of them routing send: lines", len(lines), sendLines)
+	for i, line := range lines {
+		if i > 25 {
+			t.Errorf("  ... further differences truncated")
+			break
+		}
+		t.Errorf("  %s", line)
+	}
+}
+
+// TestNamedProfileRenderAcrossNamespaceCreation is the one follow-up iteration
+// the timebox allows, aimed at a variable every previous probe held constant.
+//
+// ALL of my probes so far used team.DefaultProfile. The 2026-08-02 field hit used
+// the NAMED profile squad-v2-27-0. That is not a cosmetic difference:
+// resolveAMQEnvForTeamLaunchProfile (amq_env.go:49-87) BRANCHES on it. The default
+// profile asks real `amq env` and can fall back to a synthesized
+// "fresh_project_default" envelope when AMQ cannot determine a root; a named
+// profile takes resolveAMQEnvForTeamProfile and a deterministic
+// squadnamespace.AMQRoot instead. Two different resolvers feed the root that is
+// embedded throughout the rendered prompt.
+//
+// I noticed this branch in my first hour and never came back to it, which is
+// why it is worth one run: a variable held constant across every probe is
+// exactly where a surviving mechanism hides.
+func TestNamedProfileRenderAcrossNamespaceCreation(t *testing.T) {
+	const profile = "squad-probe-618"
+	dir := t.TempDir()
+	if err := team.WriteProfile(dir, profile, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		// The shared-cwd exception is required, not incidental: three
+		// mutation-capable members in one directory is otherwise a readiness
+		// BLOCKER, and the field-hit profile squad-v2-27-0 carried exactly this
+		// exception. Without it the fixture fails on worktree_isolation before it
+		// can say anything about bootstrap drift.
+		SharedCwdException: "probe fixture: single-directory squad matching the #618 field-hit profile",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	}); err != nil {
+		t.Fatalf("seed named profile: %v", err)
+	}
+	prepStdout, prepStderr, prepErr := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", profile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Hunt #618 mechanism 2 under a NAMED profile",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	})
+	if prepErr != nil {
+		// Print the blocked rows rather than only the summary. "artifact readiness
+		// failed after preparation" on a fresh NAMED-profile namespace is itself
+		// #618's shape, so the rows are the evidence, not noise to be swallowed.
+		t.Errorf("prepare named-profile fixture: %v", prepErr)
+		t.Errorf("--- stdout ---\n%s", prepStdout)
+		t.Errorf("--- stderr ---\n%s", prepStderr)
+		return
+	}
+
+	session := "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(tm.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Members = initial
+	binding := acceptedGoalBinding{
+		Text: manifest.GoalText, Source: manifest.GoalSource,
+		Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+	}
+	accepted := acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology}
+
+	for _, member := range initial {
+		before, err := preparedBootstrap(dir, profile, session, binding, tm, member, accepted)
+		if err != nil {
+			t.Fatalf("render %s before namespace creation: %v", member.Role, err)
+		}
+		acceptedDigest := manifest.BootstrapDigests[member.Role]
+		if got := digestRunArtifactBytes([]byte(before)); got != acceptedDigest {
+			t.Errorf("MECHANISM 2 FOUND (named profile, pre-creation): role %s re-render already differs"+
+				" from the digest preparation accepted", member.Role)
+			t.Errorf("  accepted=%s regenerated=%s", acceptedDigest, got)
+			return
+		}
+	}
+
+	root := squadnamespace.AMQRoot(dir, profile, session)
+	for _, m := range tm.Members {
+		handle := memberHandle(m)
+		for _, sub := range []string{"inbox/cur", "inbox/new", "inbox/tmp", "outbox"} {
+			if err := os.MkdirAll(filepath.Join(root, "agents", handle, sub), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	for _, member := range initial {
+		after, err := preparedBootstrap(dir, profile, session, binding, tm, member, accepted)
+		if err != nil {
+			t.Fatalf("render %s after namespace creation: %v", member.Role, err)
+		}
+		acceptedDigest := manifest.BootstrapDigests[member.Role]
+		got := digestRunArtifactBytes([]byte(after))
+		if got == acceptedDigest {
+			t.Logf("named profile, role %s: render still matches the accepted digest after namespace creation", member.Role)
+			continue
+		}
+		t.Errorf("MECHANISM 2 FOUND (named profile): role %s drifts from the accepted digest"+
+			" once the namespace exists -- the field-hit signature", member.Role)
+		t.Errorf("  accepted=%s regenerated=%s", acceptedDigest, got)
+		before, _ := preparedBootstrap(dir, profile, session, binding, tm, member, accepted)
+		for i, line := range diffPromptLines(before, after) {
+			if i > 25 {
+				t.Errorf("  ... truncated")
+				break
+			}
+			t.Errorf("  %s", line)
+		}
+	}
+}
+
+// TestPanePathRenderMatchesAcceptedDigest renders the PANE path, which no probe
+// and no existing fixture has ever rendered.
+//
+// Everything so far compared preparedBootstrap against preparedBootstrap and
+// found the render deterministic across every boundary I could build: default
+// profile, named profile, spawn materialization, real AMQ mailboxes. That
+// establishes preparedBootstrap is stable. It says NOTHING about the path that
+// actually runs in the pane, because the pane does not call preparedBootstrap.
+//
+// launch.go:697-701 builds the context with bootstrapContextFor and then
+// overrides exactly ONE thing (CurrentTeam+Warnings). preparedBootstrap
+// overrides FIVE (CurrentTeam+Warnings, Execution, ActorExecution, PlannerLead,
+// MutationCapable). So four fields reach the pane prompt straight from
+// bootstrapContextFor, which reads live state, while the ACCEPTED digest was
+// computed with team-derived replacements for those same four fields.
+//
+// If mechanism 2 is anywhere, it is in those four fields, and this is the first
+// comparison that can see them.
+//
+// WHAT IN THIS TEST'S DIFF IS THE TEST'S OWN FAULT. Recorded so a reader does
+// not attribute fixture noise to the product. The launch.Record below is
+// hand-built to mirror preparedBootstrap's construction, and it does not mirror
+// it exactly, so three diff lines are MINE:
+//   - the CWD spelling (/var vs /private/var): preparedBootstrap runs
+//     canonicalDir on the member cwd; this rec does not.
+//   - relative vs absolute AMQ root in the role/launch paths: preparedBootstrap
+//     takes root from resolveAMQEnvForTeamLaunchProfile; this rec sets it directly.
+//   - "native_goal" vs "native_goal_missing": preparedBootstrap sets
+//     rec.GoalBinding for the lead; this rec leaves it empty.
+//
+// NOT the test's fault, and the reason this test exists: the routing block
+// collapsing to "send: unavailable" in the ACCEPTED prompt. That comes from
+// bootstrapCurrentTeamForTeam comparing samePath(rec.CWD, m.EffectiveCWD(...))
+// where run_start_readiness.go:1103 resolved one side through canonicalDir and
+// bootstrap.go:493 left the other raw. That asymmetry is real code and holds
+// however the record was built.
+func TestPanePathRenderMatchesAcceptedDigest(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		SharedCwdException: "probe fixture: single-directory squad matching the #618 field-hit profile",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "senior-dev", Handle: "senior-dev", Binary: "claude", Session: "prepared", CWD: ""},
+			{Role: "qa", Handle: "qa", Binary: "codex", Session: "prepared", CWD: "", ToolProfile: team.ToolProfileFull},
+		},
+	})
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Render the pane path for #618 mechanism 2",
+			"--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare fixture: %v", err)
+	}
+
+	profile, session := team.DefaultProfile, "prepared"
+	manifest, err := readPreparedRunManifest(dir, profile, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm, err := team.ReadProfile(dir, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, err := partitionPreparedRunMembers(tm.Members, session, manifest.StagedRoster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tm.Members = initial
+
+	// Materialize what spawn writes, so the pane render sees the world the pane
+	// actually sees.
+	root := squadnamespace.AMQRoot(dir, profile, session)
+	for _, m := range tm.Members {
+		handle := memberHandle(m)
+		materializeSpawnState(t, dir, profile, session, handle, m.Role)
+		for _, sub := range []string{"inbox/cur", "inbox/new", "inbox/tmp", "outbox"} {
+			if err := os.MkdirAll(filepath.Join(root, "agents", handle, sub), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	for _, member := range initial {
+		handle := memberHandle(member)
+		agentDir := filepath.Join(root, "agents", handle)
+		// rec mirrors preparedBootstrap's construction (run_start_readiness.go:1129-1136)
+		// so the ONLY difference between the two renders is which fields get
+		// overridden, not the record they are derived from.
+		rec := launch.Record{
+			Role: member.Role, Handle: handle, Binary: member.Binary,
+			ToolProfile: member.EffectiveToolProfile(), ToolConfig: member.ToolConfig,
+			Session: session, CWD: dir, Root: root,
+			TeamHome: dir, TeamProfile: profile, SharedWorkstream: true,
+		}
+		// Drive the REAL pane renderer, not a hand-assembled imitation of it.
+		// The first version of this test rebuilt launch.go's context inline, which
+		// meant it could pass while the shipped path still diverged -- a test of my
+		// reconstruction rather than of the product. launchBootstrapPrompt IS what
+		// the pane calls.
+		panePrompt, err := launchBootstrapPrompt(rec, agentDir, dir, &preparedLaunchRecordContext{
+			Manifest: manifest,
+			Team:     tm,
+			Member:   member,
+			Binding: acceptedGoalBinding{
+				Text: manifest.GoalText, Source: manifest.GoalSource,
+				Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+			},
+		})
+		if err != nil {
+			t.Fatalf("pane render for %s: %v", member.Role, err)
+		}
+		paneDigest := digestRunArtifactBytes([]byte(panePrompt))
+		acceptedDigest := manifest.BootstrapDigests[member.Role]
+		if paneDigest == acceptedDigest {
+			t.Logf("role %s: PANE render matches the accepted digest", member.Role)
+			continue
+		}
+
+		binding := acceptedGoalBinding{
+			Text: manifest.GoalText, Source: manifest.GoalSource,
+			Digest: manifest.GoalDigest, Namespace: manifest.GoalNamespace,
+		}
+		acceptedPrompt, renderErr := preparedBootstrap(dir, profile, session, binding, tm, member,
+			acceptedRunContext{Version: manifest.Environment.BinaryVersion, Topology: manifest.Topology})
+		t.Errorf("MECHANISM 2: role %s PANE render does NOT match the accepted digest", member.Role)
+		t.Errorf("  accepted(prepare path)=%s", acceptedDigest)
+		t.Errorf("  generated(pane path)  =%s", paneDigest)
+		if renderErr != nil {
+			t.Errorf("  (could not re-render accepted prompt for a diff: %v)", renderErr)
+			continue
+		}
+		for i, line := range diffPromptLines(acceptedPrompt, panePrompt) {
+			if i > 30 {
+				t.Errorf("  ... truncated")
+				break
+			}
+			t.Errorf("  %s", line)
+		}
+	}
+}
+
+// stagedRolesForShape618 returns the staged roles a shape's proposal will accept.
+func stagedRolesForShape618(shape string) string {
+	if shape == runwizard.LaunchShapeLeadOnlyStaged {
+		return "senior-dev,qa"
+	}
+	return "qa"
+}

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -559,9 +559,12 @@ func runLeadRegisterWithPreparedToken(args []string, requestedPreparedToken prep
 	rec.GoalBinding = preparedBinding
 	preparedPrompt := ""
 	if preparedContext != nil {
-		bootstrapContext := bootstrapContextFor(rec, agentDir, projectDir)
-		bootstrapContext.CurrentTeam, bootstrapContext.Warnings = bootstrapCurrentTeamWithRoster(rec, projectDir, true)
-		preparedPrompt, err = buildBootstrapPrompt(bootstrapContext)
+		// #618: the external-lead adoption path is the THIRD render site and had
+		// the same one-of-five override defect as the pane path. It renders
+		// through the shared accepted-state renderer for the same reason: the
+		// prompt must be a function of what preparation accepted, not of the
+		// live process that happens to be adopting the pane.
+		preparedPrompt, err = launchBootstrapPrompt(rec, agentDir, projectDir, preparedContext)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Render prepared launches from accepted state (#618)

A fresh-namespace `run start --prepare` then `--go` bricked: every pane died validating its own
bootstrap against the preview preparation had just accepted, retrying reproduced it exactly, and the
only way through was abandoning the gated path.

## The render was already deterministic

Proved before writing any fix: rendering the same member before and after namespace creation —
under default *and* named profiles, with and without real AMQ mailboxes — produces byte-identical
prompts.

So the drift is not one render seeing a changed world. It is **two renders handed different
inputs** — an asymmetry between call sites, not a determinism problem inside any one of them. A fix
aimed at the namespace boundary would have been a no-op.

Worth stating up front because #618 reasonably reads the symptom the other way. The operator
diagnosed it from a bricked namespace with two opaque sha256s and no diff tooling — which is #609,
still open, and the diagnosis-tooling half of this fix.

## The defect

Three call sites each assembled the prompt context themselves:

| site | context overrides | record |
|---|---|---|
| `preparedBootstrap` (computes the accepted digest) | **5** | `rec.CWD = canonicalDir(...)` — resolved |
| `launch.go` (pane) | **1** | `rec.CWD = os.Getwd()` — raw |
| `team_lead.go` (external lead) | **1** | same |

Four context fields (`Execution`, `ActorExecution`, `PlannerLead`, `MutationCapable`) plus two
rendered record fields reached the pane prompt from a world preparation never saw. `os.Getwd` honours
`$PWD`, so it returns *the spelling the operator's shell was carrying* — which is why the field hit
was fresh-namespace shaped, and why the field profile's recorded path case mattered.

## What changed

- **Prepared launches render through `preparedBootstrap` itself**, fed from the
  `preparedLaunchRecordContext` that already carried `Manifest`, `Team`, `Member`, `Binding`.
  Byte-identity is **constructional**, not three call sites agreeing to stay in step — the property
  that kept failing.
- `team_lead.go`'s external-lead path had the identical defect and is converted. It was the third
  site and would have been the next occurrence.
- Unprepared launches keep `bootstrapContextFor` unchanged: no accepted preview exists there for
  live-state reads to contradict.
- `acceptedRenderRoster` mirrors `buildPreparedRunManifest`'s per-member-class roster selection. The
  launch context does **not** already match it — its initial branch carries a session-filtered roster
  with staged roles still present, which would have rendered initial members against a roster
  preparation excluded. Found by this PR's own `-race` run, not by review.

## The accepted roster is read, not re-derived

`acceptedRenderRoster` selects `prepared.Team` members whose role appears in **`Manifest.InitialRoster`**
— the accepted artifact itself. It does not re-run `partitionPreparedRunMembers`.

That distinction was found in peer review, and the re-derivation was a real defect. The partition
helper exists to *validate a full profile* and requires every staged role to be present in the members
it is handed. `preparedContextForLaunchRecord` legitimately narrows the roster to the active session's
members, so a staged role pinned to **another** session is correctly absent — and the partition
refused a launch preparation had explicitly accepted:

```
staged role "qa" has no complete profile member definition
```

Worth recording that the intermediate state was **worse than what preceded it**: while the error was
swallowed, the result was a wrong roster but a launch that proceeded; propagating it turned a silent
wrong answer into a refused launch for an accepted shape. The review item asking for propagation was
right about the code as it stood; implementing it without checking which errors were *reachable* was
not.

**The error that remains is a different kind.** A staged role missing from the narrowed roster is
**normal** — it belongs to another session. An **initial** role missing is **irreproducible**: the
accepted manifest names a member the launch context cannot supply, so the accepted digest could not be
reproduced even in principle. That refuses and names the role.

The alternative — letting it render a short roster and fail closed at the digest gate — was considered
and rejected. A short roster produces a **well-formed-looking prompt that routes to nobody**, reported
as an opaque digest mismatch. That is precisely the reads-like-corruption misdirection this issue
exists to eliminate; building a new instance of it into the fix would be self-defeating.

## Two adjacent paths, checked structurally

Neither needs a test, and saying why is more useful than a green assertion:

- **The staged branch cannot reach this code.** `stagedRenderIsForked` returns at the top of
  `launchBootstrapPrompt`, before any roster selection. A test asserting a call that never occurs
  would be a test of nothing.
- **`team_lead.go` is the same path, not a parallel one.** It builds its context from the same
  `preparedContextForLaunchRecord` and calls the same `launchBootstrapPrompt`, so it receives this fix
  by construction rather than by duplication.

## Scope: staged members are forked out

Staged members keep the shipped path **byte-for-byte**, so this change has zero regression surface
there. Rendering them from accepted state does not reproduce their accepted digest: preparation pins
a staged member's `ActorMode` to `review`, the on-disk profile carries none (resolving to
`implementation`), and the existing path agrees with the digest only by projecting the staged
**claim** — runtime admission state that cannot exist at preparation time and therefore must not be
what a digest-checked body depends on.

Settled by instrumenting both renders: identical rosters, identical execution and lead mode, one
differing field. Forked with that evidence rather than guessed at under a deadline.

## Evidence

**Behavioural bisect.** `bootstrap_routing_canonical_618_test.go` fails at this PR's parent and
passes with the fix. Both tests report the real defect — every peer line reading
`send: unavailable (AMQ project identity is missing...)` in a squad where all members share one
checkout — and they assert the routing *property* rather than digest equality, deliberately: two
identically-broken prompts would satisfy every digest check here while shipping a squad that cannot
coordinate.

**Property tests.** The render-identity tests in `prepared_render_identity_618_test.go` cannot fail
at the parent — `launchBootstrapPrompt` does not exist there — so they are property tests of the new
renderer, not bisecting evidence. Labelled as such rather than presented as proof.

**Parent reproduction, documented and re-runnable.** With this fix removed at the parent, a probe
replicating the old pane render inline shows #618 reproducing for all three roles with
accepted-vs-pane digests printed. It cannot ship as a test: with the fix applied it still fails,
because it drives the *old* path directly, which this PR deliberately leaves in place for unprepared
launches.

**An operator-entrypoint regression was attempted and abandoned**, for a structural reason worth
recording: `agent up` re-resolves AMQ identity under admission against the *process* working
directory (`launch.go:502-513`) and refuses before reaching bootstrap validation; `t.Chdir` does not
clear it. Making it work means replicating the staged path's claim machinery or bending the admission
gate in test-only ways. Filed as a follow-up — that check compares unresolved paths, the same
path-normalization family as #617 and #618, in a third place.

**`-race`:** clean at the exact head (`516.791s`, zero data races, zero failures). Not verification of
this fix — #618 is not concurrency-class — but suite-reliability data, and it earned its place twice
on this branch by catching defects every focused test missed.

## A dropped commit

A defensive `samePath`/`sameLaunchTarget` canonicalization originally shipped with those guards. It
was load-bearing at `f8b0911` and is **not** at the current base: #621 canonicalizes the profile path
and `run start` restamps recorded member CWDs on ingestion, so both operands are already canonical
however the operator spelled them. Verified by bisect — the explicit-recorded-CWD case passes with
and without it. Hardening with no reachable failing state does not ship in a release-critical PR.

## Durable negative evidence

Ruled out while hunting this, recorded so nobody re-derives it:

- the routing **roster** — identical in the field shape (three members, session-matched, nothing staged)
- `bootstrapContextFor`'s `exactSessionRoster` `os.Stat` — **dead**; all three prepared paths override
  `CurrentTeam` immediately after
- `role.ExistingPath` / `launch.ExistingPath` — same string in both reachable cases
- any timestamp — #598's determinism test passes, and a clock input would drift *every* render
- `amq env`'s `root_id`/`base_root_id` — genuinely differ across the boundary, but discarded by the
  `amqEnv` unmarshal
- the staged projection and execution-contract roster width — no-ops when nothing is staged
- prompt render across `materializeSpawnState` — already excluded as `rc1_bisect` delta 3

## The seam has three sides

| site | state |
|---|---|
| `canonicalDir` (`team.go`) | normalized by #617 / #621 |
| `m.EffectiveCWD(...)` (`bootstrap.go:493`) | raw, from `team.json` |
| `os.Getwd()` (`launch.go:339`) | raw, from the process |

An early read of this evidence claimed #617 and #618 were the same bug. That was **verified against
#621's exact head and disproved**: same family, same seam, one side each.

## Scope

Does **not** close #618. The `GenerationRef` consequence — gated-path launches must produce records
carrying a usable task-lifecycle `GenerationRef` — is a different surface, untouched here, and
recorded on the issue.

Refs #618, #598, #617, #609.
