### PR TITLE
fix: compose managed native args once (#510)

### DIFF
--- a/internal/cli/run_start_exact_head_test.go
+++ b/internal/cli/run_start_exact_head_test.go
@@ -209,6 +209,85 @@ func TestPreparedManagedLeadExactBootstrapEvidenceCodexClaude(t *testing.T) {
 	}
 }
 
+func TestPreparedManagedLaunchComposesPerMemberEffortOnceWithToolPolicy(t *testing.T) {
+	setupFakeAMQSessionRoots(t)
+	dir := t.TempDir()
+	if _, _, err := captureOutput(t, func() error {
+		return runRunStart([]string{
+			"--project", dir, "--profile", team.DefaultProfile, "--session", "prepared",
+			"--roles", "cto", "--binary", "cto=claude", "--lead", "cto",
+			"--effort", "cto=high", "--tool-profile", "cto=coding",
+			"--launch-shape", runwizard.LaunchShapeWorkingTeamTogether,
+			"--goal", "Launch the accepted effort fixture", "--visibility", "detached", "--prepare",
+		}, "test")
+	}); err != nil {
+		t.Fatalf("prepare effort fixture: %v", err)
+	}
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tm.Members) != 1 {
+		t.Fatalf("prepared roster members = %d, want 1", len(tm.Members))
+	}
+	member := tm.Members[0]
+	manifest, err := readPreparedRunManifest(dir, team.DefaultProfile, "prepared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := manifest.Members[member.Role]
+	token := reservedPreparedRunTokenForTest(t, dir, team.DefaultProfile, "prepared")
+	trust := defaultTrustMode()
+	nativeArgs := composeBinaryArgs(member.Binary, binaryArgsFor(member.Binary, tm.BinaryArgs), member.ExtraArgs())
+	preview := teamCommandPreview(emitTeamCommandInput{
+		CWD: dir, SquadBin: "amq-squad", TeamHome: dir, Member: member,
+		Workstream: "prepared", Profile: team.DefaultProfile, TrustMode: trust,
+		Model: accepted.Model, PreparedRunToken: token,
+	})
+	launchArgs := []string{
+		"--project", dir, "--team-home", dir, "--team-profile", team.DefaultProfile,
+		"--role", member.Role, "--me", member.Handle, "--session", "prepared",
+		"--trust", trust, "--tool-profile", member.EffectiveToolProfile(),
+		"--tool-config", member.ToolConfig, "--team-workstream", "--dry-run",
+	}
+	if accepted.Model != "" {
+		launchArgs = append(launchArgs, "--model", accepted.Model)
+	}
+	if member.ToolMCPConfig != "" {
+		launchArgs = append(launchArgs, "--tool-mcp-config", member.ToolMCPConfig)
+	}
+	for _, entry := range member.ToolAllowlist {
+		launchArgs = append(launchArgs, "--tool-allow", entry)
+	}
+	for _, entry := range member.ToolBlocklist {
+		launchArgs = append(launchArgs, "--tool-block", entry)
+	}
+	if len(nativeArgs) > 0 {
+		launchArgs = append(launchArgs, "--claude-args="+joinedAgentArgs(nativeArgs))
+	}
+	launchArgs = append(launchArgs, member.Binary, "--")
+	launchArgs = append(launchArgs, preview.ChildArgs...)
+
+	var observed launch.Record
+	oldObserver := launchPlanObserver
+	launchPlanObserver = func(rec launch.Record, _ []string) { observed = rec }
+	t.Cleanup(func() { launchPlanObserver = oldObserver })
+	if _, _, err := captureOutput(t, func() error {
+		return runLaunchWithPreparedToken(launchArgs, token)
+	}); err != nil {
+		t.Fatalf("prepared managed launch rejected composed identity: %v", err)
+	}
+	effortCount := 0
+	for i := 0; i+1 < len(observed.Argv); i++ {
+		if observed.Argv[i] == "--effort" && observed.Argv[i+1] == "high" {
+			effortCount++
+		}
+	}
+	if effortCount != 1 {
+		t.Fatalf("prepared managed launch effort count = %d, want exactly 1; argv=%q", effortCount, observed.Argv)
+	}
+}
+
 func TestPreparedMemberIdentityUsesEffectiveModelAndEffortLayers(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -1571,24 +1571,41 @@ func emitTeamCommandWithPreview(in emitTeamCommandInput, preview teamCommandPrev
 
 func teamCommandPreview(in emitTeamCommandInput) teamCommandPreviewData {
 	m := in.Member
-	extraDefaultArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, in.BinaryArgs), m.ExtraArgs())
+	nativeArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, in.BinaryArgs), m.ExtraArgs())
 	modelArgs := modelArgsForBinary(m.Binary, in.Model)
-	defaultArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, extraDefaultArgs, in.TrustMode)
+	childNativeArgs := nativeArgs
+	switch normalizedAgentBinary(m.Binary) {
+	case "claude", "codex":
+		childNativeArgs = nil
+	}
+	// Claude/Codex native args already travel through the typed
+	// --claude-args/--codex-args launch flag emitted above. Mirroring them after
+	// the child -- boundary gives
+	// runLaunch two sources for the same flags. When tool-policy args split their
+	// common prefix, ensureLeadingChildArgs appends that mirrored tail and turns a
+	// singleton such as --effort into a duplicate (#510). Keep the child preview
+	// to launcher-owned model/trust defaults; runLaunch composes nativeArgs once.
+	// Unknown/custom binaries have no compact native-arg transport, so they keep
+	// their native args in the child surface.
+	childArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, childNativeArgs, in.TrustMode)
+	// Preview/audit metadata still reflects explicit permissions carried by the
+	// native transport even though they are no longer duplicated in ChildArgs.
+	effectiveArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgs, nativeArgs, in.TrustMode)
 	// Launcher policy is display/audit metadata only at preview time. It must
 	// never ride inside the executable child argv: runLaunch recomputes it from
-	// the current member policy, making every allowed-tools value already in
-	// ChildArgs explicit by construction.
+	// the current member policy. Configured allowed-tools values remain explicit
+	// in the native transport and in effectiveArgs for preview audit metadata.
 	launcherActions := claudeLauncherPreauthActions(in.TeamHome, in.Profile, m.Role, m.Binary, in.Workstream, true)
-	explicitActions := childArgsAllowedTools(defaultArgs)
+	explicitActions := childArgsAllowedTools(effectiveArgs)
 	preauthorized := appendUniquePermissionPatterns(explicitActions, launcherActions...)
 	bootstrap := "suppressed"
 	if in.NoBootstrap {
 		bootstrap = "disabled"
-	} else if shouldAppendBootstrapWithDefaults(defaultArgs, defaultArgs) {
+	} else if shouldAppendBootstrapWithDefaults(childArgs, childArgs) {
 		bootstrap = "appended"
 	}
 	return teamCommandPreviewData{
-		ChildArgs:            defaultArgs,
+		ChildArgs:            childArgs,
 		LauncherAddedArgs:    claudePreauthChildArgs(launcherActions),
 		PreauthorizedActions: preauthorized,
 		Bootstrap:            bootstrap,

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -302,10 +302,10 @@ func TestRunTeamLaunchDryRunUsesBinaryArgs(t *testing.T) {
 	for _, want := range []string{
 		"agent up codex",
 		"--codex-args=",
-		"-- --dangerously-bypass-approvals-and-sandbox --enable goals",
+		"-- --dangerously-bypass-approvals-and-sandbox",
 		"agent up claude",
 		"--claude-args=--chrome",
-		"-- --permission-mode auto --chrome",
+		"-- --permission-mode auto",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("dry-run output missing %q in:\n%s", want, stdout)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -315,11 +315,14 @@ func TestEmitTeamCommandAddsConfiguredBinaryArgs(t *testing.T) {
 	for _, want := range []string{
 		"agent up codex",
 		"--codex-args='--enable goals'",
-		"-- --dangerously-bypass-approvals-and-sandbox --enable goals",
+		"-- --dangerously-bypass-approvals-and-sandbox",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
 		}
+	}
+	if got := strings.Count(cmd, "--enable goals"); got != 1 {
+		t.Errorf("configured native arg rendered %d times, want exactly once: %s", got, cmd)
 	}
 }
 
@@ -631,7 +634,7 @@ func TestRunTeamShowMergesStoredAndRunBinaryArgs(t *testing.T) {
 		"# binary args: codex: --enable goals --profile fast",
 		"agent up codex",
 		"--codex-args='--enable goals --profile fast'",
-		"-- --dangerously-bypass-approvals-and-sandbox --enable goals --profile fast",
+		"-- --dangerously-bypass-approvals-and-sandbox",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("team show output missing %q in:\n%s", want, stdout)

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -362,10 +362,11 @@ func TestValidateTeamSymphonyRejectsSharedCodexCWD(t *testing.T) {
 	}
 }
 
-func TestEmitTeamCommandAppendsPerMemberArgsAfterTeamArgs(t *testing.T) {
+func TestEmitTeamCommandTransportsPerMemberArgsOnce(t *testing.T) {
 	// #111: member claude_args ride after the team-level binary_args so the
-	// member-specific value wins by position, and they appear BOTH in the
-	// persisted --claude-args= flag and the explicit child args after --.
+	// member-specific value wins by position. #510: the composed native args
+	// travel only through --claude-args; mirroring them after -- makes agent up
+	// merge the same singleton twice when tool-policy args split the prefix.
 	m := team.Member{
 		Role: "analyst", Binary: "claude", Handle: "analyst", Session: "s",
 		ClaudeArgs: []string{"--settings", ".claude/agent-overlays/analyst.json"},
@@ -378,19 +379,22 @@ func TestEmitTeamCommandAppendsPerMemberArgsAfterTeamArgs(t *testing.T) {
 	for _, want := range []string{
 		"agent up claude",
 		"--claude-args='--chrome --settings .claude/agent-overlays/analyst.json'",
-		"-- --permission-mode auto --chrome --settings .claude/agent-overlays/analyst.json",
+		"-- --permission-mode auto",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("emitTeamCommand missing %q in: %s", want, cmd)
 		}
+	}
+	if strings.Count(cmd, "--chrome") != 1 || strings.Count(cmd, ".claude/agent-overlays/analyst.json") != 1 {
+		t.Fatalf("native args were rendered through more than one transport: %s", cmd)
 	}
 }
 
 func TestEmitTeamCommandComposesRecognizedSingletonOnce(t *testing.T) {
 	claude := team.Member{Role: "lead", Binary: "claude", Handle: "lead", ClaudeArgs: []string{"--effort", "max"}}
 	cmd := emitTeamCommand(emitTeamCommandInput{CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p", Member: claude, Workstream: "s", TrustMode: trustModeSandboxed, BinaryArgs: map[string][]string{"claude": {"--effort", "low", "--effort", "high"}}})
-	if strings.Count(cmd, "--effort") != 2 { // once in --claude-args and once after the child -- boundary
-		t.Fatalf("expected one effective effort span in each mirrored argv surface: %s", cmd)
+	if strings.Count(cmd, "--effort") != 1 {
+		t.Fatalf("expected exactly one rendered effort span: %s", cmd)
 	}
 	if strings.Contains(cmd, "--effort low") || strings.Contains(cmd, "--effort high") || !strings.Contains(cmd, "--effort max") {
 		t.Fatalf("member precedence not applied: %s", cmd)
@@ -398,7 +402,7 @@ func TestEmitTeamCommandComposesRecognizedSingletonOnce(t *testing.T) {
 
 	codex := team.Member{Role: "worker", Binary: "codex", Handle: "worker", CodexArgs: []string{"-c", "model_reasoning_effort=max"}}
 	cmd = emitTeamCommand(emitTeamCommandInput{CWD: "/p", SquadBin: "amq-squad", TeamHome: "/p", Member: codex, Workstream: "s", TrustMode: trustModeSandboxed, BinaryArgs: map[string][]string{"codex": {"-c", "model_reasoning_effort=low", "-c", "model_reasoning_effort=high"}}})
-	if strings.Contains(cmd, "model_reasoning_effort=low") || strings.Contains(cmd, "model_reasoning_effort=high") || strings.Count(cmd, "model_reasoning_effort=max") != 2 {
+	if strings.Contains(cmd, "model_reasoning_effort=low") || strings.Contains(cmd, "model_reasoning_effort=high") || strings.Count(cmd, "model_reasoning_effort=max") != 1 {
 		t.Fatalf("codex config precedence not applied: %s", cmd)
 	}
 }


### PR DESCRIPTION
## Summary

Managed team command rendering carried Claude/Codex native arguments through both the typed compact flag and the trailing child argv. When tool-policy defaults split the shared prefix, launch recomposition appended the mirrored tail and duplicated singleton flags such as effort, causing prepared identity admission to reject the generated launch.

This change keeps Claude/Codex native args only in the typed claude-args/codex-args transport. Trailing child args retain launcher-owned model and trust defaults. Custom binaries keep the existing child transport because they have no typed compact native-arg path. Preview permission auditing still evaluates the effective native args.

## Verification

- RED before production change: renderer tests observed duplicate native transports and effort twice.
- GREEN after fix on base 5670d5c: 5 focused tests passed in 3.804s.
- New initial managed prepared-launch regression uses a Claude member with coding tool policy plus high effort, requires prepared identity acceptance, and observes exactly one effort pair in the final launch argv.
- Existing staged prepared baseline remains green.
- gofmt and git diff --check clean.

Refs #510