### PR TITLE
fix: accept session in shared-cwd exception remedy

### DIFF
--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -1633,7 +1633,7 @@ func calculateRunReadinessWithContext(project, profile, session string, context 
 				add("member:"+member.Role, "ready", fmt.Sprintf("staged handle=%s binary=%s model=%s effort=%s task=%s tool_policy=%s", current.Handle, current.Binary, current.Model, current.Effort, current.TaskOwnership, current.ToolProfile), "")
 			}
 		}
-		row := worktreeIsolationReadinessRow(tm, profile)
+		row := worktreeIsolationReadinessRowForSession(tm, profile, session)
 		add(row.Artifact, row.Status, row.Evidence, row.Fix)
 	}
 	briefPath := briefPathForProfile(project, profile, session)

--- a/internal/cli/team_shared_cwd.go
+++ b/internal/cli/team_shared_cwd.go
@@ -17,7 +17,7 @@ func runTeamSharedCwdException(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad team shared-cwd-exception - record or clear the shared-worktree exception
 
 Usage:
-  amq-squad team shared-cwd-exception set "<reason>" [--project DIR] [--profile NAME]
+  amq-squad team shared-cwd-exception set "<reason>" [--project DIR] [--profile NAME] [--session S]
   amq-squad team shared-cwd-exception clear [--project DIR] [--profile NAME]
   amq-squad team shared-cwd-exception show [--json] [--project DIR] [--profile NAME]
 
@@ -51,11 +51,17 @@ func runTeamSharedCwdExceptionSet(args []string) error {
 	fs := flag.NewFlagSet("team shared-cwd-exception set", flag.ContinueOnError)
 	projectFlag := fs.String("project", "", "project/team-home directory (default: cwd)")
 	profileFlag := fs.String("profile", "", "team profile to mutate (default: default profile)")
+	sessionFlag := fs.String("session", "", "active workstream session (validated for preparation-flow compatibility; the exception remains profile-wide)")
 	if err := parseFlags(fs, rest); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return usageErrorf("unexpected argument %q", fs.Arg(0))
+	}
+	if flagWasSet(fs, "session") {
+		if err := team.ValidateSessionName(strings.TrimSpace(*sessionFlag)); err != nil {
+			return usageErrorf("--session: %v", err)
+		}
 	}
 	projectDir, profile, err := resolveExistingTeamProfile(*projectFlag, *profileFlag, flagWasSet(fs, "project"))
 	if err != nil {

--- a/internal/cli/team_shared_cwd_test.go
+++ b/internal/cli/team_shared_cwd_test.go
@@ -78,3 +78,37 @@ func TestTeamSharedCwdExceptionSetRequiresReason(t *testing.T) {
 		t.Fatal("expected an error for an empty reason")
 	}
 }
+
+func TestTeamSharedCwdExceptionSetAcceptsValidSessionScope(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	seedBlockedSquad(t, dir)
+
+	if err := runTeam([]string{
+		"shared-cwd-exception", "set", "serialized writers",
+		"--project", dir, "--profile", "squad", "--session", "v2-27-0",
+	}); err != nil {
+		t.Fatalf("set with preparation scope: %v", err)
+	}
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tm.SharedCwdException != "serialized writers" {
+		t.Fatalf("SharedCwdException = %q", tm.SharedCwdException)
+	}
+}
+
+func TestTeamSharedCwdExceptionSetRejectsInvalidSessionScope(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	seedBlockedSquad(t, dir)
+
+	err := runTeam([]string{
+		"shared-cwd-exception", "set", "serialized writers",
+		"--project", dir, "--profile", "squad", "--session", "NOT VALID",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--session: invalid session name") {
+		t.Fatalf("expected invalid --session error, got %v", err)
+	}
+}

--- a/internal/cli/worktree_isolation.go
+++ b/internal/cli/worktree_isolation.go
@@ -60,6 +60,14 @@ import (
 // with stage-appropriate severity and remedy. If you change one side's condition
 // or exception handling, change both.
 func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow {
+	return worktreeIsolationReadinessRowForSession(t, profile, "")
+}
+
+// worktreeIsolationReadinessRowForSession carries the active preparation
+// session into remedies whose CLI accepts it. The exception itself remains a
+// profile-wide property; accepting the session keeps the printed command
+// compatible with the rest of the preparation flow without changing scope.
+func worktreeIsolationReadinessRowForSession(t team.Team, profile, session string) runReadinessRow {
 	groups := map[string][]string{}
 	groupDisplay := map[string]string{}
 	proxied := map[string]bool{}
@@ -129,7 +137,7 @@ func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow 
 		Artifact: "worktree_isolation",
 		Status:   "blocked",
 		Evidence: fmt.Sprintf("2+ mutation-capable members share one working directory without a recorded exception: %s", evidence),
-		Fix:      worktreeIsolationFix(t.Project, profile, sharedCwdCollisionRoles(groups)),
+		Fix:      worktreeIsolationFix(t.Project, profile, session, sharedCwdCollisionRoles(groups)),
 	}
 }
 
@@ -148,7 +156,7 @@ func worktreeIsolationReadinessRow(t team.Team, profile string) runReadinessRow 
 // exists (readiness just read it), so `new profile NAME` would build an unrelated
 // roster rather than fix this one. The creation forms belong only to the
 // transactional-rollback case, which the preparation failure message owns.
-func worktreeIsolationFix(project, profile string, roles []string) string {
+func worktreeIsolationFix(project, profile, session string, roles []string) string {
 	example := "ROLE"
 	if len(roles) > 0 {
 		example = roles[0]
@@ -162,12 +170,19 @@ func worktreeIsolationFix(project, profile string, roles []string) string {
 	if pr := strings.TrimSpace(profile); pr != "" && pr != team.DefaultProfile {
 		scope += " --profile " + shellQuote(pr)
 	}
+	// team member update uses --session as a mutation, not a scoping flag. Add
+	// the preparation session only to the exception command that treats it as
+	// compatibility context.
+	exceptionScope := scope
+	if session := strings.TrimSpace(session); session != "" {
+		exceptionScope += " --session " + shellQuote(session)
+	}
 	return strings.Join([]string{
 		"give each mutation-capable member its own working directory with " +
 			"'amq-squad team member update " + example + " --cwd /path/to/worktree" + scope + "'" +
 			" (repeat per member; a relative --cwd resolves against the project)",
 		"or accept the shared checkout deliberately with " +
-			`'amq-squad team shared-cwd-exception set "<reason>"` + scope + "'",
+			`'amq-squad team shared-cwd-exception set "<reason>"` + exceptionScope + "'",
 	}, "; ")
 }
 

--- a/internal/cli/worktree_isolation_reachability_test.go
+++ b/internal/cli/worktree_isolation_reachability_test.go
@@ -171,7 +171,7 @@ func TestWorktreeIsolationFixNamesScopedExecutableRemedies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fix := worktreeIsolationReadinessRow(tm, "squad").Fix
+	fix := worktreeIsolationReadinessRowForSession(tm, "squad", "prepared").Fix
 	if fix == "" {
 		t.Fatal("a blocked row must carry a fix")
 	}
@@ -181,6 +181,7 @@ func TestWorktreeIsolationFixNamesScopedExecutableRemedies(t *testing.T) {
 		"amq-squad team shared-cwd-exception set",
 		"--profile " + shellQuote("squad"),
 		"--project " + shellQuote(dir),
+		"--session " + shellQuote("prepared"),
 		"dev-1",
 	} {
 		if !strings.Contains(fix, want) {
@@ -191,12 +192,45 @@ func TestWorktreeIsolationFixNamesScopedExecutableRemedies(t *testing.T) {
 	if strings.Contains(fix, "new profile") {
 		t.Fatalf("fix text must not offer a creation remedy for an EXISTING blocked profile; text was: %s", fix)
 	}
+	memberArgv := extractQuotedCommand(t, fix, "amq-squad team member update")
+	if strings.Contains(strings.Join(memberArgv, " "), "--session") {
+		t.Fatalf("member update --session changes the member's pin and is not scope; command was: %v", memberArgv)
+	}
+}
+
+func TestSharedCwdExceptionFixCommandExecutesAsDisplayed(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	seedBlockedSquad(t, dir)
+	chdir(t, t.TempDir())
+	tm, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fix := worktreeIsolationReadinessRowForSession(tm, "squad", "prepared").Fix
+	argv := extractQuotedCommand(t, fix, "amq-squad team shared-cwd-exception set")
+	if len(argv) < 3 || argv[0] != "amq-squad" || argv[1] != "team" {
+		t.Fatalf("unexpected command shape: %v", argv)
+	}
+	if !strings.Contains(strings.Join(argv, " "), "--session prepared") {
+		t.Fatalf("displayed exception command lost its preparation session: %v", argv)
+	}
+	if _, _, err := captureOutput(t, func() error { return runTeam(argv[2:]) }); err != nil {
+		t.Fatalf("the command the row DISPLAYS failed to run: %v\nargv: %v", err, argv)
+	}
+	fixed, err := team.ReadProfile(dir, "squad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row := worktreeIsolationReadinessRowForSession(fixed, "squad", "prepared"); row.Status != "ready" {
+		t.Fatalf("running the displayed exception remedy left the row %s (%s)", row.Status, row.Evidence)
+	}
 }
 
 // A blocked DEFAULT profile must not be told to pass --profile default.
 func TestWorktreeIsolationFixOmitsDefaultProfileScope(t *testing.T) {
 	dir := t.TempDir()
-	fix := worktreeIsolationFix(dir, team.DefaultProfile, []string{"dev-1", "dev-2"})
+	fix := worktreeIsolationFix(dir, team.DefaultProfile, "", []string{"dev-1", "dev-2"})
 	if strings.Contains(fix, "--profile") {
 		t.Fatalf("default profile needs no --profile scope; text was: %s", fix)
 	}


### PR DESCRIPTION
## Summary

- accept and validate `--session` on `team shared-cwd-exception set` while keeping the exception profile-wide
- carry the active preparation session into the printed shared-cwd-exception remedy
- keep `--session` off the alternative `team member update` command, where it would mutate the member pin rather than scope the command
- execute the displayed exception remedy from a neutral directory in regression coverage

## Tests

- `go test ./internal/cli -count=1` (PASS, 480.548s on the pre-refinement tree)
- `go test ./internal/cli -run 'TestTeamSharedCwdException|TestWorktreeIsolationFix|TestSharedCwdExceptionFixCommandExecutesAsDisplayed|TestFixTextCommandExecutesAsDisplayed' -count=1` (PASS, 0.902s at final head)
- hosted CI run `30753462404`: 5/5 PASS at final head, including `make ci`

Refs #564
