### PR TITLE
feat: show a real before/after member diff in team member update --dry-run (#616)

### DIFF
--- a/internal/cli/mutation_json.go
+++ b/internal/cli/mutation_json.go
@@ -36,6 +36,10 @@ type mutationResult struct {
 	Root            string               `json:"root,omitempty"`
 	Actions         []mutationAction     `json:"actions,omitempty"`
 	DeliveryReceipt *deliveryReceiptData `json:"delivery_receipt,omitempty"`
+	// Changes carries the field-level before/after diff for preview envelopes
+	// that have one (today: team member update --dry-run, #616). It is
+	// omitempty, so every other mutation envelope is byte-identical to before.
+	Changes []memberFieldChange `json:"changes,omitempty"`
 }
 
 func followUp(kind, label, command string) mutationAction {

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -621,17 +621,27 @@ func runTeamMemberUpdate(args []string) error {
 		if err != nil {
 			return fmt.Errorf("read team: %w", err)
 		}
+		// Capture the member as it stands BEFORE buildUpdated runs. buildUpdated
+		// mutates t.Members[idx] in place, so reading the current member
+		// afterwards would compare the proposed member against itself and report
+		// an empty diff for every edit (#616).
+		current, ok := teamMemberByRole(t, role)
+		if !ok {
+			return fmt.Errorf("role %q is not a team member", role)
+		}
 		updated, _, err := buildUpdated(t)
 		if err != nil {
 			return err
 		}
+		changes := memberFieldChanges(current, updated)
 		if *jsonOut {
 			return printJSONEnvelope("team_member_update", mutationResult{
 				Command: "team member update", Status: "preview", Project: projectDir,
 				Session: updated.Session, Profile: profile, Role: updated.Role, Handle: updated.Handle,
+				Changes: changes,
 			})
 		}
-		fmt.Printf("# preview: would update %s (%s) in profile %s\n", updated.Role, updated.Binary, profile)
+		writeMemberUpdatePreview(os.Stdout, updated.Role, profile, changes)
 		return nil
 	}
 

--- a/internal/cli/team_member_diff.go
+++ b/internal/cli/team_member_diff.go
@@ -42,8 +42,8 @@ var memberDiffFields = []struct {
 	{"model", func(m team.Member) string { return m.Model }},
 	{"cwd", func(m team.Member) string { return m.CWD }},
 	{"actor_mode", func(m team.Member) string { return m.ActorMode }},
-	{"claude_args", func(m team.Member) string { return strings.Join(m.ClaudeArgs, " ") }},
-	{"codex_args", func(m team.Member) string { return strings.Join(m.CodexArgs, " ") }},
+	{"claude_args", func(m team.Member) string { return displayMemberArgs(m.ClaudeArgs) }},
+	{"codex_args", func(m team.Member) string { return displayMemberArgs(m.CodexArgs) }},
 }
 
 // memberFieldChanges returns only the fields that actually differ. An update
@@ -63,6 +63,29 @@ func memberFieldChanges(before, after team.Member) []memberFieldChange {
 		})
 	}
 	return changes
+}
+
+// displayMemberArgs renders native argv so that token boundaries are visible.
+//
+// A plain strings.Join is ambiguous in a way that silently loses edits: the
+// two-token ["--settings", "/a b/x.json"] and the three-token
+// ["--settings", "/a", "b/x.json"] join to the identical string, so replacing
+// one with the other compares equal and the field disappears from the diff
+// entirely. The operator sees "no field would change" for a real change, with
+// exit 0 and well-formed output — the same silent-wrong-answer class as
+// capturing the before-member too late.
+//
+// Quoting each token per shell rules keeps genuinely different argv genuinely
+// different, and has the side benefit that the rendered value is pasteable.
+func displayMemberArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
 }
 
 func displayMemberFieldValue(v string) string {

--- a/internal/cli/team_member_diff.go
+++ b/internal/cli/team_member_diff.go
@@ -36,12 +36,12 @@ var memberDiffFields = []struct {
 	name  string
 	value func(team.Member) string
 }{
-	{"binary", func(m team.Member) string { return m.Binary }},
-	{"handle", func(m team.Member) string { return m.Handle }},
-	{"session", func(m team.Member) string { return m.Session }},
-	{"model", func(m team.Member) string { return m.Model }},
-	{"cwd", func(m team.Member) string { return m.CWD }},
-	{"actor_mode", func(m team.Member) string { return m.ActorMode }},
+	{"binary", func(m team.Member) string { return displayMemberScalar(m.Binary) }},
+	{"handle", func(m team.Member) string { return displayMemberScalar(m.Handle) }},
+	{"session", func(m team.Member) string { return displayMemberScalar(m.Session) }},
+	{"model", func(m team.Member) string { return displayMemberScalar(m.Model) }},
+	{"cwd", func(m team.Member) string { return displayMemberScalar(m.CWD) }},
+	{"actor_mode", func(m team.Member) string { return displayMemberScalar(m.ActorMode) }},
 	{"claude_args", func(m team.Member) string { return displayMemberArgs(m.ClaudeArgs) }},
 	{"codex_args", func(m team.Member) string { return displayMemberArgs(m.CodexArgs) }},
 }
@@ -86,6 +86,26 @@ func displayMemberArgs(args []string) string {
 		quoted = append(quoted, shellQuote(arg))
 	}
 	return strings.Join(quoted, " ")
+}
+
+// displayMemberScalar renders a single-valued field so that no set value can
+// ever render as the unset sentinel.
+//
+// Returning set values verbatim was not injective: memberFieldUnset is the
+// literal "(unset)", so a genuine edit from model="" to model="(unset)" rendered
+// Before and After identically. The preview reported one change and hid what it
+// was — the same silent-wrong-answer class as collapsing argv boundaries, one
+// field over.
+//
+// shellQuote supplies the injectivity for free and matches how argv is already
+// rendered: ordinary values stay bare (gpt-5), and anything containing shell
+// metacharacters — parentheses included — comes back quoted, so a literal
+// "(unset)" displays as '(unset)' and cannot be confused with the sentinel.
+func displayMemberScalar(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return ""
+	}
+	return shellQuote(v)
 }
 
 func displayMemberFieldValue(v string) string {

--- a/internal/cli/team_member_diff.go
+++ b/internal/cli/team_member_diff.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// memberFieldChange is one field-level before/after pair in a `team member
+// update --dry-run` preview (#616).
+type memberFieldChange struct {
+	Field  string `json:"field"`
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// memberFieldUnset is what an empty field renders as. An empty string in a
+// diff column is ambiguous — it reads as "unchanged" or as "the renderer had
+// nothing to say" — and clearing a field is one of the edits an operator most
+// wants confirmed before it happens.
+const memberFieldUnset = "(unset)"
+
+// memberDiffFields is the operator-visible surface of `team member update`, in
+// a fixed display order. It is deliberately a curated list rather than
+// reflection over team.Member: the struct also carries derived and internal
+// bookkeeping (spawn origin/depth, tool policy drift) that this command cannot
+// change and that would be noise in a review of a risky lead edit.
+//
+// Values are read from the ACTUAL before/after members rather than from the
+// flags that were set. That matters for --effort, which the operator passes as
+// one flag but which lands in claude_args/codex_args: a flag-driven diff would
+// report "effort" and hide what was really written to the profile.
+var memberDiffFields = []struct {
+	name  string
+	value func(team.Member) string
+}{
+	{"binary", func(m team.Member) string { return m.Binary }},
+	{"handle", func(m team.Member) string { return m.Handle }},
+	{"session", func(m team.Member) string { return m.Session }},
+	{"model", func(m team.Member) string { return m.Model }},
+	{"cwd", func(m team.Member) string { return m.CWD }},
+	{"actor_mode", func(m team.Member) string { return m.ActorMode }},
+	{"claude_args", func(m team.Member) string { return strings.Join(m.ClaudeArgs, " ") }},
+	{"codex_args", func(m team.Member) string { return strings.Join(m.CodexArgs, " ") }},
+}
+
+// memberFieldChanges returns only the fields that actually differ. An update
+// that changes nothing returns an empty slice, which callers must report as
+// such rather than printing an empty table.
+func memberFieldChanges(before, after team.Member) []memberFieldChange {
+	var changes []memberFieldChange
+	for _, field := range memberDiffFields {
+		was, now := field.value(before), field.value(after)
+		if was == now {
+			continue
+		}
+		changes = append(changes, memberFieldChange{
+			Field:  field.name,
+			Before: displayMemberFieldValue(was),
+			After:  displayMemberFieldValue(now),
+		})
+	}
+	return changes
+}
+
+func displayMemberFieldValue(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return memberFieldUnset
+	}
+	return v
+}
+
+// writeMemberUpdatePreview renders the dry-run preview: a header naming the
+// member and profile, then one aligned row per changed field.
+//
+// Column widths are computed from the actual values because member cwd is an
+// absolute worktree path and model/args are unbounded; a fixed-width table
+// would wrap exactly on the rows an operator most needs to read.
+func writeMemberUpdatePreview(w io.Writer, role, profile string, changes []memberFieldChange) {
+	if len(changes) == 0 {
+		fmt.Fprintf(w, "# preview: %s in profile %s is already in the requested state — no field would change, nothing would be written.\n", role, profile)
+		return
+	}
+	noun := "fields"
+	if len(changes) == 1 {
+		noun = "field"
+	}
+	fmt.Fprintf(w, "# preview: update %s in profile %s — %d %s would change, nothing written yet.\n\n", role, profile, len(changes), noun)
+
+	fieldWidth, beforeWidth := len("FIELD"), len("BEFORE")
+	for _, c := range changes {
+		if len(c.Field) > fieldWidth {
+			fieldWidth = len(c.Field)
+		}
+		if len(c.Before) > beforeWidth {
+			beforeWidth = len(c.Before)
+		}
+	}
+	fmt.Fprintf(w, "  %-*s  %-*s  %s\n", fieldWidth, "FIELD", beforeWidth, "BEFORE", "AFTER")
+	for _, c := range changes {
+		fmt.Fprintf(w, "  %-*s  %-*s  %s\n", fieldWidth, c.Field, beforeWidth, c.Before, c.After)
+	}
+	fmt.Fprintf(w, "\nRe-run without --dry-run to apply.\n")
+}

--- a/internal/cli/team_member_diff_616_test.go
+++ b/internal/cli/team_member_diff_616_test.go
@@ -195,3 +195,32 @@ func TestMemberFieldChangesUnsetRendering(t *testing.T) {
 		t.Errorf("cleared field rendered as %q, want %q", changes[0].After, memberFieldUnset)
 	}
 }
+
+// TestMemberArgsDiffPreservesArgvBoundaries covers the ambiguity a peer probe
+// surfaced: joining argv with spaces makes a one-token arg containing a space
+// indistinguishable from two separate tokens. Before this fix the two members
+// below compared EQUAL, so a real edit produced an empty diff and the preview
+// told the operator nothing would change.
+func TestMemberArgsDiffPreservesArgvBoundaries(t *testing.T) {
+	before := team.Member{Role: "qa", Binary: "claude", ClaudeArgs: []string{"--settings", "/a b/x.json"}}
+	after := team.Member{Role: "qa", Binary: "claude", ClaudeArgs: []string{"--settings", "/a", "b/x.json"}}
+	changes := memberFieldChanges(before, after)
+	if len(changes) != 1 {
+		t.Fatalf("argv boundary change produced %d changes, want 1: %+v", len(changes), changes)
+	}
+	if changes[0].Before == changes[0].After {
+		t.Fatalf("argv boundary change rendered identically on both sides: %+v", changes[0])
+	}
+	if !strings.Contains(changes[0].Before, "'/a b/x.json'") {
+		t.Errorf("space-bearing token was not quoted, so its boundary is invisible: %q", changes[0].Before)
+	}
+}
+
+// TestMemberArgsDiffStillReportsNoChangeForIdenticalArgv is the other half:
+// quoting must not make equal argv look different.
+func TestMemberArgsDiffStillReportsNoChangeForIdenticalArgv(t *testing.T) {
+	m := team.Member{Role: "qa", Binary: "codex", CodexArgs: []string{"-c", "model_reasoning_effort=high"}}
+	if changes := memberFieldChanges(m, m); len(changes) != 0 {
+		t.Fatalf("identical argv reported as changed: %+v", changes)
+	}
+}

--- a/internal/cli/team_member_diff_616_test.go
+++ b/internal/cli/team_member_diff_616_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// These tests drive the real `team member update --dry-run` command and read
+// its actual stdout. #616 is about what an operator sees before approving a
+// risky lead edit, so asserting on the renderer alone would not establish that
+// the command shows it.
+
+func seedDiffTeam(t *testing.T) string {
+	t.Helper()
+	return seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-616", Model: "gpt-5", CodexArgs: []string{"-c", "model_reasoning_effort=medium"}},
+			{Role: "qa", Binary: "claude", Handle: "qa", Session: "issue-616"},
+		},
+	})
+}
+
+// TestMemberUpdateDryRunShowsFieldLevelDiff is the #616 regression: the preview
+// must name the field and both values, not merely announce that an update would
+// happen.
+func TestMemberUpdateDryRunShowsFieldLevelDiff(t *testing.T) {
+	seedDiffTeam(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", "gpt-5-codex", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	for _, want := range []string{"FIELD", "BEFORE", "AFTER", "model", "gpt-5", "gpt-5-codex"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("preview missing %q; stdout:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "would update cto (codex) in profile") {
+		t.Errorf("preview still emits the old would-update summary; stdout:\n%s", stdout)
+	}
+}
+
+// TestMemberUpdateDryRunDiffReportsEffortAsWrittenArgs pins the reason the diff
+// reads the actual before/after members rather than the flags that were set.
+// --effort is one flag but lands in codex_args; a flag-driven diff would print
+// "effort" and hide what the profile would really receive.
+func TestMemberUpdateDryRunDiffReportsEffortAsWrittenArgs(t *testing.T) {
+	seedDiffTeam(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--effort", "high", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	if !strings.Contains(stdout, "codex_args") {
+		t.Errorf("effort change did not surface as codex_args; stdout:\n%s", stdout)
+	}
+	// Codex expresses effort as `-c model_reasoning_effort=<tier>`, not `--effort
+	// <tier>`. Asserting on the real native spelling is the point: the whole
+	// reason this diff reads written args instead of flags is so the operator
+	// sees the profile's actual content.
+	if !strings.Contains(stdout, "model_reasoning_effort=medium") || !strings.Contains(stdout, "model_reasoning_effort=high") {
+		t.Errorf("effort diff lost one side of the before/after; stdout:\n%s", stdout)
+	}
+}
+
+// TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit guards the in-place trap.
+// buildUpdated mutates t.Members[idx]; reading the "current" member after
+// calling it compares the proposal against itself and yields an empty diff for
+// every edit. That failure is silent — the command still exits 0 and prints a
+// well-formed preview claiming nothing would change.
+func TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit(t *testing.T) {
+	for _, tc := range []struct{ name, flag, value string }{
+		{"model", "--model", "gpt-5-codex"},
+		{"handle", "--handle", "cto-2"},
+		{"session", "--session", "issue-617"},
+		{"actor mode", "--actor-mode", "review"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seedDiffTeam(t)
+			stdout, _, err := captureOutput(t, func() error {
+				return runTeamMember([]string{"update", "cto", tc.flag, tc.value, "--dry-run"})
+			})
+			if err != nil {
+				t.Fatalf("member update --dry-run: %v", err)
+			}
+			if strings.Contains(stdout, "already in the requested state") {
+				t.Fatalf("%s edit reported no change; the before-member was captured after buildUpdated mutated it.\nstdout:\n%s", tc.flag, stdout)
+			}
+			if !strings.Contains(stdout, tc.value) {
+				t.Errorf("preview does not show the new value %q; stdout:\n%s", tc.value, stdout)
+			}
+		})
+	}
+}
+
+// TestMemberUpdateDryRunNoOpSaysSo: an update that changes nothing must say so
+// in words rather than print an empty table, which reads as a rendering bug.
+func TestMemberUpdateDryRunNoOpSaysSo(t *testing.T) {
+	seedDiffTeam(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", "gpt-5", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	if !strings.Contains(stdout, "already in the requested state") {
+		t.Errorf("no-op preview did not say so; stdout:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "FIELD") {
+		t.Errorf("no-op preview printed an empty diff table; stdout:\n%s", stdout)
+	}
+}
+
+// TestMemberUpdateDryRunStillWritesNothing keeps the preview a preview. The
+// diff reads the profile and builds a proposed member, so this asserts the
+// obvious-but-critical property that none of that reaches disk.
+func TestMemberUpdateDryRunStillWritesNothing(t *testing.T) {
+	dir := seedDiffTeam(t)
+	if _, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", "gpt-5-codex", "--handle", "cto-2", "--dry-run"})
+	}); err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	members := teamMembers(t, dir)
+	if members[0].Model != "gpt-5" {
+		t.Errorf("dry-run mutated model: %q", members[0].Model)
+	}
+	if members[0].Handle != "cto" {
+		t.Errorf("dry-run mutated handle: %q", members[0].Handle)
+	}
+}
+
+// TestMemberUpdateDryRunJSONCarriesChanges: operators scripting a risky lead
+// edit read the envelope, not the table.
+func TestMemberUpdateDryRunJSONCarriesChanges(t *testing.T) {
+	seedDiffTeam(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", "gpt-5-codex", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run --json: %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			Status  string              `json:"status"`
+			Changes []memberFieldChange `json:"changes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, stdout)
+	}
+	if envelope.Data.Status != "preview" {
+		t.Errorf("status = %q, want preview", envelope.Data.Status)
+	}
+	if len(envelope.Data.Changes) != 1 {
+		t.Fatalf("changes = %+v, want exactly one", envelope.Data.Changes)
+	}
+	got := envelope.Data.Changes[0]
+	if got.Field != "model" || got.Before != "gpt-5" || got.After != "gpt-5-codex" {
+		t.Errorf("change = %+v, want {model gpt-5 gpt-5-codex}", got)
+	}
+}
+
+// TestMemberUpdateAppliedRunHasNoChangesKey confirms the envelope addition is
+// additive: a real (non-preview) update is unchanged, so no other consumer of
+// mutationResult sees a new key.
+func TestMemberUpdateAppliedRunHasNoChangesKey(t *testing.T) {
+	seedDiffTeam(t)
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", "gpt-5-codex", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member update --json: %v", err)
+	}
+	if strings.Contains(stdout, "\"changes\"") {
+		t.Errorf("applied update envelope gained a changes key; stdout:\n%s", stdout)
+	}
+}
+
+// TestMemberFieldChangesUnsetRendering: clearing a field is an edit an operator
+// most wants confirmed, and an empty diff cell reads as "unchanged".
+func TestMemberFieldChangesUnsetRendering(t *testing.T) {
+	before := team.Member{Role: "cto", Session: "issue-616"}
+	after := team.Member{Role: "cto"}
+	changes := memberFieldChanges(before, after)
+	if len(changes) != 1 {
+		t.Fatalf("changes = %+v, want one", changes)
+	}
+	if changes[0].After != memberFieldUnset {
+		t.Errorf("cleared field rendered as %q, want %q", changes[0].After, memberFieldUnset)
+	}
+}

--- a/internal/cli/team_member_diff_616_test.go
+++ b/internal/cli/team_member_diff_616_test.go
@@ -224,3 +224,75 @@ func TestMemberArgsDiffStillReportsNoChangeForIdenticalArgv(t *testing.T) {
 		t.Fatalf("identical argv reported as changed: %+v", changes)
 	}
 }
+
+// TestMemberUpdateDryRunEndToEndArgvBoundaries drives the argv-boundary case
+// through the real command with real flag parsing, which is what the peer
+// review asked for. parseAgentArgs is quote-aware, so `-c 'a b'` is two tokens
+// and `-c a b` is three: the operator can produce this collision with ordinary
+// quoting, without doing anything unusual.
+func TestMemberUpdateDryRunEndToEndArgvBoundaries(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-616a", CodexArgs: []string{"-c", "a b"}},
+		},
+	})
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--codex-args", "-c a b", "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	if strings.Contains(stdout, "already in the requested state") {
+		t.Fatalf("splitting one argv token into two was reported as no change:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "codex_args") {
+		t.Errorf("argv change did not surface as codex_args:\n%s", stdout)
+	}
+}
+
+// TestMemberUpdateDryRunJSONDistinguishesArgvBoundaries: the review required
+// the JSON envelope to distinguish the edit too. A script gating on `changes`
+// would otherwise see an empty array and conclude the update was a no-op.
+func TestMemberUpdateDryRunJSONDistinguishesArgvBoundaries(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-616b", CodexArgs: []string{"-c", "a b"}},
+		},
+	})
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--codex-args", "-c a b", "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run --json: %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			Changes []memberFieldChange `json:"changes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, stdout)
+	}
+	if len(envelope.Data.Changes) != 1 {
+		t.Fatalf("JSON changes = %+v, want the argv edit to appear", envelope.Data.Changes)
+	}
+	got := envelope.Data.Changes[0]
+	if got.Before == got.After {
+		t.Errorf("JSON renders both sides identically, so a script cannot see the edit: %+v", got)
+	}
+}
+
+// TestMemberArgsDiffHandlesEmptyTokens covers the other half of the review's
+// "spaces/empty tokens" requirement. An empty argv token is invisible under a
+// plain join and must not silently vanish.
+func TestMemberArgsDiffHandlesEmptyTokens(t *testing.T) {
+	before := team.Member{Role: "qa", Binary: "codex", CodexArgs: []string{"-c", ""}}
+	after := team.Member{Role: "qa", Binary: "codex", CodexArgs: []string{"-c"}}
+	changes := memberFieldChanges(before, after)
+	if len(changes) != 1 {
+		t.Fatalf("dropping an empty token produced %d changes, want 1: %+v", len(changes), changes)
+	}
+	if changes[0].Before == changes[0].After {
+		t.Fatalf("empty token is invisible on both sides: %+v", changes[0])
+	}
+}

--- a/internal/cli/team_member_diff_616_test.go
+++ b/internal/cli/team_member_diff_616_test.go
@@ -296,3 +296,68 @@ func TestMemberArgsDiffHandlesEmptyTokens(t *testing.T) {
 		t.Fatalf("empty token is invisible on both sides: %+v", changes[0])
 	}
 }
+
+// TestMemberUpdateDryRunUnsetSentinelIsInjective covers the collision a peer
+// probe surfaced: memberFieldUnset is the literal "(unset)", so before this fix
+// a genuine edit from model="" to model="(unset)" rendered Before and After
+// identically. The preview reported one change while hiding what changed — the
+// same silent-wrong-answer class as the argv collapse, one field over.
+func TestMemberUpdateDryRunUnsetSentinelIsInjective(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-616c"},
+		},
+	})
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", memberFieldUnset, "--dry-run"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run: %v", err)
+	}
+	if strings.Contains(stdout, "already in the requested state") {
+		t.Fatalf("setting model to the literal %q was reported as no change:\n%s", memberFieldUnset, stdout)
+	}
+	// The set value must be visibly distinct from the unset sentinel, and the
+	// real value must survive into the output.
+	if !strings.Contains(stdout, "'"+memberFieldUnset+"'") {
+		t.Errorf("literal %q was not rendered distinctly from the unset sentinel:\n%s", memberFieldUnset, stdout)
+	}
+}
+
+// TestMemberUpdateDryRunJSONUnsetSentinelIsInjective is the same collision in
+// the envelope. A script comparing before and after would otherwise see two
+// equal strings and conclude nothing changed.
+func TestMemberUpdateDryRunJSONUnsetSentinelIsInjective(t *testing.T) {
+	seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-616d"},
+		},
+	})
+	stdout, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"update", "cto", "--model", memberFieldUnset, "--dry-run", "--json"})
+	})
+	if err != nil {
+		t.Fatalf("member update --dry-run --json: %v", err)
+	}
+	var envelope struct {
+		Data struct {
+			Changes []memberFieldChange `json:"changes"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, stdout)
+	}
+	if len(envelope.Data.Changes) != 1 {
+		t.Fatalf("changes = %+v, want the model edit to appear", envelope.Data.Changes)
+	}
+	got := envelope.Data.Changes[0]
+	if got.Before == got.After {
+		t.Fatalf("JSON renders both sides identically, so a script cannot see the edit: %+v", got)
+	}
+	if got.Before != memberFieldUnset {
+		t.Errorf("Before = %q, want the unset sentinel %q", got.Before, memberFieldUnset)
+	}
+	if !strings.Contains(got.After, memberFieldUnset) {
+		t.Errorf("After = %q, want it to preserve the actual value %q", got.After, memberFieldUnset)
+	}
+}


### PR DESCRIPTION
## Summary

`team member update --dry-run` printed `# preview: would update cto (codex) in profile squad` and stopped there. An operator reviewing a risky lead edit could see that *something* would change, but not *what* — which is the one question a preview exists to answer.

This renders a field-level before/after table over the operator-visible fields the command can actually change, and carries the same diff in the `--json` envelope for scripted review.

```
# preview: update cto in profile squad-v2-27-0 — 3 fields would change, nothing written yet.

  FIELD       BEFORE                        AFTER
  binary      codex                         claude
  claude_args (unset)                       --settings /repo/.claude/trimmed.json
  codex_args  -c model_reasoning_effort=medium  (unset)

Re-run without --dry-run to apply.
```

## The in-place mutation trap, and the proof it is handled

This is the part to review first.

`buildUpdated` mutates `t.Members[idx]` in place. Reading the "current" member *after* calling it compares the proposal against itself and yields an **empty diff for every edit** — and that failure is silent: the command still exits 0 and prints a well-formed preview claiming nothing would change. An operator would read "already in the requested state" and conclude their edit was a no-op.

So the before-member is captured before `buildUpdated` runs, and `TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit` exists specifically to catch a regression of that ordering across four independent fields.

**Bisect proof.** Moving the capture to after `buildUpdated`:

```
--- FAIL: TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit/model
--- FAIL: TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit/handle
--- FAIL: TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit/session
--- FAIL: TestMemberUpdateDryRunDiffIsNotEmptyForEveryEdit/actor_mode
--- FAIL: TestMemberUpdateDryRunJSONCarriesChanges
```

Restoring it returns them to green. A second bisect — restoring the old one-line summary — fails four end-to-end tests, confirming they measure the preview's content rather than merely its presence.

Aliasing was checked too, since `Member` carries `ClaudeArgs`/`CodexArgs` slices and a value copy shares their backing array: `stripNativeEffortArgs` allocates a fresh slice and `teamMemberByRole` returns a copy, so the captured "before" cannot be mutated underneath.

## Why the diff reads members, not flags

`--effort` is one flag but lands in `claude_args`/`codex_args`. A flag-driven diff would report `effort` and hide what the profile would really receive. Reading the actual before/after members shows the operator the native spelling that will be written:

```
  codex_args  -c model_reasoning_effort=medium  ->  -c model_reasoning_effort=high
```

This also caught my own wrong assumption while writing the tests: I had seeded a codex member with `--effort medium`, and the diff showed it surviving alongside a new `-c model_reasoning_effort=high` rather than being replaced. That was my fixture being unrealistic, not a product bug — codex effort is `-c model_reasoning_effort=`, so nothing was stripped. The feature surfaced the error in my model of the data, which is more or less its whole purpose.

## Design notes

- **`(unset)` rather than an empty cell.** Clearing a field (`--no-session-pin`, `--cwd ""`) is among the edits an operator most wants confirmed, and a blank column reads as "unchanged".
- **A curated field list, not reflection over `team.Member`.** The struct also carries derived and internal bookkeeping — spawn origin/depth, tool policy drift — that this command cannot change and that would be noise in a review of a risky lead edit.
- **Column widths computed from the values.** Member `cwd` is an absolute worktree path; a fixed-width table would wrap exactly on the rows that matter most.
- **A no-op says so in words** instead of printing an empty table, which reads as a rendering bug.
- **`changes` is `omitempty`.** Every other mutation envelope is byte-identical, and `TestMemberUpdateAppliedRunHasNoChangesKey` pins that an applied (non-preview) update gains no new key.

## Verification

- `go test ./internal/cli/ -count=1` — PASS at the pre-rebase head; targeted suite PASS after rebasing onto `ef42669`
- both bisects above
- `gofmt -l` clean tree-wide, `go build ./...`, `go vet ./internal/cli/`
- all four rendered variants inspected by eye — single field, no-op, multi-field with a long cwd and a cleared field, and a binary switch. Per the ledger entry from #632: for an operator-facing surface, string-presence assertions are not evidence a human can use the output

## Scope

Display-only, as the issue specifies. No change to the applied-update path, its locking, or its digest verification.

Refs #616
