### PR TITLE
Release v2.29.3 — drafter backends, role draft, send resolver, release-check CI

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2292" id="toc-whats-new-in-v2292">What's new
-in v2.29.2</a></li>
+<li><a href="#whats-new-in-v2293" id="toc-whats-new-in-v2293">What's new
+in v2.29.3</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2292">What's new in v2.29.2</a></li>
+<li><a href="#whats-new-in-v2293">What's new in v2.29.3</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,29 +342,30 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2292">What's new in v2.29.2</h2>
-<p>v2.29.2 rebases amq-squad onto the AMQ 0.60.x series (#677, #683).
-The supported floor rises fail-closed from 0.52.2 to 0.60.0:
-<code>doctor</code>, the release-policy checker, and both real-AMQ CI
-matrices (pinned <code>v0.60.0</code> + <code>latest</code>) now agree
-on the new floor. Wake lifecycle authority moves to AMQ: new external
-inject-via wakes persist and start with
-<code>--retry-until injected</code> (legacy records replay
-<code>drained</code> until an active re-registration migrates them, with
-an audit trail), exact retirement replays the recorded policy and
-accepts <code>retired_with_residue</code> only after verified lock
-absence, wake locks are decoded fail-closed and preserved — never
-unlinked locally — and every successful stop must prove exact
-handle/root quiescence through <code>amq wake check</code>, with a
-bounded stable-sample filesystem proof when the check surface is
-unavailable. Duplicate raw wake doorbells to busy agents are fixed
-(#654, #684): a positively verified live AMQ wake is the single
-terminal-input owner, and the session notifier keeps a crash-safe
-per-root, per-handle message-ID ledger giving at-most-one fallback
-across restarts. <code>dispatch</code> also now delivers to the
-canonical team root for worktree-cwd members instead of their
-worktree-local mailbox (#681, #682). Full detail in <a
-href="docs/v2.29.2-release-notes.md">the v2.29.2 release notes</a>.</p>
+<h2 id="whats-new-in-v2293">What's new in v2.29.3</h2>
+<p>v2.29.3 ships the drafter theme plus two run-friction fixes from the
+v2.29.2 live run. Team profiles gain an optional schema-6
+<code>drafter</code> block (#679) selecting a headless LLM backend for
+cli/wizard prose generation — presets for <code>yoetz</code>,
+<code>claude -p</code>, and <code>codex exec</code>, plus argv-only
+<code>custom</code> templates with validated
+<code>{prompt}</code>/<code>{out}</code>/<code>{model}</code>/<code>{effort}</code>
+tokens, bounded captured stdout/stderr, context timeouts, and an
+explicit keyless-environment fallback that returns the filled prompt
+with exact command evidence instead of failing. On top of it, the new
+<code>amq-squad role draft</code> command (#665) generates a reusable
+custom role.md, deterministically validates shape and
+session/version/task/branch neutrality, and stages it atomically without
+ever adding or launching a member (see <a
+href="docs/drafter-backends.md">drafter backends</a>).
+<code>send --role</code> now resolves worktree-cwd members through the
+canonical team-home launch record, matching dispatch and status (#686,
+the #681/#682 resolver family). CI now runs the VERSION-bound
+<code>make release-check</code> on release pull requests — detected via
+<code>release/*</code> head refs or a plugin-manifest version change
+against the PR base — so invalid release metadata can no longer ride a
+green pipeline (#687, found live on release PR #685). Full detail in <a
+href="docs/v2.29.3-release-notes.md">the v2.29.3 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
 Releases</a> and <a href="docs/">docs/</a> (per-release notes
@@ -375,7 +376,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.2</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.3</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -965,6 +966,17 @@ Markdown with a <code># Role:</code> heading, or metadata-only
 YAML/JSON. They are staged under
 <code>.amq-squad/roles/&lt;id&gt;.md</code>; launch seeds each agent's
 role file and does not clobber later edits.</p>
+<p>To generate a role file instead of authoring one,
+<code>amq-squad role draft &lt;id&gt; --binary claude|codex --purpose TEXT</code>
+drafts a reusable persona through the profile's optional headless
+drafter (<a href="https://github.com/avivsinai/yoetz">yoetz</a>, a
+CLI-first multi-provider LLM gateway; <code>claude -p</code>;
+<code>codex exec</code>; or a custom argv template), validates its shape
+and neutrality deterministically, and stages it without adding or
+launching a member. Without a configured backend it prints the filled
+prompt for manual completion. See <a
+href="docs/drafter-backends.md">drafter backends</a> for the profile
+<code>drafter</code> block and preset commands.</p>
 <p>Model and effort picker suggestions can be overlaid globally in
 <code>~/.amq-squad/catalog.json</code> and per project in
 <code>&lt;team-home&gt;/.amq-squad/catalog.json</code>; the project

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.2](#whats-new-in-v2292)
+- [What's new in v2.29.3](#whats-new-in-v2293)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,26 +38,27 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.2
+## What's new in v2.29.3
 
-v2.29.2 rebases amq-squad onto the AMQ 0.60.x series (#677, #683). The
-supported floor rises fail-closed from 0.52.2 to 0.60.0: `doctor`, the
-release-policy checker, and both real-AMQ CI matrices (pinned `v0.60.0` +
-`latest`) now agree on the new floor. Wake lifecycle authority moves to AMQ:
-new external inject-via wakes persist and start with `--retry-until injected`
-(legacy records replay `drained` until an active re-registration migrates
-them, with an audit trail), exact retirement replays the recorded policy and
-accepts `retired_with_residue` only after verified lock absence, wake locks
-are decoded fail-closed and preserved — never unlinked locally — and every
-successful stop must prove exact handle/root quiescence through
-`amq wake check`, with a bounded stable-sample filesystem proof when the
-check surface is unavailable. Duplicate raw wake doorbells to busy agents
-are fixed (#654, #684): a positively verified live AMQ wake is the single
-terminal-input owner, and the session notifier keeps a crash-safe per-root,
-per-handle message-ID ledger giving at-most-one fallback across restarts.
-`dispatch` also now delivers to the canonical team root for worktree-cwd
-members instead of their worktree-local mailbox (#681, #682). Full detail in
-[the v2.29.2 release notes](docs/v2.29.2-release-notes.md).
+v2.29.3 ships the drafter theme plus two run-friction fixes from the v2.29.2
+live run. Team profiles gain an optional schema-6 `drafter` block (#679)
+selecting a headless LLM backend for cli/wizard prose generation — presets
+for `yoetz`, `claude -p`, and `codex exec`, plus argv-only `custom`
+templates with validated `{prompt}`/`{out}`/`{model}`/`{effort}` tokens,
+bounded captured stdout/stderr, context timeouts, and an explicit
+keyless-environment fallback that returns the filled prompt with exact
+command evidence instead of failing. On top of it, the new `amq-squad role draft` command (#665)
+generates a reusable custom role.md, deterministically validates shape and
+session/version/task/branch neutrality, and stages it atomically without
+ever adding or launching a member (see
+[drafter backends](docs/drafter-backends.md)). `send --role` now resolves
+worktree-cwd members through the canonical team-home launch record, matching
+dispatch and status (#686, the #681/#682 resolver family). CI now runs the
+VERSION-bound `make release-check` on release pull requests — detected via
+`release/*` head refs or a plugin-manifest version change against the PR
+base — so invalid release metadata can no longer ride a green pipeline
+(#687, found live on release PR #685). Full detail in
+[the v2.29.3 release notes](docs/v2.29.3-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -75,7 +76,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.2
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.3
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -505,6 +506,17 @@ Custom role files can be Markdown with YAML frontmatter, plain Markdown with a
 `# Role:` heading, or metadata-only YAML/JSON. They are staged under
 `.amq-squad/roles/<id>.md`; launch seeds each agent's role file and does not
 clobber later edits.
+
+To generate a role file instead of authoring one, `amq-squad role draft <id>
+--binary claude|codex --purpose TEXT` drafts a reusable persona through the
+profile's optional headless drafter
+([yoetz](https://github.com/avivsinai/yoetz), a CLI-first multi-provider LLM
+gateway; `claude -p`; `codex exec`; or a
+custom argv template), validates its shape and neutrality deterministically,
+and stages it without adding or launching a member. Without a configured
+backend it prints the filled prompt for manual completion. See
+[drafter backends](docs/drafter-backends.md) for the profile `drafter` block
+and preset commands.
 
 Model and effort picker suggestions can be overlaid globally in
 `~/.amq-squad/catalog.json` and per project in

--- a/docs/drafter-backends.md
+++ b/docs/drafter-backends.md
@@ -53,6 +53,11 @@ being accepted but silently ignored.
 
 ### yoetz
 
+[yoetz](https://github.com/avivsinai/yoetz) is a fast CLI-first LLM gateway:
+one local command that fronts multiple model providers (and can convene a
+multi-model "council"), with provider API keys configured once per yoetz
+install — amq-squad never sees them.
+
 ```json
 {
   "drafter": {

--- a/docs/v2.29.3-release-notes.md
+++ b/docs/v2.29.3-release-notes.md
@@ -1,0 +1,95 @@
+# amq-squad v2.29.3
+
+Headless drafter backends, built-in role drafting, and two run-friction
+fixes from the v2.29.2 live run. Milestone issues: #679, #665, #686, #687.
+PRs: #693, #694, #695.
+
+## Configurable headless drafter backends (#679)
+
+Team profiles gain an optional `drafter` block (team schema 6; profiles
+without the block keep the backward-compatible `in_session` behavior, and
+older binaries fail closed on schema-6 files instead of lossily rewriting
+them):
+
+- **Backends**: `in_session` (default), `yoetz`, `claude` (`claude -p`),
+  `codex` (`codex exec`), and `custom`.
+- **Argv-only execution.** Commands are argv arrays — no shell ever parses
+  them. Custom templates support four validated tokens: `{prompt}` (private
+  `0600` prompt file), `{out}` (output file), `{model}`, `{effort}`. Without
+  `{prompt}`/`{out}` the prompt goes to stdin and the draft is read from
+  stdout. A configured `model`/`effort` on a custom command requires its
+  matching token, so a knob can never be silently ignored.
+- **Bounded runs.** Context timeout (default 180s, max 3600s) and a 4 MiB
+  cap on captured stdout/stderr.
+- **Explicit keyless-environment fallback.** `on_failure: in_session` (the
+  default) turns any backend failure — missing binary, missing provider key,
+  timeout, empty draft — into a structured fallback carrying the reason, an
+  actionable remedy, and the exact argv attempted, so the caller can finish
+  from the generated prompt in the active session. `on_failure: error` fails
+  closed with the same evidence. This closes the v2.29.2 gap where personas
+  had to be hand-drafted because yoetz had no provider key in the squad
+  shell.
+- **Evidence discipline.** Every invocation records backend, exact command,
+  model/effort, timeout, duration, exit code, and bounded stderr. Prompt
+  content stays in the private file/stdin and never leaks into evidence.
+- Credentials remain entirely each backend CLI's own concern; amq-squad
+  never reads, stores, or passes provider keys.
+
+See [drafter backends](drafter-backends.md) for settings and preset argv.
+
+## Built-in fast persona drafting: `amq-squad role draft` (#665)
+
+- `amq-squad role draft <id> --binary claude|codex --purpose TEXT` generates
+  a reusable custom role document through the profile's configured drafter,
+  with the active brief passed as explicitly untrusted context.
+- **Deterministic validation before staging**: exact frontmatter fields
+  (`id`, `label`, `binary`, `peers`, each exactly once), required
+  `# Role:` / `## Mission` / `## Boundaries` / `## Protocol` structure in
+  order, under 45 lines, no code fences, and neutrality checks — the
+  document may not name a task id, version, active session, or active
+  branch, so the persona stays reusable.
+- **Atomic no-clobber staging** to `.amq-squad/roles/<id>.md` via hard-link
+  publication; an existing file is refused before the drafter is even
+  invoked.
+- **No lifecycle authority.** The command never adds, launches, or mutates a
+  member, roster, gate, or task; it prints the follow-up
+  `team member add` command instead. Without an external backend it prints
+  the filled manual prompt and writes nothing.
+
+## `send --role` reaches worktree-cwd members (#686)
+
+`send --role` failed with "no live tmux pane" for members whose execution
+cwd is an isolated worktree, because both `runSend` resolution sites looked
+for the launch record under the member cwd. Both now resolve through the
+canonical team-home record, matching dispatch and status (the #681/#682
+resolver family). Regression-tested with a named-profile worktree-cwd member
+and a live pane: delivery reaches the recorded pane and no worktree-local
+`.agent-mail` is created.
+
+## Release PRs run the VERSION-bound release-check in CI (#687)
+
+Found live on release PR #685: full CI green while release metadata was
+invalid. CI now detects release pull requests — head ref matching
+`release/*`, or a plugin-manifest version change against the PR base — and
+runs `make release-check VERSION=<detected>`. The version binds from an
+exact `release/vX.Y.Z` branch name when present, otherwise from the codex
+plugin manifest, so a one-sided manifest bump still triggers the check and
+fails on the cross-manifest validator. Non-release PRs pay only a cheap
+detection step. Detector unit tests run under `make ci`
+(`release-validator-test`).
+
+## Compatibility
+
+- The supported AMQ series remains 0.60.x with a fail-closed minimum of
+  0.60.0; both real-AMQ CI matrices stay pinned `v0.60.0` + `latest`.
+- Team profiles: schema 6 is written only when a `drafter` block is
+  configured; actor-mode/permission-allowlist profiles keep schema 5 and
+  legacy profiles keep schema 3.
+
+## Follow-ups (v2.29.4)
+
+- #696 — global user-level drafter config with an ordered backend fallback
+  chain (`yoetz` → `claude` → `codex` → `in_session`) and a user-layer-only
+  trust rule for custom argv templates.
+- #697 — `amq-squad setup`: interactive machine-level configuration writing
+  the global config.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.2",
+  "version": "2.29.3",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.2",
+  "version": "2.29.3",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.2"  # x-release-please-version
+version: "2.29.3"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release PR for **v2.29.3** per RELEASING.md. Ships the four milestone items already merged to main: #679 + #665 (PR #695, drafter backends + `role draft`), #686 (PR #693, send resolver), #687 (PR #694, release-check CI wiring).

This PR carries the release metadata only: both plugin manifests → 2.29.3, regenerated skill mirrors (version stamped from manifests), README What's-new **replaced** with v2.29.3 (single section, install tag bumped, drafter/yoetz coverage in Customize), regenerated README.html, and `docs/v2.29.3-release-notes.md`.

This is also the first live release PR under the new #687 gate: the detector should report `run_release_check=true` (release branch + manifest bump) and `make release-check VERSION=v2.29.3` must pass in CI.

Evidence at exact head 8f0bf8a: local make ci PASS (clean detached worktree); all four real-AMQ lanes PASS (pinned v0.60.0 + latest=v0.60.1); release-check PASS; two independent exact-head reviews PASS (drafter-dev + fixes-dev; one blocking README-accuracy finding fixed and re-verified — behavioral hardening tracked in #698).

Tag + GitHub release follow merge, gated on operator approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)