### PR TITLE
fix(drafter): bound {out} file reads to the 4 MiB output budget (#698)

### DIFF
--- a/internal/drafter/run.go
+++ b/internal/drafter/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -132,7 +133,7 @@ func Run(ctx context.Context, config *Config, request Request) (Result, error) {
 
 	var output []byte
 	if outputFile {
-		output, err = os.ReadFile(outputPath)
+		output, err = readFileLimited(outputPath, outputLimit)
 		if err != nil {
 			return failureResult(*config, evidence, fmt.Errorf("read configured {out} file: %w", err))
 		}
@@ -144,6 +145,23 @@ func Run(ctx context.Context, config *Config, request Request) (Result, error) {
 		return failureResult(*config, evidence, fmt.Errorf("command produced an empty draft"))
 	}
 	return Result{Text: text, Evidence: evidence}, nil
+}
+
+func readFileLimited(path string, limit int) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	output, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(output) > limit {
+		return nil, fmt.Errorf("output exceeds %d-byte limit", limit)
+	}
+	return output, nil
 }
 
 func buildCommand(config Config, promptPath, outputPath string) ([]string, bool, bool, error) {

--- a/internal/drafter/run_test.go
+++ b/internal/drafter/run_test.go
@@ -117,6 +117,53 @@ func TestRunTimeoutUsesFallbackPolicy(t *testing.T) {
 	}
 }
 
+func TestRunOutputFileLimitUsesFailurePolicy(t *testing.T) {
+	script := writeExecutable(t, `#!/bin/sh
+dd if=/dev/zero of="$1" bs=1048576 count=4 2>/dev/null
+printf x >> "$1"
+`)
+	tests := []struct {
+		name      string
+		mode      string
+		wantError bool
+	}{
+		{name: "fallback", mode: FailureInSession},
+		{name: "fail-closed", mode: FailureError, wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Backend:   BackendCustom,
+				Command:   []string{script, "{out}"},
+				OnFailure: tc.mode,
+			}
+			result, err := Run(context.Background(), cfg, Request{Prompt: "draft"})
+			if tc.wantError {
+				var runErr *RunError
+				if !errors.As(err, &runErr) {
+					t.Fatalf("Run error = %v, want RunError", err)
+				}
+				if result.UseInSession || result.Fallback {
+					t.Fatalf("result = %+v, want fail-closed result", result)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Run fallback: %v", err)
+				}
+				if !result.UseInSession || !result.Fallback {
+					t.Fatalf("result = %+v, want in-session fallback", result)
+				}
+			}
+			if result.Evidence.ExitCode != 0 {
+				t.Fatalf("exit code = %d, want successful command evidence", result.Evidence.ExitCode)
+			}
+			if !strings.Contains(result.Reason, "read configured {out} file: output exceeds 4194304-byte limit") {
+				t.Fatalf("reason = %q, want explicit output limit failure", result.Reason)
+			}
+		})
+	}
+}
+
 func TestBuildCommandPresets(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Closes #698.

`internal/drafter/run.go` capped captured stdout/stderr at 4 MiB via `limitedBuffer`, but `{out}` template files were read with unbounded `os.ReadFile` — and the default yoetz preset uses `{out}`. This bounds the read to the same budget.

## Changes
- `readFileLimited`: max-plus-one read via `io.LimitReader`, explicit rejection over `outputLimit` (4 MiB)
- Over-limit failures route through the normal `failureResult` path — fallback (`in_session`) or fail-closed (`error`) per `on_failure`, preserving successful command evidence
- Test `TestRunOutputFileLimitUsesFailurePolicy` covers both policies with a 4 MiB+1 payload

## Evidence
- head: b134e48c556b29cb3281bac12e205170b5eb7b76 (base a43d45f)
- make ci: PASS; real-AMQ matrices pinned v0.60.0 + latest (v0.60.1): compatibility + wake all PASS
- Reviews (exact-head, independent): lead APPROVE; config-dev-v2294 APPROVE — recorded on AMQ thread task/t1-gh698

Implemented by fixes-dev-v2294 (amq-squad session squad-v2-29-3/v2-29-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
