### PR TITLE
fix: tolerate legacy base-root shape during pane teardown

### DIFF
--- a/internal/cli/pane_cleanup.go
+++ b/internal/cli/pane_cleanup.go
@@ -284,7 +284,9 @@ func validatePaneCleanupRecord(req PaneCleanupRequest, canonicalDir func(string)
 	pathMatch("team_home", scope.TeamHome, rec.TeamHome)
 	pathMatch("cwd", scope.CWD, rec.CWD)
 	pathMatch("root", scope.Root, rec.Root)
-	pathMatch("base_root", scope.BaseRoot, rec.BaseRoot)
+	if !paneCleanupBaseRootMatches(scope, rec, canonicalDir) {
+		out = append(out, PaneCleanupMismatch{Field: "base_root", Expected: scope.BaseRoot, Actual: rec.BaseRoot})
+	}
 	if !squadnamespace.ProfilesEqual(scope.Profile, rec.TeamProfile) {
 		out = append(out, PaneCleanupMismatch{Field: "profile", Expected: squadnamespace.NormalizeProfile(scope.Profile), Actual: squadnamespace.NormalizeProfile(rec.TeamProfile)})
 	}
@@ -334,6 +336,37 @@ func validatePaneCleanupRecord(req PaneCleanupRequest, canonicalDir func(string)
 	match("terminal.pane_id", rec.Tmux.PaneID, rec.Terminal.PaneID)
 	match("terminal.target", rec.Tmux.Target, rec.Terminal.Target)
 	return out
+}
+
+// paneCleanupBaseRootMatches accepts the exact current base-root identity and
+// one historical AMQ envelope shape. Older `amq env --json` responses omitted
+// base_root; the parser therefore fell back to root and launch records persisted
+// BaseRoot == Root. Newer AMQ versions report the session container, so teardown
+// sees BaseRoot == parent(Root) for the same live namespace (#596).
+//
+// This is deliberately structural rather than a general stale-record bypass:
+// both sides must still resolve to the same exact root, the record's base must
+// resolve to that root, and the current base must resolve to its direct parent.
+// Every project, profile, session, member, pane, process, and tmux check remains
+// independently fail-closed.
+func paneCleanupBaseRootMatches(scope PaneCleanupScope, rec launch.Record, canonicalDir func(string) (string, error)) bool {
+	wantBase, wantBaseErr := canonicalDir(scope.BaseRoot)
+	recordedBase, recordedBaseErr := canonicalDir(rec.BaseRoot)
+	if wantBaseErr != nil || recordedBaseErr != nil {
+		return false
+	}
+	if wantBase == recordedBase {
+		return true
+	}
+	if strings.TrimSpace(scope.Session) == "" || strings.TrimSpace(scope.Session) != strings.TrimSpace(rec.Session) {
+		return false
+	}
+	wantRoot, wantRootErr := canonicalDir(scope.Root)
+	recordedRoot, recordedRootErr := canonicalDir(rec.Root)
+	if wantRootErr != nil || recordedRootErr != nil || wantRoot != recordedRoot {
+		return false
+	}
+	return recordedBase == recordedRoot && wantBase == filepath.Dir(recordedRoot)
 }
 
 func attestInspectedPane(identity PaneCleanupIdentity, recordedCWD string, pane tmuxpane.TmuxPane, canonicalDir func(string) (string, error)) (PaneCleanupPaneEvidence, []PaneCleanupMismatch) {

--- a/internal/cli/pane_cleanup_down_wiring_test.go
+++ b/internal/cli/pane_cleanup_down_wiring_test.go
@@ -87,6 +87,93 @@ func TestStopPanePrepareSignalCloseOrdering(t *testing.T) {
 	}
 }
 
+// TestStopClosePanesAcceptsPriorGenerationBaseRootShape is the #596 effect
+// regression. Older AMQ env envelopes omitted base_root, so launch recording
+// fell back to root and persisted BaseRoot == Root. A newer binary resolves the
+// same namespace as BaseRoot == parent(Root). Teardown must accept that one
+// known historical shape without re-validating stale prepared/bootstrap state:
+// an in-place upgrade must still be able to stop the agent and close its exact
+// pane.
+func TestStopClosePanesAcceptsPriorGenerationBaseRootShape(t *testing.T) {
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.BaseRoot = record.Root
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []string
+	closeCalls := 0
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, record.Session,
+		eventTerminator{events: &events},
+		downFakeProbe(map[int]bool{record.AgentPID: true}, map[int]bool{record.AgentPID: true}),
+		nil, true,
+		PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(parent int) []int {
+					if parent == pane.PID {
+						return []int{record.AgentPID}
+					}
+					return nil
+				}, nil
+			},
+			Close: func(string) error { closeCalls++; return nil },
+		},
+	)
+
+	if !reflect.DeepEqual(events, []string{"signal"}) {
+		t.Fatalf("events=%v report=%+v, want exactly one agent signal before pane close", events, report)
+	}
+	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupClosed || closeCalls != 1 {
+		t.Fatalf("report=%+v close calls=%d, want stopped/closed/1", report, closeCalls)
+	}
+}
+
+// The compatibility rule above is about one launch-record path shape, not a
+// license to trust whatever currently occupies the recorded pane id. Even with
+// the legacy BaseRoot == Root spelling, a pane from another tmux session must
+// remain preserved and never reach the closer.
+func TestStopClosePanesPriorGenerationShapeStillRefusesForeignPane(t *testing.T) {
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.BaseRoot = record.Root
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatal(err)
+	}
+	pane.Session = "foreign-session"
+
+	closeCalls := 0
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, record.Session,
+		&recordingTerminator{},
+		downFakeProbe(map[int]bool{record.AgentPID: true}, map[int]bool{record.AgentPID: true}),
+		nil, true,
+		PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(parent int) []int {
+					if parent == pane.PID {
+						return []int{record.AgentPID}
+					}
+					return nil
+				}, nil
+			},
+			Close: func(string) error { closeCalls++; return nil },
+		},
+	)
+
+	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupPreservedIdentityUnconfirmed || closeCalls != 0 {
+		t.Fatalf("report=%+v close calls=%d, want stopped/preserved/0", report, closeCalls)
+	}
+	if len(report.Pane.Mismatches) != 1 || report.Pane.Mismatches[0].Field != "pane.session" {
+		t.Fatalf("foreign-pane refusal mismatches=%+v, want pane.session only", report.Pane.Mismatches)
+	}
+}
+
 func TestStopSignalsWhenPanePreparationRefusesAndReturnsPartial(t *testing.T) {
 	configured, member, _, _, project := completeDownPaneFixture(t)
 	var events []string

--- a/internal/cli/pane_cleanup_test.go
+++ b/internal/cli/pane_cleanup_test.go
@@ -151,6 +151,29 @@ func TestPaneCleanupRootAndBaseRootCanonicalExisting(t *testing.T) {
 		}
 	})
 
+	t.Run("prior generation recorded root as base root", func(t *testing.T) {
+		fx := newPaneCleanupFixture(t)
+		fx.req.Record.BaseRoot = fx.req.Record.Root
+		closeCalls := 0
+		prepared := PreparePaneCleanup(fx.req, cleanupDeps([]tmuxpane.PaneInspection{foundPane(fx.pane)}, nil, &closeCalls))
+		if !prepared.Ready {
+			t.Fatalf("historical BaseRoot == Root shape should prepare: %+v", prepared.Result)
+		}
+	})
+
+	t.Run("unrelated existing base root", func(t *testing.T) {
+		fx := newPaneCleanupFixture(t)
+		fx.req.Record.BaseRoot = t.TempDir()
+		closeCalls := 0
+		prepared := PreparePaneCleanup(fx.req, cleanupDeps([]tmuxpane.PaneInspection{foundPane(fx.pane)}, nil, &closeCalls))
+		if prepared.Ready || prepared.Result.Outcome != PaneCleanupPreservedIdentityUnconfirmed || closeCalls != 0 {
+			t.Fatalf("unrelated existing base root prepared=%t result=%+v close calls=%d", prepared.Ready, prepared.Result, closeCalls)
+		}
+		if len(prepared.Result.Mismatches) != 1 || prepared.Result.Mismatches[0].Field != "base_root" {
+			t.Fatalf("unrelated existing base root mismatches=%+v, want base_root only", prepared.Result.Mismatches)
+		}
+	})
+
 	for _, name := range []string{"missing root", "broken root symlink", "missing base root", "broken base symlink"} {
 		t.Run(name, func(t *testing.T) {
 			fx := newPaneCleanupFixture(t)

--- a/internal/cli/pane_cleanup_test.go
+++ b/internal/cli/pane_cleanup_test.go
@@ -199,6 +199,52 @@ func TestPaneCleanupRootAndBaseRootCanonicalExisting(t *testing.T) {
 	}
 }
 
+// The legacy compatibility branch is safe only while it remains bound to the
+// exact root and session under teardown. These cases deliberately keep the
+// accepted historical shape (record BaseRoot == Root) so they reach those two
+// guards instead of refusing earlier at recordedBase != recordedRoot.
+func TestPaneCleanupLegacyBaseRootShapeRequiresRootAndSessionBinding(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*paneCleanupFixture)
+	}{
+		{
+			name: "different root",
+			mutate: func(f *paneCleanupFixture) {
+				f.req.Scope.Root = t.TempDir()
+			},
+		},
+		{
+			name: "different session",
+			mutate: func(f *paneCleanupFixture) {
+				f.req.Scope.Session = "foreign-session"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newPaneCleanupFixture(t)
+			fx.req.Record.BaseRoot = fx.req.Record.Root
+			tt.mutate(&fx)
+			closeCalls := 0
+			prepared := PreparePaneCleanup(fx.req, cleanupDeps([]tmuxpane.PaneInspection{foundPane(fx.pane)}, nil, &closeCalls))
+			if prepared.Ready || prepared.Result.Outcome != PaneCleanupPreservedIdentityUnconfirmed || closeCalls != 0 {
+				t.Fatalf("prepared=%t result=%+v close calls=%d, want preserved/0", prepared.Ready, prepared.Result, closeCalls)
+			}
+			foundBaseRoot := false
+			for _, mismatch := range prepared.Result.Mismatches {
+				if mismatch.Field == "base_root" {
+					foundBaseRoot = true
+					break
+				}
+			}
+			if !foundBaseRoot {
+				t.Fatalf("mismatches=%+v, want base_root to prove the legacy compatibility branch stayed bound", prepared.Result.Mismatches)
+			}
+		})
+	}
+}
+
 func TestPaneCleanupCWDAndInspectionFailuresFailClosed(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

- accept the historical launch-record shape where an older AMQ envelope persisted BaseRoot equal to the session Root
- constrain compatibility to the same canonical root with the current base as its direct parent
- preserve every project, member, process, and tmux-pane identity check
- add end-to-end stop coverage plus unrelated-base and foreign-pane negative controls

## Verification

- red proof: the older record stopped the agent but preserved the pane solely on the base_root mismatch
- go test ./internal/cli -run 'Test(PaneCleanup|StopPane|StopClosePanes)' -count=1
- go test ./internal/cli -count=1

Refs #596
