### PR TITLE
fix(dispatch): use canonical team root for worktree-cwd members (Fixes #681)

### DIFF
--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -250,13 +250,12 @@ Examples:
 		}
 	}
 
-	// Resolve the workstream root for the SENDER. The durable message lands in
-	// .agent-mail/<workstream> regardless of which session the lead runs from,
-	// so an external lead (no AM_ROOT injected) reaches the child's real mailbox
-	// instead of the default .agent-mail (#152's misroute, the root cause #153
-	// builds on).
-	cwd := member.EffectiveCWD(t.Project)
-	ctx, err := resolveAMQContextForNamespace(cwd, profile, workstream, from)
+	// Resolve the workstream root from the canonical TEAM HOME, not the
+	// recipient's execution cwd. Implementation members commonly run from an
+	// isolated worktree whose project-local .agent-mail is not the squad's
+	// durable namespace. Route and status both treat projectDir/t.Project as the
+	// namespace authority; dispatch must do the same.
+	ctx, err := resolveAMQContextForNamespace(projectDir, profile, workstream, from)
 	if err != nil {
 		return fmt.Errorf("resolve amq root for dispatch: %w", err)
 	}
@@ -310,7 +309,7 @@ Examples:
 	waitPosture := waitPostureForContext("dispatch", "amq_delivery", ctx, waitTimeout, waitFor != "" && waitTimeout == 0, waitFor != "", *overrideWaitPosture, *waitPostureReason)
 	out, sendResult, err := runOwnedAMQSend(ownedAMQSendOptions{
 		WaitPosture: waitPosture,
-	}, amqCommandRequest{Dir: cwd, Env: amqCommandEnv(ctx), Arg: sendCmd})
+	}, amqCommandRequest{Dir: projectDir, Env: amqCommandEnv(ctx), Arg: sendCmd})
 	msgID := sendResult.MessageID
 	if err != nil {
 		if !dispatchSendWaitTimedOut(out, err, waitFor) {
@@ -699,7 +698,7 @@ func teamMemberByRole(t team.Team, role string) (team.Member, bool) {
 // uncertain (no record, no root, dead sidecar) returns false so dispatch falls
 // back to the explicit last-resort pane nudge. Read-only.
 func defaultDispatchRecipientWakeLive(projectDir, profile, session string, explicitSession bool, role string) bool {
-	mr, workstream, err := resolveMemberRuntime(projectDir, profile, session, explicitSession, role)
+	mr, workstream, err := resolveDispatchMemberRuntime(projectDir, profile, session, explicitSession, role)
 	if err != nil || !mr.HasRecord {
 		return false
 	}
@@ -712,7 +711,7 @@ func defaultDispatchRecipientWakeLive(projectDir, profile, session string, expli
 }
 
 func defaultDispatchWakePane(projectDir, profile, session string, explicitSession bool, role string, force bool) (dispatchOutcome, error) {
-	mr, workstream, err := resolveMemberRuntime(projectDir, profile, session, explicitSession, role)
+	mr, workstream, err := resolveDispatchMemberRuntime(projectDir, profile, session, explicitSession, role)
 	if err != nil {
 		return dispatchOutcome{}, err
 	}
@@ -738,7 +737,7 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 		// Don't talk over a working agent: a prompt pushed into a busy pane lands
 		// in a tool-result buffer and is lost. The durable task is still queued,
 		// so skipping is safe — the agent drains it between turns.
-		if busy, berr := tmuxpane.PaneBusy(paneID); berr == nil && busy {
+		if busy, berr := paneBusyForSend(paneID); berr == nil && busy {
 			return dispatchOutcome{Skipped: fmt.Sprintf("pane %s is busy (mid-turn); the agent drains the task when idle, or re-dispatch with --force", paneID)}, nil
 		}
 	}
@@ -746,8 +745,52 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 	if strings.TrimSpace(root) == "" || root == "." {
 		return dispatchOutcome{}, fmt.Errorf("resolve exact AMQ root for dispatch nudge from agent dir %q", mr.AgentDir)
 	}
-	err = tmuxpane.SendPromptToPane(paneID, dispatchNudgePrompt(root))
-	return classifyNudgeResult(paneID, err, tmuxpane.PaneBusy)
+	err = sendPromptToPane(paneID, dispatchNudgePrompt(root))
+	return classifyNudgeResult(paneID, err, paneBusyForSend)
+}
+
+// resolveDispatchMemberRuntime selects the recipient launch record through the
+// same team-home scan and profile/session/team-home/handle authority used by
+// status. Falling back to the legacy runtime resolver preserves support for
+// members with no launch record, while recorded worktree-cwd members no longer
+// get looked up beneath their worktree-local .agent-mail directory.
+func resolveDispatchMemberRuntime(projectDir, profile, session string, explicitSession bool, role string) (memberRuntime, string, error) {
+	t, err := team.ReadProfile(projectDir, profile)
+	if err != nil {
+		return memberRuntime{}, "", fmt.Errorf("read team: %w", err)
+	}
+	workstream, err := resolveTeamWorkstreamName(t, session, explicitSession)
+	if err != nil {
+		return memberRuntime{}, "", err
+	}
+	member, ok := teamMemberByRole(t, role)
+	if !ok {
+		return memberRuntime{}, workstream, fmt.Errorf("no team member with role %q in this team", strings.ToLower(strings.TrimSpace(role)))
+	}
+	entries, scanErr := launch.ScanEntries(t.Project)
+	if scanErr != nil {
+		return memberRuntime{}, workstream, fmt.Errorf("scan launch records: %w", scanErr)
+	}
+	selection := selectStatusLaunchRecord(t, profile, member, workstream, defaultDuplicateLaunchProbe, entries)
+	if len(selection.DuplicatePaths) > 0 {
+		return memberRuntime{}, workstream, fmt.Errorf("multiple authoritative live launch records for %s: %s", memberHandle(member), strings.Join(selection.DuplicatePaths, ", "))
+	}
+	if !selection.Found {
+		return resolveMemberRuntime(projectDir, profile, session, explicitSession, role)
+	}
+	rec := selection.Entry.Record
+	handle := strings.TrimSpace(rec.Handle)
+	if handle == "" {
+		handle = memberHandle(member)
+	}
+	cwd := member.EffectiveCWD(t.Project)
+	if strings.TrimSpace(rec.CWD) != "" {
+		cwd = rec.CWD
+	}
+	return memberRuntime{
+		Member: member, Profile: profile, Handle: handle, CWD: cwd,
+		AgentDir: selection.Entry.AgentDir, HasRecord: true, Record: rec,
+	}, workstream, nil
 }
 
 // classifyNudgeResult maps a pane-nudge result to a dispatchOutcome. A

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -741,7 +741,11 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 			return dispatchOutcome{Skipped: fmt.Sprintf("pane %s is busy (mid-turn); the agent drains the task when idle, or re-dispatch with --force", paneID)}, nil
 		}
 	}
-	root := filepath.Dir(filepath.Dir(mr.AgentDir))
+	// Status's launch scan can preserve the lexical team-home path (for example
+	// /var/... on Darwin) even when AMQ resolved the durable root through that
+	// symlink (/private/var/...). Keep the fallback prompt on the same canonical
+	// root as the durable send so the receiving shell drains the exact namespace.
+	root := canonicalFilesystemPath(filepath.Dir(filepath.Dir(mr.AgentDir)))
 	if strings.TrimSpace(root) == "" || root == "." {
 		return dispatchOutcome{}, fmt.Errorf("resolve exact AMQ root for dispatch nudge from agent dir %q", mr.AgentDir)
 	}

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -71,9 +71,12 @@ type dispatchEnvelopeData struct {
 	Nudge     dispatchOutcome `json:"nudge"`
 }
 
-// dispatchWakePane delivers a rooted dispatchNudgePrompt to a member's live pane. It is a
-// package var so tests can drive runDispatch without a tmux server.
-var dispatchWakePane = defaultDispatchWakePane
+// dispatchWakePane delivers a rooted dispatchNudgePrompt to a member's live
+// pane. dispatchRoot is the already-resolved durable-send root; carrying it
+// across the nudge boundary prevents fallback runtime discovery from selecting
+// a different mailbox below a worktree cwd. It is a package var so tests can
+// drive runDispatch without a tmux server.
+var dispatchWakePane = defaultDispatchWakePaneAtRoot
 
 // dispatchRecipientWakeLive reports whether the dispatch recipient currently has
 // a positively-live wake sidecar, so dispatch can rely on durable AMQ + wake
@@ -446,7 +449,7 @@ Examples:
 		return nil
 	}
 
-	outcome, werr := dispatchWakePane(projectDir, profile, *sessionFlag, flagWasSet(fs, "session"), *roleFlag, *forceFlag)
+	outcome, werr := dispatchWakePane(projectDir, profile, *sessionFlag, flagWasSet(fs, "session"), *roleFlag, *forceFlag, ctx.Root)
 	if werr != nil {
 		// The durable task is already queued; a wake failure is advisory, not a
 		// dispatch failure. Surface it (warnings bypass quietNotice) so the
@@ -710,11 +713,30 @@ func defaultDispatchRecipientWakeLive(projectDir, profile, session string, expli
 	return live.Signals.WakeAlive
 }
 
+// defaultDispatchWakePane is retained for direct runtime-control callers and
+// tests. Production dispatch already owns the authoritative durable-send root
+// and calls defaultDispatchWakePaneAtRoot so send and nudge cannot diverge.
 func defaultDispatchWakePane(projectDir, profile, session string, explicitSession bool, role string, force bool) (dispatchOutcome, error) {
 	mr, workstream, err := resolveDispatchMemberRuntime(projectDir, profile, session, explicitSession, role)
 	if err != nil {
 		return dispatchOutcome{}, err
 	}
+	ctx, err := resolveAMQContextForNamespace(projectDir, profile, workstream, mr.Handle)
+	if err != nil {
+		return dispatchOutcome{}, fmt.Errorf("resolve exact AMQ root for dispatch nudge: %w", err)
+	}
+	return dispatchWakePaneForRuntime(mr, workstream, force, ctx.Root)
+}
+
+func defaultDispatchWakePaneAtRoot(projectDir, profile, session string, explicitSession bool, role string, force bool, dispatchRoot string) (dispatchOutcome, error) {
+	mr, workstream, err := resolveDispatchMemberRuntime(projectDir, profile, session, explicitSession, role)
+	if err != nil {
+		return dispatchOutcome{}, err
+	}
+	return dispatchWakePaneForRuntime(mr, workstream, force, dispatchRoot)
+}
+
+func dispatchWakePaneForRuntime(mr memberRuntime, workstream string, force bool, dispatchRoot string) (dispatchOutcome, error) {
 	if reason, disabled := mr.nativePromptInjectionDisabledReason(); disabled {
 		return dispatchOutcome{Skipped: reason + "; durable AMQ dispatch was queued"}, nil
 	}
@@ -741,13 +763,13 @@ func defaultDispatchWakePane(projectDir, profile, session string, explicitSessio
 			return dispatchOutcome{Skipped: fmt.Sprintf("pane %s is busy (mid-turn); the agent drains the task when idle, or re-dispatch with --force", paneID)}, nil
 		}
 	}
-	// Status's launch scan can preserve the lexical team-home path (for example
-	// /var/... on Darwin) even when AMQ resolved the durable root through that
-	// symlink (/private/var/...). Keep the fallback prompt on the same canonical
-	// root as the durable send so the receiving shell drains the exact namespace.
-	root := canonicalFilesystemPath(filepath.Dir(filepath.Dir(mr.AgentDir)))
+	// Canonicalize the authoritative durable-send root (for example /var/... to
+	// /private/var/... on Darwin). Never derive it from mr.AgentDir: the no-record
+	// fallback may construct AgentDir below a worktree-local .agent-mail even
+	// though the durable message was sent to the canonical team-home namespace.
+	root := canonicalFilesystemPath(dispatchRoot)
 	if strings.TrimSpace(root) == "" || root == "." {
-		return dispatchOutcome{}, fmt.Errorf("resolve exact AMQ root for dispatch nudge from agent dir %q", mr.AgentDir)
+		return dispatchOutcome{}, fmt.Errorf("resolve exact AMQ root for dispatch nudge from durable-send root %q", dispatchRoot)
 	}
 	err = sendPromptToPane(paneID, dispatchNudgePrompt(root))
 	return classifyNudgeResult(paneID, err, paneBusyForSend)

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -668,7 +668,7 @@ func TestDefaultDispatchWakePaneUsesStatusRecordForWorktreeMember(t *testing.T) 
 	if sentPane != "%7" {
 		t.Fatalf("nudge pane = %q, want %%7", sentPane)
 	}
-	if !strings.Contains(sentPrompt, "--root "+shellQuote(canonicalRoot)) {
+	if !strings.Contains(sentPrompt, "--root "+shellQuote(canonicalFilesystemPath(canonicalRoot))) {
 		t.Fatalf("nudge prompt root is not canonical: %q", sentPrompt)
 	}
 	worktreeRoot := filepath.Join(worktree, ".agent-mail", profile, session)

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -590,6 +590,78 @@ func TestRunDispatchWorktreeMemberUsesCanonicalTeamRoot(t *testing.T) {
 	}
 }
 
+func TestRunDispatchWorktreeMemberWithoutLaunchRecordNudgesCanonicalSendRoot(t *testing.T) {
+	teamHome := t.TempDir()
+	worktree := t.TempDir()
+	const session = "issue-96"
+	if err := team.WriteProfile(teamHome, team.DefaultProfile, team.Team{
+		Project:      teamHome,
+		Workstream:   session,
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: session, CWD: worktree},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-worktree-no-record to qa\n")
+	pane := tmuxpane.TmuxPane{
+		Session: "amq-squad", Window: "7", Pane: "0", WindowID: "@7", PaneID: "%7",
+		CWD: worktree, Title: paneTitleToken(session, "qa"),
+	}
+	oldLister, oldBusy, oldSend := statusPaneLister, paneBusyForSend, sendPromptToPane
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return []tmuxpane.TmuxPane{pane}, nil }
+	paneBusyForSend = func(string) (bool, error) { return false, nil }
+	var sentPane, sentPrompt string
+	sendPromptToPane = func(paneID, prompt string) error {
+		sentPane, sentPrompt = paneID, prompt
+		return nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister, paneBusyForSend, sendPromptToPane = oldLister, oldBusy, oldSend
+	})
+
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{
+			"--project", teamHome,
+			"--session", session,
+			"--role", "qa",
+			"--subject", "worktree no-record nudge root regression",
+			"--body", "run",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("dispatch worktree member without launch record: %v\n%s", err, stdout)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("amq calls = %d, want 1", len(*calls))
+	}
+	sendRoot := amqFlagValue((*calls)[0].Arg, "root")
+	wantRoot := filepath.Join(teamHome, ".agent-mail", session)
+	if sendRoot != wantRoot {
+		t.Fatalf("durable send root = %q, want canonical team root %q", sendRoot, wantRoot)
+	}
+	if sentPane != "%7" {
+		t.Fatalf("nudge pane = %q, want %%7 live title/cwd match", sentPane)
+	}
+	canonicalSendRoot := canonicalFilesystemPath(sendRoot)
+	if !strings.Contains(sentPrompt, "--root "+shellQuote(canonicalSendRoot)) {
+		t.Fatalf("nudge prompt root must equal canonical durable-send root %q: %q", canonicalSendRoot, sentPrompt)
+	}
+	worktreeRoot := filepath.Join(worktree, ".agent-mail", session)
+	if strings.Contains(sentPrompt, worktreeRoot) {
+		t.Fatalf("nudge prompt leaked no-record worktree-local root %q: %q", worktreeRoot, sentPrompt)
+	}
+	result := decodeJSONEnvelope[mutationResult](t, stdout)
+	if result.Data.Root != sendRoot || result.Data.Status != "queued_and_nudged" {
+		t.Fatalf("dispatch result = %+v, want root %q and queued_and_nudged", result.Data, sendRoot)
+	}
+}
+
 func TestDefaultDispatchWakePaneUsesStatusRecordForWorktreeMember(t *testing.T) {
 	teamHome := t.TempDir()
 	worktree := t.TempDir()
@@ -682,7 +754,7 @@ func withDispatchWakeSeam(t *testing.T, outcome dispatchOutcome, err error) *[]s
 	t.Helper()
 	var calls []string
 	prev := dispatchWakePane
-	dispatchWakePane = func(projectDir, profile, session string, explicitSession bool, role string, force bool) (dispatchOutcome, error) {
+	dispatchWakePane = func(projectDir, profile, session string, explicitSession bool, role string, force bool, dispatchRoot string) (dispatchOutcome, error) {
 		calls = append(calls, role)
 		return outcome, err
 	}

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -535,6 +535,148 @@ func writeDispatchTeam(t *testing.T, dir string) {
 	}
 }
 
+func TestRunDispatchWorktreeMemberUsesCanonicalTeamRoot(t *testing.T) {
+	teamHome := t.TempDir()
+	worktree := t.TempDir()
+	const (
+		profile = "review"
+		session = "issue-96"
+	)
+	if err := team.WriteProfile(teamHome, profile, team.Team{
+		Project:      teamHome,
+		Workstream:   session,
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: session, CWD: worktree},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withAMQCommandSeams(t, amqEnv{}, "Sent msg-worktree to qa\n")
+	stdout, _, err := captureOutput(t, func() error {
+		return runDispatch([]string{
+			"--project", teamHome,
+			"--profile", profile,
+			"--session", session,
+			"--role", "qa",
+			"--subject", "worktree root regression",
+			"--body", "run",
+			"--no-wake",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("dispatch worktree member: %v\n%s", err, stdout)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("amq calls = %d, want 1", len(*calls))
+	}
+	canonicalRoot := filepath.Join(teamHome, ".agent-mail", profile, session)
+	if got := amqFlagValue((*calls)[0].Arg, "root"); got != canonicalRoot {
+		t.Fatalf("dispatch root = %q, want canonical team root %q (member worktree %q must not be root authority)", got, canonicalRoot, worktree)
+	}
+	if got := (*calls)[0].Dir; got != teamHome {
+		t.Fatalf("amq send cwd = %q, want canonical team home %q", got, teamHome)
+	}
+	result := decodeJSONEnvelope[mutationResult](t, stdout)
+	if result.Data.Root != canonicalRoot {
+		t.Fatalf("dispatch envelope root = %q, want %q", result.Data.Root, canonicalRoot)
+	}
+	if _, statErr := os.Stat(filepath.Join(worktree, ".agent-mail")); !os.IsNotExist(statErr) {
+		t.Fatalf("dispatch touched worktree-local .agent-mail: %v", statErr)
+	}
+}
+
+func TestDefaultDispatchWakePaneUsesStatusRecordForWorktreeMember(t *testing.T) {
+	teamHome := t.TempDir()
+	worktree := t.TempDir()
+	const (
+		profile = "review"
+		session = "issue-96"
+	)
+	if err := team.WriteProfile(teamHome, profile, team.Team{
+		Project:      teamHome,
+		Workstream:   session,
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: session, CWD: worktree},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	canonicalRoot := filepath.Join(teamHome, ".agent-mail", profile, session)
+	canonicalAgentDir := filepath.Join(canonicalRoot, "agents", "qa")
+	if err := launch.Write(canonicalAgentDir, launch.Record{
+		CWD: worktree, Binary: "codex", Session: session, Handle: "qa", Role: "qa",
+		Root: canonicalRoot, BaseRoot: filepath.Dir(canonicalRoot), TeamProfile: profile,
+		TeamHome: teamHome, AgentPID: 4242,
+		Tmux: &launch.TmuxInfo{Session: "amq-squad", WindowID: "@7", PaneID: "%7"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pane := tmuxpane.TmuxPane{
+		Session: "amq-squad", Window: "7", Pane: "0", WindowID: "@7", PaneID: "%7",
+		CWD: worktree, Title: paneTitleToken(session, "qa"),
+	}
+	oldLister, oldInspector := statusPaneLister, statusPaneInspector
+	oldBusy, oldSend := paneBusyForSend, sendPromptToPane
+	oldProbe := defaultDuplicateLaunchProbe
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return []tmuxpane.TmuxPane{pane}, nil }
+	statusPaneInspector = func(id string) (tmuxpane.TmuxPane, bool) { return pane, id == pane.PaneID }
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive:     func(pid int) bool { return pid == 4242 },
+		ProcessMatch: func(pid int, _ func(string) bool) bool { return pid == 4242 },
+		ProcessTTY:   func(int) (string, bool) { return "", false },
+		Now:          time.Now,
+	}
+	paneBusyForSend = func(string) (bool, error) { return false, nil }
+	var sentPane, sentPrompt string
+	sendPromptToPane = func(paneID, prompt string) error {
+		sentPane, sentPrompt = paneID, prompt
+		return nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister, statusPaneInspector = oldLister, oldInspector
+		paneBusyForSend, sendPromptToPane = oldBusy, oldSend
+		defaultDuplicateLaunchProbe = oldProbe
+	})
+	configured, err := team.ReadProfile(teamHome, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qa, ok := teamMemberByRole(configured, "qa")
+	if !ok {
+		t.Fatal("qa member missing")
+	}
+	statusRow := classifyMemberStatus(configured, profile, qa, session, defaultDuplicateLaunchProbe)
+	if statusRow.Status != statusStateLive || statusRow.AgentDir != canonicalAgentDir {
+		t.Fatalf("status classification = %+v, want live canonical launch record", statusRow)
+	}
+
+	outcome, err := defaultDispatchWakePane(teamHome, profile, session, true, "qa", false)
+	if err != nil {
+		t.Fatalf("dispatch wake pane: %v", err)
+	}
+	if outcome.PaneID != "%7" || outcome.Skipped != "" {
+		t.Fatalf("dispatch outcome = %+v, want canonical live pane %%7", outcome)
+	}
+	if sentPane != "%7" {
+		t.Fatalf("nudge pane = %q, want %%7", sentPane)
+	}
+	if !strings.Contains(sentPrompt, "--root "+shellQuote(canonicalRoot)) {
+		t.Fatalf("nudge prompt root is not canonical: %q", sentPrompt)
+	}
+	worktreeRoot := filepath.Join(worktree, ".agent-mail", profile, session)
+	if strings.Contains(sentPrompt, worktreeRoot) {
+		t.Fatalf("nudge prompt leaked worktree-local root %q: %q", worktreeRoot, sentPrompt)
+	}
+}
+
 // withDispatchWakeSeam records the nudge call and returns a canned outcome.
 func withDispatchWakeSeam(t *testing.T, outcome dispatchOutcome, err error) *[]string {
 	t.Helper()


### PR DESCRIPTION
Fixes #681

## What

`amq-squad dispatch --role <member>` for a member whose roster cwd is an isolated worktree delivered the durable todo to the worktree-local `.agent-mail` root and reported a false "no live pane" while the member was live on the canonical team root.

- Durable send now resolves the AMQ namespace from the canonical team home (`projectDir`), the same authority `amq route` and `status` use — never the recipient's execution cwd.
- Wake/pane selection goes through a new `resolveDispatchMemberRuntime` that reuses status's launch-record scan and selection (fail-closed on duplicate authoritative records, legacy resolver fallback for members with no launch record).
- Pane busy/nudge calls use the owned `paneBusyForSend`/`sendPromptToPane` seams instead of raw `tmuxpane` calls.

## Tests

- `TestRunDispatchWorktreeMemberUsesCanonicalTeamRoot` — reproduced red before the fix: asserts the `--root` flag, send cwd, and JSON envelope all use the canonical team root and the worktree-local `.agent-mail` is never created.
- `TestDefaultDispatchWakePaneUsesStatusRecordForWorktreeMember` — wake targets the pane from the canonical launch record, the nudge prompt carries the canonical root, and the worktree-local root never leaks into the prompt.

## Evidence

- Implemented by squad worker `dispatch-dev` in an isolated worktree; exact head reviewed by lead.
- Exact-head `make ci` PASS — evidence `t4-make-ci-ce1941a`, summary sha256 `5a0d0788bebc363526351e38b9707e9496706829d0b5e1c09082659251939c69`.
- Live repro and workaround recorded in #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
