### PR TITLE
Release v2.28.1 — AMQ 0.52.2 supported floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.51.1, latest]
+        amq-version: [v0.52.2, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.51.1, latest]
+        amq-version: [v0.52.2, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,6 +43,29 @@ ordinary AMQ messages, not a second delivery or reconciliation state machine.
 Existing v2.27 launch records remain compatibility input; old prepared and
 receipt directories are ignored and are not auto-deleted.
 
+## What's new in 2.28.1: AMQ 0.52.2 floor
+
+**Action required.** Upgrade AMQ to 0.52.2 or newer before upgrading
+amq-squad. Every 0.49.x, 0.50.x, and 0.51.x release is now below the supported
+floor and is rejected fail-closed. Run `amq upgrade`, then stop and
+resume/relaunch agents so their parent shells receive the complete current AMQ
+identity tuple. Confirm the result with `amq-squad doctor`.
+
+Upstream AMQ introduced a wake-doorbell retry ladder in v0.49.11 that re-rings
+the doorbell on a backoff while an inbox stays undrained; busy Ink-based CLIs
+(Claude Code, Codex) queue every injected repetition and flush them as
+duplicate "AMQ doorbell" bursts when the turn ends
+([avivsinai/agent-message-queue#426](https://github.com/avivsinai/agent-message-queue/issues/426)).
+AMQ v0.52.2 bounds this to at most 4 reminders per unchanged inbox cohort
+before parking, with a lifetime cap of 8 per continuously-undrained cohort
+(upstream PR #428). Both real-AMQ matrices now run pinned `v0.52.2` and
+`latest` only.
+
+Upstream #424 (`--retry-until injected` presentation acknowledgement) and #422
+(macOS EINTR kqueue watcher fix) remain open and are not adopted in this
+release; amq-squad picks them up in v2.29.0 when AMQ 0.53.0 ships
+(tracked on #654).
+
 ## What's new in 2.26.0: AMQ 0.51.1 floor
 
 **Action required.** Upgrade AMQ to 0.51.1 or newer before upgrading

--- a/README.html
+++ b/README.html
@@ -272,6 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
+<li><a href="#whats-new-in-v2281" id="toc-whats-new-in-v2281">What's new
+in v2.28.1</a></li>
 <li><a href="#whats-new-in-v2280" id="toc-whats-new-in-v2280">What's new
 in v2.28.0</a></li>
 <li><a href="#whats-new-in-v2270" id="toc-whats-new-in-v2270">What's new
@@ -332,6 +334,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
+<li><a href="#whats-new-in-v2281">What's new in v2.28.1</a></li>
 <li><a href="#whats-new-in-v2280">What's new in v2.28.0</a></li>
 <li><a href="#whats-new-in-v2270">What's new in v2.27.0</a></li>
 <li><a href="#install">Install</a></li>
@@ -351,6 +354,36 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
+<h2 id="whats-new-in-v2281">What's new in v2.28.1</h2>
+<p>v2.28.1 is a patch release that raises the supported AMQ floor from
+0.51.1 to 0.52.2 (#656; context in #654). <code>amq-squad doctor</code>
+flags an older AMQ, and <code>agent up</code> refuses to launch against
+one, naming <code>amq upgrade</code> as the remedy.</p>
+<ul>
+<li><strong>Why the floor moved.</strong> Upstream AMQ introduced a
+wake-doorbell retry ladder in v0.49.11 ("fix(wake): preserve retry
+delivery guarantees") that re-rings the doorbell on a backoff while an
+inbox stays undrained. Busy Ink-based CLIs (Claude Code, Codex) queue
+every injected repetition and flush them as duplicate "AMQ doorbell"
+bursts when the turn ends (<a
+href="https://github.com/avivsinai/agent-message-queue/issues/426">avivsinai/agent-message-queue#426</a>).</li>
+<li><strong>The fix.</strong> Upstream PR #428 ("bound doorbell
+reminders per undrained cohort"), released in AMQ v0.52.2, bounds
+delivery to at most 4 reminders per unchanged inbox cohort before the
+doorbell parks; each new arrival grants one bounded top-up, with a
+lifetime cap of 8 per continuously-undrained cohort. Parked state is
+visible in <code>amq doctor --ops</code>.</li>
+<li><strong>CI matrices.</strong> Both real-AMQ matrices move from
+pinned v0.51.1 to pinned v0.52.2 (plus <code>latest</code>).</li>
+<li><strong>Not in this release.</strong> Upstream #424
+(<code>--retry-until injected</code> presentation acknowledgement, #423)
+and #422 (macOS EINTR kqueue watcher fix, #421) remain open upstream;
+amq-squad adopts them in v2.29.0 when AMQ 0.53.0 ships. #654 stays open
+in the v2.29.0 milestone for that follow-up.</li>
+</ul>
+<p>Migration: see <a href="MIGRATION.md">MIGRATION.md</a> for the
+required AMQ upgrade action. Full detail in <a
+href="docs/v2.28.1-release-notes.md">the v2.28.1 release notes</a>.</p>
 <h2 id="whats-new-in-v2280">What's new in v2.28.0</h2>
 <p>v2.28.0 "Simple Mode" removes the ceremony layer (#646). The launch
 failures investigated across recent releases traced to the verification
@@ -596,7 +629,7 @@ summary, and residual risks.</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.1</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -1365,7 +1398,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.51.1 on <code>PATH</code></li>
+<li><code>amq</code> 0.52.2 on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>
@@ -1375,11 +1408,11 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>AMQ 0.51.x is the supported series, with 0.51.1 as the minimum
-supported release. Both real-AMQ matrices validate pinned v0.51.1 and
+<p>AMQ 0.52.x is the supported series, with 0.52.2 as the minimum
+supported release. Both real-AMQ matrices validate pinned v0.52.2 and
 <code>latest</code>; <code>latest</code> remains a forward-compatibility
-canary and is not a support claim. Every 0.49.x, 0.50.x, and 0.51.0
-release is unsupported, and releases older than 0.51.1 are rejected
+canary and is not a support claim. Every 0.49.x, 0.50.x, and 0.51.x
+release is unsupported, and releases older than 0.52.2 are rejected
 fail-closed. Because the version assertion is skipped for
 <code>latest</code>, the pinned lane is the one that records what was
 proved.</p>
@@ -1395,12 +1428,12 @@ proved.</p>
 <tr>
 <td>Queue, routing, receipts, doctor, lifecycle</td>
 <td>Ubuntu</td>
-<td><code>v0.51.1</code>, <code>latest</code></td>
+<td><code>v0.52.2</code>, <code>latest</code></td>
 </tr>
 <tr>
 <td>Native real-PTY wake and teardown</td>
 <td>macOS</td>
-<td><code>v0.51.1</code>, <code>latest</code></td>
+<td><code>v0.52.2</code>, <code>latest</code></td>
 </tr>
 </tbody>
 </table>
@@ -1447,7 +1480,7 @@ authorization authority for amq-squad evidence/receipt flows. See the <a
 href="docs/amq-0.51.x-assessment.md">AMQ 0.51.x support
 assessment</a>.</p>
 <p>AMQ 0.42.1 historically introduced the complete injected identity
-contract; 0.51.1 is the supported floor for the 0.51.x series. After
+contract; 0.52.2 is the supported floor for the 0.52.x series. After
 upgrading AMQ, stop and resume/relaunch agents so their parent shells
 refresh the complete identity tuple; a child command cannot repair stale
 parent environment variables. Default-profile sessions use

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
+- [What's new in v2.28.1](#whats-new-in-v2281)
 - [What's new in v2.28.0](#whats-new-in-v2280)
 - [What's new in v2.27.0](#whats-new-in-v2270)
 - [Install](#install)
@@ -38,6 +39,33 @@ The 30-second mental model:
 - [Cross-project teams](#cross-project-teams)
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
+
+## What's new in v2.28.1
+
+v2.28.1 is a patch release that raises the supported AMQ floor from 0.51.1 to
+0.52.2 (#656; context in #654). `amq-squad doctor` flags an older AMQ, and
+`agent up` refuses to launch against one, naming `amq upgrade` as the remedy.
+
+- **Why the floor moved.** Upstream AMQ introduced a wake-doorbell retry ladder
+  in v0.49.11 ("fix(wake): preserve retry delivery guarantees") that re-rings
+  the doorbell on a backoff while an inbox stays undrained. Busy Ink-based CLIs
+  (Claude Code, Codex) queue every injected repetition and flush them as
+  duplicate "AMQ doorbell" bursts when the turn ends
+  ([avivsinai/agent-message-queue#426](https://github.com/avivsinai/agent-message-queue/issues/426)).
+- **The fix.** Upstream PR #428 ("bound doorbell reminders per undrained
+  cohort"), released in AMQ v0.52.2, bounds delivery to at most 4 reminders per
+  unchanged inbox cohort before the doorbell parks; each new arrival grants one
+  bounded top-up, with a lifetime cap of 8 per continuously-undrained cohort.
+  Parked state is visible in `amq doctor --ops`.
+- **CI matrices.** Both real-AMQ matrices move from pinned v0.51.1 to pinned
+  v0.52.2 (plus `latest`).
+- **Not in this release.** Upstream #424 (`--retry-until injected` presentation
+  acknowledgement, #423) and #422 (macOS EINTR kqueue watcher fix, #421) remain
+  open upstream; amq-squad adopts them in v2.29.0 when AMQ 0.53.0 ships. #654
+  stays open in the v2.29.0 milestone for that follow-up.
+
+Migration: see [MIGRATION.md](MIGRATION.md) for the required AMQ upgrade
+action. Full detail in [the v2.28.1 release notes](docs/v2.28.1-release-notes.md).
 
 ## What's new in v2.28.0
 
@@ -269,7 +297,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.1
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -846,7 +874,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.51.1 on `PATH`
+- `amq` 0.52.2 on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend
@@ -856,17 +884,17 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-AMQ 0.51.x is the supported series, with 0.51.1 as the minimum supported
-release. Both real-AMQ matrices validate pinned v0.51.1 and `latest`; `latest`
+AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported
+release. Both real-AMQ matrices validate pinned v0.52.2 and `latest`; `latest`
 remains a forward-compatibility canary and is not a support claim. Every 0.49.x,
-0.50.x, and 0.51.0 release is unsupported, and releases older than 0.51.1 are
+0.50.x, and 0.51.x release is unsupported, and releases older than 0.52.2 are
 rejected fail-closed. Because the version assertion is skipped for `latest`,
 the pinned lane is the one that records what was proved.
 
 | Real-AMQ lane | Runner | Versions |
 | --- | --- | --- |
-| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.51.1`, `latest` |
-| Native real-PTY wake and teardown | macOS | `v0.51.1`, `latest` |
+| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.52.2`, `latest` |
+| Native real-PTY wake and teardown | macOS | `v0.52.2`, `latest` |
 
 AMQ 0.47.1 introduced the supervised `coop exec` wake contract used by every
 supported release: instead of injecting message headers or subjects, managed
@@ -910,7 +938,7 @@ for amq-squad evidence/receipt flows. See the
 [AMQ 0.51.x support assessment](docs/amq-0.51.x-assessment.md).
 
 AMQ 0.42.1 historically introduced the complete injected identity contract;
-0.51.1 is the supported floor for the 0.51.x series. After upgrading AMQ, stop and
+0.52.2 is the supported floor for the 0.52.x series. After upgrading AMQ, stop and
 resume/relaunch agents so their parent shells refresh the complete identity
 tuple; a child command cannot repair stale parent environment variables.
 Default-profile sessions use

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -9,9 +9,9 @@ The authoritative live-lead skill route is `amq-squad:orchestrator`.
 
 ## Preconditions
 
-- `amq-squad` and AMQ 0.51.1 or newer are on `PATH`. AMQ 0.51.x is the
-  supported series, with 0.51.1 as the minimum supported release. Both real-AMQ
-  matrices validate pinned v0.51.1 and latest; latest remains a
+- `amq-squad` and AMQ 0.52.2 or newer are on `PATH`. AMQ 0.52.x is the
+  supported series, with 0.52.2 as the minimum supported release. Both real-AMQ
+  matrices validate pinned v0.52.2 and latest; latest remains a
   forward-compatibility canary and is not a support claim.
 - Each project has a configured team or named profile.
 - Visible launches run inside managed tmux.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -706,12 +706,12 @@ version skew.</p>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. AMQ 0.51.x is the supported
-series, with 0.51.1 as the minimum supported release. Both real-AMQ
-matrices validate pinned v0.51.1 and <code>latest</code>;
+<code>--settings</code> file is missing. AMQ 0.52.x is the supported
+series, with 0.52.2 as the minimum supported release. Both real-AMQ
+matrices validate pinned v0.52.2 and <code>latest</code>;
 <code>latest</code> remains a forward-compatibility canary and is not a
-support claim. Releases older than 0.51.1 are rejected fail-closed;
-upgrade to v0.51.1 or newer and stop/resume agents so their parent
+support claim. Releases older than 0.52.2 are rejected fail-closed;
+upgrade to v0.52.2 or newer and stop/resume agents so their parent
 shells refresh the complete identity tuple. A child command cannot
 repair stale injected environment. Default profiles use
 <code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -255,10 +255,10 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ 0.51.x is the supported series, with 0.51.1 as the minimum
-supported release. Both real-AMQ matrices validate pinned v0.51.1 and `latest`;
+missing. AMQ 0.52.x is the supported series, with 0.52.2 as the minimum
+supported release. Both real-AMQ matrices validate pinned v0.52.2 and `latest`;
 `latest` remains a forward-compatibility canary and is not a support claim.
-Releases older than 0.51.1 are rejected fail-closed; upgrade to v0.51.1 or
+Releases older than 0.52.2 are rejected fail-closed; upgrade to v0.52.2 or
 newer and stop/resume agents so their parent shells refresh the complete
 identity tuple. A child command cannot repair stale injected environment.
 Default profiles use `AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty

--- a/docs/v2.28.1-release-notes.md
+++ b/docs/v2.28.1-release-notes.md
@@ -1,0 +1,62 @@
+# amq-squad v2.28.1
+
+## Summary
+
+v2.28.1 is a patch release with a single change: the supported AMQ floor rises
+from 0.51.1 to 0.52.2 (#656; context in #654). `amq-squad doctor` flags an older AMQ, and
+`agent up` refuses to launch against one, naming `amq upgrade` as the remedy.
+Both real-AMQ CI matrices move from pinned v0.51.1 to pinned v0.52.2.
+
+## The floor change (#656)
+
+- **Minimum supported release:** AMQ 0.52.2. Every 0.49.x, 0.50.x, and 0.51.x
+  release is now below the floor and is rejected fail-closed.
+- **CI matrices:** both real-AMQ lanes (queue/routing/receipts/doctor/lifecycle
+  on Ubuntu, native real-PTY wake and teardown on macOS) run pinned `v0.52.2`
+  and `latest`.
+- **Diagnostics:** `amq-squad doctor` reports the resolved AMQ version and
+  flags a below-floor install; `agent up` refuses to launch against one,
+  naming `amq upgrade` as the remedy rather than describing a bare refusal.
+
+## Upstream root cause
+
+Upstream AMQ introduced a wake-doorbell retry ladder in **v0.49.11**
+("fix(wake): preserve retry delivery guarantees", 2026-07-30) that re-rings the
+doorbell on a backoff while an inbox stays undrained. Busy Ink-based CLIs
+(Claude Code, Codex) queue every injected repetition and flush them as
+duplicate "AMQ doorbell" bursts when the turn ends — upstream tracked this as
+[avivsinai/agent-message-queue#426](https://github.com/avivsinai/agent-message-queue/issues/426).
+
+The fix landed as upstream **PR #428** ("bound doorbell reminders per
+undrained cohort"), released in **AMQ v0.52.2** (2026-08-05):
+
+- At most 4 reminders are delivered per unchanged inbox cohort, then the
+  doorbell parks.
+- Each new arrival to a parked cohort grants one bounded top-up.
+- A lifetime cap of 8 reminders applies per continuously-undrained cohort.
+- Parked state is visible in `amq doctor --ops`.
+
+## What is deliberately NOT in this release
+
+Two related upstream items remain open and are **not** adopted here:
+
+- **#424** — `--retry-until injected` presentation acknowledgement (upstream
+  #423).
+- **#422** — macOS EINTR kqueue watcher fix (upstream #421).
+
+amq-squad adopts both when AMQ 0.53.0 ships, targeted for **v2.29.0**. #654
+stays open in the v2.29.0 milestone to track that follow-up adoption.
+
+## Migration action
+
+Upgrade AMQ to 0.52.2 or newer before upgrading amq-squad. Every 0.49.x,
+0.50.x, and 0.51.x release is now below the supported floor and is rejected
+fail-closed. Run `amq upgrade`, then stop and resume/relaunch agents so their
+parent shells receive the complete current AMQ identity tuple. Confirm the
+result with `amq-squad doctor`. See [MIGRATION.md](../MIGRATION.md#whats-new-in-2281-amq-0522-floor)
+for the complete note.
+
+## Validation
+
+- PR #TBD
+- `make ci` green

--- a/docs/v2.28.1-release-notes.md
+++ b/docs/v2.28.1-release-notes.md
@@ -58,5 +58,8 @@ for the complete note.
 
 ## Validation
 
-- PR #TBD
-- `make ci` green
+- PR #657, closing #656.
+- Local `make ci` green against the release tree (one pre-existing local-only
+  test failure from an untracked evidence file, absent on clean checkouts;
+  verified unrelated to this change). GitHub CI on the PR is the merge gate,
+  including both real-AMQ matrices at pinned v0.52.2 and latest.

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -95,7 +95,7 @@ if [ "$1" = "env" ]; then
     echo "unexpected cwd: $actual" >&2
     exit 17
   fi
-  printf '{"root":"%s","amq_version":"0.51.1"}\n' "$AMQ_FAKE_ROOT"
+  printf '{"root":"%s","amq_version":"0.52.2"}\n' "$AMQ_FAKE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2
@@ -261,7 +261,7 @@ if [ "$1" = "env" ]; then
     echo "session should not be passed to amq env when named-profile root is explicit: $saw_session" >&2
     exit 18
   fi
-  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.51.1"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
+  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.52.2"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -26,7 +26,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.51.1"
+const doctorMinAMQVersion = "0.52.2"
 
 type doctorStatus string
 
@@ -92,7 +92,7 @@ type doctorExecution struct {
 	Getenv func(name string) string
 	// LookupEnv preserves the distinction between an absent value and an
 	// explicitly empty AM_SESSION. AMQ 0.42.1 introduced that distinction as
-	// part of the injected identity contract; 0.51.1 is the supported floor.
+	// part of the injected identity contract; 0.52.2 is the supported floor.
 	LookupEnv func(name string) (string, bool)
 	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
 	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
@@ -1207,7 +1207,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy exact-root/sessionless pin (AM_ROOT=AM_BASE_ROOT; AM_SESSION omitted; AM_ME set)"}
 		}
 		if sessionOK && session == "" {
-			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.51.1; a child command cannot repair its parent shell"}
+			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.52.2; a child command cannot repair its parent shell"}
 		}
 		if session != "" && sameResolvedDir(root, filepath.Join(base, session)) {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy sessionful pin (AM_ROOT=AM_BASE_ROOT/AM_SESSION; AM_ME set)"}
@@ -1224,7 +1224,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 	return doctorCheck{
 		Name:   "amq identity pin",
 		Status: doctorWarn,
-		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.51.1; a child command cannot repair its parent shell",
+		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.52.2; a child command cannot repair its parent shell",
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -575,13 +575,13 @@ if [ -n "$AM_ROOT_ID$AM_BASE_ROOT_ID" ]; then
   echo "inherited AMQ root identity metadata leaked" >&2
   exit 92
 fi
-printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.51.1"}'
+printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.52.2"}'
 `)
 
 	d := defaultDoctorExecution(t.TempDir())
 	check := doctorCheckAMQVersion(d)
-	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.51.1") {
-		t.Fatalf("doctor amq version check = %+v, want ok 0.51.1", check)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.52.2") {
+		t.Fatalf("doctor amq version check = %+v, want ok 0.52.2", check)
 	}
 	if got := os.Getenv("AMQ_NO_UPDATE_CHECK"); got != "0" {
 		t.Fatalf("parent AMQ_NO_UPDATE_CHECK = %q, want unchanged 0", got)
@@ -637,9 +637,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts0511AndNewerCanary(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0522AndNewerCanary(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.51.1", "v0.52.0-rc1", "0.52.0", "1.0.0+build51"} {
+	for _, v := range []string{"0.52.2", "v0.53.0-rc1", "0.53.0", "1.0.0+build51"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -659,9 +659,10 @@ func TestExecuteDoctorAMQVersionAccepts0511AndNewerCanary(t *testing.T) {
 
 // The v2.26.0 floor raise to 0.51.1 makes every 0.49.x and 0.50.x release
 // unsupported, including the previous floor and the immediately preceding
-// 0.51.0 release.
-func TestExecuteDoctorAMQVersionRejectsOlderThan0511(t *testing.T) {
-	for _, version := range []string{"0.42.1", "0.49.9", "0.50.0", "0.50.1", "0.51.0", "0.51.1-rc1"} {
+// 0.51.0 release. The v2.28.1 floor raise to 0.52.2 additionally makes the
+// entire 0.51.x and 0.52.0/0.52.1 line unsupported.
+func TestExecuteDoctorAMQVersionRejectsOlderThan0522(t *testing.T) {
+	for _, version := range []string{"0.42.1", "0.49.9", "0.50.0", "0.50.1", "0.51.0", "0.51.1", "0.52.0", "0.52.1", "0.52.2-rc1"} {
 		t.Run(version, func(t *testing.T) {
 			dir := t.TempDir()
 			d := newDoctorExec(t, dir)
@@ -671,10 +672,10 @@ func TestExecuteDoctorAMQVersionRejectsOlderThan0511(t *testing.T) {
 			var buf bytes.Buffer
 			d.Out = &buf
 			if err := executeDoctor(d); err == nil {
-				t.Fatalf("doctor should fail when amq %s is below the 0.51.1 floor", version)
+				t.Fatalf("doctor should fail when amq %s is below the 0.52.2 floor", version)
 			}
 			amqLine := firstLineWith(buf.String(), "amq version")
-			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.51.1") {
+			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.52.2") {
 				t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 			}
 			if !strings.Contains(amqLine, "amq upgrade") {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -998,38 +998,91 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 		}
 	}
 
-	presencePath := filepath.Join(agentDir, "presence.json")
-	if data, err := os.ReadFile(presencePath); err == nil {
-		var pres presenceFile
-		if jsonErr := json.Unmarshal(data, &pres); jsonErr == nil {
-			if pres.Handle != "" && pres.Handle != handle {
-				// Foreign handle wrote this file; leave it alone.
-				return result
-			}
-			// Only flip ACTIVE+FRESH presence: a stale "active" file is not
-			// blocking anyone (preflight ignores anything past the freshness
-			// window), so touching it is pure noise. A fresh active file with
-			// a dead agent/wake is the zombie-heartbeat case #38 / #44 — that
-			// is what needs flipping so the next `up` is not blocked.
-			if strings.EqualFold(pres.Status, "active") && !pres.LastSeen.IsZero() && probe.Now().Sub(pres.LastSeen) <= presenceFreshness {
-				pres.Status = "offline"
-				pres.LastSeen = probe.Now().UTC()
-				if pres.Schema == 0 {
-					pres.Schema = 1
-				}
-				if pres.Handle == "" {
-					pres.Handle = handle
-				}
-				if newData, marshErr := json.Marshal(pres); marshErr == nil {
-					if writeErr := os.WriteFile(presencePath, newData, 0o600); writeErr == nil {
-						result.PresenceFlip = true
-					}
-				}
-			}
+	presenceWasActive := presenceStatusActive(agentDir, handle)
+	if flipFreshActivePresenceOffline(agentDir, handle, probe) {
+		result.PresenceFlip = true
+	}
+
+	// amq >=0.52.2's wake sidecar persists doorbell status into presence.json
+	// during its own teardown via a locked read-modify-write that preserves
+	// whatever Status it read and always refreshes LastSeen to now. If that
+	// read happened before our flip above, its write lands after and
+	// restores a stale "active" over our "offline" (lost update),
+	// recreating the zombie-heartbeat class (#38/#44). Re-assert offline
+	// once the wake PID is confirmed dead, so its teardown write (if any)
+	// has already landed before we check again.
+	wakePID := rec.WakePID
+	if wakePID <= 0 {
+		wakePID = result.WakeKilled
+	}
+	if wakePID > 0 && (result.PresenceFlip || presenceWasActive) && wakeConfirmedDeadWithinDeadline(wakePID, probe) {
+		if flipFreshActivePresenceOffline(agentDir, handle, probe) {
+			result.PresenceFlip = true
 		}
 	}
 
 	return result
+}
+
+// presenceStatusActive reports whether presence.json currently reads Status
+// "active" for this handle, independent of freshness. Used to decide
+// whether the post-teardown re-assert above is worth waiting for even when
+// the initial flip did not fire because the file was not yet within the
+// freshness window at the time we first read it.
+func presenceStatusActive(agentDir, handle string) bool {
+	data, err := os.ReadFile(filepath.Join(agentDir, "presence.json"))
+	if err != nil {
+		return false
+	}
+	var pres presenceFile
+	if json.Unmarshal(data, &pres) != nil {
+		return false
+	}
+	if pres.Handle != "" && pres.Handle != handle {
+		return false
+	}
+	return strings.EqualFold(pres.Status, "active")
+}
+
+// flipFreshActivePresenceOffline flips presence.json from active to offline
+// for this handle when it is still within the freshness window, so a fresh
+// active file left behind by a dead agent/wake (the zombie-heartbeat case
+// #38/#44) does not block the next `up`. Reports whether it wrote a flip.
+func flipFreshActivePresenceOffline(agentDir, handle string, probe duplicateLaunchProbe) bool {
+	presencePath := filepath.Join(agentDir, "presence.json")
+	data, err := os.ReadFile(presencePath)
+	if err != nil {
+		return false
+	}
+	var pres presenceFile
+	if json.Unmarshal(data, &pres) != nil {
+		return false
+	}
+	if pres.Handle != "" && pres.Handle != handle {
+		// Foreign handle wrote this file; leave it alone.
+		return false
+	}
+	// Only flip ACTIVE+FRESH presence: a stale "active" file is not
+	// blocking anyone (preflight ignores anything past the freshness
+	// window), so touching it is pure noise. A fresh active file with
+	// a dead agent/wake is the zombie-heartbeat case #38 / #44 — that
+	// is what needs flipping so the next `up` is not blocked.
+	if !strings.EqualFold(pres.Status, "active") || pres.LastSeen.IsZero() || probe.Now().Sub(pres.LastSeen) > presenceFreshness {
+		return false
+	}
+	pres.Status = "offline"
+	pres.LastSeen = probe.Now().UTC()
+	if pres.Schema == 0 {
+		pres.Schema = 1
+	}
+	if pres.Handle == "" {
+		pres.Handle = handle
+	}
+	newData, marshErr := json.Marshal(pres)
+	if marshErr != nil {
+		return false
+	}
+	return os.WriteFile(presencePath, newData, 0o600) == nil
 }
 
 type nativeWakeRetireResult struct {
@@ -1159,6 +1212,22 @@ func wakeSelfCleanedAfterRetire(lockPath string, wakePID int, probe duplicateLau
 	for {
 		_, statErr := os.Stat(lockPath)
 		if os.IsNotExist(statErr) && !probe.PIDAlive(wakePID) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// wakeConfirmedDeadWithinDeadline polls briefly for the wake PID to exit,
+// mirroring wakeSelfCleanedAfterRetire's poll style and deadline: bounded so
+// a wake stuck mid-exit cannot hang `down` indefinitely.
+func wakeConfirmedDeadWithinDeadline(wakePID int, probe duplicateLaunchProbe) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if !probe.PIDAlive(wakePID) {
 			return true
 		}
 		if time.Now().After(deadline) {

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -309,6 +309,109 @@ func TestReapResultOwnerRecoveryStatusesFailWithoutPID(t *testing.T) {
 	}
 }
 
+// TestReapPresenceReassertsOfflineAfterWakeDies covers the amq >=0.52.2 lost
+// update: the dying wake's own teardown does a locked read-modify-write of
+// presence.json that preserves whatever Status it read (active, from before
+// our flip) and refreshes LastSeen. If that write lands after our initial
+// flip but before the wake process actually exits, our flip is clobbered by
+// a fresh "active" file that would recreate the zombie-heartbeat class
+// (#38/#44). reapStaleArtifacts must wait for the wake PID to die and
+// re-assert offline once it does.
+func TestReapPresenceReassertsOfflineAfterWakeDies(t *testing.T) {
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	callCount := 0
+	rewritten := false
+	probe := duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool {
+			if pid != 4242 {
+				return false
+			}
+			callCount++
+			if callCount <= 2 {
+				return true
+			}
+			if !rewritten {
+				// The dying wake's own teardown persist: it read Status
+				// "active" before our flip below landed, and now writes
+				// that stale value back with a freshly-bumped LastSeen.
+				writePresence(t, agentDir, presenceFile{
+					Schema: 1, Handle: "qa", Status: "active",
+					LastSeen: time.Now(),
+				})
+				rewritten = true
+			}
+			return false
+		},
+		Now: time.Now,
+	}
+
+	term := &recordingTerminator{}
+	rec := launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242}
+	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe)
+
+	if !result.PresenceFlip {
+		t.Fatalf("expected PresenceFlip=true, got %+v", result)
+	}
+	if !rewritten {
+		t.Fatalf("test setup did not exercise the lost-update rewrite; callCount=%d", callCount)
+	}
+	if len(term.calls) != 0 {
+		t.Fatalf("no wake lock present; terminator should not have been called: %v", term.calls)
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "offline") {
+		t.Fatalf("presence should be re-asserted offline after the wake's stale rewrite; got %q", pres.Status)
+	}
+}
+
+// TestReapPresenceFlipSkipsReassertWhenWakeAlreadyDead covers the no-race
+// case: the wake PID is already dead by the time we check, so the bounded
+// wait resolves immediately and the single up-front flip stands unchanged.
+func TestReapPresenceFlipSkipsReassertWhenWakeAlreadyDead(t *testing.T) {
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	writePresence(t, agentDir, presenceFile{
+		Schema: 1, Handle: "qa", Status: "active",
+		LastSeen: time.Now().Add(-5 * time.Second),
+	})
+
+	pidAliveCalls := 0
+	probe := duplicateLaunchProbe{
+		PIDAlive: func(int) bool {
+			pidAliveCalls++
+			return false
+		},
+		Now: time.Now,
+	}
+
+	term := &recordingTerminator{}
+	rec := launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242}
+	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe)
+
+	if !result.PresenceFlip {
+		t.Fatalf("expected PresenceFlip=true, got %+v", result)
+	}
+	if pidAliveCalls == 0 {
+		t.Fatalf("expected the bounded wait to check wake liveness at least once")
+	}
+	pres, err := readPresenceForEntry(agentDir)
+	if err != nil {
+		t.Fatalf("read presence: %v", err)
+	}
+	if !strings.EqualFold(pres.Status, "offline") {
+		t.Fatalf("presence should be offline; got %q", pres.Status)
+	}
+}
+
 // downFakeProbe implements duplicateLaunchProbe with explicit per-PID liveness and
 // binary-match decisions so tests never shell out to ps or send real signals.
 func downFakeProbe(alive map[int]bool, match map[int]bool) duplicateLaunchProbe {

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1152,15 +1152,15 @@ func TestRunLaunchRejectsAMQBelowSupportedFloorBeforeSideEffects(t *testing.T) {
 	}
 }
 
-func TestValidateSupportedAMQVersionUses0511Floor(t *testing.T) {
-	for _, version := range []string{"0.51.1", "v0.51.1", "0.52.0-rc1"} {
+func TestValidateSupportedAMQVersionUses0522Floor(t *testing.T) {
+	for _, version := range []string{"0.52.2", "v0.52.2", "0.53.0-rc1"} {
 		if err := validateSupportedAMQVersion(version); err != nil {
 			t.Errorf("validateSupportedAMQVersion(%q): %v", version, err)
 		}
 	}
-	for _, version := range []string{"0.49.9", "0.50.1", "0.51.0", "0.51.1-rc1"} {
+	for _, version := range []string{"0.49.9", "0.50.1", "0.51.0", "0.51.1", "0.52.0", "0.52.1", "0.52.2-rc1"} {
 		err := validateSupportedAMQVersion(version)
-		if err == nil || !strings.Contains(err.Error(), "older than required 0.51.1") || !strings.Contains(err.Error(), "amq upgrade") {
+		if err == nil || !strings.Contains(err.Error(), "older than required 0.52.2") || !strings.Contains(err.Error(), "amq upgrade") {
 			t.Errorf("validateSupportedAMQVersion(%q) = %v, want actionable floor rejection", version, err)
 		}
 	}

--- a/internal/cli/real_amq_env_test.go
+++ b/internal/cli/real_amq_env_test.go
@@ -68,7 +68,7 @@ func TestRealAMQFixtureEnvSanitizesManagedContext(t *testing.T) {
 		"PATH=/fixture/bin",
 		"AMQ_NO_UPDATE_CHECK=0",
 		"AMQ_SQUAD_REAL_AMQ=/fixture/amq",
-		"AMQ_SQUAD_REAL_AMQ_VERSION=v0.51.1",
+		"AMQ_SQUAD_REAL_AMQ_VERSION=v0.52.2",
 	}
 	poisoned := append(append([]string(nil), clean...), realAMQManagedContextPoison...)
 	want := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(clean))

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -104,7 +104,7 @@ if [ "$1" = "env" ]; then
   if [ -n "$session" ]; then
     base_root=$(dirname "$root")
   fi
-  printf '{"schema_version":1,"amq_version":"0.51.1","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
+  printf '{"schema_version":1,"amq_version":"0.52.2","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
   exit 0
 fi
 if [ "$1" = "route" ] && [ "$2" = "explain" ]; then

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true
@@ -22,11 +22,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.51.x is the supported series, with 0.51.1 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.51.1 and latest; latest remains a
+AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.51.1 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 # amq-squad:cli
 
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.51.x is the supported series, with 0.51.1 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.51.1 and latest; latest remains a
+AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.51.1 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.28.0"  # x-release-please-version
+version: "2.28.1"  # x-release-please-version
 ---
 # amq-squad:wizard
 

--- a/plugins/skills-src/cli/SKILL.md
+++ b/plugins/skills-src/cli/SKILL.md
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.51.x is the supported series, with 0.51.1 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.51.1 and latest; latest remains a
+AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.51.1 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -22,9 +22,9 @@ SKILL_FRONTMATTER_VERSION_RE = re.compile(
     r'^version:[ \t]*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
     re.MULTILINE,
 )
-AMQ_MIN_VERSION = "0.51.1"
+AMQ_MIN_VERSION = "0.52.2"
 AMQ_COMPATIBILITY_POLICY = (
-    f"AMQ 0.51.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
+    f"AMQ 0.52.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
     f"supported release. Both real-AMQ matrices validate pinned "
     f"v{AMQ_MIN_VERSION} and latest; latest remains a forward-compatibility "
     "canary and is not a support claim."

--- a/scripts/test_check_release_version.py
+++ b/scripts/test_check_release_version.py
@@ -33,14 +33,14 @@ class RequireReleaseNotesTest(unittest.TestCase):
     def test_policy_normalization_ignores_markdown_and_html_markup(self) -> None:
         policy = CHECK_RELEASE_VERSION.AMQ_COMPATIBILITY_POLICY
         markdown = policy.replace(
-            "AMQ 0.51.x is the supported series",
-            "AMQ **0.51.x is the supported series**",
+            "AMQ 0.52.x is the supported series",
+            "AMQ **0.52.x is the supported series**",
         ).replace("latest", "`latest`")
         html_body = (
             "<p>"
             + policy.replace(
-                "AMQ 0.51.x is the supported series",
-                "AMQ <strong>0.51.x is the supported series</strong>",
+                "AMQ 0.52.x is the supported series",
+                "AMQ <strong>0.52.x is the supported series</strong>",
             ).replace("latest", "<code>latest</code>")
             + "</p>"
         )


### PR DESCRIPTION
## Release v2.28.1 — AMQ 0.52.2 supported floor

Closes #656. Related: #654 (stays open in v2.29.0 for the 0.53.0 adoption).

### Why

amq v0.52.2 ships upstream avivsinai/agent-message-queue#428 (fixes upstream #426): wake-doorbell reminders are bounded to at most 4 per unchanged inbox cohort, then the doorbell parks — one bounded top-up per new arrival, lifetime cap 8, parked state visible in `amq doctor --ops`. This bounds the duplicate raw-doorbell bursts reported in #654.

The burst behavior was a regression introduced upstream in amq v0.49.11 (the wake retry ladder): before it, one message produced one doorbell; after it, an undrained inbox re-rang on a backoff indefinitely, and busy Ink CLIs queued every repetition. 0.52.2 keeps the delivery-retry guarantee but caps the repetition.

### What changed

- `doctorMinAMQVersion` 0.51.1 → 0.52.2 — doctor flags older amq; `agent up` refuses to launch with it (fail-closed, "run `amq upgrade` to update").
- Real-AMQ CI matrices: pinned `v0.52.2` + `latest`.
- Test stubs that hardcoded the old floor updated.
- Docs, skills, migration notes, and release notes: floor statements updated; `docs/v2.28.1-release-notes.md` added.

### Explicitly not in this release

- `--retry-until injected` adoption (upstream #424, open) and the macOS EINTR watcher fix (upstream #422, open) — both target amq 0.53.0; amq-squad adopts them in v2.29.0 (#654, #628).

### Migration

Upgrade amq to 0.52.2+ **before** upgrading amq-squad; 0.49.x/0.50.x/0.51.x are refused at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
