### PR TITLE
feat: hand the operator their role, console, and gate surface at launch (#493)

### DIFF
--- a/internal/cli/operator_handoff_card.go
+++ b/internal/cli/operator_handoff_card.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// operatorHandoffCard is the post-launch operator handoff card (#493): the last
+// thing a successful launch prints, telling the human who they are in this
+// session, where their attention belongs, and how decisions will reach them.
+//
+// It exists because "launched ✓" is not a handoff. In the 2026-07-18 session
+// the squad finished its goal in 23 minutes and sent the operator an ACK plus
+// two gate decisions; the human found them roughly 50 minutes later and asked
+// why the CTO was not speaking to them. The profile had been configured
+// operator_delivery=lead_pane, notifications=false, poll_required=false — a
+// coherent configuration that nothing had ever explained to the person it
+// depended on.
+//
+// Two properties are load-bearing:
+//
+//   - Every field derives from the profile's actual operator block. A card that
+//     printed plausible defaults would reproduce the exact failure it exists to
+//     prevent, and would do it while sounding authoritative.
+//   - It renders to stdout unconditionally, never through quietNotice. The
+//     launch notices above it are quiet-suppressible because they are progress
+//     chatter; this is the one output that tells the operator they are on the
+//     hook, and --quiet must not be able to turn it off (#493 safety output).
+type operatorHandoffCard struct {
+	// Enabled mirrors the profile's operator block. When false the card
+	// reports that no gate will reach a human, which is a different and
+	// equally important thing to be told.
+	Enabled bool
+	Handle  string
+	Profile string
+	Session string
+	// Console is the human-readable attention surface for the configured
+	// interaction mode, naming the actual lead role where one applies.
+	Console string
+	// Contract is the mode's own statement of how approvals are given.
+	Contract string
+
+	NotificationsEnabled bool
+	SinkTypes            []string
+	PollRequired         bool
+
+	NextCommand    string
+	MonitorCommand string
+	AnswerCommand  string
+	StatusCommand  string
+
+	DisabledReason string
+}
+
+// newOperatorHandoffCard derives the card from the launched team's operator
+// block and the exact profile/session that was just brought up. It takes the
+// resolved team rather than re-reading the profile so the card describes the
+// roster that actually launched.
+func newOperatorHandoffCard(t team.Team, profile, session string) operatorHandoffCard {
+	d := operatorDeliveryForTeam(t)
+	next, monitor, answer, status := operatorHandoffCommands(profile, session)
+	card := operatorHandoffCard{
+		Enabled:        d.Enabled,
+		Handle:         d.Handle,
+		Profile:        strings.TrimSpace(profile),
+		Session:        strings.TrimSpace(session),
+		NextCommand:    next,
+		MonitorCommand: monitor,
+		AnswerCommand:  answer,
+		StatusCommand:  status,
+	}
+	if !d.Enabled {
+		card.DisabledReason = d.Reason
+		return card
+	}
+	card.Console = operatorConsoleSurface(t, d)
+	card.Contract = d.Contract
+	card.NotificationsEnabled = d.NotificationsEnabled
+	card.SinkTypes = d.NotificationSinkTypes
+	card.PollRequired = d.PollRequired
+	return card
+}
+
+// operatorHandoffCommands builds the four scoped commands the card prints.
+// They carry --profile/--session but deliberately not --project: the card is
+// printed into the terminal the operator launched from, whose cwd is already
+// the project, and the adjacent "next:" launch notice scopes itself the same
+// way. Keeping both consistent matters more than portability to another cwd.
+func operatorHandoffCommands(profile, session string) (next, monitor, answer, status string) {
+	scope := commandProfileArg(profile)
+	if s := strings.TrimSpace(session); s != "" {
+		scope += " --session " + shellQuote(s)
+	}
+	next = "amq-squad next" + scope
+	monitor = "amq-squad monitor" + scope
+	answer = "amq-squad operator answer" + scope + " --gate <topic> --approved|--denied [--reason TEXT]"
+	status = "amq-squad status" + scope
+	return next, monitor, answer, status
+}
+
+// operatorConsoleSurface names where this operator's attention is supposed to
+// live. lead_pane names the actual lead role: "the lead pane" is not actionable
+// to someone looking at a grid of identical panes.
+func operatorConsoleSurface(t team.Team, d operatorDeliveryData) string {
+	switch d.InteractionMode {
+	case team.OperatorInteractionLeadPane:
+		if lead := strings.TrimSpace(t.Lead); lead != "" {
+			return fmt.Sprintf("the lead pane (role %s)", lead)
+		}
+		return "the lead pane"
+	case team.OperatorInteractionSeparateTerminal:
+		return "a separate terminal — this one; the squad runs in its own panes"
+	case team.OperatorInteractionNOC:
+		return "the NOC/global board"
+	case team.OperatorInteractionSelfOperator:
+		return fmt.Sprintf("the lead, under self-operator policy; only allowlisted gates are delegated, the rest still come to %s", d.Handle)
+	default:
+		return "not configured — no console was assigned to you"
+	}
+}
+
+const operatorHandoffCardRule = "────────────────────────────────────────────────────────────────────"
+
+// writeOperatorHandoffCard renders the card. Callers must pass os.Stdout
+// directly rather than routing through quietNotice; see the type doc.
+func writeOperatorHandoffCard(w io.Writer, c operatorHandoffCard) {
+	fmt.Fprintf(w, "\n%s\n", operatorHandoffCardRule)
+	if !c.Enabled {
+		fmt.Fprintf(w, " OPERATOR GATES ARE DISABLED FOR THIS PROFILE\n")
+		fmt.Fprintf(w, "%s\n", operatorHandoffCardRule)
+		if c.DisabledReason != "" {
+			fmt.Fprintf(w, " %s.\n", c.DisabledReason)
+		}
+		fmt.Fprintf(w, " No gate thread will be routed to a human for this session; the team\n")
+		fmt.Fprintf(w, " lead owns these decisions under the team rules.\n\n")
+		fmt.Fprintf(w, " Board    %s\n", c.StatusCommand)
+		fmt.Fprintf(w, "%s\n\n", operatorHandoffCardRule)
+		return
+	}
+
+	fmt.Fprintf(w, " YOU ARE THE OPERATOR FOR THIS SESSION\n")
+	fmt.Fprintf(w, "%s\n", operatorHandoffCardRule)
+	fmt.Fprintf(w, " Handle   %s — messages addressed to %q are addressed to you.\n", c.Handle, c.Handle)
+	fmt.Fprintf(w, " Console  %s\n", c.Console)
+	fmt.Fprintln(w)
+
+	if c.NotificationsEnabled {
+		sinks := "an unnamed sink"
+		if len(c.SinkTypes) > 0 {
+			sinks = strings.Join(c.SinkTypes, ", ")
+		}
+		fmt.Fprintf(w, " ALERTS   ON via %s. The launch-host watcher will notify you.\n", sinks)
+		fmt.Fprintf(w, "          Health is reported by `amq-squad status`, not by this card.\n")
+	} else {
+		fmt.Fprintf(w, " ALERTS   OFF — NOTHING WILL INTERRUPT YOU.\n")
+		fmt.Fprintf(w, "          No desktop, terminal, or sound alert is configured. If you\n")
+		fmt.Fprintf(w, "          walk away, the squad's questions wait silently until you\n")
+		fmt.Fprintf(w, "          come back and look. You have to poll:\n")
+		fmt.Fprintf(w, "            %s\n", c.NextCommand)
+		fmt.Fprintf(w, "            %s\n", c.MonitorCommand)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, " DECISIONS Gates arrive as durable gate/<topic> threads addressed to\n")
+	fmt.Fprintf(w, "          %q. They do not expire and they do not resend.\n", c.Handle)
+	if c.Contract != "" {
+		fmt.Fprintf(w, "          Contract: %s.\n", c.Contract)
+	}
+	fmt.Fprintf(w, "          Read:   %s\n", c.NextCommand)
+	fmt.Fprintf(w, "          Answer: %s\n", c.AnswerCommand)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, " Board    %s\n", c.StatusCommand)
+	fmt.Fprintf(w, "%s\n\n", operatorHandoffCardRule)
+}
+
+// printOperatorHandoffCard is the single call site helper used by the launch
+// routes. It writes to stdout on purpose: see operatorHandoffCard's doc for why
+// --quiet must not suppress this.
+func printOperatorHandoffCard(w io.Writer, t team.Team, profile, session string) {
+	writeOperatorHandoffCard(w, newOperatorHandoffCard(t, profile, session))
+}

--- a/internal/cli/operator_handoff_card.go
+++ b/internal/cli/operator_handoff_card.go
@@ -47,10 +47,12 @@ type operatorHandoffCard struct {
 	SinkTypes            []string
 	PollRequired         bool
 
-	NextCommand    string
-	MonitorCommand string
-	AnswerCommand  string
-	StatusCommand  string
+	NextCommand     string
+	MonitorCommand  string
+	ApproveCommand  string
+	DenyCommand     string
+	StatusCommand   string
+	ExampleGateName string
 
 	DisabledReason string
 }
@@ -61,16 +63,18 @@ type operatorHandoffCard struct {
 // roster that actually launched.
 func newOperatorHandoffCard(t team.Team, profile, session string) operatorHandoffCard {
 	d := operatorDeliveryForTeam(t)
-	next, monitor, answer, status := operatorHandoffCommands(profile, session)
+	scope := operatorHandoffScope(t.Project, profile, session)
 	card := operatorHandoffCard{
-		Enabled:        d.Enabled,
-		Handle:         d.Handle,
-		Profile:        strings.TrimSpace(profile),
-		Session:        strings.TrimSpace(session),
-		NextCommand:    next,
-		MonitorCommand: monitor,
-		AnswerCommand:  answer,
-		StatusCommand:  status,
+		Enabled:         d.Enabled,
+		Handle:          d.Handle,
+		Profile:         strings.TrimSpace(profile),
+		Session:         strings.TrimSpace(session),
+		NextCommand:     "amq-squad next" + scope,
+		MonitorCommand:  "amq-squad monitor" + scope,
+		ApproveCommand:  "amq-squad operator answer" + scope + " --gate " + operatorHandoffExampleGate + " --approved --reason " + shellQuote("looks right"),
+		DenyCommand:     "amq-squad operator answer" + scope + " --gate " + operatorHandoffExampleGate + " --denied --reason " + shellQuote("not yet"),
+		StatusCommand:   "amq-squad status" + scope,
+		ExampleGateName: operatorHandoffExampleGate,
 	}
 	if !d.Enabled {
 		card.DisabledReason = d.Reason
@@ -84,21 +88,32 @@ func newOperatorHandoffCard(t team.Team, profile, session string) operatorHandof
 	return card
 }
 
-// operatorHandoffCommands builds the four scoped commands the card prints.
-// They carry --profile/--session but deliberately not --project: the card is
-// printed into the terminal the operator launched from, whose cwd is already
-// the project, and the adjacent "next:" launch notice scopes itself the same
-// way. Keeping both consistent matters more than portability to another cwd.
-func operatorHandoffCommands(profile, session string) (next, monitor, answer, status string) {
-	scope := commandProfileArg(profile)
+// operatorHandoffExampleGate is the placeholder gate topic in the printed
+// answer commands. It is a bare word, not <topic>: the card presents these
+// under "What to run", and angle brackets are shell redirection. A reader who
+// copies the line must get a command that runs, even if they then have to swap
+// the topic for a real one.
+const operatorHandoffExampleGate = "release"
+
+// operatorHandoffScope builds the namespace flags shared by every command the
+// card prints.
+//
+// --project is included and resolved. An earlier version omitted it on the
+// assumption that the operator's shell is already sitting in the project, which
+// is false for `up --project DIR`: runInProject chdirs the launching PROCESS and
+// restores the old directory on return, so the operator's shell never moved.
+// Without --project those commands would silently resolve against whatever
+// directory the operator happened to be in.
+func operatorHandoffScope(project, profile, session string) string {
+	scope := ""
+	if p := strings.TrimSpace(project); p != "" {
+		scope += " --project " + shellQuote(p)
+	}
+	scope += commandProfileArg(profile)
 	if s := strings.TrimSpace(session); s != "" {
 		scope += " --session " + shellQuote(s)
 	}
-	next = "amq-squad next" + scope
-	monitor = "amq-squad monitor" + scope
-	answer = "amq-squad operator answer" + scope + " --gate <topic> --approved|--denied [--reason TEXT]"
-	status = "amq-squad status" + scope
-	return next, monitor, answer, status
+	return scope
 }
 
 // operatorConsoleSurface names where this operator's attention is supposed to
@@ -186,7 +201,9 @@ func writeOperatorHandoffCard(w io.Writer, c operatorHandoffCard) {
 	fmt.Fprintf(w, " What to run:\n")
 	fmt.Fprintf(w, "   # what needs you right now\n   %s\n", c.NextCommand)
 	fmt.Fprintf(w, "   # block until something needs you\n   %s\n", c.MonitorCommand)
-	fmt.Fprintf(w, "   # answer a gate\n   %s\n", c.AnswerCommand)
+	fmt.Fprintf(w, "   # answer a gate — swap %s for the topic named in the gate message\n", c.ExampleGateName)
+	fmt.Fprintf(w, "   %s\n", c.ApproveCommand)
+	fmt.Fprintf(w, "   %s\n", c.DenyCommand)
 	fmt.Fprintf(w, "   # the board\n   %s\n", c.StatusCommand)
 	fmt.Fprintf(w, "%s\n\n", operatorHandoffCardRule)
 }

--- a/internal/cli/operator_handoff_card.go
+++ b/internal/cli/operator_handoff_card.go
@@ -124,8 +124,23 @@ func operatorConsoleSurface(t team.Team, d operatorDeliveryData) string {
 
 const operatorHandoffCardRule = "────────────────────────────────────────────────────────────────────"
 
+// operatorHandoffCardField renders one "Label   value" row. Every label shares
+// an 8-column field so continuation lines can align under the value with a
+// fixed 10-space indent; see operatorHandoffCardWrapIndent.
+func operatorHandoffCardField(w io.Writer, label, value string) {
+	fmt.Fprintf(w, " %-8s %s\n", label, value)
+}
+
+const operatorHandoffCardWrapIndent = "          "
+
 // writeOperatorHandoffCard renders the card. Callers must pass os.Stdout
 // directly rather than routing through quietNotice; see the type doc.
+//
+// Commands are never inlined after a label. They are long enough (a scoped
+// `operator answer` runs past 110 columns) that a label prefix guarantees an
+// ugly soft-wrap, and a soft-wrapped command is one a hurried operator
+// copy-pastes incorrectly. Each command gets its own full-width line under a
+// short comment instead.
 func writeOperatorHandoffCard(w io.Writer, c operatorHandoffCard) {
 	fmt.Fprintf(w, "\n%s\n", operatorHandoffCardRule)
 	if !c.Enabled {
@@ -134,17 +149,22 @@ func writeOperatorHandoffCard(w io.Writer, c operatorHandoffCard) {
 		if c.DisabledReason != "" {
 			fmt.Fprintf(w, " %s.\n", c.DisabledReason)
 		}
-		fmt.Fprintf(w, " No gate thread will be routed to a human for this session; the team\n")
-		fmt.Fprintf(w, " lead owns these decisions under the team rules.\n\n")
-		fmt.Fprintf(w, " Board    %s\n", c.StatusCommand)
+		fmt.Fprintf(w, " No gate thread will be routed to a human for this session; the\n")
+		fmt.Fprintf(w, " team lead owns these decisions under the team rules.\n\n")
+		fmt.Fprintf(w, " Check the board with:\n   %s\n", c.StatusCommand)
 		fmt.Fprintf(w, "%s\n\n", operatorHandoffCardRule)
 		return
 	}
 
 	fmt.Fprintf(w, " YOU ARE THE OPERATOR FOR THIS SESSION\n")
 	fmt.Fprintf(w, "%s\n", operatorHandoffCardRule)
-	fmt.Fprintf(w, " Handle   %s — messages addressed to %q are addressed to you.\n", c.Handle, c.Handle)
-	fmt.Fprintf(w, " Console  %s\n", c.Console)
+	operatorHandoffCardField(w, "Handle", fmt.Sprintf("%s — messages addressed to %q are for you.", c.Handle, c.Handle))
+	operatorHandoffCardField(w, "Console", c.Console)
+	operatorHandoffCardField(w, "Gates", fmt.Sprintf("durable gate/<topic> threads addressed to %q.", c.Handle))
+	fmt.Fprintf(w, "%sThey do not expire, and they do not resend.\n", operatorHandoffCardWrapIndent)
+	if c.Contract != "" {
+		fmt.Fprintf(w, "%sHow you answer: %s.\n", operatorHandoffCardWrapIndent, c.Contract)
+	}
 	fmt.Fprintln(w)
 
 	if c.NotificationsEnabled {
@@ -152,27 +172,22 @@ func writeOperatorHandoffCard(w io.Writer, c operatorHandoffCard) {
 		if len(c.SinkTypes) > 0 {
 			sinks = strings.Join(c.SinkTypes, ", ")
 		}
-		fmt.Fprintf(w, " ALERTS   ON via %s. The launch-host watcher will notify you.\n", sinks)
-		fmt.Fprintf(w, "          Health is reported by `amq-squad status`, not by this card.\n")
+		operatorHandoffCardField(w, "ALERTS", fmt.Sprintf("ON via %s.", sinks))
+		fmt.Fprintf(w, "%sThe launch-host watcher will notify you. Its health is\n", operatorHandoffCardWrapIndent)
+		fmt.Fprintf(w, "%sreported by `amq-squad status`, not by this card.\n", operatorHandoffCardWrapIndent)
 	} else {
-		fmt.Fprintf(w, " ALERTS   OFF — NOTHING WILL INTERRUPT YOU.\n")
-		fmt.Fprintf(w, "          No desktop, terminal, or sound alert is configured. If you\n")
-		fmt.Fprintf(w, "          walk away, the squad's questions wait silently until you\n")
-		fmt.Fprintf(w, "          come back and look. You have to poll:\n")
-		fmt.Fprintf(w, "            %s\n", c.NextCommand)
-		fmt.Fprintf(w, "            %s\n", c.MonitorCommand)
+		operatorHandoffCardField(w, "ALERTS", "OFF — NOTHING WILL INTERRUPT YOU.")
+		fmt.Fprintf(w, "%sNo alert of any kind is configured for this session. If you\n", operatorHandoffCardWrapIndent)
+		fmt.Fprintf(w, "%swalk away, the squad's questions wait silently until you come\n", operatorHandoffCardWrapIndent)
+		fmt.Fprintf(w, "%sback and look. Polling is on you.\n", operatorHandoffCardWrapIndent)
 	}
 	fmt.Fprintln(w)
 
-	fmt.Fprintf(w, " DECISIONS Gates arrive as durable gate/<topic> threads addressed to\n")
-	fmt.Fprintf(w, "          %q. They do not expire and they do not resend.\n", c.Handle)
-	if c.Contract != "" {
-		fmt.Fprintf(w, "          Contract: %s.\n", c.Contract)
-	}
-	fmt.Fprintf(w, "          Read:   %s\n", c.NextCommand)
-	fmt.Fprintf(w, "          Answer: %s\n", c.AnswerCommand)
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, " Board    %s\n", c.StatusCommand)
+	fmt.Fprintf(w, " What to run:\n")
+	fmt.Fprintf(w, "   # what needs you right now\n   %s\n", c.NextCommand)
+	fmt.Fprintf(w, "   # block until something needs you\n   %s\n", c.MonitorCommand)
+	fmt.Fprintf(w, "   # answer a gate\n   %s\n", c.AnswerCommand)
+	fmt.Fprintf(w, "   # the board\n   %s\n", c.StatusCommand)
 	fmt.Fprintf(w, "%s\n\n", operatorHandoffCardRule)
 }
 

--- a/internal/cli/operator_handoff_card_493_test.go
+++ b/internal/cli/operator_handoff_card_493_test.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -54,8 +57,8 @@ func TestLiveLaunchPrintsOperatorHandoffCard(t *testing.T) {
 		"YOU ARE THE OPERATOR FOR THIS SESSION",
 		"Handle   user",
 		"the lead pane (role cto)",
-		"amq-squad operator answer --session issue-493 --gate <topic> --approved|--denied",
-		"amq-squad status --session issue-493",
+		"--gate release --approved",
+		"--session issue-493",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("launch stdout missing %q; full output:\n%s", want, stdout)
@@ -122,8 +125,8 @@ func TestLiveLaunchCardWarnsWhenNotificationsOff(t *testing.T) {
 	}
 	for _, want := range []string{
 		"ALERTS   OFF — NOTHING WILL INTERRUPT YOU.",
-		"amq-squad next --session issue-493n",
-		"amq-squad monitor --session issue-493n",
+		"amq-squad next --project",
+		"amq-squad monitor --project",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("notifications-off launch missing %q; stdout:\n%s", want, stdout)
@@ -210,21 +213,153 @@ func TestOperatorHandoffCardWhenOperatorGatesDisabled(t *testing.T) {
 	}
 }
 
-// TestOperatorHandoffCommandsScopeToProfileAndSession keeps the printed
-// commands copy-pasteable. A non-default profile must appear, and the default
-// profile must not be spelled out (matching the adjacent launch "next:" line).
-func TestOperatorHandoffCommandsScopeToProfileAndSession(t *testing.T) {
-	next, monitor, answer, status := operatorHandoffCommands("squad-v2-27-0", "v2-27-0")
-	for _, got := range []string{next, monitor, answer, status} {
-		if !strings.Contains(got, "--profile squad-v2-27-0") {
-			t.Errorf("%q missing --profile", got)
-		}
-		if !strings.Contains(got, "--session v2-27-0") {
-			t.Errorf("%q missing --session", got)
+// TestOperatorHandoffScopeCarriesProjectProfileSession keeps the printed
+// commands runnable from wherever the operator's shell actually is. --project
+// is not optional: `up --project DIR` chdirs the launching process and restores
+// it, so the operator's shell never moved into the project.
+func TestOperatorHandoffScopeCarriesProjectProfileSession(t *testing.T) {
+	scope := operatorHandoffScope("/repo/team", "squad-v2-27-0", "v2-27-0")
+	for _, want := range []string{"--project /repo/team", "--profile squad-v2-27-0", "--session v2-27-0"} {
+		if !strings.Contains(scope, want) {
+			t.Errorf("scope %q missing %q", scope, want)
 		}
 	}
-	defaultNext, _, _, _ := operatorHandoffCommands(team.DefaultProfile, "v2-27-0")
-	if strings.Contains(defaultNext, "--profile") {
-		t.Errorf("default profile should stay implicit, got %q", defaultNext)
+	if strings.Contains(operatorHandoffScope("/repo/team", team.DefaultProfile, "s"), "--profile") {
+		t.Error("default profile should stay implicit")
+	}
+}
+
+// TestOperatorHandoffCommandsAreShellSafe is the fix for the reviewer's second
+// blocker. The card presents these under "What to run", so every displayed
+// command must survive being pasted into a shell. The previous form,
+// `--gate <topic> --approved|--denied [--reason TEXT]`, is usage notation: in a
+// shell `<topic>` redirects stdin, `|` starts a pipeline, and the brackets are
+// glob syntax. A hurried paste would fail or do something unintended.
+func TestOperatorHandoffCommandsAreShellSafe(t *testing.T) {
+	card := newOperatorHandoffCard(handoffCardTeam("s", operatorEnabled(team.OperatorInteractionLeadPane, nil)), "p", "s")
+	commands := map[string]string{
+		"next":    card.NextCommand,
+		"monitor": card.MonitorCommand,
+		"approve": card.ApproveCommand,
+		"deny":    card.DenyCommand,
+		"status":  card.StatusCommand,
+	}
+	for name, cmd := range commands {
+		for _, meta := range []string{"<", ">", "|", "[", "]"} {
+			if strings.Contains(cmd, meta) {
+				t.Errorf("%s command contains shell metacharacter %q and is not safe to paste: %s", name, meta, cmd)
+			}
+		}
+	}
+	if !strings.Contains(card.ApproveCommand, "--approved") || strings.Contains(card.ApproveCommand, "--denied") {
+		t.Errorf("approve command is not an unambiguous approval: %s", card.ApproveCommand)
+	}
+	if !strings.Contains(card.DenyCommand, "--denied") || strings.Contains(card.DenyCommand, "--approved") {
+		t.Errorf("deny command is not an unambiguous denial: %s", card.DenyCommand)
+	}
+}
+
+// TestRenderedCardHasNoUsageNotation guards the whole rendered "What to run"
+// block, not just the fields, so a future edit cannot reintroduce placeholder
+// syntax into a line the card tells the operator to run.
+func TestRenderedCardHasNoUsageNotation(t *testing.T) {
+	var sb strings.Builder
+	writeOperatorHandoffCard(&sb, newOperatorHandoffCard(handoffCardTeam("s", operatorEnabled(team.OperatorInteractionLeadPane, nil)), "p", "s"))
+	for _, line := range strings.Split(sb.String(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "amq-squad ") {
+			continue
+		}
+		for _, meta := range []string{"<", ">", "|", "[", "]"} {
+			if strings.Contains(trimmed, meta) {
+				t.Errorf("displayed command line carries %q: %s", meta, trimmed)
+			}
+		}
+	}
+}
+
+// TestResumeExecPrintsOperatorHandoffCard is the fix for the reviewer's first
+// blocker. `resume --exec` is a launch route that never passes through
+// executeTeamLaunch, so wiring the card there covered `up` and left resume
+// silent — while the PR claimed every launch path ends with the card. An
+// operator resuming a session is in exactly the position the card exists for.
+func TestResumeExecPrintsOperatorHandoffCard(t *testing.T) {
+	dir := t.TempDir()
+	base := setupFakeAMQSessionRoots(t)
+	resumeChdir(t, dir)
+	if err := team.Write(dir, team.Team{
+		Workstream: "issue-493r", Orchestrated: true, Lead: "cto", ExecutionMode: executionModeProjectLead,
+		Operator: operatorEnabled(team.OperatorInteractionLeadPane, nil),
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-493r"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-493r"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, role := range []string{"cto", "qa"} {
+		writeMemberLaunchRecord(t, base, "issue-493r", role, launch.Record{
+			CWD: dir, Binary: "codex", Role: role, Handle: role, Session: "issue-493r", StartedAt: time.Now(),
+		})
+	}
+	oldRun, oldVerify, oldReady := runTmuxLaunchPlanForResume, verifyResumeExecLaunchRecordsNow, verifyResumeLeadReadyNow
+	runTmuxLaunchPlanForResume = func(tmuxLaunchPlan) error { return nil }
+	verifyResumeLeadReadyNow = func(resumeExecLaunchCheck) error { return nil }
+	verifyResumeExecLaunchRecordsNow = func(checks []resumeExecLaunchCheck, _ map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+		out := make([]resumeExecLaunchResult, 0, len(checks))
+		for _, check := range checks {
+			out = append(out, resumeExecLaunchResult{Check: check, State: resumeExecLaunchStateLaunched})
+		}
+		return out
+	}
+	t.Cleanup(func() {
+		runTmuxLaunchPlanForResume, verifyResumeExecLaunchRecordsNow, verifyResumeLeadReadyNow = oldRun, oldVerify, oldReady
+	})
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runResume([]string{"--exec", "--stagger", "0"})
+	})
+	if err != nil {
+		t.Fatalf("resume --exec: %v\nstderr:\n%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "YOU ARE THE OPERATOR FOR THIS SESSION") {
+		t.Fatalf("resume --exec did not print the handoff card; stdout:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "--session issue-493r") {
+		t.Errorf("resume card is not scoped to the resumed session; stdout:\n%s", stdout)
+	}
+}
+
+// TestLaunchCardProjectFlagSurvivesRemoteProject is the fix for the reviewer's
+// third blocker, driven end to end. `up --project DIR` runs from a DIFFERENT
+// cwd, and runInProject restores that cwd before the operator's shell sees the
+// card. Every printed command must therefore name the project explicitly.
+func TestLaunchCardProjectFlagSurvivesRemoteProject(t *testing.T) {
+	useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	project := seedTeam(t, handoffCardTeam("issue-493p", operatorEnabled(team.OperatorInteractionLeadPane, nil)))
+	// Move the operator's shell somewhere that is NOT the project, which is the
+	// whole point of --project.
+	elsewhere := t.TempDir()
+	chdir(t, elsewhere)
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"--project", project, "--terminal", "fake", "--session", "issue-493p", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("up --project: %v", err)
+	}
+	if !strings.Contains(stdout, "YOU ARE THE OPERATOR FOR THIS SESSION") {
+		t.Fatalf("remote-project launch printed no card; stdout:\n%s", stdout)
+	}
+	// The card prints the project as the launcher resolved it. On macOS the
+	// temp dir arrives via a /var -> /private/var symlink, so compare canonical
+	// paths rather than spellings — the #618 lesson, applied to a test.
+	wantProject, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "--project "+shellQuote(wantProject)) {
+		t.Errorf("card commands omit the resolved --project %q; from cwd %q they would resolve against the wrong team.\nstdout:\n%s", wantProject, elsewhere, stdout)
 	}
 }

--- a/internal/cli/operator_handoff_card_493_test.go
+++ b/internal/cli/operator_handoff_card_493_test.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// The tests in this file lead with the end-to-end launch path on purpose.
+// #493 is a defect about what a real launch prints to a real human, so the
+// primary assertions drive runUp and read its actual stdout. The renderer unit
+// tests below them cover mode-by-mode wording; they are the supporting cast,
+// not the proof.
+
+func handoffCardTeam(session string, op *team.OperatorConfig) team.Team {
+	return team.Team{
+		Orchestrated: true,
+		Lead:         "cto",
+		Operator:     op,
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+			{Role: "dev-1", Binary: "claude", Handle: "dev-1", Session: session},
+		},
+	}
+}
+
+func operatorEnabled(mode string, notifications *team.OperatorNotificationPolicy) *team.OperatorConfig {
+	return &team.OperatorConfig{
+		Enabled:         true,
+		Handle:          "user",
+		InteractionMode: mode,
+		Participant:     true,
+		Notifications:   notifications,
+	}
+}
+
+// TestLiveLaunchPrintsOperatorHandoffCard is the core #493 regression: a real
+// live launch must end by telling the human they are the operator. Before this
+// change the launch ended at "started <session>" and the operator was never
+// told the squad would be talking to them.
+func TestLiveLaunchPrintsOperatorHandoffCard(t *testing.T) {
+	useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, handoffCardTeam("issue-493", operatorEnabled(team.OperatorInteractionLeadPane, nil)))
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"--terminal", "fake", "--session", "issue-493", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	for _, want := range []string{
+		"YOU ARE THE OPERATOR FOR THIS SESSION",
+		"Handle   user",
+		"the lead pane (role cto)",
+		"amq-squad operator answer --session issue-493 --gate <topic> --approved|--denied",
+		"amq-squad status --session issue-493",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("launch stdout missing %q; full output:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestQuietDoesNotSuppressOperatorHandoffCard pins the #493 safety-output
+// requirement. The test is only meaningful if --quiet is genuinely in effect,
+// so it also asserts that a quiet-suppressible notice really did disappear:
+// otherwise a broken policy would make this pass vacuously.
+func TestQuietDoesNotSuppressOperatorHandoffCard(t *testing.T) {
+	useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, handoffCardTeam("issue-493q", operatorEnabled(team.OperatorInteractionSeparateTerminal, nil)))
+	withOutputPolicy(t, outputPolicy{Quiet: true})
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runUp([]string{"--terminal", "fake", "--session", "issue-493q", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	// Control: prove quiet was actually applied.
+	if strings.Contains(stderr, "started issue-493q") {
+		t.Fatalf("quiet policy was not in effect; stderr still carries the launch notice:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "YOU ARE THE OPERATOR FOR THIS SESSION") {
+		t.Errorf("--quiet suppressed the operator handoff card; stdout:\n%s", stdout)
+	}
+}
+
+// TestDryRunPrintsNoOperatorHandoffCard: a plan is not a handoff. Printing the
+// card for --dry-run would tell an operator they are on the hook for a session
+// that was never launched.
+func TestDryRunPrintsNoOperatorHandoffCard(t *testing.T) {
+	useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, handoffCardTeam("issue-493d", operatorEnabled(team.OperatorInteractionLeadPane, nil)))
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"--dry-run", "--terminal", "fake", "--session", "issue-493d", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("up --dry-run: %v", err)
+	}
+	if strings.Contains(stdout, "YOU ARE THE OPERATOR") {
+		t.Errorf("--dry-run printed the handoff card; stdout:\n%s", stdout)
+	}
+}
+
+// TestLiveLaunchCardWarnsWhenNotificationsOff covers the line the issue calls
+// the important one: silent-by-design has to become an informed choice.
+func TestLiveLaunchCardWarnsWhenNotificationsOff(t *testing.T) {
+	useFakeBackend(t)
+	setupFakeAMQSessionRoots(t)
+	seedTeam(t, handoffCardTeam("issue-493n", operatorEnabled(team.OperatorInteractionLeadPane, nil)))
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runUp([]string{"--terminal", "fake", "--session", "issue-493n", "--no-bootstrap"})
+	})
+	if err != nil {
+		t.Fatalf("up: %v", err)
+	}
+	for _, want := range []string{
+		"ALERTS   OFF — NOTHING WILL INTERRUPT YOU.",
+		"amq-squad next --session issue-493n",
+		"amq-squad monitor --session issue-493n",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("notifications-off launch missing %q; stdout:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestOperatorHandoffCardReportsConfiguredSinks proves the ON branch reads the
+// profile's real sink types rather than asserting a generic "notifications are
+// on". A card that cannot name the sink cannot be checked by the operator.
+func TestOperatorHandoffCardReportsConfiguredSinks(t *testing.T) {
+	policy := &team.OperatorNotificationPolicy{
+		Enabled: true,
+		Sinks: []team.OperatorNotificationSinkConfig{
+			{ID: "desk", Type: "desktop"},
+			{ID: "term", Type: "terminal-bell"},
+		},
+	}
+	card := newOperatorHandoffCard(handoffCardTeam("s", operatorEnabled(team.OperatorInteractionLeadPane, policy)), "", "s")
+	if !card.NotificationsEnabled {
+		t.Fatal("NotificationsEnabled = false, want true")
+	}
+	var sb strings.Builder
+	writeOperatorHandoffCard(&sb, card)
+	got := sb.String()
+	if !strings.Contains(got, "ALERTS   ON via desktop, terminal-bell.") {
+		t.Errorf("card did not name the configured sinks; got:\n%s", got)
+	}
+	if strings.Contains(got, "NOTHING WILL INTERRUPT YOU") {
+		t.Errorf("card printed the OFF warning while notifications are on; got:\n%s", got)
+	}
+}
+
+// TestOperatorHandoffCardConsolePerInteractionMode: the console line must be
+// derived, not boilerplate. Each mode sends the human somewhere different, and
+// the 2026-07-18 failure was precisely a human who did not know which.
+func TestOperatorHandoffCardConsolePerInteractionMode(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want string
+	}{
+		{team.OperatorInteractionLeadPane, "the lead pane (role cto)"},
+		{team.OperatorInteractionSeparateTerminal, "a separate terminal"},
+		{team.OperatorInteractionNOC, "the NOC/global board"},
+		{team.OperatorInteractionSelfOperator, "under self-operator policy"},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			card := newOperatorHandoffCard(handoffCardTeam("s", operatorEnabled(tc.mode, nil)), "", "s")
+			if !strings.Contains(card.Console, tc.want) {
+				t.Errorf("Console = %q, want it to contain %q", card.Console, tc.want)
+			}
+		})
+	}
+}
+
+// TestOperatorHandoffCardLeadPaneWithoutLeadRole guards the derivation: when no
+// lead role is configured the card must degrade to the generic phrase rather
+// than print "role " with nothing after it.
+func TestOperatorHandoffCardLeadPaneWithoutLeadRole(t *testing.T) {
+	tm := handoffCardTeam("s", operatorEnabled(team.OperatorInteractionLeadPane, nil))
+	tm.Lead = ""
+	card := newOperatorHandoffCard(tm, "", "s")
+	if card.Console != "the lead pane" {
+		t.Errorf("Console = %q, want %q", card.Console, "the lead pane")
+	}
+}
+
+// TestOperatorHandoffCardWhenOperatorGatesDisabled: "no human is on the hook"
+// is itself a fact the operator needs at handoff. The card must not claim a
+// handle that will never receive anything.
+func TestOperatorHandoffCardWhenOperatorGatesDisabled(t *testing.T) {
+	card := newOperatorHandoffCard(handoffCardTeam("s", &team.OperatorConfig{Enabled: false}), "", "s")
+	if card.Enabled {
+		t.Fatal("Enabled = true, want false")
+	}
+	var sb strings.Builder
+	writeOperatorHandoffCard(&sb, card)
+	got := sb.String()
+	if !strings.Contains(got, "OPERATOR GATES ARE DISABLED FOR THIS PROFILE") {
+		t.Errorf("disabled card missing its headline; got:\n%s", got)
+	}
+	if strings.Contains(got, "YOU ARE THE OPERATOR") {
+		t.Errorf("disabled card still claims the reader is the operator; got:\n%s", got)
+	}
+}
+
+// TestOperatorHandoffCommandsScopeToProfileAndSession keeps the printed
+// commands copy-pasteable. A non-default profile must appear, and the default
+// profile must not be spelled out (matching the adjacent launch "next:" line).
+func TestOperatorHandoffCommandsScopeToProfileAndSession(t *testing.T) {
+	next, monitor, answer, status := operatorHandoffCommands("squad-v2-27-0", "v2-27-0")
+	for _, got := range []string{next, monitor, answer, status} {
+		if !strings.Contains(got, "--profile squad-v2-27-0") {
+			t.Errorf("%q missing --profile", got)
+		}
+		if !strings.Contains(got, "--session v2-27-0") {
+			t.Errorf("%q missing --session", got)
+		}
+	}
+	defaultNext, _, _, _ := operatorHandoffCommands(team.DefaultProfile, "v2-27-0")
+	if strings.Contains(defaultNext, "--profile") {
+		t.Errorf("default profile should stay implicit, got %q", defaultNext)
+	}
+}

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -431,6 +431,10 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 			if opts.ResultSink != nil {
 				opts.ResultSink(teamLaunchResult{})
 			}
+			// An external-lead-only launch is still a launch: the operator is
+			// on the hook for its gates exactly as they would be for a full
+			// roster, so this success path gets the handoff card too (#493).
+			printOperatorHandoffCard(os.Stdout, t, opts.Profile, opts.Workstream)
 			return nil
 		}
 		return fmt.Errorf("no team members to launch after external lead filtering")
@@ -550,6 +554,10 @@ func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTru
 				opts.Workstream, briefPathForProfile(t.Project, opts.Profile, opts.Workstream))
 		}
 	}
+	// The handoff card is the last thing a successful launch prints (#493).
+	// It goes to stdout, not quietNotice, so --quiet cannot silence the one
+	// output that tells the human they are the operator.
+	printOperatorHandoffCard(os.Stdout, t, opts.Profile, opts.Workstream)
 	return nil
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -820,6 +820,11 @@ func execResumePlan(t team.Team, profile, workstream string, plans []resumePlan,
 			return err
 		}
 	}
+	// `resume --exec` is a launch route in its own right and does not pass
+	// through executeTeamLaunch, so it needs its own handoff card (#493). An
+	// operator resuming a session is in exactly the position the card exists
+	// for: agents are live again and will start addressing them.
+	printOperatorHandoffCard(os.Stdout, t, profile, workstream)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Launch ended at `started <session>` and said nothing about the human's role from that moment on.

In the 2026-07-18 session the squad completed its goal in 23 minutes and sent the operator an ACK plus two `gate/*` decisions. The human found them roughly 50 minutes later and asked why the CTO was not speaking to them. The profile was `operator_delivery: lead_pane, notifications=false, poll_required=false` — a perfectly coherent configuration that nothing had ever explained to the person it depended on.

This renders an operator handoff card as the last output of every successful launch route, derived from the profile's actual operator block.

## What the card tells the operator

1. **Who they are** — their handle, and that messages addressed to it are addressed to them.
2. **Where their attention belongs** — the console for the configured interaction mode. `lead_pane` names the actual lead role, because "the lead pane" is not actionable to someone looking at a grid of identical panes.
3. **How decisions reach them and how to answer** — that gates are durable `gate/<topic>` threads which do not expire and do not resend, the mode's own answer contract, and the exact scoped commands to read, watch, answer, and check the board.

The alerts line is the one the issue calls out as important, and it is the one that would have prevented the original incident:

```
 ALERTS   OFF — NOTHING WILL INTERRUPT YOU.
          No alert of any kind is configured for this session. If you
          walk away, the squad's questions wait silently until you come
          back and look. Polling is on you.
```

## Two properties that are load-bearing

**It goes to stdout, never through `quietNotice`.** The launch notices above it are stderr and quiet-suppressible because they are progress chatter. `--quiet` must not be able to suppress the one output that tells the operator they are on the hook. There is a regression test for this, and it asserts a suppressible notice really did disappear in the same run — otherwise a broken policy would let the test pass vacuously.

**Every field derives from the profile.** A card printing plausible defaults would reproduce the exact failure it exists to prevent, while sounding authoritative.

## Scope: first slice

The issue is a UX surface with unbounded ambition, so this is deliberately the minimal card. Explicitly **not** in this PR, and still open under #493:

- launch-time watcher health / self-test when notifications are enabled (review gap #1)
- topology validation, and warning when configured delivery and actual topology disagree — `lead_pane` being configured is not proof anyone is sitting there
- pending gate count at handoff
- structural inclusion in JSON launch results. Today `up --json` requires `--dry-run` and the live path is human-only, so there is no live JSON result to carry it
- wizard skill text requiring verbatim relay of the card

## Verification

- `go test ./internal/cli/ -count=1` — PASS, `ok ... 439.869s`, exit 0
- expected-red bisect: with both call sites removed, the three end-to-end tests fail with meaningful diffs; restored, they pass. The card's presence is genuinely what they measure
- `gofmt -l` clean tree-wide, `go build ./...`, `go vet ./internal/cli/`
- all four rendered variants inspected by eye. That is how the two layout defects in the second commit were found: assertions confirmed the strings were present while the `DECISIONS` label was breaking the alignment column and a scoped `operator answer` was soft-wrapping past 110 columns. A soft-wrapped command is one a hurried operator copy-pastes wrong

## Test approach

The end-to-end tests lead, and the renderer unit tests support them. #493 is a defect about what a real launch prints to a real human, so the primary assertions drive `runUp` against the fake backend and read its actual stdout. Three of my last reviews turned up defects that my own tests could not see because they interrogated my construction instead of production behaviour; this file is written the other way round.

Every command the card prints was checked against the real flag sets before being printed — `next`, `monitor`, `operator answer`, and `status` all accept the `--profile`/`--session` scoping shown, and `monitor --session` is repeatable via `fs.Var`.

Refs #493
