### PR TITLE
test: guarded v2.28 contract tests for the 14 acceptance criteria (step 1) (#646)

### DIFF
--- a/internal/cli/v228_contract_canonical_path_test.go
+++ b/internal/cli/v228_contract_canonical_path_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// AC1 (#643 class): a fresh project whose path the operator spelled with the
+// wrong on-disk case must launch on the first try. The v2.28 contract is that
+// the project path is canonicalized ONCE (EvalSymlinks + on-disk case) and every
+// later component consumes that canonical value instead of re-deriving its own
+// spelling. #643 was two components deriving the same path differently and then
+// comparing the results.
+
+// v228MiscasedProject creates a real directory with a mixed-case leaf and
+// returns (realSpelling, lowercasedSpelling). It skips when the filesystem is
+// case sensitive, because the defect class only exists on a case-insensitive one.
+func v228MiscasedProject(t *testing.T) (string, string) {
+	t.Helper()
+	parent := t.TempDir()
+	real := filepath.Join(parent, "Project")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	miscased := filepath.Join(parent, "project")
+	if _, err := os.Stat(miscased); err != nil {
+		t.Skipf("case-insensitive filesystem required for the #643 repro: %v", err)
+	}
+	return real, miscased
+}
+
+func TestV228ContractMiscasedProjectRendersOneCanonicalBootstrap(t *testing.T) {
+	requireV228Contract(t)
+	real, miscased := v228MiscasedProject(t)
+	const (
+		profile = "v228"
+		session = "ac1"
+		handle  = "cto"
+	)
+	canonical := canonicalFilesystemPath(real)
+	v228SeedProfile(t, real, profile, session, []team.Member{
+		{Role: handle, Binary: "codex", Handle: handle, Session: session},
+	})
+
+	build := func(project string) (bootstrapContext, string) {
+		t.Helper()
+		root := squadnamespace.AMQRoot(project, profile, session)
+		agentDir := filepath.Join(root, "agents", handle)
+		rec := launch.Record{
+			Binary: "codex", Role: handle, Handle: handle, Session: session,
+			TeamProfile: profile, TeamHome: project, CWD: project, Root: root,
+			AgentPID: 4101, StartedAt: v228Now,
+		}
+		ctx := bootstrapContextFor(rec, agentDir, project)
+		prompt, err := buildBootstrapPrompt(ctx)
+		if err != nil {
+			t.Fatalf("buildBootstrapPrompt(%s): %v", project, err)
+		}
+		return ctx, prompt
+	}
+
+	canonicalCtx, canonicalPrompt := build(canonical)
+	miscasedCtx, miscasedPrompt := build(miscased)
+
+	// The rendered prompt must never embed a non-canonical spelling: the bootstrap
+	// bytes are what #643 hashed and compared across the prepare/spawn boundary.
+	for _, field := range []struct {
+		name string
+		got  string
+	}{
+		{"TeamHome", miscasedCtx.TeamHome},
+		{"CWD", miscasedCtx.CWD},
+		{"Root", miscasedCtx.Root},
+		{"AgentDir", miscasedCtx.AgentDir},
+		{"BriefPath", miscasedCtx.BriefPath},
+		{"TeamRulesPath", miscasedCtx.TeamRulesPath},
+		{"LaunchPath", miscasedCtx.LaunchPath},
+	} {
+		if field.got == "" {
+			continue
+		}
+		if want := canonicalFilesystemPath(field.got); want != field.got {
+			t.Errorf("bootstrap context %s = %q, want the canonical spelling %q", field.name, field.got, want)
+		}
+	}
+	if miscasedPrompt != canonicalPrompt {
+		t.Errorf("bootstrap prompt differs between two spellings of the same directory;\ncanonical context = %+v\nmiscased context  = %+v", canonicalCtx, miscasedCtx)
+	}
+}
+
+func TestV228ContractMiscasedProjectStatusReportsCanonicalCoordinates(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+	real, miscased := v228MiscasedProject(t)
+	const (
+		profile = "v228"
+		session = "ac1"
+		handle  = "cto"
+		pid     = 4102
+	)
+	canonical := canonicalFilesystemPath(real)
+	// The operator typed the wrong case, so that is what the profile records.
+	v228SeedProfile(t, miscased, profile, session, []team.Member{
+		{Role: handle, Binary: "codex", Handle: handle, Session: session},
+	})
+	canonicalRoot := v228CanonicalRoot(real, profile, session)
+	v228SeedLiveRecord(t, canonicalRoot, launch.Record{
+		Binary: "codex", Role: handle, Handle: handle, Session: session,
+		TeamProfile: profile, TeamHome: canonical, CWD: canonical,
+		Root: canonicalRoot, BaseRoot: filepath.Dir(canonicalRoot),
+		AgentPID: pid, StartedAt: v228Now.Add(-time.Minute),
+	})
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       miscased,
+		Profile:          profile,
+		RequestedSession: session,
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            v228Probe(pid),
+	})
+	if err != nil {
+		t.Fatalf("executeStatus with a miscased --project: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	if env.Data.TeamHome != canonical {
+		t.Errorf("status team_home = %q, want the canonical spelling %q", env.Data.TeamHome, canonical)
+	}
+	if len(env.Data.Records) != 1 {
+		t.Fatalf("status records = %+v, want one row", env.Data.Records)
+	}
+	row := env.Data.Records[0]
+	if row.Status != statusStateLive {
+		t.Errorf("status for a live agent reached through a miscased project = %q (%s), want live", row.Status, row.Detail)
+	}
+	if row.Root != canonicalRoot {
+		t.Errorf("status root = %q, want the canonical root %q", row.Root, canonicalRoot)
+	}
+	if row.CWD != canonical {
+		t.Errorf("status cwd = %q, want the canonical spelling %q", row.CWD, canonical)
+	}
+	if strings.Contains(row.Root, filepath.Base(miscased)+string(os.PathSeparator)) {
+		t.Errorf("status re-derived the root from the operator's spelling: %q", row.Root)
+	}
+}

--- a/internal/cli/v228_contract_concurrent_start_test.go
+++ b/internal/cli/v228_contract_concurrent_start_test.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/flock"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// AC5: two (here: eight) concurrent `start` invocations must produce exactly one
+// squad — one spawn per role, no duplicate workers. The mechanism the plan keeps
+// is the session launch lock plus a liveness re-read UNDER that lock: whoever
+// gets in first spawns, everyone after that observes the live record and rolls
+// forward instead of spawning again.
+//
+// The reconcile body below is driven by the production pieces it must use: the
+// duplicate-launch preflight (the liveness re-read) and locked atomic launch
+// record writes. Spawning itself is represented by the record write, because a
+// real child process is not hermetic — the contract under test is "how many
+// times does the launcher decide to spawn", which is decided before exec.
+//
+// TODO(P2): replace v228SessionLaunchLockPath with the launcher's exported
+// session launch lock once the simple launcher lands, so the test locks the same
+// file production does instead of an agreed-upon path.
+func v228SessionLaunchLockPath(project, profile, session string) string {
+	dir := filepath.Join(project, team.DirName, "locks")
+	return filepath.Join(dir, squadnamespace.NormalizeProfile(profile)+"."+session+".launch.lock")
+}
+
+func TestV228ContractConcurrentStartsLaunchOneSquad(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile     = "v228"
+		session     = "ac5"
+		starters    = 8
+		basePIDUnit = 1000
+	)
+	roles := []string{"cto", "dev"}
+	members := make([]team.Member, 0, len(roles))
+	for _, role := range roles {
+		members = append(members, team.Member{Role: role, Binary: "codex", Handle: role, Session: session})
+	}
+	v228SeedProfile(t, project, profile, session, members)
+
+	root := v228CanonicalRoot(project, profile, session)
+	lockPath := v228SessionLaunchLockPath(project, profile, session)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu           sync.Mutex
+		spawns       = map[string][]int{}
+		holders      int
+		maxHolders   int
+		aliveByPID   = map[int]bool{}
+		spawnFailure error
+	)
+	probe := duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return aliveByPID[pid]
+		},
+		ProcessMatch: func(pid int, _ func(args string) bool) bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return aliveByPID[pid]
+		},
+		Now: func() time.Time { return v228Now },
+	}
+
+	// startOnce is one `start` invocation: under the session launch lock, for each
+	// role, re-read liveness and spawn only what is not already live.
+	startOnce := func(attempt int) error {
+		return flock.WithLock(lockPath, func() error {
+			mu.Lock()
+			holders++
+			if holders > maxHolders {
+				maxHolders = holders
+			}
+			mu.Unlock()
+			defer func() {
+				mu.Lock()
+				holders--
+				mu.Unlock()
+			}()
+
+			for i, role := range roles {
+				agentDir := filepath.Join(root, "agents", role)
+				plan := agentLaunchPreflight{
+					Role: role, CWD: project, AgentDir: agentDir, Handle: role,
+					Workstream: session, Root: root, BaseRoot: filepath.Dir(root),
+					Binary: "codex",
+					// Read-only inspection: a concurrent start must never delete
+					// another starter's in-flight artifacts.
+					DryRun: true,
+				}
+				blocker, err := plan.check(probe)
+				if err != nil {
+					return fmt.Errorf("preflight %s: %w", role, err)
+				}
+				if blocker != nil && len(blocker.Reasons) > 0 {
+					// Already live: keep it, roll forward.
+					continue
+				}
+				pid := basePIDUnit*(attempt+1) + i
+				if err := launch.Write(agentDir, launch.Record{
+					Binary: "codex", Role: role, Handle: role, Session: session,
+					TeamProfile: profile, TeamHome: project, CWD: project,
+					Root: root, BaseRoot: filepath.Dir(root),
+					AgentPID: pid, StartedAt: v228Now,
+				}); err != nil {
+					return fmt.Errorf("record %s: %w", role, err)
+				}
+				mu.Lock()
+				aliveByPID[pid] = true
+				spawns[role] = append(spawns[role], pid)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	for attempt := 0; attempt < starters; attempt++ {
+		wg.Add(1)
+		go func(attempt int) {
+			defer wg.Done()
+			<-release
+			if err := startOnce(attempt); err != nil {
+				mu.Lock()
+				if spawnFailure == nil {
+					spawnFailure = err
+				}
+				mu.Unlock()
+			}
+		}(attempt)
+	}
+	close(release)
+	wg.Wait()
+
+	if spawnFailure != nil {
+		t.Fatalf("concurrent start failed: %v", spawnFailure)
+	}
+	if maxHolders != 1 {
+		t.Errorf("session launch lock allowed %d concurrent holders, want 1 (a shared lock cannot prevent double-spawn)", maxHolders)
+	}
+	for _, role := range roles {
+		if got := spawns[role]; len(got) != 1 {
+			t.Errorf("%s spawned %d times (pids %v), want exactly 1", role, len(got), got)
+		}
+	}
+	entries, err := launch.ScanEntries(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	perRole := map[string]int{}
+	for _, entry := range entries {
+		perRole[entry.Record.Role]++
+	}
+	for _, role := range roles {
+		if perRole[role] != 1 {
+			t.Errorf("%s has %d launch records on disk, want 1", role, perRole[role])
+		}
+	}
+	if len(entries) != len(roles) {
+		t.Errorf("scanned %d launch records, want %d (one squad)", len(entries), len(roles))
+	}
+}

--- a/internal/cli/v228_contract_crash_injection_test.go
+++ b/internal/cli/v228_contract_crash_injection_test.go
@@ -1,0 +1,335 @@
+//go:build v228seam
+
+// AC2 / AC6 (#644 class) crash-injection contract tests.
+//
+// This file is written against the REAL Phase 2 seam in simple_start.go:
+// runStartWithDependencies, simpleStartDependencies.AfterCheckpoint, the four
+// simpleStartCheckpoint* constants, and *simpleStartCheckpointError. Those
+// symbols live on wt/v2-28-0-senior and are not on this branch yet, so the file
+// is gated behind the v228seam build tag: main cannot see it and stays green.
+//
+// P2 INTEGRATION STEP: delete the //go:build line above. That is the whole
+// change — no placeholder types to unwind, no assertions to rewrite. Until then:
+//
+//	go test ./internal/cli/ -tags v228seam -run TestV228   # fails to compile pre-merge, by design
+//
+// The env guard is kept so the tests stay opt-in after the tag goes away.
+//
+// Only the announced contract is used. Internal helpers of the simple launcher
+// (plan building, record verification) are deliberately not touched: they were
+// still being renamed while this was written, and depending on them would make
+// the file break on refactors that do not change the seam.
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/rules"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+var errV228InjectedCrash = errors.New("v2.28 contract: injected launcher crash")
+
+// v228CrashFixture is one project/profile/session with two roles.
+type v228CrashFixture struct {
+	Project string
+	Profile string
+	Session string
+	Root    string
+	Roles   []string
+	PIDs    map[string]int
+}
+
+func v228NewCrashFixture(t *testing.T) v228CrashFixture {
+	t.Helper()
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "v228"
+		session = "ac2"
+	)
+	roles := []string{"cto", "dev"}
+	members := make([]team.Member, 0, len(roles))
+	for _, role := range roles {
+		members = append(members, team.Member{Role: role, Binary: "codex", Handle: role, Session: session})
+	}
+	v228SeedProfile(t, project, profile, session, members)
+	// start reads the team rules to compose the one startup instruction.
+	if err := os.MkdirAll(filepath.Dir(rules.Path(project)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rules.Path(project), []byte("# team rules\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return v228CrashFixture{
+		Project: project, Profile: profile, Session: session,
+		Root:  v228CanonicalRoot(project, profile, session),
+		Roles: roles,
+		PIDs:  map[string]int{"cto": 4601, "dev": 4602},
+	}
+}
+
+// v228CrashRun is one `start` invocation plus what the launcher did on the way.
+type v228CrashRun struct {
+	Err      error
+	Output   string
+	Launches int
+	Reached  []simpleStartCheckpoint
+}
+
+// v228RunCrashStart drives the real start command with an abort injected at
+// abortAt (empty = no abort). Everything external is stubbed: no tmux server, no
+// child processes, no real amq.
+//
+// The fake Launch stands in for the managed tmux backend, including its two
+// checkpoints (pane creation, child dispatch) in the backend's own order, and
+// writes the launch records a real backend produces via `agent up`.
+func v228RunCrashStart(t *testing.T, fixture v228CrashFixture, abortAt simpleStartCheckpoint) v228CrashRun {
+	t.Helper()
+	run := v228CrashRun{}
+	alive := map[int]bool{}
+	for _, role := range fixture.Roles {
+		if rec, err := launch.Read(filepath.Join(fixture.Root, "agents", role)); err == nil && rec.AgentPID > 0 {
+			// Records surviving an earlier aborted attempt describe live agents.
+			alive[rec.AgentPID] = true
+		}
+	}
+
+	fired := false
+	hook := func(checkpoint simpleStartCheckpoint) error {
+		run.Reached = append(run.Reached, checkpoint)
+		if abortAt != "" && checkpoint == abortAt && !fired {
+			fired = true
+			return errV228InjectedCrash
+		}
+		return nil
+	}
+
+	var out bytes.Buffer
+	deps := simpleStartDependencies{
+		AfterCheckpoint: hook,
+		LookPath: func(name string) (string, error) {
+			return filepath.Join("/usr/bin", name), nil
+		},
+		ResolveAMQEnv: func(string, string, string, string) (amqEnv, error) {
+			return amqEnv{Root: fixture.Root, BaseRoot: filepath.Dir(fixture.Root), AMQVersion: doctorMinAMQVersion}, nil
+		},
+		DuplicateProbe: duplicateLaunchProbe{
+			PIDAlive:     func(pid int) bool { return alive[pid] },
+			ProcessMatch: func(pid int, _ func(string) bool) bool { return alive[pid] },
+			ProcessTTY:   func(int) (string, bool) { return "", false },
+			Now:          func() time.Time { return v228Now },
+		},
+		RuntimeProbe: launchRuntimeProbe{
+			PIDAlive:     func(pid int) bool { return alive[pid] },
+			ProcessMatch: func(int, func(string) bool) bool { return true },
+			ProcessTTY:   func(int) (string, bool) { return "", false },
+		},
+		Launch: func(spawn team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+			run.Launches++
+			// callSimpleStartCheckpoint is how the real tmux backend reaches the
+			// hook, so the abort arrives wrapped exactly as production wraps it.
+			if err := callSimpleStartCheckpoint(hook, simpleStartCheckpointPaneCreation); err != nil {
+				// The backend preserves created panes/windows: no rollback here
+				// either, so a rerun rolls forward over them.
+				return teamLaunchResult{}, err
+			}
+			if err := callSimpleStartCheckpoint(hook, simpleStartCheckpointChildDispatch); err != nil {
+				return teamLaunchResult{}, err
+			}
+			result := teamLaunchResult{}
+			for i, member := range spawn.Members {
+				pid := fixture.PIDs[member.Role]
+				if pid == 0 {
+					pid = 4700 + i
+				}
+				tmuxInfo := &launch.TmuxInfo{
+					Session:  fixture.Session,
+					WindowID: fmt.Sprintf("@%d", 200+i),
+					PaneID:   fmt.Sprintf("%%%d", 100+i),
+					Target:   opts.Target,
+				}
+				agentDir := filepath.Join(fixture.Root, "agents", member.Handle)
+				if err := os.MkdirAll(agentDir, 0o755); err != nil {
+					return teamLaunchResult{}, err
+				}
+				// A real launch records pane ownership; start verifies the record
+				// owns the pane it was told about, so the fake must too.
+				if err := launch.Write(agentDir, launch.Record{
+					Schema: launch.SchemaVersion, Binary: member.Binary,
+					Role: member.Role, Handle: member.Handle, Session: fixture.Session,
+					TeamProfile: fixture.Profile, TeamHome: fixture.Project, CWD: fixture.Project,
+					Root: fixture.Root, BaseRoot: filepath.Dir(fixture.Root),
+					Trust: opts.Trust, ToolProfile: team.ToolProfileFull,
+					AgentPID: pid, StartedAt: v228Now,
+					Tmux: tmuxInfo, Terminal: launch.TerminalInfoFromTmux(tmuxInfo),
+				}); err != nil {
+					return teamLaunchResult{}, err
+				}
+				alive[pid] = true
+				result.Panes = append(result.Panes, teamLaunchResultPane{
+					Role:     member.Role,
+					PaneID:   tmuxInfo.PaneID,
+					WindowID: tmuxInfo.WindowID,
+				})
+			}
+			return result, nil
+		},
+		StartWatcher: func(team.Team, string, string, string) error { return nil },
+	}
+
+	run.Err = runStartWithDependencies([]string{
+		"--project", fixture.Project,
+		"--profile", fixture.Profile,
+		"--session", fixture.Session,
+		"--terminal", "tmux",
+		"--yes",
+	}, deps, strings.NewReader(""), &out)
+	run.Output = out.String()
+	return run
+}
+
+// v228AssertCrashConverges is the shared AC2 body: abort at one checkpoint, rerun
+// `start`, converge to all-live, delete nothing.
+func v228AssertCrashConverges(t *testing.T, checkpoint simpleStartCheckpoint) {
+	t.Helper()
+	fixture := v228NewCrashFixture(t)
+
+	crashed := v228RunCrashStart(t, fixture, checkpoint)
+	var checkpointErr *simpleStartCheckpointError
+	if !errors.As(crashed.Err, &checkpointErr) {
+		t.Fatalf("abort at %s returned %v (%T), want *simpleStartCheckpointError", checkpoint, crashed.Err, crashed.Err)
+	}
+	if checkpointErr.Checkpoint != checkpoint {
+		t.Fatalf("abort reported checkpoint %q, want %q", checkpointErr.Checkpoint, checkpoint)
+	}
+	if !errors.Is(crashed.Err, errV228InjectedCrash) {
+		t.Errorf("checkpoint error dropped the injected cause: %v", crashed.Err)
+	}
+
+	// What the partial launch left behind. Nothing here may be removed: the #644
+	// dead-end was recovery that required deleting state, which re-armed the
+	// failure it was recovering from.
+	partialRoot := v228InventoryPaths(t, fixture.Root)
+	partialSquad := v228InventoryPaths(t, filepath.Join(fixture.Project, team.DirName))
+	if len(partialRoot) == 0 {
+		t.Fatalf("abort at %s left no namespace state to roll forward over", checkpoint)
+	}
+
+	rerun := v228RunCrashStart(t, fixture, "")
+	if rerun.Err != nil {
+		t.Fatalf("rerun after abort at %s: %v\n%s", checkpoint, rerun.Err, rerun.Output)
+	}
+	if !strings.Contains(rerun.Output, "AM_ROOT: "+fixture.Root) {
+		t.Errorf("rerun did not report the canonical root:\n%s", rerun.Output)
+	}
+
+	for path := range partialRoot {
+		if !v228InventoryPaths(t, fixture.Root)[path] {
+			t.Errorf("rerun after abort at %s deleted %s from the namespace", checkpoint, path)
+		}
+	}
+	afterSquad := v228InventoryPaths(t, filepath.Join(fixture.Project, team.DirName))
+	for path := range partialSquad {
+		if !afterSquad[path] {
+			t.Errorf("rerun after abort at %s deleted %s from .amq-squad", checkpoint, path)
+		}
+	}
+
+	// Converged: every role has exactly one live record at the canonical root.
+	entries, err := launch.ScanEntries(fixture.Project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byRole := map[string]int{}
+	for _, entry := range entries {
+		if entry.Record.Root != fixture.Root {
+			t.Errorf("record for %s sits at %q, want the canonical root %q", entry.Record.Role, entry.Record.Root, fixture.Root)
+		}
+		byRole[entry.Record.Role]++
+	}
+	for _, role := range fixture.Roles {
+		if byRole[role] != 1 {
+			t.Errorf("%s has %d launch records after recovery, want 1", role, byRole[role])
+		}
+	}
+
+	// A third `start` has nothing left to do: that is "all live" stated by the
+	// launcher itself rather than inferred from the records it just wrote.
+	settled := v228RunCrashStart(t, fixture, "")
+	if settled.Err != nil {
+		t.Fatalf("settled rerun after abort at %s: %v\n%s", checkpoint, settled.Err, settled.Output)
+	}
+	if !strings.Contains(settled.Output, "already started") {
+		t.Errorf("third start did not report an already-live squad:\n%s", settled.Output)
+	}
+	if settled.Launches != 0 {
+		t.Errorf("third start spawned %d time(s), want 0 (live roles are kept)", settled.Launches)
+	}
+}
+
+func TestV228ContractAbortAfterNamespaceCreationConverges(t *testing.T) {
+	requireV228Contract(t)
+	v228AssertCrashConverges(t, simpleStartCheckpointNamespaceCreation)
+}
+
+func TestV228ContractAbortAfterPaneCreationConverges(t *testing.T) {
+	requireV228Contract(t)
+	v228AssertCrashConverges(t, simpleStartCheckpointPaneCreation)
+}
+
+func TestV228ContractAbortAfterChildDispatchConverges(t *testing.T) {
+	requireV228Contract(t)
+	v228AssertCrashConverges(t, simpleStartCheckpointChildDispatch)
+}
+
+func TestV228ContractAbortAfterLaunchRecordWriteConverges(t *testing.T) {
+	requireV228Contract(t)
+	v228AssertCrashConverges(t, simpleStartCheckpointLaunchRecordWrite)
+}
+
+// AC6: a role whose child dies on dispatch must produce a precise per-role
+// failure, and a rerun must converge. The launch-record write is what proves the
+// child came up, so a backend that dispatches without producing a record is the
+// immediate-death case.
+func TestV228ContractChildDeathIsPerRoleAndRerunConverges(t *testing.T) {
+	requireV228Contract(t)
+	fixture := v228NewCrashFixture(t)
+
+	crashed := v228RunCrashStart(t, fixture, simpleStartCheckpointChildDispatch)
+	if crashed.Err == nil {
+		t.Fatal("a child that never records a launch must fail the start")
+	}
+	if !strings.Contains(crashed.Err.Error(), string(simpleStartCheckpointChildDispatch)) {
+		t.Errorf("failure does not name the checkpoint it happened at: %v", crashed.Err)
+	}
+
+	rerun := v228RunCrashStart(t, fixture, "")
+	if rerun.Err != nil {
+		t.Fatalf("rerun after child death: %v\n%s", rerun.Err, rerun.Output)
+	}
+	for _, role := range fixture.Roles {
+		rec, err := launch.Read(filepath.Join(fixture.Root, "agents", role))
+		if err != nil {
+			t.Fatalf("no launch record for %s after recovery: %v", role, err)
+		}
+		if rec.AgentPID != fixture.PIDs[role] {
+			t.Errorf("%s recovered with pid %d, want %d", role, rec.AgentPID, fixture.PIDs[role])
+		}
+	}
+}
+
+// The seam must be inert in production: nothing shipped may abort a launch.
+func TestV228ContractProductionStartHasNoCheckpointHook(t *testing.T) {
+	requireV228Contract(t)
+	if defaultSimpleStartDependencies().AfterCheckpoint != nil {
+		t.Fatal("production start dependencies carry an AfterCheckpoint hook; it must be nil outside tests")
+	}
+}

--- a/internal/cli/v228_contract_deleted_vocabulary_test.go
+++ b/internal/cli/v228_contract_deleted_vocabulary_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// AC10: `grep -r "sha256\|drift\|generation token\|readiness" internal/cli` must
+// have no launch-path hits once the ceremony layer is deleted. This test pins the
+// deletion outcome so the machinery cannot come back in one file at a time.
+//
+// It is deliberately scoped to the launch path rather than the whole package:
+// other areas (release evidence, task message digests) legitimately compute
+// digests over EXTERNAL inputs, which the governing rule allows. The rule this
+// pins is the other one — no owned representation whose sole purpose is to
+// certify another owned representation.
+var v228DeletedVocabulary = regexp.MustCompile(`(?i)sha256|drift|generation token|readiness`)
+
+// v228LaunchPathSourcePrefixes selects the launch-path sources of internal/cli.
+var v228LaunchPathSourcePrefixes = []string{
+	"bootstrap",
+	"doctor",
+	"down",
+	"identity_drift",
+	"launch",
+	"preflight",
+	"prepared",
+	"run_start",
+	"status",
+	"team_launch",
+	"team_member_staged_launch",
+	"up",
+}
+
+func v228IsLaunchPathSource(name string) bool {
+	if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+		return false
+	}
+	for _, prefix := range v228LaunchPathSourcePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestV228ContractLaunchPathHasNoCeremonyVocabulary(t *testing.T) {
+	requireV228Contract(t)
+	// go test runs in the package directory, so this is internal/cli itself.
+	pkgDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(pkgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hits []string
+	scanned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !v228IsLaunchPathSource(entry.Name()) {
+			continue
+		}
+		scanned++
+		f, err := os.Open(filepath.Join(pkgDir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		line := 0
+		for scanner.Scan() {
+			line++
+			text := scanner.Text()
+			if match := v228DeletedVocabulary.FindString(text); match != "" {
+				hits = append(hits, entry.Name()+":"+strconv.Itoa(line)+": "+match+" | "+strings.TrimSpace(text))
+			}
+		}
+		scanErr := scanner.Err()
+		f.Close()
+		if scanErr != nil {
+			t.Fatal(scanErr)
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("no launch-path sources matched; the file-name prefixes need updating")
+	}
+	if len(hits) > 0 {
+		sort.Strings(hits)
+		t.Fatalf("%d launch-path hit(s) for the deleted ceremony vocabulary across %d file(s):\n%s",
+			len(hits), scanned, strings.Join(hits, "\n"))
+	}
+}

--- a/internal/cli/v228_contract_duplicate_live_test.go
+++ b/internal/cli/v228_contract_duplicate_live_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// AC4: two genuinely live matching launch records must produce an explicit
+// duplicate_live outcome. Neither is silently elected the winner — the whole
+// point of the v2.28 conflict semantics is that ambiguity is reported, not
+// resolved by scan order.
+//
+// v228StateDuplicateLive is a string literal on purpose: the state does not
+// exist on main, so this file must not depend on a constant that P2 adds.
+const v228StateDuplicateLive = "duplicate_live"
+
+func TestV228ContractTwoLiveMatchingRecordsReportDuplicateLive(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "v228"
+		session = "ac4"
+		handle  = "dev"
+		pidA    = 4401
+		pidB    = 4402
+	)
+	v228SeedProfile(t, project, profile, session, []team.Member{
+		{Role: handle, Binary: "codex", Handle: handle, Session: session},
+	})
+
+	canonicalRoot := v228CanonicalRoot(project, profile, session)
+	// A second root inside the same project base root, from the legacy
+	// session-only layout that ScanEntries still reads. Both records are live and
+	// match the same member identity.
+	legacyRoot := filepath.Join(project, ".agent-mail", session)
+	record := func(root string, pid int) launch.Record {
+		return launch.Record{
+			Binary: "codex", Role: handle, Handle: handle, Session: session,
+			TeamProfile: profile, TeamHome: project, CWD: project,
+			Root: root, BaseRoot: filepath.Dir(root),
+			AgentPID: pid, StartedAt: v228Now.Add(-time.Hour),
+		}
+	}
+	dirA := v228SeedLiveRecord(t, canonicalRoot, record(canonicalRoot, pidA))
+	dirB := v228SeedLiveRecord(t, legacyRoot, record(legacyRoot, pidB))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       project,
+		Profile:          profile,
+		RequestedSession: session,
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            v228Probe(pidA, pidB),
+	})
+	if err != nil {
+		t.Fatalf("executeStatus: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	if len(env.Data.Records) != 1 {
+		t.Fatalf("status records = %+v, want one row for the one configured member", env.Data.Records)
+	}
+	row := env.Data.Records[0]
+	if string(row.Status) != v228StateDuplicateLive && row.RecordState != v228StateDuplicateLive {
+		t.Fatalf("two live matching records reported status=%q record_state=%q, want %s in one of them (detail: %s)",
+			row.Status, row.RecordState, v228StateDuplicateLive, row.Detail)
+	}
+	if row.Status == statusStateLive {
+		t.Errorf("one of two live records was silently elected: status=%q root=%q pid=%d", row.Status, row.Root, row.Signals.AgentPID)
+	}
+	// The operator must be able to act, so the conflict names both records.
+	for _, want := range []string{launch.ExistingPath(dirA), launch.ExistingPath(dirB)} {
+		if !strings.Contains(row.Detail, want) {
+			t.Errorf("duplicate_live detail %q does not name %q", row.Detail, want)
+		}
+	}
+}
+
+func TestV228ContractOneLiveOneDeadRecordSelectsTheLiveOne(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "v228"
+		session = "ac4"
+		handle  = "dev"
+		livePID = 4403
+		deadPID = 4404
+	)
+	v228SeedProfile(t, project, profile, session, []team.Member{
+		{Role: handle, Binary: "codex", Handle: handle, Session: session},
+	})
+	canonicalRoot := v228CanonicalRoot(project, profile, session)
+	legacyRoot := filepath.Join(project, ".agent-mail", session)
+	record := func(root string, pid int) launch.Record {
+		return launch.Record{
+			Binary: "codex", Role: handle, Handle: handle, Session: session,
+			TeamProfile: profile, TeamHome: project, CWD: project,
+			Root: root, BaseRoot: filepath.Dir(root),
+			AgentPID: pid, StartedAt: v228Now.Add(-time.Hour),
+		}
+	}
+	v228SeedLiveRecord(t, canonicalRoot, record(canonicalRoot, livePID))
+	v228SeedLiveRecord(t, legacyRoot, record(legacyRoot, deadPID))
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       project,
+		Profile:          profile,
+		RequestedSession: session,
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            v228Probe(livePID),
+	})
+	if err != nil {
+		t.Fatalf("executeStatus: %v\n%s", err, out)
+	}
+	row := decodeJSONEnvelope[statusEnvelopeData](t, out).Data.Records[0]
+	// Exactly one live record is not a conflict: select it, at its canonical root.
+	if row.Status != statusStateLive {
+		t.Errorf("single live record status = %q (%s), want live", row.Status, row.Detail)
+	}
+	if row.Root != canonicalRoot || row.Signals.AgentPID != livePID {
+		t.Errorf("selected record = root %q pid %d, want %q / %d", row.Root, row.Signals.AgentPID, canonicalRoot, livePID)
+	}
+}

--- a/internal/cli/v228_contract_support_test.go
+++ b/internal/cli/v228_contract_support_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// v2.28 "Simple Mode" class-level contract tests (docs/v2.28-simple-mode-plan.md).
+//
+// These tests pin the v2.28 acceptance criteria for #643/#644/#645. They are
+// opt-in: without AMQ_SQUAD_V228_CONTRACT=1 every one of them skips, so main
+// stays green while the target behavior is still being built. Under the env var
+// they are expected to FAIL on main — that is what they are for.
+//
+// Every test here is hermetic: temp dirs only, injected probes, no real tmux
+// server and no reads of the developer's ~/.amq state.
+const v228ContractEnv = "AMQ_SQUAD_V228_CONTRACT"
+
+// requireV228Contract is the opt-in guard every v2.28 contract test starts with.
+func requireV228Contract(t *testing.T) {
+	t.Helper()
+	if os.Getenv(v228ContractEnv) != "1" {
+		t.Skip("v2.28 contract test; enable with AMQ_SQUAD_V228_CONTRACT=1")
+	}
+}
+
+// v228Probe is a deterministic liveness probe: the listed PIDs are alive and
+// binary-matched, everything else is dead. Birth time and TTY are left unset so
+// the shared classifier takes its record-only path.
+func v228Probe(alivePIDs ...int) duplicateLaunchProbe {
+	alive := map[int]bool{}
+	for _, pid := range alivePIDs {
+		alive[pid] = true
+	}
+	return duplicateLaunchProbe{
+		PIDAlive:     func(pid int) bool { return alive[pid] },
+		ProcessMatch: func(pid int, _ func(args string) bool) bool { return alive[pid] },
+		Now:          func() time.Time { return v228Now },
+	}
+}
+
+var v228Now = time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+// v228SeedProfile writes a named profile without going through seedTeam's cwd
+// switch, so a test can address the same project through two path spellings.
+func v228SeedProfile(t *testing.T, projectDir, profile, session string, members []team.Member) {
+	t.Helper()
+	if err := team.WriteProfile(projectDir, profile, team.Team{
+		Project:            projectDir,
+		Workstream:         session,
+		Members:            members,
+		SharedCwdException: "v2.28 contract fixture: not exercising #497 worktree isolation",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// v228SeedLiveRecord writes a launch record for handle under the exact root the
+// caller names, so a test controls which root is authoritative.
+func v228SeedLiveRecord(t *testing.T, root string, rec launch.Record) string {
+	t.Helper()
+	agentDir := filepath.Join(root, "agents", rec.Handle)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	return agentDir
+}
+
+// v228CanonicalRoot is the one canonical AMQ root for a project/profile/session
+// under v2.28: no custom roots, no multi-candidate election.
+func v228CanonicalRoot(project, profile, session string) string {
+	return squadnamespace.AMQRoot(canonicalFilesystemPath(project), profile, session)
+}
+
+// v228InventoryPaths lists every path under dir, used to assert that a rerun of
+// `start` after an aborted launch deletes nothing.
+func v228InventoryPaths(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+	err := filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		found[rel] = true
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("inventory %s: %v", dir, err)
+	}
+	return found
+}

--- a/internal/cli/v228_contract_worktree_remnant_test.go
+++ b/internal/cli/v228_contract_worktree_remnant_test.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// AC3 (#645 class): an isolated-worktree actor with a stale worktree-local
+// .agent-mail remnant AND a live canonical launch record must be reported as the
+// same live actor at the same canonical root by status, doctor, and down. A stale
+// remnant is informational; it is never grounds for "missing".
+//
+// The v2.27 defect is that each surface re-resolves the AMQ root from the
+// member's cwd (the worktree) instead of reading the launch record, so the
+// worktree remnant wins over the live canonical record.
+
+type v228RemnantFixture struct {
+	Project       string
+	Worktree      string
+	CanonicalRoot string
+	RemnantRoot   string
+	Profile       string
+	Session       string
+}
+
+func v228SeedWorktreeRemnantFixture(t *testing.T) (v228RemnantFixture, map[string]int) {
+	t.Helper()
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "v228"
+		session = "ac3"
+	)
+	worktree := filepath.Join(project, ".amq-squad", "worktrees", "dev")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v228SeedProfile(t, project, profile, session, []team.Member{
+		{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+		{Role: "dev", Binary: "codex", Handle: "dev", Session: session, CWD: worktree},
+	})
+
+	// The stale remnant from a prior failed launch: a worktree-local root that
+	// carries AMQ config but no live agent.
+	remnantRoot := filepath.Join(worktree, ".agent-mail", profile, session)
+	if err := os.MkdirAll(filepath.Join(remnantRoot, "meta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(remnantRoot, "meta", "config.json"), []byte(`{"agents":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	canonicalRoot := v228CanonicalRoot(project, profile, session)
+	pids := map[string]int{"cto": 4301, "dev": 4302}
+	for _, member := range []struct {
+		handle string
+		cwd    string
+	}{{"cto", project}, {"dev", worktree}} {
+		v228SeedLiveRecord(t, canonicalRoot, launch.Record{
+			Binary: "codex", Role: member.handle, Handle: member.handle, Session: session,
+			TeamProfile: profile, TeamHome: project, CWD: member.cwd,
+			Root: canonicalRoot, BaseRoot: filepath.Dir(canonicalRoot),
+			AgentPID: pids[member.handle], StartedAt: v228Now.Add(-time.Hour),
+		})
+	}
+	return v228RemnantFixture{
+		Project: project, Worktree: worktree, CanonicalRoot: canonicalRoot,
+		RemnantRoot: remnantRoot, Profile: profile, Session: session,
+	}, pids
+}
+
+func TestV228ContractWorktreeRemnantStatusReportsLiveCanonicalActor(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+	fixture, pids := v228SeedWorktreeRemnantFixture(t)
+
+	out, err := runStatusExec(t, statusExecution{
+		ProjectDir:       fixture.Project,
+		Profile:          fixture.Profile,
+		RequestedSession: fixture.Session,
+		ExplicitSession:  true,
+		JSON:             true,
+		Probe:            v228Probe(pids["cto"], pids["dev"]),
+	})
+	if err != nil {
+		t.Fatalf("executeStatus: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[statusEnvelopeData](t, out)
+	if len(env.Data.Records) != 2 {
+		t.Fatalf("status records = %+v, want two rows", env.Data.Records)
+	}
+	for _, row := range env.Data.Records {
+		if row.Status != statusStateLive {
+			t.Errorf("%s status = %q (%s), want live", row.Role, row.Status, row.Detail)
+		}
+		if row.Root != fixture.CanonicalRoot {
+			t.Errorf("%s root = %q, want the canonical root %q", row.Role, row.Root, fixture.CanonicalRoot)
+		}
+		if strings.HasPrefix(row.Root, fixture.Worktree) {
+			t.Errorf("%s resolved the worktree-local remnant root %q", row.Role, row.Root)
+		}
+		if row.Signals.AgentPID != pids[row.Role] {
+			t.Errorf("%s probed pid = %d, want the recorded pid %d", row.Role, row.Signals.AgentPID, pids[row.Role])
+		}
+	}
+	// The remnant must survive untouched: it is an observation, not a target.
+	if _, err := os.Stat(filepath.Join(fixture.RemnantRoot, "meta", "config.json")); err != nil {
+		t.Errorf("status mutated the informational worktree remnant: %v", err)
+	}
+}
+
+func TestV228ContractWorktreeRemnantDoctorAgreesWithStatus(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+	fixture, pids := v228SeedWorktreeRemnantFixture(t)
+
+	d := newDoctorExec(t, fixture.Project)
+	d.Profile = fixture.Profile
+	d.WorkstreamHint = fixture.Session
+	d.Probe = v228Probe(pids["cto"], pids["dev"])
+	// newDoctorExec injects a canned wake builder; the whole point here is the
+	// real record-first member classification, so drop the override.
+	d.WakeOverride = nil
+
+	checks, workstream := doctorCheckWake(d)
+	if workstream != fixture.Session {
+		t.Fatalf("doctor workstream = %q, want %q", workstream, fixture.Session)
+	}
+	for _, role := range []string{"cto", "dev"} {
+		check := findCheck(checks, "wake "+role)
+		if check == nil {
+			t.Fatalf("doctor emitted no check for %s: %+v", role, checks)
+		}
+		if check.Status != doctorOK {
+			t.Errorf("doctor %s = %q (%s), want ok for a live recorded actor", role, check.Status, check.Detail)
+		}
+		// doctorCheckFromStatus maps BOTH live and missing to ok, so status alone
+		// cannot tell "found it alive" from "decided it was never there". The
+		// detail is the discriminator: it must carry the probed pid evidence.
+		if !strings.Contains(check.Detail, fmt.Sprintf("pid %d", pids[role])) {
+			t.Errorf("doctor %s detail %q does not report the live recorded pid %d", role, check.Detail, pids[role])
+		}
+		if strings.Contains(check.Detail, fixture.Worktree) {
+			t.Errorf("doctor %s detail names the worktree-local remnant: %s", role, check.Detail)
+		}
+	}
+}
+
+func TestV228ContractWorktreeRemnantDownTargetsCanonicalRoot(t *testing.T) {
+	requireV228Contract(t)
+	setupFakeAMQSessionRoots(t)
+	swapStatusPaneLister(t, nil, nil)
+	fixture, pids := v228SeedWorktreeRemnantFixture(t)
+
+	// `down --dry-run` does not exist yet (v2.28 adds it). The selection pipeline
+	// under test is the same one the dry run reports from, so this drives it with
+	// an inert terminator: nothing is signaled, and the reported target/root is
+	// exactly what a dry run must print.
+	terminator := &recordingTerminator{}
+	out, err := runDownExec(t, downExecution{
+		Verb:             "stop",
+		ProjectDir:       fixture.Project,
+		Profile:          fixture.Profile,
+		RequestedSession: fixture.Session,
+		ExplicitProject:  true,
+		ExplicitProfile:  true,
+		ExplicitSession:  true,
+		Role:             "dev",
+		Terminator:       terminator,
+		Probe:            v228Probe(pids["cto"], pids["dev"]),
+		JSON:             true,
+	})
+	if err != nil {
+		t.Fatalf("executeDown: %v\n%s", err, out)
+	}
+	env := decodeJSONEnvelope[downEnvelopeData](t, out)
+	if env.Data.Root != fixture.CanonicalRoot {
+		t.Errorf("down root = %q, want the canonical root %q", env.Data.Root, fixture.CanonicalRoot)
+	}
+	if len(env.Data.Reports) != 1 || env.Data.Reports[0].Role != "dev" {
+		t.Fatalf("down reports = %+v, want exactly the dev actor", env.Data.Reports)
+	}
+	if got := terminator.calls; len(got) != 1 || got[0] != pids["dev"] {
+		t.Errorf("down signaled %v, want the recorded canonical pid %d", got, pids["dev"])
+	}
+}


### PR DESCRIPTION
## Step 1 of the v2.28 "Simple Mode" sequencing (#646)

15 class-level contract tests pinning the Simple Mode acceptance criteria before the implementation lands (plan: `docs/v2.28-simple-mode-plan.md`):

- **AC1** (#643 class): canonical-path launch — miscased/symlinked project spellings must render one canonical bootstrap and report canonical status coordinates.
- **AC2/AC6** (#644 class): crash-injection roll-forward at all four launcher checkpoints + per-role child-death convergence (gated behind the `v228seam` build tag until the step-2 launcher merges).
- **AC3** (#645 class): record-first status/doctor/down for isolated-worktree actors with stale remnants.
- **AC4**: explicit `duplicate_live` conflict semantics, no silent election (+ companion proving no over-trigger).
- **AC5**: two concurrent starts → one squad.
- **AC10**: launch-path ceremony-vocabulary deletion pin (161-hit baseline; goes green at step 5).

All tests skip by default (`AMQ_SQUAD_V228_CONTRACT=1` enables) so main stays green until each phase lands. Verified: 7 tests fail on main for exactly the predicted defect (failure text quotes the real mechanism, e.g. `status.go:1715` root re-derivation for #645); 2 regression pins pass; crash tests validated against the step-2 branch (14/15 matrix, stable across three review SHAs).

Merge order: this PR first; step 2 (simple launcher, `wt/v2-28-0-senior`) depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)