### PR TITLE
fix: make prepared and receipt errors actionable (#520)

### DIFF
--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -192,7 +192,7 @@ func writeDeliveryReceipt(projectDir, profile, session string, receipt *delivery
 	return flock.WithFile(lockFile, filepath.Join(dir, lockName), func() error {
 		if current, err := readDeliveryReceiptAt(dirRoot, receipt.AttemptID+".json", path); err == nil {
 			if receipt.Generation > current.Generation {
-				return fmt.Errorf("receipt_corrupt: incoming generation %d is ahead of persisted generation %d", receipt.Generation, current.Generation)
+				return receiptCorruptf("incoming generation %d is ahead of persisted generation %d", receipt.Generation, current.Generation)
 			}
 			merged, mergeErr := mergeDeliveryReceipt(current, *receipt)
 			if mergeErr != nil {
@@ -220,18 +220,18 @@ func mergeDeliveryReceipt(current, incoming deliveryReceiptData) (deliveryReceip
 		return deliveryReceiptData{}, err
 	}
 	if current.MessageID != "" && incoming.MessageID != "" && current.MessageID != incoming.MessageID {
-		return deliveryReceiptData{}, fmt.Errorf("receipt_corrupt: attempt %s maps to conflicting message ids %s and %s", incoming.AttemptID, current.MessageID, incoming.MessageID)
+		return deliveryReceiptData{}, receiptCorruptf("attempt %s maps to conflicting message ids %s and %s", incoming.AttemptID, current.MessageID, incoming.MessageID)
 	}
 	merged := incoming
 	if merged.MessageID == "" {
 		merged.MessageID = current.MessageID
 	}
 	if current.CommittedPath != "" && incoming.CommittedPath != "" && filepath.Clean(current.CommittedPath) != filepath.Clean(incoming.CommittedPath) {
-		return deliveryReceiptData{}, fmt.Errorf("receipt_corrupt: attempt %s maps to conflicting committed paths %s and %s", incoming.AttemptID, current.CommittedPath, incoming.CommittedPath)
+		return deliveryReceiptData{}, receiptCorruptf("attempt %s maps to conflicting committed paths %s and %s", incoming.AttemptID, current.CommittedPath, incoming.CommittedPath)
 	}
 	merged.CommittedPath = mergeSetOnce(current.CommittedPath, incoming.CommittedPath)
 	if current.ReconciledMessageID != "" && incoming.ReconciledMessageID != "" && current.ReconciledMessageID != incoming.ReconciledMessageID {
-		return deliveryReceiptData{}, fmt.Errorf("receipt_corrupt: attempt %s maps to conflicting reconciled message ids %s and %s", incoming.AttemptID, current.ReconciledMessageID, incoming.ReconciledMessageID)
+		return deliveryReceiptData{}, receiptCorruptf("attempt %s maps to conflicting reconciled message ids %s and %s", incoming.AttemptID, current.ReconciledMessageID, incoming.ReconciledMessageID)
 	}
 	merged.ReconciledMessageID = mergeSetOnce(current.ReconciledMessageID, incoming.ReconciledMessageID)
 	// ESTABLISH-THEN-FREEZE CARRY-FORWARD (#613). validateReceiptMergeIdentity
@@ -316,62 +316,62 @@ func mergeDeliveryReceipt(current, incoming deliveryReceiptData) (deliveryReceip
 func validateDeliveryReceiptCrossFields(receipt deliveryReceiptData) error {
 	if receipt.CommittedPath != "" {
 		if !filepath.IsAbs(receipt.CommittedPath) || filepath.Clean(receipt.CommittedPath) != receipt.CommittedPath || strings.TrimSpace(receipt.MessageID) == "" || !receipt.AMQInvoked {
-			return fmt.Errorf("receipt_corrupt: committed-indeterminate evidence is incomplete for attempt %s", receipt.AttemptID)
+			return receiptCorruptf("committed-indeterminate evidence is incomplete for attempt %s", receipt.AttemptID)
 		}
 		if receipt.DeliveryState != deliveryStateCommittedIndeterminate && receipt.DeliveryState != deliveryStateDrained && receipt.DeliveryState != deliveryStateFailed {
-			return fmt.Errorf("receipt_corrupt: committed path has inconsistent delivery state %s for attempt %s", receipt.DeliveryState, receipt.AttemptID)
+			return receiptCorruptf("committed path has inconsistent delivery state %s for attempt %s", receipt.DeliveryState, receipt.AttemptID)
 		}
 		if err := validateCommittedDeliveryEvidence(receipt, committedDeliveryEvidence{MessageID: receipt.MessageID, FinalPath: receipt.CommittedPath}); err != nil {
-			return fmt.Errorf("receipt_corrupt: invalid committed-indeterminate evidence for attempt %s: %w", receipt.AttemptID, err)
+			return receiptCorruptf("invalid committed-indeterminate evidence for attempt %s: %w", receipt.AttemptID, err)
 		}
 	}
 	reconciledID := strings.TrimSpace(receipt.ReconciledMessageID)
 	if reconciledID == "" {
 		if receipt.ReconciledMessageID != "" {
-			return fmt.Errorf("receipt_corrupt: reconciled message id is not canonical for attempt %s", receipt.AttemptID)
+			return receiptCorruptf("reconciled message id is not canonical for attempt %s", receipt.AttemptID)
 		}
 		if receipt.Status == deliveryStateReconciledExisting || receipt.DeliveryState == deliveryStateReconciledExisting {
-			return fmt.Errorf("receipt_corrupt: reconciled state has no reconciled message id for attempt %s", receipt.AttemptID)
+			return receiptCorruptf("reconciled state has no reconciled message id for attempt %s", receipt.AttemptID)
 		}
 		if receipt.EvidenceSource == deliveryStateReconciledExisting {
-			return fmt.Errorf("receipt_corrupt: reconciled evidence has no reconciled message id for attempt %s", receipt.AttemptID)
+			return receiptCorruptf("reconciled evidence has no reconciled message id for attempt %s", receipt.AttemptID)
 		}
 		for _, stage := range receipt.Stages {
 			if stage.State == deliveryStateReconciledExisting {
-				return fmt.Errorf("receipt_corrupt: reconciled stage has no reconciled message id for attempt %s", receipt.AttemptID)
+				return receiptCorruptf("reconciled stage has no reconciled message id for attempt %s", receipt.AttemptID)
 			}
 		}
 		for _, consumer := range receipt.Consumers {
 			if consumer.State == deliveryStateReconciledExisting {
-				return fmt.Errorf("receipt_corrupt: reconciled consumer %s has no reconciled message id for attempt %s", consumer.Consumer, receipt.AttemptID)
+				return receiptCorruptf("reconciled consumer %s has no reconciled message id for attempt %s", consumer.Consumer, receipt.AttemptID)
 			}
 		}
 		return nil
 	}
 	if receipt.SchemaVersion != deliveryReceiptSchemaVersion {
-		return fmt.Errorf("receipt_corrupt: reconciled message id requires schema %d for attempt %s", deliveryReceiptSchemaVersion, receipt.AttemptID)
+		return receiptCorruptf("reconciled message id requires schema %d for attempt %s", deliveryReceiptSchemaVersion, receipt.AttemptID)
 	}
 	if reconciledID != receipt.ReconciledMessageID || strings.ContainsAny(reconciledID, "\r\n\x00") {
-		return fmt.Errorf("receipt_corrupt: reconciled message id is not canonical for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled message id is not canonical for attempt %s", receipt.AttemptID)
 	}
 	if receipt.AMQInvoked || receipt.MessageID != "" || receipt.Status != deliveryStateReconciledExisting || receipt.DeliveryState != deliveryStateReconciledExisting {
-		return fmt.Errorf("receipt_corrupt: reconciled receipt has inconsistent invocation or message state for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled receipt has inconsistent invocation or message state for attempt %s", receipt.AttemptID)
 	}
 	if receipt.EvidenceSource != deliveryStateReconciledExisting || receipt.LastCheckedAt != nil || receipt.LastCheckError != "" || receipt.Acknowledged || receipt.Fallback {
-		return fmt.Errorf("receipt_corrupt: reconciled receipt has inconsistent replay or refresh evidence for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled receipt has inconsistent replay or refresh evidence for attempt %s", receipt.AttemptID)
 	}
 	if len(receipt.Recipients) == 0 || len(receipt.Consumers) != len(receipt.Recipients) {
-		return fmt.Errorf("receipt_corrupt: reconciled receipt has inconsistent recipient projection for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled receipt has inconsistent recipient projection for attempt %s", receipt.AttemptID)
 	}
 	seenConsumers := make(map[string]bool, len(receipt.Consumers))
 	for _, consumer := range receipt.Consumers {
 		if consumer.Consumer == "" || seenConsumers[consumer.Consumer] || !slices.Contains(receipt.Recipients, consumer.Consumer) || consumer.State != deliveryStateReconciledExisting || consumer.Stage != "" || consumer.DrainedAt != nil || consumer.FailedAt != nil {
-			return fmt.Errorf("receipt_corrupt: reconciled consumer %s has inconsistent delivery evidence for attempt %s", consumer.Consumer, receipt.AttemptID)
+			return receiptCorruptf("reconciled consumer %s has inconsistent delivery evidence for attempt %s", consumer.Consumer, receipt.AttemptID)
 		}
 		seenConsumers[consumer.Consumer] = true
 	}
 	if receipt.NativeStage != "" || receipt.DrainedAt != nil || receipt.FailedAt != nil {
-		return fmt.Errorf("receipt_corrupt: reconciled receipt has native or terminal delivery evidence for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled receipt has native or terminal delivery evidence for attempt %s", receipt.AttemptID)
 	}
 	reconciledStage := false
 	for _, stage := range receipt.Stages {
@@ -379,11 +379,11 @@ func validateDeliveryReceiptCrossFields(receipt deliveryReceiptData) error {
 		case deliveryStateReconciledExisting:
 			reconciledStage = true
 		case "amq_invocation_boundary", deliveryStateDeliveredNotDrained, deliveryStatePartiallyDrained, deliveryStateDrained, deliveryStateFailed:
-			return fmt.Errorf("receipt_corrupt: reconciled receipt has invocation or delivery stage %s for attempt %s", stage.State, receipt.AttemptID)
+			return receiptCorruptf("reconciled receipt has invocation or delivery stage %s for attempt %s", stage.State, receipt.AttemptID)
 		}
 	}
 	if !reconciledStage {
-		return fmt.Errorf("receipt_corrupt: reconciled receipt has no reconciled stage for attempt %s", receipt.AttemptID)
+		return receiptCorruptf("reconciled receipt has no reconciled stage for attempt %s", receipt.AttemptID)
 	}
 	return nil
 }
@@ -442,12 +442,12 @@ func validateReceiptMergeIdentity(current, incoming deliveryReceiptData) error {
 	}
 	for _, check := range checks {
 		if !check.ok {
-			return fmt.Errorf("receipt_corrupt: immutable %s changed for attempt %s", check.name, incoming.AttemptID)
+			return receiptCorruptf("immutable %s changed for attempt %s", check.name, incoming.AttemptID)
 		}
 	}
 	for _, pair := range [][2]string{{current.TaskID, incoming.TaskID}, {current.OutboxIntentID, incoming.OutboxIntentID}, {current.PaneID, incoming.PaneID}} {
 		if pair[0] != "" && pair[1] != "" && pair[0] != pair[1] {
-			return fmt.Errorf("receipt_corrupt: linked task/outbox provenance changed for attempt %s", incoming.AttemptID)
+			return receiptCorruptf("linked task/outbox provenance changed for attempt %s", incoming.AttemptID)
 		}
 	}
 	return nil
@@ -541,10 +541,10 @@ func hasTerminalConsumerEvidence(consumers []deliveryConsumerState) bool {
 
 func mergeConsumerState(a, b deliveryConsumerState) (deliveryConsumerState, error) {
 	if a.Consumer != b.Consumer {
-		return deliveryConsumerState{}, fmt.Errorf("receipt_corrupt: cannot merge different consumers")
+		return deliveryConsumerState{}, receiptCorruptf("cannot merge different consumers")
 	}
 	if a.Stage != "" && b.Stage != "" && a.Stage != b.Stage {
-		return deliveryConsumerState{}, fmt.Errorf("receipt_corrupt: consumer %s has conflicting terminal stages %s and %s", a.Consumer, a.Stage, b.Stage)
+		return deliveryConsumerState{}, receiptCorruptf("consumer %s has conflicting terminal stages %s and %s", a.Consumer, a.Stage, b.Stage)
 	}
 	if a.Stage != "" {
 		return a, nil
@@ -592,7 +592,7 @@ func mergeReceiptStages(a, b []deliveryReceiptStage) []deliveryReceiptStage {
 
 func writeDeliveryReceiptFile(dirRoot *os.Root, name, path string, receipt *deliveryReceiptData) error {
 	if receipt == nil {
-		return fmt.Errorf("receipt_corrupt: nil delivery receipt")
+		return receiptCorruptf("nil delivery receipt")
 	}
 	if err := validateDeliveryReceiptCrossFields(*receipt); err != nil {
 		return err
@@ -1032,7 +1032,7 @@ func firstJSONObject(data []byte) []byte {
 
 func applyNativeReceipt(receipt *deliveryReceiptData, native nativeAMQReceipt) error {
 	if receipt != nil && receipt.ReconciledMessageID != "" {
-		return fmt.Errorf("receipt_corrupt: reconciled existing receipt cannot adopt native delivery evidence")
+		return receiptCorruptf("reconciled existing receipt cannot adopt native delivery evidence")
 	}
 	if receipt == nil || native.MsgID != receipt.MessageID || !containsString(receipt.Recipients, native.Consumer) {
 		return fmt.Errorf("native receipt provenance does not match message/consumer")
@@ -1048,7 +1048,7 @@ func applyNativeReceipt(receipt *deliveryReceiptData, native nativeAMQReceipt) e
 		return fmt.Errorf("native receipt consumer %s is not projected", native.Consumer)
 	}
 	if native.Stage != "drained" && native.Stage != "dlq" {
-		return fmt.Errorf("receipt_corrupt: unsupported native stage %q", native.Stage)
+		return receiptCorruptf("unsupported native stage %q", native.Stage)
 	}
 	if consumer.Stage != "" && consumer.Stage != native.Stage {
 		receipt.DeliveryState = deliveryStateAmbiguousUnknown
@@ -1058,7 +1058,7 @@ func applyNativeReceipt(receipt *deliveryReceiptData, native nativeAMQReceipt) e
 	}
 	when, err := time.Parse(time.RFC3339Nano, native.EmittedAt)
 	if err != nil {
-		return fmt.Errorf("receipt_corrupt: invalid emitted_at %q for %s/%s", native.EmittedAt, native.Consumer, native.Stage)
+		return receiptCorruptf("invalid emitted_at %q for %s/%s", native.EmittedAt, native.Consumer, native.Stage)
 	}
 	when = when.UTC()
 	receipt.NativeStage = native.Stage

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -834,7 +834,7 @@ func dispatchGenerationRef(project, profile, session, root, sender, assignee str
 		if !left.any && !right.any && (left.err == nil || errors.Is(left.err, os.ErrNotExist)) && (right.err == nil || errors.Is(right.err, os.ErrNotExist)) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("launch records carry prepared identity but the namespace has no accepted prepared artifact")
+		return nil, fmt.Errorf("launch records carry prepared identity but the namespace has no accepted prepared artifact; remedy: %s", preparedRunRecoveryCommand(project, profile, session))
 	}
 	for _, item := range []observed{left, right} {
 		if item.err != nil {
@@ -845,10 +845,10 @@ func dispatchGenerationRef(project, profile, session, root, sender, assignee str
 		}
 	}
 	if left.ref != right.ref {
-		return nil, fmt.Errorf("sender %s and assignee %s launch generation_ref values disagree", sender, assignee)
+		return nil, fmt.Errorf("sender %s and assignee %s launch generation_ref values disagree; remedy: %s", sender, assignee, preparedRunRecoveryCommand(project, profile, session))
 	}
 	if left.ref != *prepared {
-		return nil, fmt.Errorf("launch generation_ref does not match the current accepted prepared artifact")
+		return nil, fmt.Errorf("launch generation_ref does not match the current accepted prepared artifact; remedy: %s", preparedRunRecoveryCommand(project, profile, session))
 	}
 	ref := left.ref
 	return &ref, nil

--- a/internal/cli/error_taxonomy_520_test.go
+++ b/internal/cli/error_taxonomy_520_test.go
@@ -125,6 +125,9 @@ func TestNextMissingTeamUsesSharedActionableError(t *testing.T) {
 }
 
 func TestReceiptCorruptionKeepsStablePrefixAndAddsRecovery(t *testing.T) {
+	if strings.ContainsRune(receiptCorruptRecovery, '%') {
+		t.Fatal("receipt recovery is spliced into a format string; % would become a formatting verb")
+	}
 	err := receiptCorruptf("committed-indeterminate evidence is incomplete for attempt %s", "attempt-1")
 	if !strings.HasPrefix(err.Error(), "receipt_corrupt: committed-indeterminate evidence is incomplete for attempt attempt-1") {
 		t.Fatalf("receipt error changed its stable parseable prefix/detail: %v", err)
@@ -154,8 +157,11 @@ func TestReceiptMergeCorruptionSurfacesSharedRecovery(t *testing.T) {
 }
 
 // The receipt_corrupt prefix is consumed outside this package. Every producer
-// must go through receiptCorruptf so new refusal paths cannot lose either the
-// stable prefix or the shared recovery suffix.
+// in internal/cli (the complete producer set today) must go through
+// receiptCorruptf so new refusal paths cannot lose either the stable prefix or
+// the shared recovery suffix. This audit is deliberately package-local and
+// non-recursive; a producer introduced in another package needs a matching
+// package audit rather than being silently assumed covered here.
 func TestNoRawReceiptCorruptErrorProducers(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	if err != nil {

--- a/internal/cli/error_taxonomy_520_test.go
+++ b/internal/cli/error_taxonomy_520_test.go
@@ -136,6 +136,23 @@ func TestReceiptCorruptionKeepsStablePrefixAndAddsRecovery(t *testing.T) {
 	}
 }
 
+func TestReceiptMergeCorruptionSurfacesSharedRecovery(t *testing.T) {
+	current := baseReceipt613()
+	current.MessageID = "2026-08-02T15-00-00Z_current"
+	incoming := baseReceipt613()
+	incoming.MessageID = "2026-08-02T15-00-01Z_incoming"
+	_, err := mergeDeliveryReceipt(current, incoming)
+	if err == nil {
+		t.Fatal("conflicting receipt message ids unexpectedly merged")
+	}
+	if !strings.HasPrefix(err.Error(), "receipt_corrupt: attempt "+incoming.AttemptID+" maps to conflicting message ids") {
+		t.Fatalf("production merge lost stable receipt prefix/detail: %v", err)
+	}
+	if !strings.Contains(err.Error(), "; remedy: "+receiptCorruptRecovery) {
+		t.Fatalf("production merge did not surface the shared receipt recovery: %v", err)
+	}
+}
+
 // The receipt_corrupt prefix is consumed outside this package. Every producer
 // must go through receiptCorruptf so new refusal paths cannot lose either the
 // stable prefix or the shared recovery suffix.

--- a/internal/cli/error_taxonomy_520_test.go
+++ b/internal/cli/error_taxonomy_520_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/liveidentity"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func TestPreparedRunIdentityMismatchNamesExecutableNextCommand(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream:   "audit",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "codex", Session: "audit"},
+		},
+	})
+	chdir(t, dir)
+
+	err := preparedRunIdentityMismatchf("prepared generation gen-old already has terminal launch evidence")
+	if !strings.HasPrefix(err.Error(), "prepared generation gen-old already has terminal launch evidence; remedy: ") {
+		t.Fatalf("identity error lost what failed and why: %v", err)
+	}
+	const displayed = "amq-squad status --json"
+	if !strings.Contains(err.Error(), "'"+displayed+"'") {
+		t.Fatalf("identity error does not name the canonical inspection command: %v", err)
+	}
+	if strings.Contains(preparedRunIdentityRecoveryHint, "<") {
+		t.Fatalf("generic recovery must not print unresolved placeholders: %s", preparedRunIdentityRecoveryHint)
+	}
+	argv := strings.Fields(displayed)
+	if _, _, runErr := captureOutput(t, func() error { return Run(argv[1:], "test") }); runErr != nil {
+		t.Fatalf("the command displayed by the error did not execute: %v", runErr)
+	}
+}
+
+func TestPreparedRunScopedRecoveryCommandExecutesAsDisplayed(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	useFakeTmuxBackend(t)
+	dir := seedTeam(t, team.Team{
+		Workstream:   "audit",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "codex", Session: "audit"},
+		},
+	})
+	command := preparedRunRecoveryCommand(dir, team.DefaultProfile, "audit")
+	if strings.Contains(command, "<") {
+		t.Fatalf("scoped recovery printed an unresolved placeholder: %s", command)
+	}
+	argv := strings.Fields(command)
+	if len(argv) < 3 || strings.Join(argv[:3], " ") != "amq-squad run start" {
+		t.Fatalf("unexpected recovery command shape: %v", argv)
+	}
+	if _, _, err := captureOutput(t, func() error { return Run(argv[1:], "test") }); err != nil {
+		t.Fatalf("the scoped command displayed by the error did not execute: %v\ncommand: %s", err, command)
+	}
+}
+
+func TestMissingPreparedRunBinaryNamesBothExactAssignments(t *testing.T) {
+	err := missingPreparedRunBinaryError("special-reviewer")
+	for _, want := range []string{
+		"bootstrap blocker [missing] special-reviewer",
+		"--binary special-reviewer=claude",
+		"--binary special-reviewer=codex",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("missing-binary error lacks %q: %v", want, err)
+		}
+	}
+}
+
+func TestLiveIdentityRecoveryNamesRegisteredExecutableCommands(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream:   "audit",
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Handle: "cto", Binary: "codex", Session: "audit"},
+		},
+	})
+	chdir(t, dir)
+	for _, displayed := range []string{"amq-squad status --json", "amq-squad team resume"} {
+		if !strings.Contains(liveidentity.RecoveryAction, "'"+displayed+"'") {
+			t.Fatalf("live-identity recovery lacks %q: %s", displayed, liveidentity.RecoveryAction)
+		}
+		argv := strings.Fields(displayed)
+		if _, _, err := captureOutput(t, func() error { return Run(argv[1:], "test") }); err != nil {
+			t.Fatalf("the live-identity recovery command %q did not execute: %v", displayed, err)
+		}
+	}
+	if strings.Contains(liveidentity.RecoveryAction, "<") {
+		t.Fatalf("live-identity recovery must not print unresolved placeholders: %s", liveidentity.RecoveryAction)
+	}
+}
+
+func TestNextMissingTeamUsesSharedActionableError(t *testing.T) {
+	dir := t.TempDir()
+	err := runNext([]string{"--project", dir, "--profile", "review", "--session", "audit"})
+	if err == nil {
+		t.Fatal("next unexpectedly accepted an unconfigured profile")
+	}
+	for _, want := range []string{
+		`no team configured for profile "review"`,
+		"Run 'amq-squad new profile review' first.",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("next missing-team error lacks %q: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "read team:") {
+		t.Fatalf("next leaked the raw storage failure instead of the shared remedy: %v", err)
+	}
+}
+
+func TestReceiptCorruptionKeepsStablePrefixAndAddsRecovery(t *testing.T) {
+	err := receiptCorruptf("committed-indeterminate evidence is incomplete for attempt %s", "attempt-1")
+	if !strings.HasPrefix(err.Error(), "receipt_corrupt: committed-indeterminate evidence is incomplete for attempt attempt-1") {
+		t.Fatalf("receipt error changed its stable parseable prefix/detail: %v", err)
+	}
+	for _, want := range []string{"; remedy: ", "preserve the receipt artifact", "amq-squad receipt show <message-id> --json"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("receipt error lacks %q: %v", want, err)
+		}
+	}
+}
+
+// The receipt_corrupt prefix is consumed outside this package. Every producer
+// must go through receiptCorruptf so new refusal paths cannot lose either the
+// stable prefix or the shared recovery suffix.
+func TestNoRawReceiptCorruptErrorProducers(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Clean(entry.Name())
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok {
+				ast.Inspect(declaration, func(node ast.Node) bool {
+					literal, literalOK := node.(*ast.BasicLit)
+					if !literalOK || literal.Kind != token.STRING {
+						return true
+					}
+					value, unquoteErr := strconv.Unquote(literal.Value)
+					if unquoteErr == nil && strings.HasPrefix(value, "receipt_corrupt:") {
+						t.Errorf("raw receipt_corrupt producer in package declaration in %s; use receiptCorruptf", path)
+					}
+					return true
+				})
+				continue
+			}
+			if function.Body == nil {
+				continue
+			}
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				literal, ok := node.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					return true
+				}
+				value, unquoteErr := strconv.Unquote(literal.Value)
+				if unquoteErr == nil && strings.HasPrefix(value, "receipt_corrupt:") && function.Name.Name != "receiptCorruptf" {
+					t.Errorf("raw receipt_corrupt producer in %s function %s; use receiptCorruptf", path, function.Name.Name)
+				}
+				return true
+			})
+		}
+	}
+}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -595,7 +595,7 @@ Examples:
 		}
 		adm := preparedRunActorAdmission(manifest, manifestDigest, prepared, rec.Role, rec.Handle, nil)
 		if adm.required() {
-			return fmt.Errorf("agent up refused before launch-record or process side effects: %s", adm.Reason)
+			return fmt.Errorf("agent up refused before launch-record or process side effects: %s; recovery: %s", adm.Reason, adm.Recovery)
 		}
 	}
 	if requestedPreparedToken.empty() {

--- a/internal/cli/next.go
+++ b/internal/cli/next.go
@@ -10,6 +10,7 @@ import (
 
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
 // nextActionData is the kind="next" payload: a single canonical action object
@@ -82,6 +83,9 @@ Examples:
 		return err
 	}
 	emitContextDiagnostics(ctx)
+	if !team.ExistsProfile(ctx.ProjectDir, ctx.Profile) {
+		return fmt.Errorf("no team configured for profile %q. Run '%s' first.", ctx.Profile, profileInitCommand(ctx.Profile))
+	}
 	return executeNext(nextExecution{
 		ProjectDir:      ctx.ProjectDir,
 		Profile:         ctx.Profile,

--- a/internal/cli/prepared_run_admission.go
+++ b/internal/cli/prepared_run_admission.go
@@ -193,3 +193,14 @@ func fieldOrPlaceholder(value, name string) string {
 	}
 	return shellQuote(strings.TrimSpace(value))
 }
+
+// preparedRunRecoveryCommand reopens the canonical run-start flow for the exact
+// namespace. It intentionally does not print --prepare: a valid preparation
+// command also needs the accepted launch shape and goal binding, which these
+// error sites cannot reconstruct safely. The guided preview emits that complete
+// command without mutating immutable generation or launch evidence.
+func preparedRunRecoveryCommand(project, profile, session string) string {
+	return "amq-squad run start --project " + projectOrPlaceholder(project) +
+		" --profile " + fieldOrPlaceholder(profile, "profile") +
+		" --session " + fieldOrPlaceholder(session, "session")
+}

--- a/internal/cli/prepared_run_state_test.go
+++ b/internal/cli/prepared_run_state_test.go
@@ -704,8 +704,13 @@ func TestAgentUpStagedSpawnProductPathBindsActiveClaimWithoutConsuming(t *testin
 		"--project", dir, "--team-home", dir, "--team-profile", team.DefaultProfile,
 		"--role", "qa", "--me", "qa", "--session", "prepared", "--trust", trustModeApproveForMe, "claude",
 	}
-	if _, _, err := captureOutput(t, func() error { return runLaunch(args) }); err == nil || !strings.Contains(err.Error(), "requires an exact single-use spawn reservation") {
-		t.Fatalf("ungated direct staged agent up error = %v", err)
+	_, _, directErr := captureOutput(t, func() error { return runLaunch(args) })
+	if directErr == nil || !strings.Contains(directErr.Error(), "requires an exact single-use spawn reservation") {
+		t.Fatalf("ungated direct staged agent up error = %v", directErr)
+	}
+	if want := "recovery: amq-squad agent up"; !strings.Contains(directErr.Error(), want) ||
+		!strings.Contains(directErr.Error(), "--staged-spawn --staged-claim") {
+		t.Fatalf("ungated direct staged agent up did not surface its executable reservation remedy: %v", directErr)
 	}
 	if execCalls != 0 {
 		t.Fatalf("ungated direct staged agent up executed %d time(s)", execCalls)

--- a/internal/cli/prepared_task_mutation_race_test.go
+++ b/internal/cli/prepared_task_mutation_race_test.go
@@ -425,6 +425,9 @@ func TestAdvancedCurrentRejectsDelayedOutboxAndCompletionReconcile(t *testing.T)
 			if err == nil || !strings.Contains(err.Error(), "task lifecycle generation_ref does not match the current accepted prepared artifact") {
 				t.Fatalf("stale %s err=%v", mode, err)
 			}
+			if want := preparedRunRecoveryCommand(fixture.project, "review", "s"); !strings.Contains(err.Error(), "remedy: "+want) {
+				t.Fatalf("stale %s error lacks the exact namespace-scoped recovery %q: %v", mode, want, err)
+			}
 			after, err := os.ReadFile(path)
 			if err != nil || string(after) != string(before) {
 				t.Fatalf("stale %s mutated task: err=%v", mode, err)

--- a/internal/cli/receipt.go
+++ b/internal/cli/receipt.go
@@ -222,27 +222,27 @@ func validateReceiptProvenance(receipt deliveryReceiptData, projectDir, profile,
 	}
 	recordProject, err := canonicalPathForReceipt(receipt.Target.ProjectDir)
 	if err != nil || filepath.Clean(recordProject) != filepath.Clean(projectAbs) {
-		return fmt.Errorf("receipt_corrupt: project provenance %q does not match selected project %q", receipt.Target.ProjectDir, projectAbs)
+		return receiptCorruptf("project provenance %q does not match selected project %q", receipt.Target.ProjectDir, projectAbs)
 	}
 	profile = squadnamespace.NormalizeProfile(profile)
 	session = strings.TrimSpace(session)
 	if squadnamespace.NormalizeProfile(receipt.Target.Profile) != profile || strings.TrimSpace(receipt.Target.Session) != session || receipt.Target.NamespaceID != squadnamespace.ID(profile, session) {
-		return fmt.Errorf("receipt_corrupt: namespace provenance %s/%s (%s) does not match selected %s/%s", receipt.Target.Profile, receipt.Target.Session, receipt.Target.NamespaceID, profile, session)
+		return receiptCorruptf("namespace provenance %s/%s (%s) does not match selected %s/%s", receipt.Target.Profile, receipt.Target.Session, receipt.Target.NamespaceID, profile, session)
 	}
 	expectedPath := filepath.Join(deliveryReceiptDir(projectAbs, profile, session), receipt.AttemptID+".json")
 	actualPath, actualErr := canonicalPathForReceipt(path)
 	recordedPath, recordedErr := canonicalPathForReceipt(receipt.Path)
 	if actualErr != nil || recordedErr != nil || filepath.Clean(actualPath) != filepath.Clean(expectedPath) || filepath.Base(path) != receipt.AttemptID+".json" || filepath.Clean(recordedPath) != filepath.Clean(expectedPath) {
-		return fmt.Errorf("receipt_corrupt: attempt filename/path does not match %s", expectedPath)
+		return receiptCorruptf("attempt filename/path does not match %s", expectedPath)
 	}
 	expectedRoot := squadnamespace.AMQRoot(projectAbs, profile, session)
 	recordRoot, rootErr := canonicalPathForReceipt(receipt.Root)
 	expectedCanonicalRoot, expectedRootErr := canonicalPathForReceipt(expectedRoot)
 	if rootErr != nil || expectedRootErr != nil || filepath.Clean(recordRoot) != filepath.Clean(expectedCanonicalRoot) {
-		return fmt.Errorf("receipt_corrupt: AMQ root %q does not match canonical root %q", receipt.Root, expectedRoot)
+		return receiptCorruptf("AMQ root %q does not match canonical root %q", receipt.Root, expectedRoot)
 	}
 	if receipt.Sender == "" || len(receipt.Recipients) == 0 || receipt.Thread == "" {
-		return fmt.Errorf("receipt_corrupt: sender, recipients, and thread provenance are mandatory")
+		return receiptCorruptf("sender, recipients, and thread provenance are mandatory")
 	}
 	return nil
 }
@@ -271,7 +271,7 @@ func canonicalPathForReceipt(path string) (string, error) {
 
 func refreshDeliveryReceipt(receipt *deliveryReceiptData, projectDir, profile, session string) error {
 	if receipt == nil {
-		return fmt.Errorf("receipt_corrupt: nil delivery receipt")
+		return receiptCorruptf("nil delivery receipt")
 	}
 	if err := validateDeliveryReceiptCrossFields(*receipt); err != nil {
 		return err

--- a/internal/cli/receipt_error.go
+++ b/internal/cli/receipt_error.go
@@ -1,0 +1,12 @@
+package cli
+
+import "fmt"
+
+const receiptCorruptRecovery = "preserve the receipt artifact and do not retry delivery; from the selected project, inspect it with `amq-squad receipt show <message-id> --json` using the receipt's recorded message_id before manual reconciliation"
+
+// receiptCorruptf owns the stable machine-consumed prefix and the operator
+// recovery for every corrupt durable-receipt refusal. Consumers rely on the
+// prefix, so the actionable suffix must be additive.
+func receiptCorruptf(format string, args ...any) error {
+	return fmt.Errorf("receipt_corrupt: "+format+"; remedy: "+receiptCorruptRecovery, args...)
+}

--- a/internal/cli/run_start_preparation.go
+++ b/internal/cli/run_start_preparation.go
@@ -386,7 +386,7 @@ func buildRunPreparationProposal(in runPreparationProposalInput) (runPreparation
 		handle := memberHandle(member)
 		binary := strings.TrimSpace(member.Binary)
 		if binary != "codex" && binary != "claude" {
-			return proposal, fmt.Errorf("bootstrap blocker [missing] %s: explicit codex or claude binary is required", roleID)
+			return proposal, missingPreparedRunBinaryError(roleID)
 		}
 		policyEvidence := fmt.Sprintf("handle=%s binary=%s effective=%s config=%s mcp=%s", handle, binary, member.EffectiveToolProfile(), member.ToolConfig, member.ToolMCPConfig)
 		for _, file := range policyFiles[roleID] {
@@ -425,6 +425,11 @@ func buildRunPreparationProposal(in runPreparationProposalInput) (runPreparation
 	proposal.MutationPaths = cleanUniquePreparationPaths(proposal.MutationPaths)
 	sort.SliceStable(proposal.Rows, func(i, j int) bool { return proposal.Rows[i].Artifact < proposal.Rows[j].Artifact })
 	return proposal, nil
+}
+
+func missingPreparedRunBinaryError(roleID string) error {
+	return fmt.Errorf("bootstrap blocker [missing] %s: explicit codex or claude binary is required; remedy: re-run the same command with --binary %s or --binary %s",
+		roleID, shellQuote(roleID+"=claude"), shellQuote(roleID+"=codex"))
 }
 
 func freshRunPreparationAMQRemedy(project string, tm team.Team, detail string) string {

--- a/internal/cli/run_start_readiness.go
+++ b/internal/cli/run_start_readiness.go
@@ -149,8 +149,10 @@ type preparedRunIdentityMismatchError struct {
 	detail string
 }
 
+const preparedRunIdentityRecoveryHint = "remedy: from the affected project, run 'amq-squad status --json' to identify the current accepted generation and exact active claim; if the recorded generation is terminal or invalid, re-run that namespace's accepted preparation flow"
+
 func (e *preparedRunIdentityMismatchError) Error() string {
-	return e.detail
+	return e.detail + "; " + preparedRunIdentityRecoveryHint
 }
 
 func preparedRunIdentityMismatchf(format string, args ...any) error {

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -242,17 +242,17 @@ func taskLifecycleGenerationRef(ns squadnamespace.Ref, actor string, explicit ta
 		return task.GenerationRef{}, err
 	}
 	if prepared == nil {
-		return task.GenerationRef{}, fmt.Errorf("task lifecycle requires the current accepted prepared artifact")
+		return task.GenerationRef{}, fmt.Errorf("task lifecycle requires the current accepted prepared artifact; remedy: %s", preparedRunRecoveryCommand(ns.TeamHome, ns.Profile, ns.Session))
 	}
 	if ref != *prepared {
-		return task.GenerationRef{}, fmt.Errorf("actor launch generation_ref does not match the current accepted prepared artifact")
+		return task.GenerationRef{}, fmt.Errorf("actor launch generation_ref does not match the current accepted prepared artifact; remedy: %s", preparedRunRecoveryCommand(ns.TeamHome, ns.Profile, ns.Session))
 	}
 	if provided {
 		if err := task.ValidateGenerationRef(explicit); err != nil {
 			return task.GenerationRef{}, err
 		}
 		if explicit != ref {
-			return task.GenerationRef{}, fmt.Errorf("explicit generation_ref does not match the current managed actor launch record")
+			return task.GenerationRef{}, fmt.Errorf("explicit generation_ref does not match the current managed actor launch record; remedy: omit the stale explicit generation_ref and retry after running %s", preparedRunRecoveryCommand(ns.TeamHome, ns.Profile, ns.Session))
 		}
 	}
 	return ref, nil
@@ -286,7 +286,7 @@ func validateTaskPreparedGeneration(ns squadnamespace.Ref, current task.Task, op
 		return err
 	}
 	if prepared == nil || *current.LifecycleGenerationRef != *prepared {
-		return fmt.Errorf("%s refused: task lifecycle generation_ref does not match the current accepted prepared artifact", operation)
+		return fmt.Errorf("%s refused: task lifecycle generation_ref does not match the current accepted prepared artifact; remedy: %s", operation, preparedRunRecoveryCommand(ns.TeamHome, ns.Profile, ns.Session))
 	}
 	return nil
 }

--- a/internal/liveidentity/identity.go
+++ b/internal/liveidentity/identity.go
@@ -17,7 +17,7 @@ const (
 	// RecoveryAction is the single recovery offered for every failed binding.
 	// Callers may add context around it, but must not synthesize a different
 	// action for individual mismatch classes.
-	RecoveryAction = "stop the contradictory runtime, then relaunch the actor from the current prepared generation"
+	RecoveryAction = "from the affected team project, run 'amq-squad status --json' to identify the contradictory role and exact namespace, stop that reported role, then run 'amq-squad team resume' and execute its current prepared-generation plan"
 	WakeRequired   = "required"
 	WakeDisabled   = "disabled"
 )


### PR DESCRIPTION
## Summary

- make prepared/staged identity mismatches name an executable inspection path, and surface the admission recovery that `agent up` already computes
- add namespace-scoped run-start recovery to task/dispatch generation drift, exact binary assignments to custom-role preparation failures, and executable status/resume steps to live-identity failures
- give `next` the shared missing-team/init error instead of leaking a storage ENOENT
- preserve the machine-consumed `receipt_corrupt:` prefix while routing every receipt corruption producer through one actionable recovery helper

## Error-taxonomy survey

The issue's 30-error sample started at 12 actionable, 8 failure-only, and 10 internal-jargon messages. The focused audit produced these dispositions:

| Surface | Disposition |
| --- | --- |
| prepared/staged identity mismatch | Fixed once at `preparedRunIdentityMismatchError`: what failed stays first; recovery runs `amq-squad status --json` from the affected project and directs terminal generations back through accepted preparation |
| staged `agent up` admission | Fixed at the execution boundary by including the predicate-owned `Recovery` command instead of dropping it |
| task/dispatch `generation_ref` drift | Fixed with the exact project/profile/session run-start recovery flow; displayed commands are executed by regression tests |
| custom role without binary | Fixed with both exact `--binary role=claude` and `--binary role=codex` assignments |
| live-identity mismatch | Fixed once in `liveidentity.RecoveryAction` with registered `status --json` and `team resume` commands; both execute in regression tests |
| missing team from `next` | Fixed with the shared `no team configured ... Run 'amq-squad new ...' first` contract |
| durable receipt corruption | Fixed across 35 direct producers (29 in `delivery_receipt.go`, 6 in `receipt.go`) through `receiptCorruptf`; prefix and field/detail wording remain additive and byte-stable at the front |
| goal binding source | Already actionable from #610 (`--seed-from` / `--goal`); credited, not rewritten |
| unknown subcommands | Already canonical/actionable from #627; credited, not rewritten |
| worktree/shared-CWD collision | Already supplies executable remedies after #629; credited, not rewritten |

The durable guard is AST-based: comments are ignored, and any future non-test Go function or package declaration that introduces a raw `receipt_corrupt:` string fails the suite unless it is the shared helper itself.

## Verification

- `go test ./internal/cli ./internal/liveidentity -count=1 -timeout 20m` — PASS (`internal/cli` 430.616s, `internal/liveidentity` 0.942s)
- consolidated effect/execute-as-displayed suite — PASS (`internal/cli` 4.094s; `internal/liveidentity` 0.360s)
- receipt RED→GREEN proof: the AST audit first enumerated exactly 29 remaining `delivery_receipt.go` producers, then passed after migration
- #630 compatibility suite (`EstablishThenFreeze*`, `AlwaysFrozenFields*`, `MergePreservesEstablishedFields`) — PASS
- `gofmt` and `git diff --check` — clean

Closes #520
