### PR TITLE
fix(cli): preserve shared CWD exception in profile clones

### DIFF
--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -791,6 +791,7 @@ func runRunStart(args []string, version string) error {
 			if proposalTeam.Members, err = applyRunStartCloneEffort(project, proposalTeam.Members, *effortFlag); err != nil {
 				return err
 			}
+			applyRunStartCloneSharedCwdException(&proposalTeam, *sharedCwdExceptionFlag)
 			// A cloned roster keeps the source's own lead/lead-mode (part of the
 			// cloned "launch shape") unless the operator explicitly overrides them.
 			if explicitLead != "" {
@@ -1019,7 +1020,7 @@ func runRunStart(args []string, version string) error {
 		result, err := executeRunPreparationTransaction(project, profile, session, preparationProposal.MutationPaths, preparedRunPath(project, profile, session), func() (runReadinessResult, error) {
 			if freshRoster {
 				quietNotice("preparing accepted roster; no panes will launch...\n")
-				if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
+				if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, *sharedCwdExceptionFlag, newTeamArgs); err != nil {
 					return runReadinessResult{}, err
 				}
 			} else if len(newTeamArgs) > 0 {
@@ -1098,7 +1099,7 @@ func runRunStart(args []string, version string) error {
 		}
 		if freshRoster {
 			quietNotice("creating roster...\n")
-			if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
+			if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, *sharedCwdExceptionFlag, newTeamArgs); err != nil {
 				return err
 			}
 		} else if len(newTeamArgs) > 0 {
@@ -1174,7 +1175,7 @@ func runRunStart(args []string, version string) error {
 	// 1) roster
 	if freshRoster {
 		quietNotice("creating roster...\n")
-		if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, newTeamArgs); err != nil {
+		if err := runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, cloneLeadModeOverride, *effortFlag, *sharedCwdExceptionFlag, newTeamArgs); err != nil {
 			return err
 		}
 		if err := applyRunStartToolProfiles(project, profile, *toolProfileFlag); err != nil {
@@ -1668,9 +1669,9 @@ func runStartRolesFixArg(roles string) string {
 // and explicitLeadMode override the cloned source's own lead/lead-mode only
 // when the operator passed --lead / --lead-mode; otherwise the clone keeps
 // the source roster's lead as part of its cloned launch shape.
-func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, explicitLeadMode, effort string, newTeamArgs []string) error {
+func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitLead, explicitLeadMode, effort, sharedCwdException string, newTeamArgs []string) error {
 	if strings.TrimSpace(fromProfile) != "" {
-		return runStartCloneRosterProfile(project, profile, fromProfile, session, explicitLead, explicitLeadMode, effort)
+		return runStartCloneRosterProfile(project, profile, fromProfile, session, explicitLead, explicitLeadMode, effort, sharedCwdException)
 	}
 	return runNew(newTeamArgs)
 }
@@ -1679,7 +1680,7 @@ func runStartCreateFreshRoster(project, profile, session, fromProfile, explicitL
 // the source profile's roster shape and write it under targetProfile, pinned
 // to session. Goal binding, brief, prepared generations, and launch records
 // are never part of team.Team and are therefore never touched here.
-func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, explicitLead, explicitLeadMode, effort string) error {
+func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, explicitLead, explicitLeadMode, effort, sharedCwdException string) error {
 	source, err := team.ReadProfile(project, sourceProfile)
 	if err != nil {
 		return fmt.Errorf("read source profile %q: %w", sourceProfile, err)
@@ -1701,6 +1702,7 @@ func runStartCloneRosterProfile(project, targetProfile, sourceProfile, session, 
 	if cloned.Members, err = applyRunStartCloneEffort(project, cloned.Members, effort); err != nil {
 		return err
 	}
+	applyRunStartCloneSharedCwdException(&cloned, sharedCwdException)
 	if err := team.WriteProfile(project, targetProfile, cloned); err != nil {
 		return fmt.Errorf("write cloned profile %q: %w", targetProfile, err)
 	}
@@ -2040,4 +2042,15 @@ func applyRunStartCloneEffort(project string, members []team.Member, effort stri
 		return nil, err
 	}
 	return applyLaunchEffortOverridesCatalogMode(members, overrides, loadAgentCatalogAndWarn(project), false)
+}
+
+// applyRunStartCloneSharedCwdException applies an explicit creation-time
+// exception to the effective clone. An omitted flag preserves the source
+// profile's inherited value; explicit operator input wins without rewriting
+// that source. Proposal and materialization both use this helper so readiness
+// cannot accept a different roster contract from the one persisted (#607).
+func applyRunStartCloneSharedCwdException(cloned *team.Team, explicit string) {
+	if reason := strings.TrimSpace(explicit); reason != "" {
+		cloned.SharedCwdException = reason
+	}
 }

--- a/internal/cli/run_start_from_profile_test.go
+++ b/internal/cli/run_start_from_profile_test.go
@@ -23,7 +23,7 @@ func TestRunStartCloneRosterProfileWritesRestampedRoster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "", "", ""); err != nil {
+	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "", "", "", ""); err != nil {
 		t.Fatalf("runStartCloneRosterProfile: %v", err)
 	}
 
@@ -66,7 +66,7 @@ func TestRunStartCloneRosterProfileHonorsExplicitLeadOverride(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "qa", "", ""); err != nil {
+	if err := runStartCloneRosterProfile(dir, "release-squad-v2", "release-squad", "v2", "qa", "", "", ""); err != nil {
 		t.Fatalf("runStartCloneRosterProfile: %v", err)
 	}
 	cloned, err := team.ReadProfile(dir, "release-squad-v2")
@@ -123,6 +123,72 @@ func TestRunStartFromProfileAndRolesConflict(t *testing.T) {
 	err := runRunStart([]string{"-p", dir, "-s", "v2", "-P", "release-squad-v2", "--from-profile", "release-squad", "--roles", "cto"}, "test")
 	if err == nil || !strings.Contains(err.Error(), "exactly one") {
 		t.Fatalf("expected a conflicting-roster-source refusal, got %v", err)
+	}
+}
+
+// #607: run start accepted --shared-cwd-exception alongside --from-profile,
+// but only forwarded the flag through the --roles/new-team path. The clone
+// path silently discarded it and preparation later failed the shared-worktree
+// readiness check. Drive the stable operator entry point and assert the
+// recorded effect, not merely the absence of that later refusal. The source
+// carries a different exception so the test also pins precedence: explicit
+// operator input overrides the inherited value without rewriting the source.
+func TestRunStartFromProfileRecordsSharedCwdExceptionOnTargetOnly(t *testing.T) {
+	dir := t.TempDir()
+	const (
+		sourceProfile   = "release-squad"
+		targetProfile   = "release-squad-v2"
+		inheritedReason = "source roster shares a checkout for its original session"
+		explicitReason  = "cto owns the shared checkout; qa is review-only"
+	)
+	if err := team.WriteProfile(dir, sourceProfile, team.Team{
+		Orchestrated:       true,
+		Lead:               "cto",
+		SharedCwdException: inheritedReason,
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "v1"},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "v1"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := team.ProfilePath(dir, sourceProfile)
+	sourceBefore, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir,
+			"--profile", targetProfile,
+			"--session", "v2",
+			"--from-profile", sourceProfile,
+			"--shared-cwd-exception", explicitReason,
+			"--launch-shape", "working-team-together",
+			"--goal", "Verify the cloned shared-worktree exception",
+			"--visibility", "detached",
+			"--prepare",
+		}, "test")
+	})
+	if err != nil {
+		t.Fatalf("run start --from-profile --shared-cwd-exception --prepare: %v", err)
+	}
+
+	cloned, err := team.ReadProfile(dir, targetProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cloned.SharedCwdException != explicitReason {
+		t.Fatalf("target SharedCwdException = %q, want explicit override %q", cloned.SharedCwdException, explicitReason)
+	}
+
+	sourceAfter, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceAfter) != string(sourceBefore) {
+		t.Fatalf("--from-profile rewrote the source profile\nbefore:\n%s\nafter:\n%s", sourceBefore, sourceAfter)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the source shared-CWD exception when cloning with --from-profile
- let an explicit --shared-cwd-exception override the inherited value on the target only
- apply the same override during proposal and materialization so readiness validates the persisted contract
- add an operator-entrypoint regression test that also proves the source profile remains byte-identical

## Tests

- go test ./internal/cli/ -run '^(TestRunStartCloneRosterProfile|TestRunStartFromProfile)' -count=1 -v
- go test ./internal/cli/ -run '^(TestRunStartEffortIsActuallyAppliedToTheClonedRoster|TestRunStartFromProfileRecordsSharedCwdExceptionOnTargetOnly)$' -count=1 -v
- git diff --check

Closes #607