### PR TITLE
Release v2.29.0 — durable lead identity, dynamic membership, executed skill docs

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,6 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
+<li><a href="#whats-new-in-v2290" id="toc-whats-new-in-v2290">What's new
+in v2.29.0</a></li>
 <li><a href="#whats-new-in-v2281" id="toc-whats-new-in-v2281">What's new
 in v2.28.1</a></li>
 <li><a href="#whats-new-in-v2280" id="toc-whats-new-in-v2280">What's new
@@ -334,6 +336,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
+<li><a href="#whats-new-in-v2290">What's new in v2.29.0</a></li>
 <li><a href="#whats-new-in-v2281">What's new in v2.28.1</a></li>
 <li><a href="#whats-new-in-v2280">What's new in v2.28.0</a></li>
 <li><a href="#whats-new-in-v2270">What's new in v2.27.0</a></li>
@@ -354,6 +357,47 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
+<h2 id="whats-new-in-v2290">What's new in v2.29.0</h2>
+<p>v2.29.0 makes squads durable across agent self-upgrades and makes the
+roster genuinely dynamic (#655, #659, #660).</p>
+<ul>
+<li><strong>Lead readiness survives in-place lead restart.</strong> A
+lead whose CLI re-execed in its own pane (e.g. Claude Code
+<code>/upgrade</code>) no longer hard-blocks
+<code>team member add --launch</code> and <code>resume --exec</code>
+with a false <code>lead pane %N is not live</code>. Every launch path
+stamps the durable <code>@amq_squad_title</code> pane option; when the
+visible title was clobbered, the readiness gate corroborates the pane by
+tying the verified-live agent PID to the pane's pty and then re-stamps
+the durable token. A pane carrying a different agent's token still fails
+closed, and <code>--skip-lead-check</code> (on
+<code>resume --exec</code> and <code>team member add --launch</code>) is
+the loud recovery escape hatch.</li>
+<li><strong>Dynamic membership.</strong> The orchestrator skill now
+teaches the lead to grow and shrink the roster mid-run:
+<code>team member add</code> + a <code>--role</code>-scoped
+<code>resume --exec --target new-window</code>,
+<code>team member rm --stop --close-panes</code>, replace via
+<code>down</code> → update → <code>start</code>. Composition authority
+is unchanged (one durable operator gate per added member).</li>
+<li><strong>Roles are a menu, not a whitelist.</strong> Any slug with an
+explicit <code>--binary</code> is a valid role;
+<code>.amq-squad/roles/&lt;id&gt;.md</code> seeds the persona (verbatim,
+frontmatter included) and a missing persona file never blocks adding a
+seat — launch generates a neutral contract.</li>
+<li><strong>Documented commands are executed in CI.</strong> The new
+<code>skill-invocation-check</code> gate runs every documented skill
+invocation against a fixture project; its first run caught four doc'd
+commands missing a required <code>--session</code>. The wizard skill
+gained a numbered end-to-end flow.</li>
+<li><strong>Team rules: Tangible Progress and Honest Credit.</strong>
+Every generated team-rules file now carries an anti-ceremony norm block:
+process artifacts are not progress, the task list stays feature-first,
+honesty is absolute, and refusal is not delivery. Existing squads adopt
+it via <code>team rules init --force</code>.</li>
+</ul>
+<p>Full detail in <a href="docs/v2.29.0-release-notes.md">the v2.29.0
+release notes</a>.</p>
 <h2 id="whats-new-in-v2281">What's new in v2.28.1</h2>
 <p>v2.28.1 is a patch release that raises the supported AMQ floor from
 0.51.1 to 0.52.2 (#656; context in #654). <code>amq-squad doctor</code>
@@ -378,8 +422,8 @@ pinned v0.51.1 to pinned v0.52.2 (plus <code>latest</code>).</li>
 <li><strong>Not in this release.</strong> Upstream #424
 (<code>--retry-until injected</code> presentation acknowledgement, #423)
 and #422 (macOS EINTR kqueue watcher fix, #421) remain open upstream;
-amq-squad adopts them in v2.29.0 when AMQ 0.53.0 ships. #654 stays open
-in the v2.29.0 milestone for that follow-up.</li>
+amq-squad adopts them when AMQ 0.53.0 ships (#654 tracks the follow-up;
+it did not make v2.29.0).</li>
 </ul>
 <p>Migration: see <a href="MIGRATION.md">MIGRATION.md</a> for the
 required AMQ upgrade action. Full detail in <a
@@ -629,7 +673,7 @@ summary, and residual risks.</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.1</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.html
+++ b/README.html
@@ -365,8 +365,8 @@ roster genuinely dynamic (#655, #659, #660).</p>
 lead whose CLI re-execed in its own pane (e.g. Claude Code
 <code>/upgrade</code>) no longer hard-blocks
 <code>team member add --launch</code> and <code>resume --exec</code>
-with a false <code>lead pane %N is not live</code>. Every launch path
-stamps the durable <code>@amq_squad_title</code> pane option; when the
+with a false <code>lead pane %N is not live</code>. Managed launch paths
+stamp the durable <code>@amq_squad_title</code> pane option; when the
 visible title was clobbered, the readiness gate corroborates the pane by
 tying the verified-live agent PID to the pane's pty and then re-stamps
 the durable token. A pane carrying a different agent's token still fails

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ genuinely dynamic (#655, #659, #660).
 - **Lead readiness survives in-place lead restart.** A lead whose CLI
   re-execed in its own pane (e.g. Claude Code `/upgrade`) no longer
   hard-blocks `team member add --launch` and `resume --exec` with a false
-  `lead pane %N is not live`. Every launch path stamps the durable
+  `lead pane %N is not live`. Managed launch paths stamp the durable
   `@amq_squad_title` pane option; when the visible title was clobbered, the
   readiness gate corroborates the pane by tying the verified-live agent PID
   to the pane's pty and then re-stamps the durable token. A pane carrying a

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
+- [What's new in v2.29.0](#whats-new-in-v2290)
 - [What's new in v2.28.1](#whats-new-in-v2281)
 - [What's new in v2.28.0](#whats-new-in-v2280)
 - [What's new in v2.27.0](#whats-new-in-v2270)
@@ -39,6 +40,43 @@ The 30-second mental model:
 - [Cross-project teams](#cross-project-teams)
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
+
+## What's new in v2.29.0
+
+v2.29.0 makes squads durable across agent self-upgrades and makes the roster
+genuinely dynamic (#655, #659, #660).
+
+- **Lead readiness survives in-place lead restart.** A lead whose CLI
+  re-execed in its own pane (e.g. Claude Code `/upgrade`) no longer
+  hard-blocks `team member add --launch` and `resume --exec` with a false
+  `lead pane %N is not live`. Every launch path stamps the durable
+  `@amq_squad_title` pane option; when the visible title was clobbered, the
+  readiness gate corroborates the pane by tying the verified-live agent PID
+  to the pane's pty and then re-stamps the durable token. A pane carrying a
+  different agent's token still fails closed, and
+  `--skip-lead-check` (on `resume --exec` and `team member add --launch`)
+  is the loud recovery escape hatch.
+- **Dynamic membership.** The orchestrator skill now teaches the lead to
+  grow and shrink the roster mid-run: `team member add` + a `--role`-scoped
+  `resume --exec --target new-window`, `team member rm --stop
+  --close-panes`, replace via `down` → update → `start`. Composition
+  authority is unchanged (one durable operator gate per added member).
+- **Roles are a menu, not a whitelist.** Any slug with an explicit
+  `--binary` is a valid role; `.amq-squad/roles/<id>.md` seeds the persona
+  (verbatim, frontmatter included) and a missing persona file never blocks
+  adding a seat — launch generates a neutral contract.
+- **Documented commands are executed in CI.** The new
+  `skill-invocation-check` gate runs every documented skill invocation
+  against a fixture project; its first run caught four doc'd commands
+  missing a required `--session`. The wizard skill gained a numbered
+  end-to-end flow.
+- **Team rules: Tangible Progress and Honest Credit.** Every generated
+  team-rules file now carries an anti-ceremony norm block: process artifacts
+  are not progress, the task list stays feature-first, honesty is absolute,
+  and refusal is not delivery. Existing squads adopt it via
+  `team rules init --force`.
+
+Full detail in [the v2.29.0 release notes](docs/v2.29.0-release-notes.md).
 
 ## What's new in v2.28.1
 
@@ -61,8 +99,8 @@ v2.28.1 is a patch release that raises the supported AMQ floor from 0.51.1 to
   v0.52.2 (plus `latest`).
 - **Not in this release.** Upstream #424 (`--retry-until injected` presentation
   acknowledgement, #423) and #422 (macOS EINTR kqueue watcher fix, #421) remain
-  open upstream; amq-squad adopts them in v2.29.0 when AMQ 0.53.0 ships. #654
-  stays open in the v2.29.0 milestone for that follow-up.
+  open upstream; amq-squad adopts them when AMQ 0.53.0 ships (#654 tracks the
+  follow-up; it did not make v2.29.0).
 
 Migration: see [MIGRATION.md](MIGRATION.md) for the required AMQ upgrade
 action. Full detail in [the v2.28.1 release notes](docs/v2.28.1-release-notes.md).
@@ -297,7 +335,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.28.1
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.28.1-release-notes.md
+++ b/docs/v2.28.1-release-notes.md
@@ -46,6 +46,8 @@ Two related upstream items remain open and are **not** adopted here:
 
 amq-squad adopts both when AMQ 0.53.0 ships, targeted for **v2.29.0**. #654
 stays open in the v2.29.0 milestone to track that follow-up adoption.
+*(Update, 2026-08-06: the 0.53.0 adoption did not make v2.29.0; #654 remains
+open for a later release.)*
 
 ## Migration action
 

--- a/docs/v2.29.0-release-notes.md
+++ b/docs/v2.29.0-release-notes.md
@@ -23,8 +23,9 @@ app inside the pane owns and rewrites.
 Three-part fix:
 
 - **Durable fingerprint.** Every managed launch path now stamps the launcher-owned
-  `@amq_squad_title` pane option (which the pane inspector already prefers)
-  alongside the visible title, so identity survives any in-pane title rewrite.
+  `@amq_squad_title` pane option (which the pane inspector already prefers);
+  the visible title is stamped too where moving focus is acceptable. Identity
+  survives any in-pane title rewrite.
 - **Process-tty corroboration with self-heal.** When the title check fails,
   the runtime identity classifier ties the verified-live recorded agent PID to
   the pane through its controlling pty: the same device means the live agent
@@ -47,8 +48,9 @@ permanent token would outlive the agent.
 ## Dynamic membership and non-binding roles
 
 - The `amq-squad:orchestrator` skill now carries a **Dynamic membership**
-  protocol: the lead may grow the roster mid-run (`team member add` +
-  `resume --exec --target new-window`, or `add --launch`), wind a finished
+  protocol: the lead may grow the roster mid-run (`team member add` + a
+  `--role`-scoped `resume --exec --target new-window`, or `add --launch` —
+  the unscoped forms relaunch every non-live member), wind a finished
   seat down (`team member rm --stop --close-panes`), or replace a role
   (`down` → update → `start`). Composition authority is unchanged: one durable
   operator gate per added member, spawn guard lead-only, worker requests are
@@ -83,8 +85,9 @@ easy paperwork is reward hacking; the task list stays feature-first; honesty
 is absolute (no faked tests, no fixture presented as live proof, no weakened
 assertions; a false DONE is reopened with an incident note on the task
 thread); refusal is not delivery, and refusal-only work never closes a
-feature task. Existing squads pick the section up on their next
-`team rules init --force`; rules files are never rewritten in place.
+feature task. Existing squads pick the section up via
+`team rules init --force` — rules files are never regenerated automatically;
+`--force` is the explicit opt-in rewrite.
 
 ## What is deliberately NOT in this release
 

--- a/docs/v2.29.0-release-notes.md
+++ b/docs/v2.29.0-release-notes.md
@@ -1,0 +1,93 @@
+# amq-squad v2.29.0
+
+## Summary
+
+v2.29.0 makes squads durable across agent self-upgrades and makes the roster
+genuinely dynamic. The lead-readiness gate no longer hard-blocks member
+launches after an in-place lead restart (#655), the lead protocol now teaches
+mid-run add/remove/replace of members, role ids are documented as a menu
+rather than a whitelist, every documented skill invocation is executed in CI,
+and every generated team-rules file gains an anti-ceremony
+"Tangible Progress and Honest Credit" norm section.
+
+## Lead readiness survives in-place lead restart (#655)
+
+After the lead binary restarted inside its original tmux pane (for example a
+Claude Code `/upgrade`, which re-execs in the same pane), the readiness gate
+reported `lead pane %N is not live` even while the pane, the pty, and the
+agent process were all demonstrably alive — hard-blocking
+`team member add --launch` and `resume --exec` for the rest of the session.
+The gate verified pane identity only by the visible `#{pane_title}`, which the
+app inside the pane owns and rewrites.
+
+Three-part fix:
+
+- **Durable fingerprint.** Every launch path now stamps the launcher-owned
+  `@amq_squad_title` pane option (which the pane inspector already prefers)
+  alongside the visible title, so identity survives any in-pane title rewrite.
+- **Process-tty corroboration with self-heal.** When the title check fails,
+  the runtime identity classifier ties the verified-live recorded agent PID to
+  the pane through its controlling pty: the same device means the live agent
+  runs in exactly that pane, regardless of title. The readiness gate then
+  re-stamps the durable token (never the focus-moving visible title). A pane
+  on a different pty — a reused pane id after a tmux server restart — still
+  refuses.
+- **Escape hatch.** `resume --exec --skip-lead-check` and
+  `team member add --launch --skip-lead-check` bypass the gate with a loud
+  warning, so a stale lead record can never hard-block member launches again.
+  Goal redelivery still verifies the lead.
+
+Codex-review hardening on top of the fix: the tty corroboration fails closed
+when the pane carries a valid `amq:` token for a *different* agent (a
+reassigned pane's owner is never out-voted by a lingering process on the same
+pty), and capture paths (direct `agent up`, external-lead adoption) do not
+stamp the durable token — External-record liveness is title-based, so a
+permanent token would outlive the agent.
+
+## Dynamic membership and non-binding roles
+
+- The `amq-squad:orchestrator` skill now carries a **Dynamic membership**
+  protocol: the lead may grow the roster mid-run (`team member add` +
+  `resume --exec --target new-window`, or `add --launch`), wind a finished
+  seat down (`team member rm --stop --close-panes`), or replace a role
+  (`down` → update → `start`). Composition authority is unchanged: one durable
+  operator gate per added member, spawn guard lead-only, worker requests are
+  data.
+- **Roles are a menu, not a whitelist.** The binary has accepted arbitrary
+  role slugs (with an explicit `--binary`, or a role file carrying `binary:`)
+  all along; the skills now teach it. A custom role's persona lives at
+  `.amq-squad/roles/<id>.md` (optional frontmatter plus verbatim body); with
+  no file, launch generates a neutral contract that defers scope to team
+  rules, the brief, and the dispatched task — a missing persona never blocks
+  adding a seat.
+
+## Skill determinism
+
+- **New CI gate `skill-invocation-check`.** Every documented `amq-squad ...`
+  invocation in the skills is extracted, placeholder-substituted, and
+  **executed** against an empty fixture project; a usage-classed failure
+  (exit 1) fails the build. Flag existence was already gated (#534), but
+  existence is not invocation correctness: this gate's first run caught
+  `evidence run`/`evidence recover` documented without the required
+  `--session` in four places (fixed).
+- **wizard "The flow".** The end-to-end setup procedure is now one numbered
+  spine — coordinates → roster → brief → preview (answer No) → operator
+  approval → identical invocation with `--yes` → verify and hand off — with
+  the failure branch named per step.
+
+## Team rules: Tangible Progress and Honest Credit
+
+Every generated team-rules template now includes an anti-ceremony norm block,
+placed before Quality Gates: process artifacts are not progress and choosing
+easy paperwork is reward hacking; the task list stays feature-first; honesty
+is absolute (no faked tests, no fixture presented as live proof, no weakened
+assertions; a false DONE is reopened with an incident note on the task
+thread); refusal is not delivery, and refusal-only work never closes a
+feature task. Existing squads pick the section up on their next
+`team rules init --force`; rules files are never rewritten in place.
+
+## What is deliberately NOT in this release
+
+The AMQ 0.53.0 adoption (`--retry-until` injection, EINTR fix) earmarked in
+the v2.28.1 notes under #654 is not in v2.29.0; it moves to a later release.
+The supported AMQ floor is unchanged at 0.52.2.

--- a/docs/v2.29.0-release-notes.md
+++ b/docs/v2.29.0-release-notes.md
@@ -22,7 +22,7 @@ app inside the pane owns and rewrites.
 
 Three-part fix:
 
-- **Durable fingerprint.** Every launch path now stamps the launcher-owned
+- **Durable fingerprint.** Every managed launch path now stamps the launcher-owned
   `@amq_squad_title` pane option (which the pane inspector already prefers)
   alongside the visible title, so identity survives any in-pane title rewrite.
 - **Process-tty corroboration with self-heal.** When the title check fails,

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.28.1"  # x-release-please-version
+version: "2.29.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release PR for v2.29.0. Rolls up #659 (fixes #655) and #660, both merged to main after codex review + full CI.

## In this release

- **Lead readiness survives in-place lead restart (#655/#659).** Durable `@amq_squad_title` pane fingerprint on managed launches, process-tty corroboration with self-heal restamp when the visible title was clobbered, conflicting-token fail-closed, `--skip-lead-check` escape hatch on `resume --exec` / `team member add --launch`.
- **Dynamic membership + non-binding roles (#660).** Orchestrator teaches mid-run add (`--role`-scoped resume) / remove / replace; any role slug is valid with an explicit binary; staged persona files seed `role.md` verbatim; missing persona never blocks a seat.
- **Executed skill docs (#660).** New `skill-invocation-check` CI gate runs every documented skill invocation against a fixture project (caught 4 doc'd commands missing `--session`); wizard gained a numbered end-to-end flow.
- **Team rules: Tangible Progress and Honest Credit (#660).** Anti-ceremony norm block in every generated template, mirror-contract-pinned.

## Release mechanics

- plugin manifests → 2.29.0; mirrors regenerated (`make skills-generate`); `make release-check VERSION=v2.29.0` green
- README What's new + install tag → v2.29.0; `README.html` regenerated; the v2.28.1 section's "#654 lands in v2.29.0" promise corrected — the AMQ 0.53.0 adoption (#654) did **not** make this release and stays open
- `docs/v2.29.0-release-notes.md` added

After merge: tag `v2.29.0` on the merge commit, create the GitHub release, then `make release-smoke VERSION=v2.29.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)