### PR TITLE
Release v2.29.2 — AMQ 0.60.x rebase

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2291" id="toc-whats-new-in-v2291">What's new
-in v2.29.1</a></li>
+<li><a href="#whats-new-in-v2292" id="toc-whats-new-in-v2292">What's new
+in v2.29.2</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2291">What's new in v2.29.1</a></li>
+<li><a href="#whats-new-in-v2292">What's new in v2.29.2</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,23 +342,29 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2291">What's new in v2.29.1</h2>
-<p>v2.29.1 is a patch release (#663, #664). Mid-run member adds
-(<code>team member add --launch</code>, <code>resume --exec</code> on an
-orchestrated team in the current window, no explicit
-<code>--layout</code>) now arrange the lead's window as
-<code>main-vertical</code>: the lead keeps a full-height left column
-(60% width, best-effort) and added workers stack in rows to its right,
-instead of each add halving whichever pane was active. The lead is
-<em>guaranteed</em> to occupy the main pane — resolved by geometry and
-swapped in when a worker landed there — and the arrangement applies only
-when the resume runs inside the lead's own recorded pane, so a resume
-from an operator or worker pane never rearranges the caller's window.
-Failed launches restore the window's prior <code>main-pane-width</code>.
-The orchestrator skill also gained the dynamic-membership field gotchas
-from the first v2.29.0 live run (actor-mode grant collisions on the
-mid-run path; bare <code>agent up</code> ghost seats). Full detail in <a
-href="docs/v2.29.1-release-notes.md">the v2.29.1 release notes</a>.</p>
+<h2 id="whats-new-in-v2292">What's new in v2.29.2</h2>
+<p>v2.29.2 rebases amq-squad onto the AMQ 0.60.x series (#677, #683).
+The supported floor rises fail-closed from 0.52.2 to 0.60.0:
+<code>doctor</code>, the release-policy checker, and both real-AMQ CI
+matrices (pinned <code>v0.60.0</code> + <code>latest</code>) now agree
+on the new floor. Wake lifecycle authority moves to AMQ: new external
+inject-via wakes persist and start with
+<code>--retry-until injected</code> (legacy records replay
+<code>drained</code> until an active re-registration migrates them, with
+an audit trail), exact retirement replays the recorded policy and
+accepts <code>retired_with_residue</code> only after verified lock
+absence, wake locks are decoded fail-closed and preserved — never
+unlinked locally — and every successful stop must prove exact
+handle/root quiescence through <code>amq wake check</code>, with a
+bounded stable-sample filesystem proof when the check surface is
+unavailable. Duplicate raw wake doorbells to busy agents are fixed
+(#654, #684): a positively verified live AMQ wake is the single
+terminal-input owner, and the session notifier keeps a crash-safe
+per-root, per-handle message-ID ledger giving at-most-one fallback
+across restarts. <code>dispatch</code> also now delivers to the
+canonical team root for worktree-cwd members instead of their
+worktree-local mailbox (#681, #682). Full detail in <a
+href="docs/v2.29.2-release-notes.md">the v2.29.2 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
 Releases</a> and <a href="docs/">docs/</a> (per-release notes
@@ -369,7 +375,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.1</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.2</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.1](#whats-new-in-v2291)
+- [What's new in v2.29.2](#whats-new-in-v2292)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,23 +38,26 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.1
+## What's new in v2.29.2
 
-v2.29.1 is a patch release (#663, #664). Mid-run member adds
-(`team member add --launch`, `resume --exec` on an orchestrated team in the
-current window, no explicit `--layout`) now arrange the lead's window as
-`main-vertical`: the lead keeps a full-height left column (60% width,
-best-effort) and added workers stack in rows to its right, instead of each
-add halving whichever pane was active. The lead is *guaranteed* to occupy
-the main pane — resolved by geometry and swapped in when a worker landed
-there — and the arrangement applies only when the resume runs inside the
-lead's own recorded pane, so a resume from an operator or worker pane never
-rearranges the caller's window. Failed launches restore the window's prior
-`main-pane-width`. The orchestrator skill also gained the
-dynamic-membership field gotchas from the first v2.29.0 live run
-(actor-mode grant collisions on the mid-run path; bare `agent up` ghost
-seats). Full detail in
-[the v2.29.1 release notes](docs/v2.29.1-release-notes.md).
+v2.29.2 rebases amq-squad onto the AMQ 0.60.x series (#677, #683). The
+supported floor rises fail-closed from 0.52.2 to 0.60.0: `doctor`, the
+release-policy checker, and both real-AMQ CI matrices (pinned `v0.60.0` +
+`latest`) now agree on the new floor. Wake lifecycle authority moves to AMQ:
+new external inject-via wakes persist and start with `--retry-until injected`
+(legacy records replay `drained` until an active re-registration migrates
+them, with an audit trail), exact retirement replays the recorded policy and
+accepts `retired_with_residue` only after verified lock absence, wake locks
+are decoded fail-closed and preserved — never unlinked locally — and every
+successful stop must prove exact handle/root quiescence through
+`amq wake check`, with a bounded stable-sample filesystem proof when the
+check surface is unavailable. Duplicate raw wake doorbells to busy agents
+are fixed (#654, #684): a positively verified live AMQ wake is the single
+terminal-input owner, and the session notifier keeps a crash-safe per-root,
+per-handle message-ID ledger giving at-most-one fallback across restarts.
+`dispatch` also now delivers to the canonical team root for worktree-cwd
+members instead of their worktree-local mailbox (#681, #682). Full detail in
+[the v2.29.2 release notes](docs/v2.29.2-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -72,7 +75,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.1
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.2
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.29.2-release-notes.md
+++ b/docs/v2.29.2-release-notes.md
@@ -1,4 +1,6 @@
-# amq-squad v2.29.2 — AMQ 0.60.x rebase
+# amq-squad v2.29.2
+
+AMQ 0.60.x rebase.
 
 v2.29.2 raises the supported AMQ floor from 0.52.2 to 0.60.x and fixes two
 wake-delivery bugs surfaced by live squad runs. Milestone issues: #677, #654,

--- a/docs/v2.29.2-release-notes.md
+++ b/docs/v2.29.2-release-notes.md
@@ -1,0 +1,104 @@
+# amq-squad v2.29.2 — AMQ 0.60.x rebase
+
+v2.29.2 raises the supported AMQ floor from 0.52.2 to 0.60.x and fixes two
+wake-delivery bugs surfaced by live squad runs. Milestone issues: #677, #654,
+#681. PRs: #682, #683, #684.
+
+## Supported AMQ floor: 0.60.0 (#677, #683)
+
+- `doctorMinAMQVersion` and the fail-closed version rejection rise to
+  `0.60.0`. The README support statement, active CLI-skill policy (and
+  generated mirrors), global runbook, and `scripts/check-release-version.py`
+  all state the same policy: AMQ 0.60.x is the supported series, 0.60.0 the
+  minimum, `latest` a forward-compatibility canary.
+- Both real-AMQ CI matrices (compatibility and wake compatibility) move from
+  pinned `v0.52.2` to pinned `v0.60.0` + `latest`.
+- RELEASING.md gains the floor statement and a release-checklist alignment
+  step.
+
+## Wake lifecycle authority moves to AMQ (#677, #683)
+
+Adaptations to the 0.52.3 → 0.60.0 upstream delta (state-bound wake locks,
+submit-only nudges, integrated wake supervisor, Darwin image identity and
+self-restart):
+
+- **Retry policy is persisted and replayed.** New external inject-via wakes
+  start with `--retry-until injected` (AMQ 0.54's presentation-level
+  acknowledgement). Launch records persist the policy in `wake_retry_until`;
+  records written before the policy existed replay AMQ's historical
+  `drained`. Exact retirement replays the recorded policy.
+- **Retirement accepts `retired_with_residue`** (AMQ 0.53+) only after the
+  wake lock is verifiably absent; otherwise the stop is a failure, never a
+  silent success.
+- **Wake locks are decoded fail-closed** (duplicate/null known fields
+  rejected; `state_generation`/`state_digest` binding validated against the
+  wake mode) and are **preserved, never unlinked locally** — corrupt or
+  ambiguous locks are left for AMQ's guarded cleanup, and `--force-duplicate`
+  cannot override an integrity blocker (the real remediation hint is shown
+  instead).
+- **Every successful stop proves quiescence.** `down` requires exact
+  handle/root quiescence via authoritative `amq wake check` (schema 1) within
+  a bounded budget (2s per attempt inside 20s total). When the check surface
+  is unavailable, a filesystem proof requires five consecutive stable
+  samples of the exact no-live terminal state — either lock absence or a
+  cleanly decoded, identity-bound dead-PID stale lock
+  (`fs_stale_lock_preserved`), consistent with the preservation policy. PID
+  liveness is sampled on both sides of each lock read so PID reuse cannot
+  inherit a stale observation. Live, mismatched, corrupt, or unstable
+  observations fail closed.
+- **Keepalive posture decision**: amq-squad keeps its cross-platform session
+  notifier; `amq-keepalive` remains an optional operator-managed Darwin
+  companion, never a required dependency. AMQ owns per-wake lifecycle, image
+  identity, restart, and newer-image adoption; local PID/argv heuristics are
+  advisory only.
+
+## Duplicate raw wake doorbells to busy agents (#654, #684)
+
+One relayed message to a busy agent produced one structured dispatch
+notification plus multiple identical raw doorbell injections, while the
+durable inbox held exactly one message. Root cause: the session notifier
+raced AMQ's raw wake sidecar for the same inbox file with a process-local
+seen-set, restart re-announcement, and indefinite retry.
+
+- A **positively verified live AMQ wake is the single terminal-input owner**:
+  the notifier skips pane input only when the wake lock's root matches the
+  exact notifier root and the live process matches the exact handle+root.
+  Foreign-root or ambiguous evidence takes exactly one fallback attempt —
+  duplicate-over-loss, never silent suppression.
+- A **crash-safe per-root, per-handle message-ID ledger** (flock +
+  ownership-token) reserves each AMQ message ID before pane input, survives
+  restarts and failed sends, prunes only after the file leaves `inbox/new`,
+  caps at 512 and fails closed at capacity — the unread durable message is
+  always the recovery source.
+- **Legacy policy migration**: an active re-registration of the same external
+  injector migrates omitted/`drained` retry policy to `injected`, recording a
+  `wake_retry_transition` audit (from/to/source/timestamp). Records at rest
+  are never rewritten; injector identity is pane + executable + verbatim
+  args, independent of flag explicitness.
+- The real-AMQ regression captures the pre-fix duplicate (two injected
+  prompts for one unread message) and proves the fixed path delivers exactly
+  one doorbell with the inbox intact.
+
+## Dispatch root resolution for worktree-cwd members (#681, #682)
+
+`amq-squad dispatch --role <member>` resolved the target's AMQ root from the
+member's cwd, so members in isolated worktrees received the durable todo in a
+worktree-local mailbox they never drain, with a false "no live pane" report.
+Dispatch now resolves the namespace from the canonical team home (the same
+authority as `amq route` and `status`), reuses status's launch-record
+selection for wake/pane liveness (fail-closed on duplicate records), and
+threads the already-resolved durable-send root across the nudge boundary so
+send and nudge can never diverge — including the no-launch-record fallback.
+
+## Compatibility
+
+- Supported AMQ: 0.60.x series, minimum 0.60.0, fail-closed below the floor.
+  `latest` is validated as a canary, not a support claim.
+- No CLI surface changes; `wake_retry_until` and `wake_retry_transition` are
+  new optional launch-record fields.
+
+## Credits
+
+Implemented by squad workers `rebase-dev` and `dispatch-dev` under lead
+orchestration with mandatory cross-review; every PR carried two independent
+exact-head approvals, full `make ci`, and both real-AMQ matrices.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.1"  # x-release-please-version
+version: "2.29.2"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release v2.29.2 — the AMQ 0.60.x rebase.

Closes milestone v2.29.2: #677 (floor raise, PR #683), #654 (busy-agent doorbell dedupe, PR #684), #681 (dispatch worktree-root fix, PR #682) — all already merged to main.

This PR carries the release mechanics only:

- Plugin manifests → `2.29.2` (claude + codex); `make skills-generate` restamped all skill mirrors.
- README: single What's-new section REPLACING v2.29.1 per policy (outgoing text lives in `docs/v2.29.1-release-notes.md` and the GitHub release); install pin → `@v2.29.2`; `README.html` regenerated.
- `docs/v2.29.2-release-notes.md` added (floor policy, wake-lifecycle authority, doorbell dedupe, dispatch root fix, compatibility notes).

Validation: full `make ci` PASS in a clean detached worktree at exact head `cb90cfe` (the canonical checkout carries untracked local evidence files that trip the repo-scan test; the tracked tree is clean).

After merge: tag `v2.29.2` on the merge commit (operator-gated), GitHub release, `make release-smoke VERSION=v2.29.2`, close the milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
