### PR TITLE
Release v2.27.0

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,6 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
+<li><a href="#whats-new-in-v2270" id="toc-whats-new-in-v2270">What's new
+in v2.27.0</a></li>
 <li><a href="#whats-new-in-v2260" id="toc-whats-new-in-v2260">What's new
 in v2.26.0</a></li>
 <li><a href="#whats-new-in-v2251" id="toc-whats-new-in-v2251">What's new
@@ -328,7 +330,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2260">What's new in v2.26.0</a></li>
+<li><a href="#whats-new-in-v2270">What's new in v2.27.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -346,6 +348,57 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
+<h2 id="whats-new-in-v2270">What's new in v2.27.0</h2>
+<p>v2.27.0 is an operator-experience and error-actionability release.
+The milestone began as thirteen goal issues and the operator expanded it
+mid-cycle to seventeen: twelve ship and retire here, three ship in part
+with their remainder on v2.27.1, and two move to v2.27.1
+undelivered.</p>
+<ul>
+<li><strong>Post-launch operator handoff card (#493, PR #632).</strong>
+Launch no longer ends at "launched ✓". Every successful route —
+<code>up</code> and <code>resume --exec</code> — now prints who you are
+in this session, the console your attention belongs in, how gates reach
+you, and the exact commands to read and answer them. When no alert sink
+is configured the card says so plainly: nothing will interrupt you, and
+polling is on you. It writes to stdout, so <code>--quiet</code> cannot
+suppress it. First slice; the remaining items stay tracked on #493.</li>
+<li><strong>Errors name the remedy, not just the refusal (#520, PR #631;
+#561, PR #627).</strong> Prepared-run identity, staged admission,
+generation drift, live identity, and durable receipts now carry an
+executable recovery path instead of describing a refusal.
+Unknown-subcommand errors share one canonical format across the whole
+CLI.</li>
+<li><strong>Prepared launches render from accepted state (#618, PR
+#622).</strong> Fresh namespaces no longer drift between what was
+accepted and what a pane receives; an absent initial-roster member is
+refused loudly instead of being silently re-derived.</li>
+<li><strong>Receipts tell the truth about delivery (#613, PR #630; #589,
+PR #637).</strong> Derived-yet-immutable receipt fields no longer read
+as corruption, and a send AMQ refused outright is now recorded as
+definitely failed rather than ambiguous — which is what an operator
+needs during an outage.</li>
+<li><strong>Launch- and teardown-failure fixes.</strong> Path-case
+identity on case-insensitive filesystems (#617, PR #621), duplicated
+per-member effort args tripping the prepared-identity gate (#510, PR
+#635), <code>stop --close-panes</code> refusing every pane after an
+in-place binary upgrade (#596, PR #640), shared-CWD exception dropped
+when cloning a profile (#607, PR #623), and its remedy rejecting
+<code>--session</code> (#564, PR #629).</li>
+<li><strong>DX.</strong> <code>team member update --dry-run</code> shows
+a real field-level before/after diff (#616, PR #634), and two
+session-reuse guards were relaxed (#597, PR #610 — two of five items;
+the rest tracked on #608/#609).</li>
+</ul>
+<p><strong>Moved to v2.27.1:</strong> #619 and #620, undelivered, by
+operator decision — the two slide-eligible issues added when scope
+expanded. The deliberately-partial #493, #597, and #618 shipped real
+work here and carry their remainder there; #617, the other mid-cycle
+addition, shipped in full. #612 is triaged upstream as <a
+href="https://github.com/avivsinai/agent-message-queue/issues/418">avivsinai/agent-message-queue#418</a>
+with consumer-side hardening tracked in #628.</p>
+<p>Full detail in <a href="docs/v2.27.0-release-notes.md">the v2.27.0
+release notes</a>.</p>
 <h2 id="whats-new-in-v2260">What's new in v2.26.0</h2>
 <p>v2.26.0 is an AMQ-compatibility, launch-reliability, and
 team-management release. Four of the milestone's five issues ship:</p>
@@ -492,7 +545,7 @@ summary, and residual risks.</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.26.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.27.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.26.0](#whats-new-in-v2260)
+- [What's new in v2.27.0](#whats-new-in-v2270)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -37,6 +37,52 @@ The 30-second mental model:
 - [Cross-project teams](#cross-project-teams)
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
+
+## What's new in v2.27.0
+
+v2.27.0 is an operator-experience and error-actionability release. The
+milestone began as thirteen goal issues and the operator expanded it mid-cycle
+to seventeen: twelve ship and retire here, three ship in part with their
+remainder on v2.27.1, and two move to v2.27.1 undelivered.
+
+- **Post-launch operator handoff card (#493, PR #632).** Launch no longer ends
+  at "launched ✓". Every successful route — `up` and `resume --exec` — now
+  prints who you are in this session, the console your attention belongs in,
+  how gates reach you, and the exact commands to read and answer them. When no
+  alert sink is configured the card says so plainly: nothing will interrupt
+  you, and polling is on you. It writes to stdout, so `--quiet` cannot suppress
+  it. First slice; the remaining items stay tracked on #493.
+- **Errors name the remedy, not just the refusal (#520, PR #631; #561, PR #627).**
+  Prepared-run identity, staged admission, generation drift, live identity, and
+  durable receipts now carry an executable recovery path instead of describing
+  a refusal. Unknown-subcommand errors share one canonical format across the
+  whole CLI.
+- **Prepared launches render from accepted state (#618, PR #622).** Fresh
+  namespaces no longer drift between what was accepted and what a pane
+  receives; an absent initial-roster member is refused loudly instead of being
+  silently re-derived.
+- **Receipts tell the truth about delivery (#613, PR #630; #589, PR #637).**
+  Derived-yet-immutable receipt fields no longer read as corruption, and a send
+  AMQ refused outright is now recorded as definitely failed rather than
+  ambiguous — which is what an operator needs during an outage.
+- **Launch- and teardown-failure fixes.** Path-case identity on
+  case-insensitive filesystems (#617, PR #621), duplicated per-member effort
+  args tripping the prepared-identity gate (#510, PR #635), `stop
+  --close-panes` refusing every pane after an in-place binary upgrade (#596,
+  PR #640), shared-CWD exception dropped when cloning a profile (#607,
+  PR #623), and its remedy rejecting `--session` (#564, PR #629).
+- **DX.** `team member update --dry-run` shows a real field-level before/after
+  diff (#616, PR #634), and two session-reuse guards were relaxed (#597,
+  PR #610 — two of five items; the rest tracked on #608/#609).
+
+**Moved to v2.27.1:** #619 and #620, undelivered, by operator decision — the
+two slide-eligible issues added when scope expanded. The deliberately-partial
+#493, #597, and #618 shipped real work here and carry their remainder there;
+#617, the other mid-cycle addition, shipped in full. #612 is triaged upstream as
+[avivsinai/agent-message-queue#418](https://github.com/avivsinai/agent-message-queue/issues/418)
+with consumer-side hardening tracked in #628.
+
+Full detail in [the v2.27.0 release notes](docs/v2.27.0-release-notes.md).
 
 ## What's new in v2.26.0
 
@@ -181,7 +227,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.26.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.27.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.27.0-release-notes.md
+++ b/docs/v2.27.0-release-notes.md
@@ -1,0 +1,320 @@
+# amq-squad v2.27.0
+
+## Summary
+
+v2.27.0 is an operator-experience and error-actionability release. The
+launcher stops ending at "launched ✓" and hands the human an explicit
+statement of their role, console, and gate surface (#493). Error messages that
+previously described a refusal now name the command that resolves it, across
+prepared-run identity, durable receipts, live identity, and unknown
+subcommands (#520, #561). Prepared launches render from accepted state rather
+than live process state, ending the fresh-namespace bootstrap drift observed
+in the field (#618).
+
+The milestone began as thirteen goal issues and the operator expanded it
+mid-cycle to seventeen, adding #617 and #618 as release-critical and #619 and
+#620 as slide-eligible. Final disposition of all seventeen:
+
+- **Shipped and retired here (12):** #510, #520, #561, #564, #578, #589, #596,
+  #607, #612 (by upstream triage), #613, #616, #617.
+- **Shipped in part (3):** #493 (first slice), #597 (two of five items), and
+  #618 (the field-observed defect). Each shipped real operator-visible work in
+  this release; each remains open on v2.27.1 for its remainder, and each says
+  so in its own section below.
+- **Moved to v2.27.1 undelivered (2):** #619 and #620, by operator decision —
+  flagged here rather than silently dropped.
+
+Milestone v2.27.0 itself closes with zero open issues.
+
+## Post-launch operator handoff card (#493, PR #632)
+
+The launch flow ended at "launched ✓" and said nothing about the operator's
+role from that moment on. In a real session the squad completed its goal in 23
+minutes and sent an acknowledgement plus two gate decisions to the operator
+mailbox; the human discovered them roughly 50 minutes later and asked why the
+lead was not speaking to them. The profile was configured
+`operator_delivery: lead_pane, notifications=false` — a coherent
+configuration that nothing had ever explained to the person it depended on.
+
+- Every successful launch route now ends with an operator handoff card: `up`
+  and `resume --exec` both print it after verified launch success.
+- The card names the operator's handle, the console their attention belongs in
+  (naming the actual lead role for `lead_pane`, not a generic phrase), that
+  gates arrive as durable `gate/<topic>` threads which do not expire and do not
+  resend, and the exact scoped commands to read, watch, answer, and check the
+  board.
+- When no alert sink is configured the card says so in those terms: nothing
+  will interrupt you, and polling is on the operator. This converts a
+  silent-by-design configuration into an informed choice.
+- Every field derives from the profile's actual operator block. A card printing
+  plausible defaults would reproduce the failure it exists to prevent while
+  sounding authoritative.
+- The card writes to stdout unconditionally and never through the
+  quiet-suppressible notice path. `--quiet` suppresses progress chatter; it
+  must not suppress the one output that tells a human they are on the hook.
+- Printed commands carry the resolved `--project`. `up --project DIR` changes
+  the launching process's directory and restores it on return, so the
+  operator's shell never moved; commands without an explicit project would
+  resolve against the wrong team.
+
+This is the first slice. Five items remain open on #493: a launch-time
+notification watcher health check, topology validation that warns when
+configured delivery and actual topology disagree, a pending-gate count at
+handoff, structural inclusion in JSON launch results, and the wizard skill
+requirement to relay the card verbatim. The JSON item is blocked rather than
+deferred: `up --json` requires `--dry-run` today, so no live JSON launch result
+exists to carry the card.
+
+## Actionable prepared-run and receipt errors (#520, PR #631)
+
+An audit of a 30-error sample started at 12 actionable, 8 failure-only, and 10
+internal-jargon messages. Each disposition is now recorded rather than implied.
+
+- Prepared and staged identity mismatches name an executable inspection path
+  and direct terminal generations back through accepted preparation.
+- Staged `agent up` admission surfaces the recovery command the predicate
+  already computed instead of dropping it.
+- Task and dispatch generation drift carries the exact
+  project/profile/session run-start recovery flow; the displayed commands are
+  executed by regression tests rather than only asserted as strings.
+- A custom role without a binary names both exact assignments.
+- Live-identity failures carry registered `status --json` and `team resume`
+  recovery commands.
+- `next` returns the shared missing-team error instead of leaking a storage
+  `ENOENT`.
+- All 35 durable-receipt corruption producers route through one helper, so the
+  machine-consumed `receipt_corrupt:` prefix stays byte-stable at the front
+  while the actionable remedy is appended.
+
+The receipt guard is an AST audit that inspects string literals inside
+function bodies. It is comment-blind by construction rather than by filtering,
+so documentation quoting an error verbatim does not need special-casing.
+
+## Prepared launches render from accepted state (#618, PR #622)
+
+Fresh-namespace launches could render a bootstrap prompt from live process
+state rather than from the accepted preparation, producing drift between what
+was accepted and what a pane received.
+
+- Prepared launches route through one shared renderer fed by accepted state.
+- The renderer refuses loudly when the accepted initial roster names a member
+  that is absent, rather than silently re-deriving a roster.
+- Peer routing compares canonical filesystem paths instead of recorded
+  spellings, so a launch record written with a different but equivalent path
+  spelling no longer misroutes.
+
+#618 stays open. The `GenerationRef` consequence is unresolved, and #625
+records the staged-digest reconstructibility work required before the
+remaining case can be retired. #609 remains the open diagnosis-tooling gap:
+persisted bootstrap previews cannot support a real diff until its publication
+and integrity design lands.
+
+## Established-then-frozen receipt fields (#613, PR #630)
+
+Receipt merge identity validated `recipient`, `recipients`, and `thread` with
+strict equality while the normalizer *derived* those same fields. A receipt
+that arrived without them, then acquired them through normalization, was
+rejected as corrupt. Six field artifacts from a real session reproduced it
+deterministically.
+
+- Those three fields move to an explicit establish-then-freeze class: they may
+  be set once from empty, and are immutable thereafter.
+- The remaining identity fields stay always-frozen, and the guard covering
+  them now names the complete set rather than a subset.
+- Merge carries established fields forward, so acceptance is no longer lossy.
+  Strict equality had been silently protecting this path by refusing the input
+  that would expose it.
+
+## Path-case identity on case-insensitive filesystems (#617, PR #621)
+
+- Existing filesystem paths canonicalize to their on-disk case at the shared
+  comparison seam, with a Darwin fast path and a portable directory-entry and
+  inode fallback.
+- Pane, context-root, launch/resume, prepared-identity, and AMQ-root
+  comparisons all route through that seam.
+- Windows drive and UNC volume prefixes normalize while directory components
+  are proved with `SameFile`.
+
+## Canonical unknown-subcommand errors (#561, PR #627)
+
+- One formatter produces every unknown-subcommand error:
+  `unknown 'VERB' subcommand: "GIVEN". Try 'a', 'b', or 'c'.`
+- Producers must supply a non-empty, duplicate-free, complete subcommand list;
+  one-, two-, and many-item lists get deterministic grammar.
+- All 29 original producers are migrated, with an AST audit that rejects
+  ad-hoc wording and pins the production-call count.
+- The skill drift gate's tolerant union regex is replaced by an exact,
+  verb-bound canonical parser.
+
+## Two happy-path session-reuse guards relaxed (#597, PR #610)
+
+PR #610 delivers **two of #597's five items**; three are deferred with design
+records rather than attempted.
+
+- Item 4 — `--effort` composes with `--from-profile`. Shipped.
+- Item 3 — plan-stage brief binding honors `--seed-from`. Shipped.
+- Item 1 — profile reusable across sessions. Deferred, tracked by #608.
+- Item 2 — profile/session naming collision. Deferred, requires a
+  namespace-layout migration.
+- Item 5 — persist-and-diff. Deferred, tracked by #609.
+
+## Definite receipts for refused sends (#589, PR #637)
+
+`amq-squad amq send` wrote a receipt with `state=ambiguous_unknown` and an
+empty `message_id` for a send AMQ had refused outright. Non-delivery was
+provable — the command rejected the request before attempting any write — so
+the receipt trail was misleading exactly when it is read most carefully,
+during outage forensics.
+
+- A refused send now produces `delivery_failed` with its timestamp, evidence
+  source, stage text, and per-consumer state.
+- Classification uses positive typed evidence only: the pinned AMQ exits 5 for
+  an explicit refusal and 2 for a usage rejection, both pre-delivery by
+  construction. Anything else — a timeout, a signal, an unparseable failure
+  mid-commit — stays ambiguous, because it is.
+- `ambiguous_unknown` remains the default, and the new predicate may only
+  *downgrade* an unknown outcome to a definite failure, never the reverse.
+  Calling an uncertain send definitely-failed invites a retry that duplicates
+  a message which did land; calling a definite failure ambiguous costs one
+  manual check. One error is recoverable and the other is not.
+- Positive evidence outranks the exit code: a parsed message id, or a
+  committed-delivery path, keeps its own state even when the process also
+  exited 2 or 5.
+
+#638 records the remaining downstream contradiction: the task store still maps
+such a receipt to `uncertain`, which needs a `taskstore` vocabulary decision
+rather than a mapping tweak.
+
+## Also in this release
+
+- **Shared-CWD exception preserved in profile clones (#607, PR #623).**
+  Cloning with `--from-profile` preserves the source shared-CWD exception; an
+  explicit `--shared-cwd-exception` overrides it on the target only, and the
+  source profile stays byte-identical.
+- **Shared-CWD exception remedy accepts a session (#564, PR #629).**
+  `team shared-cwd-exception set` accepts and validates `--session` while the
+  exception itself stays profile-wide, and the printed remedy carries the
+  active preparation session. `--session` is deliberately kept off the
+  alternative `team member update` command, where it would mutate the member
+  pin rather than scope the command.
+- **Field-level member diff in `team member update --dry-run` (#616, PR #634).**
+  The preview showed a would-update summary; it now shows a before/after table
+  over the fields the command can change, and carries the same diff in the
+  `--json` envelope. The diff reads the actual before/after members rather than
+  the flags that were set, so `--effort` surfaces as the native args it
+  actually writes. Native argv is rendered with per-token quoting so that
+  token boundaries stay visible — a plain join made a one-token argument
+  containing a space compare equal to two separate tokens, which silently
+  reported a real edit as no change.
+- **Managed native args composed once (#510, PR #635).** Claude and Codex
+  native args travel through the typed `--claude-args`/`--codex-args`
+  transport and are no longer mirrored after the child `--` boundary, where
+  tool-policy prefix splitting could turn a singleton such as `--effort` into
+  a duplicate. Unknown and custom binaries, which have no compact transport,
+  keep their native args in the child surface.
+- **`stop --close-panes` after an in-place binary upgrade (#596, PR #640).**
+  Pane teardown refused every pane once a record carried a historical
+  base-root shape. The accepted historical shape now closes normally, while an
+  unrelated existing base root still refuses as `base_root` and a legacy-shape
+  record pointing at a foreign tmux session still refuses as `pane.session` —
+  so the compatibility widening does not weaken the foreign-pane control. Both
+  new guards are mutation-pinned: deleting either one fails a named test.
+- **Dead `printGlobalCheatsheet` deleted (#578, PR #636).** The function had
+  no call sites since v2.24.0 but was still compiled in, carrying pre-#454
+  guidance that told operators to pass registration flags that are now
+  defaults.
+
+## Upstream triage
+
+#612 is a defect in the AMQ layer, not in amq-squad. It is recorded as
+triaged-upstream for this release, and its amq-squad tracking issue is retired
+on that basis rather than on a local code change. The upstream report is
+[avivsinai/agent-message-queue#418](https://github.com/avivsinai/agent-message-queue/issues/418),
+with the amq-squad-to-amq boundary named at a specific file and line rather
+than described: `internal/cli/launch.go:764`, where amq-squad hands
+`--wake-inject-mode` across to amq. No amq-squad code change is part of this
+release for #612. Consumer-side hardening is filed separately as #628.
+
+## Verification and process
+
+- Every merged PR passed `make ci` plus both real-AMQ compatibility lanes and
+  both real-AMQ wake lanes at its exact final head — five hosted lanes each,
+  read from named JSON status fields rather than parsed from columns.
+- Behavior changes were required to fail at their parent with the committed
+  test unchanged. Compile failures and no-test runs did not count as proof.
+  Several fixes were bisect-verified by removing the fix and observing the
+  named test fail.
+- Reviews are bound to an exact head SHA. A rebase invalidates them: rebased
+  PRs carried `git range-diff` content-identity proof and re-issued their
+  reviews at the new head rather than carrying approvals across.
+- **Review independence is AMQ-attested, not provider-attested.** Every squad
+  agent drives `gh` under the same GitHub identity, so GitHub refuses a
+  non-author review with `Review Can not approve your own pull request`, and
+  `gh pr view --json reviews` returns an empty list for PRs that received two
+  independent exact-head reviews. The attestation of record is the AMQ
+  `review_response` plus the `amq-squad verify merge` evidence bundle; PR
+  comments carry the review text as an interim provider-side record. The same
+  property applies to the non-author-merge rule: the provider cannot
+  distinguish our actors, so actor discipline enforces it. #633 records the
+  work to mirror AMQ review attestation into the PR at gate time.
+- **The `-race` lane is still not permanent.** #624 records the gap. Three
+  clean `-race` baselines were taken during this cycle, one of which caught a
+  regression that a non-race run had passed.
+- A gate-authorization defect was found by a merge halting at its own hard
+  check: two typed bindings on one gate topic made the earlier one
+  unverifiable, and the failure rewarded the *sloppier* raise order. The merge
+  was stopped and escalated rather than worked around; topics are now split per
+  action (#639).
+- Cross-review found release-blocking defects that the authoring agent's own
+  tests could not surface, including a validator narrowing that opened a lossy
+  merge path, a launch route that never printed the handoff card, a displayed
+  command that was usage notation rather than runnable syntax, and an argv
+  comparison that reported a real edit as no change, and a diff sentinel that
+  collided with a legitimate value. The last three share one property — a
+  display or comparison encoding that is not injective silently loses real
+  differences — and the durable rule is that any diff renderer needs its
+  encoding proven injective: can two different inputs produce the same two
+  cells? The recurring shape: an
+  author tests the mechanism they just built, using values that exercise that
+  mechanism; a reviewer tests with values a user would actually pass.
+
+## Known issues
+
+- **#618 is partially delivered.** The field-observed bootstrap drift no
+  longer reproduces, but the `GenerationRef` consequence remains open, and #625 records the
+  staged-digest reconstructibility work it depends on.
+- **#626 records an admission-gate comparison on unresolved paths.** Filed
+  during this cycle, not addressed here.
+- **#638 records a task-store vocabulary contradiction.** After #589 a
+  fail-closed send produces a definite `delivery_failed` receipt while
+  `taskDeliveryOutcome` still reports `uncertain`. No existing task-store state
+  means "invoked, definitely not delivered", so this needs a vocabulary
+  decision rather than a mapping change.
+- **#639 records an action-blind gate resolver.** `verify action` selects a
+  gate binding by recency rather than the one matching the
+  requested action, so a second binding on one topic silently shadows the
+  first. Encountered live during the #635 merge, which halted at the hard
+  check rather than proceeding. The interim rule — one gate topic, one typed
+  action — is in force and verified working.
+- **#628 records consumer-side hardening for the upstream #612 defect.**
+- **#606 remains unverified**, unchanged from v2.26.0: the AMQ session-root
+  containment check is tautological by code inspection, but no live
+  reproduction has established the exposure.
+- **#590 remains a pre-existing timing flake** in owner-bound managed-wake
+  cleanup, unchanged from v2.26.0.
+
+## Upgrade notes
+
+AMQ 0.51.1 remains the supported floor, unchanged from v2.26.0. No team or
+profile schema migration is required.
+
+Operators who script against `team member update --dry-run --json` will see a
+new optional `changes` array on preview envelopes. It is omitted entirely from
+applied-update envelopes and from every other mutation envelope, so existing
+consumers are unaffected.
+
+Install the pinned release with:
+
+```sh
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.27.0
+```

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | console | up | focus | send | resume | fork | rm | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | activity | gate | resume | stop | archive | context | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | spawn | dispatch | monitor | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | stage goal|brief|rules|roles|profile|readiness|launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` and its roles stage. Role authoring is part of the reviewed goal-to-launch preparation flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, preparation, readiness, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, resolve an ambiguous namespace, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, watch for events without burning turns, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"monitor the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first amq-squad preparation and launch wizard. Use when turning a request into reviewed coordination artifacts, proving roster and bootstrap readiness, or presenting the separate default-No launch gate. Triggers include \"set up a squad for X\", \"show me the plan\", \"prepare it\", \"is it ready\", \"launch it\", \"why did readiness block\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.26.0"  # x-release-please-version
+version: "2.27.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
# Release v2.27.0

The milestone began as thirteen goal issues and the operator expanded it mid-cycle to seventeen. This PR carries the version bump, the release notes, and the README release section.

## Contents

- `plugins/{claude,codex}` plugin manifests and all 14 skill manifests bumped `2.26.0` → `2.27.0`
- `docs/v2.27.0-release-notes.md` (new)
- `README.md` release section, contents link, and install pin; `README.html` regenerated with `make readme-html` (not hand-edited)

19 files, matching the shape of the v2.26.0 release commit `f8b0911`.

## Gates

| gate | result |
|---|---|
| `make release-check VERSION=2.27.0` | exit 0 at this head — "release metadata matches v2.27.0" |
| `make ci` (hosted) | SUCCESS at this exact head — run 30763071721, headSha `61417c787e406728d774846a000924bd23d340aa` |
| `make ci` (local) | 46 packages ok, zero FAIL, `internal/cli` 463.562s — run at `234d0c2`, **not** at this head. Every delta since is documentation-only; no Go source changed. |
| `make readme-html-check` | in sync, re-run locally at this head |
| `make docs-html-check` | in sync, re-run locally at this head |

`make ci` includes `fmt-check`, `vet`, `test`, both html checks, `skills-check`, `skill-routing-check`, `skill-command-check`, `release-validator-test`, and `go-files-scope-test`.

## Milestone disposition

Scope began at thirteen goal issues; the operator expanded it mid-cycle to seventeen, adding #617 and #618 as release-critical and #619/#620 as slide-eligible. Final disposition of all seventeen:

- **Shipped and retired here (12):** #510, #520, #561, #564, #578, #589, #596, #607, #612 (upstream triage), #613, #616, #617
- **Shipped in part (3):** #493 (first slice), #597 (two of five items), #618 (the field-observed defect) — each shipped real operator-visible work here and each remains open on v2.27.1 for its remainder
- **Moved to v2.27.1 undelivered (2):** #619, #620, by operator decision — flagged in the notes, not dropped

Milestone v2.27.0 itself has zero open issues.
- **#612** is recorded as triaged-upstream ([avivsinai/agent-message-queue#418](https://github.com/avivsinai/agent-message-queue/issues/418)); consumer-side hardening tracked in #628


## Follow-ups filed during the cycle

#624 (permanent `-race` lane), #625, #626, #628, #633 (AMQ-carried review attestation), #638 (task-store vocabulary), #639 (action-blind gate resolver).

## Note on issue references

Every issue reference in this body and in the release notes uses non-closing phrasing deliberately. Both keyword scans were run on `docs/v2.27.0-release-notes.md` and `README.md`: no keyword appears in GitHub parse position. The single scan hit is the literal flag name `--close-panes` in the #596 entry, which names the command the fix is about and was explicitly ruled to stay.

Refs #39



