### PR TITLE
docs(skills): dynamic-membership field gotchas from the first v2.29.0 live run

### DIFF
--- a/plugins/claude/skills/orchestrator/LEARNINGS.md
+++ b/plugins/claude/skills/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/claude/skills/orchestrator/LEARNINGS.md
+++ b/plugins/claude/skills/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -118,6 +118,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -139,6 +156,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -101,7 +101,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 

--- a/plugins/codex/skills/orchestrator/LEARNINGS.md
+++ b/plugins/codex/skills/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/codex/skills/orchestrator/LEARNINGS.md
+++ b/plugins/codex/skills/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -114,6 +114,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -135,6 +152,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -97,7 +97,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 

--- a/plugins/skills-src/orchestrator/LEARNINGS.md
+++ b/plugins/skills-src/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/skills-src/orchestrator/LEARNINGS.md
+++ b/plugins/skills-src/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/skills-src/orchestrator/SKILL.md
+++ b/plugins/skills-src/orchestrator/SKILL.md
@@ -114,6 +114,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -135,6 +152,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -97,7 +97,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 


### PR DESCRIPTION
First live run of v2.29.0's dynamic membership (a fresh PM-copilot lead grew its roster to three seats within minutes) surfaced two real traps, both invisible until `doctor`. This PR encodes them in the skills; #662 tracks the binary-level fix for the first one.

1. **Implementation grants collide silently on the mid-run path.** `member add` defaults to `--actor-mode review`; the lead granted `implementation` to both new seats in the shared cwd. `start` would have refused fail-closed, but `resume --exec` runs no isolation preflight — `doctor` flagged `worktree/shared-index-collision` only after both seats were live with claimed tasks. Orchestrator's Dynamic membership now teaches: actor mode is a grant, a non-editing seat needs none, and implementers get their own `--cwd` before concurrent mutation. Wizard's roster-checks section names the same asymmetry.
2. **Bare `agent up` produces a ghost seat.** One seat was launched via `agent up` directly (the un-managed option `member add`'s own output offers): mailbox + pane + claimed task, but no `team.json` entry, so roster-scoped `rm`/`update`/`resume` can't manage it. New rule: squad seats always go through the roster.

Both recorded in orchestrator's LEARNINGS.md as the raw field material, per the graduation loop. Mirrors regenerated; `skills-check`, `skill-command-check`, `skill-invocation-check` all green (64 invocations execute cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)