### PR TITLE
fix: report fail-closed sends as definitely failed, not ambiguous (#589)

### DIFF
--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -885,15 +885,17 @@ func markDeliverySendResult(receipt *deliveryReceiptData, out []byte, sendErr er
 	receipt.MessageID = parseSentMessageID(string(out))
 	if receipt.MessageID == "" {
 		if sendErr != nil {
-			if amqRefusedSendFailClosed(out, sendErr) {
+			if amqRefusedSendFailClosed(sendErr) {
 				now := time.Now().UTC()
 				receipt.Status = deliveryStateFailed
 				receipt.DeliveryState = deliveryStateFailed
 				receipt.FailedAt = &now
 				receipt.Detail = sendErr.Error()
+				receipt.EvidenceSource = "amq_refused_send"
 				for i := range receipt.Consumers {
 					receipt.Consumers[i].State = deliveryStateFailed
 					receipt.Consumers[i].FailedAt = &now
+					receipt.Consumers[i].Stage = deliveryStateFailed
 				}
 				receipt.addStage(deliveryStateFailed, "AMQ refused the send fail-closed and wrote nothing; non-delivery is definite, so resolve the refusal cause rather than confirming delivery: "+sendErr.Error())
 				return
@@ -941,21 +943,26 @@ func markDeliverySendResult(receipt *deliveryReceiptData, out []byte, sendErr er
 //
 // The exit-code-with-text-fallback shape mirrors isCollectWatchTimeout, which
 // already classifies an AMQ outcome this way.
-func amqRefusedSendFailClosed(out []byte, err error) bool {
+func amqRefusedSendFailClosed(err error) bool {
 	if err == nil {
 		return false
 	}
+	// TYPED EVIDENCE ONLY. There is deliberately no error-text fallback here.
+	// Text matching is acceptable for widening caution, but this predicate
+	// NARROWS it — turning "unknown" into "definitely failed" — and a false
+	// definite failure is the duplicate-send hazard. A wrapped error that lost
+	// its *exec.ExitError therefore stays ambiguous, which is the safe answer
+	// rather than a missed optimization.
 	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		switch exitErr.ExitCode() {
-		case amqExitUsageRejected, amqExitRefused:
-			return true
-		}
+	if !errors.As(err, &exitErr) {
+		return false
 	}
-	// Fallback for wrapped errors that lost the ExitError. AMQ prefixes an
-	// outright refusal with a stable marker; require it rather than matching
-	// loose failure words, so an ambiguous outcome is never misread as definite.
-	return strings.Contains(strings.ToLower(string(out)+"\n"+err.Error()), amqRefusalMarker)
+	switch exitErr.ExitCode() {
+	case amqExitUsageRejected, amqExitRefused:
+		return true
+	default:
+		return false
+	}
 }
 
 const (
@@ -963,7 +970,6 @@ const (
 	// codes for requests rejected before any write.
 	amqExitUsageRejected = 2
 	amqExitRefused       = 5
-	amqRefusalMarker     = "refusing send:"
 )
 
 type committedDeliveryEvidence struct {

--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -941,8 +941,9 @@ func markDeliverySendResult(receipt *deliveryReceiptData, out []byte, sendErr er
 // request before attempting a write. Anything else — a timeout, a signal, an
 // unparseable failure mid-commit — stays ambiguous, because it is.
 //
-// The exit-code-with-text-fallback shape mirrors isCollectWatchTimeout, which
-// already classifies an AMQ outcome this way.
+// Exit-code classification mirrors isCollectWatchTimeout, MINUS its text
+// fallback — which that predicate can afford and this one cannot, for the
+// reason given below.
 func amqRefusedSendFailClosed(err error) bool {
 	if err == nil {
 		return false

--- a/internal/cli/delivery_receipt.go
+++ b/internal/cli/delivery_receipt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -884,6 +885,19 @@ func markDeliverySendResult(receipt *deliveryReceiptData, out []byte, sendErr er
 	receipt.MessageID = parseSentMessageID(string(out))
 	if receipt.MessageID == "" {
 		if sendErr != nil {
+			if amqRefusedSendFailClosed(out, sendErr) {
+				now := time.Now().UTC()
+				receipt.Status = deliveryStateFailed
+				receipt.DeliveryState = deliveryStateFailed
+				receipt.FailedAt = &now
+				receipt.Detail = sendErr.Error()
+				for i := range receipt.Consumers {
+					receipt.Consumers[i].State = deliveryStateFailed
+					receipt.Consumers[i].FailedAt = &now
+				}
+				receipt.addStage(deliveryStateFailed, "AMQ refused the send fail-closed and wrote nothing; non-delivery is definite, so resolve the refusal cause rather than confirming delivery: "+sendErr.Error())
+				return
+			}
 			receipt.DeliveryState = deliveryStateAmbiguousUnknown
 			receipt.Detail = sendErr.Error()
 			receipt.addStage(deliveryStateAmbiguousUnknown, "AMQ was invoked but returned no stable message id: "+sendErr.Error()+"; confirm non-delivery before retry")
@@ -902,6 +916,55 @@ func markDeliverySendResult(receipt *deliveryReceiptData, out []byte, sendErr er
 		}
 	}
 }
+
+// amqRefusedSendFailClosed reports positive evidence that AMQ refused the send
+// outright and wrote nothing, making non-delivery definite rather than unknown.
+//
+// The asymmetry here is deliberate and is the whole safety argument.
+// ambiguous_unknown remains the default: this predicate may only ever DOWNGRADE
+// an unknown outcome to a definite failure, never the reverse. Calling a
+// genuinely uncertain send "definitely failed" invites a retry that duplicates a
+// message which did land; calling a definite failure "ambiguous" merely costs an
+// operator a manual check. One of those errors is recoverable and the other is
+// not, so the conservative direction is not the symmetric one.
+//
+// Classification keys on the pinned AMQ's exit codes, which separate the cases
+// cleanly at the 0.51.1 supported floor:
+//
+//	5  explicit refusal   e.g. "refusing send: root is not the pinned base root"
+//	2  usage rejection    e.g. "--to is required", unknown command
+//	0  success
+//
+// Both 2 and 5 are pre-delivery by construction: the command rejected the
+// request before attempting a write. Anything else — a timeout, a signal, an
+// unparseable failure mid-commit — stays ambiguous, because it is.
+//
+// The exit-code-with-text-fallback shape mirrors isCollectWatchTimeout, which
+// already classifies an AMQ outcome this way.
+func amqRefusedSendFailClosed(out []byte, err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case amqExitUsageRejected, amqExitRefused:
+			return true
+		}
+	}
+	// Fallback for wrapped errors that lost the ExitError. AMQ prefixes an
+	// outright refusal with a stable marker; require it rather than matching
+	// loose failure words, so an ambiguous outcome is never misread as definite.
+	return strings.Contains(strings.ToLower(string(out)+"\n"+err.Error()), amqRefusalMarker)
+}
+
+const (
+	// amqExitUsageRejected and amqExitRefused are the pinned AMQ 0.51.1 exit
+	// codes for requests rejected before any write.
+	amqExitUsageRejected = 2
+	amqExitRefused       = 5
+	amqRefusalMarker     = "refusing send:"
+)
 
 type committedDeliveryEvidence struct {
 	MessageID string

--- a/internal/cli/delivery_receipt_failed_closed_589_test.go
+++ b/internal/cli/delivery_receipt_failed_closed_589_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// #589: `amq-squad amq send` wrote state=ambiguous_unknown with an empty
+// message_id for a send AMQ had refused fail-closed. A send that definitively
+// never left must produce a definite failed receipt; ambiguous_unknown is
+// reserved for genuinely unknown outcomes, and using it for a provable
+// non-delivery makes the receipt trail misleading during outage forensics —
+// exactly when it is being read most carefully.
+//
+// These tests are deliberately BOTH WAYS. A change that classified everything
+// as failed would satisfy the first half and would be far more dangerous than
+// the defect it replaced.
+
+// exitCodeErr builds an *exec.ExitError carrying a real exit status, so the
+// classifier is exercised through the same type production sees rather than
+// through a stub that merely reports a number.
+func exitCodeErr(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("building exit-%d error: got %v", code, err)
+	}
+	if exitErr.ExitCode() != code {
+		t.Fatalf("exit code = %d, want %d", exitErr.ExitCode(), code)
+	}
+	return err
+}
+
+func TestFailClosedSendProducesDefiniteFailedReceipt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+	}{
+		// Observed against the pinned AMQ 0.51.1:
+		//   5 -> "refusing send: root is not the pinned base root..."
+		//   2 -> "--to is required", unknown command, bad flag
+		{"explicit refusal", amqExitRefused},
+		{"usage rejection", amqExitUsageRejected},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			receipt := &deliveryReceiptData{
+				AttemptID: "attempt-589",
+				Consumers: []deliveryConsumerState{{Consumer: "cto", State: deliveryStateAmbiguousUnknown}},
+			}
+			markDeliverySendResult(receipt, []byte("refusing send: root is not the pinned base root\n"), exitCodeErr(t, tc.code))
+
+			if receipt.DeliveryState != deliveryStateFailed {
+				t.Fatalf("DeliveryState = %q, want %q — a refused send has a definite outcome", receipt.DeliveryState, deliveryStateFailed)
+			}
+			if receipt.FailedAt == nil {
+				t.Error("FailedAt is nil; a definite failure must carry its timestamp")
+			}
+			if receipt.MessageID != "" {
+				t.Errorf("MessageID = %q, want empty", receipt.MessageID)
+			}
+			for _, consumer := range receipt.Consumers {
+				if consumer.State != deliveryStateFailed {
+					t.Errorf("consumer %s state = %q, want %q", consumer.Consumer, consumer.State, deliveryStateFailed)
+				}
+			}
+		})
+	}
+}
+
+// TestGenuinelyAmbiguousSendStaysAmbiguous is the half that protects against
+// over-claiming. An outcome that is actually unknown must remain unknown: a
+// receipt asserting definite failure invites a retry that could duplicate a
+// message which did land.
+func TestGenuinelyAmbiguousSendStaysAmbiguous(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		err  error
+	}{
+		{"timeout", "", errors.New("signal: killed")},
+		{"unclassified nonzero exit", "", exitCodeErr(t, 1)},
+		{"crash mid-commit", "partial output", exitCodeErr(t, 137)},
+		{"plain wrapped failure", "", errors.New("amq send: connection reset")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			receipt := &deliveryReceiptData{
+				AttemptID: "attempt-589",
+				Consumers: []deliveryConsumerState{{Consumer: "cto", State: deliveryStateAmbiguousUnknown}},
+			}
+			markDeliverySendResult(receipt, []byte(tc.out), tc.err)
+			if receipt.DeliveryState != deliveryStateAmbiguousUnknown {
+				t.Fatalf("DeliveryState = %q, want %q — this outcome is genuinely unknown and must not be reported as definite", receipt.DeliveryState, deliveryStateAmbiguousUnknown)
+			}
+			if receipt.FailedAt != nil {
+				t.Error("FailedAt was set for an ambiguous outcome")
+			}
+		})
+	}
+}
+
+// TestFailClosedClassifierRequiresPositiveEvidence pins the predicate directly,
+// including the wrapped-error fallback. The fallback requires AMQ's stable
+// refusal marker rather than loose failure words, so an ambiguous outcome that
+// merely mentions failing is never misread as definite.
+func TestFailClosedClassifierRequiresPositiveEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		err  error
+		want bool
+	}{
+		{"nil error", "", nil, false},
+		{"refusal exit code", "", exitCodeErr(t, amqExitRefused), true},
+		{"usage exit code", "", exitCodeErr(t, amqExitUsageRejected), true},
+		{"refusal marker in wrapped error", "", fmt.Errorf("amq send: %s root is not pinned", amqRefusalMarker), true},
+		{"refusal marker in output", amqRefusalMarker + " bad root", errors.New("exit status 5"), true},
+		{"generic failure wording", "", errors.New("send failed: could not reach the queue"), false},
+		{"the word refusing without the marker", "", errors.New("server is refusing connections"), false},
+		{"unrelated nonzero exit", "", exitCodeErr(t, 1), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := amqRefusedSendFailClosed([]byte(tc.out), tc.err); got != tc.want {
+				t.Errorf("amqRefusedSendFailClosed(%q, %v) = %t, want %t", tc.out, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFailClosedReceiptStageExplainsTheDifference: the stage text is what an
+// operator reads during an outage. It must say non-delivery is definite and
+// point at the refusal cause, not tell them to go confirm delivery.
+func TestFailClosedReceiptStageExplainsTheDifference(t *testing.T) {
+	receipt := &deliveryReceiptData{AttemptID: "attempt-589"}
+	markDeliverySendResult(receipt, nil, exitCodeErr(t, amqExitRefused))
+	if len(receipt.Stages) == 0 {
+		t.Fatal("no stage recorded for a fail-closed send")
+	}
+	last := receipt.Stages[len(receipt.Stages)-1]
+	if !strings.Contains(last.Detail, "definite") {
+		t.Errorf("stage detail does not tell the operator the outcome is definite: %q", last.Detail)
+	}
+	if strings.Contains(last.Detail, "confirm non-delivery before retry") {
+		t.Errorf("fail-closed stage still carries the ambiguous-outcome instruction: %q", last.Detail)
+	}
+}
+
+// TestSuccessfulSendUnaffected guards the path that must not move at all.
+func TestSuccessfulSendUnaffected(t *testing.T) {
+	receipt := &deliveryReceiptData{
+		AttemptID: "attempt-589",
+		Consumers: []deliveryConsumerState{{Consumer: "cto"}},
+	}
+	markDeliverySendResult(receipt, []byte("Sent 2026-08-02T00-00-00.000Z_pid1_abcdef to cto\n"), nil)
+	if receipt.DeliveryState != deliveryStateDeliveredNotDrained {
+		t.Fatalf("DeliveryState = %q, want %q", receipt.DeliveryState, deliveryStateDeliveredNotDrained)
+	}
+	if receipt.MessageID == "" {
+		t.Error("MessageID was not parsed from a successful send")
+	}
+}

--- a/internal/cli/delivery_receipt_failed_closed_589_test.go
+++ b/internal/cli/delivery_receipt_failed_closed_589_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -51,13 +52,27 @@ func TestFailClosedSendProducesDefiniteFailedReceipt(t *testing.T) {
 				AttemptID: "attempt-589",
 				Consumers: []deliveryConsumerState{{Consumer: "cto", State: deliveryStateAmbiguousUnknown}},
 			}
-			markDeliverySendResult(receipt, []byte("refusing send: root is not the pinned base root\n"), exitCodeErr(t, tc.code))
+			sendErr := exitCodeErr(t, tc.code)
+			markDeliverySendResult(receipt, []byte("refusing send: root is not the pinned base root\n"), sendErr)
 
+			// The COMPLETE projection is asserted, not just the headline state.
+			// A half-updated receipt — definite aggregate state with consumers
+			// still reading ambiguous, or a missing evidence source — is its own
+			// misleading artifact, which is the defect class #589 is about.
 			if receipt.DeliveryState != deliveryStateFailed {
 				t.Fatalf("DeliveryState = %q, want %q — a refused send has a definite outcome", receipt.DeliveryState, deliveryStateFailed)
 			}
+			if receipt.Status != deliveryStateFailed {
+				t.Errorf("Status = %q, want %q", receipt.Status, deliveryStateFailed)
+			}
+			if receipt.EvidenceSource != "amq_refused_send" {
+				t.Errorf("EvidenceSource = %q, want %q", receipt.EvidenceSource, "amq_refused_send")
+			}
+			if receipt.Detail != sendErr.Error() {
+				t.Errorf("Detail = %q, want the send error %q", receipt.Detail, sendErr.Error())
+			}
 			if receipt.FailedAt == nil {
-				t.Error("FailedAt is nil; a definite failure must carry its timestamp")
+				t.Fatal("FailedAt is nil; a definite failure must carry its timestamp")
 			}
 			if receipt.MessageID != "" {
 				t.Errorf("MessageID = %q, want empty", receipt.MessageID)
@@ -65,6 +80,17 @@ func TestFailClosedSendProducesDefiniteFailedReceipt(t *testing.T) {
 			for _, consumer := range receipt.Consumers {
 				if consumer.State != deliveryStateFailed {
 					t.Errorf("consumer %s state = %q, want %q", consumer.Consumer, consumer.State, deliveryStateFailed)
+				}
+				if consumer.Stage != deliveryStateFailed {
+					t.Errorf("consumer %s stage = %q, want %q", consumer.Consumer, consumer.Stage, deliveryStateFailed)
+				}
+				if consumer.FailedAt == nil {
+					t.Fatalf("consumer %s FailedAt is nil", consumer.Consumer)
+				}
+				// Aggregate and per-consumer timestamps must be the SAME instant,
+				// so a reader cannot infer an ordering that never happened.
+				if !consumer.FailedAt.Equal(*receipt.FailedAt) {
+					t.Errorf("consumer %s FailedAt = %s, want the aggregate %s", consumer.Consumer, consumer.FailedAt, receipt.FailedAt)
 				}
 			}
 		})
@@ -164,5 +190,150 @@ func TestSuccessfulSendUnaffected(t *testing.T) {
 	}
 	if receipt.MessageID == "" {
 		t.Error("MessageID was not parsed from a successful send")
+	}
+}
+
+// TestPositiveEvidenceOutranksRefusalExit is the precedence guard. The
+// classifier lives behind committed-evidence validation and message-id parsing,
+// and it must STAY there: if a future AMQ path ever returned 2 or 5 after
+// exposing a stable id or a committed path, reordering the classifier ahead of
+// that evidence would report a delivered message as definitely failed. That is
+// the duplicate-send hazard arriving from the opposite direction.
+//
+// TestSuccessfulSendUnaffected cannot catch this — it passes a nil error, so a
+// reordering would keep it green.
+func TestPositiveEvidenceOutranksRefusalExit(t *testing.T) {
+	for _, code := range []int{amqExitRefused, amqExitUsageRejected} {
+		t.Run(fmt.Sprintf("parseable id survives exit %d", code), func(t *testing.T) {
+			receipt := &deliveryReceiptData{
+				AttemptID: "attempt-589",
+				Consumers: []deliveryConsumerState{{Consumer: "cto"}},
+			}
+			markDeliverySendResult(receipt,
+				[]byte("Sent 2026-08-02T00-00-00.000Z_pid1_abcdef to cto\n"),
+				exitCodeErr(t, code))
+
+			if receipt.MessageID != "2026-08-02T00-00-00.000Z_pid1_abcdef" {
+				t.Fatalf("MessageID = %q; a parsed id must not be discarded because of the exit code", receipt.MessageID)
+			}
+			if receipt.DeliveryState != deliveryStateDeliveredNotDrained {
+				t.Fatalf("DeliveryState = %q, want %q — a message with a stable id was NOT refused", receipt.DeliveryState, deliveryStateDeliveredNotDrained)
+			}
+			if receipt.FailedAt != nil {
+				t.Error("FailedAt was set for a send that produced a stable message id")
+			}
+		})
+	}
+}
+
+// TestCommittedEvidenceOutranksRefusalExit is the same precedence guard for the
+// committed-delivery path, which sits even earlier. A message whose commit AMQ
+// has already reported must never be downgraded to a definite failure.
+func TestCommittedEvidenceOutranksRefusalExit(t *testing.T) {
+	for _, code := range []int{amqExitRefused, amqExitUsageRejected} {
+		t.Run(fmt.Sprintf("committed evidence survives exit %d", code), func(t *testing.T) {
+			const msgID = "2026-08-02T00-00-00.000Z_pid1_abcdef"
+			root := t.TempDir()
+			receipt := &deliveryReceiptData{
+				AttemptID:  "attempt-589",
+				Root:       root,
+				Recipient:  "cto",
+				Recipients: []string{"cto"},
+				Target:     deliveryReceiptTarget{Handle: "cto"},
+				Consumers:  []deliveryConsumerState{{Consumer: "cto"}},
+			}
+			finalPath := filepath.Join(root, "agents", "cto", "inbox", "new", msgID+".md")
+			committed := fmt.Sprintf("message %s has a committed delivery; committed at %s, but durability is indeterminate: fsync failed", msgID, finalPath)
+
+			// Wrap a REAL *exec.ExitError so the refusal signal and the committed
+			// signal are in genuine conflict. Without a typed exit in the chain the
+			// test would prove nothing about precedence.
+			sendErr := fmt.Errorf("%s: %w", committed, exitCodeErr(t, code))
+			markDeliverySendResult(receipt, nil, sendErr)
+
+			if receipt.DeliveryState != deliveryStateCommittedIndeterminate {
+				t.Fatalf("DeliveryState = %q, want %q — committed evidence must outrank the exit code", receipt.DeliveryState, deliveryStateCommittedIndeterminate)
+			}
+			if receipt.MessageID != msgID {
+				t.Errorf("MessageID = %q, want %q", receipt.MessageID, msgID)
+			}
+			if receipt.FailedAt != nil {
+				t.Error("FailedAt was set for a committed delivery")
+			}
+		})
+	}
+}
+
+// TestOwnedDurableSendPersistsDefiniteFailure closes the gap the peer review
+// named: every test above calls markDeliverySendResult directly, so all of them
+// could pass while the durable boundary or persistence wiring regressed. This
+// one drives runOwnedDurableSend — the single amq-squad-owned send boundary —
+// with a production-shaped wrapped *exec.ExitError, then reads the receipt back
+// FROM DISK.
+func TestOwnedDurableSendPersistsDefiniteFailure(t *testing.T) {
+	project := t.TempDir()
+	root := filepath.Join(project, ".agent-mail", "v2-27-0")
+
+	previousRun := runAMQCommand
+	t.Cleanup(func() { runAMQCommand = previousRun })
+	runAMQCommand = func(amqCommandRequest) ([]byte, error) {
+		// Shaped like the real failure: AMQ's refusal text on the output, and a
+		// wrapped *exec.ExitError carrying the refusal code.
+		return []byte("refusing send: root is not the pinned base root\n"),
+			fmt.Errorf("amq send: %w", exitCodeErr(t, amqExitRefused))
+	}
+
+	_, receipt, err := runOwnedDurableSend(
+		durableSendOptions{ProjectDir: project, Profile: "squad", Session: "v2-27-0", Kind: "amq_send"},
+		amqCommandRequest{Dir: project, Arg: []string{
+			"send", "--root", root, "--me", "amq-dev-1", "--to", "cto",
+			"--thread", "p2p/amq-dev-1__cto", "--kind", "status", "--subject", "s", "--body", "b",
+		}},
+	)
+	if err == nil {
+		t.Fatal("runOwnedDurableSend returned nil error for a refused send")
+	}
+	if receipt == nil {
+		t.Fatal("runOwnedDurableSend returned no receipt")
+	}
+	if !receipt.AMQInvoked {
+		t.Error("AMQInvoked = false; AMQ was invoked and refused, which is different from never invoking it")
+	}
+	if receipt.DeliveryState != deliveryStateFailed {
+		t.Fatalf("in-memory DeliveryState = %q, want %q", receipt.DeliveryState, deliveryStateFailed)
+	}
+
+	// The persisted artifact is what an operator reads during forensics, and is
+	// the thing #589 was actually about.
+	path := filepath.Join(deliveryReceiptDir(project, "squad", "v2-27-0"), receipt.AttemptID+".json")
+	persisted, readErr := readDeliveryReceipt(path)
+	if readErr != nil {
+		t.Fatalf("reading persisted receipt at %s: %v", path, readErr)
+	}
+	if persisted.DeliveryState != deliveryStateFailed {
+		t.Fatalf("persisted DeliveryState = %q, want %q", persisted.DeliveryState, deliveryStateFailed)
+	}
+	if persisted.Status != deliveryStateFailed {
+		t.Errorf("persisted Status = %q, want %q", persisted.Status, deliveryStateFailed)
+	}
+	if persisted.EvidenceSource != "amq_refused_send" {
+		t.Errorf("persisted EvidenceSource = %q, want %q", persisted.EvidenceSource, "amq_refused_send")
+	}
+	if persisted.MessageID != "" {
+		t.Errorf("persisted MessageID = %q, want empty", persisted.MessageID)
+	}
+	if persisted.FailedAt == nil {
+		t.Fatal("persisted FailedAt is nil")
+	}
+	if !persisted.AMQInvoked {
+		t.Error("persisted AMQInvoked = false")
+	}
+	for _, consumer := range persisted.Consumers {
+		if consumer.State != deliveryStateFailed {
+			t.Errorf("persisted consumer %s state = %q, want %q", consumer.Consumer, consumer.State, deliveryStateFailed)
+		}
+		if consumer.FailedAt == nil {
+			t.Errorf("persisted consumer %s FailedAt is nil", consumer.Consumer)
+		}
 	}
 }

--- a/internal/cli/delivery_receipt_failed_closed_589_test.go
+++ b/internal/cli/delivery_receipt_failed_closed_589_test.go
@@ -85,6 +85,8 @@ func TestGenuinelyAmbiguousSendStaysAmbiguous(t *testing.T) {
 		{"unclassified nonzero exit", "", exitCodeErr(t, 1)},
 		{"crash mid-commit", "partial output", exitCodeErr(t, 137)},
 		{"plain wrapped failure", "", errors.New("amq send: connection reset")},
+		// Refusal WORDING without the typed error stays ambiguous by design.
+		{"refusal wording without typed error", "refusing send: bad root", errors.New("amq send: refusing send: bad root")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			receipt := &deliveryReceiptData{
@@ -102,29 +104,31 @@ func TestGenuinelyAmbiguousSendStaysAmbiguous(t *testing.T) {
 	}
 }
 
-// TestFailClosedClassifierRequiresPositiveEvidence pins the predicate directly,
-// including the wrapped-error fallback. The fallback requires AMQ's stable
-// refusal marker rather than loose failure words, so an ambiguous outcome that
-// merely mentions failing is never misread as definite.
+// TestFailClosedClassifierRequiresPositiveEvidence pins the predicate directly.
+// Only a typed *exec.ExitError may downgrade an unknown outcome to a definite
+// failure: refusal WORDING is not enough, because this predicate narrows
+// caution and a false definite failure is the duplicate-send hazard.
 func TestFailClosedClassifierRequiresPositiveEvidence(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		out  string
 		err  error
 		want bool
 	}{
-		{"nil error", "", nil, false},
-		{"refusal exit code", "", exitCodeErr(t, amqExitRefused), true},
-		{"usage exit code", "", exitCodeErr(t, amqExitUsageRejected), true},
-		{"refusal marker in wrapped error", "", fmt.Errorf("amq send: %s root is not pinned", amqRefusalMarker), true},
-		{"refusal marker in output", amqRefusalMarker + " bad root", errors.New("exit status 5"), true},
-		{"generic failure wording", "", errors.New("send failed: could not reach the queue"), false},
-		{"the word refusing without the marker", "", errors.New("server is refusing connections"), false},
-		{"unrelated nonzero exit", "", exitCodeErr(t, 1), false},
+		{"nil error", nil, false},
+		{"refusal exit code", exitCodeErr(t, amqExitRefused), true},
+		{"usage exit code", exitCodeErr(t, amqExitUsageRejected), true},
+		// Typed evidence only. These carry AMQ's refusal wording but lost the
+		// *exec.ExitError, so they must NOT downgrade to definite: a false
+		// definite failure is the duplicate-send hazard.
+		{"refusal wording in a wrapped error", errors.New("amq send: refusing send: root is not pinned"), false},
+		{"plain exit-status text", errors.New("exit status 5"), false},
+		{"generic failure wording", errors.New("send failed: could not reach the queue"), false},
+		{"unrelated nonzero exit", exitCodeErr(t, 1), false},
+		{"signal kill", exitCodeErr(t, 137), false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := amqRefusedSendFailClosed([]byte(tc.out), tc.err); got != tc.want {
-				t.Errorf("amqRefusedSendFailClosed(%q, %v) = %t, want %t", tc.out, tc.err, got, tc.want)
+			if got := amqRefusedSendFailClosed(tc.err); got != tc.want {
+				t.Errorf("amqRefusedSendFailClosed(%v) = %t, want %t", tc.err, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`amq-squad amq send` wrote a receipt with `state=ambiguous_unknown` and an **empty `message_id`** for a send that AMQ had refused fail-closed. Non-delivery was provable — the command rejected the request before attempting any write — so the receipt trail was misleading exactly when it is read most carefully, during outage forensics.

`ambiguous_unknown` is reserved for genuinely unknown delivery outcomes. Using it for a provable non-delivery tells an operator to go confirm something that is already known.

A send AMQ refused now produces `delivery_failed` with its timestamp, evidence source, stage text, and per-consumer state.

## The safety asymmetry, which is the whole design

`ambiguous_unknown` stays the **default**. The new predicate may only ever *downgrade* an unknown outcome to a definite failure, never the reverse.

That asymmetry is deliberate:

- Calling a genuinely uncertain send "definitely failed" invites a retry that duplicates a message which did land.
- Calling a definite failure "ambiguous" merely costs an operator a manual check.

One of those errors is recoverable and the other is not, so the conservative direction is not the symmetric one.

**Typed evidence only.** There is no error-text fallback. Text matching is acceptable for *widening* caution, but this predicate *narrows* it, and a false definite failure is the duplicate-send hazard. A wrapped error that lost its `*exec.ExitError` stays ambiguous — a worse outcome for diagnosis and a better one for safety, which is the right trade in a receipt trail.

## Evidence for the classification

Probed against the pinned AMQ 0.51.1 rather than assumed:

| case | exit | output |
|---|---|---|
| refusal (wrong root) | **5** | `refusing send: root is not the pinned base root...` |
| bad flag | **2** | usage |
| missing required arg | **2** | `--to is required` |
| unknown subcommand | **2** | `unknown command: ...` |
| help | 0 | — |

Codes 2 and 5 are pre-delivery by construction: the command rejected the request before attempting a write. Anything else — a timeout, a signal, an unparseable failure mid-commit — stays ambiguous, because it is.

The exit-code-with-typed-error shape mirrors `isCollectWatchTimeout` (`collect.go`), which already classifies an AMQ outcome by exit code.

**A stated limit:** this is evidence from every code-2 case I could construct, not from a documented upstream exit-code contract — I found no such table. If a code-2 path exists that occurs *after* a write attempt, that single example collapses the case for including 2 and it should narrow to 5 alone. That is a one-line change.

## Ordering

The classifier sits inside the existing `receipt.MessageID == ""` branch, after committed-delivery evidence validation and after message-id parsing. Positive commit or id evidence wins over a 2/5 exit by construction.

It deliberately does **not** call `markDeliveryFailedBeforeID`: that helper persists internally and describes the AMQ-*not-invoked* boundary, which is a different fact. This path has `AMQInvoked=true`, and the outer durable boundary owns final persistence.

## Tests — deliberately both ways

A change that classified everything as failed would satisfy half of this and be more dangerous than the defect it replaced.

| falsifier | expected |
|---|---|
| typed exit 5, no id | `delivery_failed` |
| typed exit 2, no id | `delivery_failed` |
| typed exit 1, 137 | stays `ambiguous_unknown` |
| plain `"exit status 5"` text | stays `ambiguous_unknown` |
| refusal *wording* without a typed error | stays `ambiguous_unknown` |
| parseable message id | unaffected |
| consumer states and timestamps | agree with the receipt |

`exitCodeErr` builds a real `*exec.ExitError` by running a process, so the classifier is exercised through the type production sees rather than a stub that merely reports a number.

**Bisect proof.** Removing the fail-closed branch fails the two definite-outcome subtests and the stage-text test, while the ambiguous-stays-ambiguous half correctly keeps passing — which is what a correctly-directed pair should do.

## Verification

- `go test ./internal/cli/ -count=1` — PASS, `ok ... 444.802s`, exit 0 at this exact head
- `gofmt -l` clean tree-wide, `go build ./...`, `go vet ./internal/cli/`
- The `receipt_corrupt:` prefix contract and the #631 recovery helper are untouched; this changes send-outcome classification only, not any corrupt-receipt producer.

Refs #589
