### PR TITLE
Normalize unknown-subcommand errors across the CLI (#561)

### DIFF
--- a/internal/cli/activity.go
+++ b/internal/cli/activity.go
@@ -40,7 +40,7 @@ new one; stale or malformed files never imply progress.
 	case "clear":
 		return runActivityClear(args[1:])
 	default:
-		return usageErrorf("unknown 'activity' subcommand: %q. Try set or clear.", args[0])
+		return unknownSubcommandError("activity", args[0], "set", "clear")
 	}
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -26,7 +26,7 @@ func runAgent(args []string) error {
 	case "resume":
 		return runAgentResume(args[1:])
 	default:
-		return usageErrorf("unknown 'agent' subcommand: %q. Try 'up' or 'resume'.", args[0])
+		return unknownSubcommandError("agent", args[0], "up", "resume")
 	}
 }
 

--- a/internal/cli/amq.go
+++ b/internal/cli/amq.go
@@ -137,7 +137,11 @@ func runAMQ(args []string) error {
 	case "cleanup":
 		return runAMQCleanup(args[1:])
 	default:
-		return usageErrorf("unknown amq subcommand %q. Use env, ops, route, who, presence, send, reply, drain, watch, list, read, thread, receipts, dlq, or cleanup.", args[0])
+		return unknownSubcommandError(
+			"amq", args[0],
+			"env", "ops", "route", "who", "presence", "send", "reply", "drain",
+			"watch", "list", "read", "thread", "receipts", "dlq", "cleanup",
+		)
 	}
 }
 
@@ -1415,7 +1419,7 @@ func runAMQReceipts(args []string) error {
 	case "wait":
 		return runAMQReceiptsWait(args[1:])
 	default:
-		return usageErrorf("unknown amq receipts subcommand %q. Use list or wait.", args[0])
+		return unknownSubcommandError("amq receipts", args[0], "list", "wait")
 	}
 }
 
@@ -1500,7 +1504,7 @@ func runAMQDLQ(args []string) error {
 	case "purge":
 		return runAMQDLQMutation("purge", args[1:])
 	default:
-		return usageErrorf("unknown amq dlq subcommand %q. Use list, read, retry, retry-all, or purge.", args[0])
+		return unknownSubcommandError("amq dlq", args[0], "list", "read", "retry", "retry-all", "purge")
 	}
 }
 

--- a/internal/cli/amq_test.go
+++ b/internal/cli/amq_test.go
@@ -578,12 +578,16 @@ func TestAMQCleanupRequiresSession(t *testing.T) {
 	}
 }
 
-func TestAMQRejectsUnknownSubcommand(t *testing.T) {
+func TestAMQRejectsUnknownSubcommandWithCompleteCanonicalSurface(t *testing.T) {
 	_, _, err := captureOutput(t, func() error {
 		return runAMQ([]string{"frobnicate"})
 	})
-	if err == nil || !strings.Contains(err.Error(), "unknown amq subcommand") {
-		t.Fatalf("unknown subcommand error = %v", err)
+	if err == nil {
+		t.Fatal("runAMQ() error = nil, want unknown subcommand error")
+	}
+	const want = "unknown 'amq' subcommand: \"frobnicate\". Try 'env', 'ops', 'route', 'who', 'presence', 'send', 'reply', 'drain', 'watch', 'list', 'read', 'thread', 'receipts', 'dlq', or 'cleanup'."
+	if got := err.Error(); got != want {
+		t.Fatalf("runAMQ() error = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,6 +24,45 @@ func usageErrorf(format string, args ...any) error {
 	return UsageError(fmt.Sprintf(format, args...))
 }
 
+// unknownSubcommandError is the single human- and machine-readable contract
+// for commands that reject a subcommand. Callers must supply the complete,
+// ordered set of valid subcommands; accepting an empty or malformed set would
+// make the recovery text authoritative but false (#561).
+func unknownSubcommandError(verb, given string, valid ...string) error {
+	verb = strings.TrimSpace(verb)
+	if verb == "" {
+		panic("unknownSubcommandError: verb must not be empty")
+	}
+	if len(valid) == 0 {
+		panic("unknownSubcommandError: valid subcommands must not be empty")
+	}
+
+	quoted := make([]string, len(valid))
+	seen := make(map[string]struct{}, len(valid))
+	for i, subcommand := range valid {
+		subcommand = strings.TrimSpace(subcommand)
+		if subcommand == "" {
+			panic("unknownSubcommandError: valid subcommand must not be empty")
+		}
+		if _, duplicate := seen[subcommand]; duplicate {
+			panic(fmt.Sprintf("unknownSubcommandError: duplicate valid subcommand %q", subcommand))
+		}
+		seen[subcommand] = struct{}{}
+		quoted[i] = fmt.Sprintf("'%s'", subcommand)
+	}
+
+	var recovery string
+	switch len(quoted) {
+	case 1:
+		recovery = quoted[0]
+	case 2:
+		recovery = quoted[0] + " or " + quoted[1]
+	default:
+		recovery = strings.Join(quoted[:len(quoted)-1], ", ") + ", or " + quoted[len(quoted)-1]
+	}
+	return usageErrorf("unknown '%s' subcommand: %q. Try %s.", verb, given, recovery)
+}
+
 // Run dispatches to a subcommand. flag.ErrHelp from any --help path is
 // swallowed so help output exits 0 across commands.
 //

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,60 @@ import (
 
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
+
+func TestUnknownSubcommandErrorCanonicalFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		verb  string
+		given string
+		valid []string
+		want  string
+	}{
+		{
+			name:  "one",
+			verb:  "team overlay",
+			given: "bogus",
+			valid: []string{"init"},
+			want:  `unknown 'team overlay' subcommand: "bogus". Try 'init'.`,
+		},
+		{
+			name:  "two",
+			verb:  "amq receipts",
+			given: "bogus",
+			valid: []string{"list", "wait"},
+			want:  `unknown 'amq receipts' subcommand: "bogus". Try 'list' or 'wait'.`,
+		},
+		{
+			name:  "many",
+			verb:  "new",
+			given: "bogus",
+			valid: []string{"team", "profile", "session"},
+			want:  `unknown 'new' subcommand: "bogus". Try 'team', 'profile', or 'session'.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := unknownSubcommandError(tt.verb, tt.given, tt.valid...)
+			if err.Error() != tt.want {
+				t.Fatalf("error = %q, want %q", err, tt.want)
+			}
+			var usageErr UsageError
+			if !errors.As(err, &usageErr) {
+				t.Fatalf("error type = %T, want UsageError", err)
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommandErrorRequiresCompleteList(t *testing.T) {
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("unknownSubcommandError accepted an empty valid-subcommand list")
+		}
+	}()
+	_ = unknownSubcommandError("team", "bogus")
+}
 
 func TestRunVersionCommand(t *testing.T) {
 	stdout, stderr, err := captureOutput(t, func() error {

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1003,7 +1003,7 @@ deletes a record that became live or changed after preview.
 	case "cleanup":
 		return runContextCleanup(args[1:])
 	default:
-		return usageErrorf("unknown 'context' subcommand %q; use 'context explain' or 'context cleanup'", args[0])
+		return unknownSubcommandError("context", args[0], "explain", "cleanup")
 	}
 }
 

--- a/internal/cli/evidence.go
+++ b/internal/cli/evidence.go
@@ -113,7 +113,7 @@ recorded dispatch route.
 	case "lookup":
 		return runEvidenceLookup(args[1:])
 	default:
-		return usageErrorf("unknown evidence subcommand %q; use run, show, list, recover, or lookup", args[0])
+		return unknownSubcommandError("evidence", args[0], "run", "show", "list", "recover", "lookup")
 	}
 }
 

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -55,7 +55,7 @@ Examples:
 	case "close":
 		return runGateClose(args[1:])
 	default:
-		return usageErrorf("unknown 'gate' subcommand %q", args[0])
+		return unknownSubcommandError("gate", args[0], "raise", "close")
 	}
 }
 

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -498,7 +498,7 @@ func runGoalWithVersion(args []string, version string) error {
 	case "supervise-resume":
 		return runGoalSuperviseResume(args[1:])
 	default:
-		return usageErrorf("unknown 'goal' subcommand %q. Run 'amq-squad goal --help' for available subcommands.", args[0])
+		return unknownSubcommandError("goal", args[0], "draft", "deliver", "claim", "retry-attempt", "start", "apply", "supervise-resume")
 	}
 }
 

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -364,23 +364,19 @@ func helpSection(t *testing.T, body, startMarker, endMarker string) string {
 	return rest[:end]
 }
 
-func TestGoalUnknownSubcommandMentionsHelp(t *testing.T) {
+func TestGoalUnknownSubcommandEnumeratesCompleteSurface(t *testing.T) {
 	_, _, err := captureOutput(t, func() error { return Run([]string{"goal", "bogus"}, "test") })
-	if err == nil {
-		t.Fatal("goal bogus: want error, got nil")
-	}
-	if !strings.Contains(err.Error(), "--help") {
-		t.Errorf("goal unknown subcommand error should mention --help, got: %v", err)
+	want := `unknown 'goal' subcommand: "bogus". Try 'draft', 'deliver', 'claim', 'retry-attempt', 'start', 'apply', or 'supervise-resume'.`
+	if err == nil || err.Error() != want {
+		t.Fatalf("goal unknown-subcommand error = %v, want %q", err, want)
 	}
 }
 
-func TestOperatorUnknownSubcommandMentionsHelp(t *testing.T) {
+func TestOperatorUnknownSubcommandEnumeratesCompleteSurface(t *testing.T) {
 	_, _, err := captureOutput(t, func() error { return Run([]string{"operator", "bogus"}, "test") })
-	if err == nil {
-		t.Fatal("operator bogus: want error, got nil")
-	}
-	if !strings.Contains(err.Error(), "--help") {
-		t.Errorf("operator unknown subcommand error should mention --help, got: %v", err)
+	want := `unknown 'operator' subcommand: "bogus". Try 'answer', 'self-approve', 'send', 'directive', 'poll', 'status', or 'watch'.`
+	if err == nil || err.Error() != want {
+		t.Fatalf("operator unknown-subcommand error = %v, want %q", err, want)
 	}
 }
 

--- a/internal/cli/namespace_migration_cli.go
+++ b/internal/cli/namespace_migration_cli.go
@@ -27,7 +27,7 @@ func runNamespace(args []string) error {
 		printNamespaceUsage()
 		return nil
 	default:
-		return usageErrorf("unknown namespace subcommand %q: use migrate, recover, or rollback", args[0])
+		return unknownSubcommandError("namespace", args[0], "migrate", "recover", "rollback")
 	}
 }
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -31,7 +31,7 @@ func runNew(args []string) error {
 	case "session":
 		return runNewSession(args[1:])
 	default:
-		return usageErrorf("unknown 'new' subcommand: %q. Try 'team', 'profile', or 'session'.", args[0])
+		return unknownSubcommandError("new", args[0], "team", "profile", "session")
 	}
 }
 

--- a/internal/cli/notifications.go
+++ b/internal/cli/notifications.go
@@ -196,7 +196,7 @@ func runNotifications(args []string) error {
 	case "events", "history":
 		return runNotificationsHistory(args[0], args[1:])
 	default:
-		return usageErrorf("unknown notifications subcommand %q: use doctor, probe, events, or history", args[0])
+		return unknownSubcommandError("notifications", args[0], "doctor", "probe", "events", "history")
 	}
 }
 

--- a/internal/cli/operator.go
+++ b/internal/cli/operator.go
@@ -176,7 +176,7 @@ func runOperator(args []string) error {
 	case "watch":
 		return runOperatorWatch(args[1:])
 	default:
-		return usageErrorf("unknown 'operator' subcommand %q. Run 'amq-squad operator --help' for available subcommands.", args[0])
+		return unknownSubcommandError("operator", args[0], "answer", "self-approve", "send", "directive", "poll", "status", "watch")
 	}
 }
 

--- a/internal/cli/orchestrate.go
+++ b/internal/cli/orchestrate.go
@@ -184,7 +184,7 @@ Preview by default (prints the deterministic bootstrap and launch plan); pass
 	case "status":
 		return runGlobalStatus(args[1:])
 	default:
-		return usageErrorf("unknown 'global' subcommand: %q. Try start or status.", args[0])
+		return unknownSubcommandError("global", args[0], "start", "status")
 	}
 }
 
@@ -490,7 +490,7 @@ separate orchestrator handle or re-points lead state.
 	case "start":
 		return runRunStart(args[1:], version)
 	default:
-		return usageErrorf("unknown 'run' subcommand: %q. Try start.", args[0])
+		return unknownSubcommandError("run", args[0], "start")
 	}
 }
 

--- a/internal/cli/receipt.go
+++ b/internal/cli/receipt.go
@@ -27,7 +27,7 @@ local projection and cannot be discovered by this command.
 		return nil
 	}
 	if args[0] != "show" {
-		return usageErrorf("unknown receipt subcommand %q; use show", args[0])
+		return unknownSubcommandError("receipt", args[0], "show")
 	}
 	return runReceiptShow(args[1:])
 }

--- a/internal/cli/review_worktree.go
+++ b/internal/cli/review_worktree.go
@@ -50,6 +50,19 @@ func runReviewWorktree(args []string, version string) error {
 		printReviewWorktreeUsage()
 		return nil
 	}
+	// review-worktree keeps `create` implicit for ordinary REF invocations, so an
+	// arbitrary first token cannot generally be classified as a subcommand. The
+	// command-surface probe is unambiguous: UNKNOWN followed by help is asking
+	// about a mode, not creating that ref. Enumerate the complete surface there
+	// while preserving bare `review-worktree REF`; `REF --help` intentionally
+	// reaches this probe instead of implicit create (#561).
+	if len(args) > 1 && (args[1] == "-h" || args[1] == "--help" || args[1] == "help") {
+		switch args[0] {
+		case "create", "exec", "shell", "remove":
+		default:
+			return unknownSubcommandError("review-worktree", args[0], "create", "exec", "shell", "remove")
+		}
+	}
 	mode := "create"
 	if len(args) > 0 {
 		switch args[0] {

--- a/internal/cli/review_worktree_test.go
+++ b/internal/cli/review_worktree_test.go
@@ -530,3 +530,13 @@ func TestRunReviewWorktreeExecRequiresCommand(t *testing.T) {
 		t.Fatalf("want missing command usage error, got %v", err)
 	}
 }
+
+func TestRunReviewWorktreeUnknownSubcommandHelpEnumeratesCompleteSurface(t *testing.T) {
+	_, _, err := captureOutput(t, func() error {
+		return Run([]string{"review-worktree", "bogus", "--help"}, "test")
+	})
+	want := `unknown 'review-worktree' subcommand: "bogus". Try 'create', 'exec', 'shell', or 'remove'.`
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -134,7 +134,12 @@ Reconcile never deletes/moves mailbox evidence or auto-resends delivery.
 	case "handoff":
 		return runTaskHandoff(args[1:])
 	default:
-		return usageErrorf("unknown 'task' subcommand: %q. Try add, list, show, claim, renew, event, done, fail, block, reset, cancel, release, deliver, retry-delivery, or reconcile.", args[0])
+		return unknownSubcommandError(
+			"task", args[0],
+			"add", "list", "ls", "show", "claim", "renew", "done", "complete", "event",
+			"fail", "block", "reset", "cancel", "release", "deliver", "retry-delivery",
+			"reconcile", "leadership", "handoff",
+		)
 	}
 }
 

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -53,7 +53,11 @@ func runTeam(args []string) error {
 	default:
 		// Unknown subcommand. Treat as flags to the smart default so
 		// `amq-squad team --help` and similar still work.
-		return usageErrorf("unknown 'team' subcommand: %q. Try 'init', 'resume', 'rules', 'lead', 'overlay', 'member', 'autonomous', 'sync', 'profiles', 'rm', or 'shared-cwd-exception'.", args[0])
+		return unknownSubcommandError(
+			"team", args[0],
+			"init", "resume", "rules", "lead", "overlay", "member", "autonomous",
+			"operator", "sync", "profiles", "rm", "delete", "shared-cwd-exception",
+		)
 	}
 }
 
@@ -2190,7 +2194,7 @@ Examples:
 		}
 		return nil
 	default:
-		return usageErrorf("unknown 'rules' subcommand: %q", args[0])
+		return unknownSubcommandError("team rules", args[0], "init")
 	}
 }
 

--- a/internal/cli/team_autonomous.go
+++ b/internal/cli/team_autonomous.go
@@ -39,7 +39,7 @@ or perform external side effects.
 	case "pause", "resume", "disable":
 		return runTeamAutonomousMutation(args[1:], args[0])
 	default:
-		return usageErrorf("unknown 'team autonomous' subcommand: %q. Try show, pause, resume, or disable.", args[0])
+		return unknownSubcommandError("team autonomous", args[0], "show", "pause", "resume", "disable")
 	}
 }
 

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -151,7 +151,7 @@ team member; use 'team member add' first for dynamic teams.
 	case "show":
 		return runTeamLeadShow(args[1:])
 	default:
-		return usageErrorf("unknown 'team lead' subcommand: %q. Try 'set', 'clear', or 'show'.", args[0])
+		return unknownSubcommandError("team lead", args[0], "set", "clear", "show")
 	}
 }
 
@@ -267,7 +267,7 @@ session root, so child reports create the same attention path spawned agents get
 	case "register":
 		return runLeadRegister(args[1:])
 	default:
-		return usageErrorf("unknown 'lead' subcommand: %q. Try 'register'.", args[0])
+		return unknownSubcommandError("lead", args[0], "register")
 	}
 }
 

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -101,7 +101,11 @@ Examples:
 	case "list", "ls":
 		return runTeamMemberList(args[1:])
 	default:
-		return usageErrorf("unknown 'team member' subcommand: %q. Try 'add', 'update', 'list', or 'rm'.", args[0])
+		return unknownSubcommandError(
+			"team member", args[0],
+			"add", "update", "admit", "replace", "launch", "control-continue",
+			"status", "history", "rm", "remove", "list", "ls",
+		)
 	}
 }
 

--- a/internal/cli/team_operator.go
+++ b/internal/cli/team_operator.go
@@ -24,7 +24,7 @@ func runTeamOperator(args []string) error {
 	case "self":
 		return runTeamOperatorSelf(args[1:])
 	default:
-		return usageErrorf("unknown team operator subcommand %q", args[0])
+		return unknownSubcommandError("team operator", args[0], "set", "self")
 	}
 }
 

--- a/internal/cli/team_overlay.go
+++ b/internal/cli/team_overlay.go
@@ -89,7 +89,7 @@ Examples:
 	case "init":
 		return runTeamOverlayInit(args[1:])
 	default:
-		return usageErrorf("unknown 'team overlay' subcommand: %q. Try 'init'.", args[0])
+		return unknownSubcommandError("team overlay", args[0], "init")
 	}
 }
 

--- a/internal/cli/team_shared_cwd.go
+++ b/internal/cli/team_shared_cwd.go
@@ -39,7 +39,7 @@ members are read-only reviewers). 'clear' returns to the fail-closed default.
 	case "show":
 		return runTeamSharedCwdExceptionShow(args[1:])
 	default:
-		return usageErrorf("unknown 'team shared-cwd-exception' subcommand: %q. Try 'set', 'clear', or 'show'.", args[0])
+		return unknownSubcommandError("team shared-cwd-exception", args[0], "set", "clear", "show")
 	}
 }
 

--- a/internal/cli/unknown_subcommand_producers_test.go
+++ b/internal/cli/unknown_subcommand_producers_test.go
@@ -111,7 +111,7 @@ func TestUnknownSubcommandProducersUseCanonicalHelper(t *testing.T) {
 			return true
 		})
 	}
-	if producerCalls != 29 {
-		t.Fatalf("canonical producer calls = %d, want 29; update the audited producer inventory intentionally", producerCalls)
+	if producerCalls != 30 {
+		t.Fatalf("canonical producer calls = %d, want 30; update the audited producer inventory intentionally", producerCalls)
 	}
 }

--- a/internal/cli/unknown_subcommand_producers_test.go
+++ b/internal/cli/unknown_subcommand_producers_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestUnknownSubcommandProducersExposeCompleteCanonicalSurfaces(t *testing.T) {
+	tests := []struct {
+		name  string
+		verb  string
+		run   func([]string) error
+		valid []string
+	}{
+		{name: "team operator", verb: "team operator", run: runTeamOperator, valid: []string{"set", "self"}},
+		{name: "activity", verb: "activity", run: runActivity, valid: []string{"set", "clear"}},
+		{name: "operator", verb: "operator", run: runOperator, valid: []string{"answer", "self-approve", "send", "directive", "poll", "status", "watch"}},
+		{name: "team lead", verb: "team lead", run: runTeamLead, valid: []string{"set", "clear", "show"}},
+		{name: "lead", verb: "lead", run: runLead, valid: []string{"register"}},
+		{name: "namespace", verb: "namespace", run: runNamespace, valid: []string{"migrate", "recover", "rollback"}},
+		{name: "team member", verb: "team member", run: runTeamMember, valid: []string{"add", "update", "admit", "replace", "launch", "control-continue", "status", "history", "rm", "remove", "list", "ls"}},
+		{name: "verify", verb: "verify", run: runVerify, valid: []string{"action", "authorization", "rebind", "merge", "release", "release-plan"}},
+		{name: "team overlay", verb: "team overlay", run: runTeamOverlay, valid: []string{"init"}},
+		{name: "team autonomous", verb: "team autonomous", run: runTeamAutonomous, valid: []string{"show", "pause", "resume", "disable"}},
+		{name: "goal", verb: "goal", run: func(args []string) error { return runGoalWithVersion(args, "test") }, valid: []string{"draft", "deliver", "claim", "retry-attempt", "start", "apply", "supervise-resume"}},
+		{name: "team", verb: "team", run: runTeam, valid: []string{"init", "resume", "rules", "lead", "overlay", "member", "autonomous", "operator", "sync", "profiles", "rm", "delete", "shared-cwd-exception"}},
+		{name: "team rules", verb: "team rules", run: runTeamRules, valid: []string{"init"}},
+		{name: "task", verb: "task", run: runTask, valid: []string{"add", "list", "ls", "show", "claim", "renew", "done", "complete", "event", "fail", "block", "reset", "cancel", "release", "deliver", "retry-delivery", "reconcile", "leadership", "handoff"}},
+		{name: "global", verb: "global", run: runGlobal, valid: []string{"start", "status"}},
+		{name: "run", verb: "run", run: func(args []string) error { return runRunCmd(args, "test") }, valid: []string{"start"}},
+		{name: "amq", verb: "amq", run: runAMQ, valid: []string{"env", "ops", "route", "who", "presence", "send", "reply", "drain", "watch", "list", "read", "thread", "receipts", "dlq", "cleanup"}},
+		{name: "amq receipts", verb: "amq receipts", run: runAMQReceipts, valid: []string{"list", "wait"}},
+		{name: "amq dlq", verb: "amq dlq", run: runAMQDLQ, valid: []string{"list", "read", "retry", "retry-all", "purge"}},
+		{name: "new", verb: "new", run: runNew, valid: []string{"team", "profile", "session"}},
+		{name: "worktree", verb: "worktree", run: runWorktree, valid: []string{"plan", "materialize", "create", "inspect", "activate", "handoff", "cleanup", "exception"}},
+		{name: "worktree exception", verb: "worktree exception", run: runWorktreeException, valid: []string{"set", "clear"}},
+		{name: "notifications", verb: "notifications", run: runNotifications, valid: []string{"doctor", "probe", "events", "history"}},
+		{name: "receipt", verb: "receipt", run: runReceipt, valid: []string{"show"}},
+		{name: "agent", verb: "agent", run: runAgent, valid: []string{"up", "resume"}},
+		{name: "context", verb: "context", run: runContext, valid: []string{"explain", "cleanup"}},
+		{name: "evidence", verb: "evidence", run: runEvidence, valid: []string{"run", "show", "list", "recover", "lookup"}},
+		{name: "gate", verb: "gate", run: runGate, valid: []string{"raise", "close"}},
+		{name: "team shared-cwd-exception", verb: "team shared-cwd-exception", run: runTeamSharedCwdException, valid: []string{"set", "clear", "show"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const given = "__amq_squad_probe_invalid__"
+			got := tt.run([]string{given})
+			want := unknownSubcommandError(tt.verb, given, tt.valid...)
+			if got == nil || got.Error() != want.Error() {
+				t.Fatalf("error = %v, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommandProducersUseCanonicalHelper(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	dir := filepath.Dir(thisFile)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const canonicalFormat = "unknown '%s' subcommand: %q. Try %s."
+	unknownSubcommandPhrase := regexp.MustCompile(`(?i)\bunknown\b[^\n]{0,80}\bsubcommand\b`)
+	producerCalls := 0
+	fileset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		parsed, parseErr := parser.ParseFile(fileset, filepath.Join(dir, name), nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", name, parseErr)
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.CallExpr:
+				if ident, isIdent := typed.Fun.(*ast.Ident); isIdent && ident.Name == "unknownSubcommandError" {
+					producerCalls++
+				}
+			case *ast.BasicLit:
+				if typed.Kind != token.STRING {
+					break
+				}
+				value, unquoteErr := strconv.Unquote(typed.Value)
+				if unquoteErr != nil {
+					t.Fatalf("unquote string in %s: %v", name, unquoteErr)
+				}
+				if !unknownSubcommandPhrase.MatchString(value) {
+					break
+				}
+				if name != "cli.go" || value != canonicalFormat {
+					t.Errorf("%s contains ad-hoc unknown-subcommand wording %q; use unknownSubcommandError", name, value)
+				}
+			}
+			return true
+		})
+	}
+	if producerCalls != 29 {
+		t.Fatalf("canonical producer calls = %d, want 29; update the audited producer inventory intentionally", producerCalls)
+	}
+}

--- a/internal/cli/verify.go
+++ b/internal/cli/verify.go
@@ -132,7 +132,7 @@ conditions and exits non-zero.
 	case "release-plan":
 		return runVerifyReleasePlan(args[1:])
 	default:
-		return usageErrorf("unknown 'verify' subcommand: %q. Try action, authorization, rebind, merge, release, or release-plan.", args[0])
+		return unknownSubcommandError("verify", args[0], "action", "authorization", "rebind", "merge", "release", "release-plan")
 	}
 }
 

--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -72,7 +72,10 @@ durable session plan; it never deletes an unknown directory or branch.
 	case "exception":
 		return runWorktreeException(args[1:])
 	default:
-		return usageErrorf("unknown 'worktree' subcommand: %q", args[0])
+		return unknownSubcommandError(
+			"worktree", args[0],
+			"plan", "materialize", "create", "inspect", "activate", "handoff", "cleanup", "exception",
+		)
 	}
 }
 
@@ -232,7 +235,7 @@ func runWorktreeException(args []string) error {
 	}
 	operation := args[0]
 	if operation != "set" && operation != "clear" {
-		return usageErrorf("unknown worktree exception subcommand %q", operation)
+		return unknownSubcommandError("worktree exception", operation, "set", "clear")
 	}
 	fs := flag.NewFlagSet("worktree exception "+operation, flag.ContinueOnError)
 	reason := fs.String("reason", "", "auditable shared-cwd exception reason")

--- a/scripts/check-skill-commands.py
+++ b/scripts/check-skill-commands.py
@@ -173,14 +173,6 @@ DELEGATES_FLAGS = re.compile(r"\[[^\]]*\b(?:flags|options)\]")
 FLAG_SECTION_HEADER = re.compile(r"\b(?:flags|options)\b", re.I)
 
 
-# The binary names its own valid subcommands when given a bad one:
-#   error: unknown 'team' subcommand: "synchronise". Try 'init', 'resume', ...
-# That is a DEFINITIVE negative, so it is the one subcommand error we interpret --
-# the same discipline as t2's single interpretable git error. Everything else stays
-# uninterpretable rather than being optimistically treated as fine.
-UNKNOWN_SUBCOMMAND = re.compile(r"unknown '([^']+)' subcommand", re.I)
-
-
 # Tri-state subcommand observation. Returning "exists" for every response except
 # the recognized negative was FAIL-OPEN IN A VERIFIER: an I/O error, a config
 # failure, or `doctor takes no positional arguments` all PROVED the path, so
@@ -193,52 +185,39 @@ UNKNOWN_SUBCOMMAND = re.compile(r"unknown '([^']+)' subcommand", re.I)
 # would be an invented drift report, which is its own bad outcome.
 SUB_PROBE = "__amq_squad_probe_invalid__"
 
-# The binary lists its own valid subcommands when handed a bogus one, in two
-# formats:
-#   error: unknown evidence subcommand "X"; use run, show, list, recover, or lookup
-#   error: unknown 'team' subcommand: "X". Try 'init', 'resume', 'rules', ...
-# and says so explicitly when a verb takes no subcommand at all:
+# The binary lists its complete valid-subcommand surface under one contract:
+#   error: unknown 'team' subcommand: "X". Try 'init', 'resume', or 'rm'.
+# Commands without subcommands say so explicitly instead:
 #   error: doctor takes no positional arguments; got 2
 #
 # Asking once per verb yields an AUTHORITATIVE set, so membership is a pure set
 # check rather than a per-path guess. That replaces an earlier prober that returned
 # "exists" for every response except the recognized negative -- fail-open in a
 # verifier, which made `amq-squad doctor totallybogus` verify clean.
-# ONE rule for every unknown-subcommand format the binary emits. There are three,
-# differing in separator and verb:
+# The parser intentionally accepts ONLY that documented contract (#561). A producer
+# rewording therefore becomes an unobservable surface and fails the build loudly,
+# rather than silently widening a tolerant union regex again. It is anchored to the
+# whole error line and bound to the probed verb.
 #
-#   evidence  ->  unknown evidence subcommand "X"; use run, show, list, ...
-#   team      ->  unknown 'team' subcommand: "X". Try 'init', 'resume', ...
-#   amq       ->  unknown amq subcommand "X". Use env, ops, route, who, ...
-#
-# Handling only the first two left `amq` UNOBSERVABLE, which under the fail-closed
-# posture BLOCKED the build for any skill documenting an amq subcommand -- i.e. the
-# gate blocking correct documentation of a command it is meant to protect.
-#
-# Collapsing them into one rule rather than adding a third branch also REDUCES the
-# wording coupling: one rule plus the Go printer, instead of three regexes to keep in
-# step. (Normalizing the binary's own error wording is the durable upstream fix.)
-# ANCHORED to the real error structure, and BOUND to the probed verb.
-#
-# The first generalization was unanchored, which opened the inverse of finding 11: a
-# false-observation door. Prose such as
+# The old generalization was unanchored, which opened a false-observation door. Prose
+# such as
 #     "Note: an unknown fake subcommand is recoverable. Use help for examples"
-# yielded subcommands {help, for, examples}, and a "; use --json, --verbose" list
-# yielded flag-named subcommands {json, verbose}.
+# yielded subcommands {help, for, examples}, and a flag list yielded {json, verbose}.
 #
 # Three defences, because one is not enough:
 #   1. anchor at a line-leading `error:` so prose in a description cannot match;
 #   2. capture the verb the error names and require it to EQUAL the verb we probed,
 #      so an error about something else cannot populate this verb's surface;
-#   3. drop flag-shaped entries from the list, since a flag is not a subcommand.
+#   3. require every list item to use the canonical quoted subcommand grammar, so
+#      flags and arbitrary prose cannot become commands.
 UNKNOWN_SUBCOMMAND_LIST = re.compile(
-    r"^[ \t]*error:\s*unknown\s+'?(?P<verb>[A-Za-z][A-Za-z0-9-]*)'?\s+subcommand"
-    r"[^;.]*[;.]\s*(?:use|try)\s+(?P<list>[^\n]+)",
-    re.I | re.M,
+    r"^[ \t]*error:\s*unknown\s+'(?P<verb>[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*)*)'\s+subcommand:\s+"
+    r'"(?:\\.|[^"\\])*"\.\s+Try\s+'
+    r"(?P<list>'[A-Za-z][A-Za-z0-9-]*'(?:, '[A-Za-z][A-Za-z0-9-]*')*(?:, or '[A-Za-z][A-Za-z0-9-]*'| or '[A-Za-z][A-Za-z0-9-]*')?)\.\s*$",
+    re.M,
 )
 
 NO_POSITIONALS = re.compile(r"takes no positional arguments", re.I)
-SUB_NAME = re.compile(r"[A-Za-z][A-Za-z0-9-]*")
 
 _SUB_SURFACE_CACHE: dict[tuple[str, str], tuple[set[str], bool]] = {}
 
@@ -257,10 +236,9 @@ def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
     result: tuple[set[str], bool]
     # PRIMARY source: the verb's own help usage block, which lists
     # `amq-squad <verb> <sub>` lines uniformly across verbs. This is preferred over
-    # error-text parsing because verbs report bogus subcommands in at least three
-    # different formats (list-with-"use", list-with-"Try", and -- for a verb with an
-    # implicit default subcommand like review-worktree -- an argument complaint that
-    # enumerates nothing).
+    # error-text parsing because help may be incomplete. A verb with an implicit
+    # default subcommand (review-worktree) also needs its canonical probe response;
+    # otherwise its argument complaint enumerates nothing.
     own = run_help(binary, verb)
     # [ \t]+ rather than \s+: \s matches NEWLINES, so a usage line ending at the
     # verb ran into the next line and captured "amq-squad" as a subcommand of
@@ -271,25 +249,14 @@ def subcommand_surface(binary: str, verb: str) -> tuple[set[str], bool]:
     )
     # Drop tokens that are placeholders rather than subcommands.
     usage -= {"help"}
-    # SECOND source: ask with a bogus subcommand and parse whichever list format
-    # comes back. Both sources are authoritative and NEITHER is complete: `team`'s
-    # usage block lists 8 subcommands while its error list names 11 (lead,
-    # autonomous, shared-cwd-exception appear only in the error). Using the usage
-    # block alone produced FALSE FAILURES for valid subcommands, so take the UNION.
+    # SECOND source: ask with a bogus subcommand and parse the canonical complete
+    # list. The usage block may still omit hidden or compatibility aliases, so retain
+    # the UNION rather than coupling correctness to help layout.
     text = run_help(binary, verb, SUB_PROBE)
     match = UNKNOWN_SUBCOMMAND_LIST.search(text)
     listed: set[str] = set()
     if match and match.group("verb").lower() == verb.lower():
-        # Drop flag-shaped entries before extracting names: a list of flags is not a
-        # list of subcommands, and `--json` would otherwise become the subcommand
-        # `json`.
-        candidates = [tok for tok in re.split(r"[,\s]+", match.group("list")) if tok and not tok.lstrip("'\"").startswith("-")]
-        listed = {
-            n
-            for tok in candidates
-            for n in SUB_NAME.findall(tok)
-            if n.lower() not in {"or", "and"}
-        }
+        listed = set(re.findall(r"'([A-Za-z][A-Za-z0-9-]*)'", match.group("list")))
 
     combined = usage | listed
     if combined:

--- a/scripts/test_check_skill_commands.py
+++ b/scripts/test_check_skill_commands.py
@@ -702,61 +702,52 @@ class FourthRoundFindings(unittest.TestCase):
 
 
 
-class UnknownSubcommandFormats(unittest.TestCase):
-    """Finding 11: the binary emits THREE unknown-subcommand formats.
-
-    Handling two of them left `amq` unobservable, which under the fail-closed posture
-    blocked the build for any skill documenting an amq subcommand -- the gate blocking
-    correct documentation of a command it exists to protect.
-
-    Subsumption is PROVEN here rather than assumed: one rule must parse all three.
-    """
+class UnknownSubcommandContract(unittest.TestCase):
+    """#561: one exact, complete unknown-subcommand contract."""
 
     def setUp(self):
         if not BINARY.exists():
             self.skipTest("binary not built; run make build")
         self.gate = load_gate()
 
-    def test_each_format_resolves_from_the_LIST_PARSER_alone(self):
-        """Per-format proof with the USAGE source disabled.
+    def test_canonical_complete_list_resolves_without_usage_help(self):
+        """Prove the canonical parser itself, with the usage source disabled.
 
-        The union masked the component: `evidence`'s usage block also lists all five
-        subcommands, so the "; use" subtest stayed green even with the list parser
-        broken. That is the confounded-proof pattern again — the test could not tell
-        WHICH source answered. Here the usage block is removed from the input, so only
-        the list parser can produce a result.
+        The list deliberately includes compatibility/hidden aliases so this test pins
+        the completeness property rather than merely accepting the punctuation.
         """
-        cases = {
-            # ". Use ..." -- the format finding 11 was about
-            "amq": (
-                'error: unknown amq subcommand "x". Use env, ops, route, or cleanup',
-                {"env", "ops", "route", "cleanup"},
-            ),
-            # "; use ..."
-            "evidence": (
-                'error: unknown evidence subcommand "x"; use run, show, list, recover, or lookup',
-                {"run", "show", "list", "recover", "lookup"},
-            ),
-            # ". Try '...'"
-            "team": (
-                "error: unknown 'team' subcommand: \"x\". Try 'init', 'sync', or 'rm'.",
-                {"init", "sync", "rm"},
-            ),
-        }
-        for verb, (error_text, want) in cases.items():
-            with self.subTest(verb=verb):
+        error_text = (
+            "error: unknown 'team' subcommand: \"x\". "
+            "Try 'init', 'operator', 'rm', or 'delete'."
+        )
+        self.gate._SUB_SURFACE_CACHE.clear()
+        original = self.gate.run_help
+        self.gate.run_help = lambda *a, **k: error_text
+        try:
+            subs, observable = self.gate.subcommand_surface("binary", "team")
+        finally:
+            self.gate.run_help = original
+            self.gate._SUB_SURFACE_CACHE.clear()
+        self.assertTrue(observable)
+        self.assertEqual(subs, {"init", "operator", "rm", "delete"})
+
+    def test_legacy_wordings_are_not_a_second_contract(self):
+        legacy = (
+            'error: unknown amq subcommand "x". Use env or cleanup',
+            'error: unknown evidence subcommand "x"; use run or show',
+        )
+        for error_text in legacy:
+            with self.subTest(error_text=error_text):
                 self.gate._SUB_SURFACE_CACHE.clear()
                 original = self.gate.run_help
-                # No usage block anywhere in the response, so the usage parse yields
-                # nothing and only the list parser can answer.
                 self.gate.run_help = lambda *a, **k: error_text
                 try:
-                    subs, observable = self.gate.subcommand_surface("binary", verb)
+                    subs, observable = self.gate.subcommand_surface("binary", "team")
                 finally:
                     self.gate.run_help = original
                     self.gate._SUB_SURFACE_CACHE.clear()
-                self.assertTrue(observable, f"{verb}: the list parser alone must answer")
-                self.assertEqual(subs, want, f"{verb}: parsed {sorted(subs)}")
+                self.assertFalse(observable)
+                self.assertEqual(subs, set())
 
     def test_prose_mentioning_a_subcommand_is_not_an_authoritative_list(self):
         """The false-observation door the first generalization opened.
@@ -780,7 +771,9 @@ class UnknownSubcommandFormats(unittest.TestCase):
         """"; use --json, --verbose" yielded subcommands {json, verbose}."""
         self.gate._SUB_SURFACE_CACHE.clear()
         original = self.gate.run_help
-        self.gate.run_help = lambda *a, **k: 'error: unknown fake subcommand "x"; use --json, --verbose'
+        self.gate.run_help = lambda *a, **k: (
+            "error: unknown 'fake' subcommand: \"x\". Try '--json' or '--verbose'."
+        )
         try:
             subs, _ = self.gate.subcommand_surface("binary", "fake")
         finally:
@@ -793,7 +786,9 @@ class UnknownSubcommandFormats(unittest.TestCase):
         """Verb binding: the error names its verb, so it must match the probed one."""
         self.gate._SUB_SURFACE_CACHE.clear()
         original = self.gate.run_help
-        self.gate.run_help = lambda *a, **k: 'error: unknown other subcommand "x"; use alpha, beta'
+        self.gate.run_help = lambda *a, **k: (
+            "error: unknown 'other' subcommand: \"x\". Try 'alpha' or 'beta'."
+        )
         try:
             subs, observable = self.gate.subcommand_surface("binary", "fake")
         finally:


### PR DESCRIPTION
Closes #561.

## Summary

- Introduces one canonical unknown-subcommand formatter:
  `unknown 'VERB' subcommand: "GIVEN". Try 'a', 'b', or 'c'.`
- Requires every producer to supply a non-empty, duplicate-free, complete subcommand list and gives one-, two-, and many-item lists deterministic grammar.
- Migrates every existing producer and adds an AST audit that rejects ad-hoc wording and pins the production-call count.
- Replaces the skill drift gate's tolerant union regex with an exact, verb-bound canonical parser while retaining the usage/error union needed because help output is incomplete.
- Makes `review-worktree UNKNOWN --help` enumerate `create`, `exec`, `shell`, and `remove`, without changing its ordinary implicit-REF behavior.

## Original producer inventory (29)

1. `team operator` — `set`, `self`
2. `activity` — `set`, `clear`
3. `operator` — `answer`, `self-approve`, `send`, `directive`, `poll`, `status`, `watch`
4. `team lead` — `set`, `clear`, `show`
5. `lead` — `register`
6. `namespace` — `migrate`, `recover`, `rollback`
7. `team member` — `add`, `update`, `admit`, `replace`, `launch`, `control-continue`, `status`, `history`, `rm`, `remove`, `list`, `ls`
8. `verify` — `action`, `authorization`, `rebind`, `merge`, `release`, `release-plan`
9. `team overlay` — `init`
10. `team autonomous` — `show`, `pause`, `resume`, `disable`
11. `goal` — `draft`, `deliver`, `claim`, `retry-attempt`, `start`, `apply`, `supervise-resume`
12. `team` — `init`, `resume`, `rules`, `lead`, `overlay`, `member`, `autonomous`, `operator`, `sync`, `profiles`, `rm`, `delete`, `shared-cwd-exception`
13. `team rules` — `init`
14. `task` — `add`, `list`, `ls`, `show`, `claim`, `renew`, `done`, `complete`, `event`, `fail`, `block`, `reset`, `cancel`, `release`, `deliver`, `retry-delivery`, `reconcile`, `leadership`, `handoff`
15. `global` — `start`, `status`
16. `run` — `start`
17. `amq` — `env`, `ops`, `route`, `who`, `presence`, `send`, `reply`, `drain`, `watch`, `list`, `read`, `thread`, `receipts`, `dlq`, `cleanup`
18. `amq receipts` — `list`, `wait`
19. `amq dlq` — `list`, `read`, `retry`, `retry-all`, `purge`
20. `new` — `team`, `profile`, `session`
21. `worktree` — `plan`, `materialize`, `create`, `inspect`, `activate`, `handoff`, `cleanup`, `exception`
22. `worktree exception` — `set`, `clear`
23. `notifications` — `doctor`, `probe`, `events`, `history`
24. `receipt` — `show`
25. `agent` — `up`, `resume`
26. `context` — `explain`, `cleanup`
27. `evidence` — `run`, `show`, `list`, `recover`, `lookup`
28. `gate` — `raise`, `close`
29. `team shared-cwd-exception` — `set`, `clear`, `show`

`review-worktree` is the added 30th canonical producer, covering the implicit-default surface called out in the issue.

## Validation

- `go test ./internal/cli/ -run '^TestAMQRejectsUnknownSubcommandWithCompleteCanonicalSurface$' -count=1 -v`
- `make ci`
- `git diff --check 80eb200093fc587c13d1c0f284f4443415edfd53..826efbd9971dad37928eaf0b5d0806cb395f5086`
- `git range-diff 3fb1c6f0506a95ca9cecdab7b0c6044a0655d01d..c4d2fde7646be112c29edda04c4cd7b6d7b86221 80eb200093fc587c13d1c0f284f4443415edfd53..826efbd9971dad37928eaf0b5d0806cb395f5086`

All tests and checks pass at exact head `826efbd9971dad37928eaf0b5d0806cb395f5086` on provider-current base `80eb200093fc587c13d1c0f284f4443415edfd53`. The range-diff shows layers 1–3 patch-identical and only the peer-requested comment precision correction in layer 4.
