### PR TITLE
Distinguish established-then-frozen receipt fields from always-frozen (#613)

### DIFF
--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -234,8 +234,26 @@ func mergeDeliveryReceipt(current, incoming deliveryReceiptData) (deliveryReceip
 		return deliveryReceiptData{}, fmt.Errorf("receipt_corrupt: attempt %s maps to conflicting reconciled message ids %s and %s", incoming.AttemptID, current.ReconciledMessageID, incoming.ReconciledMessageID)
 	}
 	merged.ReconciledMessageID = mergeSetOnce(current.ReconciledMessageID, incoming.ReconciledMessageID)
+	// ESTABLISH-THEN-FREEZE CARRY-FORWARD (#613). validateReceiptMergeIdentity
+	// accepts establishment in EITHER direction, because which side carries the
+	// derived value depends on read/write ordering. The merge must therefore
+	// preserve the established value when the incoming side is the empty one --
+	// otherwise acceptance is lossy: the validator says "fine, this is
+	// establishment", and the merge then writes the established value back to
+	// empty, which is the opposite of freezing it.
+	//
+	// Recipients already had this. recipient and thread did not, and before the
+	// validator was narrowed the gap was unreachable: strict equality refused
+	// populated-vs-empty outright. Narrowing the check without widening the
+	// carry-forward is what made it reachable, so the two must move together.
 	if len(merged.Recipients) == 0 {
 		merged.Recipients = append([]string(nil), current.Recipients...)
+	}
+	if merged.Recipient == "" {
+		merged.Recipient = current.Recipient
+	}
+	if merged.Thread == "" {
+		merged.Thread = current.Thread
 	}
 	consumerMap := map[string]deliveryConsumerState{}
 	for _, c := range current.Consumers {

--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -370,7 +370,32 @@ func validateDeliveryReceiptCrossFields(receipt deliveryReceiptData) error {
 	return nil
 }
 
+// establishedString compares a field that the normalizer DERIVES when absent, so
+// it is immutable once ESTABLISHED rather than immutable always (#613).
+//
+// The distinction is the whole bug. receipt.Recipient, receipt.Recipients and
+// receipt.Thread are all filled in by normalizeReceipt when they arrive empty --
+// recipient from Target.Handle or Recipients[0], recipients from the singular,
+// thread from receiptCanonicalP2P(sender, recipient). A receipt is therefore
+// legitimately persisted without them and read back WITH them, and comparing the
+// two as strictly equal reports derivation as mutation:
+//
+//	receipt_corrupt: immutable recipients changed for attempt <id>-pane_send-...
+//
+// on an operation that delivered successfully. Empty-to-value is ESTABLISHMENT;
+// only value-to-different-value is mutation, and that still refuses.
+func establishedString(current, incoming string) bool {
+	return current == "" || incoming == "" || current == incoming
+}
+
+// establishedStrings is establishedString for the recipients vector.
+func establishedStrings(current, incoming []string) bool {
+	return len(current) == 0 || len(incoming) == 0 || slices.Equal(current, incoming)
+}
+
 func validateReceiptMergeIdentity(current, incoming deliveryReceiptData) error {
+	// ALWAYS-FROZEN: present from the first write and never derived. Any change,
+	// including from empty, is corruption.
 	checks := []struct {
 		name string
 		ok   bool
@@ -380,10 +405,15 @@ func validateReceiptMergeIdentity(current, incoming deliveryReceiptData) error {
 		{"kind", current.Kind == incoming.Kind},
 		{"target", current.Target == incoming.Target},
 		{"sender", current.Sender == incoming.Sender},
-		{"recipient", current.Recipient == incoming.Recipient},
-		{"recipients", slices.Equal(current.Recipients, incoming.Recipients)},
+		// ESTABLISH-THEN-FREEZE: derived by normalizeReceipt when absent. See
+		// establishedString. Keep this set in step with the derivations at the
+		// bottom of this file; a field that is derived must never be compared
+		// with strict equality here, and a field that is never derived must never
+		// be moved into this class.
+		{"recipient", establishedString(current.Recipient, incoming.Recipient)},
+		{"recipients", establishedStrings(current.Recipients, incoming.Recipients)},
+		{"thread", establishedString(current.Thread, incoming.Thread)},
 		{"root", filepath.Clean(current.Root) == filepath.Clean(incoming.Root)},
-		{"thread", current.Thread == incoming.Thread},
 		{"path", filepath.Clean(current.Path) == filepath.Clean(incoming.Path)},
 		{"created_at", current.CreatedAt.Equal(incoming.CreatedAt)},
 		{"prepared_run_generation", current.PreparedRunGeneration == incoming.PreparedRunGeneration},

--- a/internal/cli/delivery_receipt_established_613_test.go
+++ b/internal/cli/delivery_receipt_established_613_test.go
@@ -18,6 +18,18 @@ func baseReceipt613() deliveryReceiptData {
 		Kind:          "pane_send",
 		Sender:        "cto",
 		CreatedAt:     time.Date(2026, 8, 1, 18, 6, 56, 0, time.UTC),
+		// Every always-frozen field is populated here on purpose: a
+		// "mutate it to empty" case against an already-empty base would be
+		// empty-to-empty and pass vacuously, which is the failure mode the
+		// guard-on-the-guard exists to prevent in the first place.
+		Target:                   deliveryReceiptTarget{ProjectDir: "/p", Profile: "squad-v2-26-0", Session: "v2-26-0", Role: "amq-dev-1", Handle: "amq-dev-1"},
+		Root:                     "/p/.agent-mail/squad-v2-26-0/v2-26-0",
+		Path:                     "/p/.amq-squad/receipts/squad-v2-26-0/v2-26-0/a.json",
+		PreparedRunGeneration:    "gen-1",
+		PreparedRunLaunchAttempt: "attempt-1",
+		PreparedRunDigest:        "sha256:digest",
+		PreparedRunGoalNamespace: "squad-v2-26-0/v2-26-0",
+		PreparedRunGoalDigest:    "sha256:goal",
 	}
 }
 
@@ -101,6 +113,12 @@ func TestEstablishThenFreezeStillRefusesGenuineMutation(t *testing.T) {
 // later refactor, at which point corruption would merge silently. This asserts
 // the always-frozen set still refuses on any change INCLUDING from-empty, so the
 // two classes cannot be confused without a test failing.
+//
+// The table is COMPLETE, not representative: it names every field in the
+// always-frozen set. A representative subset would leave the unlisted fields
+// free to drift into establish-then-freeze unobserved, which is precisely the
+// drift this test claims to prevent. If a field is added to the always-frozen
+// set in the checks table, it must be added here too.
 func TestAlwaysFrozenFieldsRefuseEvenFromEmpty(t *testing.T) {
 	for _, tc := range []struct {
 		field  string
@@ -111,6 +129,14 @@ func TestAlwaysFrozenFieldsRefuseEvenFromEmpty(t *testing.T) {
 		{"kind", func(r deliveryReceiptData) deliveryReceiptData { r.Kind = ""; return r }},
 		{"sender", func(r deliveryReceiptData) deliveryReceiptData { r.Sender = ""; return r }},
 		{"created_at", func(r deliveryReceiptData) deliveryReceiptData { r.CreatedAt = time.Time{}; return r }},
+		{"target", func(r deliveryReceiptData) deliveryReceiptData { r.Target = deliveryReceiptTarget{}; return r }},
+		{"root", func(r deliveryReceiptData) deliveryReceiptData { r.Root = ""; return r }},
+		{"path", func(r deliveryReceiptData) deliveryReceiptData { r.Path = ""; return r }},
+		{"prepared_run_generation", func(r deliveryReceiptData) deliveryReceiptData { r.PreparedRunGeneration = ""; return r }},
+		{"prepared_run_launch_attempt", func(r deliveryReceiptData) deliveryReceiptData { r.PreparedRunLaunchAttempt = ""; return r }},
+		{"prepared_run_digest", func(r deliveryReceiptData) deliveryReceiptData { r.PreparedRunDigest = ""; return r }},
+		{"prepared_run_goal_namespace", func(r deliveryReceiptData) deliveryReceiptData { r.PreparedRunGoalNamespace = ""; return r }},
+		{"prepared_run_goal_digest", func(r deliveryReceiptData) deliveryReceiptData { r.PreparedRunGoalDigest = ""; return r }},
 	} {
 		t.Run(tc.field+"/to-empty", func(t *testing.T) {
 			if err := validateReceiptMergeIdentity(baseReceipt613(), tc.mutate(baseReceipt613())); err == nil {
@@ -119,4 +145,58 @@ func TestAlwaysFrozenFieldsRefuseEvenFromEmpty(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMergePreservesEstablishedFields is amq-dev-2's F1, turned into a
+// regression, and it tests the EFFECT rather than the predicate.
+//
+// The validator accepting establishment in both directions is only half a
+// contract. If the merge then writes the established value back to empty,
+// acceptance is LOSSY: the check says "this is establishment, not mutation" and
+// the merge un-establishes it. Establish-then-freeze has to mean frozen.
+//
+// This gap was unreachable before the validator was narrowed — strict equality
+// refused populated-vs-empty outright — so narrowing the check without widening
+// the carry-forward is what opened it. The two must move together, and this test
+// is what holds them together.
+//
+// Note deliberately what the other tests in this file CANNOT do: they call
+// validateReceiptMergeIdentity directly, so they prove refusal and acceptance
+// but never observe the merged receipt. A predicate test cannot catch a lossy
+// merge. That is why this one drives mergeDeliveryReceipt.
+func TestMergePreservesEstablishedFields(t *testing.T) {
+	established := func(r deliveryReceiptData) deliveryReceiptData {
+		r.Recipient = "amq-dev-1"
+		r.Recipients = []string{"amq-dev-1"}
+		r.Thread = "p2p/amq-dev-1__cto"
+		return r
+	}
+
+	t.Run("incoming-empty-keeps-established", func(t *testing.T) {
+		merged, err := mergeDeliveryReceipt(established(baseReceipt613()), baseReceipt613())
+		if err != nil {
+			t.Fatalf("merging an empty incoming over established values must not fail: %v", err)
+		}
+		if merged.Recipient != "amq-dev-1" {
+			t.Errorf("recipient was un-established by the merge: got %q", merged.Recipient)
+		}
+		if len(merged.Recipients) != 1 || merged.Recipients[0] != "amq-dev-1" {
+			t.Errorf("recipients was un-established by the merge: got %v", merged.Recipients)
+		}
+		if merged.Thread != "p2p/amq-dev-1__cto" {
+			t.Errorf("thread was un-established by the merge: got %q", merged.Thread)
+		}
+	})
+
+	t.Run("incoming-established-over-empty-current", func(t *testing.T) {
+		merged, err := mergeDeliveryReceipt(baseReceipt613(), established(baseReceipt613()))
+		if err != nil {
+			t.Fatalf("establishing values over an empty current must not fail: %v", err)
+		}
+		if merged.Recipient != "amq-dev-1" || merged.Thread != "p2p/amq-dev-1__cto" ||
+			len(merged.Recipients) != 1 {
+			t.Errorf("establishment in this direction must land: recipient=%q recipients=%v thread=%q",
+				merged.Recipient, merged.Recipients, merged.Thread)
+		}
+	})
 }

--- a/internal/cli/delivery_receipt_established_613_test.go
+++ b/internal/cli/delivery_receipt_established_613_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// baseReceipt613 is a minimal receipt in the shape the field artifacts show:
+// the always-frozen fields populated, the derived fields ABSENT. That is the
+// state a pane_send actually persists (verified against 6 of 6 receipts in the
+// v2-26-0 session under .amq-squad/receipts/), and it is the precondition for
+// the bug this file pins.
+func baseReceipt613() deliveryReceiptData {
+	return deliveryReceiptData{
+		SchemaVersion: 2,
+		AttemptID:     "20260801T180656.781302000Z-pane_send-amq-dev-1-amq-dev-1-p60908-0000000000000001",
+		Kind:          "pane_send",
+		Sender:        "cto",
+		CreatedAt:     time.Date(2026, 8, 1, 18, 6, 56, 0, time.UTC),
+	}
+}
+
+// TestEstablishThenFreezeAcceptsDerivation is #613's primary regression: a
+// receipt persisted WITHOUT the derived fields, read back WITH them, must merge
+// cleanly. Before the fix each of these produced
+//
+//	receipt_corrupt: immutable <field> changed for attempt <id>
+//
+// on a pane_send that had already delivered successfully — the false error that
+// trains operators to ignore errors.
+func TestEstablishThenFreezeAcceptsDerivation(t *testing.T) {
+	for _, tc := range []struct {
+		field   string
+		derived func(deliveryReceiptData) deliveryReceiptData
+	}{
+		{"recipient", func(r deliveryReceiptData) deliveryReceiptData { r.Recipient = "amq-dev-1"; return r }},
+		{"recipients", func(r deliveryReceiptData) deliveryReceiptData { r.Recipients = []string{"amq-dev-1"}; return r }},
+		{"thread", func(r deliveryReceiptData) deliveryReceiptData { r.Thread = "p2p/amq-dev-1__cto"; return r }},
+	} {
+		t.Run(tc.field+"/absent-then-derived", func(t *testing.T) {
+			if err := validateReceiptMergeIdentity(baseReceipt613(), tc.derived(baseReceipt613())); err != nil {
+				t.Fatalf("establishing %s must not be reported as mutation: %v", tc.field, err)
+			}
+		})
+		// Symmetric: the derived side may equally be the CURRENT one, because
+		// which side carries the derivation depends on read/write ordering.
+		t.Run(tc.field+"/derived-then-absent", func(t *testing.T) {
+			if err := validateReceiptMergeIdentity(tc.derived(baseReceipt613()), baseReceipt613()); err != nil {
+				t.Fatalf("establishing %s in the other direction must not be reported as mutation: %v", tc.field, err)
+			}
+		})
+	}
+}
+
+// TestEstablishThenFreezeStillRefusesGenuineMutation is the other half, and the
+// half that makes the fix a narrowing rather than a deletion. Relaxing a guard
+// is not removing it: once a derived field is ESTABLISHED, changing it to a
+// different value is still corruption and must still refuse with the same
+// receipt_corrupt string — consumers parse it.
+func TestEstablishThenFreezeStillRefusesGenuineMutation(t *testing.T) {
+	for _, tc := range []struct {
+		field    string
+		current  func(deliveryReceiptData) deliveryReceiptData
+		incoming func(deliveryReceiptData) deliveryReceiptData
+	}{
+		{
+			"recipient",
+			func(r deliveryReceiptData) deliveryReceiptData { r.Recipient = "amq-dev-1"; return r },
+			func(r deliveryReceiptData) deliveryReceiptData { r.Recipient = "amq-dev-2"; return r },
+		},
+		{
+			"recipients",
+			func(r deliveryReceiptData) deliveryReceiptData { r.Recipients = []string{"amq-dev-1"}; return r },
+			func(r deliveryReceiptData) deliveryReceiptData { r.Recipients = []string{"amq-dev-2"}; return r },
+		},
+		{
+			"thread",
+			func(r deliveryReceiptData) deliveryReceiptData { r.Thread = "p2p/amq-dev-1__cto"; return r },
+			func(r deliveryReceiptData) deliveryReceiptData { r.Thread = "p2p/amq-dev-2__cto"; return r },
+		},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			err := validateReceiptMergeIdentity(tc.current(baseReceipt613()), tc.incoming(baseReceipt613()))
+			if err == nil {
+				t.Fatalf("changing an established %s is corruption and must refuse", tc.field)
+			}
+			// Assert the exact contract, not merely that something failed: the
+			// message names the field and keeps the receipt_corrupt prefix.
+			if !strings.Contains(err.Error(), "receipt_corrupt: immutable "+tc.field+" changed") {
+				t.Fatalf("refusal must name the field and keep the parseable prefix, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestAlwaysFrozenFieldsRefuseEvenFromEmpty is the GUARD ON THE GUARD.
+//
+// The fix introduces an establish-then-freeze class. The risk it creates is that
+// a field which must NEVER be empty quietly drifts into that class during a
+// later refactor, at which point corruption would merge silently. This asserts
+// the always-frozen set still refuses on any change INCLUDING from-empty, so the
+// two classes cannot be confused without a test failing.
+func TestAlwaysFrozenFieldsRefuseEvenFromEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		field  string
+		mutate func(deliveryReceiptData) deliveryReceiptData
+	}{
+		{"schema_version", func(r deliveryReceiptData) deliveryReceiptData { r.SchemaVersion = 0; return r }},
+		{"attempt_id", func(r deliveryReceiptData) deliveryReceiptData { r.AttemptID = ""; return r }},
+		{"kind", func(r deliveryReceiptData) deliveryReceiptData { r.Kind = ""; return r }},
+		{"sender", func(r deliveryReceiptData) deliveryReceiptData { r.Sender = ""; return r }},
+		{"created_at", func(r deliveryReceiptData) deliveryReceiptData { r.CreatedAt = time.Time{}; return r }},
+	} {
+		t.Run(tc.field+"/to-empty", func(t *testing.T) {
+			if err := validateReceiptMergeIdentity(baseReceipt613(), tc.mutate(baseReceipt613())); err == nil {
+				t.Fatalf("%s is always-frozen: even a change to empty must refuse, or it has silently"+
+					" joined the establish-then-freeze class", tc.field)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Distinguish established-then-frozen receipt fields from always-frozen (#613)

Every `amq-squad send --session S --role R` in the v2-26-0 session returned

```
error: receipt_corrupt: immutable recipients changed for attempt <id>-pane_send-...
```

while the send itself **succeeded**, verified by pane capture each time. A persistent false error on a
working operation trains operators to ignore errors, which is how the real one gets missed.

## The check table lacked a distinction

The merge validator treated every identity field as immutable and compared with strict equality. Three
of those fields are **derived by the normalizer when absent**:

| field | derived from |
|---|---|
| `recipient` | `Target.Handle`, or `Recipients[0]` when there is exactly one |
| `recipients` | the singular `recipient` |
| `thread` | `receiptCanonicalP2P(sender, recipients[0])` |

The merge itself expects them empty and fills them in. So a receipt is legitimately persisted
*without* them and read back *with* them — and the validator compared `nil` against the derived value
and called it mutation.

The issue asks whether this is a real bookkeeping bug or cosmetic noise to silence. **Neither.** The
guard is correct in *intent* — these fields genuinely must not change once established — and wrong in
*scope*, firing on `nil → derived`, which is not a change. Silencing it would delete a guard that
should catch real mutation.

So the fix adds the missing distinction rather than patching three predicates:

- **Always-frozen** — present from the first write, never derived. Any change, *including from empty*,
  is corruption. (`schema_version`, `attempt_id`, `kind`, `target`, `sender`, `root`, `path`,
  `created_at`, `prepared_run_*`)
- **Establish-then-freeze** — derived when absent. Empty→value is **establishment**;
  value→different-value is still corruption. (`recipient`, `recipients`, `thread`)

The table now documents the contract the normalizer already implements, which is why this is the
honest fix rather than three narrowed comparisons.

## Reproduction evidence

All **six** `pane_send` receipts from the v2-26-0 session under `.amq-squad/receipts/` carry **no
`recipients` key at all** while `recipient` is populated:

```
20260801T180656.78  recipients=None  recipient='amq-dev-1'
20260801T183521.48  recipients=None  recipient='amq-dev-1'
... (6 of 6 identical shape)
```

That is exactly the state which triggers the backfill on the next read — which is why this fired on
*every* send rather than intermittently, and why delivery succeeded every time while only the
bookkeeping refused.

## Scope: three fields, not one

`recipients` is what the issue reports. `recipient` and `thread` were found by checking whether the
same asymmetry existed elsewhere; both have it. Fixing only the reported field would ship two known
instances of a closed-class defect.

## The guard's intent is preserved

A genuine mutation still refuses with the same `receipt_corrupt: immutable <field> changed` string —
#534-class consumers parse it, so the message contract is asserted rather than assumed.

Three regressions, each asserting the **effect** both ways:

1. **Establishment accepted**, in either direction — which side carries the derivation depends on
   read/write ordering, so both are tested.
2. **Genuine mutation refused**, asserting the exact message contract rather than merely that an error
   occurred.
3. **Guard on the guard** — the always-frozen set still refuses even a change *to empty*, so a field
   that must never be empty cannot silently drift into the new class during a later refactor.

Verified to bisect: reverting the three predicates to strict equality reproduces the exact
`receipt_corrupt` strings from the issue, for all three fields, in both directions.

Refs #613
