### PR TITLE
fix: dedupe busy-agent wake doorbells (Fixes #654)

### DIFF
--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -1279,6 +1279,7 @@ func registerGoalOrchestrator(opts goalDeliveryOptions, handle, wakeInjectMode s
 		WakeInjectMode:           wakeInjectMode,
 		WakeInjectCmd:            wakeInjectCmdValue,
 		WakeRetryUntil:           wakeConfig.RetryUntil,
+		WakeRetryTransition:      wakeConfig.RetryTransition,
 		WakePID:                  wakePID,
 		WakeRecordID:             wakeBinding.RecordID,
 		WakeRecordDigest:         wakeBinding.RecordDigest,

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -159,12 +159,13 @@ func classifyAgentLivenessWithReplacementResolver(agentDir, root, expectedProfil
 	}
 	if hasWakePID {
 		out.Signals.WakePID = wakeLock.PID
-		if probe.PIDAlive(wakeLock.PID) {
-			expectedRoot := root
-			if wakeLock.Root != "" {
-				expectedRoot = wakeLock.Root
-			}
-			if probe.ProcessMatch(wakeLock.PID, wakeProcessMatcher(handle, expectedRoot)) {
+		// A wake lock is positive liveness evidence only for the exact root
+		// being classified. Never let a lock planted under this agent directory
+		// substitute its own foreign root into the process matcher: notifier
+		// delivery reserves the message ID before consulting this signal, so a
+		// false positive here would permanently suppress the one fallback input.
+		if strings.TrimSpace(wakeLock.Root) != "" && rootsMatch(wakeLock.Root, root) && probe.PIDAlive(wakeLock.PID) {
+			if probe.ProcessMatch(wakeLock.PID, wakeProcessMatcher(handle, wakeLock.Root)) {
 				out.Signals.WakeAlive = true
 			}
 		}

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 )
 
 const realAMQCoopWakeDoorbell = ": AMQ doorbell run amq drain --include-body then act on it"
@@ -93,6 +94,17 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 		h.send("cto", "qa", "managed-raw", "managed wake canary")
 		line := h.oneSubmittedLine()
 		assertRealAMQCoopWakePayload(t, line)
+	})
+
+	t.Run("busy managed agent has one terminal-input owner", func(t *testing.T) {
+		t.Run("pre-fix control captures duplicate full prompts", func(t *testing.T) {
+			lines := realAMQBusyWakeOwnershipCase(t, tmux, amq, squad, nativeRecorder, true)
+			t.Logf("pre-fix duplicate reproduction (one durable inbox message): %#v", lines)
+		})
+		t.Run("verified native wake suppresses notifier fallback", func(t *testing.T) {
+			lines := realAMQBusyWakeOwnershipCase(t, tmux, amq, squad, nativeRecorder, false)
+			t.Logf("fixed single-owner capture through retry horizon: %#v", lines)
+		})
 	})
 
 	t.Run("managed stop resume and cleanup", func(t *testing.T) {
@@ -246,6 +258,184 @@ func TestRealAMQWakeCompatibility(t *testing.T) {
 	})
 }
 
+func realAMQBusyWakeOwnershipCase(t *testing.T, tmux, amq, squad, recorder string, emulateLegacyNotifier bool) []string {
+	t.Helper()
+	h := newRealWakeHarness(t, tmux, amq)
+	writeRealWakeTeamBinaries(t, h.project, h.session, recorder, recorder)
+	h.init("cto", "qa")
+	args := []string{
+		"agent", "up", recorder, "--project", h.project, "--role", "qa", "--session", h.session,
+		"--team-workstream", "--me", "qa", "--no-bootstrap", "--no-default-args", "--wake-inject-mode", "raw",
+	}
+	h.startBusy(append([]string{squad}, args...))
+	t.Setenv("TMUX_TMPDIR", h.tmuxTmpDir)
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+
+	agentDir := filepath.Join(h.root, "agents", "qa")
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatalf("read busy managed launch record: %v", err)
+	}
+	if rec.Tmux == nil || strings.TrimSpace(rec.Tmux.PaneID) == "" {
+		t.Fatalf("busy managed launch lacks real pane evidence: %+v", rec)
+	}
+	if !verifiedSessionNotifierWakeLive(agentDir, h.root, team.DefaultProfile, h.session, "qa", rec) {
+		wake, wakeErr := readWakeLock(agentDir)
+		t.Fatalf("busy managed target lacks positively verified native wake: launch=%+v wake=%+v wake_err=%v", rec, wake, wakeErr)
+	}
+
+	h.send("cto", "qa", "busy-single-owner", "one durable message while the agent is busy")
+	pending, err := snapshotSessionInboxMessages(h.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("busy target inbox/new contains %d messages, want exactly one: %+v", len(pending), pending)
+	}
+	var messagePath string
+	for path := range pending {
+		messagePath = path
+	}
+	messageID, err := readSessionNotifierMessageID(messagePath)
+	if err != nil {
+		t.Fatalf("read real AMQ message identity: %v", err)
+	}
+
+	// Keep the agent process blocked before its first stdin read. Wait until the
+	// native AMQ owner has queued its full raw doorbell in the real tmux PTY,
+	// then exercise either the historical unconditional notifier path or the
+	// fixed verified-owner gate against that same unread durable message.
+	waitForRealWakeCondition(t, "native AMQ doorbell queued while recorder is busy", func() bool {
+		cmd := exec.Command(tmux, "capture-pane", "-p", "-t", rec.Tmux.PaneID, "-S", "-80")
+		cmd.Env = h.env()
+		out, captureErr := cmd.Output()
+		return captureErr == nil && strings.Contains(strings.ReplaceAll(string(out), "\r", ""), realAMQCoopWakeDoorbell)
+	})
+	wakeLive := verifiedSessionNotifierWakeLive
+	if emulateLegacyNotifier {
+		wakeLive = sessionNotifierWakeAbsent
+	}
+	stopNotifier := make(chan os.Signal, 1)
+	notifierDone := make(chan error, 1)
+	sendDone := make(chan error, 1)
+	go func() {
+		notifierDone <- executeSessionNotifier(sessionNotifierExecution{
+			ProjectDir: h.project, Profile: team.DefaultProfile, Session: h.session, Root: h.root,
+			Token: "busy-owner-" + strconv.FormatBool(emulateLegacyNotifier),
+			TTL:   time.Minute, Heartbeat: time.Hour, Stop: stopNotifier, Now: time.Now,
+			WakeLive: wakeLive,
+			SendKeys: func(paneID, prompt string) error {
+				err := tmuxpane.SendPromptToPane(paneID, prompt)
+				sendDone <- err
+				return err
+			},
+		})
+	}()
+	notifierPath := sessionNotifierRuntimePath(h.project, team.DefaultProfile, h.session)
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		persisted, readErr := readSessionNotifierRecord(notifierPath)
+		if readErr == nil && sessionNotifierAttempted(persisted.AttemptedMessageIDs, "qa", messageID) {
+			break
+		}
+		select {
+		case notifierErr := <-notifierDone:
+			t.Fatalf("real session notifier exited before reserving %s: %v", messageID, notifierErr)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("real session notifier did not durably reserve %s: read_err=%v", messageID, readErr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if emulateLegacyNotifier {
+		select {
+		case notifyErr := <-sendDone:
+			t.Logf("pre-fix notifier result while target busy: err=%v", notifyErr)
+		case <-time.After(8 * time.Second):
+			t.Fatal("pre-fix real session notifier did not attempt the competing prompt")
+		}
+	} else {
+		select {
+		case notifyErr := <-sendDone:
+			t.Fatalf("verified native wake still allowed notifier input: %v", notifyErr)
+		default:
+		}
+	}
+
+	if !emulateLegacyNotifier {
+		// AMQ's external injection timeout is five seconds. Keeping the target
+		// unread beyond that first retry horizon proves the fixed notifier does
+		// not introduce a second full prompt while durable work remains queued.
+		time.Sleep(6 * time.Second)
+		select {
+		case notifyErr := <-sendDone:
+			t.Fatalf("verified native wake allowed delayed notifier input: %v", notifyErr)
+		default:
+		}
+	}
+	stopNotifier <- os.Interrupt
+	if notifierErr := <-notifierDone; notifierErr != nil {
+		t.Fatalf("stop real session notifier: %v", notifierErr)
+	}
+	h.releaseBusy()
+	wantLines := 1
+	if emulateLegacyNotifier {
+		wantLines = 2
+	}
+	deadline = time.Now().Add(8 * time.Second)
+	for {
+		b, readErr := os.ReadFile(h.capture)
+		if readErr == nil && len(nonemptyLines(string(b))) >= wantLines {
+			break
+		}
+		if time.Now().After(deadline) {
+			cmd := exec.Command(tmux, "capture-pane", "-p", "-t", rec.Tmux.PaneID, "-S", "-120")
+			cmd.Env = h.env()
+			pane, captureErr := cmd.CombinedOutput()
+			t.Fatalf("timed out waiting for %d busy wake capture lines; read_err=%v capture=%q pane_err=%v\npane:\n%s", wantLines, readErr, string(b), captureErr, string(pane))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Give already-queued terminal input a bounded interval to reach the
+	// recorder before asserting the complete prompt cohort.
+	time.Sleep(300 * time.Millisecond)
+	b, err := os.ReadFile(h.capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := nonemptyLines(string(b))
+	for _, line := range lines {
+		assertMarkerFreeWake(t, line)
+	}
+	rawCount, fallbackCount := 0, 0
+	wantFallback := dispatchNudgePrompt(h.root)
+	for _, line := range lines {
+		switch line {
+		case realAMQCoopWakeDoorbell:
+			rawCount++
+		case wantFallback:
+			fallbackCount++
+		}
+	}
+	if emulateLegacyNotifier {
+		if len(lines) != 2 || rawCount != 1 || fallbackCount != 1 {
+			t.Fatalf("pre-fix control capture=%#v, want one AMQ doorbell plus one notifier fallback", lines)
+		}
+	} else if len(lines) != 1 || rawCount != 1 || fallbackCount != 0 {
+		t.Fatalf("fixed busy capture=%#v, want exactly one AMQ doorbell and no notifier fallback", lines)
+	}
+	pending, err = snapshotSessionInboxMessages(h.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("busy target inbox changed before drain: got %d messages, want the original one", len(pending))
+	}
+	return lines
+}
+
 func buildRealWakeRecorder(t *testing.T, dir string) string {
 	t.Helper()
 	buildDir := t.TempDir()
@@ -257,6 +447,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"time"
 )
 
 func main() {
@@ -275,6 +466,17 @@ func main() {
 	if err := os.WriteFile(ready, []byte("ready"), 0o644); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+	if release := os.Getenv("WAKE_RELEASE"); release != "" {
+		for {
+			if _, err := os.Stat(release); err == nil {
+				break
+			} else if !os.IsNotExist(err) {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
 	}
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -324,6 +526,7 @@ type realWakeHarness struct {
 	recorder    string
 	capture     string
 	ready       string
+	release     string
 }
 
 func newRealWakeHarness(t *testing.T, tmux, amq string) *realWakeHarness {
@@ -373,6 +576,22 @@ func (h *realWakeHarness) start(argv []string) {
 	h.startSession(h.tmuxSession, h.capture, h.ready, argv)
 }
 
+func (h *realWakeHarness) startBusy(argv []string) {
+	h.t.Helper()
+	h.release = filepath.Join(h.project, "release-input")
+	h.start(argv)
+}
+
+func (h *realWakeHarness) releaseBusy() {
+	h.t.Helper()
+	if strings.TrimSpace(h.release) == "" {
+		h.t.Fatal("busy recorder release path is empty")
+	}
+	if err := os.WriteFile(h.release, []byte("release"), 0o600); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
 func (h *realWakeHarness) startAuxiliary(session, capture, ready string, argv []string) {
 	h.t.Helper()
 	h.t.Cleanup(func() {
@@ -385,9 +604,25 @@ func (h *realWakeHarness) startAuxiliary(session, capture, ready string, argv []
 
 func (h *realWakeHarness) startSession(session, capture, ready string, argv []string) {
 	h.t.Helper()
-	command := shellCommand("env", append([]string{"WAKE_CAPTURE=" + capture, "WAKE_READY=" + ready, "PATH=" + filepath.Dir(h.amq) + string(os.PathListSeparator) + os.Getenv("PATH"), "AMQ_NO_UPDATE_CHECK=1"}, argv...)...)
+	envArgs := []string{"WAKE_CAPTURE=" + capture, "WAKE_READY=" + ready, "PATH=" + filepath.Dir(h.amq) + string(os.PathListSeparator) + os.Getenv("PATH"), "AMQ_NO_UPDATE_CHECK=1"}
+	if strings.TrimSpace(h.release) != "" {
+		envArgs = append(envArgs, "WAKE_RELEASE="+h.release)
+	}
+	command := shellCommand("env", append(envArgs, argv...)...)
 	realWakeCommand(h.t, h.project, h.env(), h.tmux, "new-session", "-d", "-s", session, "-c", h.project, command)
-	waitForRealWakeFile(h.t, ready, "recorder readiness")
+	deadline := time.Now().Add(8 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cmd := exec.Command(h.tmux, "capture-pane", "-p", "-t", session, "-S", "-120")
+			cmd.Env = h.env()
+			pane, captureErr := cmd.CombinedOutput()
+			h.t.Fatalf("timed out waiting for recorder readiness at %s; capture_err=%v\npane:\n%s", ready, captureErr, string(pane))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func (h *realWakeHarness) killSessionIfPresent(session string) {

--- a/internal/cli/real_amq_wake_compatibility_test.go
+++ b/internal/cli/real_amq_wake_compatibility_test.go
@@ -380,21 +380,22 @@ func realAMQBusyWakeOwnershipCase(t *testing.T, tmux, amq, squad, recorder strin
 		t.Fatalf("stop real session notifier: %v", notifierErr)
 	}
 	h.releaseBusy()
-	wantLines := 1
-	if emulateLegacyNotifier {
-		wantLines = 2
-	}
 	deadline = time.Now().Add(8 * time.Second)
 	for {
 		b, readErr := os.ReadFile(h.capture)
-		if readErr == nil && len(nonemptyLines(string(b))) >= wantLines {
-			break
+		if readErr == nil {
+			if emulateLegacyNotifier && strings.Contains(string(b), realAMQCoopWakeDoorbell) && strings.Contains(string(b), dispatchNudgePrompt(h.root)) {
+				break
+			}
+			if !emulateLegacyNotifier && len(nonemptyLines(string(b))) >= 1 {
+				break
+			}
 		}
 		if time.Now().After(deadline) {
 			cmd := exec.Command(tmux, "capture-pane", "-p", "-t", rec.Tmux.PaneID, "-S", "-120")
 			cmd.Env = h.env()
 			pane, captureErr := cmd.CombinedOutput()
-			t.Fatalf("timed out waiting for %d busy wake capture lines; read_err=%v capture=%q pane_err=%v\npane:\n%s", wantLines, readErr, string(b), captureErr, string(pane))
+			t.Fatalf("timed out waiting for busy wake prompt cohort; read_err=%v capture=%q pane_err=%v\npane:\n%s", readErr, string(b), captureErr, string(pane))
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -409,18 +410,17 @@ func realAMQBusyWakeOwnershipCase(t *testing.T, tmux, amq, squad, recorder strin
 	for _, line := range lines {
 		assertMarkerFreeWake(t, line)
 	}
-	rawCount, fallbackCount := 0, 0
 	wantFallback := dispatchNudgePrompt(h.root)
-	for _, line := range lines {
-		switch line {
-		case realAMQCoopWakeDoorbell:
-			rawCount++
-		case wantFallback:
-			fallbackCount++
-		}
-	}
+	rawCount := strings.Count(string(b), realAMQCoopWakeDoorbell)
+	fallbackCount := strings.Count(string(b), wantFallback)
 	if emulateLegacyNotifier {
-		if len(lines) != 2 || rawCount != 1 || fallbackCount != 1 {
+		// A busy real PTY may deliver the two complete inputs as separate scanner
+		// lines or coalesce them before the recorder's first read. Count exact
+		// full prompt occurrences in the byte stream, then reject any residual
+		// non-whitespace content so both forms prove the same two-owner defect.
+		residual := strings.Replace(string(b), realAMQCoopWakeDoorbell, "", 1)
+		residual = strings.Replace(residual, wantFallback, "", 1)
+		if rawCount != 1 || fallbackCount != 1 || strings.TrimSpace(residual) != "" {
 			t.Fatalf("pre-fix control capture=%#v, want one AMQ doorbell plus one notifier fallback", lines)
 		}
 	} else if len(lines) != 1 || rawCount != 1 || fallbackCount != 0 {

--- a/internal/cli/session_notifier.go
+++ b/internal/cli/session_notifier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/flock"
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
+	"github.com/omriariav/amq-squad/v2/internal/operatorauth"
 	"github.com/omriariav/amq-squad/v2/internal/procinfo"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -28,6 +29,8 @@ const (
 	sessionNotifierTTL           = 15 * time.Second
 	sessionNotifierHeartbeat     = 3 * time.Second
 	sessionNotifierStartupBudget = 5 * time.Second
+	sessionNotifierAttemptLimit  = 512
+	sessionNotifierMessageLimit  = 10 * 1024 * 1024
 )
 
 type sessionNotifierRecord struct {
@@ -45,6 +48,10 @@ type sessionNotifierRecord struct {
 	LeaseExpiresAt time.Time `json:"lease_expires_at"`
 	LastNudgeAt    time.Time `json:"last_nudge_at,omitempty"`
 	LastError      string    `json:"last_error,omitempty"`
+	// AttemptedMessageIDs is namespaced by handle; Root on this same record is
+	// the namespace half of the key. An ID is reserved before pane input so a
+	// crash or failed send can never turn into a duplicate notifier attempt.
+	AttemptedMessageIDs map[string][]string `json:"attempted_message_ids,omitempty"`
 }
 
 type sessionNotifierStatus struct {
@@ -55,6 +62,13 @@ type sessionNotifierStatus struct {
 }
 
 type sessionNotifierSendKeys func(paneID, keys string) error
+type sessionNotifierWakeLive func(agentDir, root, profile, session, handle string, rec launch.Record) bool
+
+type sessionNotifierAttemptLedger struct {
+	attempted map[string][]string
+	reserve   func(handle, messageID string) (bool, map[string][]string, error)
+	prune     func(pending map[string]map[string]struct{}) (map[string][]string, error)
+}
 
 type sessionNotifierExecution struct {
 	ProjectDir string
@@ -68,6 +82,7 @@ type sessionNotifierExecution struct {
 	Now        func() time.Time
 	NewWatcher func() (*fsnotify.Watcher, error)
 	SendKeys   sessionNotifierSendKeys
+	WakeLive   sessionNotifierWakeLive
 }
 
 var (
@@ -135,6 +150,161 @@ func writeSessionNotifierRecord(path string, rec sessionNotifierRecord) error {
 		_ = os.Remove(tmp)
 		return err
 	}
+	return nil
+}
+
+func cloneSessionNotifierAttempts(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for handle, ids := range in {
+		out[handle] = append([]string(nil), ids...)
+	}
+	return out
+}
+
+func sessionNotifierAttempted(attempted map[string][]string, handle, messageID string) bool {
+	for _, existing := range attempted[strings.TrimSpace(handle)] {
+		if existing == messageID {
+			return true
+		}
+	}
+	return false
+}
+
+func appendSessionNotifierAttempt(attempted map[string][]string, handle, messageID string) (map[string][]string, error) {
+	out := cloneSessionNotifierAttempts(attempted)
+	if out == nil {
+		out = make(map[string][]string)
+	}
+	handle = strings.TrimSpace(handle)
+	ids := out[handle]
+	if len(ids) >= sessionNotifierAttemptLimit {
+		// Never evict an attempted ID while it may still be pending: doing so
+		// would make the next rescan inject that same message again. Pruning is
+		// driven by inbox/new departures; until then, a full ledger fails closed
+		// and leaves the durable message as the recovery source.
+		return nil, fmt.Errorf("session notifier attempt ledger for %s reached limit %d", handle, sessionNotifierAttemptLimit)
+	}
+	ids = append(ids, messageID)
+	out[handle] = ids
+	return out, nil
+}
+
+func pruneSessionNotifierAttempts(attempted map[string][]string, pending map[string]map[string]struct{}) map[string][]string {
+	if len(attempted) == 0 {
+		return nil
+	}
+	out := make(map[string][]string)
+	for handle, ids := range attempted {
+		keep := pending[handle]
+		if len(keep) == 0 {
+			continue
+		}
+		for _, id := range ids {
+			if _, ok := keep[id]; ok {
+				out[handle] = append(out[handle], id)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func newSessionNotifierAttemptLedger(seed map[string][]string) *sessionNotifierAttemptLedger {
+	return &sessionNotifierAttemptLedger{attempted: cloneSessionNotifierAttempts(seed)}
+}
+
+func newPersistentSessionNotifierAttemptLedger(path, token, root string, rec *sessionNotifierRecord) *sessionNotifierAttemptLedger {
+	ledger := newSessionNotifierAttemptLedger(rec.AttemptedMessageIDs)
+	ledger.reserve = func(handle, messageID string) (bool, map[string][]string, error) {
+		var (
+			reserved bool
+			attempts map[string][]string
+		)
+		err := flock.WithLock(path+".lock", func() error {
+			current, err := readSessionNotifierRecord(path)
+			if err != nil {
+				return err
+			}
+			if current.OwnerToken != token || !sameResolvedDir(current.Root, root) {
+				return fmt.Errorf("session notifier ownership changed while reserving message %s", messageID)
+			}
+			attempts = cloneSessionNotifierAttempts(current.AttemptedMessageIDs)
+			if sessionNotifierAttempted(attempts, handle, messageID) {
+				return nil
+			}
+			attempts, err = appendSessionNotifierAttempt(attempts, handle, messageID)
+			if err != nil {
+				return err
+			}
+			current.AttemptedMessageIDs = cloneSessionNotifierAttempts(attempts)
+			if err := writeSessionNotifierRecord(path, current); err != nil {
+				return err
+			}
+			reserved = true
+			return nil
+		})
+		return reserved, attempts, err
+	}
+	ledger.prune = func(pending map[string]map[string]struct{}) (map[string][]string, error) {
+		var attempts map[string][]string
+		err := flock.WithLock(path+".lock", func() error {
+			current, err := readSessionNotifierRecord(path)
+			if err != nil {
+				return err
+			}
+			if current.OwnerToken != token || !sameResolvedDir(current.Root, root) {
+				return fmt.Errorf("session notifier ownership changed while pruning message attempts")
+			}
+			attempts = pruneSessionNotifierAttempts(current.AttemptedMessageIDs, pending)
+			current.AttemptedMessageIDs = cloneSessionNotifierAttempts(attempts)
+			return writeSessionNotifierRecord(path, current)
+		})
+		return attempts, err
+	}
+	return ledger
+}
+
+func (l *sessionNotifierAttemptLedger) Reserve(handle, messageID string) (bool, error) {
+	if l == nil {
+		return false, fmt.Errorf("session notifier message-attempt ledger is required")
+	}
+	if sessionNotifierAttempted(l.attempted, handle, messageID) {
+		return false, nil
+	}
+	if l.reserve != nil {
+		reserved, attempts, err := l.reserve(handle, messageID)
+		if err != nil {
+			return false, err
+		}
+		l.attempted = cloneSessionNotifierAttempts(attempts)
+		return reserved, nil
+	}
+	attempted, err := appendSessionNotifierAttempt(l.attempted, handle, messageID)
+	if err != nil {
+		return false, err
+	}
+	l.attempted = attempted
+	return true, nil
+}
+
+func (l *sessionNotifierAttemptLedger) Prune(pending map[string]map[string]struct{}) error {
+	if l == nil {
+		return fmt.Errorf("session notifier message-attempt ledger is required")
+	}
+	if l.prune != nil {
+		attempts, err := l.prune(pending)
+		if err != nil {
+			return err
+		}
+		l.attempted = cloneSessionNotifierAttempts(attempts)
+		return nil
+	}
+	l.attempted = pruneSessionNotifierAttempts(l.attempted, pending)
 	return nil
 }
 
@@ -335,6 +505,9 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 	if n.SendKeys == nil {
 		n.SendKeys = tmuxpane.SendPromptToPane
 	}
+	if n.WakeLive == nil {
+		n.WakeLive = verifiedSessionNotifierWakeLive
+	}
 	if n.TTL <= 0 {
 		n.TTL = sessionNotifierTTL
 	}
@@ -364,6 +537,11 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 		if current.OwnerToken != "" && current.OwnerToken != n.Token && n.Now().Before(current.LeaseExpiresAt) {
 			return fmt.Errorf("session notifier lease is already held by pid %d", current.PID)
 		}
+		if current.SchemaVersion == sessionNotifierSchema &&
+			current.ProjectDir == n.ProjectDir && current.Profile == squadnamespace.NormalizeProfile(n.Profile) &&
+			current.Session == n.Session && sameResolvedDir(current.Root, n.Root) {
+			rec.AttemptedMessageIDs = cloneSessionNotifierAttempts(current.AttemptedMessageIDs)
+		}
 		return writeSessionNotifierRecord(path, rec)
 	}); err != nil {
 		return err
@@ -374,6 +552,7 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 			returnErr = errors.Join(returnErr, err)
 		}
 	}()
+	ledger := newPersistentSessionNotifierAttemptLedger(path, n.Token, n.Root, &rec)
 
 	watcher, err := n.NewWatcher()
 	if err != nil {
@@ -382,24 +561,27 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 	defer watcher.Close()
 	// Snapshot before installing watches, then once more afterwards. A file
 	// already in inbox/new is still pending work and may have arrived while the
-	// notifier was down, so startup nudges it. This deliberately provides
-	// at-least-once delivery across notifier restarts: a crash before the agent
-	// drains the message may cause a duplicate wake. Within one process, seen
-	// still guarantees at most one successful nudge per message. The second
-	// snapshot closes the watcher-install race, and queued events dedupe through
-	// the same map.
+	// notifier was down, so startup observes it. The durable reservation ledger
+	// makes each root+handle+message ID an at-most-once pane-input attempt across
+	// notifier restarts. The second snapshot closes the watcher-install race,
+	// and queued events dedupe through the same ledger.
 	pending, err := snapshotSessionInboxMessages(n.Root)
 	if err != nil {
 		return err
 	}
+	if err := ledger.Prune(sessionNotifierPendingIDs(n.Root, pending)); err != nil {
+		return fmt.Errorf("prune stale notifier message attempts during startup: %w", err)
+	}
+	rec.AttemptedMessageIDs = cloneSessionNotifierAttempts(ledger.attempted)
 	if err := addNotificationWatchTree(watcher, n.Root); err != nil {
 		return fmt.Errorf("watch canonical session root: %w", err)
 	}
-	seen := make(map[string]struct{}, len(pending))
+	var startupErrs []error
 	for messagePath := range pending {
-		nudged, err := notifySessionInboxArrival(n.Root, n.Profile, n.Session, messagePath, seen, n.SendKeys)
+		nudged, err := notifySessionInboxArrival(n.Root, n.Profile, n.Session, messagePath, ledger, n.WakeLive, n.SendKeys)
 		if err != nil {
-			return fmt.Errorf("nudge pending inbox arrival during notifier startup: %w", err)
+			startupErrs = append(startupErrs, fmt.Errorf("observe pending inbox arrival during notifier startup: %w", err))
+			continue
 		}
 		if nudged {
 			rec.LastNudgeAt, rec.LastError = n.Now().UTC(), ""
@@ -410,16 +592,17 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 		return err
 	}
 	for messagePath := range catchUp {
-		if _, existed := seen[messagePath]; existed {
-			continue
-		}
-		nudged, err := notifySessionInboxArrival(n.Root, n.Profile, n.Session, messagePath, seen, n.SendKeys)
+		nudged, err := notifySessionInboxArrival(n.Root, n.Profile, n.Session, messagePath, ledger, n.WakeLive, n.SendKeys)
 		if err != nil {
-			return fmt.Errorf("nudge inbox arrival during notifier startup: %w", err)
+			startupErrs = append(startupErrs, fmt.Errorf("observe inbox arrival during notifier startup: %w", err))
+			continue
 		}
 		if nudged {
 			rec.LastNudgeAt, rec.LastError = n.Now().UTC(), ""
 		}
+	}
+	if startupErr := errors.Join(startupErrs...); startupErr != nil {
+		rec.LastError = startupErr.Error()
 	}
 	heartbeat := time.NewTicker(n.Heartbeat)
 	defer heartbeat.Stop()
@@ -439,7 +622,7 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 			if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename) == 0 {
 				continue
 			}
-			nudged, nudgeErr := notifySessionInboxArrival(n.Root, n.Profile, n.Session, event.Name, seen, n.SendKeys)
+			nudged, nudgeErr := notifySessionInboxArrival(n.Root, n.Profile, n.Session, event.Name, ledger, n.WakeLive, n.SendKeys)
 			if nudgeErr != nil {
 				rec.LastError = nudgeErr.Error()
 			} else if nudged {
@@ -452,8 +635,13 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 			rec.LastError = watchErr.Error()
 		case <-heartbeat.C:
 			heartbeatErr := addNotificationWatchTree(watcher, n.Root)
-			nudged, rescanErr := rescanSessionInboxMessages(n.Root, n.Profile, n.Session, seen, n.SendKeys)
-			heartbeatErr = errors.Join(heartbeatErr, rescanErr)
+			nudged, rescanErr := rescanSessionInboxMessages(n.Root, n.Profile, n.Session, ledger, n.WakeLive, n.SendKeys)
+			pending, snapshotErr := snapshotSessionInboxMessages(n.Root)
+			var pruneErr error
+			if snapshotErr == nil {
+				pruneErr = ledger.Prune(sessionNotifierPendingIDs(n.Root, pending))
+			}
+			heartbeatErr = errors.Join(heartbeatErr, rescanErr, snapshotErr, pruneErr)
 			if heartbeatErr != nil {
 				rec.LastError = heartbeatErr.Error()
 			} else if nudged {
@@ -461,6 +649,7 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 			}
 		}
 		now = n.Now().UTC()
+		rec.AttemptedMessageIDs = cloneSessionNotifierAttempts(ledger.attempted)
 		rec.HeartbeatAt, rec.LeaseExpiresAt = now, now.Add(n.TTL)
 		if err := refreshSessionNotifier(path, n.Token, rec); err != nil {
 			return err
@@ -468,7 +657,7 @@ func executeSessionNotifier(n sessionNotifierExecution) (returnErr error) {
 	}
 }
 
-func rescanSessionInboxMessages(root, profile, session string, seen map[string]struct{}, sendKeys sessionNotifierSendKeys) (bool, error) {
+func rescanSessionInboxMessages(root, profile, session string, ledger *sessionNotifierAttemptLedger, wakeLive sessionNotifierWakeLive, sendKeys sessionNotifierSendKeys) (bool, error) {
 	pending, err := snapshotSessionInboxMessages(root)
 	if err != nil {
 		return false, err
@@ -478,7 +667,7 @@ func rescanSessionInboxMessages(root, profile, session string, seen map[string]s
 		nudgeErrs []error
 	)
 	for messagePath := range pending {
-		nudged, err := notifySessionInboxArrival(root, profile, session, messagePath, seen, sendKeys)
+		nudged, err := notifySessionInboxArrival(root, profile, session, messagePath, ledger, wakeLive, sendKeys)
 		if err != nil {
 			nudgeErrs = append(nudgeErrs, err)
 			continue
@@ -503,30 +692,135 @@ func snapshotSessionInboxMessages(root string) (map[string]struct{}, error) {
 	return seen, nil
 }
 
-func notifySessionInboxArrival(root, profile, session, messagePath string, seen map[string]struct{}, sendKeys sessionNotifierSendKeys) (bool, error) {
+func sessionNotifierMessageTarget(root, messagePath string) (string, bool) {
 	path := canonicalFilesystemPath(messagePath)
 	rel, err := filepath.Rel(canonicalFilesystemPath(root), path)
 	if err != nil {
-		return false, nil
+		return "", false
 	}
 	parts := strings.Split(filepath.ToSlash(rel), "/")
 	if len(parts) != 5 || parts[0] != "agents" || parts[2] != "inbox" || parts[3] != "new" || parts[4] == "" {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func readSessionNotifierMessageID(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("not a regular message file")
+	}
+	if info.Size() > sessionNotifierMessageLimit {
+		return "", fmt.Errorf("message exceeds %d-byte notifier limit", sessionNotifierMessageLimit)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	const start = "---json\n"
+	if !bytes.HasPrefix(data, []byte(start)) {
+		return "", fmt.Errorf("missing ---json frontmatter fence")
+	}
+	payload := data[len(start):]
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return "", fmt.Errorf("parse message frontmatter: %w", err)
+	}
+	if err := operatorauth.ValidateUnambiguousJSON(raw); err != nil {
+		return "", fmt.Errorf("ambiguous message frontmatter: %w", err)
+	}
+	rest := bytes.TrimLeft(payload[dec.InputOffset():], " \t\r\n")
+	if !bytes.HasPrefix(rest, []byte("---\n")) {
+		return "", fmt.Errorf("unterminated message frontmatter")
+	}
+	var header struct {
+		Schema int    `json:"schema"`
+		ID     string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return "", fmt.Errorf("decode message frontmatter: %w", err)
+	}
+	id := strings.TrimSpace(header.ID)
+	if header.Schema != 1 || id == "" || id != header.ID || strings.ContainsAny(id, "/\\\r\n\x00") || filepath.Base(id) != id {
+		return "", fmt.Errorf("message header has noncanonical schema/id")
+	}
+	if filepath.Base(path) != id+".md" {
+		return "", fmt.Errorf("message id %q does not match filename", id)
+	}
+	return id, nil
+}
+
+func sessionNotifierPendingIDs(root string, paths map[string]struct{}) map[string]map[string]struct{} {
+	pending := make(map[string]map[string]struct{})
+	for path := range paths {
+		handle, ok := sessionNotifierMessageTarget(root, path)
+		if !ok {
+			continue
+		}
+		name := filepath.Base(path)
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".md")
+		if id == "" || strings.ContainsAny(id, "/\\\r\n\x00") || filepath.Base(id) != id {
+			continue
+		}
+		if pending[handle] == nil {
+			pending[handle] = make(map[string]struct{})
+		}
+		pending[handle][id] = struct{}{}
+	}
+	return pending
+}
+
+func verifiedSessionNotifierWakeLive(agentDir, root, profile, session, handle string, rec launch.Record) bool {
+	role := strings.TrimSpace(rec.Role)
+	if role == "" {
+		role = handle
+	}
+	live := classifyAgentLiveness(agentDir, root, profile, handle, role, rec.Binary, session, rec.CWD, defaultDuplicateLaunchProbe)
+	return live.Signals.WakeAlive
+}
+
+func notifySessionInboxArrival(root, profile, session, messagePath string, ledger *sessionNotifierAttemptLedger, wakeLive sessionNotifierWakeLive, sendKeys sessionNotifierSendKeys) (bool, error) {
+	path := canonicalFilesystemPath(messagePath)
+	handle, ok := sessionNotifierMessageTarget(root, path)
+	if !ok {
 		return false, nil
 	}
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() {
-		return false, nil
+	messageID, err := readSessionNotifierMessageID(path)
+	if err != nil {
+		return false, fmt.Errorf("resolve notifier message id at %s: %w", path, err)
 	}
-	if _, ok := seen[path]; ok {
-		return false, nil
-	}
-	handle := parts[1]
-	rec, err := launch.Read(filepath.Join(root, "agents", handle))
+	agentDir := filepath.Join(root, "agents", handle)
+	rec, err := launch.Read(agentDir)
 	if err != nil {
 		return false, fmt.Errorf("resolve notifier target %s from launch record: %w", handle, err)
 	}
 	if rec.Handle != handle || rec.Session != session || squadnamespace.NormalizeProfile(rec.TeamProfile) != squadnamespace.NormalizeProfile(profile) || !sameResolvedDir(rec.Root, root) {
 		return false, fmt.Errorf("resolve notifier target %s: launch record scope mismatch", handle)
+	}
+	reserved, err := ledger.Reserve(handle, messageID)
+	if err != nil {
+		return false, fmt.Errorf("reserve notifier attempt for %s/%s: %w", handle, messageID, err)
+	}
+	if !reserved {
+		return false, nil
+	}
+	if wakeLive == nil {
+		wakeLive = verifiedSessionNotifierWakeLive
+	}
+	// AMQ's positively verified wake owns terminal input. The session notifier
+	// records the ID as observed but must not race a second rooted prompt into
+	// the same pane. Ambiguous or absent wake evidence falls through to the
+	// one-attempt durable-inbox fallback below.
+	if wakeLive(agentDir, root, profile, session, handle, rec) {
+		return false, nil
 	}
 	if rec.Tmux == nil || strings.TrimSpace(rec.Tmux.PaneID) == "" {
 		return false, fmt.Errorf("resolve notifier target %s: launch record has no pane", handle)
@@ -534,10 +828,9 @@ func notifySessionInboxArrival(root, profile, session, messagePath string, seen 
 	if err := sendKeys(rec.Tmux.PaneID, dispatchNudgePrompt(root)); err != nil {
 		return false, err
 	}
-	// Mark the arrival handled only after tmux accepted the nudge. A transient
-	// send-keys failure can therefore be retried by a later fsnotify event,
-	// while a successful delivery can never double-nudge the pane.
-	seen[path] = struct{}{}
+	// The attempt was durably reserved before sendKeys. A transient failure is
+	// deliberately not retried: at-most-one pane input wins over a duplicate,
+	// while the unread durable message remains the recovery source.
 	return true, nil
 }
 
@@ -560,6 +853,10 @@ func releaseSessionNotifier(path string, n sessionNotifierExecution, rec session
 		if err != nil || current.OwnerToken != n.Token {
 			return err
 		}
+		// The on-disk ledger is authoritative because Reserve writes it before
+		// pane input. A stop signal can arrive before the main loop copies that
+		// reservation into rec; never let graceful release roll it back.
+		rec.AttemptedMessageIDs = cloneSessionNotifierAttempts(current.AttemptedMessageIDs)
 		now := n.Now().UTC()
 		rec.PID, rec.OwnerToken, rec.Expected = 0, "", false
 		rec.Health, rec.LastError = "inactive", ""

--- a/internal/cli/session_notifier_test.go
+++ b/internal/cli/session_notifier_test.go
@@ -296,6 +296,55 @@ func TestSessionNotifierVerifiedWakeOwnsInput(t *testing.T) {
 	}
 }
 
+func TestSessionNotifierForeignRootWakeFallsBackBeforeReservationBecomesPermanent(t *testing.T) {
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "review"
+		session = "wake"
+		handle  = "dev"
+		paneID  = "%81"
+		wakePID = 4281
+	)
+	root := filepath.Join(project, ".agent-mail", profile, session)
+	foreignRoot := filepath.Join(project, ".agent-mail", profile, "foreign")
+	agentDir := filepath.Join(root, "agents", handle)
+	if err := os.MkdirAll(filepath.Join(agentDir, "inbox", "new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Schema: launch.SchemaVersion, Role: handle, Handle: handle, Binary: "codex",
+		Session: session, TeamProfile: profile, TeamHome: project, CWD: project,
+		Root: root, BaseRoot: filepath.Dir(root), Tmux: &launch.TmuxInfo{PaneID: paneID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: wakePID, Root: foreignRoot, Agent: handle, Started: time.Now()})
+
+	previousProbe := defaultDuplicateLaunchProbe
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == wakePID },
+		ProcessMatch: func(pid int, predicate func(string) bool) bool {
+			return pid == wakePID && predicate("amq wake --me "+handle+" --root "+foreignRoot)
+		},
+		Now: time.Now,
+	}
+	t.Cleanup(func() { defaultDuplicateLaunchProbe = previousProbe })
+
+	message := filepath.Join(agentDir, "inbox", "new", "foreign-root.md")
+	writeSessionNotifierMessage(t, message, "foreign-root")
+	sends := 0
+	nudged, err := notifySessionInboxArrival(root, profile, session, message, newSessionNotifierAttemptLedger(nil), nil, func(gotPane, _ string) error {
+		if gotPane != paneID {
+			t.Fatalf("fallback pane = %q, want %q", gotPane, paneID)
+		}
+		sends++
+		return nil
+	})
+	if err != nil || !nudged || sends != 1 {
+		t.Fatalf("foreign-root wake fallback nudged=%t sends=%d err=%v, want exactly one fallback", nudged, sends, err)
+	}
+}
+
 func TestSessionNotifierPersistentReservationSurvivesFailedSend(t *testing.T) {
 	project := canonicalFilesystemPath(t.TempDir())
 	const (

--- a/internal/cli/session_notifier_test.go
+++ b/internal/cli/session_notifier_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,7 +13,23 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
-func TestSessionNotifierNudgesRecordedPaneExactlyOncePerMessage(t *testing.T) {
+func writeSessionNotifierMessage(t *testing.T, path, id string) {
+	t.Helper()
+	body := `---json
+{"schema":1,"id":"` + id + `","from":"lead","to":["dev"],"thread":"task/test","created":"2026-08-09T00:00:00Z","kind":"todo"}
+---
+body
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sessionNotifierWakeAbsent(string, string, string, string, string, launch.Record) bool {
+	return false
+}
+
+func TestSessionNotifierUnverifiedWakeFallsBackExactlyOncePerMessage(t *testing.T) {
 	project := canonicalFilesystemPath(t.TempDir())
 	const (
 		profile = "review"
@@ -34,18 +51,16 @@ func TestSessionNotifierNudgesRecordedPaneExactlyOncePerMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	message := filepath.Join(agentDir, "inbox", "new", "m1.md")
-	if err := os.WriteFile(message, []byte("message"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeSessionNotifierMessage(t, message, "m1")
 	type nudge struct{ pane, keys string }
 	var nudges []nudge
-	seen := map[string]struct{}{}
+	ledger := newSessionNotifierAttemptLedger(nil)
 	sendKeys := func(pane, keys string) error {
 		nudges = append(nudges, nudge{pane: pane, keys: keys})
 		return nil
 	}
 	for i := 0; i < 2; i++ {
-		nudged, err := notifySessionInboxArrival(root, profile, session, message, seen, sendKeys)
+		nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, sendKeys)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,7 +76,146 @@ func TestSessionNotifierNudgesRecordedPaneExactlyOncePerMessage(t *testing.T) {
 	}
 }
 
-func TestSessionNotifierRetriesFailedNudgeWithoutDoubleSending(t *testing.T) {
+func TestSessionNotifierAttemptLedgerNamespacesMessageIDsByHandle(t *testing.T) {
+	ledger := newSessionNotifierAttemptLedger(nil)
+	for _, tc := range []struct {
+		handle string
+		want   bool
+	}{
+		{handle: "dev", want: true},
+		{handle: "qa", want: true},
+		{handle: "dev", want: false},
+		{handle: "qa", want: false},
+	} {
+		got, err := ledger.Reserve(tc.handle, "shared-id")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.want {
+			t.Fatalf("Reserve(%q, shared-id) = %t, want %t", tc.handle, got, tc.want)
+		}
+	}
+}
+
+func TestSessionNotifierAttemptLedgerIsBoundedAndPruned(t *testing.T) {
+	ledger := newSessionNotifierAttemptLedger(nil)
+	for i := 0; i < sessionNotifierAttemptLimit; i++ {
+		if reserved, err := ledger.Reserve("dev", fmt.Sprintf("message-%03d", i)); err != nil || !reserved {
+			t.Fatalf("reserve message %d: reserved=%t err=%v", i, reserved, err)
+		}
+	}
+	if got := len(ledger.attempted["dev"]); got != sessionNotifierAttemptLimit {
+		t.Fatalf("bounded attempt count = %d, want %d", got, sessionNotifierAttemptLimit)
+	}
+	if reserved, err := ledger.Reserve("dev", "overflow"); err == nil || reserved {
+		t.Fatalf("overflow reserve = %t, %v; want fail-closed capacity error", reserved, err)
+	}
+	if !sessionNotifierAttempted(ledger.attempted, "dev", "message-000") {
+		t.Fatal("full ledger evicted a still-pending attempt")
+	}
+	newest := fmt.Sprintf("message-%03d", sessionNotifierAttemptLimit-1)
+	if err := ledger.Prune(map[string]map[string]struct{}{
+		"dev": {newest: {}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := ledger.attempted["dev"]; len(got) != 1 || got[0] != newest {
+		t.Fatalf("pruned attempts = %+v, want [%s]", got, newest)
+	}
+	if reserved, err := ledger.Reserve("dev", "after-prune"); err != nil || !reserved {
+		t.Fatalf("reserve after prune = %t, %v; want capacity restored", reserved, err)
+	}
+}
+
+func TestSessionNotifierMalformedMessageFailsClosed(t *testing.T) {
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "review"
+		session = "wake"
+		handle  = "dev"
+	)
+	root := filepath.Join(project, ".agent-mail", profile, session)
+	agentDir := filepath.Join(root, "agents", handle)
+	if err := os.MkdirAll(filepath.Join(agentDir, "inbox", "new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Schema: launch.SchemaVersion, Role: handle, Handle: handle, Binary: "codex",
+		Session: session, TeamProfile: profile, TeamHome: project, CWD: project,
+		Root: root, BaseRoot: filepath.Dir(root), Tmux: &launch.TmuxInfo{PaneID: "%10"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	message := filepath.Join(agentDir, "inbox", "new", "malformed.md")
+	body := "---json\n{\"schema\":1,\"id\":\"malformed\",\"id\":\"malformed\"}\n---\nbody\n"
+	if err := os.WriteFile(message, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ledger := newSessionNotifierAttemptLedger(nil)
+	sends := 0
+	for i := 0; i < 2; i++ {
+		nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, func(string, string) error {
+			sends++
+			return nil
+		})
+		if err == nil || nudged {
+			t.Fatalf("malformed arrival %d nudged=%t err=%v, want fail-closed error", i, nudged, err)
+		}
+	}
+	if sends != 0 || len(ledger.attempted) != 0 {
+		t.Fatalf("malformed message sends=%d attempts=%+v, want neither", sends, ledger.attempted)
+	}
+}
+
+func TestSessionNotifierMalformedStartupMessageDoesNotBlockValidWork(t *testing.T) {
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "review"
+		session = "wake"
+		handle  = "dev"
+		paneID  = "%11"
+	)
+	root := filepath.Join(project, ".agent-mail", profile, session)
+	agentDir := filepath.Join(root, "agents", handle)
+	inbox := filepath.Join(agentDir, "inbox", "new")
+	if err := os.MkdirAll(inbox, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Schema: launch.SchemaVersion, Role: handle, Handle: handle, Binary: "codex",
+		Session: session, TeamProfile: profile, TeamHome: project, CWD: project,
+		Root: root, BaseRoot: filepath.Dir(root), Tmux: &launch.TmuxInfo{PaneID: paneID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inbox, "malformed.md"), []byte("not frontmatter\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeSessionNotifierMessage(t, filepath.Join(inbox, "valid.md"), "valid")
+	stop := make(chan os.Signal, 1)
+	sends := 0
+	err := executeSessionNotifier(sessionNotifierExecution{
+		ProjectDir: project, Profile: profile, Session: session, Root: root, Token: "malformed-startup",
+		TTL: time.Minute, Heartbeat: time.Hour, Stop: stop, Now: time.Now,
+		WakeLive: sessionNotifierWakeAbsent,
+		SendKeys: func(gotPane, _ string) error {
+			if gotPane != paneID {
+				t.Fatalf("nudge pane = %q, want %q", gotPane, paneID)
+			}
+			sends++
+			stop <- os.Interrupt
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("malformed startup neighbor stopped notifier: %v", err)
+	}
+	if sends != 1 {
+		t.Fatalf("valid startup sends = %d, want one", sends)
+	}
+}
+
+func TestSessionNotifierFailedNudgeIsReservedWithoutRetry(t *testing.T) {
 	project := canonicalFilesystemPath(t.TempDir())
 	const (
 		profile = "review"
@@ -81,10 +235,8 @@ func TestSessionNotifierRetriesFailedNudgeWithoutDoubleSending(t *testing.T) {
 		t.Fatal(err)
 	}
 	message := filepath.Join(agentDir, "inbox", "new", "m2.md")
-	if err := os.WriteFile(message, []byte("message"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	seen := map[string]struct{}{}
+	writeSessionNotifierMessage(t, message, "m2")
+	ledger := newSessionNotifierAttemptLedger(nil)
 	attempts := 0
 	sendKeys := func(string, string) error {
 		attempts++
@@ -93,17 +245,108 @@ func TestSessionNotifierRetriesFailedNudgeWithoutDoubleSending(t *testing.T) {
 		}
 		return nil
 	}
-	if nudged, err := notifySessionInboxArrival(root, profile, session, message, seen, sendKeys); err == nil || nudged {
+	if nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, sendKeys); err == nil || nudged {
 		t.Fatalf("first arrival nudged=%t err=%v, want retryable failure", nudged, err)
 	}
-	if nudged, err := notifySessionInboxArrival(root, profile, session, message, seen, sendKeys); err != nil || !nudged {
-		t.Fatalf("retry arrival nudged=%t err=%v, want successful nudge", nudged, err)
-	}
-	if nudged, err := notifySessionInboxArrival(root, profile, session, message, seen, sendKeys); err != nil || nudged {
+	if nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, sendKeys); err != nil || nudged {
 		t.Fatalf("post-success arrival nudged=%t err=%v, want deduped", nudged, err)
 	}
-	if attempts != 2 {
-		t.Fatalf("send attempts=%d, want one failure plus one success", attempts)
+	if attempts != 1 {
+		t.Fatalf("send attempts=%d, want one reserved attempt despite failure", attempts)
+	}
+}
+
+func TestSessionNotifierVerifiedWakeOwnsInput(t *testing.T) {
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "review"
+		session = "wake"
+		handle  = "dev"
+	)
+	root := filepath.Join(project, ".agent-mail", profile, session)
+	agentDir := filepath.Join(root, "agents", handle)
+	if err := os.MkdirAll(filepath.Join(agentDir, "inbox", "new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Schema: launch.SchemaVersion, Role: handle, Handle: handle, Binary: "codex",
+		Session: session, TeamProfile: profile, TeamHome: project, CWD: project,
+		Root: root, BaseRoot: filepath.Dir(root), Tmux: &launch.TmuxInfo{PaneID: "%8"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	message := filepath.Join(agentDir, "inbox", "new", "wake-owned.md")
+	writeSessionNotifierMessage(t, message, "wake-owned")
+	ledger := newSessionNotifierAttemptLedger(nil)
+	sends := 0
+	nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger,
+		func(gotAgentDir, gotRoot, gotProfile, gotSession, gotHandle string, _ launch.Record) bool {
+			if gotAgentDir != agentDir || gotRoot != root || gotProfile != profile || gotSession != session || gotHandle != handle {
+				t.Fatalf("wake-live scope = %q %q %q %q %q", gotAgentDir, gotRoot, gotProfile, gotSession, gotHandle)
+			}
+			return true
+		},
+		func(string, string) error { sends++; return nil },
+	)
+	if err != nil || nudged || sends != 0 {
+		t.Fatalf("wake-owned notification nudged=%t sends=%d err=%v, want observed with no pane input", nudged, sends, err)
+	}
+	if again, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, func(string, string) error { sends++; return nil }); err != nil || again || sends != 0 {
+		t.Fatalf("wake-owned ID was retried after wake state changed: nudged=%t sends=%d err=%v", again, sends, err)
+	}
+}
+
+func TestSessionNotifierPersistentReservationSurvivesFailedSend(t *testing.T) {
+	project := canonicalFilesystemPath(t.TempDir())
+	const (
+		profile = "review"
+		session = "wake"
+		handle  = "dev"
+		token   = "attempt-owner"
+	)
+	root := filepath.Join(project, ".agent-mail", profile, session)
+	agentDir := filepath.Join(root, "agents", handle)
+	if err := os.MkdirAll(filepath.Join(agentDir, "inbox", "new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := launch.Write(agentDir, launch.Record{
+		Schema: launch.SchemaVersion, Role: handle, Handle: handle, Binary: "codex",
+		Session: session, TeamProfile: profile, TeamHome: project, CWD: project,
+		Root: root, BaseRoot: filepath.Dir(root), Tmux: &launch.TmuxInfo{PaneID: "%9"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	message := filepath.Join(agentDir, "inbox", "new", "crash-safe.md")
+	writeSessionNotifierMessage(t, message, "crash-safe")
+	path := sessionNotifierRuntimePath(project, profile, session)
+	rec := sessionNotifierRecord{
+		SchemaVersion: sessionNotifierSchema, ProjectDir: project, Profile: profile, Session: session,
+		Root: root, PID: os.Getpid(), OwnerToken: token, Expected: true, Health: "healthy",
+	}
+	if err := writeSessionNotifierRecord(path, rec); err != nil {
+		t.Fatal(err)
+	}
+	ledger := newPersistentSessionNotifierAttemptLedger(path, token, root, &rec)
+	sends := 0
+	if nudged, err := notifySessionInboxArrival(root, profile, session, message, ledger, sessionNotifierWakeAbsent, func(string, string) error {
+		sends++
+		return errors.New("injected tmux failure")
+	}); err == nil || nudged {
+		t.Fatalf("failed reserved attempt nudged=%t err=%v, want one failure", nudged, err)
+	}
+	persisted, err := readSessionNotifierRecord(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sessionNotifierAttempted(persisted.AttemptedMessageIDs, handle, "crash-safe") {
+		t.Fatalf("failed attempt was not durably reserved: %+v", persisted.AttemptedMessageIDs)
+	}
+	restarted := newPersistentSessionNotifierAttemptLedger(path, token, root, &persisted)
+	if nudged, err := notifySessionInboxArrival(root, profile, session, message, restarted, sessionNotifierWakeAbsent, func(string, string) error {
+		sends++
+		return nil
+	}); err != nil || nudged || sends != 1 {
+		t.Fatalf("restart retried reserved failure: nudged=%t sends=%d err=%v", nudged, sends, err)
 	}
 }
 
@@ -129,9 +372,7 @@ func TestSessionNotifierStartupNudgesPendingInboxMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	message := filepath.Join(agentDir, "inbox", "new", "pending.md")
-	if err := os.WriteFile(message, []byte("pending"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	writeSessionNotifierMessage(t, message, "pending")
 
 	stop := make(chan os.Signal, 1)
 	nudges := 0
@@ -146,12 +387,20 @@ func TestSessionNotifierStartupNudgesPendingInboxMessage(t *testing.T) {
 			stop <- os.Interrupt
 			return nil
 		},
+		WakeLive: sessionNotifierWakeAbsent,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if nudges != 1 {
 		t.Fatalf("startup nudges = %d, want exactly one for pending inbox message", nudges)
+	}
+	persisted, err := readSessionNotifierRecord(sessionNotifierRuntimePath(project, profile, session))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sessionNotifierAttempted(persisted.AttemptedMessageIDs, handle, "pending") {
+		t.Fatalf("graceful startup stop lost durable reservation: %+v", persisted.AttemptedMessageIDs)
 	}
 }
 
@@ -176,12 +425,10 @@ func TestSessionNotifierHeartbeatRescansUnseenInboxMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	message := filepath.Join(agentDir, "inbox", "new", "missed-event.md")
-	if err := os.WriteFile(message, []byte("pending"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	seen := map[string]struct{}{}
+	writeSessionNotifierMessage(t, message, "missed-event")
+	ledger := newSessionNotifierAttemptLedger(nil)
 	nudges := 0
-	nudged, err := rescanSessionInboxMessages(root, profile, session, seen, func(gotPane, _ string) error {
+	nudged, err := rescanSessionInboxMessages(root, profile, session, ledger, sessionNotifierWakeAbsent, func(gotPane, _ string) error {
 		if gotPane != paneID {
 			t.Fatalf("nudge pane = %q, want %q", gotPane, paneID)
 		}
@@ -191,7 +438,7 @@ func TestSessionNotifierHeartbeatRescansUnseenInboxMessage(t *testing.T) {
 	if err != nil || !nudged || nudges != 1 {
 		t.Fatalf("heartbeat rescan nudged=%t count=%d err=%v", nudged, nudges, err)
 	}
-	nudged, err = rescanSessionInboxMessages(root, profile, session, seen, func(string, string) error {
+	nudged, err = rescanSessionInboxMessages(root, profile, session, ledger, sessionNotifierWakeAbsent, func(string, string) error {
 		nudges++
 		return nil
 	})

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -37,10 +37,11 @@ type leadWakeOptions struct {
 }
 
 type wakeInjectConfig struct {
-	Mode       string
-	Via        string
-	Args       []string
-	RetryUntil string
+	Mode            string
+	Via             string
+	Args            []string
+	RetryUntil      string
+	RetryTransition *launch.WakeRetryTransition
 }
 
 const (
@@ -466,35 +467,36 @@ func runLeadRegister(args []string) (retErr error) {
 	}
 	wakePID := 0
 	rec := launch.Record{
-		CWD:              cwd,
-		Binary:           member.Binary,
-		Session:          env.SessionName,
-		SharedWorkstream: true,
-		Handle:           handle,
-		Role:             role,
-		Root:             root,
-		BaseRoot:         absoluteAMQRoot(cwd, env.BaseRoot),
-		RootSource:       env.RootSource,
-		AMQVersion:       env.AMQVersion,
-		Model:            memberResolvedModel(member, nil, t.BinaryArgs),
-		ToolProfile:      member.EffectiveToolProfile(),
-		ToolConfig:       strings.TrimSpace(member.ToolConfig),
-		ToolMCPConfig:    strings.TrimSpace(member.ToolMCPConfig),
-		Trust:            strings.TrimSpace(t.Trust),
-		External:         true,
-		AdoptionMode:     auth.AdoptionMode,
-		NoRequireWake:    *noRequireWake,
-		NoWakeReason:     auth.NoWakeReason,
-		WakeInjectVia:    wakeInjectViaValue,
-		WakeInjectArgs:   wakeInjectArgValues,
-		WakeInjectMode:   wakeInjectModeValue,
-		WakeInjectCmd:    wakeInjectCmdValue,
-		WakeRetryUntil:   wakeRetryUntilValue,
-		WakePID:          wakePID,
-		AgentTTY:         currentLaunchTTY(),
-		StartedAt:        time.Now().UTC(),
-		TeamProfile:      profile,
-		TeamHome:         projectDir,
+		CWD:                 cwd,
+		Binary:              member.Binary,
+		Session:             env.SessionName,
+		SharedWorkstream:    true,
+		Handle:              handle,
+		Role:                role,
+		Root:                root,
+		BaseRoot:            absoluteAMQRoot(cwd, env.BaseRoot),
+		RootSource:          env.RootSource,
+		AMQVersion:          env.AMQVersion,
+		Model:               memberResolvedModel(member, nil, t.BinaryArgs),
+		ToolProfile:         member.EffectiveToolProfile(),
+		ToolConfig:          strings.TrimSpace(member.ToolConfig),
+		ToolMCPConfig:       strings.TrimSpace(member.ToolMCPConfig),
+		Trust:               strings.TrimSpace(t.Trust),
+		External:            true,
+		AdoptionMode:        auth.AdoptionMode,
+		NoRequireWake:       *noRequireWake,
+		NoWakeReason:        auth.NoWakeReason,
+		WakeInjectVia:       wakeInjectViaValue,
+		WakeInjectArgs:      wakeInjectArgValues,
+		WakeInjectMode:      wakeInjectModeValue,
+		WakeInjectCmd:       wakeInjectCmdValue,
+		WakeRetryUntil:      wakeRetryUntilValue,
+		WakeRetryTransition: wakeConfig.RetryTransition,
+		WakePID:             wakePID,
+		AgentTTY:            currentLaunchTTY(),
+		StartedAt:           time.Now().UTC(),
+		TeamProfile:         profile,
+		TeamHome:            projectDir,
 		Tmux: &launch.TmuxInfo{
 			Session:    id.Session,
 			WindowID:   id.WindowID,
@@ -654,6 +656,7 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 			resolved.Via = strings.TrimSpace(existing.WakeInjectVia)
 			resolved.Args = append([]string(nil), existing.WakeInjectArgs...)
 			resolved.RetryUntil = strings.TrimSpace(existing.WakeRetryUntil)
+			resolved.RetryTransition = cloneWakeRetryTransition(existing.WakeRetryTransition)
 			inheritedInjector = true
 		}
 	}
@@ -672,9 +675,21 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 		resolved.RetryUntil = ""
 		return resolved, nil
 	}
-	if inheritedInjector && resolved.RetryUntil == "" {
-		// AMQ used drained as its default before the policy became persistable.
-		resolved.RetryUntil = wakeRetryUntilDrained
+	if inheritedInjector && (resolved.RetryUntil == "" || strings.EqualFold(resolved.RetryUntil, wakeRetryUntilDrained)) {
+		// Active re-registration is the upgrade boundary for legacy external
+		// injectors. AMQ treated both an omitted value and explicit drained as
+		// reannounce-until-inbox-progress; migrate that live target to the
+		// presentation acknowledgement introduced in 0.54. Passive record reads
+		// never call this resolver and therefore never rewrite policy at rest.
+		source := "persisted"
+		if strings.TrimSpace(resolved.RetryUntil) == "" {
+			source = "legacy_omitted"
+		}
+		resolved.RetryUntil = wakeRetryUntilInjected
+		resolved.RetryTransition = &launch.WakeRetryTransition{
+			From: wakeRetryUntilDrained, To: wakeRetryUntilInjected,
+			Source: source, At: time.Now().UTC(),
+		}
 	} else if resolved.RetryUntil == "" {
 		// New external injection adopts AMQ 0.54+'s presentation-level
 		// acknowledgement so a successful injector is not re-announced merely
@@ -686,6 +701,14 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 		return wakeInjectConfig{}, fmt.Errorf("stored external wake config: %w", err)
 	}
 	return resolved, nil
+}
+
+func cloneWakeRetryTransition(in *launch.WakeRetryTransition) *launch.WakeRetryTransition {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func preserveExternalGoalBinding(rec launch.Record, err error, role, session string) bool {

--- a/internal/cli/team_lead.go
+++ b/internal/cli/team_lead.go
@@ -649,16 +649,25 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 		Args:       append([]string(nil), requested.Args...),
 		RetryUntil: strings.TrimSpace(requested.RetryUntil),
 	}
-	inheritedInjector := false
-	if !modeExplicit && existingErr == nil && existing.External && launchRecordMatchesSamePaneIdentity(existing, role, handle, profile, session, root, paneID) {
+	samePaneIdentity := existingErr == nil && existing.External && launchRecordMatchesSamePaneIdentity(existing, role, handle, profile, session, root, paneID)
+	if !modeExplicit && samePaneIdentity {
 		resolved.Mode = strings.TrimSpace(existing.WakeInjectMode)
 		if !viaExplicit && !argsExplicit {
 			resolved.Via = strings.TrimSpace(existing.WakeInjectVia)
 			resolved.Args = append([]string(nil), existing.WakeInjectArgs...)
 			resolved.RetryUntil = strings.TrimSpace(existing.WakeRetryUntil)
 			resolved.RetryTransition = cloneWakeRetryTransition(existing.WakeRetryTransition)
-			inheritedInjector = true
 		}
+	}
+	sameInjector := samePaneIdentity && resolved.Via != "" && strings.TrimSpace(existing.WakeInjectVia) != "" &&
+		resolved.Via == strings.TrimSpace(existing.WakeInjectVia) && equalWakeInjectArgs(resolved.Args, existing.WakeInjectArgs)
+	if sameInjector {
+		// Flag explicitness does not create a new injector. Preserve the live
+		// target's policy and audit when via/args were repeated verbatim.
+		if resolved.RetryUntil == "" {
+			resolved.RetryUntil = strings.TrimSpace(existing.WakeRetryUntil)
+		}
+		resolved.RetryTransition = cloneWakeRetryTransition(existing.WakeRetryTransition)
 	}
 	mode, err := normalizeWakeInjectMode(resolved.Mode)
 	if err != nil {
@@ -675,14 +684,15 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 		resolved.RetryUntil = ""
 		return resolved, nil
 	}
-	if inheritedInjector && (resolved.RetryUntil == "" || strings.EqualFold(resolved.RetryUntil, wakeRetryUntilDrained)) {
+	existingRetryUntil := strings.TrimSpace(existing.WakeRetryUntil)
+	if sameInjector && (existingRetryUntil == "" || strings.EqualFold(existingRetryUntil, wakeRetryUntilDrained)) {
 		// Active re-registration is the upgrade boundary for legacy external
 		// injectors. AMQ treated both an omitted value and explicit drained as
 		// reannounce-until-inbox-progress; migrate that live target to the
 		// presentation acknowledgement introduced in 0.54. Passive record reads
 		// never call this resolver and therefore never rewrite policy at rest.
 		source := "persisted"
-		if strings.TrimSpace(resolved.RetryUntil) == "" {
+		if existingRetryUntil == "" {
 			source = "legacy_omitted"
 		}
 		resolved.RetryUntil = wakeRetryUntilInjected
@@ -701,6 +711,18 @@ func resolveExternalWakeInjectConfig(requested wakeInjectConfig, modeExplicit, v
 		return wakeInjectConfig{}, fmt.Errorf("stored external wake config: %w", err)
 	}
 	return resolved, nil
+}
+
+func equalWakeInjectArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func cloneWakeRetryTransition(in *launch.WakeRetryTransition) *launch.WakeRetryTransition {

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -906,6 +906,37 @@ func TestResolveExternalWakeInjectConfigMigratesPersistedDrainedOnlyDuringReregi
 	}
 }
 
+func TestResolveExternalWakeInjectConfigAuditsExplicitSameLegacyInjector(t *testing.T) {
+	for _, test := range []struct {
+		name, storedRetry, wantSource string
+	}{
+		{name: "legacy-omitted", wantSource: "legacy_omitted"},
+		{name: "persisted-drained", storedRetry: wakeRetryUntilDrained, wantSource: "persisted"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rec := launch.Record{
+				External: true, Role: "cto", Handle: "cto", Session: "issue-96",
+				Root: "/repo/.agent-mail/issue-96", WakeInjectMode: "paste",
+				WakeInjectVia: "/opt/inject", WakeInjectArgs: []string{"--pane", "%5"},
+				WakeRetryUntil: test.storedRetry, Tmux: &launch.TmuxInfo{PaneID: "%5"},
+			}
+			got, err := resolveExternalWakeInjectConfig(
+				wakeInjectConfig{Via: "/opt/inject", Args: []string{"--pane", "%5"}},
+				false, true, true, rec, nil, rec.Binary,
+				"cto", "cto", "default", "issue-96", rec.Root, "%5",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.RetryUntil != wakeRetryUntilInjected || got.RetryTransition == nil ||
+				got.RetryTransition.From != wakeRetryUntilDrained || got.RetryTransition.To != wakeRetryUntilInjected ||
+				got.RetryTransition.Source != test.wantSource || got.RetryTransition.At.IsZero() {
+				t.Fatalf("explicit same-injector migration = %+v, want injected/%s transition", got, test.wantSource)
+			}
+		})
+	}
+}
+
 func TestResolveExternalWakeInjectConfigScopesAndPreservesRetryAudit(t *testing.T) {
 	transition := &launch.WakeRetryTransition{
 		From: wakeRetryUntilDrained, To: wakeRetryUntilInjected, Source: "legacy_omitted",
@@ -924,12 +955,22 @@ func TestResolveExternalWakeInjectConfigScopesAndPreservesRetryAudit(t *testing.
 	if got.RetryTransition == nil || *got.RetryTransition != *transition || got.RetryTransition == transition {
 		t.Fatalf("inherited retry audit = %+v, want cloned %+v", got.RetryTransition, transition)
 	}
+	got, err = resolveExternalWakeInjectConfig(
+		wakeInjectConfig{Via: "/opt/inject"}, false, true, true,
+		associated, nil, associated.Binary, "cto", "cto", "default", "issue-96", associated.Root, "%5",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetryTransition == nil || *got.RetryTransition != *transition || got.RetryTransition == transition {
+		t.Fatalf("explicit same-injector retry audit = %+v, want cloned %+v", got.RetryTransition, transition)
+	}
 
-	// Audit from a different pane identity must not leak into a newly specified
-	// injector. The transition belongs to the live target that was migrated.
+	// A different executable is a genuinely new injector even on the same pane,
+	// so the old target's transition must not leak into it.
 	got, err = resolveExternalWakeInjectConfig(
 		wakeInjectConfig{Mode: "raw", Via: "/new/inject"}, true, true, false,
-		associated, nil, "codex", "cto", "cto", "default", "issue-96", associated.Root, "%9",
+		associated, nil, "codex", "cto", "cto", "default", "issue-96", associated.Root, "%5",
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -861,7 +861,7 @@ func TestResolveExternalWakeInjectConfigMigratesLegacyManagedModesAndPreservesOv
 	}
 }
 
-func TestResolveExternalWakeInjectConfigInheritsAssociatedInjector(t *testing.T) {
+func TestResolveExternalWakeInjectConfigMigratesInheritedLegacyInjector(t *testing.T) {
 	rec := launch.Record{
 		External:       true,
 		Role:           "cto",
@@ -877,8 +877,65 @@ func TestResolveExternalWakeInjectConfigInheritsAssociatedInjector(t *testing.T)
 	if err != nil {
 		t.Fatalf("inherit external wake config: %v", err)
 	}
-	if got.Mode != "paste" || got.Via != "/opt/inject" || strings.Join(got.Args, ",") != "--pane,%5" || got.RetryUntil != wakeRetryUntilDrained {
+	if got.Mode != "paste" || got.Via != "/opt/inject" || strings.Join(got.Args, ",") != "--pane,%5" || got.RetryUntil != wakeRetryUntilInjected {
 		t.Fatalf("inherited config = %+v", got)
+	}
+	if got.RetryTransition == nil || got.RetryTransition.From != wakeRetryUntilDrained || got.RetryTransition.To != wakeRetryUntilInjected || got.RetryTransition.Source != "legacy_omitted" || got.RetryTransition.At.IsZero() {
+		t.Fatalf("legacy retry transition = %+v, want drained -> injected audit evidence", got.RetryTransition)
+	}
+}
+
+func TestResolveExternalWakeInjectConfigMigratesPersistedDrainedOnlyDuringReregistration(t *testing.T) {
+	rec := launch.Record{
+		External: true, Role: "cto", Handle: "cto", Session: "issue-96",
+		Root: "/repo/.agent-mail/issue-96", WakeInjectMode: "paste",
+		WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilDrained,
+		Tmux: &launch.TmuxInfo{PaneID: "%5"},
+	}
+	got, err := resolveExternalWakeInjectConfig(wakeInjectConfig{}, false, false, false, rec, nil, rec.Binary, "cto", "cto", "default", "issue-96", rec.Root, "%5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetryUntil != wakeRetryUntilInjected || got.RetryTransition == nil || got.RetryTransition.Source != "persisted" {
+		t.Fatalf("persisted drained migration = %+v, want injected/persisted transition", got)
+	}
+	// A passive decoded record remains untouched; only the active resolver
+	// above constructs transition evidence for the replacement wake.
+	if rec.WakeRetryUntil != wakeRetryUntilDrained || rec.WakeRetryTransition != nil {
+		t.Fatalf("input record mutated at rest: %+v", rec)
+	}
+}
+
+func TestResolveExternalWakeInjectConfigScopesAndPreservesRetryAudit(t *testing.T) {
+	transition := &launch.WakeRetryTransition{
+		From: wakeRetryUntilDrained, To: wakeRetryUntilInjected, Source: "legacy_omitted",
+		At: time.Date(2026, 8, 9, 17, 0, 0, 0, time.UTC),
+	}
+	associated := launch.Record{
+		External: true, Role: "cto", Handle: "cto", Session: "issue-96",
+		Root: "/repo/.agent-mail/issue-96", WakeInjectMode: "paste",
+		WakeInjectVia: "/opt/inject", WakeRetryUntil: wakeRetryUntilInjected,
+		WakeRetryTransition: transition, Tmux: &launch.TmuxInfo{PaneID: "%5"},
+	}
+	got, err := resolveExternalWakeInjectConfig(wakeInjectConfig{}, false, false, false, associated, nil, associated.Binary, "cto", "cto", "default", "issue-96", associated.Root, "%5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetryTransition == nil || *got.RetryTransition != *transition || got.RetryTransition == transition {
+		t.Fatalf("inherited retry audit = %+v, want cloned %+v", got.RetryTransition, transition)
+	}
+
+	// Audit from a different pane identity must not leak into a newly specified
+	// injector. The transition belongs to the live target that was migrated.
+	got, err = resolveExternalWakeInjectConfig(
+		wakeInjectConfig{Mode: "raw", Via: "/new/inject"}, true, true, false,
+		associated, nil, "codex", "cto", "cto", "default", "issue-96", associated.Root, "%9",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RetryTransition != nil {
+		t.Fatalf("unassociated retry audit leaked into new injector: %+v", got.RetryTransition)
 	}
 }
 

--- a/internal/cli/v228_contract_idle_wake_step3_test.go
+++ b/internal/cli/v228_contract_idle_wake_step3_test.go
@@ -36,7 +36,8 @@ func v228SeedInboxMessage(t *testing.T, root, handle, name string) string {
 		t.Fatal(err)
 	}
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("---json\n{\"id\":\""+name+"\"}\n---\nbody\n"), 0o600); err != nil {
+	id := strings.TrimSuffix(name, ".md")
+	if err := os.WriteFile(path, []byte("---json\n{\"schema\":1,\"id\":\""+id+"\"}\n---\nbody\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return path
@@ -73,8 +74,8 @@ func TestV228ContractIdleAgentActsOnMessageWithoutKeystrokes(t *testing.T) {
 	}
 
 	messagePath := v228SeedInboxMessage(t, root, handle, "m1.md")
-	seen := map[string]struct{}{}
-	nudged, err := notifySessionInboxArrival(root, profile, session, messagePath, seen, sendKeys)
+	ledger := newSessionNotifierAttemptLedger(nil)
+	nudged, err := notifySessionInboxArrival(root, profile, session, messagePath, ledger, sessionNotifierWakeAbsent, sendKeys)
 	if err != nil {
 		t.Fatalf("inbox arrival for an idle agent: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestV228ContractIdleAgentActsOnMessageWithoutKeystrokes(t *testing.T) {
 	}
 
 	// Same arrival again must not double-nudge.
-	again, err := notifySessionInboxArrival(root, profile, session, messagePath, seen, sendKeys)
+	again, err := notifySessionInboxArrival(root, profile, session, messagePath, ledger, sessionNotifierWakeAbsent, sendKeys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +108,7 @@ func TestV228ContractIdleAgentActsOnMessageWithoutKeystrokes(t *testing.T) {
 
 	// A second, distinct message nudges once more: one nudge per arrival.
 	next := v228SeedInboxMessage(t, root, handle, "m2.md")
-	if _, err := notifySessionInboxArrival(root, profile, session, next, seen, sendKeys); err != nil {
+	if _, err := notifySessionInboxArrival(root, profile, session, next, ledger, sessionNotifierWakeAbsent, sendKeys); err != nil {
 		t.Fatal(err)
 	}
 	if len(nudges) != 2 {
@@ -117,7 +118,7 @@ func TestV228ContractIdleAgentActsOnMessageWithoutKeystrokes(t *testing.T) {
 	// A handle with no launch record is an error, not a scan fallback: guessing a
 	// pane is what woke the wrong agent in 2.27.
 	orphan := v228SeedInboxMessage(t, root, "ghost", "m3.md")
-	if _, err := notifySessionInboxArrival(root, profile, session, orphan, seen, sendKeys); err == nil {
+	if _, err := notifySessionInboxArrival(root, profile, session, orphan, ledger, sessionNotifierWakeAbsent, sendKeys); err == nil {
 		t.Error("a recordless handle must fail closed rather than fall back to a pane scan")
 	}
 	if len(nudges) != 2 {
@@ -178,6 +179,7 @@ func v228RunNotifierUntil(t *testing.T, fixture v228NotifierFixture, token strin
 				nudged <- pane
 				return nil
 			},
+			WakeLive: sessionNotifierWakeAbsent,
 		})
 	}()
 
@@ -213,8 +215,9 @@ func v228RunNotifierUntil(t *testing.T, fixture v228NotifierFixture, token strin
 // the notifier was down is still pending work — skipping it is wake loss, which
 // is the 2.27 bug class this criterion exists to prevent.
 //
-// Semantics per senior-dev's ruling: exactly-once WITHIN one notifier process,
-// at-least-once ACROSS a restart. A duplicate wake is accepted; a lost wake is not.
+// The durable inbox is the recovery source, so terminal input is at-most-once
+// across notifier restarts. A reservation survives even while the message is
+// still pending; a later distinct message remains eligible for one nudge.
 func TestV228ContractNotifierAnnouncesPendingInboxOnStartup(t *testing.T) {
 	requireV228Contract(t)
 	fixture := v228NewNotifierFixture(t, "ac13", "dev", "%88", 6121)
@@ -237,14 +240,9 @@ func TestV228ContractNotifierAnnouncesPendingInboxOnStartup(t *testing.T) {
 	v228SeedInboxMessage(t, fixture.Root, fixture.Handle, "pending-2.md")
 	second := v228RunNotifierUntil(t, fixture, "token-run-2", 1)
 
-	// At-least-once across the restart boundary. Re-announcing pending-1 is
-	// ALLOWED (duplicate wake beats wake loss), so the count is a range, not an
-	// equality: the range IS the contract. What is forbidden is zero.
-	if len(second) < 1 {
-		t.Fatalf("restart announced nothing; pending inbox work must survive a notifier restart")
-	}
-	if len(second) > 2 {
-		t.Errorf("restart produced %d nudges for 2 pending messages: %v", len(second), second)
+	// pending-1 was already reserved in run 1, so only pending-2 is announced.
+	if len(second) != 1 {
+		t.Fatalf("restart produced %d nudges, want exactly one for the new message: %v", len(second), second)
 	}
 	for _, pane := range second {
 		if pane != fixture.PaneID {

--- a/internal/launch/record.go
+++ b/internal/launch/record.go
@@ -123,6 +123,11 @@ type Record struct {
 	// external inject-via wake. Records written before AMQ 0.54 omit it; an
 	// omitted value therefore means AMQ's historical "drained" policy.
 	WakeRetryUntil string `json:"wake_retry_until,omitempty"`
+	// WakeRetryTransition is additive audit evidence that an active external
+	// re-registration upgraded an older drained retry policy to injected. It is
+	// never synthesized by a passive record read or rewrite: the registration
+	// path records the exact old/new policy while it replaces the live wake.
+	WakeRetryTransition *WakeRetryTransition `json:"wake_retry_transition,omitempty"`
 	// WakeInjectCmd records the literal instruction the wake sidecar injects on
 	// each durable-message arrival (amq wake --inject-cmd). amq-squad sets it to
 	// the standard drain instruction so an inbound directive re-engages a lead
@@ -174,6 +179,16 @@ type Record struct {
 	// planes can select a controller by backend while legacy clients keep using
 	// the stable tmux block.
 	Terminal *TerminalInfo `json:"terminal,omitempty"`
+}
+
+// WakeRetryTransition records one active-registration policy migration. An
+// omitted legacy value is normalized to "drained" in From; Source preserves
+// whether that old policy was implicit or explicitly persisted.
+type WakeRetryTransition struct {
+	From   string    `json:"from"`
+	To     string    `json:"to"`
+	Source string    `json:"source"`
+	At     time.Time `json:"at"`
 }
 
 // OrchestratorRegistration is additive launch-record provenance for the

--- a/internal/launch/record_test.go
+++ b/internal/launch/record_test.go
@@ -145,6 +145,21 @@ func TestWakeRetryUntilAdditiveBackCompat(t *testing.T) {
 	if !strings.Contains(string(raw), `"wake_retry_until":"injected"`) {
 		t.Fatalf("retry policy missing from launch JSON: %s", raw)
 	}
+	transition := &WakeRetryTransition{
+		From: "drained", To: "injected", Source: "legacy_omitted",
+		At: time.Date(2026, 8, 9, 17, 0, 0, 0, time.UTC),
+	}
+	raw, err = json.Marshal(Record{WakeRetryUntil: "injected", WakeRetryTransition: transition})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var migrated Record
+	if err := json.Unmarshal(raw, &migrated); err != nil {
+		t.Fatal(err)
+	}
+	if migrated.WakeRetryTransition == nil || *migrated.WakeRetryTransition != *transition {
+		t.Fatalf("wake retry transition round-trip = %+v, want %+v", migrated.WakeRetryTransition, transition)
+	}
 }
 
 // TestSymphonyAdditiveBackCompat proves the #336 Symphony flag is additive:


### PR DESCRIPTION
Fixes #654

## What

A single relayed message to a busy agent produced one structured amq-squad dispatch notification plus multiple identical raw `: AMQ doorbell` injections, while the durable inbox held exactly one message. Root cause: the amq-squad session notifier independently injected `dispatchNudgePrompt` for the same inbox file as AMQ's raw wake sidecar, with a process-local seen-set, restart re-announcement, and indefinite retry of failed sends.

- **Single input owner**: before pane input, the notifier verifies the exact target's wake liveness (launch-record/wake-lock PID + process identity). A *positively verified* live wake owns terminal input — the notifier records the message as observed and does not inject. Absent or unverified wake evidence falls through to exactly one rooted fallback attempt.
- **Durable message-ID dedupe**: per-root, per-handle AMQ message-ID reservations persisted in the session-notifier runtime record (flock + ownership-token checked). IDs are reserved *before* send, survive restart and failed delivery, prune only after the file leaves `inbox/new`, cap at 512, and fail closed on malformed input or capacity — the unread durable message stays the recovery source. Failed pane sends are deliberately not retried (at-most-once).
- **Legacy policy migration**: active re-registration migrates inherited external inject-via records with omitted/`drained` retry policy to `injected` (AMQ 0.54 presentation ack), recording a `WakeRetryTransition` audit (from/to/source/timestamp) in the launch record. Passive reads never rewrite policy at rest.

## Tests

- Real-AMQ busy-agent regression (real tmux, native managed wake, full notifier loop): pre-fix control captures exactly **2** injected prompts for **1** unread inbox file; fixed path captures exactly **1** raw doorbell, **0** notifier prompts, inbox exactly 1 through the retry horizon.
- Focused suites: ledger reserve/restart/failure at-most-once, per-handle namespacing, bounded prune, malformed fail-closed, positive-wake ownership, legacy-migration audit.

## Evidence (exact head a2901aa)

- `make ci` (serialized): `t2-duplicate-wake-ci-a2901aa-20260809`
- Real AMQ v0.60.0 compat + wake, latest compat + wake: `t2-real-{compat,wake}-{v0600,latest}-a2901aa-20260809`, all succeeded and linked.
- Known caveat: pre-existing load-sensitive `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout` flaked twice in broad plain runs, passed isolated; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
