### PR TITLE
feat(cli): mid-run member adds arrange the lead's window as main-vertical (v2.29.1)

### DIFF
--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -81,6 +81,11 @@ of members (e.g. bring up two workers without relaunching a live lead).
 Orchestrated resumes verify the configured lead is live and operator-
 addressable before launching dependent roles; --skip-lead-check bypasses
 that gate (with a warning) when a stale lead record blocks recovery.
+When an orchestrated resume adds members to the current window while the
+lead is already live (the mid-run member-add flow), the window arranges as
+main-vertical: the launching pane keeps a full-height left column and the
+added members stack in rows to its right. Pass --layout explicitly to keep
+the legacy even-split behavior.
 With --json, emits a schema-versioned
 resume_plan envelope for clients: per-member action plus a liveness block
 (status/detail/signals) consistent with 'status --json', and -- where available
@@ -170,6 +175,7 @@ Examples:
 			PromptIn:           os.Stdin,
 			PromptOut:          os.Stderr,
 			SkipLeadCheck:      *skipLeadCheck,
+			LayoutExplicit:     flagWasSet(fs, "layout"),
 		}
 	}
 	return executeResume(resumeExecution{

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -1210,3 +1210,71 @@ func walkDir(root string, fn func(path string, info os.FileInfo) error) error {
 	}
 	return nil
 }
+
+// The lead-main arrangement fires ONLY on the mid-run member-add signature:
+// orchestrated, current-window, lead already live (not in the plan). Every
+// other shape — lead-only plan, lead being relaunched — clears the candidate
+// flag before the tmux plan runs.
+func TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch(t *testing.T) {
+	oldRun := runTmuxLaunchPlanForResume
+	oldVerify := verifyResumeExecLaunchRecordsNow
+	oldReady := verifyResumeLeadReadyNow
+	t.Cleanup(func() {
+		runTmuxLaunchPlanForResume = oldRun
+		verifyResumeExecLaunchRecordsNow = oldVerify
+		verifyResumeLeadReadyNow = oldReady
+	})
+	var flags []bool
+	runTmuxLaunchPlanForResume = func(plan tmuxLaunchPlan) error {
+		flags = append(flags, plan.LeadMainCurrentWindow)
+		return nil
+	}
+	verifyResumeExecLaunchRecordsNow = func(checks []resumeExecLaunchCheck, _ map[string]resumeExecLaunchSnapshot) []resumeExecLaunchResult {
+		out := make([]resumeExecLaunchResult, 0, len(checks))
+		for _, check := range checks {
+			out = append(out, resumeExecLaunchResult{Check: check, State: resumeExecLaunchStateLaunched})
+		}
+		return out
+	}
+	verifyResumeLeadReadyNow = func(resumeExecLaunchCheck) error { return nil }
+
+	base := tmuxLaunchPlan{Target: "current-window", LeadMainCurrentWindow: true}
+	tm := team.Team{Orchestrated: true, Lead: "cto"}
+
+	// Mid-run add: dependents only — flag survives.
+	plan := base
+	plan.Panes = []teamLaunchPane{{Role: "researcher"}}
+	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
+		[]resumeExecLaunchCheck{{Role: "researcher", Handle: "researcher"}, {Role: "cto", Handle: "cto"}},
+		map[string]resumeExecLaunchSnapshot{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lead-only plan: cleared.
+	plan = base
+	plan.Panes = []teamLaunchPane{{Role: "cto"}}
+	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
+		[]resumeExecLaunchCheck{{Role: "cto", Handle: "cto"}},
+		map[string]resumeExecLaunchSnapshot{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lead + dependents relaunch: cleared on both the lead and dependent plans.
+	plan = base
+	plan.Panes = []teamLaunchPane{{Role: "cto"}, {Role: "qa"}}
+	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
+		[]resumeExecLaunchCheck{{Role: "cto", Handle: "cto"}, {Role: "qa", Handle: "qa"}},
+		map[string]resumeExecLaunchSnapshot{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []bool{true, false, false, false}
+	if len(flags) != len(want) {
+		t.Fatalf("plan runs = %d, want %d (%v)", len(flags), len(want), flags)
+	}
+	for i, flag := range flags {
+		if flag != want[i] {
+			t.Fatalf("plan run %d LeadMainCurrentWindow = %t, want %t (%v)", i, flag, want[i], flags)
+		}
+	}
+}

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -1212,17 +1212,21 @@ func walkDir(root string, fn func(path string, info os.FileInfo) error) error {
 }
 
 // The lead-main arrangement fires ONLY on the mid-run member-add signature:
-// orchestrated, current-window, lead already live (not in the plan). Every
-// other shape — lead-only plan, lead being relaunched — clears the candidate
-// flag before the tmux plan runs.
+// orchestrated, current-window, lead already live (not in the plan), AND the
+// resume invoked from the lead's own recorded pane. Every other shape —
+// lead-only plan, lead being relaunched, a resume issued from an operator or
+// worker pane, or a --skip-lead-check bypass — clears the candidate flag
+// before the tmux plan runs.
 func TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch(t *testing.T) {
 	oldRun := runTmuxLaunchPlanForResume
 	oldVerify := verifyResumeExecLaunchRecordsNow
 	oldReady := verifyResumeLeadReadyNow
+	oldFromLead := resumeLaunchedFromLeadPaneNow
 	t.Cleanup(func() {
 		runTmuxLaunchPlanForResume = oldRun
 		verifyResumeExecLaunchRecordsNow = oldVerify
 		verifyResumeLeadReadyNow = oldReady
+		resumeLaunchedFromLeadPaneNow = oldFromLead
 	})
 	var flags []bool
 	runTmuxLaunchPlanForResume = func(plan tmuxLaunchPlan) error {
@@ -1237,11 +1241,13 @@ func TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch(t *testing.T) {
 		return out
 	}
 	verifyResumeLeadReadyNow = func(resumeExecLaunchCheck) error { return nil }
+	launchedFromLeadPane := true
+	resumeLaunchedFromLeadPaneNow = func(resumeExecLaunchCheck) bool { return launchedFromLeadPane }
 
 	base := tmuxLaunchPlan{Target: "current-window", LeadMainCurrentWindow: true}
 	tm := team.Team{Orchestrated: true, Lead: "cto"}
 
-	// Mid-run add: dependents only — flag survives.
+	// Mid-run add: dependents only, invoked from the lead pane — flag survives.
 	plan := base
 	plan.Panes = []teamLaunchPane{{Role: "researcher"}}
 	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
@@ -1268,7 +1274,30 @@ func TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []bool{true, false, false, false}
+	// Dependents only, but the resume is NOT running in the lead's recorded
+	// pane (operator shell, worker pane): the lead is live somewhere, yet
+	// arranging main-vertical here would rearrange the CALLER's window.
+	launchedFromLeadPane = false
+	plan = base
+	plan.Panes = []teamLaunchPane{{Role: "researcher"}}
+	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
+		[]resumeExecLaunchCheck{{Role: "researcher", Handle: "researcher"}, {Role: "cto", Handle: "cto"}},
+		map[string]resumeExecLaunchSnapshot{}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// --skip-lead-check: no live lead verified at all, so the flag must not
+	// survive even when the pane tie would have matched.
+	launchedFromLeadPane = true
+	plan = base
+	plan.Panes = []teamLaunchPane{{Role: "researcher"}}
+	if _, err := runResumeTmuxPlanWithLeadGate(tm, team.DefaultProfile, "s", plan,
+		[]resumeExecLaunchCheck{{Role: "researcher", Handle: "researcher"}, {Role: "cto", Handle: "cto"}},
+		map[string]resumeExecLaunchSnapshot{}, true); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []bool{true, false, false, false, false, false}
 	if len(flags) != len(want) {
 		t.Fatalf("plan runs = %d, want %d (%v)", len(flags), len(want), flags)
 	}
@@ -1276,5 +1305,53 @@ func TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch(t *testing.T) {
 		if flag != want[i] {
 			t.Fatalf("plan run %d LeadMainCurrentWindow = %t, want %t (%v)", i, flag, want[i], flags)
 		}
+	}
+}
+
+// resumeLaunchedFromLeadPane ties the arrangement to REAL identity evidence:
+// the lead launch record's pane id must equal the invoking $TMUX_PANE, and
+// every missing side fails closed.
+func TestResumeLaunchedFromLeadPaneComparesRecordedPane(t *testing.T) {
+	dir := t.TempDir()
+	writeRecord := func(paneID string) {
+		rec := launch.Record{Handle: "cto", Role: "cto", Tmux: &launch.TmuxInfo{PaneID: paneID}}
+		data, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := launch.Path(dir)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	check := resumeExecLaunchCheck{Role: "cto", Handle: "cto", AgentDir: dir}
+
+	writeRecord("%7")
+	t.Setenv("TMUX_PANE", "%7")
+	if !resumeLaunchedFromLeadPane(check) {
+		t.Fatal("matching recorded pane and TMUX_PANE not recognized")
+	}
+
+	t.Setenv("TMUX_PANE", "%9")
+	if resumeLaunchedFromLeadPane(check) {
+		t.Fatal("mismatched TMUX_PANE accepted as the lead pane")
+	}
+
+	t.Setenv("TMUX_PANE", "")
+	if resumeLaunchedFromLeadPane(check) {
+		t.Fatal("resume outside tmux accepted as the lead pane")
+	}
+
+	t.Setenv("TMUX_PANE", "%7")
+	writeRecord("")
+	if resumeLaunchedFromLeadPane(check) {
+		t.Fatal("record without a pane id accepted as the lead pane")
+	}
+
+	if resumeLaunchedFromLeadPane(resumeExecLaunchCheck{Role: "cto", Handle: "cto", AgentDir: filepath.Join(dir, "missing")}) {
+		t.Fatal("missing launch record accepted as the lead pane")
 	}
 }

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -147,23 +147,43 @@ func setTmuxLaunchPaneMetadata(plan tmuxLaunchPlan, paneID, role string) error {
 // itself is best-effort (tmux applies the layout without it); everything after
 // select-layout is not.
 func applyLeadMainVerticalLayout(windowTarget, leadPaneID string) (func(), error) {
+	// Snapshot the LOCAL window option, not the effective value: querying the
+	// option by name reports the inherited default too, which would "restore"
+	// an originally-unset option as an explicit local override. Listing without
+	// a name prints only options set on this window.
 	prevWidth := ""
 	hadWidth := false
-	if out, err := tmuxOutputCommand("tmux", "show-options", "-w", "-v", "-t", windowTarget, "main-pane-width"); err == nil {
-		if trimmed := strings.TrimSpace(out); trimmed != "" {
-			prevWidth, hadWidth = trimmed, true
+	snapshotOK := false
+	if out, err := tmuxOutputCommand("tmux", "show-options", "-w", "-t", windowTarget); err == nil {
+		snapshotOK = true
+		for _, line := range strings.Split(out, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 2 && fields[0] == "main-pane-width" {
+				prevWidth, hadWidth = fields[1], true
+				break
+			}
 		}
 	}
 	undo := func() {
+		// Nothing was mutated when the snapshot failed, and mutating here on a
+		// guessed baseline could destroy a pre-existing local value.
+		if !snapshotOK {
+			return
+		}
 		if hadWidth {
 			_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", prevWidth)
 			return
 		}
 		_ = tmuxRunCommand("tmux", "set-option", "-w", "-u", "-t", windowTarget, "main-pane-width")
 	}
-	if out, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", windowTarget, "#{window_width}"); err == nil {
-		if width, convErr := strconv.Atoi(strings.TrimSpace(out)); convErr == nil && width > 0 {
-			_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", strconv.Itoa(width*3/5))
+	// The width is best-effort (tmux applies main-vertical without it), so it
+	// is skipped entirely when its prior state could not be snapshotted — a
+	// mutation that cannot be undone is worse than the default width.
+	if snapshotOK {
+		if out, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", windowTarget, "#{window_width}"); err == nil {
+			if width, convErr := strconv.Atoi(strings.TrimSpace(out)); convErr == nil && width > 0 {
+				_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", strconv.Itoa(width*3/5))
+			}
 		}
 	}
 	if err := tmuxRunCommand("tmux", "select-layout", "-t", windowTarget, "main-vertical"); err != nil {

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -134,6 +134,88 @@ func setTmuxLaunchPaneMetadata(plan tmuxLaunchPlan, paneID, role string) error {
 	return tmuxRunCommand("tmux", "select-pane", "-t", paneID, "-T", token)
 }
 
+// applyLeadMainVerticalLayout arranges a mid-run member add as main-vertical
+// and guarantees the LEAD pane ends up as the main (full-height left) pane.
+// The splits and metadata stamping move the active pane to the last-added
+// worker, and select-layout assigns the main slot by pane order rather than by
+// who launched -- so the main pane is resolved by geometry afterwards and the
+// lead is swapped into it when something else landed there.
+//
+// The returned undo restores the window's prior main-pane-width; callers run
+// it when the launch later fails, because rolling back the created panes does
+// not undo a window option mutated in the operator's own window. The width
+// itself is best-effort (tmux applies the layout without it); everything after
+// select-layout is not.
+func applyLeadMainVerticalLayout(windowTarget, leadPaneID string) (func(), error) {
+	prevWidth := ""
+	hadWidth := false
+	if out, err := tmuxOutputCommand("tmux", "show-options", "-w", "-v", "-t", windowTarget, "main-pane-width"); err == nil {
+		if trimmed := strings.TrimSpace(out); trimmed != "" {
+			prevWidth, hadWidth = trimmed, true
+		}
+	}
+	undo := func() {
+		if hadWidth {
+			_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", prevWidth)
+			return
+		}
+		_ = tmuxRunCommand("tmux", "set-option", "-w", "-u", "-t", windowTarget, "main-pane-width")
+	}
+	if out, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", windowTarget, "#{window_width}"); err == nil {
+		if width, convErr := strconv.Atoi(strings.TrimSpace(out)); convErr == nil && width > 0 {
+			_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", strconv.Itoa(width*3/5))
+		}
+	}
+	if err := tmuxRunCommand("tmux", "select-layout", "-t", windowTarget, "main-vertical"); err != nil {
+		return undo, err
+	}
+	// main-vertical leaves exactly one pane in column 0: the main pane. Resolve
+	// it by geometry, never by active-pane state.
+	out, err := tmuxOutputCommand("tmux", "list-panes", "-t", windowTarget, "-F", "#{pane_id}\t#{pane_left}")
+	if err != nil {
+		return undo, fmt.Errorf("resolve main pane after main-vertical: %w", err)
+	}
+	mainPane := ""
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Split(strings.TrimRight(line, "\r"), "\t")
+		if len(fields) != 2 {
+			return undo, fmt.Errorf("resolve main pane after main-vertical: malformed list-panes line %q", line)
+		}
+		if strings.TrimSpace(fields[1]) != "0" {
+			continue
+		}
+		if mainPane != "" {
+			return undo, fmt.Errorf("resolve main pane after main-vertical: panes %s and %s both claim column 0", mainPane, strings.TrimSpace(fields[0]))
+		}
+		mainPane = strings.TrimSpace(fields[0])
+	}
+	if mainPane == "" {
+		return undo, fmt.Errorf("resolve main pane after main-vertical: no pane in column 0")
+	}
+	if mainPane != leadPaneID {
+		if err := tmuxRunCommand("tmux", "swap-pane", "-d", "-s", leadPaneID, "-t", mainPane); err != nil {
+			return undo, fmt.Errorf("move lead %s into main pane %s: %w", leadPaneID, mainPane, err)
+		}
+	}
+	// Verify by geometry with an identity echo: display-message answers about
+	// the ACTIVE pane when the target vanished, so the id must be read back
+	// alongside the position (same contract as the post-delivery liveness read).
+	probe, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", leadPaneID, "#{pane_id}\t#{pane_left}")
+	if err != nil {
+		return undo, fmt.Errorf("verify lead main pane %s: %w", leadPaneID, err)
+	}
+	probeFields := strings.Split(strings.TrimRight(probe, "\r\n"), "\t")
+	if len(probeFields) != 2 || strings.TrimSpace(probeFields[0]) != leadPaneID || strings.TrimSpace(probeFields[1]) != "0" {
+		return undo, fmt.Errorf("lead pane %s did not land in the main column after main-vertical (probe %q)", leadPaneID, strings.TrimSpace(probe))
+	}
+	// The splits moved focus to the last-added worker; the lead is the
+	// operator's working pane, so give focus back.
+	if err := tmuxRunCommand("tmux", "select-pane", "-t", leadPaneID); err != nil {
+		return undo, fmt.Errorf("restore focus to lead pane %s: %w", leadPaneID, err)
+	}
+	return undo, nil
+}
+
 func rollbackTmuxLaunchPanes(createdSession string, paneIDs []string) error {
 	if createdSession != "" {
 		return tmuxRunCommand("tmux", "kill-session", "-t", createdSession)
@@ -509,9 +591,16 @@ func runTmuxLaunchPlanInternal(plan tmuxLaunchPlan, collectResult bool) (teamLau
 	reuseExistingSession := false
 	createdSession := ""
 	createdTargets := []string{}
+	// Set once the lead-main arrangement has mutated window options: rollback
+	// kills the created panes, but a window option would otherwise outlive the
+	// failed launch in the operator's own window.
+	var undoLeadMainLayout func()
 	failCreated := func(cause error) (teamLaunchResult, error) {
 		if preserveTmuxCheckpointFailure(cause) {
 			return teamLaunchResult{}, cause
+		}
+		if undoLeadMainLayout != nil {
+			undoLeadMainLayout()
 		}
 		return teamLaunchResult{}, errors.Join(cause, rollbackTmuxLaunchPanes(createdSession, createdTargets))
 	}
@@ -619,14 +708,10 @@ func runTmuxLaunchPlanInternal(plan tmuxLaunchPlan, collectResult bool) (teamLau
 	if plan.LeadMainCurrentWindow && plan.Target == "current-window" {
 		// Mid-run member add: the launcher pane is the lead, and the window now
 		// holds lead + added workers. main-vertical keeps the lead a full-height
-		// left column with the workers stacked in rows to its right; the width
-		// option is best-effort (tmux still applies the layout without it).
-		if out, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", windowTarget, "#{window_width}"); err == nil {
-			if width, convErr := strconv.Atoi(strings.TrimSpace(out)); convErr == nil && width > 0 {
-				_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", strconv.Itoa(width*3/5))
-			}
-		}
-		if err := tmuxRunCommand("tmux", "select-layout", "-t", windowTarget, "main-vertical"); err != nil {
+		// left column with the workers stacked in rows to its right.
+		undo, err := applyLeadMainVerticalLayout(windowTarget, firstTarget)
+		undoLeadMainLayout = undo
+		if err != nil {
 			return failCreated(err)
 		}
 	} else if len(targets) > 1 {

--- a/internal/cli/team_launch_tmux.go
+++ b/internal/cli/team_launch_tmux.go
@@ -31,6 +31,12 @@ type tmuxLaunchPlan struct {
 	AllowExistingSession  bool
 	PreserveLauncherFocus bool
 	AfterCheckpoint       func(simpleStartCheckpoint) error
+	// LeadMainCurrentWindow arranges a current-window launch as main-vertical:
+	// the launcher's pane (the lead, in the mid-run member-add flow) keeps a
+	// full-height left column and every added pane stacks in rows to its
+	// right. Set by orchestrated resume --exec when the operator did not pick
+	// a layout explicitly; ignored for other targets.
+	LeadMainCurrentWindow bool
 }
 
 type tmuxClient struct {
@@ -610,7 +616,20 @@ func runTmuxLaunchPlanInternal(plan tmuxLaunchPlan, collectResult bool) (teamLau
 	if len(targets) != len(plan.Panes) {
 		return failCreated(fmt.Errorf("tmux launch created %d pane target(s), want %d", len(targets), len(plan.Panes)))
 	}
-	if len(targets) > 1 {
+	if plan.LeadMainCurrentWindow && plan.Target == "current-window" {
+		// Mid-run member add: the launcher pane is the lead, and the window now
+		// holds lead + added workers. main-vertical keeps the lead a full-height
+		// left column with the workers stacked in rows to its right; the width
+		// option is best-effort (tmux still applies the layout without it).
+		if out, err := tmuxOutputCommand("tmux", "display-message", "-p", "-t", windowTarget, "#{window_width}"); err == nil {
+			if width, convErr := strconv.Atoi(strings.TrimSpace(out)); convErr == nil && width > 0 {
+				_ = tmuxRunCommand("tmux", "set-option", "-w", "-t", windowTarget, "main-pane-width", strconv.Itoa(width*3/5))
+			}
+		}
+		if err := tmuxRunCommand("tmux", "select-layout", "-t", windowTarget, "main-vertical"); err != nil {
+			return failCreated(err)
+		}
+	} else if len(targets) > 1 {
 		if err := tmuxRunCommand("tmux", "select-layout", "-t", windowTarget, tmuxSelectLayout(plan.Layout)); err != nil {
 			return failCreated(err)
 		}

--- a/internal/cli/team_launch_tmux_result_test.go
+++ b/internal/cli/team_launch_tmux_result_test.go
@@ -279,6 +279,8 @@ func TestRunTmuxCurrentWindowLeadMainAppliesMainVertical(t *testing.T) {
 		switch {
 		case strings.Contains(call, "#{session_name}:#{window_index}"):
 			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "show-options":
+			return "", nil
 		case len(args) > 0 && args[0] == "split-window":
 			nextPane++
 			return fmt.Sprintf("%%%d\n", nextPane), nil
@@ -286,6 +288,13 @@ func TestRunTmuxCurrentWindowLeadMainAppliesMainVertical(t *testing.T) {
 			return "200\n", nil
 		case strings.Contains(call, "#{window_id}"):
 			return "@7\n", nil
+		// select-layout put the LAST pane in the main column, not the lead:
+		// the arrangement must detect that and swap the lead in.
+		case len(args) > 0 && args[0] == "list-panes":
+			return "%2\t0\n%1\t121\n", nil
+		case strings.Contains(call, "#{pane_left}"):
+			// Post-swap verification probe: the lead now sits in column 0.
+			return "%1\t0\n", nil
 		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
 			return fakePaneIdentityReply(args), nil
 		default:
@@ -307,8 +316,104 @@ func TestRunTmuxCurrentWindowLeadMainAppliesMainVertical(t *testing.T) {
 	if !strings.Contains(joined, "select-layout -t loco:1 main-vertical") {
 		t.Fatalf("main-vertical not applied:\n%s", joined)
 	}
+	// The whole point of the arrangement: the LEAD becomes the main pane, not
+	// whichever pane the layout pass happened to leave in column 0.
+	if !strings.Contains(joined, "swap-pane -d -s %1 -t %2") {
+		t.Fatalf("lead not swapped into the main pane:\n%s", joined)
+	}
+	if !strings.Contains(joined, "select-pane -t %1\n") && !strings.HasSuffix(joined, "select-pane -t %1") {
+		t.Fatalf("focus not restored to the lead pane:\n%s", joined)
+	}
 	if strings.Contains(joined, "even-horizontal") || strings.Contains(joined, "even-vertical") || strings.Contains(joined, "tiled") {
 		t.Fatalf("generic layout pass must not run alongside lead-main:\n%s", joined)
+	}
+}
+
+// When the layout pass already left the lead in the main column, no swap runs
+// -- swapping unconditionally would move the lead OUT of the main pane.
+func TestRunTmuxCurrentWindowLeadMainSkipsSwapWhenLeadAlreadyMain(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "show-options":
+			return "", nil
+		case len(args) > 0 && args[0] == "split-window":
+			return "%2\n", nil
+		case strings.Contains(call, "#{window_width}"):
+			return "200\n", nil
+		case len(args) > 0 && args[0] == "list-panes":
+			return "%1\t0\n%2\t121\n", nil
+		case strings.Contains(call, "#{pane_left}"):
+			return "%1\t0\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	if err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		LeadMainCurrentWindow: true,
+		Panes:                 []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if joined := strings.Join(*runCalls, "\n"); strings.Contains(joined, "swap-pane") {
+		t.Fatalf("swap-pane must not run when the lead already holds the main pane:\n%s", joined)
+	}
+}
+
+// A failed arrangement rolls back the created panes AND the window option it
+// mutated: the operator's own window must not keep a stray main-pane-width
+// after a launch that reported failure.
+func TestRunTmuxCurrentWindowLeadMainFailureRestoresWindowOptions(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "show-options":
+			return "", nil
+		case len(args) > 0 && args[0] == "split-window":
+			return "%2\n", nil
+		case strings.Contains(call, "#{window_width}"):
+			return "200\n", nil
+		case len(args) > 0 && args[0] == "list-panes":
+			return "%2\t0\n%1\t121\n", nil
+		case strings.Contains(call, "#{pane_left}"):
+			// Verification probe: the lead is NOT in the main column even
+			// after the swap -- the arrangement must fail, not shrug.
+			return "%1\t121\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		LeadMainCurrentWindow: true,
+		Panes:                 []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "did not land in the main column") {
+		t.Fatalf("unverified lead-main arrangement unexpectedly accepted: %v", err)
+	}
+	joined := strings.Join(*runCalls, "\n")
+	if !strings.Contains(joined, "set-option -w -u -t loco:1 main-pane-width") {
+		t.Fatalf("mutated main-pane-width not restored on failure:\n%s", joined)
+	}
+	if !strings.Contains(joined, "kill-pane -t %2") {
+		t.Fatalf("created worker pane not rolled back on failure:\n%s", joined)
 	}
 }
 

--- a/internal/cli/team_launch_tmux_result_test.go
+++ b/internal/cli/team_launch_tmux_result_test.go
@@ -261,3 +261,84 @@ func TestCompleteTeamLaunchResultFailsClosed(t *testing.T) {
 		})
 	}
 }
+
+// The mid-run member-add default: a current-window plan flagged
+// LeadMainCurrentWindow arranges the window as main-vertical (launcher/lead
+// keeps a full-height left column, added workers stack in rows to its right)
+// with a best-effort 60% main-pane-width, and does NOT run the generic
+// even-layout pass. A single added worker still gets the arrangement — the
+// window already holds the lead — where the legacy path applied no layout at
+// all.
+func TestRunTmuxCurrentWindowLeadMainAppliesMainVertical(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	nextPane := 1
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "split-window":
+			nextPane++
+			return fmt.Sprintf("%%%d\n", nextPane), nil
+		case strings.Contains(call, "#{window_width}"):
+			return "200\n", nil
+		case strings.Contains(call, "#{window_id}"):
+			return "@7\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	if err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		LeadMainCurrentWindow: true,
+		Panes:                 []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(*runCalls, "\n")
+	if !strings.Contains(joined, "set-option -w -t loco:1 main-pane-width 120") {
+		t.Fatalf("main-pane-width not set to 60%% of window width:\n%s", joined)
+	}
+	if !strings.Contains(joined, "select-layout -t loco:1 main-vertical") {
+		t.Fatalf("main-vertical not applied:\n%s", joined)
+	}
+	if strings.Contains(joined, "even-horizontal") || strings.Contains(joined, "even-vertical") || strings.Contains(joined, "tiled") {
+		t.Fatalf("generic layout pass must not run alongside lead-main:\n%s", joined)
+	}
+}
+
+// Without the flag (explicit --layout, non-orchestrated, or a lead launch),
+// current-window keeps its legacy behavior: no layout pass for a single pane.
+func TestRunTmuxCurrentWindowWithoutLeadMainKeepsLegacyLayout(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "split-window":
+			return "%2\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	if err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		Panes: []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if joined := strings.Join(*runCalls, "\n"); strings.Contains(joined, "select-layout") || strings.Contains(joined, "main-pane-width") {
+		t.Fatalf("single-pane legacy path must not apply a layout:\n%s", joined)
+	}
+}

--- a/internal/cli/team_launch_tmux_result_test.go
+++ b/internal/cli/team_launch_tmux_result_test.go
@@ -417,6 +417,98 @@ func TestRunTmuxCurrentWindowLeadMainFailureRestoresWindowOptions(t *testing.T) 
 	}
 }
 
+// A window that already carried a LOCAL main-pane-width gets that exact value
+// back on failure — unsetting it would destroy operator configuration, and
+// restoring the inherited effective value would freeze a default into a local
+// override.
+func TestRunTmuxCurrentWindowLeadMainFailureRestoresPreexistingWidth(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "show-options":
+			// Only locally-set window options are listed; this window has one.
+			return "pane-border-status top\nmain-pane-width 90\n", nil
+		case len(args) > 0 && args[0] == "split-window":
+			return "%2\n", nil
+		case strings.Contains(call, "#{window_width}"):
+			return "200\n", nil
+		case len(args) > 0 && args[0] == "list-panes":
+			return "%2\t0\n%1\t121\n", nil
+		case strings.Contains(call, "#{pane_left}"):
+			return "%1\t121\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		LeadMainCurrentWindow: true,
+		Panes:                 []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	})
+	if err == nil {
+		t.Fatal("unverified lead-main arrangement unexpectedly accepted")
+	}
+	joined := strings.Join(*runCalls, "\n")
+	if !strings.Contains(joined, "set-option -w -t loco:1 main-pane-width 90") {
+		t.Fatalf("pre-existing local main-pane-width 90 not restored on failure:\n%s", joined)
+	}
+	if strings.Contains(joined, "set-option -w -u -t loco:1 main-pane-width") {
+		t.Fatalf("pre-existing local main-pane-width unset instead of restored:\n%s", joined)
+	}
+}
+
+// When the local-option snapshot itself fails, the width must not be touched
+// at all: a mutation whose baseline is unknown cannot be undone, and undoing
+// on a guessed baseline could destroy a pre-existing local value. The layout
+// still applies — the width is best-effort by contract.
+func TestRunTmuxCurrentWindowLeadMainSkipsWidthWhenSnapshotFails(t *testing.T) {
+	stubExactPaneInspection(t)
+	t.Setenv("TMUX", "/tmp/fake-tmux,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	runCalls := stubTmuxResultCommands(t, func(name string, args ...string) (string, error) {
+		call := strings.Join(args, " ")
+		switch {
+		case strings.Contains(call, "#{session_name}:#{window_index}"):
+			return "loco:1\n", nil
+		case len(args) > 0 && args[0] == "show-options":
+			return "", fmt.Errorf("show-options failed")
+		case len(args) > 0 && args[0] == "split-window":
+			return "%2\n", nil
+		case len(args) > 0 && args[0] == "list-panes":
+			return "%2\t0\n%1\t121\n", nil
+		case strings.Contains(call, "#{pane_left}"):
+			return "%1\t0\n", nil
+		case strings.Contains(call, "#{pane_pid}"), strings.Contains(call, "#{pane_dead}"):
+			return fakePaneIdentityReply(args), nil
+		default:
+			return "", fmt.Errorf("unexpected output command: %s %s", name, call)
+		}
+	})
+
+	if err := runTmuxLaunchPlan(tmuxLaunchPlan{
+		Session: "unused", Workstream: "omri-mem", Target: "current-window", Layout: "vertical",
+		LeadMainCurrentWindow: true,
+		Panes:                 []teamLaunchPane{{Role: "researcher", CWD: "/repo", Command: "worker-command"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(*runCalls, "\n")
+	if strings.Contains(joined, "main-pane-width") {
+		t.Fatalf("main-pane-width mutated despite a failed snapshot:\n%s", joined)
+	}
+	if !strings.Contains(joined, "select-layout -t loco:1 main-vertical") {
+		t.Fatalf("main-vertical must still apply without the width:\n%s", joined)
+	}
+}
+
 // Without the flag (explicit --layout, non-orchestrated, or a lead launch),
 // current-window keeps its legacy behavior: no layout pass for a single pane.
 func TestRunTmuxCurrentWindowWithoutLeadMainKeepsLegacyLayout(t *testing.T) {

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -259,6 +259,9 @@ type resumeExecOptions struct {
 	// launches (--skip-lead-check). Recovery escape hatch for a stale recorded
 	// lead runtime identity (#655); goal redelivery still verifies the lead.
 	SkipLeadCheck bool
+	// LayoutExplicit records that the operator passed --layout, which opts a
+	// current-window mid-run add out of the default lead-main arrangement.
+	LayoutExplicit bool
 }
 
 type resumeExecLaunchCheck struct {
@@ -765,6 +768,11 @@ func execResumePlan(t team.Team, profile, workstream string, plans []resumePlan,
 		Panes:                panes,
 		StartDelay:           opts.Stagger,
 		AllowExistingSession: true,
+		// Candidate only: the lead gate clears it unless this launch is the
+		// mid-run member-add signature (orchestrated, lead already live, plan
+		// holds dependents only) — the flow where the launcher pane IS the lead
+		// and the window should keep the lead a full-height left column.
+		LeadMainCurrentWindow: t.Orchestrated && opts.Target == "current-window" && !exec.LayoutExplicit,
 	}
 	if plan.Session == "" {
 		plan.Session = defaultTmuxSessionName(t.Project)
@@ -862,6 +870,10 @@ func verifyResumeGoalPostBaselineReady(results []resumeExecLaunchResult, plan ru
 func runResumeTmuxPlanWithLeadGate(t team.Team, profile, workstream string, plan tmuxLaunchPlan, checks []resumeExecLaunchCheck, snapshots map[string]resumeExecLaunchSnapshot, skipLeadCheck bool) ([]resumeExecLaunchResult, error) {
 	leadRole := strings.TrimSpace(t.Lead)
 	if !t.Orchestrated || !resumePlanHasDependents(plan, leadRole) {
+		// Not the mid-run add signature (non-orchestrated, or a lead-only
+		// plan): the launcher pane is not established as the lead, so the
+		// lead-main arrangement does not apply.
+		plan.LeadMainCurrentWindow = false
 		if err := runTmuxLaunchPlanForResume(plan); err != nil {
 			return nil, err
 		}
@@ -894,6 +906,11 @@ func runResumeTmuxPlanWithLeadGate(t team.Team, profile, workstream string, plan
 		}
 		return verifyResumeExecLaunchRecordsNow(checks, snapshots), nil
 	}
+
+	// The lead itself is being (re)launched: the launcher pane is the
+	// operator's shell, not the lead, so neither the lead plan nor the
+	// dependent plan gets the lead-main arrangement.
+	plan.LeadMainCurrentWindow = false
 
 	leadPlan := plan
 	leadPlan.Panes = []teamLaunchPane{leadPane}

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -302,6 +302,7 @@ var (
 	runTmuxLaunchPlanForResume       = runTmuxLaunchPlan
 	verifyResumeExecLaunchRecordsNow = verifyResumeExecLaunchRecords
 	verifyResumeLeadReadyNow         = verifyResumeLeadReady
+	resumeLaunchedFromLeadPaneNow    = resumeLaunchedFromLeadPane
 	resumeExecLaunchVerifyTimeout    = 5 * time.Second
 	resumeExecLaunchVerifyInterval   = 100 * time.Millisecond
 	resumeLeadReadyTimeout           = 5 * time.Second
@@ -898,8 +899,20 @@ func runResumeTmuxPlanWithLeadGate(t team.Team, profile, workstream string, plan
 	if !leadPlanned {
 		if skipLeadCheck {
 			warnSkippedLeadGate()
+			// The bypass launches with NO lead verified at all, so nothing
+			// establishes the launcher pane as the lead's: never rearrange
+			// the caller's window on unproven identity.
+			plan.LeadMainCurrentWindow = false
 		} else if err := verifyResumeLeadReadyNow(leadCheck); err != nil {
 			return nil, fmt.Errorf("lead readiness failed for %s before dependent launch: %w (a stale lead record can be bypassed with --skip-lead-check)", leadRole, err)
+		}
+		// The readiness gate proves the lead is live SOMEWHERE; the lead-main
+		// arrangement additionally requires that this resume is running INSIDE
+		// the lead's recorded pane. Without that tie, a resume issued from an
+		// operator shell or worker pane would rearrange the CALLER's window as
+		// if it were the lead's.
+		if plan.LeadMainCurrentWindow && !resumeLaunchedFromLeadPaneNow(leadCheck) {
+			plan.LeadMainCurrentWindow = false
 		}
 		if err := runTmuxLaunchPlanForResume(plan); err != nil {
 			return nil, err
@@ -1003,6 +1016,25 @@ func resumeLeadLaunchCheck(t team.Team, profile, workstream string, checks []res
 // fresh launch record: a live matching agent process (or a registered external
 // lead) and a live addressable tmux pane. Bootstrap acknowledgement is not part
 // of Simple Mode readiness.
+// resumeLaunchedFromLeadPane reports whether this resume process is running
+// inside the lead's recorded tmux pane. It compares the lead launch record's
+// pane id against the invoking process's $TMUX_PANE — both exact tmux pane
+// ids — and fails closed on any missing side: no record, no recorded pane, or
+// a resume issued outside tmux all mean the launcher pane is NOT established
+// as the lead's.
+func resumeLaunchedFromLeadPane(check resumeExecLaunchCheck) bool {
+	current := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	if current == "" {
+		return false
+	}
+	rec, err := launch.Read(check.AgentDir)
+	if err != nil || rec.Tmux == nil {
+		return false
+	}
+	recorded := strings.TrimSpace(rec.Tmux.PaneID)
+	return recorded != "" && recorded == current
+}
+
 func verifyResumeLeadReady(check resumeExecLaunchCheck) error {
 	deadline := time.Now().Add(resumeLeadReadyTimeout)
 	last := "lead readiness evidence unavailable"

--- a/plugins/claude/skills/orchestrator/LEARNINGS.md
+++ b/plugins/claude/skills/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/claude/skills/orchestrator/LEARNINGS.md
+++ b/plugins/claude/skills/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -118,6 +118,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -139,6 +156,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -98,15 +98,22 @@ Add, after the gate is answered:
 
 ```sh
 amq-squad team member add researcher --binary codex --project P --profile R --session S
-amq-squad resume --project P --profile R --session S --exec --target new-window --role researcher
+amq-squad resume --project P --profile R --session S --exec --role researcher
 ```
+
+Run the resume from your own pane. By default the new member opens as a pane
+in your window, and the window arranges as main-vertical: you keep a
+full-height left column and workers stack in rows to your right. Pass an
+explicit `--layout` to opt out, or `--target new-window` to give the member a
+full-size window instead.
 
 Scope the resume with `--role` so only the new member launches. Without it,
 `resume --exec` brings back **every** non-live member — live roles are
 skipped, but a deliberately stopped role would respawn. Either way the lead's
 own live pane is verified before any dependent spawns.
 `amq-squad team member add ROLE --binary B --launch` runs the unscoped form
-in one command — fine when every other role is live or should be running.
+in one command (its default target is `new-window`) — fine when every other
+role is live or should be running.
 Then dispatch to the new member like any other: durable `todo` on its task
 thread, pane input as wake only.
 

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -101,7 +101,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 

--- a/plugins/codex/skills/orchestrator/LEARNINGS.md
+++ b/plugins/codex/skills/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/codex/skills/orchestrator/LEARNINGS.md
+++ b/plugins/codex/skills/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -114,6 +114,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -135,6 +152,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -94,15 +94,22 @@ Add, after the gate is answered:
 
 ```sh
 amq-squad team member add researcher --binary codex --project P --profile R --session S
-amq-squad resume --project P --profile R --session S --exec --target new-window --role researcher
+amq-squad resume --project P --profile R --session S --exec --role researcher
 ```
+
+Run the resume from your own pane. By default the new member opens as a pane
+in your window, and the window arranges as main-vertical: you keep a
+full-height left column and workers stack in rows to your right. Pass an
+explicit `--layout` to opt out, or `--target new-window` to give the member a
+full-size window instead.
 
 Scope the resume with `--role` so only the new member launches. Without it,
 `resume --exec` brings back **every** non-live member — live roles are
 skipped, but a deliberately stopped role would respawn. Either way the lead's
 own live pane is verified before any dependent spawns.
 `amq-squad team member add ROLE --binary B --launch` runs the unscoped form
-in one command — fine when every other role is live or should be running.
+in one command (its default target is `new-window`) — fine when every other
+role is live or should be running.
 Then dispatch to the new member like any other: durable `todo` on its task
 thread, pane input as wake only.
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -97,7 +97,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 

--- a/plugins/skills-src/orchestrator/LEARNINGS.md
+++ b/plugins/skills-src/orchestrator/LEARNINGS.md
@@ -19,10 +19,12 @@ were live with claimed tasks. The default at `member add` is `review`; the
 grant was the mistake, and for talking-points work no grant was needed at all.
 
 **Bare `agent up` produces a ghost seat.** One of the two seats was launched
-with `agent up` directly (the un-managed option `member add`'s own output
-offers), so it runs with a mailbox, a pane, and a claimed task — but no
-`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
-and an operator reading the roster undercounts the live squad. Squad seats go
+with `agent up` directly, with no prior `member add` — so it runs with a
+mailbox, a pane, and a claimed task, but no `team.json` entry. (`member add`
+itself persists the roster entry before printing its `agent up` hint, so that
+path still leaves a rostered seat; only the bare launch skips the roster.)
+Roster-scoped `member rm`/`update`/`resume` cannot see a ghost seat, and an
+operator reading the roster undercounts the live squad. Squad seats go
 through the roster, always.
 
 ---

--- a/plugins/skills-src/orchestrator/LEARNINGS.md
+++ b/plugins/skills-src/orchestrator/LEARNINGS.md
@@ -5,6 +5,28 @@ table in `SKILL.md` once they generalise.
 
 ---
 
+## Dynamic membership, first field run (v2.29.0 day one)
+
+A fresh PM-copilot lead grew its roster to three seats within minutes of launch
+and hit two traps the same hour, both invisible until `doctor`:
+
+**Implementation grants collide silently on the mid-run path.** The lead gave
+both new seats `--actor-mode implementation` in the shared project cwd. `start`
+would have refused that roster fail-closed (worktree isolation), but the seats
+were launched via `resume --exec` after `member add`, which runs no isolation
+preflight — `doctor` reported `worktree/shared-index-collision` only after both
+were live with claimed tasks. The default at `member add` is `review`; the
+grant was the mistake, and for talking-points work no grant was needed at all.
+
+**Bare `agent up` produces a ghost seat.** One of the two seats was launched
+with `agent up` directly (the un-managed option `member add`'s own output
+offers), so it runs with a mailbox, a pane, and a claimed task — but no
+`team.json` entry. Roster-scoped `member rm`/`update`/`resume` cannot see it,
+and an operator reading the roster undercounts the live squad. Squad seats go
+through the roster, always.
+
+---
+
 ## Observation should not cost turns
 
 A hand-rolled polling loop spends one model turn per tick, indefinitely. Simple Mode

--- a/plugins/skills-src/orchestrator/SKILL.md
+++ b/plugins/skills-src/orchestrator/SKILL.md
@@ -114,6 +114,23 @@ at launch the staged file seeds the agent's `role.md` verbatim, frontmatter
 included) before the add; with no file, launch generates a neutral contract
 that defers scope to team rules, the brief, and the dispatched task.
 
+Two constraints on the seats you add:
+
+- **Actor mode is a grant, not a label.** `member add` defaults to `review`
+  (read-only). Grant `--actor-mode implementation` only to a seat that will
+  edit files, and know the cost: two mutation-capable seats sharing one
+  working directory share one Git index, and `start`'s fail-closed isolation
+  preflight does NOT guard the mid-run `resume --exec` path — the collision
+  surfaces only in `doctor`. Before two implementers work concurrently, give
+  each its own cwd (`member add --cwd`, or the worktree plan/materialize
+  commands doctor names). A seat that only researches, reviews, or reports
+  needs no grant at all.
+- **Always add through the roster.** `member add` + scoped resume, or
+  `add --launch` — never bare `agent up` for a squad seat. An agent-up seat
+  gets a mailbox and a pane but no roster entry, so `member rm`,
+  `member update`, and roster-scoped `resume` cannot manage it, and the next
+  operator to read `team.json` cannot see it exists.
+
 Remove, when a seat's work is complete and its evidence is linked:
 
 ```sh
@@ -135,6 +152,8 @@ rerun `start` — only the missing role respawns.
 | Evidence recorded but not linked to the task | A blocker completed mid-run and changed the task record | `amq-squad evidence recover TASK ATTEMPT --me H --session S`. Under parallel work this is a **normal** step, not a repair |
 | `evidence run` rejects your worktree | Its cwd must be inside the project; a sibling worktree is refused | Create a detached worktree under the project, record there, and keep it alive until `task done` completes |
 | `task done` fails on a command-subject snapshot | The evidence cwd was removed before DONE ran | Recreate the same detached worktree at the same SHA, re-run DONE, then clean up |
+| `doctor` fails `worktree/shared-index-collision` after mid-run adds | Two implementation-mode seats share one cwd; the mid-run launch path does not run `start`'s isolation preflight | Downgrade non-editing seats to `--actor-mode review`, or give each implementer its own cwd before concurrent mutation |
+| A live seat is missing from `team.json` | It was launched with bare `agent up`, not `member add` | Register it: `team member add ROLE --binary B` with the same role/handle, then manage it through the roster |
 
 ## Recovery
 

--- a/plugins/skills-src/orchestrator/SKILL.md
+++ b/plugins/skills-src/orchestrator/SKILL.md
@@ -94,15 +94,22 @@ Add, after the gate is answered:
 
 ```sh
 amq-squad team member add researcher --binary codex --project P --profile R --session S
-amq-squad resume --project P --profile R --session S --exec --target new-window --role researcher
+amq-squad resume --project P --profile R --session S --exec --role researcher
 ```
+
+Run the resume from your own pane. By default the new member opens as a pane
+in your window, and the window arranges as main-vertical: you keep a
+full-height left column and workers stack in rows to your right. Pass an
+explicit `--layout` to opt out, or `--target new-window` to give the member a
+full-size window instead.
 
 Scope the resume with `--role` so only the new member launches. Without it,
 `resume --exec` brings back **every** non-live member — live roles are
 skipped, but a deliberately stopped role would respawn. Either way the lead's
 own live pane is verified before any dependent spawns.
 `amq-squad team member add ROLE --binary B --launch` runs the unscoped form
-in one command — fine when every other role is live or should be running.
+in one command (its default target is `new-window`) — fine when every other
+role is live or should be running.
 Then dispatch to the new member like any other: durable `todo` on its task
 thread, pane input as wake only.
 

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -97,7 +97,11 @@ instead.
 Before previewing, resolve each member's role, handle, binary, model, actor mode,
 tool profile, session pin, and working directory from the selected profile. A roster
 with two or more mutation-capable actors needs isolated worktrees unless the profile
-records an explicit shared-CWD exception.
+records an explicit shared-CWD exception. `start` enforces that isolation fail-closed,
+but the mid-run add path (`member add` + `resume --exec`) does not: `member add`
+defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
+shared cwd surfaces only as a `doctor` failure — give each implementer its own
+`--cwd` at add time.
 
 For a named roster, create it with explicit coordinates and isolation:
 


### PR DESCRIPTION
Held for the **v2.29.1 train** (base: `v2.29.1-train`), like #663.

## Problem (field feedback, first v2.29.0 dynamic-membership run)

Workers the lead adds mid-run open as panes in the lead's window (`resume --exec` default target `current-window`) — but a single added pane gets **no layout pass at all** (`select-layout` only ran for 2+ new panes), so splits land arbitrarily and the lead's column shrinks unpredictably as the roster grows.

## Fix

New default for the **mid-run member-add signature only** — orchestrated team + `current-window` + lead already live (plan holds dependents only) + no explicit `--layout`:

- after panes spawn, the window arranges as tmux `main-vertical`: the launching pane (the lead in this flow) keeps a full-height left column at ~60% width (best-effort `main-pane-width` computed from `#{window_width}`; layout still applies if the read fails), added workers stack in rows to its right
- the generic even-layout pass is skipped for this case

Everything else keeps legacy behavior, enforced by a candidate-flag pattern: `execResumePlan` sets `LeadMainCurrentWindow` only for orchestrated current-window plans without explicit `--layout`, and `runResumeTmuxPlanWithLeadGate` **clears** it for lead-only plans and full lead+dependent relaunches (where the launcher pane is the operator, not the lead). Non-current-window targets ignore the flag. `--layout` is the explicit opt-out (`LayoutExplicit` threaded through `resumeExecOptions`).

The user-requested alternative (lead inspects pane geometry and decides) was considered and rejected as overkill — `main-vertical` is exactly "lead full-height left, workers in rows right" natively.

## Tests

- `TestRunTmuxCurrentWindowLeadMainAppliesMainVertical`: main-pane-width 60% + `main-vertical` applied, generic layouts suppressed, single-pane add included
- `TestRunTmuxCurrentWindowWithoutLeadMainKeepsLegacyLayout`: legacy single-pane path unchanged
- `TestRunResumeTmuxPlanLeadMainOnlyForDependentOnlyLaunch`: flag survives only the dependents-only shape; cleared for lead-only and lead+dependents relaunches

## Docs

- orchestrator skill: the dynamic-membership add example now uses the default pane-in-your-window arrangement (`--role`-scoped resume, no `--target`), with `--target new-window` and explicit `--layout` documented as alternatives
- `resume` help text documents the default and opt-out

`make ci` skill gates green (64 documented invocations execute cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)