### PR TITLE
feat: raise the supported AMQ floor to 0.60.x (Fixes #677)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.52.2, latest]
+        amq-version: [v0.60.0, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        amq-version: [v0.52.2, latest]
+        amq-version: [v0.60.0, latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/README.html
+++ b/README.html
@@ -1138,7 +1138,7 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#
 <h2 id="requirements">Requirements</h2>
 <ul>
 <li>Go 1.25+</li>
-<li><code>amq</code> 0.52.2 on <code>PATH</code></li>
+<li><code>amq</code> 0.60.0 on <code>PATH</code></li>
 <li><code>tmux</code> on <code>PATH</code> for Tier A managed panes</li>
 <li>macOS with iTerm2 for the Tier B backend</li>
 <li>macOS Terminal.app for the Tier C backend</li>
@@ -1148,12 +1148,11 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb19-1"><a href="#
 <p>amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or
 other goal sources happens in the skills or operator tooling; the core
 binary owns team, runtime, and coordination state.</p>
-<p>AMQ 0.52.x is the supported series, with 0.52.2 as the minimum
-supported release. Both real-AMQ matrices validate pinned v0.52.2 and
+<p>AMQ 0.60.x is the supported series, with 0.60.0 as the minimum
+supported release. Both real-AMQ matrices validate pinned v0.60.0 and
 <code>latest</code>; <code>latest</code> remains a forward-compatibility
-canary and is not a support claim. Every 0.49.x, 0.50.x, and 0.51.x
-release is unsupported, and releases older than 0.52.2 are rejected
-fail-closed. Because the version assertion is skipped for
+canary and is not a support claim. Releases older than 0.60.0 are
+rejected fail-closed. Because the version assertion is skipped for
 <code>latest</code>, the pinned lane is the one that records what was
 proved.</p>
 <table>
@@ -1168,15 +1167,25 @@ proved.</p>
 <tr>
 <td>Queue, routing, receipts, doctor, lifecycle</td>
 <td>Ubuntu</td>
-<td><code>v0.52.2</code>, <code>latest</code></td>
+<td><code>v0.60.0</code>, <code>latest</code></td>
 </tr>
 <tr>
 <td>Native real-PTY wake and teardown</td>
 <td>macOS</td>
-<td><code>v0.52.2</code>, <code>latest</code></td>
+<td><code>v0.60.0</code>, <code>latest</code></td>
 </tr>
 </tbody>
 </table>
+<p>For externally injected lead and orchestrator wakes, new launch
+records use <code>amq wake --retry-until injected</code> and persist
+that retry policy so exact retirement replays the same target identity.
+Legacy records that omit the field retain AMQ's historical
+<code>drained</code> default. AMQ owns lock/state binding, quarantine,
+exact retirement, Darwin running-image identity, safe restart, and newer
+installed-image adoption. amq-squad's cross-platform session notifier
+remains the project-level tmux nudge; <code>amq-keepalive</code> is an
+optional, operator-managed Darwin companion and is not installed or
+supervised by amq-squad.</p>
 <p>AMQ 0.47.1 introduced the supervised <code>coop exec</code> wake
 contract used by every supported release: instead of injecting message
 headers or subjects, managed coop wakes submit the fixed, shell-inert
@@ -1220,7 +1229,7 @@ authorization authority for amq-squad evidence/receipt flows. See the <a
 href="docs/amq-0.51.x-assessment.md">AMQ 0.51.x support
 assessment</a>.</p>
 <p>AMQ 0.42.1 historically introduced the complete injected identity
-contract; 0.52.2 is the supported floor for the 0.52.x series. After
+contract; 0.60.0 is the supported floor for the 0.60.x series. After
 upgrading AMQ, stop and resume/relaunch agents so their parent shells
 refresh the complete identity tuple; a child command cannot repair stale
 parent environment variables. Default-profile sessions use

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ amq-squad completion fish
 ## Requirements
 
 - Go 1.25+
-- `amq` 0.52.2 on `PATH`
+- `amq` 0.60.0 on `PATH`
 - `tmux` on `PATH` for Tier A managed panes
 - macOS with iTerm2 for the Tier B backend
 - macOS Terminal.app for the Tier C backend
@@ -659,17 +659,26 @@ amq-squad is tracker-neutral. Fetching GitHub, Jira, Confluence, or other goal
 sources happens in the skills or operator tooling; the core binary owns team,
 runtime, and coordination state.
 
-AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported
-release. Both real-AMQ matrices validate pinned v0.52.2 and `latest`; `latest`
-remains a forward-compatibility canary and is not a support claim. Every 0.49.x,
-0.50.x, and 0.51.x release is unsupported, and releases older than 0.52.2 are
-rejected fail-closed. Because the version assertion is skipped for `latest`,
-the pinned lane is the one that records what was proved.
+AMQ 0.60.x is the supported series, with 0.60.0 as the minimum supported
+release. Both real-AMQ matrices validate pinned v0.60.0 and `latest`; `latest`
+remains a forward-compatibility canary and is not a support claim. Releases
+older than 0.60.0 are rejected fail-closed. Because the version assertion is
+skipped for `latest`, the pinned lane is the one that records what was proved.
 
 | Real-AMQ lane | Runner | Versions |
 | --- | --- | --- |
-| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.52.2`, `latest` |
-| Native real-PTY wake and teardown | macOS | `v0.52.2`, `latest` |
+| Queue, routing, receipts, doctor, lifecycle | Ubuntu | `v0.60.0`, `latest` |
+| Native real-PTY wake and teardown | macOS | `v0.60.0`, `latest` |
+
+For externally injected lead and orchestrator wakes, new launch records use
+`amq wake --retry-until injected` and persist that retry policy so exact
+retirement replays the same target identity. Legacy records that omit the
+field retain AMQ's historical `drained` default. AMQ owns lock/state binding,
+quarantine, exact retirement, Darwin running-image identity, safe restart, and
+newer installed-image adoption. amq-squad's cross-platform session notifier
+remains the project-level tmux nudge; `amq-keepalive` is an optional,
+operator-managed Darwin companion and is not installed or supervised by
+amq-squad.
 
 AMQ 0.47.1 introduced the supervised `coop exec` wake contract used by every
 supported release: instead of injecting message headers or subjects, managed
@@ -713,7 +722,7 @@ for amq-squad evidence/receipt flows. See the
 [AMQ 0.51.x support assessment](docs/amq-0.51.x-assessment.md).
 
 AMQ 0.42.1 historically introduced the complete injected identity contract;
-0.52.2 is the supported floor for the 0.52.x series. After upgrading AMQ, stop and
+0.60.0 is the supported floor for the 0.60.x series. After upgrading AMQ, stop and
 resume/relaunch agents so their parent shells refresh the complete identity
 tuple; a child command cannot repair stale parent environment variables.
 Default-profile sessions use

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,10 @@ Release changes must go through a PR and `make ci` before merge. `make ci`
 includes a README.html freshness check, so a release that touches `README.md`
 cannot merge without the matching regenerated `README.html` (see step 1).
 
+The supported AMQ series is 0.60.x and the fail-closed minimum is 0.60.0.
+Release validation must keep the doctor floor, active README/CLI-skill policy,
+and both real-AMQ CI matrices aligned on pinned `v0.60.0` plus `latest`.
+
 ## Patch Release Checklist
 
 0. The README carries exactly ONE "What's new" section — the release being
@@ -19,6 +23,9 @@ cannot merge without the matching regenerated `README.html` (see step 1).
    with an `x-release-please-version` marker, so bumping the manifest and running
    `make skills-generate` is sufficient. `make ci` (`skills-check`) fails if a mirror
    drifts from its manifest.
+   Confirm the doctor minimum, README and CLI-skill support text, release-policy
+   checker, and both real-AMQ matrices still agree on AMQ 0.60.0 / `v0.60.0`
+   plus the `latest` canary.
 2. Merge the release PR.
 3. Tag the merge commit:
 

--- a/docs/global-orchestrator-runbook.md
+++ b/docs/global-orchestrator-runbook.md
@@ -9,9 +9,9 @@ The authoritative live-lead skill route is `amq-squad:orchestrator`.
 
 ## Preconditions
 
-- `amq-squad` and AMQ 0.52.2 or newer are on `PATH`. AMQ 0.52.x is the
-  supported series, with 0.52.2 as the minimum supported release. Both real-AMQ
-  matrices validate pinned v0.52.2 and latest; latest remains a
+- `amq-squad` and AMQ 0.60.0 or newer are on `PATH`. AMQ 0.60.x is the
+  supported series, with 0.60.0 as the minimum supported release. Both real-AMQ
+  matrices validate pinned v0.60.0 and latest; latest remains a
   forward-compatibility canary and is not a support claim.
 - Each project has a configured team or named profile.
 - Visible launches run inside managed tmux.

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -706,12 +706,12 @@ version skew.</p>
 only — the overlay verb above generates the flagship case (a
 <code>--settings</code> overlay that trims a worker's plugins/hooks) and
 wires it for you. Plan emission fails fast when a referenced
-<code>--settings</code> file is missing. AMQ 0.52.x is the supported
-series, with 0.52.2 as the minimum supported release. Both real-AMQ
-matrices validate pinned v0.52.2 and <code>latest</code>;
+<code>--settings</code> file is missing. AMQ 0.60.x is the supported
+series, with 0.60.0 as the minimum supported release. Both real-AMQ
+matrices validate pinned v0.60.0 and <code>latest</code>;
 <code>latest</code> remains a forward-compatibility canary and is not a
-support claim. Releases older than 0.52.2 are rejected fail-closed;
-upgrade to v0.52.2 or newer and stop/resume agents so their parent
+support claim. Releases older than 0.60.0 are rejected fail-closed;
+upgrade to v0.60.0 or newer and stop/resume agents so their parent
 shells refresh the complete identity tuple. A child command cannot
 repair stale injected environment. Default profiles use
 <code>AM_ROOT=AM_BASE_ROOT/AM_SESSION</code> with a non-empty

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -255,10 +255,10 @@ Per-member `claude_args` / `codex_args` in `team.json` (v1.8.0+) carry native
 CLI args for one member only — the overlay verb above generates the flagship
 case (a `--settings` overlay that trims a worker's plugins/hooks) and wires it
 for you. Plan emission fails fast when a referenced `--settings` file is
-missing. AMQ 0.52.x is the supported series, with 0.52.2 as the minimum
-supported release. Both real-AMQ matrices validate pinned v0.52.2 and `latest`;
+missing. AMQ 0.60.x is the supported series, with 0.60.0 as the minimum
+supported release. Both real-AMQ matrices validate pinned v0.60.0 and `latest`;
 `latest` remains a forward-compatibility canary and is not a support claim.
-Releases older than 0.52.2 are rejected fail-closed; upgrade to v0.52.2 or
+Releases older than 0.60.0 are rejected fail-closed; upgrade to v0.60.0 or
 newer and stop/resume agents so their parent shells refresh the complete
 identity tuple. A child command cannot repair stale injected environment.
 Default profiles use `AM_ROOT=AM_BASE_ROOT/AM_SESSION` with a non-empty

--- a/internal/cli/deprecation_test.go
+++ b/internal/cli/deprecation_test.go
@@ -95,7 +95,7 @@ if [ "$1" = "env" ]; then
     echo "unexpected cwd: $actual" >&2
     exit 17
   fi
-  printf '{"root":"%s","amq_version":"0.52.2"}\n' "$AMQ_FAKE_ROOT"
+  printf '{"root":"%s","amq_version":"0.60.0"}\n' "$AMQ_FAKE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2
@@ -261,7 +261,7 @@ if [ "$1" = "env" ]; then
     echo "session should not be passed to amq env when named-profile root is explicit: $saw_session" >&2
     exit 18
   fi
-  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.52.2"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
+  printf '{"root":"%s","base_root":"%s","session_name":"issue-96","me":"release-reviewer","amq_version":"0.60.0"}\n' "$AMQ_EXPECT_ROOT" "$AMQ_BASE_ROOT"
   exit 0
 fi
 echo "unexpected amq command: $*" >&2

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -26,7 +26,7 @@ import (
 // expects to interoperate with. Bumped manually when amq-squad starts to
 // depend on newer AMQ behavior; the doctor check compares the running amq
 // binary's reported version against this floor.
-const doctorMinAMQVersion = "0.52.2"
+const doctorMinAMQVersion = "0.60.0"
 
 type doctorStatus string
 
@@ -92,7 +92,7 @@ type doctorExecution struct {
 	Getenv func(name string) string
 	// LookupEnv preserves the distinction between an absent value and an
 	// explicitly empty AM_SESSION. AMQ 0.42.1 introduced that distinction as
-	// part of the injected identity contract; 0.52.2 is the supported floor.
+	// part of the injected identity contract; 0.60.0 is the supported floor.
 	LookupEnv func(name string) (string, bool)
 	// TmuxShowOptions returns the value of a server-scoped tmux option (the seam
 	// behind `tmux show-options -s <name>`). It returns the raw value and ok =
@@ -1207,7 +1207,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy exact-root/sessionless pin (AM_ROOT=AM_BASE_ROOT; AM_SESSION omitted; AM_ME set)"}
 		}
 		if sessionOK && session == "" {
-			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.52.2; a child command cannot repair its parent shell"}
+			return doctorCheck{Name: "amq identity pin", Status: doctorWarn, Detail: "legacy or inconsistent injected AMQ identity pin (AM_SESSION is present but empty); stop and resume/relaunch the agent shell after upgrading to amq 0.60.0; a child command cannot repair its parent shell"}
 		}
 		if session != "" && sameResolvedDir(root, filepath.Join(base, session)) {
 			return doctorCheck{Name: "amq identity pin", Status: doctorOK, Detail: "healthy sessionful pin (AM_ROOT=AM_BASE_ROOT/AM_SESSION; AM_ME set)"}
@@ -1224,7 +1224,7 @@ func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {
 	return doctorCheck{
 		Name:   "amq identity pin",
 		Status: doctorWarn,
-		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.52.2; a child command cannot repair its parent shell",
+		Detail: "legacy or inconsistent injected AMQ identity pin (" + shape + "); stop and resume/relaunch the agent shell after upgrading to amq 0.60.0; a child command cannot repair its parent shell",
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -575,13 +575,13 @@ if [ -n "$AM_ROOT_ID$AM_BASE_ROOT_ID" ]; then
   echo "inherited AMQ root identity metadata leaked" >&2
   exit 92
 fi
-printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.52.2"}'
+printf '%s\n' '{"root":"/mail","base_root":"/mail","amq_version":"0.60.0"}'
 `)
 
 	d := defaultDoctorExecution(t.TempDir())
 	check := doctorCheckAMQVersion(d)
-	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.52.2") {
-		t.Fatalf("doctor amq version check = %+v, want ok 0.52.2", check)
+	if check.Status != doctorOK || !strings.Contains(check.Detail, "amq 0.60.0") {
+		t.Fatalf("doctor amq version check = %+v, want ok 0.60.0", check)
 	}
 	if got := os.Getenv("AMQ_NO_UPDATE_CHECK"); got != "0" {
 		t.Fatalf("parent AMQ_NO_UPDATE_CHECK = %q, want unchanged 0", got)
@@ -637,9 +637,9 @@ func TestExecuteDoctorAMQEnvCommandFails(t *testing.T) {
 	}
 }
 
-func TestExecuteDoctorAMQVersionAccepts0522AndNewerCanary(t *testing.T) {
+func TestExecuteDoctorAMQVersionAccepts0600AndNewerCanary(t *testing.T) {
 	dir := t.TempDir()
-	for _, v := range []string{"0.52.2", "v0.53.0-rc1", "0.53.0", "1.0.0+build51"} {
+	for _, v := range []string{"0.60.0", "v0.61.0-rc1", "0.61.0", "1.0.0+build60"} {
 		d := newDoctorExec(t, dir)
 		d.ResolveAMQEnv = func(string) (amqEnv, error) {
 			return amqEnv{AMQVersion: v, Root: dir}, nil
@@ -657,12 +657,8 @@ func TestExecuteDoctorAMQVersionAccepts0522AndNewerCanary(t *testing.T) {
 	}
 }
 
-// The v2.26.0 floor raise to 0.51.1 makes every 0.49.x and 0.50.x release
-// unsupported, including the previous floor and the immediately preceding
-// 0.51.0 release. The v2.28.1 floor raise to 0.52.2 additionally makes the
-// entire 0.51.x and 0.52.0/0.52.1 line unsupported.
-func TestExecuteDoctorAMQVersionRejectsOlderThan0522(t *testing.T) {
-	for _, version := range []string{"0.42.1", "0.49.9", "0.50.0", "0.50.1", "0.51.0", "0.51.1", "0.52.0", "0.52.1", "0.52.2-rc1"} {
+func TestExecuteDoctorAMQVersionRejectsOlderThan0600(t *testing.T) {
+	for _, version := range []string{"0.42.1", "0.52.2", "0.54.0", "0.57.3", "0.59.1", "0.60.0-rc1"} {
 		t.Run(version, func(t *testing.T) {
 			dir := t.TempDir()
 			d := newDoctorExec(t, dir)
@@ -672,10 +668,10 @@ func TestExecuteDoctorAMQVersionRejectsOlderThan0522(t *testing.T) {
 			var buf bytes.Buffer
 			d.Out = &buf
 			if err := executeDoctor(d); err == nil {
-				t.Fatalf("doctor should fail when amq %s is below the 0.52.2 floor", version)
+				t.Fatalf("doctor should fail when amq %s is below the 0.60.0 floor", version)
 			}
 			amqLine := firstLineWith(buf.String(), "amq version")
-			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.52.2") {
+			if !strings.Contains(amqLine, "fail") || !strings.Contains(amqLine, "older than required 0.60.0") {
 				t.Fatalf("unexpected amq version line: %q\n%s", amqLine, buf.String())
 			}
 			if !strings.Contains(amqLine, "amq upgrade") {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -68,18 +69,22 @@ type signalTerminator struct {
 }
 
 type downTerminatorFactory func(force bool) processTerminator
+type wakeCheckRunner = amqCommandRunner
 
 var (
 	runExactWakeRetire       = runAMQCommand
 	runExactWakeRecoverOwner = runAMQCommand
 	wakeOwnerRecoveryTimeout = 2 * time.Second
 	wakeOwnerRecoveryPoll    = 50 * time.Millisecond
-	// A SIGTERMed wake can take several seconds to finish its locked teardown on
-	// a loaded Darwin runner. Keep the verification bounded, but align it with
-	// the real wake lifecycle deadline so success still requires both a dead PID
-	// and an absent lock rather than treating signal delivery as completion.
-	wakeSelfCleanupTimeout = 8 * time.Second
-	wakeSelfCleanupPoll    = 50 * time.Millisecond
+	// A wake can take well beyond the old 8s filesystem-poll window to finish
+	// its locked teardown on a loaded Darwin runner. AMQ owns that lifecycle, so
+	// down polls its authoritative wake-check classification through a bounded
+	// deadline aligned with the real teardown path. Filesystem fallback is only
+	// for an unavailable check command and needs several consecutive samples.
+	wakeQuiescenceTimeout       = 20 * time.Second
+	wakeQuiescenceCheckTimeout  = 2 * time.Second
+	wakeQuiescencePoll          = 100 * time.Millisecond
+	wakeQuiescenceStableSamples = 5
 )
 
 // newSignalTerminator returns a terminator that sends SIGTERM by default, or
@@ -137,16 +142,16 @@ func signalNameOf(term processTerminator) string {
 func runDown(args []string) error {
 	return runDownWithDeps(args, func(force bool) processTerminator {
 		return newSignalTerminator(force)
-	}, defaultDuplicateLaunchProbe)
+	}, defaultDuplicateLaunchProbe, runAMQCommand)
 }
 
 // runDownWithDeps keeps the production stop dependencies immutable while
 // allowing parser-to-execution tests to supply inert process controls.
-func runDownWithDeps(args []string, terminatorForForce downTerminatorFactory, probe duplicateLaunchProbe) error {
-	return runDownWithPaneDeps(args, terminatorForForce, probe, PaneCleanupDependencies{})
+func runDownWithDeps(args []string, terminatorForForce downTerminatorFactory, probe duplicateLaunchProbe, wakeCheck wakeCheckRunner) error {
+	return runDownWithPaneDeps(args, terminatorForForce, probe, PaneCleanupDependencies{}, wakeCheck)
 }
 
-func runDownWithPaneDeps(args []string, terminatorForForce downTerminatorFactory, probe duplicateLaunchProbe, paneDeps PaneCleanupDependencies) error {
+func runDownWithPaneDeps(args []string, terminatorForForce downTerminatorFactory, probe duplicateLaunchProbe, paneDeps PaneCleanupDependencies, wakeCheck wakeCheckRunner) error {
 	fs := flag.NewFlagSet("down", flag.ContinueOnError)
 	sessionName := fs.String("session", "", "AMQ workstream session name (default: team workstream)")
 	role := fs.String("role", "", "narrow to a single configured role")
@@ -200,6 +205,7 @@ func runDownWithPaneDeps(args []string, terminatorForForce downTerminatorFactory
 		JSON:       *jsonOut,
 		DryRun:     *dryRun,
 		PaneDeps:   paneDeps,
+		WakeCheck:  wakeCheck,
 	})
 }
 
@@ -257,12 +263,17 @@ type downExecution struct {
 	JSON       bool
 	DryRun     bool
 	PaneDeps   PaneCleanupDependencies
+	WakeCheck  wakeCheckRunner
 }
 
 func executeDown(d downExecution) error {
 	verb := d.Verb
 	if verb == "" {
 		verb = "down"
+	}
+	wakeCheck := d.WakeCheck
+	if wakeCheck == nil {
+		wakeCheck = runAMQCommand
 	}
 	t, err := team.ReadProfile(d.ProjectDir, d.Profile)
 	if err != nil {
@@ -370,7 +381,7 @@ func executeDown(d downExecution) error {
 		if d.DryRun {
 			report = previewDownMember(t, d.ProjectDir, d.Profile, m, workstream, d.Terminator, d.Probe)
 		} else {
-			report = terminateMember(t, d.ProjectDir, d.Profile, m, workstream, d.Terminator, d.Probe, exceptionScope, d.ClosePanes, d.PaneDeps)
+			report = terminateMember(t, d.ProjectDir, d.Profile, m, workstream, d.Terminator, d.Probe, exceptionScope, d.ClosePanes, d.PaneDeps, wakeCheck)
 			switch report.Status {
 			case downStatusStopped, downStatusCleaned, downStatusNotLive:
 				if err := markDownLaunchRecordStopped(report, time.Now().UTC()); err != nil {
@@ -653,7 +664,7 @@ func previewDownMember(t team.Team, projectDir, profile string, m team.Member, w
 	return report
 }
 
-func terminateMember(t team.Team, projectDir, profile string, m team.Member, workstream string, term processTerminator, probe duplicateLaunchProbe, exactDownScope *exactDownNamespaceScope, closePanes bool, paneDeps PaneCleanupDependencies) downReport {
+func terminateMember(t team.Team, projectDir, profile string, m team.Member, workstream string, term processTerminator, probe duplicateLaunchProbe, exactDownScope *exactDownNamespaceScope, closePanes bool, paneDeps PaneCleanupDependencies, wakeCheck wakeCheckRunner) downReport {
 	report, rec, ok := resolveDownMemberRecord(t, projectDir, profile, m, workstream, probe, closePanes)
 	if !ok {
 		return report
@@ -705,7 +716,7 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
 			return report
 		}
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = "no pid captured at launch; " + cleaned.summary()
@@ -727,7 +738,7 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	runtimeIdentity := classifyLaunchPIDRuntimeIdentity(rec, binary, probe)
 	if !runtimeIdentity.PIDAlive {
 		report.Pane = prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: rec.Binary, Live: false}).Result
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = fmt.Sprintf("recorded pid %d is not alive; %s", rec.AgentPID, cleaned.summary())
@@ -744,7 +755,7 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	}
 	if !runtimeIdentity.PIDLive {
 		report.Pane = prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: binary, Live: true, BinaryMatch: runtimeIdentity.BinaryMatch}).Result
-		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe)
+		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
 			report.Detail = fmt.Sprintf("pid %d does not match recorded runtime identity (PID reuse); %s", rec.AgentPID, cleaned.summary())
@@ -791,16 +802,17 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	// that as downStatusFailed so renderDownReports counts it correctly;
 	// without this, the per-member detail says "wake survived" but the summary
 	// still reads as a clean success.
-	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe)
-	if !cleaned.failed() && rec.WakePID > 0 {
-		if !wakeSelfCleanedAfterRetire(wakeLockPath(report.AgentDir), rec.WakePID, probe) {
-			priorRetirement := cleaned.WakeRetirement
+	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
+	if !cleaned.failed() {
+		wakePID := rec.WakePID
+		if wakePID <= 0 {
+			wakePID = cleaned.WakeKilled
+		}
+		quiescence := waitForWakeQuiescence(report.AgentDir, report.Root, handle, wakePID, probe, wakeCheck)
+		cleaned.WakeQuiescence = quiescence.Status
+		cleaned.QuiescenceDetail = quiescence.Detail
+		if !quiescence.Verified {
 			cleaned.LockRemoved = false
-			cleaned.WakeRetirement = "raw_cleanup_unverified"
-			cleaned.RetirementDetail = fmt.Sprintf("post-teardown verification timed out waiting for recorded wake pid %d to be dead and .wake.lock to be absent", rec.WakePID)
-			if priorRetirement != "" {
-				cleaned.RetirementDetail += "; prior retirement=" + priorRetirement
-			}
 		} else if flipFreshActivePresenceOffline(report.AgentDir, handle, probe) {
 			// The final wake exit may have landed a late active presence write
 			// after reapStaleArtifacts' earlier bounded re-assertion.
@@ -814,7 +826,7 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	}
 	report.Status = downStatusStopped
 	report.Detail = fmt.Sprintf("%s sent to pid %d", sigName, rec.AgentPID)
-	if cleaned.any() {
+	if cleaned.reportable() {
 		report.Detail += "; " + cleaned.summary()
 	}
 	return report
@@ -834,10 +846,16 @@ type reapResult struct {
 	PresenceFlip     bool
 	WakeRetirement   string
 	RetirementDetail string
+	WakeQuiescence   string
+	QuiescenceDetail string
 }
 
 func (r reapResult) any() bool {
 	return r.WakeKilled > 0 || r.LockRemoved || r.PresenceFlip
+}
+
+func (r reapResult) reportable() bool {
+	return r.any() || r.WakeRetirement != "" || r.WakeQuiescence != ""
 }
 
 func (r reapResult) failed() bool {
@@ -850,7 +868,7 @@ func (r reapResult) failed() bool {
 		"raw_cleanup_unverified":
 		return true
 	default:
-		return r.WakeSignalFailed > 0
+		return r.WakeSignalFailed > 0 || r.WakeQuiescence == "unverified"
 	}
 }
 
@@ -865,6 +883,9 @@ func (r reapResult) summary() string {
 	}
 	if r.WakeRetirement != "" {
 		parts = append(parts, fmt.Sprintf("wake retirement=%s (%s)", r.WakeRetirement, r.RetirementDetail))
+	}
+	if r.WakeQuiescence != "" {
+		parts = append(parts, fmt.Sprintf("wake quiescence=%s (%s)", r.WakeQuiescence, r.QuiescenceDetail))
 	}
 	if r.WakeSignalFailed > 0 {
 		parts = append(parts, fmt.Sprintf("failed to signal wake pid %d (%s); lock and presence left intact", r.WakeSignalFailed, r.WakeSignalError))
@@ -886,7 +907,7 @@ func (r reapResult) summary() string {
 // survive. Returns a reapResult describing what was done so the caller can
 // include it in user-visible reports. AMQ-owned wake locks are preserved unless
 // native exact retirement or the wake's own signal handler removes them.
-func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec launch.Record, term processTerminator, probe duplicateLaunchProbe) reapResult {
+func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec launch.Record, term processTerminator, probe duplicateLaunchProbe, wakeCheck wakeCheckRunner) reapResult {
 	var result reapResult
 	if agentDir == "" {
 		return result
@@ -922,13 +943,16 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 			result.WakeRetirement = "amq_owner_recovered"
 			result.RetirementDetail = recovered.Reason
 			exactRetired = true
-			if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
+			quiescence := waitForWakeQuiescence(agentDir, root, handle, result.WakeKilled, probe, wakeCheck)
+			result.WakeQuiescence = quiescence.Status
+			result.QuiescenceDetail = quiescence.Detail
+			if quiescence.Verified {
 				result.LockRemoved = true
 			} else {
 				result.WakeSignalFailed = result.WakeKilled
-				result.WakeSignalError = "owner recovery returned success but the wake lock is still present; ownerless retirement and legacy signaling suppressed"
+				result.WakeSignalError = "owner recovery returned success but authoritative wake quiescence was not verified; ownerless retirement and legacy signaling suppressed"
 				result.WakeRetirement = "amq_owner_recovery_lock_remaining"
-				result.RetirementDetail = result.WakeSignalError
+				result.RetirementDetail = result.WakeSignalError + ": " + quiescence.Detail
 			}
 		}
 		if ownerless && hasPersistedInjector {
@@ -937,11 +961,14 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				// AMQ can race a gracefully SIGTERMed wake that removes
 				// its own lock before the retirer re-checks. Recognize that exact
 				// terminal state instead of reporting a spurious refusal.
-				if rec.WakePID > 0 && wakeSelfCleanedAfterRetire(lockPath, rec.WakePID, probe) {
+				quiescence := waitForWakeQuiescence(agentDir, root, handle, rec.WakePID, probe, wakeCheck)
+				result.WakeQuiescence = quiescence.Status
+				result.QuiescenceDetail = quiescence.Detail
+				if quiescence.Verified {
 					result.WakeKilled = rec.WakePID
 					result.WakeSignalName = "amq wake retire"
 					result.WakeRetirement = nativeWakeRetireSelfCleaned
-					result.RetirementDetail = "wake removed its own lock after graceful termination; end state verified: pid dead, lock absent"
+					result.RetirementDetail = "wake removed its own lock after graceful termination; " + quiescence.Detail
 					result.LockRemoved = true
 					exactRetired = true
 				} else {
@@ -963,13 +990,16 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				}
 				result.RetirementDetail = retired.Reason
 				exactRetired = true
-				if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
+				quiescence := waitForWakeQuiescence(agentDir, root, handle, retired.PID, probe, wakeCheck)
+				result.WakeQuiescence = quiescence.Status
+				result.QuiescenceDetail = quiescence.Detail
+				if quiescence.Verified {
 					result.LockRemoved = true
 				} else {
 					result.WakeSignalFailed = retired.PID
-					result.WakeSignalError = "native retirement returned success but the wake lock is still present; legacy signaling suppressed"
+					result.WakeSignalError = "native retirement returned success but authoritative wake quiescence was not verified; legacy signaling suppressed"
 					result.WakeRetirement = "amq_exact_lock_remaining"
-					result.RetirementDetail = result.WakeSignalError
+					result.RetirementDetail = result.WakeSignalError + ": " + quiescence.Detail
 				}
 			}
 		}
@@ -1018,14 +1048,17 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 			} else if termErr := term.Terminate(lock.PID); termErr == nil {
 				result.WakeKilled = lock.PID
 				result.WakeSignalName = signalNameOf(term)
-				if wakeSelfCleanedAfterRetire(lockPath, lock.PID, probe) {
+				quiescence := waitForWakeQuiescence(agentDir, root, handle, lock.PID, probe, wakeCheck)
+				result.WakeQuiescence = quiescence.Status
+				result.QuiescenceDetail = quiescence.Detail
+				if quiescence.Verified {
 					result.LockRemoved = true
 					result.WakeRetirement = "raw_self_cleaned"
-					result.RetirementDetail = "verified wake self-cleanup after signal: pid dead, lock absent"
+					result.RetirementDetail = "verified wake self-cleanup after signal: " + quiescence.Detail
 				} else {
-					result.WakeSignalError = "wake accepted signal but exact self-cleanup was not verified; lock and presence preserved"
+					result.WakeSignalError = "wake accepted signal but authoritative quiescence was not verified; lock and presence preserved"
 					result.WakeRetirement = "raw_cleanup_unverified"
-					result.RetirementDetail = result.WakeSignalError
+					result.RetirementDetail = result.WakeSignalError + ": " + quiescence.Detail
 					return result
 				}
 			} else {
@@ -1251,29 +1284,161 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 	return result, nil
 }
 
-// wakeSelfCleanedAfterRetire polls briefly because the SIGTERMed wake may
-// still be mid-exit when exact retirement returns refused. PID death must be
-// observed before lock absence: checking the lock first could sample a
-// transient absence immediately before the still-live wake rematerializes it.
-func wakeSelfCleanedAfterRetire(lockPath string, wakePID int, probe duplicateLaunchProbe) bool {
-	deadline := time.Now().Add(wakeSelfCleanupTimeout)
+type wakeQuiescenceResult struct {
+	Verified bool
+	Status   string
+	Detail   string
+}
+
+// waitForWakeQuiescence asks AMQ, the owner of wake lifecycle state, whether
+// the exact handle/root has reached the stable no-wake classification. A
+// missing or undecodable command surface is the only condition that enables
+// the compatibility fallback. Valid-but-live, stale, or unverified AMQ state
+// remains authoritative and must converge to missing before the deadline.
+func waitForWakeQuiescence(agentDir, root, handle string, wakePID int, probe duplicateLaunchProbe, wakeCheck wakeCheckRunner) wakeQuiescenceResult {
+	deadline := time.Now().Add(wakeQuiescenceTimeout)
+	lastStatus := "unknown"
+	for {
+		// A wake-check subprocess can itself block while the wake is inside its
+		// teardown critical section. Do not let one blocked observation consume
+		// the entire quiescence budget: command unavailability must leave enough
+		// time for the consecutive-sample compatibility proof.
+		checkDeadline := time.Now().Add(wakeQuiescenceCheckTimeout)
+		if checkDeadline.After(deadline) {
+			checkDeadline = deadline
+		}
+		checkContext, cancelCheck := context.WithDeadline(context.Background(), checkDeadline)
+		checked, available, err := inspectWakeQuiescence(checkContext, root, handle, wakeCheck)
+		cancelCheck()
+		if !available {
+			return waitForStableWakeFilesystem(agentDir, wakePID, probe, deadline, err)
+		}
+		if err != nil {
+			return wakeQuiescenceResult{Status: "unverified", Detail: err.Error()}
+		}
+		lastStatus = checked.WakeStatus
+		if checked.WakeStatus == "missing" && !checked.LiveWake && checked.WakePID == 0 {
+			return wakeQuiescenceResult{
+				Verified: true,
+				Status:   "amq_missing",
+				Detail:   "authoritative amq wake check confirmed wake_status=missing for the exact handle/root",
+			}
+		}
+		if time.Now().After(deadline) {
+			return wakeQuiescenceResult{
+				Status: "unverified",
+				Detail: fmt.Sprintf(
+					"authoritative amq wake check did not converge to missing within %s (last status=%s live=%t pid=%d)",
+					wakeQuiescenceTimeout,
+					lastStatus,
+					checked.LiveWake,
+					checked.WakePID,
+				),
+			}
+		}
+		time.Sleep(wakeQuiescencePoll)
+	}
+}
+
+func inspectWakeQuiescence(ctx context.Context, root, handle string, wakeCheck wakeCheckRunner) (wakeCheckBindingResult, bool, error) {
+	if wakeCheck == nil {
+		return wakeCheckBindingResult{}, false, errors.New("authoritative amq wake check is unavailable")
+	}
+	out, err := wakeCheck(amqCommandRequest{
+		Context: ctx,
+		Dir:     filepath.Dir(root),
+		Env:     os.Environ(),
+		Arg:     []string{"wake", "check", "--root", root, "--me", handle, "--json", "--json-schema", "1"},
+	})
+	if err != nil {
+		return wakeCheckBindingResult{}, false, fmt.Errorf("authoritative amq wake check unavailable: %w", err)
+	}
+	var checked wakeCheckBindingResult
+	if err := json.Unmarshal(out, &checked); err != nil {
+		return wakeCheckBindingResult{}, false, fmt.Errorf("authoritative amq wake check JSON unavailable: %w", err)
+	}
+	if checked.Schema != 1 || checked.Agent != handle || !rootsMatch(checked.Root, root) {
+		return checked, true, fmt.Errorf(
+			"authoritative amq wake check identity mismatch: schema=%d agent=%s root=%s status=%s pid=%d",
+			checked.Schema,
+			checked.Agent,
+			checked.Root,
+			checked.WakeStatus,
+			checked.WakePID,
+		)
+	}
+	if checked.WakeStatus == "missing" && (checked.LiveWake || checked.WakePID != 0) {
+		return checked, true, fmt.Errorf(
+			"authoritative amq wake check returned inconsistent missing state: live=%t pid=%d",
+			checked.LiveWake,
+			checked.WakePID,
+		)
+	}
+	return checked, true, nil
+}
+
+// waitForStableWakeFilesystem is a bounded compatibility fallback for an
+// unavailable AMQ command/JSON surface. Unlike the former single snapshot, it
+// requires the same PID-dead + lock-absent terminal state on N consecutive
+// samples. With no authoritative or recorded/observed PID it cannot prove
+// quiescence and fails closed.
+func waitForStableWakeFilesystem(agentDir string, wakePID int, probe duplicateLaunchProbe, deadline time.Time, unavailableErr error) wakeQuiescenceResult {
+	if wakePID <= 0 {
+		if lock, err := readWakeLock(agentDir); err == nil {
+			wakePID = lock.PID
+		}
+	}
+	if wakePID <= 0 {
+		return wakeQuiescenceResult{
+			Status: "unverified",
+			Detail: fmt.Sprintf(
+				"%v; filesystem fallback cannot verify PID death because no persisted or observed wake pid exists",
+				unavailableErr,
+			),
+		}
+	}
+	lockPath := wakeLockPath(agentDir)
+	stable := 0
 	for {
 		if !probe.PIDAlive(wakePID) {
 			_, statErr := os.Stat(lockPath)
 			if os.IsNotExist(statErr) {
-				return true
+				stable++
+			} else {
+				stable = 0
+			}
+		} else {
+			stable = 0
+		}
+		if stable >= wakeQuiescenceStableSamples {
+			return wakeQuiescenceResult{
+				Verified: true,
+				Status:   "stable_samples",
+				Detail: fmt.Sprintf(
+					"authoritative amq wake check unavailable; observed recorded wake pid %d dead and .wake.lock absent for %d consecutive samples",
+					wakePID,
+					wakeQuiescenceStableSamples,
+				),
 			}
 		}
 		if time.Now().After(deadline) {
-			return false
+			return wakeQuiescenceResult{
+				Status: "unverified",
+				Detail: fmt.Sprintf(
+					"%v; filesystem fallback did not observe wake pid %d dead and .wake.lock absent for %d consecutive samples within %s",
+					unavailableErr,
+					wakePID,
+					wakeQuiescenceStableSamples,
+					wakeQuiescenceTimeout,
+				),
+			}
 		}
-		time.Sleep(wakeSelfCleanupPoll)
+		time.Sleep(wakeQuiescencePoll)
 	}
 }
 
-// wakeConfirmedDeadWithinDeadline polls briefly for the wake PID to exit,
-// mirroring wakeSelfCleanedAfterRetire's poll style and deadline: bounded so
-// a wake stuck mid-exit cannot hang `down` indefinitely.
+// wakeConfirmedDeadWithinDeadline polls briefly for the wake PID to exit so a
+// wake stuck mid-exit cannot hang the presence re-assertion indefinitely.
 func wakeConfirmedDeadWithinDeadline(wakePID int, probe duplicateLaunchProbe) bool {
 	deadline := time.Now().Add(2 * time.Second)
 	for {

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -946,7 +946,7 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 			quiescence := waitForWakeQuiescence(agentDir, root, handle, result.WakeKilled, probe, wakeCheck)
 			result.WakeQuiescence = quiescence.Status
 			result.QuiescenceDetail = quiescence.Detail
-			if quiescence.Verified {
+			if quiescence.LockAbsent {
 				result.LockRemoved = true
 			} else {
 				result.WakeSignalFailed = result.WakeKilled
@@ -964,7 +964,7 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				quiescence := waitForWakeQuiescence(agentDir, root, handle, rec.WakePID, probe, wakeCheck)
 				result.WakeQuiescence = quiescence.Status
 				result.QuiescenceDetail = quiescence.Detail
-				if quiescence.Verified {
+				if quiescence.LockAbsent {
 					result.WakeKilled = rec.WakePID
 					result.WakeSignalName = "amq wake retire"
 					result.WakeRetirement = nativeWakeRetireSelfCleaned
@@ -993,7 +993,7 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				quiescence := waitForWakeQuiescence(agentDir, root, handle, retired.PID, probe, wakeCheck)
 				result.WakeQuiescence = quiescence.Status
 				result.QuiescenceDetail = quiescence.Detail
-				if quiescence.Verified {
+				if quiescence.LockAbsent {
 					result.LockRemoved = true
 				} else {
 					result.WakeSignalFailed = retired.PID
@@ -1052,9 +1052,14 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				result.WakeQuiescence = quiescence.Status
 				result.QuiescenceDetail = quiescence.Detail
 				if quiescence.Verified {
-					result.LockRemoved = true
-					result.WakeRetirement = "raw_self_cleaned"
-					result.RetirementDetail = "verified wake self-cleanup after signal: " + quiescence.Detail
+					if quiescence.LockAbsent {
+						result.LockRemoved = true
+						result.WakeRetirement = "raw_self_cleaned"
+						result.RetirementDetail = "verified wake self-cleanup after signal: " + quiescence.Detail
+					} else {
+						result.WakeRetirement = "raw_stale_preserved"
+						result.RetirementDetail = "signaled wake exited and its exact dead-pid lock remains preserved for AMQ guarded cleanup: " + quiescence.Detail
+					}
 				} else {
 					result.WakeSignalError = "wake accepted signal but authoritative quiescence was not verified; lock and presence preserved"
 					result.WakeRetirement = "raw_cleanup_unverified"
@@ -1285,16 +1290,19 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 }
 
 type wakeQuiescenceResult struct {
-	Verified bool
-	Status   string
-	Detail   string
+	Verified   bool
+	LockAbsent bool
+	Status     string
+	Detail     string
 }
 
 // waitForWakeQuiescence asks AMQ, the owner of wake lifecycle state, whether
 // the exact handle/root has reached the stable no-wake classification. A
-// missing or undecodable command surface is the only condition that enables
-// the compatibility fallback. Valid-but-live, stale, or unverified AMQ state
-// remains authoritative and must converge to missing before the deadline.
+// missing or undecodable command surface enables the compatibility proof. An
+// authoritative stale classification also enters that proof: quiescence means
+// no live wake, while AMQ's deliberately preserved exact dead-PID lock may
+// remain for guarded cleanup. Live, mismatched, or unverified state still fails
+// closed.
 func waitForWakeQuiescence(agentDir, root, handle string, wakePID int, probe duplicateLaunchProbe, wakeCheck wakeCheckRunner) wakeQuiescenceResult {
 	deadline := time.Now().Add(wakeQuiescenceTimeout)
 	lastStatus := "unknown"
@@ -1311,7 +1319,7 @@ func waitForWakeQuiescence(agentDir, root, handle string, wakePID int, probe dup
 		checked, available, err := inspectWakeQuiescence(checkContext, root, handle, wakeCheck)
 		cancelCheck()
 		if !available {
-			return waitForStableWakeFilesystem(agentDir, wakePID, probe, deadline, err)
+			return waitForStableWakeFilesystem(agentDir, root, handle, wakePID, probe, deadline, err)
 		}
 		if err != nil {
 			return wakeQuiescenceResult{Status: "unverified", Detail: err.Error()}
@@ -1319,10 +1327,36 @@ func waitForWakeQuiescence(agentDir, root, handle string, wakePID int, probe dup
 		lastStatus = checked.WakeStatus
 		if checked.WakeStatus == "missing" && !checked.LiveWake && checked.WakePID == 0 {
 			return wakeQuiescenceResult{
-				Verified: true,
-				Status:   "amq_missing",
-				Detail:   "authoritative amq wake check confirmed wake_status=missing for the exact handle/root",
+				Verified:   true,
+				LockAbsent: true,
+				Status:     "amq_missing",
+				Detail:     "authoritative amq wake check confirmed wake_status=missing for the exact handle/root",
 			}
+		}
+		if checked.WakeStatus == "stale" && !checked.LiveWake {
+			expectedPID := wakePID
+			if expectedPID <= 0 {
+				expectedPID = checked.WakePID
+			}
+			if expectedPID <= 0 || checked.WakePID != expectedPID {
+				return wakeQuiescenceResult{
+					Status: "unverified",
+					Detail: fmt.Sprintf(
+						"authoritative amq wake check reported stale with pid=%d, which does not match the recorded/observed wake pid %d",
+						checked.WakePID,
+						expectedPID,
+					),
+				}
+			}
+			return waitForStableWakeFilesystem(
+				agentDir,
+				root,
+				handle,
+				expectedPID,
+				probe,
+				deadline,
+				fmt.Errorf("authoritative amq wake check reported wake_status=stale for pid %d", expectedPID),
+			)
 		}
 		if time.Now().After(deadline) {
 			return wakeQuiescenceResult{
@@ -1377,12 +1411,12 @@ func inspectWakeQuiescence(ctx context.Context, root, handle string, wakeCheck w
 	return checked, true, nil
 }
 
-// waitForStableWakeFilesystem is a bounded compatibility fallback for an
-// unavailable AMQ command/JSON surface. Unlike the former single snapshot, it
-// requires the same PID-dead + lock-absent terminal state on N consecutive
-// samples. With no authoritative or recorded/observed PID it cannot prove
-// quiescence and fails closed.
-func waitForStableWakeFilesystem(agentDir string, wakePID int, probe duplicateLaunchProbe, deadline time.Time, unavailableErr error) wakeQuiescenceResult {
+// waitForStableWakeFilesystem is a bounded compatibility proof for an
+// unavailable AMQ command/JSON surface or an authoritative stale result. It
+// accepts either lock absence or an exact, cleanly decoded stale lock for the
+// same dead PID/root/agent on N consecutive samples. Live PIDs and every
+// identity/decode mismatch fail closed.
+func waitForStableWakeFilesystem(agentDir, root, handle string, wakePID int, probe duplicateLaunchProbe, deadline time.Time, observationErr error) wakeQuiescenceResult {
 	if wakePID <= 0 {
 		if lock, err := readWakeLock(agentDir); err == nil {
 			wakePID = lock.PID
@@ -1393,29 +1427,58 @@ func waitForStableWakeFilesystem(agentDir string, wakePID int, probe duplicateLa
 			Status: "unverified",
 			Detail: fmt.Sprintf(
 				"%v; filesystem fallback cannot verify PID death because no persisted or observed wake pid exists",
-				unavailableErr,
+				observationErr,
+			),
+		}
+	}
+	expectedAgentDir := filepath.Join(root, "agents", handle)
+	if canonicalFilesystemPath(agentDir) != canonicalFilesystemPath(expectedAgentDir) {
+		return wakeQuiescenceResult{
+			Status: "unverified",
+			Detail: fmt.Sprintf(
+				"%v; filesystem fallback agent directory identity mismatch: got %s, want %s",
+				observationErr,
+				agentDir,
+				expectedAgentDir,
 			),
 		}
 	}
 	lockPath := wakeLockPath(agentDir)
 	stable := 0
+	stableStatus := ""
+	lastDetail := "no terminal filesystem observation"
 	for {
-		if !probe.PIDAlive(wakePID) {
-			_, statErr := os.Stat(lockPath)
-			if os.IsNotExist(statErr) {
-				stable++
-			} else {
-				stable = 0
-			}
-		} else {
+		status, detail := inspectWakeFilesystemTerminal(lockPath, root, handle, wakePID, probe)
+		lastDetail = detail
+		if status == "" {
 			stable = 0
+			stableStatus = ""
+		} else if status == stableStatus {
+			stable++
+		} else {
+			stableStatus = status
+			stable = 1
 		}
 		if stable >= wakeQuiescenceStableSamples {
+			if status == "fs_stale_lock_preserved" {
+				return wakeQuiescenceResult{
+					Verified: true,
+					Status:   status,
+					Detail: fmt.Sprintf(
+						"%v; observed exact wake pid %d dead with a clean, identity-matched stale .wake.lock preserved for %d consecutive samples",
+						observationErr,
+						wakePID,
+						wakeQuiescenceStableSamples,
+					),
+				}
+			}
 			return wakeQuiescenceResult{
-				Verified: true,
-				Status:   "stable_samples",
+				Verified:   true,
+				LockAbsent: true,
+				Status:     "stable_samples",
 				Detail: fmt.Sprintf(
-					"authoritative amq wake check unavailable; observed recorded wake pid %d dead and .wake.lock absent for %d consecutive samples",
+					"%v; observed recorded/observed wake pid %d dead and .wake.lock absent for %d consecutive samples",
+					observationErr,
 					wakePID,
 					wakeQuiescenceStableSamples,
 				),
@@ -1425,16 +1488,69 @@ func waitForStableWakeFilesystem(agentDir string, wakePID int, probe duplicateLa
 			return wakeQuiescenceResult{
 				Status: "unverified",
 				Detail: fmt.Sprintf(
-					"%v; filesystem fallback did not observe wake pid %d dead and .wake.lock absent for %d consecutive samples within %s",
-					unavailableErr,
+					"%v; filesystem fallback did not observe wake pid %d in an exact no-live terminal state for %d consecutive samples within %s (last observation: %s)",
+					observationErr,
 					wakePID,
 					wakeQuiescenceStableSamples,
 					wakeQuiescenceTimeout,
+					lastDetail,
 				),
 			}
 		}
 		time.Sleep(wakeQuiescencePoll)
 	}
+}
+
+// inspectWakeFilesystemTerminal returns a non-empty status only for a
+// fail-closed terminal observation: the exact PID is dead and either the lock
+// is absent or its decoded PID/root/agent identity is exact. PID liveness is
+// checked on both sides of the filesystem read so a concurrently reused PID
+// cannot inherit a stale observation.
+func inspectWakeFilesystemTerminal(lockPath, root, handle string, wakePID int, probe duplicateLaunchProbe) (string, string) {
+	if probe.PIDAlive(wakePID) {
+		return "", fmt.Sprintf("wake pid %d is live", wakePID)
+	}
+	before, err := os.Lstat(lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if probe.PIDAlive(wakePID) {
+				return "", fmt.Sprintf("wake pid %d became live while confirming lock absence", wakePID)
+			}
+			return "stable_samples", ".wake.lock is absent and the exact wake pid is dead"
+		}
+		return "", fmt.Sprintf("cannot inspect .wake.lock: %v", err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return "", fmt.Sprintf(".wake.lock is not a regular non-symlink file (mode=%s)", before.Mode())
+	}
+	raw, err := os.ReadFile(lockPath)
+	if err != nil {
+		return "", fmt.Sprintf("cannot read .wake.lock: %v", err)
+	}
+	after, err := os.Lstat(lockPath)
+	if err != nil {
+		return "", fmt.Sprintf("cannot re-inspect .wake.lock: %v", err)
+	}
+	if after.Mode()&os.ModeSymlink != 0 || !after.Mode().IsRegular() || !os.SameFile(before, after) {
+		return "", ".wake.lock changed identity while being read"
+	}
+	lock, err := decodeWakeLockFile(raw)
+	if err != nil {
+		return "", fmt.Sprintf("cannot cleanly decode .wake.lock: %v", err)
+	}
+	if lock.PID != wakePID {
+		return "", fmt.Sprintf(".wake.lock pid %d does not match recorded/observed wake pid %d", lock.PID, wakePID)
+	}
+	if strings.TrimSpace(lock.Root) == "" || !rootsMatch(lock.Root, root) {
+		return "", fmt.Sprintf(".wake.lock root %q does not match exact root %q", lock.Root, root)
+	}
+	if strings.TrimSpace(lock.Agent) == "" || lock.Agent != handle {
+		return "", fmt.Sprintf(".wake.lock agent %q does not match exact handle %q", lock.Agent, handle)
+	}
+	if probe.PIDAlive(wakePID) {
+		return "", fmt.Sprintf("wake pid %d became live while confirming preserved stale lock", wakePID)
+	}
+	return "fs_stale_lock_preserved", "exact dead-pid .wake.lock remains preserved"
 }
 
 // wakeConfirmedDeadWithinDeadline polls briefly for the wake PID to exit so a

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -792,6 +792,21 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	// without this, the per-member detail says "wake survived" but the summary
 	// still reads as a clean success.
 	cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe)
+	if !cleaned.failed() && rec.WakePID > 0 {
+		if !wakeSelfCleanedAfterRetire(wakeLockPath(report.AgentDir), rec.WakePID, probe) {
+			priorRetirement := cleaned.WakeRetirement
+			cleaned.LockRemoved = false
+			cleaned.WakeRetirement = "raw_cleanup_unverified"
+			cleaned.RetirementDetail = fmt.Sprintf("post-teardown verification timed out waiting for recorded wake pid %d to be dead and .wake.lock to be absent", rec.WakePID)
+			if priorRetirement != "" {
+				cleaned.RetirementDetail += "; prior retirement=" + priorRetirement
+			}
+		} else if flipFreshActivePresenceOffline(report.AgentDir, handle, probe) {
+			// The final wake exit may have landed a late active presence write
+			// after reapStaleArtifacts' earlier bounded re-assertion.
+			cleaned.PresenceFlip = true
+		}
+	}
 	if cleaned.failed() {
 		report.Status = downStatusFailed
 		report.Detail = fmt.Sprintf("%s sent to pid %d; %s", sigName, rec.AgentPID, cleaned.summary())
@@ -1237,13 +1252,17 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 }
 
 // wakeSelfCleanedAfterRetire polls briefly because the SIGTERMed wake may
-// still be mid-exit when exact retirement returns refused.
+// still be mid-exit when exact retirement returns refused. PID death must be
+// observed before lock absence: checking the lock first could sample a
+// transient absence immediately before the still-live wake rematerializes it.
 func wakeSelfCleanedAfterRetire(lockPath string, wakePID int, probe duplicateLaunchProbe) bool {
 	deadline := time.Now().Add(wakeSelfCleanupTimeout)
 	for {
-		_, statErr := os.Stat(lockPath)
-		if os.IsNotExist(statErr) && !probe.PIDAlive(wakePID) {
-			return true
+		if !probe.PIDAlive(wakePID) {
+			_, statErr := os.Stat(lockPath)
+			if os.IsNotExist(statErr) {
+				return true
+			}
 		}
 		if time.Now().After(deadline) {
 			return false

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -74,6 +74,8 @@ var (
 	runExactWakeRecoverOwner = runAMQCommand
 	wakeOwnerRecoveryTimeout = 2 * time.Second
 	wakeOwnerRecoveryPoll    = 50 * time.Millisecond
+	wakeSelfCleanupTimeout   = 2 * time.Second
+	wakeSelfCleanupPoll      = 50 * time.Millisecond
 )
 
 // newSignalTerminator returns a terminator that sends SIGTERM by default, or
@@ -824,7 +826,9 @@ func (r reapResult) failed() bool {
 	case "amq_exact_refused",
 		"amq_exact_lock_remaining",
 		"amq_owner_recovery_refused",
-		"amq_owner_recovery_lock_remaining":
+		"amq_owner_recovery_lock_remaining",
+		"raw_unverified_lock_preserved",
+		"raw_cleanup_unverified":
 		return true
 	default:
 		return r.WakeSignalFailed > 0
@@ -861,9 +865,8 @@ func (r reapResult) summary() string {
 // reapStaleArtifacts cleans up the runtime side-effects an agent leaves
 // behind when its process dies but its wake sidecar and/or presence file
 // survive. Returns a reapResult describing what was done so the caller can
-// include it in user-visible reports. Errors during cleanup are best-effort
-// and do not propagate: the goal is to unblock the next launch, not to
-// guarantee atomicity.
+// include it in user-visible reports. AMQ-owned wake locks are preserved unless
+// native exact retirement or the wake's own signal handler removes them.
 func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec launch.Record, term processTerminator, probe duplicateLaunchProbe) reapResult {
 	var result reapResult
 	if agentDir == "" {
@@ -872,8 +875,14 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 
 	lockPath := wakeLockPath(agentDir)
 	lockData, lockErr := os.ReadFile(lockPath)
+	var parsedLock wakeLockFile
+	var lockDecodeErr error
+	if lockErr == nil {
+		parsedLock, lockDecodeErr = decodeWakeLockFile(lockData)
+	}
 	exactRetired := false
-	if lockErr == nil && strings.TrimSpace(rec.WakeInjectVia) != "" {
+	hasPersistedInjector := strings.TrimSpace(rec.WakeInjectVia) != ""
+	if lockErr == nil && (hasPersistedInjector || lockDecodeErr == nil && wakeLockHasOwnerBinding(parsedLock)) {
 		recovered, ownerless, recoverErr := recoverManagedWakeWithAMQ(rec, root, handle)
 		if recoverErr != nil {
 			result.WakeSignalFailed = recovered.PID
@@ -903,7 +912,7 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				result.RetirementDetail = result.WakeSignalError
 			}
 		}
-		if ownerless {
+		if ownerless && hasPersistedInjector {
 			retired, retireErr := retireWakeWithAMQ(rec, root, handle)
 			if retireErr != nil {
 				// AMQ can race a gracefully SIGTERMed wake that removes
@@ -930,6 +939,9 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				result.WakeKilled = retired.PID
 				result.WakeSignalName = "amq wake retire"
 				result.WakeRetirement = "amq_exact"
+				if retired.Status == "retired_with_residue" {
+					result.WakeRetirement = "amq_exact_with_residue"
+				}
 				result.RetirementDetail = retired.Reason
 				exactRetired = true
 				if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
@@ -942,46 +954,61 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				}
 			}
 		}
+		if ownerless && !hasPersistedInjector {
+			result.WakeRetirement = "raw_signal_fallback"
+			result.RetirementDetail = "AMQ verified the wake is ownerless and no persisted inject-via identity is available"
+		}
 	} else if lockErr == nil {
 		result.WakeRetirement = "raw_signal_fallback"
 		result.RetirementDetail = "wake is raw or has no persisted inject-via identity"
 	}
-	// canRemoveLock tracks whether we've confirmed the lock is safe to
-	// remove: confirmed stale (dead PID / PID-reused / corrupt), or we
-	// successfully signaled the live matching wake. If a matching wake is
-	// live and we FAIL to signal it, leaving the lock in place keeps the
-	// next preflight honest — operators must not be told the system is
-	// clean when a foreign-uid wake is still running.
-	canRemoveLock := false
+	// AMQ 0.53+ owns wake-lock quarantine, state binding, and exact-object
+	// removal. The raw compatibility path may signal a verified live process,
+	// but it never unlinks the lock itself. Stale valid locks are preserved for
+	// AMQ's guarded next acquisition; corrupt or ambiguous locks fail closed.
 	if !exactRetired && lockErr == nil {
-		var lock wakeLockFile
-		switch jsonErr := json.Unmarshal(lockData, &lock); {
-		case jsonErr != nil:
-			// Corrupt lock: no PID to verify, safe to remove.
-			canRemoveLock = true
+		lock, decodeErr := parsedLock, lockDecodeErr
+		switch {
+		case decodeErr != nil:
+			result.WakeRetirement = "raw_unverified_lock_preserved"
+			result.RetirementDetail = "unverified wake lock preserved for AMQ inspection: " + decodeErr.Error()
+			result.WakeSignalError = result.RetirementDetail
+			return result
 		case lock.PID <= 0:
-			canRemoveLock = true
+			result.WakeRetirement = "raw_stale_preserved"
+			result.RetirementDetail = "wake lock has no usable pid; preserved for AMQ guarded cleanup"
 		case strictRoot && strings.TrimSpace(lock.Root) != "" && !rootsMatch(lock.Root, root):
 			// The exact named-profile stop exception trusts only the selected
 			// root. A lock copied or poisoned with an explicit legacy/foreign
 			// root is stale for this named agent dir; never inspect or signal
 			// the PID it names. Empty roots retain the historical selected-root
 			// fallback for older locks.
-			canRemoveLock = true
+			result.WakeRetirement = "raw_stale_preserved"
+			result.RetirementDetail = "foreign-root wake lock preserved for AMQ guarded cleanup"
 		case !probe.PIDAlive(lock.PID):
-			canRemoveLock = true
+			result.WakeRetirement = "raw_stale_preserved"
+			result.RetirementDetail = "dead-pid wake lock preserved for AMQ guarded cleanup"
 		default:
 			expectedRoot := root
 			if lock.Root != "" {
 				expectedRoot = lock.Root
 			}
 			if !probe.ProcessMatch(lock.PID, wakeProcessMatcher(handle, expectedRoot)) {
-				// PID-reuse by an unrelated process: lock is stale.
-				canRemoveLock = true
+				result.WakeRetirement = "raw_stale_preserved"
+				result.RetirementDetail = "unrelated-pid wake lock preserved for AMQ guarded cleanup"
 			} else if termErr := term.Terminate(lock.PID); termErr == nil {
 				result.WakeKilled = lock.PID
 				result.WakeSignalName = signalNameOf(term)
-				canRemoveLock = true
+				if wakeSelfCleanedAfterRetire(lockPath, lock.PID, probe) {
+					result.LockRemoved = true
+					result.WakeRetirement = "raw_self_cleaned"
+					result.RetirementDetail = "verified wake self-cleanup after signal: pid dead, lock absent"
+				} else {
+					result.WakeSignalError = "wake accepted signal but exact self-cleanup was not verified; lock and presence preserved"
+					result.WakeRetirement = "raw_cleanup_unverified"
+					result.RetirementDetail = result.WakeSignalError
+					return result
+				}
 			} else {
 				// Live matching wake we could not signal. Surface the
 				// failure and leave both lock and presence intact so
@@ -989,11 +1016,6 @@ func reapStaleArtifacts(agentDir, handle, root string, strictRoot bool, rec laun
 				result.WakeSignalFailed = lock.PID
 				result.WakeSignalError = termErr.Error()
 				return result
-			}
-		}
-		if canRemoveLock {
-			if rmErr := os.Remove(lockPath); rmErr == nil {
-				result.LockRemoved = true
 			}
 		}
 	}
@@ -1184,6 +1206,11 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 	for _, arg := range rec.WakeInjectArgs {
 		args = append(args, "--inject-arg", arg)
 	}
+	retryUntil, retryErr := normalizeWakeRetryUntil(rec.WakeRetryUntil)
+	if retryErr != nil {
+		return nativeWakeRetireResult{}, fmt.Errorf("amq exact wake retirement: %w", retryErr)
+	}
+	args = append(args, "--retry-until", retryUntil)
 	args = append(args, "--json")
 	out, err := runExactWakeRetire(amqCommandRequest{Dir: rec.CWD, Env: os.Environ(), Arg: args})
 	var result nativeWakeRetireResult
@@ -1196,7 +1223,7 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 	if err != nil {
 		return result, fmt.Errorf("amq exact wake retirement status %s: %w", result.Status, err)
 	}
-	if result.Status != "retired" || result.Agent != handle || !rootsMatch(result.Root, root) {
+	if (result.Status != "retired" && result.Status != "retired_with_residue") || result.Agent != handle || !rootsMatch(result.Root, root) {
 		return result, fmt.Errorf("amq exact wake retirement returned mismatched result status=%s agent=%s root=%s", result.Status, result.Agent, result.Root)
 	}
 	if rec.WakePID <= 0 || result.PID != rec.WakePID {
@@ -1208,7 +1235,7 @@ func retireWakeWithAMQ(rec launch.Record, root, handle string) (nativeWakeRetire
 // wakeSelfCleanedAfterRetire polls briefly because the SIGTERMed wake may
 // still be mid-exit when exact retirement returns refused.
 func wakeSelfCleanedAfterRetire(lockPath string, wakePID int, probe duplicateLaunchProbe) bool {
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(wakeSelfCleanupTimeout)
 	for {
 		_, statErr := os.Stat(lockPath)
 		if os.IsNotExist(statErr) && !probe.PIDAlive(wakePID) {
@@ -1217,7 +1244,7 @@ func wakeSelfCleanedAfterRetire(lockPath string, wakePID int, probe duplicateLau
 		if time.Now().After(deadline) {
 			return false
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(wakeSelfCleanupPoll)
 	}
 }
 

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -74,8 +74,12 @@ var (
 	runExactWakeRecoverOwner = runAMQCommand
 	wakeOwnerRecoveryTimeout = 2 * time.Second
 	wakeOwnerRecoveryPoll    = 50 * time.Millisecond
-	wakeSelfCleanupTimeout   = 2 * time.Second
-	wakeSelfCleanupPoll      = 50 * time.Millisecond
+	// A SIGTERMed wake can take several seconds to finish its locked teardown on
+	// a loaded Darwin runner. Keep the verification bounded, but align it with
+	// the real wake lifecycle deadline so success still requires both a dead PID
+	// and an absent lock rather than treating signal delivery as completion.
+	wakeSelfCleanupTimeout = 8 * time.Second
+	wakeSelfCleanupPoll    = 50 * time.Millisecond
 )
 
 // newSignalTerminator returns a terminator that sends SIGTERM by default, or

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -201,9 +201,13 @@ func TestWakeQuiescenceUnavailableFallsBackToConsecutiveStableSamples(t *testing
 		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
 	})
 
-	agentDir := t.TempDir()
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	lockPath := wakeLockPath(agentDir)
-	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: filepath.Dir(agentDir)})
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, Agent: "qa"})
 	checks := 0
 	probe := downFakeProbe(nil, nil)
 	probe.PIDAlive = func(pid int) bool {
@@ -223,7 +227,7 @@ func TestWakeQuiescenceUnavailableFallsBackToConsecutiveStableSamples(t *testing
 	}
 	result := waitForWakeQuiescence(
 		agentDir,
-		filepath.Dir(agentDir),
+		root,
 		"qa",
 		4242,
 		probe,
@@ -243,9 +247,12 @@ func TestWakeQuiescenceBlockedCheckLeavesFallbackBudget(t *testing.T) {
 		wakeQuiescenceTimeout, wakeQuiescenceCheckTimeout, wakeQuiescencePoll = previousTimeout, previousCheckTimeout, previousPoll
 	})
 
-	agentDir := t.TempDir()
-	lockPath := wakeLockPath(agentDir)
-	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: filepath.Dir(agentDir)})
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, Agent: "qa"})
 	checks := 0
 	probe := downFakeProbe(nil, nil)
 	probe.PIDAlive = func(pid int) bool {
@@ -253,16 +260,11 @@ func TestWakeQuiescenceBlockedCheckLeavesFallbackBudget(t *testing.T) {
 			return false
 		}
 		checks++
-		if checks == 1 {
-			if err := os.Remove(lockPath); err != nil {
-				t.Fatal(err)
-			}
-		}
 		return false
 	}
 	result := waitForWakeQuiescence(
 		agentDir,
-		filepath.Dir(agentDir),
+		root,
 		"qa",
 		4242,
 		probe,
@@ -271,8 +273,91 @@ func TestWakeQuiescenceBlockedCheckLeavesFallbackBudget(t *testing.T) {
 			return nil, req.Context.Err()
 		},
 	)
-	if !result.Verified || result.Status != "stable_samples" || checks < wakeQuiescenceStableSamples {
+	if !result.Verified || result.LockAbsent || result.Status != "fs_stale_lock_preserved" || checks < 2*wakeQuiescenceStableSamples {
 		t.Fatalf("blocked-check fallback result=%+v checks=%d", result, checks)
+	}
+}
+
+func TestWakeQuiescenceUnavailableAcceptsStableExactDeadPIDStaleLock(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 100 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
+	})
+
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, Agent: "qa"})
+	result := waitForWakeQuiescence(
+		agentDir,
+		root,
+		"qa",
+		4242,
+		downFakeProbe(map[int]bool{4242: false}, nil),
+		func(amqCommandRequest) ([]byte, error) { return nil, errors.New("wake check unavailable") },
+	)
+	if !result.Verified || result.LockAbsent || result.Status != "fs_stale_lock_preserved" {
+		t.Fatalf("stable exact stale-lock result=%+v", result)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("verified stale lock must remain preserved: %v", err)
+	}
+}
+
+func TestWakeQuiescenceAcceptsAuthoritativeStaleWithStableExactLock(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 100 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
+	})
+
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, Agent: "qa"})
+	check := func(req amqCommandRequest) ([]byte, error) {
+		checkRoot, handle := wakeCheckRequestIdentity(req)
+		return []byte(fmt.Sprintf(
+			`{"schema":1,"agent":%q,"root":%q,"live_wake":false,"wake_status":"stale","wake_pid":4242}`,
+			handle,
+			checkRoot,
+		)), nil
+	}
+	result := waitForWakeQuiescence(
+		agentDir,
+		root,
+		"qa",
+		4242,
+		downFakeProbe(map[int]bool{4242: false}, nil),
+		check,
+	)
+	if !result.Verified || result.LockAbsent || result.Status != "fs_stale_lock_preserved" || !strings.Contains(result.Detail, "wake_status=stale") {
+		t.Fatalf("authoritative stale-lock result=%+v", result)
+	}
+}
+
+func TestWakeQuiescenceExactLivePIDLockFailsClosed(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 30 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
+	})
+
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, Agent: "qa"})
+	result := waitForWakeQuiescence(
+		agentDir,
+		root,
+		"qa",
+		4242,
+		downFakeProbe(map[int]bool{4242: true}, nil),
+		func(amqCommandRequest) ([]byte, error) { return nil, errors.New("wake check unavailable") },
+	)
+	if result.Verified || result.Status != "unverified" || !strings.Contains(result.Detail, "pid 4242 is live") {
+		t.Fatalf("live exact wake-lock result=%+v", result)
 	}
 }
 

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -138,6 +138,50 @@ func TestReapRawWakeRetirementFallbackIsReported(t *testing.T) {
 	}
 }
 
+func TestWakeSelfCleanedAfterRetireWaitsForDelayedCleanup(t *testing.T) {
+	if wakeSelfCleanupTimeout < 8*time.Second {
+		t.Fatalf("wake self-cleanup timeout = %s, want at least 8s for loaded teardown", wakeSelfCleanupTimeout)
+	}
+	previousTimeout, previousPoll := wakeSelfCleanupTimeout, wakeSelfCleanupPoll
+	wakeSelfCleanupTimeout = 500 * time.Millisecond
+	wakeSelfCleanupPoll = 5 * time.Millisecond
+	t.Cleanup(func() {
+		wakeSelfCleanupTimeout, wakeSelfCleanupPoll = previousTimeout, previousPoll
+	})
+
+	agentDir := t.TempDir()
+	lockPath := wakeLockPath(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: filepath.Dir(agentDir)})
+	exited := make(chan struct{})
+	cleanupDone := make(chan error, 1)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		err := os.Remove(lockPath)
+		if err == nil {
+			close(exited)
+		}
+		cleanupDone <- err
+	}()
+	probe := downFakeProbe(nil, nil)
+	probe.PIDAlive = func(pid int) bool {
+		if pid != 4242 {
+			return false
+		}
+		select {
+		case <-exited:
+			return false
+		default:
+			return true
+		}
+	}
+	if !wakeSelfCleanedAfterRetire(lockPath, 4242, probe) {
+		t.Fatal("delayed pid exit and lock removal were not observed within the bounded window")
+	}
+	if err := <-cleanupDone; err != nil {
+		t.Fatalf("delayed wake cleanup: %v", err)
+	}
+}
+
 func TestReapRawCorruptWakeFailsClosedAndPreservesLock(t *testing.T) {
 	agentDir := t.TempDir()
 	path := wakeLockPath(agentDir)

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -22,6 +23,31 @@ type recordingTerminator struct {
 	name   string // signal label this fake reports via SignalName; defaults to SIGTERM
 	calls  []int
 	failOn map[int]error
+}
+
+// selfCleaningTerminator models AMQ's signal handler: the process exits and
+// removes its own lock. Production raw-wake teardown succeeds only after both
+// effects are observable; tests that exercise that success path must model
+// them explicitly.
+type selfCleaningTerminator struct {
+	recordingTerminator
+	alive     map[int]bool
+	wakeLocks map[int]string
+}
+
+func (r *selfCleaningTerminator) Terminate(pid int) error {
+	if err := r.recordingTerminator.Terminate(pid); err != nil {
+		return err
+	}
+	if r.alive != nil {
+		r.alive[pid] = false
+	}
+	if path := r.wakeLocks[pid]; path != "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *recordingTerminator) Terminate(pid int) error {
@@ -55,7 +81,26 @@ func TestRetireWakeWithAMQUsesExactPersistedInjectorIdentity(t *testing.T) {
 	if err != nil || result.PID != 4242 {
 		t.Fatalf("retire result=%+v err=%v", result, err)
 	}
-	want := []string{"wake", "retire", "--root", root, "--me", "qa", "--inject-via", "/usr/bin/tmux", "--inject-arg", "load-buffer", "--inject-arg", "-", "--json"}
+	want := []string{"wake", "retire", "--root", root, "--me", "qa", "--inject-via", "/usr/bin/tmux", "--inject-arg", "load-buffer", "--inject-arg", "-", "--retry-until", "drained", "--json"}
+	if !reflect.DeepEqual(got.Arg, want) {
+		t.Fatalf("wake retire args=%q want=%q", got.Arg, want)
+	}
+}
+
+func TestRetireWakeWithAMQReplaysInjectedRetryPolicy(t *testing.T) {
+	previous := runExactWakeRetire
+	t.Cleanup(func() { runExactWakeRetire = previous })
+	root := filepath.Join(t.TempDir(), ".agent-mail", "s")
+	var got amqCommandRequest
+	runExactWakeRetire = func(req amqCommandRequest) ([]byte, error) {
+		got = req
+		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":4242}`, root)), nil
+	}
+	rec := launch.Record{CWD: t.TempDir(), WakePID: 4242, WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected}
+	if _, err := retireWakeWithAMQ(rec, root, "qa"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"wake", "retire", "--root", root, "--me", "qa", "--inject-via", "/opt/inject", "--retry-until", "injected", "--json"}
 	if !reflect.DeepEqual(got.Arg, want) {
 		t.Fatalf("wake retire args=%q want=%q", got.Arg, want)
 	}
@@ -85,10 +130,48 @@ func TestReapRawWakeRetirementFallbackIsReported(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
-	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
-	if result.WakeRetirement != "raw_signal_fallback" || !strings.Contains(result.summary(), "raw or has no persisted inject-via identity") || len(term.calls) != 1 || term.calls[0] != 4242 {
+	alive := map[int]bool{4242: true}
+	term := &selfCleaningTerminator{alive: alive, wakeLocks: map[int]string{4242: wakeLockPath(agentDir)}}
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion}, term, downFakeProbe(alive, map[int]bool{4242: true}))
+	if result.WakeRetirement != "raw_self_cleaned" || !strings.Contains(result.summary(), "verified wake self-cleanup") || len(term.calls) != 1 || term.calls[0] != 4242 || !result.LockRemoved {
 		t.Fatalf("raw retirement result=%+v calls=%v", result, term.calls)
+	}
+}
+
+func TestReapRawCorruptWakeFailsClosedAndPreservesLock(t *testing.T) {
+	agentDir := t.TempDir()
+	path := wakeLockPath(agentDir)
+	if err := os.WriteFile(path, []byte(`{"pid":4242,"PID":5252}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := reapStaleArtifacts(agentDir, "qa", filepath.Dir(agentDir), false, launch.Record{}, &recordingTerminator{}, downFakeProbe(nil, nil))
+	if !result.failed() || result.WakeRetirement != "raw_unverified_lock_preserved" || result.PresenceFlip || result.LockRemoved {
+		t.Fatalf("corrupt raw retirement result=%+v", result)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("corrupt raw lock must be preserved: %v", err)
+	}
+}
+
+func TestReapExactWakeRetirementAcceptsResidueAfterLockRemoval(t *testing.T) {
+	previous := runExactWakeRetire
+	t.Cleanup(func() { runExactWakeRetire = previous })
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
+	stubOwnerlessWakeRecovery(t, root, "qa", 4242)
+	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
+		if err := os.Remove(wakeLockPath(agentDir)); err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf(`{"status":"retired_with_residue","agent":"qa","root":%q,"pid":4242,"reason":"state cleanup remains"}`, root)), nil
+	}
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{WakePID: 4242, WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	if result.failed() || result.WakeRetirement != "amq_exact_with_residue" || !result.LockRemoved {
+		t.Fatalf("residue retirement result=%+v", result)
 	}
 }
 
@@ -220,6 +303,35 @@ func TestReapOwnerBoundWakeUsesRecoverOwnerWithoutOwnerlessRetire(t *testing.T) 
 	)
 	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved || recoverCalls != 2 {
 		t.Fatalf("owner-bound recovery result=%+v calls=%d", result, recoverCalls)
+	}
+}
+
+func TestReapResumeOwnerWakeUsesRecoverOwnerWithoutPersistedInjector(t *testing.T) {
+	previousRecover := runExactWakeRecoverOwner
+	previousRetire := runExactWakeRetire
+	t.Cleanup(func() {
+		runExactWakeRecoverOwner = previousRecover
+		runExactWakeRetire = previousRetire
+	})
+	root := t.TempDir()
+	agentDir := filepath.Join(root, "agents", "qa")
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root, ResumeOwner: json.RawMessage(`{"pid":5151}`)})
+	runExactWakeRecoverOwner = func(amqCommandRequest) ([]byte, error) {
+		if err := os.Remove(wakeLockPath(agentDir)); err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf(`{"status":"recovered","agent":"qa","root":%q,"pid":4242,"owner_pid":5151,"reason":"exact resume owner released"}`, root)), nil
+	}
+	runExactWakeRetire = func(amqCommandRequest) ([]byte, error) {
+		t.Fatal("resume-owner recovery must not require ownerless inject-via retirement")
+		return nil, nil
+	}
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AgentPID: 5151, WakePID: 4242}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved {
+		t.Fatalf("resume-owner recovery result=%+v", result)
 	}
 }
 
@@ -974,7 +1086,8 @@ func TestExecuteDownReapsOrphanWakeOnDeadAgent(t *testing.T) {
 		LastSeen: time.Now().Add(-5 * time.Second),
 	})
 
-	term := &recordingTerminator{}
+	alive := map[int]bool{1111: false, 3476: true}
+	term := &selfCleaningTerminator{alive: alive, wakeLocks: map[int]string{3476: wakeLockPath(agentDir)}}
 	out, err := runDownExec(t, downExecution{
 		ProjectDir:       dir,
 		RequestedSession: "issue-96",
@@ -983,7 +1096,7 @@ func TestExecuteDownReapsOrphanWakeOnDeadAgent(t *testing.T) {
 		Terminator:       term,
 		// Agent pid dead, wake pid alive; both pass process-match.
 		Probe: downFakeProbe(
-			map[int]bool{1111: false, 3476: true},
+			alive,
 			map[int]bool{1111: false, 3476: true},
 		),
 	})
@@ -1093,7 +1206,8 @@ func TestExecuteDownReapDoesNotTouchForeignPresence(t *testing.T) {
 }
 
 // TestExecuteDownReapsLockOnPIDReuse covers a stale .wake.lock whose PID
-// has been recycled by an unrelated process. The lock must be removed but
+// has been recycled by an unrelated process. The lock must be preserved for
+// AMQ's guarded cleanup but
 // the reused-PID process must not be SIGTERMed.
 func TestExecuteDownReapsLockOnPIDReuse(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
@@ -1124,8 +1238,8 @@ func TestExecuteDownReapsLockOnPIDReuse(t *testing.T) {
 	if len(term.calls) != 0 {
 		t.Fatalf("reused PID must not receive SIGTERM; got %v", term.calls)
 	}
-	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
-		t.Errorf("stale lock should still be removed even on PID reuse; stat err = %v", statErr)
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); statErr != nil {
+		t.Errorf("stale lock must be preserved for AMQ cleanup; stat err = %v", statErr)
 	}
 }
 
@@ -1210,7 +1324,7 @@ func TestExecuteDownReapKeepsLockOnSignalFailure(t *testing.T) {
 
 // TestExecuteDownReapRejectsForeignRootWake covers PID reuse where the
 // live PID belongs to a wake for a different workstream root. The lock
-// must be removed (stale for this dir) and the foreign wake must NOT be
+// must be preserved for AMQ cleanup and the foreign wake must NOT be
 // signaled. Uses the real wakeProcessMatcher predicate via synthetic ps
 // args so a future refactor that calls the wrong matcher is caught here.
 func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
@@ -1248,8 +1362,8 @@ func TestExecuteDownReapRejectsForeignRootWake(t *testing.T) {
 	if len(term.calls) != 0 {
 		t.Fatalf("foreign-root wake must not be signaled; got %v", term.calls)
 	}
-	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(statErr) {
-		t.Errorf("foreign-root lock should be removed as stale; stat err = %v", statErr)
+	if _, statErr := os.Stat(filepath.Join(agentDir, ".wake.lock")); statErr != nil {
+		t.Errorf("foreign-root lock must be preserved for AMQ cleanup; stat err = %v", statErr)
 	}
 }
 

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -126,59 +126,165 @@ func stubOwnerlessWakeRecovery(t *testing.T, root, handle string, pid int) {
 	}
 }
 
+func fakeMissingWakeCheck(req amqCommandRequest) ([]byte, error) {
+	root, handle := wakeCheckRequestIdentity(req)
+	return []byte(fmt.Sprintf(`{"schema":1,"agent":%q,"root":%q,"live_wake":false,"wake_status":"missing"}`, handle, root)), nil
+}
+
+func fakeMismatchedWakeCheck(amqCommandRequest) ([]byte, error) {
+	return []byte(`{"schema":2,"agent":"foreign","root":"/foreign","live_wake":false,"wake_status":"missing"}`), nil
+}
+
+func wakeCheckRequestIdentity(req amqCommandRequest) (root, handle string) {
+	for i, arg := range req.Arg {
+		if i+1 >= len(req.Arg) {
+			continue
+		}
+		switch arg {
+		case "--root":
+			root = req.Arg[i+1]
+		case "--me":
+			handle = req.Arg[i+1]
+		}
+	}
+	return root, handle
+}
+
 func TestReapRawWakeRetirementFallbackIsReported(t *testing.T) {
 	agentDir := t.TempDir()
 	root := filepath.Dir(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: root})
 	alive := map[int]bool{4242: true}
 	term := &selfCleaningTerminator{alive: alive, wakeLocks: map[int]string{4242: wakeLockPath(agentDir)}}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion}, term, downFakeProbe(alive, map[int]bool{4242: true}))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion}, term, downFakeProbe(alive, map[int]bool{4242: true}), fakeMissingWakeCheck)
 	if result.WakeRetirement != "raw_self_cleaned" || !strings.Contains(result.summary(), "verified wake self-cleanup") || len(term.calls) != 1 || term.calls[0] != 4242 || !result.LockRemoved {
 		t.Fatalf("raw retirement result=%+v calls=%v", result, term.calls)
 	}
 }
 
-func TestWakeSelfCleanedAfterRetireWaitsForDelayedCleanup(t *testing.T) {
-	if wakeSelfCleanupTimeout < 8*time.Second {
-		t.Fatalf("wake self-cleanup timeout = %s, want at least 8s for loaded teardown", wakeSelfCleanupTimeout)
+func TestWakeQuiescenceWaitsForDelayedAuthoritativeMissing(t *testing.T) {
+	if wakeQuiescenceTimeout < 20*time.Second {
+		t.Fatalf("wake quiescence timeout = %s, want at least 20s for loaded teardown", wakeQuiescenceTimeout)
 	}
-	previousTimeout, previousPoll := wakeSelfCleanupTimeout, wakeSelfCleanupPoll
-	wakeSelfCleanupTimeout = 500 * time.Millisecond
-	wakeSelfCleanupPoll = 5 * time.Millisecond
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 500 * time.Millisecond
+	wakeQuiescencePoll = 5 * time.Millisecond
 	t.Cleanup(func() {
-		wakeSelfCleanupTimeout, wakeSelfCleanupPoll = previousTimeout, previousPoll
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
+	})
+
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	calls := 0
+	check := func(req amqCommandRequest) ([]byte, error) {
+		calls++
+		checkRoot, handle := wakeCheckRequestIdentity(req)
+		status := "live"
+		live := true
+		pid := 4242
+		if calls >= 3 {
+			status, live, pid = "missing", false, 0
+		}
+		return []byte(fmt.Sprintf(`{"schema":1,"agent":%q,"root":%q,"live_wake":%t,"wake_status":%q,"wake_pid":%d}`, handle, checkRoot, live, status, pid)), nil
+	}
+	result := waitForWakeQuiescence(agentDir, root, "qa", 4242, downFakeProbe(nil, nil), check)
+	if !result.Verified || result.Status != "amq_missing" || calls != 3 {
+		t.Fatalf("delayed authoritative quiescence result=%+v calls=%d", result, calls)
+	}
+}
+
+func TestWakeQuiescenceUnavailableFallsBackToConsecutiveStableSamples(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 500 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
 	})
 
 	agentDir := t.TempDir()
 	lockPath := wakeLockPath(agentDir)
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: filepath.Dir(agentDir)})
-	exited := make(chan struct{})
-	cleanupDone := make(chan error, 1)
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		err := os.Remove(lockPath)
-		if err == nil {
-			close(exited)
-		}
-		cleanupDone <- err
-	}()
+	checks := 0
 	probe := downFakeProbe(nil, nil)
 	probe.PIDAlive = func(pid int) bool {
 		if pid != 4242 {
 			return false
 		}
-		select {
-		case <-exited:
-			return false
-		default:
+		checks++
+		if checks <= 2 {
 			return true
 		}
+		if checks == 3 {
+			if err := os.Remove(lockPath); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return false
 	}
-	if !wakeSelfCleanedAfterRetire(lockPath, 4242, probe) {
-		t.Fatal("delayed pid exit and lock removal were not observed within the bounded window")
+	result := waitForWakeQuiescence(
+		agentDir,
+		filepath.Dir(agentDir),
+		"qa",
+		4242,
+		probe,
+		func(amqCommandRequest) ([]byte, error) { return []byte("{"), nil },
+	)
+	if !result.Verified || result.Status != "stable_samples" || checks < 2+wakeQuiescenceStableSamples {
+		t.Fatalf("fallback quiescence result=%+v checks=%d", result, checks)
 	}
-	if err := <-cleanupDone; err != nil {
-		t.Fatalf("delayed wake cleanup: %v", err)
+}
+
+func TestWakeQuiescenceBlockedCheckLeavesFallbackBudget(t *testing.T) {
+	previousTimeout, previousCheckTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescenceCheckTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 200 * time.Millisecond
+	wakeQuiescenceCheckTimeout = 20 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescenceCheckTimeout, wakeQuiescencePoll = previousTimeout, previousCheckTimeout, previousPoll
+	})
+
+	agentDir := t.TempDir()
+	lockPath := wakeLockPath(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4242, Root: filepath.Dir(agentDir)})
+	checks := 0
+	probe := downFakeProbe(nil, nil)
+	probe.PIDAlive = func(pid int) bool {
+		if pid != 4242 {
+			return false
+		}
+		checks++
+		if checks == 1 {
+			if err := os.Remove(lockPath); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return false
+	}
+	result := waitForWakeQuiescence(
+		agentDir,
+		filepath.Dir(agentDir),
+		"qa",
+		4242,
+		probe,
+		func(req amqCommandRequest) ([]byte, error) {
+			<-req.Context.Done()
+			return nil, req.Context.Err()
+		},
+	)
+	if !result.Verified || result.Status != "stable_samples" || checks < wakeQuiescenceStableSamples {
+		t.Fatalf("blocked-check fallback result=%+v checks=%d", result, checks)
+	}
+}
+
+func TestWakeQuiescenceIdentityMismatchNeverFallsBack(t *testing.T) {
+	probe := downFakeProbe(nil, nil)
+	probe.PIDAlive = func(int) bool {
+		t.Fatal("identity mismatch must fail closed without filesystem fallback")
+		return false
+	}
+	result := waitForWakeQuiescence(t.TempDir(), t.TempDir(), "qa", 4242, probe, fakeMismatchedWakeCheck)
+	if result.Verified || result.Status != "unverified" || !strings.Contains(result.Detail, "identity mismatch") {
+		t.Fatalf("identity-mismatch quiescence result=%+v", result)
 	}
 }
 
@@ -188,7 +294,7 @@ func TestReapRawCorruptWakeFailsClosedAndPreservesLock(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"pid":4242,"PID":5252}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	result := reapStaleArtifacts(agentDir, "qa", filepath.Dir(agentDir), false, launch.Record{}, &recordingTerminator{}, downFakeProbe(nil, nil))
+	result := reapStaleArtifacts(agentDir, "qa", filepath.Dir(agentDir), false, launch.Record{}, &recordingTerminator{}, downFakeProbe(nil, nil), fakeMissingWakeCheck)
 	if !result.failed() || result.WakeRetirement != "raw_unverified_lock_preserved" || result.PresenceFlip || result.LockRemoved {
 		t.Fatalf("corrupt raw retirement result=%+v", result)
 	}
@@ -213,7 +319,7 @@ func TestReapExactWakeRetirementAcceptsResidueAfterLockRemoval(t *testing.T) {
 		}
 		return []byte(fmt.Sprintf(`{"status":"retired_with_residue","agent":"qa","root":%q,"pid":4242,"reason":"state cleanup remains"}`, root)), nil
 	}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{WakePID: 4242, WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{WakePID: 4242, WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil), fakeMissingWakeCheck)
 	if result.failed() || result.WakeRetirement != "amq_exact_with_residue" || !result.LockRemoved {
 		t.Fatalf("residue retirement result=%+v", result)
 	}
@@ -235,7 +341,7 @@ func TestReapExactWakeRetirementRecognizesSelfCleanup(t *testing.T) {
 		}
 		return []byte(fmt.Sprintf(`{"status":"refused","agent":"qa","root":%q,"pid":4242,"reason":"wake self-cleaned"}`, root)), errors.New("exit status 1")
 	}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil), fakeMissingWakeCheck)
 	if result.WakeRetirement != nativeWakeRetireSelfCleaned || result.failed() || !result.LockRemoved || result.WakeKilled != 4242 {
 		t.Fatalf("self-cleaned retirement result=%+v", result)
 	}
@@ -252,7 +358,7 @@ func TestReapExactWakeRetirementRefusalNeverFallsBackToSignal(t *testing.T) {
 		return []byte(fmt.Sprintf(`{"status":"refused","agent":"qa","root":%q,"pid":4242,"reason":"target mismatch"}`, root)), errors.New("exit status 1")
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}), fakeMismatchedWakeCheck)
 	if result.WakeRetirement != "amq_exact_refused" || !result.failed() || len(term.calls) != 0 {
 		t.Fatalf("exact refusal result=%+v fallback calls=%v", result, term.calls)
 	}
@@ -271,7 +377,7 @@ func TestReapExactWakeRetirementSuccessNeverFallsBackToSignal(t *testing.T) {
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":4242,"reason":"exact target retired"}`, root)), nil
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}), fakeMismatchedWakeCheck)
 	if result.WakeRetirement != "amq_exact_lock_remaining" || !result.failed() || len(term.calls) != 0 {
 		t.Fatalf("exact success result=%+v fallback calls=%v", result, term.calls)
 	}
@@ -288,7 +394,7 @@ func TestReapExactWakeRetirementRejectsMismatchedPIDWithoutFallback(t *testing.T
 		return []byte(fmt.Sprintf(`{"status":"retired","agent":"qa","root":%q,"pid":5252,"reason":"exact target retired"}`, root)), nil
 	}
 	term := &recordingTerminator{}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true, 5252: true}, map[int]bool{4242: true, 5252: true}))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"}, term, downFakeProbe(map[int]bool{4242: true, 5252: true}, map[int]bool{4242: true, 5252: true}), fakeMismatchedWakeCheck)
 	if result.WakeRetirement != "amq_exact_refused" || !result.failed() || !strings.Contains(result.RetirementDetail, "mismatched pid=5252") || len(term.calls) != 0 {
 		t.Fatalf("mismatched pid result=%+v fallback calls=%v", result, term.calls)
 	}
@@ -344,6 +450,7 @@ func TestReapOwnerBoundWakeUsesRecoverOwnerWithoutOwnerlessRetire(t *testing.T) 
 		launch.Record{CWD: t.TempDir(), AgentPID: 5151, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"},
 		&recordingTerminator{},
 		downFakeProbe(map[int]bool{4242: false}, nil),
+		fakeMissingWakeCheck,
 	)
 	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved || recoverCalls != 2 {
 		t.Fatalf("owner-bound recovery result=%+v calls=%d", result, recoverCalls)
@@ -373,7 +480,7 @@ func TestReapResumeOwnerWakeUsesRecoverOwnerWithoutPersistedInjector(t *testing.
 		t.Fatal("resume-owner recovery must not require ownerless inject-via retirement")
 		return nil, nil
 	}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AgentPID: 5151, WakePID: 4242}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil))
+	result := reapStaleArtifacts(agentDir, "qa", root, false, launch.Record{AgentPID: 5151, WakePID: 4242}, &recordingTerminator{}, downFakeProbe(map[int]bool{4242: false}, nil), fakeMissingWakeCheck)
 	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved {
 		t.Fatalf("resume-owner recovery result=%+v", result)
 	}
@@ -408,6 +515,7 @@ func TestReapOwnerRecoveryRejectsMismatchedOwnerWithoutFallback(t *testing.T) {
 		launch.Record{AgentPID: 5151, WakePID: 4242, WakeInjectVia: "/usr/bin/tmux"},
 		term,
 		downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}),
+		fakeMismatchedWakeCheck,
 	)
 	if !result.failed() || result.WakeRetirement != "amq_owner_recovery_refused" ||
 		!strings.Contains(result.RetirementDetail, "owner pid=6161, want persisted agent pid=5151") ||
@@ -447,6 +555,7 @@ func TestReapCorruptOwnerBoundWakeWithNoPersistedWakePIDStillFails(t *testing.T)
 		launch.Record{AgentPID: 5151, WakePID: 0, WakeInjectVia: "/usr/bin/tmux"},
 		&recordingTerminator{},
 		downFakeProbe(nil, nil),
+		fakeMismatchedWakeCheck,
 	)
 	if result.WakeSignalFailed != 0 || result.WakeRetirement != "amq_owner_recovery_refused" ||
 		!result.failed() || result.any() || !strings.Contains(result.RetirementDetail, "status refused") {
@@ -509,7 +618,7 @@ func TestReapPresenceReassertsOfflineAfterWakeDies(t *testing.T) {
 
 	term := &recordingTerminator{}
 	rec := launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe)
+	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe, fakeMissingWakeCheck)
 
 	if !result.PresenceFlip {
 		t.Fatalf("expected PresenceFlip=true, got %+v", result)
@@ -551,7 +660,7 @@ func TestReapPresenceFlipSkipsReassertWhenWakeAlreadyDead(t *testing.T) {
 
 	term := &recordingTerminator{}
 	rec := launch.Record{AMQVersion: doctorMinAMQVersion, WakePID: 4242}
-	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe)
+	result := reapStaleArtifacts(agentDir, "qa", root, false, rec, term, probe, fakeMissingWakeCheck)
 
 	if !result.PresenceFlip {
 		t.Fatalf("expected PresenceFlip=true, got %+v", result)
@@ -618,6 +727,9 @@ func runDownExec(t *testing.T, d downExecution) (string, error) {
 	t.Helper()
 	var buf bytes.Buffer
 	d.Out = &buf
+	if d.WakeCheck == nil {
+		d.WakeCheck = fakeMissingWakeCheck
+	}
 	err := executeDown(d)
 	return buf.String(), err
 }

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -1248,6 +1248,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle, wakeInjectMode s
 		WakeInjectArgs: wakeConfig.Args,
 		WakeInjectMode: wakeInjectMode,
 		WakeInjectCmd:  wakeInjectCmdValue,
+		WakeRetryUntil: wakeConfig.RetryUntil,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start external orchestrator wake: %w", err)
@@ -1277,6 +1278,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle, wakeInjectMode s
 		WakeInjectArgs:           wakeConfig.Args,
 		WakeInjectMode:           wakeInjectMode,
 		WakeInjectCmd:            wakeInjectCmdValue,
+		WakeRetryUntil:           wakeConfig.RetryUntil,
 		WakePID:                  wakePID,
 		WakeRecordID:             wakeBinding.RecordID,
 		WakeRecordDigest:         wakeBinding.RecordDigest,

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1155,15 +1155,15 @@ func TestRunLaunchRejectsAMQBelowSupportedFloorBeforeSideEffects(t *testing.T) {
 	}
 }
 
-func TestValidateSupportedAMQVersionUses0522Floor(t *testing.T) {
-	for _, version := range []string{"0.52.2", "v0.52.2", "0.53.0-rc1"} {
+func TestValidateSupportedAMQVersionUses0600Floor(t *testing.T) {
+	for _, version := range []string{"0.60.0", "v0.60.0", "0.61.0-rc1"} {
 		if err := validateSupportedAMQVersion(version); err != nil {
 			t.Errorf("validateSupportedAMQVersion(%q): %v", version, err)
 		}
 	}
-	for _, version := range []string{"0.49.9", "0.50.1", "0.51.0", "0.51.1", "0.52.0", "0.52.1", "0.52.2-rc1"} {
+	for _, version := range []string{"0.52.2", "0.54.0", "0.57.3", "0.59.1", "0.60.0-rc1"} {
 		err := validateSupportedAMQVersion(version)
-		if err == nil || !strings.Contains(err.Error(), "older than required 0.52.2") || !strings.Contains(err.Error(), "amq upgrade") {
+		if err == nil || !strings.Contains(err.Error(), "older than required 0.60.0") || !strings.Contains(err.Error(), "amq upgrade") {
 			t.Errorf("validateSupportedAMQVersion(%q) = %v, want actionable floor rejection", version, err)
 		}
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -159,8 +159,8 @@ func wakeHealthForEntry(e launch.Entry, probe duplicateLaunchProbe) string {
 	if err != nil {
 		return "missing"
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(data, &lock); err != nil {
+	lock, err := decodeWakeLockFile(data)
+	if err != nil {
 		return "stale"
 	}
 	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {

--- a/internal/cli/live_identity.go
+++ b/internal/cli/live_identity.go
@@ -41,6 +41,17 @@ type wakeRecordBinding struct {
 	RecordDigest string
 }
 
+var runWakeCheckForBinding = runAMQCommand
+
+type wakeCheckBindingResult struct {
+	Schema     int    `json:"schema"`
+	Agent      string `json:"agent"`
+	Root       string `json:"root"`
+	LiveWake   bool   `json:"live_wake"`
+	WakeStatus string `json:"wake_status"`
+	WakePID    int    `json:"wake_pid"`
+}
+
 type unmanagedLiveActorError struct {
 	Handle string
 }
@@ -170,8 +181,8 @@ func readWakeRecordBinding(agentDir string) (wakeRecordBinding, wakeLockFile, er
 	if err != nil {
 		return wakeRecordBinding{}, wakeLockFile{}, err
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(raw, &lock); err != nil {
+	lock, err := decodeWakeLockFile(raw)
+	if err != nil {
 		return wakeRecordBinding{}, wakeLockFile{}, err
 	}
 	recordID, err := filepath.EvalSymlinks(path)
@@ -195,6 +206,23 @@ func verifiedWakeRecordBinding(agentDir, root, handle string, probe duplicateLau
 	}
 	if strings.TrimSpace(lock.Root) != "" && !sameResolvedDir(lock.Root, root) {
 		return wakeRecordBinding{}, fmt.Errorf("wake lock root %s differs from launch root %s", lock.Root, root)
+	}
+	if wakeLockHasStateBinding(lock) {
+		out, checkErr := runWakeCheckForBinding(amqCommandRequest{
+			Dir: filepath.Dir(root),
+			Env: os.Environ(),
+			Arg: []string{"wake", "check", "--root", root, "--me", handle, "--json", "--json-schema", "1"},
+		})
+		if checkErr != nil {
+			return wakeRecordBinding{}, fmt.Errorf("authoritative amq wake check failed for state-bound lock: %w", checkErr)
+		}
+		var checked wakeCheckBindingResult
+		if err := json.Unmarshal(out, &checked); err != nil {
+			return wakeRecordBinding{}, fmt.Errorf("authoritative amq wake check returned invalid JSON: %w", err)
+		}
+		if checked.Schema != 1 || !checked.LiveWake || checked.WakeStatus != "live" || checked.Agent != handle || !rootsMatch(checked.Root, root) || checked.WakePID != binding.PID {
+			return wakeRecordBinding{}, fmt.Errorf("authoritative amq wake check did not verify exact live lock: schema=%d status=%s agent=%s root=%s pid=%d", checked.Schema, checked.WakeStatus, checked.Agent, checked.Root, checked.WakePID)
+		}
 	}
 	return binding, nil
 }

--- a/internal/cli/live_identity_test.go
+++ b/internal/cli/live_identity_test.go
@@ -144,7 +144,7 @@ func TestStopClosePanesAcceptsPaneProcessRecordFromDeliveryPath(t *testing.T) {
 		configured, project, team.DefaultProfile, member, "issue-465",
 		eventTerminator{events: &events},
 		downFakeProbe(map[int]bool{panePID: true}, map[int]bool{panePID: true}),
-		nil, true, deps,
+		nil, true, deps, fakeMissingWakeCheck,
 	)
 	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupClosed {
 		t.Fatalf("stop --close-panes report=%+v, want stopped and pane closed", report)
@@ -179,7 +179,7 @@ func TestPaneCleanupRejectsUnrelatedPaneProcessPID(t *testing.T) {
 				closeCalls++
 				return nil
 			},
-		},
+		}, fakeMissingWakeCheck,
 	)
 	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupPreservedIdentityUnconfirmed {
 		t.Fatalf("unrelated cleanup report=%+v, want signaled with pane preserved", report)

--- a/internal/cli/pane_cleanup_down_wiring_test.go
+++ b/internal/cli/pane_cleanup_down_wiring_test.go
@@ -78,7 +78,7 @@ func TestStopPanePrepareSignalCloseOrdering(t *testing.T) {
 		events = append(events, "match")
 		return baseMatch(pid, match)
 	}
-	report := terminateMember(configured, project, team.DefaultProfile, member, "issue-465", eventTerminator{events: &events}, probe, nil, true, deps)
+	report := terminateMember(configured, project, team.DefaultProfile, member, "issue-465", eventTerminator{events: &events}, probe, nil, true, deps, fakeMissingWakeCheck)
 	wantPrefix := []string{"alive", "match", "inspect", "children", "alive", "match", "signal", "inspect", "close"}
 	if len(events) < len(wantPrefix) || !reflect.DeepEqual(events[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("events=%v, want prefix %v", events, wantPrefix)
@@ -88,12 +88,59 @@ func TestStopPanePrepareSignalCloseOrdering(t *testing.T) {
 	}
 }
 
-func TestStopFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testing.T) {
-	previousTimeout, previousPoll := wakeSelfCleanupTimeout, wakeSelfCleanupPoll
-	wakeSelfCleanupTimeout = 50 * time.Millisecond
-	wakeSelfCleanupPoll = time.Millisecond
+func TestStopRequiresAuthoritativeMissingWithoutPersistedWakePID(t *testing.T) {
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	if record.WakePID != 0 {
+		t.Fatalf("fixture WakePID=%d, want missing persisted wake pid", record.WakePID)
+	}
+	paneClosed := false
+	checkCalls := 0
+	wakeCheck := func(req amqCommandRequest) ([]byte, error) {
+		if !paneClosed {
+			t.Fatal("authoritative wake check ran before pane teardown completed")
+		}
+		checkCalls++
+		want := []string{"wake", "check", "--root", record.Root, "--me", record.Handle, "--json", "--json-schema", "1"}
+		if !reflect.DeepEqual(req.Arg, want) {
+			t.Fatalf("wake check args=%q want=%q", req.Arg, want)
+		}
+		return fakeMissingWakeCheck(req)
+	}
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, record.Session,
+		&recordingTerminator{},
+		downFakeProbe(map[int]bool{record.AgentPID: true}, map[int]bool{record.AgentPID: true}),
+		nil, true,
+		PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(parent int) []int {
+					if parent == pane.PID {
+						return []int{record.AgentPID}
+					}
+					return nil
+				}, nil
+			},
+			Close: func(string) error {
+				paneClosed = true
+				return nil
+			},
+		},
+		wakeCheck,
+	)
+	if report.Status != downStatusStopped || checkCalls != 1 || !strings.Contains(report.Detail, "wake quiescence=amq_missing") {
+		t.Fatalf("report=%+v check calls=%d, want authoritative missing proof without WakePID", report, checkCalls)
+	}
+}
+
+func TestStopFallbackFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 50 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
 	t.Cleanup(func() {
-		wakeSelfCleanupTimeout, wakeSelfCleanupPoll = previousTimeout, previousPoll
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
 	})
 
 	configured, member, record, pane, project := completeDownPaneFixture(t)
@@ -144,9 +191,10 @@ func TestStopFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testing.T) {
 				return nil
 			},
 		},
+		func(amqCommandRequest) ([]byte, error) { return nil, errors.New("wake check unavailable") },
 	)
 
-	if report.Status != downStatusFailed || !strings.Contains(report.Detail, "wake retirement=raw_cleanup_unverified") || !strings.Contains(report.Detail, "post-teardown verification timed out") {
+	if report.Status != downStatusFailed || !strings.Contains(report.Detail, "wake quiescence=unverified") || !strings.Contains(report.Detail, "filesystem fallback did not observe") {
 		t.Fatalf("report=%+v, want fail-closed post-teardown wake verification", report)
 	}
 	if wakeChecks == 0 {
@@ -192,6 +240,7 @@ func TestStopClosePanesAcceptsPriorGenerationBaseRootShape(t *testing.T) {
 			},
 			Close: func(string) error { closeCalls++; return nil },
 		},
+		fakeMissingWakeCheck,
 	)
 
 	if !reflect.DeepEqual(events, []string{"signal"}) {
@@ -234,6 +283,7 @@ func TestStopClosePanesPriorGenerationShapeStillRefusesForeignPane(t *testing.T)
 			},
 			Close: func(string) error { closeCalls++; return nil },
 		},
+		fakeMissingWakeCheck,
 	)
 
 	if report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupPreservedIdentityUnconfirmed || closeCalls != 0 {
@@ -254,7 +304,7 @@ func TestStopSignalsWhenPanePreparationRefusesAndReturnsPartial(t *testing.T) {
 				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionUnavailable, Detail: "tmux unavailable"}
 			},
 			Close: func(string) error { closeCalls++; return nil },
-		})
+		}, fakeMissingWakeCheck)
 	if !reflect.DeepEqual(events, []string{"signal"}) || closeCalls != 0 {
 		t.Fatalf("signal events=%v close calls=%d", events, closeCalls)
 	}
@@ -282,7 +332,7 @@ func TestStopRefusesToSignalReusedSameBinaryPID(t *testing.T) {
 	}
 	report := terminateMember(
 		configured, project, team.DefaultProfile, member, "issue-465",
-		eventTerminator{events: &events}, probe, nil, true, PaneCleanupDependencies{},
+		eventTerminator{events: &events}, probe, nil, true, PaneCleanupDependencies{}, fakeMissingWakeCheck,
 	)
 	if len(events) != 0 {
 		t.Fatalf("reused same-binary PID was signaled: %v", events)

--- a/internal/cli/pane_cleanup_down_wiring_test.go
+++ b/internal/cli/pane_cleanup_down_wiring_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -84,6 +85,75 @@ func TestStopPanePrepareSignalCloseOrdering(t *testing.T) {
 	}
 	if inspections != 2 || report.Status != downStatusStopped || report.Pane.Outcome != PaneCleanupClosed {
 		t.Fatalf("report=%+v inspections=%d", report, inspections)
+	}
+}
+
+func TestStopFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testing.T) {
+	previousTimeout, previousPoll := wakeSelfCleanupTimeout, wakeSelfCleanupPoll
+	wakeSelfCleanupTimeout = 50 * time.Millisecond
+	wakeSelfCleanupPoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeSelfCleanupTimeout, wakeSelfCleanupPoll = previousTimeout, previousPoll
+	})
+
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.WakePID = 4343
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(record.Root, "agents", record.Handle)
+	lockPath := wakeLockPath(agentDir)
+
+	paneClosed := false
+	wakeChecks := 0
+	probe := downFakeProbe(map[int]bool{record.AgentPID: true}, map[int]bool{record.AgentPID: true})
+	basePIDAlive := probe.PIDAlive
+	probe.PIDAlive = func(pid int) bool {
+		if pid != record.WakePID {
+			return basePIDAlive(pid)
+		}
+		if !paneClosed {
+			t.Fatal("recorded wake was verified before pane teardown completed")
+		}
+		wakeChecks++
+		if wakeChecks == 1 {
+			// The one-shot reap observed no lock. Model the exiting wake
+			// publishing it immediately before its PID becomes observably dead.
+			writeWakeLock(t, agentDir, wakeLockFile{PID: record.WakePID, Root: record.Root})
+		}
+		return false
+	}
+
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, record.Session,
+		&recordingTerminator{}, probe, nil, true,
+		PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(parent int) []int {
+					if parent == pane.PID {
+						return []int{record.AgentPID}
+					}
+					return nil
+				}, nil
+			},
+			Close: func(string) error {
+				paneClosed = true
+				return nil
+			},
+		},
+	)
+
+	if report.Status != downStatusFailed || !strings.Contains(report.Detail, "wake retirement=raw_cleanup_unverified") || !strings.Contains(report.Detail, "post-teardown verification timed out") {
+		t.Fatalf("report=%+v, want fail-closed post-teardown wake verification", report)
+	}
+	if wakeChecks == 0 {
+		t.Fatal("post-teardown wake verification did not inspect the recorded wake pid")
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("reappeared wake lock was not preserved for inspection: %v", err)
 	}
 }
 

--- a/internal/cli/pane_cleanup_down_wiring_test.go
+++ b/internal/cli/pane_cleanup_down_wiring_test.go
@@ -166,7 +166,11 @@ func TestStopFallbackFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testin
 		if wakeChecks == 1 {
 			// The one-shot reap observed no lock. Model the exiting wake
 			// publishing it immediately before its PID becomes observably dead.
-			writeWakeLock(t, agentDir, wakeLockFile{PID: record.WakePID, Root: record.Root})
+			writeWakeLock(t, agentDir, wakeLockFile{
+				PID:   record.WakePID,
+				Root:  filepath.Join(record.Root, "foreign"),
+				Agent: record.Handle,
+			})
 		}
 		return false
 	}
@@ -202,6 +206,62 @@ func TestStopFallbackFailsClosedWhenWakeLockReappearsAfterPaneTeardown(t *testin
 	}
 	if _, err := os.Stat(lockPath); err != nil {
 		t.Fatalf("reappeared wake lock was not preserved for inspection: %v", err)
+	}
+}
+
+func TestResumedSecondStopAcceptsPreservedDeadPIDStaleWakeLock(t *testing.T) {
+	previousTimeout, previousPoll := wakeQuiescenceTimeout, wakeQuiescencePoll
+	wakeQuiescenceTimeout = 100 * time.Millisecond
+	wakeQuiescencePoll = time.Millisecond
+	t.Cleanup(func() {
+		wakeQuiescenceTimeout, wakeQuiescencePoll = previousTimeout, previousPoll
+	})
+
+	configured, member, record, pane, project := completeDownPaneFixture(t)
+	record.WakePID = 4343
+	if err := launch.Write(filepath.Join(record.Root, "agents", record.Handle), record); err != nil {
+		t.Fatal(err)
+	}
+	agentDir := filepath.Join(record.Root, "agents", record.Handle)
+	lockPath := wakeLockPath(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{
+		PID:   record.WakePID,
+		Root:  record.Root,
+		Agent: record.Handle,
+	})
+
+	report := terminateMember(
+		configured, project, team.DefaultProfile, member, record.Session,
+		&recordingTerminator{},
+		downFakeProbe(
+			map[int]bool{record.AgentPID: true, record.WakePID: false},
+			map[int]bool{record.AgentPID: true},
+		),
+		nil, true,
+		PaneCleanupDependencies{
+			Inspect: func(string) tmuxpane.PaneInspection {
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			},
+			ChildrenIndex: func() (func(int) []int, error) {
+				return func(parent int) []int {
+					if parent == pane.PID {
+						return []int{record.AgentPID}
+					}
+					return nil
+				}, nil
+			},
+			Close: func(string) error { return nil },
+		},
+		func(amqCommandRequest) ([]byte, error) { return nil, errors.New("wake check unavailable") },
+	)
+
+	if report.Status != downStatusStopped ||
+		!strings.Contains(report.Detail, "wake retirement=raw_stale_preserved") ||
+		!strings.Contains(report.Detail, "wake quiescence=fs_stale_lock_preserved") {
+		t.Fatalf("resumed second-stop report=%+v", report)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("verified stale wake lock must remain for AMQ guarded cleanup: %v", err)
 	}
 }
 

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -34,6 +34,9 @@ type blockerReason struct {
 	Message string
 	// Hint is a single suggested next action.
 	Hint string
+	// FailClosed marks integrity failures that --force-duplicate must not
+	// override. The lock remains AMQ-owned until AMQ verifies or quarantines it.
+	FailClosed bool
 }
 
 // Error implements error so a blocker can be returned as the launch error.
@@ -78,9 +81,8 @@ type agentLaunchPreflight struct {
 	// this diagnosis and continues the preview without mutating.
 	AMQFloorViolation string
 	Force             bool
-	// DryRun keeps the preflight inspection read-only: stale lock files are
-	// detected as non-blocking but never removed. Required for --dry-run paths
-	// where the operator expects zero side effects on disk.
+	// DryRun keeps the preflight inspection read-only. Wake lock lifecycle is
+	// always AMQ-owned; neither dry-run nor live preflight removes lock files.
 	DryRun bool
 }
 
@@ -109,7 +111,7 @@ var defaultDuplicateLaunchProbe = duplicateLaunchProbe{
 
 // check inspects wake locks, prior launch records, and presence. It returns
 // a *duplicateBlocker (as an error) when a hard-block condition is met and
-// Force is false. Stale artifacts are removed in place. The second return
+// Force is false. Wake artifacts are inspected without mutation. The second return
 // value is reserved for I/O errors that should abort preflight.
 func (p agentLaunchPreflight) check(probe duplicateLaunchProbe) (*duplicateBlocker, error) {
 	blocker := &duplicateBlocker{
@@ -119,11 +121,9 @@ func (p agentLaunchPreflight) check(probe duplicateLaunchProbe) (*duplicateBlock
 		AgentDir:   p.AgentDir,
 	}
 
-	// Presence first, before wake-lock cleanup runs. inspectPresence consults
+	// Presence first. inspectPresence consults
 	// the wake.lock and launch.json writer-liveness to decide whether the
-	// presence file is a zombie heartbeat; inspectWakeLock will rewrite the
-	// disk by removing stale locks, which would otherwise make wake writer
-	// status look "unknown" instead of "known dead" to the presence check.
+	// presence file is a zombie heartbeat.
 	if reason, err := p.inspectPresence(probe); err != nil {
 		return nil, err
 	} else if reason != nil {
@@ -155,6 +155,11 @@ func (p agentLaunchPreflight) check(probe duplicateLaunchProbe) (*duplicateBlock
 		return nil, nil
 	}
 	if p.Force {
+		for _, reason := range blocker.Reasons {
+			if reason.FailClosed {
+				return blocker, nil
+			}
+		}
 		// Honor force but echo what was overridden so the operator sees it.
 		fmt.Fprintln(os.Stderr, "warning: --force-duplicate overrode the following live-agent signals:")
 		for _, r := range blocker.Reasons {
@@ -174,14 +179,16 @@ func (p agentLaunchPreflight) inspectWakeLock(probe duplicateLaunchProbe) (*bloc
 		}
 		return nil, fmt.Errorf("read wake lock: %w", err)
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(data, &lock); err != nil {
-		// Corrupt lock file: treat as stale.
-		p.removeIfNotDryRun(path)
-		return nil, nil
+	lock, err := decodeWakeLockFile(data)
+	if err != nil {
+		return &blockerReason{
+			Source:     "wake",
+			Message:    "unverified wake lock preserved at " + path + ": " + err.Error(),
+			Hint:       "inspect with `amq wake check --root " + p.Root + " --me " + p.Handle + "` and `amq doctor --ops`",
+			FailClosed: true,
+		}, nil
 	}
 	if lock.PID <= 0 || !probe.PIDAlive(lock.PID) {
-		p.removeIfNotDryRun(path)
 		return nil, nil
 	}
 	expectedRoot := p.Root
@@ -193,7 +200,6 @@ func (p agentLaunchPreflight) inspectWakeLock(probe duplicateLaunchProbe) (*bloc
 		// handle, but the live PID's --root must still point to the same
 		// workstream root we're targeting; otherwise it belongs to another
 		// project's wake.
-		p.removeIfNotDryRun(path)
 		return nil, nil
 	}
 	msg := fmt.Sprintf("live amq wake at pid %d", lock.PID)
@@ -331,16 +337,15 @@ func presenceWriterIsKnownDead(agentDir, root, handle, fallbackBinary string, pr
 // when the PID is gone or the live PID does not match an amq wake for this
 // handle/root. A corrupt or unparseable lock is reported as unknown (not
 // dead): we have no evidence either way and the conservative answer for
-// the zombie-presence guard is to keep counting presence as live. The
-// stale-cleanup path in inspectWakeLock still removes the corrupt file on its
-// own.
+// the zombie-presence guard is to keep counting presence as live. AMQ owns
+// any guarded cleanup during the next acquisition.
 func wakeWriterDead(agentDir, root, handle string, probe duplicateLaunchProbe) (dead, known bool) {
 	data, err := os.ReadFile(wakeLockPath(agentDir))
 	if err != nil {
 		return false, false
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(data, &lock); err != nil {
+	lock, err := decodeWakeLockFile(data)
+	if err != nil {
 		return false, false
 	}
 	if lock.PID <= 0 {
@@ -382,14 +387,6 @@ func launchWriterDead(agentDir, fallbackBinary string, probe duplicateLaunchProb
 		return true, true
 	}
 	return false, true
-}
-
-// wakeLockFile mirrors AMQ's wake.lock JSON shape.
-type wakeLockFile struct {
-	PID     int       `json:"pid"`
-	TTY     string    `json:"tty,omitempty"`
-	Root    string    `json:"root,omitempty"`
-	Started time.Time `json:"started"`
 }
 
 type presenceFile struct {
@@ -592,15 +589,6 @@ func relativeRootMatchesAbsolute(a, b string) bool {
 		return false
 	}
 	return abs == rel || strings.HasSuffix(abs, string(filepath.Separator)+rel)
-}
-
-// removeIfNotDryRun removes path unless the preflight is in dry-run mode.
-// In dry-run, stale artifacts are detected but left untouched on disk.
-func (p agentLaunchPreflight) removeIfNotDryRun(path string) {
-	if p.DryRun {
-		return
-	}
-	_ = os.Remove(path)
 }
 
 // agentProcessMatcher returns a predicate that recognizes the agent binary.

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -58,8 +58,25 @@ func (b *duplicateBlocker) Error() string {
 		lines = append(lines, "  agent dir: "+b.AgentDir)
 	}
 	lines = append(lines, "Next actions:")
-	lines = append(lines, "  - attach the existing terminal, or stop the old process")
-	lines = append(lines, "  - rerun with --force-duplicate to launch anyway")
+	failClosed := false
+	seenHints := map[string]bool{}
+	for _, reason := range b.Reasons {
+		if !reason.FailClosed {
+			continue
+		}
+		failClosed = true
+		hint := strings.TrimSpace(reason.Hint)
+		if hint != "" && !seenHints[hint] {
+			lines = append(lines, "  - "+hint)
+			seenHints[hint] = true
+		}
+	}
+	if !failClosed {
+		lines = append(lines, "  - attach the existing terminal, or stop the old process")
+		lines = append(lines, "  - rerun with --force-duplicate to launch anyway")
+	} else if len(seenHints) == 0 {
+		lines = append(lines, "  - inspect and repair the integrity blocker before retrying")
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -92,6 +92,9 @@ func TestPreflightLiveWakeLockBlocks(t *testing.T) {
 	if !strings.Contains(blocker.Error(), "wake") || !strings.Contains(blocker.Error(), "1234") {
 		t.Fatalf("blocker should name wake source and pid: %s", blocker.Error())
 	}
+	if !strings.Contains(blocker.Error(), "--force-duplicate") {
+		t.Fatalf("ordinary live blocker should retain force override guidance: %s", blocker.Error())
+	}
 }
 
 func TestPreflightLiveWakePIDReuseIsStale(t *testing.T) {
@@ -914,6 +917,15 @@ func TestPreflightCorruptWakeLockKeepsPresenceConservative(t *testing.T) {
 	forced, err := pf.check(probe)
 	if err != nil || forced == nil {
 		t.Fatalf("--force-duplicate must not override a fail-closed lock: blocker=%v err=%v", forced, err)
+	}
+	message := forced.Error()
+	for _, want := range []string{"amq wake check --root /r --me cto", "amq doctor --ops"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("fail-closed blocker omitted remediation %q: %s", want, message)
+		}
+	}
+	if strings.Contains(message, "--force-duplicate") {
+		t.Fatalf("fail-closed blocker suggested an impossible force override: %s", message)
 	}
 }
 

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -54,7 +54,7 @@ func fakeProbe(alive map[int]bool, match map[int]string, now time.Time) duplicat
 	}
 }
 
-func TestPreflightStaleWakeLockIsRemoved(t *testing.T) {
+func TestPreflightStaleWakeLockIsPreservedForAMQ(t *testing.T) {
 	agentDir := t.TempDir()
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 99999, Root: "/r"})
 
@@ -67,8 +67,8 @@ func TestPreflightStaleWakeLockIsRemoved(t *testing.T) {
 	if blocker != nil {
 		t.Fatalf("stale lock should not block: %v", blocker)
 	}
-	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
-		t.Fatalf("stale wake lock should have been removed: stat err = %v", err)
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("stale wake lock must be preserved for AMQ cleanup: %v", err)
 	}
 }
 
@@ -111,8 +111,8 @@ func TestPreflightLiveWakePIDReuseIsStale(t *testing.T) {
 	if blocker != nil {
 		t.Fatalf("PID reuse with non-wake command should be stale: %v", blocker)
 	}
-	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
-		t.Fatalf("PID-reuse stale wake lock should be removed: %v", err)
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("PID-reuse stale wake lock must be preserved for AMQ cleanup: %v", err)
 	}
 }
 
@@ -475,7 +475,7 @@ func TestPreflightSiblingWorkstreamRootIsStale(t *testing.T) {
 	// Regression: the literal-substring fast path used to accept a sibling
 	// workstream's wake whose --root was a strict superstring of expected
 	// (e.g. issue-96 vs issue-96-old). Bounded matching must reject it and
-	// the stale lock must be removed.
+	// the stale lock must be preserved for AMQ's guarded cleanup.
 	agentDir := t.TempDir()
 	expectedRoot := "/Users/me/proj/.agent-mail/issue-96"
 	writeWakeLock(t, agentDir, wakeLockFile{PID: 5555, Root: expectedRoot})
@@ -493,8 +493,8 @@ func TestPreflightSiblingWorkstreamRootIsStale(t *testing.T) {
 	if blocker != nil {
 		t.Fatalf("sibling workstream PID reuse should not block: %v", blocker)
 	}
-	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
-		t.Fatalf("sibling-root stale lock should be removed: %v", err)
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("sibling-root stale lock must be preserved for AMQ cleanup: %v", err)
 	}
 }
 
@@ -519,8 +519,8 @@ func TestPreflightSuffixOfForeignRootIsStale(t *testing.T) {
 	if blocker != nil {
 		t.Fatalf("foreign root containing expected as suffix should not block: %v", blocker)
 	}
-	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
-		t.Fatalf("foreign-suffix stale lock should be removed: %v", err)
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("foreign-suffix stale lock must be preserved for AMQ cleanup: %v", err)
 	}
 }
 
@@ -572,8 +572,8 @@ func TestPreflightForeignRootPIDReuseIsStale(t *testing.T) {
 	if blocker != nil {
 		t.Fatalf("foreign-root PID reuse should not block: %v", blocker)
 	}
-	if _, err := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(err) {
-		t.Fatalf("foreign-root stale lock should be removed: %v", err)
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("foreign-root stale lock must be preserved for AMQ cleanup: %v", err)
 	}
 }
 
@@ -906,6 +906,30 @@ func TestPreflightCorruptWakeLockKeepsPresenceConservative(t *testing.T) {
 	}
 	if !sawPresence {
 		t.Errorf("expected presence in blocker reasons; got %+v", blocker.Reasons)
+	}
+	if _, statErr := os.Stat(wakeLockPath(agentDir)); statErr != nil {
+		t.Fatalf("corrupt lock must be preserved: %v", statErr)
+	}
+	pf.Force = true
+	forced, err := pf.check(probe)
+	if err != nil || forced == nil {
+		t.Fatalf("--force-duplicate must not override a fail-closed lock: blocker=%v err=%v", forced, err)
+	}
+}
+
+func TestPreflightDuplicateKnownWakeLockFieldFailsClosed(t *testing.T) {
+	agentDir := t.TempDir()
+	path := wakeLockPath(agentDir)
+	if err := os.WriteFile(path, []byte(`{"pid":1234,"PID":5678,"root":"/r"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pf := agentLaunchPreflight{AgentDir: agentDir, Handle: "cto", Workstream: "w", Root: "/r", Force: true}
+	blocker, err := pf.check(fakeProbe(map[int]bool{1234: false, 5678: false}, nil, time.Now()))
+	if err != nil || blocker == nil || !strings.Contains(blocker.Error(), "duplicate known field") {
+		t.Fatalf("ambiguous lock must fail closed: blocker=%v err=%v", blocker, err)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("ambiguous lock must be preserved: %v", statErr)
 	}
 }
 

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -795,9 +795,22 @@ func realAMQExactInjectViaWakeRetirement(t *testing.T, binary string) {
 	})
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- wake.Wait() }()
-	result := reapStaleArtifacts(filepath.Join(root, "agents", "consumer"), "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)
-	if result.failed() || (result.WakeRetirement != "amq_exact" && result.WakeRetirement != nativeWakeRetireSelfCleaned) || result.WakeKilled != wake.Process.Pid {
+	agentDir := filepath.Join(root, "agents", "consumer")
+	lockPath := filepath.Join(agentDir, ".wake.lock")
+	result := reapStaleArtifacts(agentDir, "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)
+	acceptedRetirement := result.WakeRetirement == "amq_exact" ||
+		result.WakeRetirement == "amq_exact_with_residue" ||
+		result.WakeRetirement == nativeWakeRetireSelfCleaned
+	if result.failed() || !acceptedRetirement || result.WakeKilled != wake.Process.Pid {
 		t.Fatalf("exact retirement result=%+v wake_log=%s", result, wakeLog.String())
+	}
+	if result.WakeRetirement == "amq_exact_with_residue" {
+		if !result.LockRemoved {
+			t.Fatalf("residue retirement did not record lock removal: result=%+v wake_log=%s", result, wakeLog.String())
+		}
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatalf("residue retirement left wake lock: %v", err)
+		}
 	}
 	select {
 	case err := <-waitErr:
@@ -812,7 +825,7 @@ func realAMQExactInjectViaWakeRetirement(t *testing.T, binary string) {
 	if defaultDuplicateLaunchProbe.PIDAlive(wake.Process.Pid) {
 		t.Fatalf("exact retirement left wake pid %d alive", wake.Process.Pid)
 	}
-	if _, err := os.Stat(filepath.Join(root, "agents", "consumer", ".wake.lock")); !os.IsNotExist(err) {
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("exact retirement left wake lock: %v", err)
 	}
 	if !defaultDuplicateLaunchProbe.PIDAlive(siblingWake.Process.Pid) {

--- a/internal/cli/real_amq_compatibility_test.go
+++ b/internal/cli/real_amq_compatibility_test.go
@@ -551,7 +551,7 @@ while :; do sleep 1; done
 	if err := term.Terminate(rec.AgentPID); err != nil {
 		t.Fatalf("signal owner-bound member: %v", err)
 	}
-	result := reapStaleArtifacts(agentDir, "member", root, false, rec, term, defaultDuplicateLaunchProbe)
+	result := reapStaleArtifacts(agentDir, "member", root, false, rec, term, defaultDuplicateLaunchProbe, runAMQCommand)
 	if result.failed() || result.WakeRetirement != "amq_owner_recovered" || !result.LockRemoved {
 		t.Fatalf("production owner-bound cleanup result=%+v\ncommand log:\n%s", result, commandLog.String())
 	}
@@ -797,7 +797,7 @@ func realAMQExactInjectViaWakeRetirement(t *testing.T, binary string) {
 	go func() { waitErr <- wake.Wait() }()
 	agentDir := filepath.Join(root, "agents", "consumer")
 	lockPath := filepath.Join(agentDir, ".wake.lock")
-	result := reapStaleArtifacts(agentDir, "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe)
+	result := reapStaleArtifacts(agentDir, "consumer", root, false, launch.Record{CWD: project, AMQVersion: doctorMinAMQVersion, WakePID: wake.Process.Pid, WakeInjectVia: injector, WakeInjectArgs: []string{"fixed"}}, &recordingTerminator{}, defaultDuplicateLaunchProbe, runAMQCommand)
 	acceptedRetirement := result.WakeRetirement == "amq_exact" ||
 		result.WakeRetirement == "amq_exact_with_residue" ||
 		result.WakeRetirement == nativeWakeRetireSelfCleaned

--- a/internal/cli/real_amq_env_test.go
+++ b/internal/cli/real_amq_env_test.go
@@ -68,7 +68,7 @@ func TestRealAMQFixtureEnvSanitizesManagedContext(t *testing.T) {
 		"PATH=/fixture/bin",
 		"AMQ_NO_UPDATE_CHECK=0",
 		"AMQ_SQUAD_REAL_AMQ=/fixture/amq",
-		"AMQ_SQUAD_REAL_AMQ_VERSION=v0.52.2",
+		"AMQ_SQUAD_REAL_AMQ_VERSION=v0.60.0",
 	}
 	poisoned := append(append([]string(nil), clean...), realAMQManagedContextPoison...)
 	want := amqexec.NoUpdateCheckEnv(envWithoutAMQIdentity(clean))

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -130,7 +130,7 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 			"down", "--project", h.project, "--profile", team.DefaultProfile, "--session", h.session, "--role", "qa")
 		t.Logf("initial managed stop: %s", strings.TrimSpace(stopOut))
 		h.killSessionIfPresent(initialSession)
-		assertRealWakeStopped(t, h, agentDir, initial.AgentPID, initialWake.PID, initialSession)
+		assertRealWakeStopped(t, h, agentDir, "qa", initial.AgentPID, initialWake.PID, initialSession, false)
 		lead, err := launch.Read(filepath.Join(h.root, "agents", "cto"))
 		if err != nil {
 			t.Fatalf("read managed lead launch record: %v", err)
@@ -178,7 +178,12 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		stopOut = realWakeCommand(t, h.project, h.env(), squad,
 			"down", "--project", h.project, "--profile", team.DefaultProfile, "--session", h.session, "--role", "qa", "--close-panes")
 		t.Logf("final managed stop: %s", strings.TrimSpace(stopOut))
-		assertRealWakeStopped(t, h, agentDir, resumed.AgentPID, resumedWake.PID, resumedSession)
+		staleLockPreserved := assertRealWakeStopped(
+			t, h, agentDir, "qa", resumed.AgentPID, resumedWake.PID, resumedSession, true,
+		)
+		if staleLockPreserved && !strings.Contains(stopOut, "wake quiescence=fs_stale_lock_preserved") {
+			t.Fatalf("final stop preserved the exact stale wake lock without reporting its verified quiescence status:\n%s", stopOut)
+		}
 	})
 
 	t.Run("dispatch force durable plus prompt fallback", func(t *testing.T) {
@@ -455,20 +460,45 @@ func waitForRealWakeFile(t *testing.T, path, label string) {
 	}
 }
 
-func assertRealWakeStopped(t *testing.T, h *realWakeHarness, agentDir string, agentPID, wakePID int, tmuxSession string) {
+func assertRealWakeStopped(
+	t *testing.T,
+	h *realWakeHarness,
+	agentDir, handle string,
+	agentPID, wakePID int,
+	tmuxSession string,
+	allowExactStaleLock bool,
+) bool {
 	t.Helper()
 	waitForRealWakePIDExit(t, "agent", agentPID)
 	waitForRealWakePIDExit(t, "wake", wakePID)
 	waitForRealWakeCondition(t, "tmux session cleanup", func() bool {
 		return !h.sessionExists(tmuxSession)
 	})
-	if _, err := os.Stat(filepath.Join(agentDir, ".wake.lock")); !os.IsNotExist(err) {
-		t.Fatalf("wake lock survived stop: %v", err)
+	staleLockPreserved := false
+	if _, err := os.Stat(filepath.Join(agentDir, ".wake.lock")); err == nil {
+		if !allowExactStaleLock {
+			t.Fatal("wake lock survived stop")
+		}
+		lock, readErr := readWakeLock(agentDir)
+		if readErr != nil || lock.PID != wakePID || lock.Agent != handle || !rootsMatch(lock.Root, h.root) {
+			t.Fatalf(
+				"wake lock survived stop without exact dead-pid identity: lock=%+v read_err=%v want pid=%d agent=%s root=%s",
+				lock,
+				readErr,
+				wakePID,
+				handle,
+				h.root,
+			)
+		}
+		staleLockPreserved = true
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("inspect wake lock after stop: %v", err)
 	}
 	presence, err := readPresenceForEntry(agentDir)
 	if err != nil || presence.Status != "offline" {
 		t.Fatalf("presence after stop = %+v / %v, want offline", presence, err)
 	}
+	return staleLockPreserved
 }
 
 func assertRealWakeProcessIdentity(t *testing.T, rec launch.Record) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1863,8 +1863,8 @@ func readWakeLock(agentDir string) (wakeLockFile, error) {
 	if err != nil {
 		return wakeLockFile{}, err
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(data, &lock); err != nil {
+	lock, err := decodeWakeLockFile(data)
+	if err != nil {
 		return wakeLockFile{}, err
 	}
 	return lock, nil

--- a/internal/cli/stop_namespace_conflict_test.go
+++ b/internal/cli/stop_namespace_conflict_test.go
@@ -28,13 +28,13 @@ type legacyTreeEntry struct {
 
 func downRunnerForTest(term processTerminator, probe duplicateLaunchProbe) func([]string) error {
 	return func(args []string) error {
-		return runDownWithDeps(args, func(bool) processTerminator { return term }, probe)
+		return runDownWithDeps(args, func(bool) processTerminator { return term }, probe, fakeMissingWakeCheck)
 	}
 }
 
 func downRunnerForPaneTest(term processTerminator, probe duplicateLaunchProbe, paneDeps PaneCleanupDependencies) func([]string) error {
 	return func(args []string) error {
-		return runDownWithPaneDeps(args, func(bool) processTerminator { return term }, probe, paneDeps)
+		return runDownWithPaneDeps(args, func(bool) processTerminator { return term }, probe, paneDeps, fakeMissingWakeCheck)
 	}
 }
 

--- a/internal/cli/stop_namespace_conflict_test.go
+++ b/internal/cli/stop_namespace_conflict_test.go
@@ -238,17 +238,19 @@ func TestRunDownExactNamedProfileConflictStopsAllAndPreservesLegacyState(t *test
 	now := time.Now().UTC()
 	alive := map[int]bool{}
 	match := map[int]bool{}
+	wakeLocks := map[int]string{}
 	for i, member := range members {
 		pid := 1100 + i
 		wakePID := 2100 + i
 		agentDir := writeExactStopRecord(t, namedRoot, member, pid, "")
 		writeWakeLock(t, agentDir, wakeLockFile{PID: wakePID, Root: namedRoot})
+		wakeLocks[wakePID] = wakeLockPath(agentDir)
 		writePresence(t, agentDir, presenceFile{Schema: 1, Handle: member.Handle, Status: "active", LastSeen: now})
 		alive[pid], alive[wakePID] = true, true
 		match[pid], match[wakePID] = true, true
 	}
 	legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
-	term := &recordingTerminator{}
+	term := &selfCleaningTerminator{alive: alive, wakeLocks: wakeLocks}
 	down := downRunnerForTest(term, downFakeProbe(alive, match))
 	swapStatusPaneLister(t, nil, nil)
 
@@ -383,8 +385,8 @@ func TestExactNamedProfileDownWakeLockRootValidation(t *testing.T) {
 		if !reflect.DeepEqual(term.calls, []int{8100}) {
 			t.Fatalf("signals = %v, want only named agent pid", term.calls)
 		}
-		if _, statErr := os.Stat(wakeLockPath(agentDir)); !os.IsNotExist(statErr) {
-			t.Fatalf("poisoned named-dir wake lock was not removed: %v", statErr)
+		if _, statErr := os.Stat(wakeLockPath(agentDir)); statErr != nil {
+			t.Fatalf("poisoned named-dir wake lock must be preserved for AMQ cleanup: %v", statErr)
 		}
 		presence, readErr := readPresenceForEntry(agentDir)
 		if readErr != nil || presence.Status != "offline" {
@@ -398,8 +400,9 @@ func TestExactNamedProfileDownWakeLockRootValidation(t *testing.T) {
 		project, namedRoot, _ := seedExactStopProject(t, []team.Member{member})
 		agentDir := writeExactStopRecord(t, namedRoot, member, 8300, "")
 		writeWakeLock(t, agentDir, wakeLockFile{PID: 8301})
+		alive := map[int]bool{8300: true, 8301: true}
 		probe := duplicateLaunchProbe{
-			PIDAlive: func(pid int) bool { return pid == 8300 || pid == 8301 },
+			PIDAlive: func(pid int) bool { return alive[pid] },
 			ProcessMatch: func(pid int, predicate func(args string) bool) bool {
 				if pid == 8300 {
 					return predicate("codex --search")
@@ -408,7 +411,7 @@ func TestExactNamedProfileDownWakeLockRootValidation(t *testing.T) {
 			},
 			Now: time.Now,
 		}
-		term := &recordingTerminator{}
+		term := &selfCleaningTerminator{alive: alive, wakeLocks: map[int]string{8301: wakeLockPath(agentDir)}}
 		stop := downRunnerForTest(term, probe)
 		swapStatusPaneLister(t, nil, nil)
 		if _, _, err := captureOutput(t, func() error { return stop(exactDownArgs(project, "--all")) }); err != nil {
@@ -617,8 +620,9 @@ func TestExactNamedProfileDownSafetyRegressions(t *testing.T) {
 		writeWakeLock(t, agentDir, wakeLockFile{PID: 6201, Root: namedRoot})
 		writePresence(t, agentDir, presenceFile{Schema: 1, Handle: "cto", Status: "active", LastSeen: time.Now()})
 		legacyBefore := snapshotLegacyTree(t, legacyRoot, namedRoot)
-		term := &recordingTerminator{}
-		stop := downRunnerForTest(term, downFakeProbe(map[int]bool{6200: false, 6201: true}, map[int]bool{6201: true}))
+		alive := map[int]bool{6200: false, 6201: true}
+		term := &selfCleaningTerminator{alive: alive, wakeLocks: map[int]string{6201: wakeLockPath(agentDir)}}
+		stop := downRunnerForTest(term, downFakeProbe(alive, map[int]bool{6201: true}))
 		swapStatusPaneLister(t, nil, nil)
 		stdout, _, err := captureOutput(t, func() error { return stop(exactDownArgs(project, "--all")) })
 		if err != nil {

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -33,12 +33,30 @@ type leadWakeOptions struct {
 	WakeInjectArgs []string
 	WakeInjectMode string
 	WakeInjectCmd  string
+	WakeRetryUntil string
 }
 
 type wakeInjectConfig struct {
-	Mode string
-	Via  string
-	Args []string
+	Mode       string
+	Via        string
+	Args       []string
+	RetryUntil string
+}
+
+const (
+	wakeRetryUntilDrained  = "drained"
+	wakeRetryUntilInjected = "injected"
+)
+
+func normalizeWakeRetryUntil(raw string) (string, error) {
+	switch value := strings.ToLower(strings.TrimSpace(raw)); value {
+	case "", wakeRetryUntilDrained:
+		return wakeRetryUntilDrained, nil
+	case wakeRetryUntilInjected:
+		return wakeRetryUntilInjected, nil
+	default:
+		return "", fmt.Errorf("unsupported wake retry policy %q (want %s or %s)", raw, wakeRetryUntilDrained, wakeRetryUntilInjected)
+	}
 }
 
 // wakeDrainInject is the standard instruction amq-squad asks the wake sidecar to
@@ -416,6 +434,7 @@ func runLeadRegister(args []string) (retErr error) {
 	wakeInjectModeValue = wakeConfig.Mode
 	wakeInjectViaValue = wakeConfig.Via
 	wakeInjectArgValues = wakeConfig.Args
+	wakeRetryUntilValue := wakeConfig.RetryUntil
 	targetMode := leadRegisterTargetMode(t, role)
 	auth, err := authorizeLeadRegister(leadRegisterAuthInput{
 		Team:               t,
@@ -470,6 +489,7 @@ func runLeadRegister(args []string) (retErr error) {
 		WakeInjectArgs:   wakeInjectArgValues,
 		WakeInjectMode:   wakeInjectModeValue,
 		WakeInjectCmd:    wakeInjectCmdValue,
+		WakeRetryUntil:   wakeRetryUntilValue,
 		WakePID:          wakePID,
 		AgentTTY:         currentLaunchTTY(),
 		StartedAt:        time.Now().UTC(),
@@ -544,6 +564,7 @@ func runLeadRegister(args []string) (retErr error) {
 			WakeInjectArgs: wakeInjectArgValues,
 			WakeInjectMode: wakeInjectModeValue,
 			WakeInjectCmd:  wakeInjectCmdValue,
+			WakeRetryUntil: wakeRetryUntilValue,
 		})
 		if err != nil {
 			return fmt.Errorf("start external lead wake: %w", err)
@@ -621,15 +642,19 @@ func writeExternalLeadLaunchRecord(agentDir string, rec launch.Record, role, ses
 
 func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, viaExplicit, argsExplicit bool, existing launch.Record, existingErr error, binary, role, handle, profile, session, root, paneID string) (wakeInjectConfig, error) {
 	resolved := wakeInjectConfig{
-		Mode: strings.TrimSpace(requested.Mode),
-		Via:  strings.TrimSpace(requested.Via),
-		Args: append([]string(nil), requested.Args...),
+		Mode:       strings.TrimSpace(requested.Mode),
+		Via:        strings.TrimSpace(requested.Via),
+		Args:       append([]string(nil), requested.Args...),
+		RetryUntil: strings.TrimSpace(requested.RetryUntil),
 	}
+	inheritedInjector := false
 	if !modeExplicit && existingErr == nil && existing.External && launchRecordMatchesSamePaneIdentity(existing, role, handle, profile, session, root, paneID) {
 		resolved.Mode = strings.TrimSpace(existing.WakeInjectMode)
 		if !viaExplicit && !argsExplicit {
 			resolved.Via = strings.TrimSpace(existing.WakeInjectVia)
 			resolved.Args = append([]string(nil), existing.WakeInjectArgs...)
+			resolved.RetryUntil = strings.TrimSpace(existing.WakeRetryUntil)
+			inheritedInjector = true
 		}
 	}
 	mode, err := normalizeWakeInjectMode(resolved.Mode)
@@ -642,6 +667,23 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 	}
 	if resolved.Via != "" && !filepath.IsAbs(resolved.Via) {
 		return wakeInjectConfig{}, usageErrorf("--wake-inject-via must be an absolute path")
+	}
+	if resolved.Via == "" {
+		resolved.RetryUntil = ""
+		return resolved, nil
+	}
+	if inheritedInjector && resolved.RetryUntil == "" {
+		// AMQ used drained as its default before the policy became persistable.
+		resolved.RetryUntil = wakeRetryUntilDrained
+	} else if resolved.RetryUntil == "" {
+		// New external injection adopts AMQ 0.54+'s presentation-level
+		// acknowledgement so a successful injector is not re-announced merely
+		// because the durable message has not yet been drained.
+		resolved.RetryUntil = wakeRetryUntilInjected
+	}
+	resolved.RetryUntil, err = normalizeWakeRetryUntil(resolved.RetryUntil)
+	if err != nil {
+		return wakeInjectConfig{}, fmt.Errorf("stored external wake config: %w", err)
 	}
 	return resolved, nil
 }
@@ -823,6 +865,11 @@ func startExternalLeadWake(opts leadWakeOptions) (leadWakeResult, error) {
 		for _, arg := range opts.WakeInjectArgs {
 			args = append(args, "--inject-arg", arg)
 		}
+		retryUntil, retryErr := normalizeWakeRetryUntil(opts.WakeRetryUntil)
+		if retryErr != nil {
+			return leadWakeResult{}, retryErr
+		}
+		args = append(args, "--retry-until", retryUntil)
 	}
 	if mode := strings.TrimSpace(opts.WakeInjectMode); mode != "" {
 		args = append(args, "--inject-mode", mode)

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -877,8 +877,22 @@ func TestResolveExternalWakeInjectConfigInheritsAssociatedInjector(t *testing.T)
 	if err != nil {
 		t.Fatalf("inherit external wake config: %v", err)
 	}
-	if got.Mode != "paste" || got.Via != "/opt/inject" || strings.Join(got.Args, ",") != "--pane,%5" {
+	if got.Mode != "paste" || got.Via != "/opt/inject" || strings.Join(got.Args, ",") != "--pane,%5" || got.RetryUntil != wakeRetryUntilDrained {
 		t.Fatalf("inherited config = %+v", got)
+	}
+}
+
+func TestResolveExternalWakeInjectConfigUsesInjectedForNewInjector(t *testing.T) {
+	got, err := resolveExternalWakeInjectConfig(
+		wakeInjectConfig{Mode: "raw", Via: "/opt/inject", Args: []string{"--pane", "%5"}},
+		true, true, true, launch.Record{}, os.ErrNotExist,
+		"codex", "cto", "cto", "default", "issue-96", "/repo/.agent-mail/issue-96", "%5",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetryUntil != wakeRetryUntilInjected {
+		t.Fatalf("new external injector retry policy = %q, want injected", got.RetryUntil)
 	}
 }
 
@@ -942,6 +956,34 @@ func TestStartExternalLeadWakeAlwaysUsesBaselineExisting(t *testing.T) {
 	}
 	if !containsString(captured, "--baseline-existing") {
 		t.Fatalf("wake args = %v; every supported AMQ requires --baseline-existing", captured)
+	}
+}
+
+func TestStartExternalLeadWakePassesPersistedRetryPolicy(t *testing.T) {
+	previous := externalLeadWakeCommand
+	var captured []string
+	externalLeadWakeCommand = func(_ string, args ...string) *exec.Cmd {
+		captured = append([]string(nil), args...)
+		return exec.Command("/bin/sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() { externalLeadWakeCommand = previous })
+
+	if _, err := startExternalLeadWake(leadWakeOptions{
+		ProjectDir: t.TempDir(), Root: filepath.Join(t.TempDir(), "root"), Handle: "cto",
+		WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wantPair := []string{"--retry-until", "injected"}
+	found := false
+	for i := 0; i+1 < len(captured); i++ {
+		if reflect.DeepEqual(captured[i:i+2], wantPair) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("wake args %v do not contain %v", captured, wantPair)
 	}
 }
 

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -1787,8 +1787,8 @@ func wakeHealthForMember(agentDir, expectedRoot, handle string, rec launch.Recor
 	if err != nil {
 		return "-"
 	}
-	var lock wakeLockFile
-	if err := json.Unmarshal(data, &lock); err != nil {
+	lock, err := decodeWakeLockFile(data)
+	if err != nil {
 		return "stale"
 	}
 	if lock.PID <= 0 || !defaultDuplicateLaunchProbe.PIDAlive(lock.PID) {

--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -104,7 +104,7 @@ if [ "$1" = "env" ]; then
   if [ -n "$session" ]; then
     base_root=$(dirname "$root")
   fi
-  printf '{"schema_version":1,"amq_version":"0.52.2","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
+  printf '{"schema_version":1,"amq_version":"0.60.0","root":"%s","base_root":"%s","session_name":"%s","me":"%s","project":"%s","root_source":"%s"}\n' "$root" "$base_root" "$session" "$me" "$project" "$root_source"
   exit 0
 fi
 if [ "$1" = "route" ] && [ "$2" = "explain" ]; then

--- a/internal/cli/wake_lock_compat.go
+++ b/internal/cli/wake_lock_compat.go
@@ -16,6 +16,7 @@ type wakeLockFile struct {
 	PID             int             `json:"pid"`
 	TTY             string          `json:"tty,omitempty"`
 	Root            string          `json:"root,omitempty"`
+	Agent           string          `json:"agent,omitempty"`
 	Started         time.Time       `json:"started"`
 	WakeMode        string          `json:"wake_mode,omitempty"`
 	TargetDigest    string          `json:"target_digest,omitempty"`

--- a/internal/cli/wake_lock_compat.go
+++ b/internal/cli/wake_lock_compat.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// wakeLockFile is the subset of AMQ 0.60's wake-lock wire format used by
+// amq-squad. Generation values stay raw because AMQ owns their representation;
+// amq-squad only verifies that the state binding repeats the same value.
+type wakeLockFile struct {
+	PID             int             `json:"pid"`
+	TTY             string          `json:"tty,omitempty"`
+	Root            string          `json:"root,omitempty"`
+	Started         time.Time       `json:"started"`
+	WakeMode        string          `json:"wake_mode,omitempty"`
+	TargetDigest    string          `json:"target_digest,omitempty"`
+	Generation      json.RawMessage `json:"generation,omitempty"`
+	StateGeneration json.RawMessage `json:"state_generation,omitempty"`
+	StateDigest     string          `json:"state_digest,omitempty"`
+	Owner           json.RawMessage `json:"owner,omitempty"`
+	ResumeOwner     json.RawMessage `json:"resume_owner,omitempty"`
+}
+
+var knownWakeLockKeys = map[string]struct{}{
+	"pid": {}, "tty": {}, "root": {}, "agent": {}, "hostname": {},
+	"started": {}, "process_start": {}, "boot_id": {}, "executable": {},
+	"args": {}, "image_path": {}, "image_version": {}, "wake_mode": {},
+	"target_digest": {}, "generation": {}, "state_generation": {},
+	"state_digest": {}, "source_generation": {}, "source_floor_digest": {},
+	"control_socket": {}, "owner_schema": {}, "owner": {}, "resume_schema": {},
+	"resume_owner": {}, "resume_signal": {}, "running_image_evidence": {},
+}
+
+// decodeWakeLockFile mirrors AMQ 0.53+'s fail-closed lock reader for the known
+// fields amq-squad consumes. encoding/json normally accepts duplicate and
+// case-folded keys; doing that for lifecycle state would let an ambiguous file
+// drive local mutation, so known duplicates and nulls are rejected first.
+func decodeWakeLockFile(raw []byte) (wakeLockFile, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	first, err := decoder.Token()
+	if err != nil {
+		return wakeLockFile{}, fmt.Errorf("decode wake lock: %w", err)
+	}
+	if delim, ok := first.(json.Delim); !ok || delim != '{' {
+		return wakeLockFile{}, fmt.Errorf("decode wake lock: top-level value must be an object")
+	}
+	seen := make(map[string]string)
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock key: %w", err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock: object key is not a string")
+		}
+		folded := strings.ToLower(key)
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock field %q: %w", key, err)
+		}
+		if _, known := knownWakeLockKeys[folded]; !known {
+			continue
+		}
+		if previous, duplicate := seen[folded]; duplicate {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock: duplicate known field %q conflicts with %q", key, previous)
+		}
+		seen[folded] = key
+		if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock: known field %q must not be null", key)
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return wakeLockFile{}, fmt.Errorf("decode wake lock object: %w", err)
+	}
+	if token, err := decoder.Token(); err != io.EOF {
+		if err != nil {
+			return wakeLockFile{}, fmt.Errorf("decode wake lock trailer: %w", err)
+		}
+		return wakeLockFile{}, fmt.Errorf("decode wake lock: unexpected trailing value %v", token)
+	}
+
+	var lock wakeLockFile
+	if err := json.Unmarshal(raw, &lock); err != nil {
+		return wakeLockFile{}, fmt.Errorf("decode wake lock fields: %w", err)
+	}
+	if err := validateWakeLockStateBinding(lock); err != nil {
+		return wakeLockFile{}, err
+	}
+	return lock, nil
+}
+
+func validateWakeLockStateBinding(lock wakeLockFile) error {
+	stateGenerationPresent := len(bytes.TrimSpace(lock.StateGeneration)) > 0
+	stateDigestPresent := strings.TrimSpace(lock.StateDigest) != ""
+	if !stateGenerationPresent && !stateDigestPresent {
+		return nil
+	}
+	if !stateGenerationPresent || !stateDigestPresent {
+		return fmt.Errorf("decode wake lock: incomplete state binding")
+	}
+	if len(bytes.TrimSpace(lock.Generation)) == 0 || !bytes.Equal(bytes.TrimSpace(lock.StateGeneration), bytes.TrimSpace(lock.Generation)) {
+		return fmt.Errorf("decode wake lock: state_generation does not match generation")
+	}
+	if strings.TrimSpace(lock.TargetDigest) == "" || lock.StateDigest != lock.TargetDigest {
+		return fmt.Errorf("decode wake lock: state_digest does not match target_digest")
+	}
+	switch strings.ToLower(strings.TrimSpace(lock.WakeMode)) {
+	case "inject-via", "inject-via-v1", "owner-inject-via-v1":
+		return nil
+	default:
+		return fmt.Errorf("decode wake lock: state binding is invalid for wake_mode %q", lock.WakeMode)
+	}
+}
+
+func wakeLockHasStateBinding(lock wakeLockFile) bool {
+	return len(bytes.TrimSpace(lock.StateGeneration)) > 0 && strings.TrimSpace(lock.StateDigest) != ""
+}
+
+func wakeLockHasOwnerBinding(lock wakeLockFile) bool {
+	for _, raw := range []json.RawMessage{lock.Owner, lock.ResumeOwner} {
+		owner := bytes.TrimSpace(raw)
+		if len(owner) > 0 && !bytes.Equal(owner, []byte("{}")) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/wake_lock_compat_test.go
+++ b/internal/cli/wake_lock_compat_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDecodeWakeLockRejectsIncompleteStateBinding(t *testing.T) {
+	_, err := decodeWakeLockFile([]byte(`{"pid":1,"generation":7,"state_generation":7,"wake_mode":"inject-via-v1"}`))
+	if err == nil || !strings.Contains(err.Error(), "incomplete state binding") {
+		t.Fatalf("decode error = %v, want incomplete binding", err)
+	}
+}
+
+func TestVerifiedWakeRecordBindingUsesAuthoritativeCheckForStateBoundLock(t *testing.T) {
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{
+		PID: 4242, Root: root, WakeMode: "inject-via-v1",
+		TargetDigest: "sha256:target", Generation: json.RawMessage("7"),
+		StateGeneration: json.RawMessage("7"), StateDigest: "sha256:target",
+	})
+	previous := runWakeCheckForBinding
+	t.Cleanup(func() { runWakeCheckForBinding = previous })
+	var got amqCommandRequest
+	runWakeCheckForBinding = func(req amqCommandRequest) ([]byte, error) {
+		got = req
+		return []byte(fmt.Sprintf(`{"schema":1,"agent":"qa","root":%q,"live_wake":true,"wake_status":"live","wake_pid":4242}`, root)), nil
+	}
+	binding, err := verifiedWakeRecordBinding(agentDir, root, "qa", downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true}))
+	if err != nil || binding.PID != 4242 {
+		t.Fatalf("binding=%+v err=%v", binding, err)
+	}
+	want := []string{"wake", "check", "--root", root, "--me", "qa", "--json", "--json-schema", "1"}
+	if strings.Join(got.Arg, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("wake check args=%q want=%q", got.Arg, want)
+	}
+}
+
+func TestVerifiedWakeRecordBindingRejectsUnverifiedStateBoundLock(t *testing.T) {
+	agentDir := t.TempDir()
+	root := filepath.Dir(agentDir)
+	writeWakeLock(t, agentDir, wakeLockFile{
+		PID: 4242, Root: root, WakeMode: "owner-inject-via-v1",
+		TargetDigest: "sha256:target", Generation: json.RawMessage("7"),
+		StateGeneration: json.RawMessage("7"), StateDigest: "sha256:target",
+	})
+	previous := runWakeCheckForBinding
+	t.Cleanup(func() { runWakeCheckForBinding = previous })
+	runWakeCheckForBinding = func(amqCommandRequest) ([]byte, error) {
+		return nil, errors.New("wake state is unverified")
+	}
+	if _, err := verifiedWakeRecordBinding(agentDir, root, "qa", downFakeProbe(map[int]bool{4242: true}, map[int]bool{4242: true})); err == nil || !strings.Contains(err.Error(), "authoritative amq wake check failed") {
+		t.Fatalf("binding error = %v, want authoritative refusal", err)
+	}
+	if _, err := os.Stat(wakeLockPath(agentDir)); err != nil {
+		t.Fatalf("unverified state-bound lock must be preserved: %v", err)
+	}
+}

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -119,6 +119,10 @@ type Record struct {
 	WakeInjectVia  string   `json:"wake_inject_via,omitempty"`
 	WakeInjectArgs []string `json:"wake_inject_args,omitempty"`
 	WakeInjectMode string   `json:"wake_inject_mode,omitempty"`
+	// WakeRetryUntil records the AMQ wake presentation milestone used by an
+	// external inject-via wake. Records written before AMQ 0.54 omit it; an
+	// omitted value therefore means AMQ's historical "drained" policy.
+	WakeRetryUntil string `json:"wake_retry_until,omitempty"`
 	// WakeInjectCmd records the literal instruction the wake sidecar injects on
 	// each durable-message arrival (amq wake --inject-cmd). amq-squad sets it to
 	// the standard drain instruction so an inbound directive re-engages a lead

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -34,6 +34,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		WakeInjectVia:                "/opt/amq-inject",
 		WakeInjectArgs:               []string{"--pane", "%42"},
 		WakeInjectMode:               "raw",
+		WakeRetryUntil:               "injected",
 		WakePID:                      1234,
 		WakeRecordID:                 "/root/agents/cto/.wake.lock",
 		WakeRecordDigest:             "sha256:abcdef",
@@ -64,7 +65,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		out.Conversation != in.Conversation ||
 		out.Handle != in.Handle || out.Role != in.Role || out.Root != in.Root ||
 		out.BaseRoot != in.BaseRoot || out.RootSource != in.RootSource ||
-		out.AMQVersion != in.AMQVersion || out.WakeInjectVia != in.WakeInjectVia || out.WakeInjectMode != in.WakeInjectMode ||
+		out.AMQVersion != in.AMQVersion || out.WakeInjectVia != in.WakeInjectVia || out.WakeInjectMode != in.WakeInjectMode || out.WakeRetryUntil != in.WakeRetryUntil ||
 		out.NoGitignore != in.NoGitignore || out.NoPreauthorizeInScope != in.NoPreauthorizeInScope || out.WakePID != in.WakePID ||
 		out.WakeRecordID != in.WakeRecordID || out.WakeRecordDigest != in.WakeRecordDigest {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", out, in)
@@ -125,6 +126,24 @@ func TestWakeInjectCmdAdditiveBackCompat(t *testing.T) {
 	}
 	if back.WakeInjectCmd != "drain now" {
 		t.Fatalf("WakeInjectCmd round-trip = %q, want %q", back.WakeInjectCmd, "drain now")
+	}
+}
+
+func TestWakeRetryUntilAdditiveBackCompat(t *testing.T) {
+	legacyJSON := `{"schema":1,"cwd":"/p","wake_inject_via":"/opt/inject"}`
+	var legacy Record
+	if err := json.Unmarshal([]byte(legacyJSON), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.WakeRetryUntil != "" {
+		t.Fatalf("legacy retry policy = %q, want omitted/drained sentinel", legacy.WakeRetryUntil)
+	}
+	raw, err := json.Marshal(Record{WakeRetryUntil: "injected"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"wake_retry_until":"injected"`) {
+		t.Fatalf("retry policy missing from launch JSON: %s", raw)
 	}
 }
 

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -22,11 +22,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
+AMQ 0.60.x is the supported series, with 0.60.0 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.60.0 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.60.0 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
+AMQ 0.60.x is the supported series, with 0.60.0 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.60.0 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.60.0 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/plugins/skills-src/cli/SKILL.md
+++ b/plugins/skills-src/cli/SKILL.md
@@ -18,11 +18,11 @@ explicit commands, not goal composition and not the live lead loop.
      content is PRESENT. Update the versions here when the policy changes; do not
      delete the section. -->
 
-AMQ 0.52.x is the supported series, with 0.52.2 as the minimum supported release.
-Both real-AMQ matrices validate pinned v0.52.2 and latest; latest remains a
+AMQ 0.60.x is the supported series, with 0.60.0 as the minimum supported release.
+Both real-AMQ matrices validate pinned v0.60.0 and latest; latest remains a
 forward-compatibility canary and is not a support claim.
 
-Releases older than 0.52.2 are rejected fail-closed. After upgrading, stop and resume
+Releases older than 0.60.0 are rejected fail-closed. After upgrading, stop and resume
 agents so their parent shells refresh the complete identity tuple.
 
 `amq-squad doctor` reports the resolved AMQ version, so check it there rather than

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -22,9 +22,9 @@ SKILL_FRONTMATTER_VERSION_RE = re.compile(
     r'^version:[ \t]*"?([0-9]+\.[0-9]+\.[0-9]+)"?',
     re.MULTILINE,
 )
-AMQ_MIN_VERSION = "0.52.2"
+AMQ_MIN_VERSION = "0.60.0"
 AMQ_COMPATIBILITY_POLICY = (
-    f"AMQ 0.52.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
+    f"AMQ 0.60.x is the supported series, with {AMQ_MIN_VERSION} as the minimum "
     f"supported release. Both real-AMQ matrices validate pinned "
     f"v{AMQ_MIN_VERSION} and latest; latest remains a forward-compatibility "
     "canary and is not a support claim."

--- a/scripts/test_check_release_version.py
+++ b/scripts/test_check_release_version.py
@@ -33,14 +33,14 @@ class RequireReleaseNotesTest(unittest.TestCase):
     def test_policy_normalization_ignores_markdown_and_html_markup(self) -> None:
         policy = CHECK_RELEASE_VERSION.AMQ_COMPATIBILITY_POLICY
         markdown = policy.replace(
-            "AMQ 0.52.x is the supported series",
-            "AMQ **0.52.x is the supported series**",
+            "AMQ 0.60.x is the supported series",
+            "AMQ **0.60.x is the supported series**",
         ).replace("latest", "`latest`")
         html_body = (
             "<p>"
             + policy.replace(
-                "AMQ 0.52.x is the supported series",
-                "AMQ <strong>0.52.x is the supported series</strong>",
+                "AMQ 0.60.x is the supported series",
+                "AMQ <strong>0.60.x is the supported series</strong>",
             ).replace("latest", "<code>latest</code>")
             + "</p>"
         )


### PR DESCRIPTION
Fixes #677

## What

Rebases amq-squad onto the AMQ 0.60.x series: floor raise, wake-lifecycle adaptation to the 0.52.3→0.60.0 upstream delta, CI matrix move, and floor-doc updates.

- **Floor**: `doctorMinAMQVersion` and fail-closed rejection raised to 0.60.0; README support statement, active CLI-skill policy + generated mirrors, global runbook, and release-version checker aligned on "AMQ 0.60.x supported, 0.60.0 minimum".
- **CI**: both real-AMQ matrices (compatibility + wake compatibility) move from pinned `v0.52.2` to pinned `v0.60.0` + `latest`.
- **Doorbell acks (0.54.0)**: external inject-via wakes persist a `wake_retry_until` policy in the launch record. New wakes default to `--retry-until injected`; records written before the policy existed replay AMQ's historical `drained`. Exact retirement replays the recorded policy.
- **Retirement (0.53+)**: `retired_with_residue` is accepted only after the lock is verifiably absent; otherwise the result is a fail state (`amq_exact_lock_remaining`).
- **State-bound locks (0.53+)**: new fail-closed lock decoder (duplicate/null known fields rejected, state binding must be complete and consistent with wake mode); corrupt or ambiguous locks are preserved for AMQ inspection, never unlinked locally; stale-lock cleanup delegates to AMQ's guarded acquisition. Raw-path signal cleanup counts only on verified self-cleanup.
- **Authority boundary**: state-bound record bindings require an authoritative `amq wake check` verification; local PID/argv heuristics remain advisory only.
- **Posture decision** (recorded on the squad `decision/keepalive-posture` thread): keep the cross-platform session notifier; do not integrate amq-keepalive. AMQ owns per-wake lifecycle, image identity, restart, and adoption.
- **RELEASING.md** gains the floor statement and a release-checklist alignment step.

Active team-rules templates contain no 0.52.2 references, so none needed changes (gh#677 checklist item verified, not skipped). Historical release notes and explicit rejected-version test cases retained.

## Validation

- Full `make ci` PASS at head.
- Local real-AMQ suites on AMQ 0.60.0: `TestRealAMQCompatibility`, `TestRealAMQWakeCompatibility` PASS.
- Immutable committed-state evidence: `t1-amq060-committed-20260809` (linked, exit 0, subject SHA 41cb3eb).

## Notes

gh#654 (duplicate raw wake doorbells) is intentionally NOT in this PR; it lands next on top of these semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
