### PR TITLE
fix(send): resolve worktree members from team home

### DIFF
--- a/internal/cli/runtime_actions.go
+++ b/internal/cli/runtime_actions.go
@@ -465,7 +465,10 @@ Examples:
 	if err := ensureTargetIsNotOperator(t, "send", *roleFlag); err != nil {
 		return err
 	}
-	mr, workstream, err := resolveMemberRuntime(projectDir, profile, ctx.Session, flagWasSet(fs, "session"), *roleFlag)
+	// Resolve through the canonical team home, matching status and dispatch.
+	// A member's execution cwd may be an isolated worktree whose local
+	// .agent-mail tree does not contain the live launch record.
+	mr, workstream, err := resolveDispatchMemberRuntime(projectDir, profile, ctx.Session, flagWasSet(fs, "session"), *roleFlag)
 	if err != nil {
 		return err
 	}
@@ -485,7 +488,7 @@ Examples:
 	if err := validateReResolvedContext(ctx, currentCtx, false); err != nil {
 		return err
 	}
-	currentRuntime, currentWorkstream, err := resolveMemberRuntime(currentCtx.ProjectDir, currentCtx.Profile, currentCtx.Session, flagWasSet(fs, "session"), *roleFlag)
+	currentRuntime, currentWorkstream, err := resolveDispatchMemberRuntime(currentCtx.ProjectDir, currentCtx.Profile, currentCtx.Session, flagWasSet(fs, "session"), *roleFlag)
 	if err != nil {
 		return fmt.Errorf("send refused: target re-resolution under admission failed: %w", err)
 	}

--- a/internal/cli/runtime_actions_test.go
+++ b/internal/cli/runtime_actions_test.go
@@ -483,6 +483,79 @@ func TestITerm2PaneInjectionVerbsReturnUnsupportedReason(t *testing.T) {
 	}
 }
 
+func TestRunSendWorktreeMemberUsesCanonicalTeamRootRecord(t *testing.T) {
+	teamHome := t.TempDir()
+	worktree := t.TempDir()
+	const (
+		profile = "review"
+		session = "issue-686"
+	)
+	if err := team.WriteProfile(teamHome, profile, team.Team{
+		Project:      teamHome,
+		Workstream:   session,
+		Orchestrated: true,
+		Lead:         "cto",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: session},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: session, CWD: worktree},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	canonicalRoot := filepath.Join(teamHome, ".agent-mail", profile, session)
+	canonicalAgentDir := filepath.Join(canonicalRoot, "agents", "qa")
+	if err := launch.Write(canonicalAgentDir, launch.Record{
+		CWD: worktree, Binary: "codex", Session: session, Handle: "qa", Role: "qa",
+		Root: canonicalRoot, BaseRoot: filepath.Dir(canonicalRoot), TeamProfile: profile,
+		TeamHome: teamHome, AgentPID: 4242,
+		Tmux: &launch.TmuxInfo{Session: "amq-squad", WindowID: "@7", PaneID: "%7"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pane := tmuxpane.TmuxPane{
+		Session: "amq-squad", Window: "7", Pane: "0", WindowID: "@7", PaneID: "%7",
+		CWD: worktree, Title: paneTitleToken(session, "qa"),
+	}
+	oldLister, oldBusy, oldSend := statusPaneLister, paneBusyForSend, sendPromptToPane
+	oldProbe := defaultDuplicateLaunchProbe
+	statusPaneLister = func() ([]tmuxpane.TmuxPane, error) { return []tmuxpane.TmuxPane{pane}, nil }
+	defaultDuplicateLaunchProbe = duplicateLaunchProbe{
+		PIDAlive:     func(pid int) bool { return pid == 4242 },
+		ProcessMatch: func(pid int, _ func(string) bool) bool { return pid == 4242 },
+		ProcessTTY:   func(int) (string, bool) { return "", false },
+		Now:          time.Now,
+	}
+	paneBusyForSend = func(string) (bool, error) { return false, nil }
+	var sentPane, sentPrompt string
+	sendPromptToPane = func(paneID, prompt string) error {
+		sentPane, sentPrompt = paneID, prompt
+		return nil
+	}
+	t.Cleanup(func() {
+		statusPaneLister, paneBusyForSend, sendPromptToPane = oldLister, oldBusy, oldSend
+		defaultDuplicateLaunchProbe = oldProbe
+	})
+
+	_, _, err := captureOutput(t, func() error {
+		return runSend([]string{
+			"--project", teamHome,
+			"--profile", profile,
+			"--session", session,
+			"--role", "qa",
+			"--body", "review issue 686",
+		})
+	})
+	if err != nil {
+		t.Fatalf("send worktree member: %v", err)
+	}
+	if sentPane != "%7" || sentPrompt != "review issue 686" {
+		t.Fatalf("send target = pane %q prompt %q, want canonical live pane %%7", sentPane, sentPrompt)
+	}
+	if _, statErr := os.Stat(filepath.Join(worktree, ".agent-mail")); !os.IsNotExist(statErr) {
+		t.Fatalf("send touched worktree-local .agent-mail: %v", statErr)
+	}
+}
+
 func TestDispatchWakePaneSkipsITerm2Nudge(t *testing.T) {
 	base := setupFakeAMQSessionRoots(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Closes #686.

`send --role` failed with "no live tmux pane" for worktree-cwd members because both `runSend` resolution sites used the legacy member-runtime resolver, which looks for the launch record under the member's execution cwd. This ports the PR #682 dispatch fix: both the initial and under-admission resolutions now go through `resolveDispatchMemberRuntime`, which prefers the canonical team-home launch record and falls back to the legacy path when no canonical record exists.

Regression test: a named-profile member executes from an isolated worktree while its launch record exists only under the canonical team root; `send` reaches the live recorded pane and never creates a worktree-local `.agent-mail`.

Evidence (exact head 0535271): make ci PASS; real-AMQ compat+wake matrices PASS on pinned v0.60.0 and latest; two independent exact-head reviews PASS (lead + drafter-dev, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)