### PR TITLE
feat: global user-level drafter config with ordered fallback chain (#696)

### DIFF
--- a/docs/drafter-backends.md
+++ b/docs/drafter-backends.md
@@ -2,12 +2,15 @@
 
 amq-squad can delegate bounded prose generation to a headless local CLI while
 keeping validation, file staging, launch policy, and lifecycle decisions in the
-amq-squad binary. The setting is profile-scoped because different team shapes
-may need different cost, latency, or credential policies.
+amq-squad binary. Machine defaults live in
+`~/.config/amq-squad/config.json`; `AMQ_SQUAD_CONFIG` may name one explicit
+alternate file for non-interactive/CI provisioning. A profile-level `drafter`
+block overrides the complete global block. Fields are not merged across the
+trust boundary.
 
-Profiles without a `drafter` block keep the backward-compatible
-`in_session` behavior. Adding the block writes team schema 6; older binaries
-fail closed instead of silently rewriting the new field.
+When neither layer has a `drafter` block, amq-squad keeps the backward-compatible
+`in_session` behavior. Adding a profile block writes team schema 6; older
+binaries fail closed instead of silently rewriting the new field.
 
 ## Settings
 
@@ -16,8 +19,7 @@ The full block is:
 ```json
 {
   "drafter": {
-    "backend": "yoetz",
-    "command": ["optional", "argv", "template"],
+    "chain": ["yoetz", "claude", "codex"],
     "model": "optional-model",
     "effort": "optional-effort",
     "timeout_seconds": 180,
@@ -26,16 +28,26 @@ The full block is:
 }
 ```
 
-`backend` accepts `in_session`, `yoetz`, `claude`, `codex`, or `custom`.
+`chain` is an explicit ordered list. amq-squad tries each named backend in
+order, records the exact command and failure for every attempt, and uses
+`in_session` only after the list is exhausted. It never discovers or inserts
+providers from `PATH`. `in_session` cannot appear as a chain hop, and duplicate
+hops are rejected.
+
+The backward-compatible single `backend` field accepts `in_session`, `yoetz`,
+`claude`, `codex`, or `custom`. `backend` and `chain` are mutually exclusive.
 `timeout_seconds` defaults to 180 and is capped at 3600. `on_failure` accepts:
 
 - `in_session` (default): return a structured fallback with the reason and an
   actionable remedy so the caller can finish from the generated prompt.
 - `error`: fail closed and return the same command evidence with an error.
 
-`command` is an argv array, not a shell command. No shell parses it. A custom
-backend requires this field; setting it on a preset overrides that preset's
-default argv. Four tokens are available:
+`command` is an argv array, not a shell command. No shell parses it. It is
+trusted only from the user-level global config; project and profile files may
+select preset backends and knobs but cannot provide executable argv or choose
+the `custom` backend. A custom backend requires `command`. With `chain`, the
+template applies only to a `custom` hop; preset hops keep their built-in argv.
+Four tokens are available:
 
 | Token | Expansion |
 | --- | --- |
@@ -105,12 +117,12 @@ session persistence disabled, plus the configured `--model` and `--effort`.
 The preset sends the prompt on stdin to `codex exec --ephemeral --color never`
 and maps effort to `--config model_reasoning_effort=...`.
 
-### Custom command
+### Custom command (global config only)
 
 ```json
 {
   "drafter": {
-    "backend": "custom",
+    "chain": ["custom", "claude"],
     "command": [
       "local-drafter",
       "--prompt-file", "{prompt}",
@@ -171,14 +183,15 @@ the launch path generates a neutral contract.
 ## Keyless environments and evidence
 
 A missing provider key, missing binary, timeout, non-zero exit, missing output
-file, or empty draft is never treated as successful generation. With the
-default `on_failure: in_session`, the result explicitly says that fallback was
-used, preserves the provider or command failure, and tells the caller to check
-credentials before retrying or finish from the prompt in the active session.
-Use `on_failure: error` when automation must stop instead.
+file, oversized output, or empty draft is never treated as successful
+generation. The next explicitly configured backend is tried. After exhaustion,
+the default `on_failure: in_session` result preserves every attempt and tells
+the caller to check credentials before retrying or finish from the prompt in
+the active session. Use `on_failure: error` when automation must stop after the
+chain is exhausted instead.
 
 Every attempted external draft records the backend, exact argv and a
 shell-escaped display form, model, effort, timeout, start time, duration, exit
-code, and bounded stderr. Prompt content is carried in a private temporary file
-or stdin rather than embedded in command evidence. Temporary prompt and output
-files are removed after the attempt.
+code, bounded stderr, and its fall-through failure. Prompt content is carried
+in a private temporary file or stdin rather than embedded in command evidence.
+Temporary prompt and output files are removed after the attempt.

--- a/internal/cli/role_draft.go
+++ b/internal/cli/role_draft.go
@@ -211,8 +211,8 @@ Examples:
 		Evidence: result.Evidence, Attempts: result.Attempts, NextCommand: next,
 	}
 	if runErr != nil {
-		if command := strings.TrimSpace(result.Evidence.CommandDisplay); command != "" {
-			return fmt.Errorf("draft role %q: %w; command: %s", id, runErr, command)
+		if evidence := roleDraftFailureEvidence(result); evidence != "" {
+			return fmt.Errorf("draft role %q: %w; %s", id, runErr, evidence)
 		}
 		return fmt.Errorf("draft role %q: %w", id, runErr)
 	}
@@ -247,6 +247,26 @@ Examples:
 	printRoleDraftAttempts(result)
 	fmt.Printf("Next:\n  %s\n", next)
 	return nil
+}
+
+func roleDraftFailureEvidence(result drafter.Result) string {
+	if len(result.Attempts) == 0 {
+		if command := strings.TrimSpace(result.Evidence.CommandDisplay); command != "" {
+			return "command: " + command
+		}
+		return ""
+	}
+	parts := make([]string, 0, len(result.Attempts))
+	for i, attempt := range result.Attempts {
+		parts = append(parts, fmt.Sprintf(
+			"attempt[%d] backend=%s command=%q fall-through=%q",
+			i+1,
+			strings.TrimSpace(attempt.Backend),
+			strings.TrimSpace(attempt.CommandDisplay),
+			strings.TrimSpace(attempt.Failure),
+		))
+	}
+	return "attempts: " + strings.Join(parts, "; ")
 }
 
 func printRoleDraftAttempts(result drafter.Result) {

--- a/internal/cli/role_draft.go
+++ b/internal/cli/role_draft.go
@@ -243,7 +243,9 @@ Examples:
 	if *jsonOut {
 		return printJSONEnvelope("role_draft", data)
 	}
-	fmt.Printf("Wrote %s.\nDrafter command: %s\nNext:\n  %s\n", path, result.Evidence.CommandDisplay, next)
+	fmt.Printf("Wrote %s.\n", path)
+	printRoleDraftAttempts(result)
+	fmt.Printf("Next:\n  %s\n", next)
 	return nil
 }
 

--- a/internal/cli/role_draft.go
+++ b/internal/cli/role_draft.go
@@ -16,6 +16,7 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/drafter"
 	"github.com/omriariav/amq-squad/v2/internal/role"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/userconfig"
 )
 
 const (
@@ -27,6 +28,7 @@ var (
 	roleDraftTaskIDPattern  = regexp.MustCompile(`(?i)(^|[^a-z0-9_-])t[0-9]+([^a-z0-9_-]|$)`)
 	roleDraftVersionPattern = regexp.MustCompile(`(?i)(^|[^a-z0-9])v?[0-9]+\.[0-9]+\.[0-9]+([^a-z0-9]|$)`)
 	runRoleDrafter          = drafter.Run
+	resolveRoleDrafter      = resolveConfiguredDrafter
 	roleDraftCurrentBranch  = func(projectDir string) string {
 		out, err := exec.Command("git", "-C", projectDir, "branch", "--show-current").Output()
 		if err != nil {
@@ -36,23 +38,43 @@ var (
 	}
 )
 
+func resolveConfiguredDrafter(profile *drafter.Config) (*drafter.Config, error) {
+	if profile != nil {
+		resolved, err := drafter.Resolve(profile, nil)
+		if err != nil {
+			return nil, err
+		}
+		return resolved.Config, nil
+	}
+	global, err := userconfig.Read()
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := drafter.Resolve(profile, global.Drafter)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.Config, nil
+}
+
 type roleDraftEnvelopeData struct {
-	ID          string           `json:"id"`
-	Label       string           `json:"label"`
-	Binary      string           `json:"binary"`
-	Peers       []string         `json:"peers,omitempty"`
-	Project     string           `json:"project"`
-	Profile     string           `json:"profile"`
-	Session     string           `json:"session,omitempty"`
-	Path        string           `json:"path"`
-	Staged      bool             `json:"staged"`
-	Manual      bool             `json:"manual,omitempty"`
-	Prompt      string           `json:"prompt,omitempty"`
-	Fallback    bool             `json:"fallback,omitempty"`
-	Reason      string           `json:"reason,omitempty"`
-	Remedy      string           `json:"remedy,omitempty"`
-	Evidence    drafter.Evidence `json:"evidence"`
-	NextCommand string           `json:"next_command"`
+	ID          string             `json:"id"`
+	Label       string             `json:"label"`
+	Binary      string             `json:"binary"`
+	Peers       []string           `json:"peers,omitempty"`
+	Project     string             `json:"project"`
+	Profile     string             `json:"profile"`
+	Session     string             `json:"session,omitempty"`
+	Path        string             `json:"path"`
+	Staged      bool               `json:"staged"`
+	Manual      bool               `json:"manual,omitempty"`
+	Prompt      string             `json:"prompt,omitempty"`
+	Fallback    bool               `json:"fallback,omitempty"`
+	Reason      string             `json:"reason,omitempty"`
+	Remedy      string             `json:"remedy,omitempty"`
+	Evidence    drafter.Evidence   `json:"evidence"`
+	Attempts    []drafter.Evidence `json:"attempts,omitempty"`
+	NextCommand string             `json:"next_command"`
 }
 
 func runRole(args []string) error {
@@ -160,6 +182,10 @@ Examples:
 	if err != nil {
 		return fmt.Errorf("read team profile: %w", err)
 	}
+	drafterConfig, err := resolveRoleDrafter(cfg.Drafter)
+	if err != nil {
+		return fmt.Errorf("resolve drafter config: %w", err)
+	}
 	session, err := resolveTeamWorkstreamName(cfg, strings.TrimSpace(*sessionFlag), flagWasSet(fs, "session"))
 	if err != nil {
 		return err
@@ -175,14 +201,14 @@ Examples:
 		return err
 	}
 	prompt := buildRoleDraftPrompt(id, label, binary, purpose, peers, brief)
-	result, runErr := runRoleDrafter(context.Background(), cfg.Drafter, drafter.Request{
+	result, runErr := runRoleDrafter(context.Background(), drafterConfig, drafter.Request{
 		Prompt: prompt, WorkingDirectory: projectDir,
 	})
 	next := roleDraftNextCommand(projectDir, profile, session, id, binary)
 	data := roleDraftEnvelopeData{
 		ID: id, Label: label, Binary: binary, Peers: peers,
 		Project: projectDir, Profile: profile, Session: session, Path: path,
-		Evidence: result.Evidence, NextCommand: next,
+		Evidence: result.Evidence, Attempts: result.Attempts, NextCommand: next,
 	}
 	if runErr != nil {
 		if command := strings.TrimSpace(result.Evidence.CommandDisplay); command != "" {
@@ -200,9 +226,7 @@ Examples:
 			return printJSONEnvelope("role_draft", data)
 		}
 		fmt.Printf("No role file was staged.\nReason: %s\nRemedy: %s\n", result.Reason, result.Remedy)
-		if command := strings.TrimSpace(result.Evidence.CommandDisplay); command != "" {
-			fmt.Printf("Drafter command: %s\n", command)
-		}
+		printRoleDraftAttempts(result)
 		fmt.Printf("\nManual drafting prompt:\n\n%s\n\nAfter reviewing and saving %s, run:\n  %s\n", prompt, path, next)
 		return nil
 	}
@@ -221,6 +245,21 @@ Examples:
 	}
 	fmt.Printf("Wrote %s.\nDrafter command: %s\nNext:\n  %s\n", path, result.Evidence.CommandDisplay, next)
 	return nil
+}
+
+func printRoleDraftAttempts(result drafter.Result) {
+	if len(result.Attempts) == 0 {
+		if command := strings.TrimSpace(result.Evidence.CommandDisplay); command != "" {
+			fmt.Printf("Drafter command: %s\n", command)
+		}
+		return
+	}
+	for _, attempt := range result.Attempts {
+		fmt.Printf("Drafter attempt (%s): %s\n", attempt.Backend, attempt.CommandDisplay)
+		if failure := strings.TrimSpace(attempt.Failure); failure != "" {
+			fmt.Printf("Fall-through: %s\n", failure)
+		}
+	}
 }
 
 func validateRoleDraftScalar(name, value string, max int, required bool) error {

--- a/internal/cli/role_draft_test.go
+++ b/internal/cli/role_draft_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -201,6 +202,51 @@ func TestRunRoleDraftChainFallbackReportsEveryAttempt(t *testing.T) {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("chain fallback output missing %q:\n%s", want, stdout)
 		}
+	}
+}
+
+func TestRunRoleDraftFailureModeErrorReportsEveryAttempt(t *testing.T) {
+	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
+		Chain:     []string{drafter.BackendYoetz, drafter.BackendClaude},
+		OnFailure: drafter.FailureError,
+	})
+	installRoleDraftRunner(t, func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
+		attempts := []drafter.Evidence{
+			{Backend: drafter.BackendYoetz, CommandDisplay: "yoetz ask --model fast", ExitCode: 17, Failure: "missing credentials"},
+			{Backend: drafter.BackendClaude, CommandDisplay: "claude -p --model fable", ExitCode: 2, Failure: "provider unavailable"},
+		}
+		return drafter.Result{
+				Reason:   "configured chain exhausted",
+				Remedy:   "fix provider configuration",
+				Evidence: attempts[1],
+				Attempts: attempts,
+			}, &drafter.RunError{
+				Cause:    errors.New("configured chain exhausted"),
+				Evidence: attempts[1],
+				Attempts: attempts,
+				Remedy:   "fix provider configuration",
+			}
+	})
+
+	_, _, err := captureOutput(t, func() error {
+		return runRoleDraft([]string{
+			"researcher", "--binary", "codex", "--purpose", "Investigate ambiguous behavior",
+			"--project", project, "--profile", profile, "--session", session,
+		})
+	})
+	if err == nil {
+		t.Fatal("chain failure returned nil error")
+	}
+	for _, want := range []string{
+		"attempt[1] backend=yoetz", `command="yoetz ask --model fast"`, `fall-through="missing credentials"`,
+		"attempt[2] backend=claude", `command="claude -p --model fable"`, `fall-through="provider unavailable"`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("fail-closed error missing %q:\n%s", want, err)
+		}
+	}
+	if _, statErr := os.Stat(team.CustomRolePath(project, "researcher")); !os.IsNotExist(statErr) {
+		t.Fatalf("fail-closed chain staged a role: %v", statErr)
 	}
 }
 

--- a/internal/cli/role_draft_test.go
+++ b/internal/cli/role_draft_test.go
@@ -5,22 +5,47 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/omriariav/amq-squad/v2/internal/drafter"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/userconfig"
 )
+
+func TestResolveConfiguredDrafterUsesWholeBlockPrecedence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"drafter":{"chain":["yoetz","codex"],"model":"global"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(userconfig.ConfigEnv, path)
+
+	global, err := resolveConfiguredDrafter(nil)
+	if err != nil {
+		t.Fatalf("resolve global: %v", err)
+	}
+	if global == nil || !reflect.DeepEqual(global.Chain, []string{drafter.BackendYoetz, drafter.BackendCodex}) || global.Model != "global" {
+		t.Fatalf("global config = %+v", global)
+	}
+
+	profile, err := resolveConfiguredDrafter(&drafter.Config{Backend: drafter.BackendClaude, Model: "profile"})
+	if err != nil {
+		t.Fatalf("resolve profile: %v", err)
+	}
+	if profile == nil || profile.Backend != drafter.BackendClaude || profile.Model != "profile" || len(profile.Chain) != 0 {
+		t.Fatalf("profile config = %+v", profile)
+	}
+}
 
 func TestRunRoleDraftStagesValidatedDocumentWithoutLaunching(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
-		Backend: drafter.BackendCustom,
-		Command: []string{"fake-drafter"},
+		Backend: drafter.BackendClaude,
 	})
 	document := validRoleDraftDocument("researcher", "Research Engineer", "codex", []string{"lead", "qa"})
 	var gotPrompt, gotWorkingDir string
 	installRoleDraftRunner(t, func(_ context.Context, cfg *drafter.Config, request drafter.Request) (drafter.Result, error) {
-		if cfg == nil || cfg.EffectiveBackend() != drafter.BackendCustom {
+		if cfg == nil || cfg.EffectiveBackend() != drafter.BackendClaude {
 			t.Fatalf("drafter config = %+v", cfg)
 		}
 		gotPrompt, gotWorkingDir = request.Prompt, request.WorkingDirectory
@@ -141,18 +166,57 @@ func TestRunRoleDraftBackendFallbackReportsEvidenceWithoutStaging(t *testing.T) 
 	}
 }
 
-func TestRunRoleDraftJSONIncludesStructuredEvidence(t *testing.T) {
+func TestRunRoleDraftChainFallbackReportsEveryAttempt(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
-		Backend: drafter.BackendCustom,
-		Command: []string{"fake-drafter"},
+		Chain: []string{drafter.BackendYoetz, drafter.BackendClaude},
 	})
 	installRoleDraftRunner(t, func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
+		attempts := []drafter.Evidence{
+			{Backend: drafter.BackendYoetz, CommandDisplay: "yoetz ask", ExitCode: 17, Failure: "missing credentials"},
+			{Backend: drafter.BackendClaude, CommandDisplay: "claude -p", ExitCode: 2, Failure: "provider unavailable"},
+		}
 		return drafter.Result{
-			Text: validRoleDraftDocument("researcher", "researcher", "codex", nil),
-			Evidence: drafter.Evidence{
-				Backend: drafter.BackendCustom, Command: []string{"fake-drafter"},
-				CommandDisplay: "fake-drafter", TimeoutSeconds: 30, ExitCode: 0,
-			},
+			UseInSession: true,
+			Fallback:     true,
+			Reason:       "configured chain exhausted",
+			Remedy:       "complete the prompt manually",
+			Evidence:     attempts[1],
+			Attempts:     attempts,
+		}, nil
+	})
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runRoleDraft([]string{
+			"researcher", "--binary", "codex", "--purpose", "Investigate ambiguous behavior",
+			"--project", project, "--profile", profile, "--session", session,
+		})
+	})
+	if err != nil {
+		t.Fatalf("chain fallback role draft: %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"Drafter attempt (yoetz): yoetz ask", "Fall-through: missing credentials",
+		"Drafter attempt (claude): claude -p", "Fall-through: provider unavailable",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("chain fallback output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestRunRoleDraftJSONIncludesStructuredEvidence(t *testing.T) {
+	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
+		Backend: drafter.BackendClaude,
+	})
+	installRoleDraftRunner(t, func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
+		attempt := drafter.Evidence{
+			Backend: drafter.BackendCustom, Command: []string{"fake-drafter"},
+			CommandDisplay: "fake-drafter", TimeoutSeconds: 30, ExitCode: 0,
+		}
+		return drafter.Result{
+			Text:     validRoleDraftDocument("researcher", "researcher", "codex", nil),
+			Evidence: attempt,
+			Attempts: []drafter.Evidence{attempt},
 		}, nil
 	})
 
@@ -182,6 +246,9 @@ func TestRunRoleDraftJSONIncludesStructuredEvidence(t *testing.T) {
 	if envelope.Data.Evidence.CommandDisplay != "fake-drafter" || envelope.Data.Evidence.TimeoutSeconds != 30 {
 		t.Fatalf("role draft evidence = %+v", envelope.Data.Evidence)
 	}
+	if len(envelope.Data.Attempts) != 1 || envelope.Data.Attempts[0].CommandDisplay != "fake-drafter" {
+		t.Fatalf("role draft attempts = %+v", envelope.Data.Attempts)
+	}
 	if envelope.Data.NextCommand == "" || envelope.Data.Path != team.CustomRolePath(project, "researcher") {
 		t.Fatalf("role draft path/next = %q / %q", envelope.Data.Path, envelope.Data.NextCommand)
 	}
@@ -189,8 +256,7 @@ func TestRunRoleDraftJSONIncludesStructuredEvidence(t *testing.T) {
 
 func TestRunRoleDraftRejectsSessionBoundOutputWithoutStaging(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
-		Backend: drafter.BackendCustom,
-		Command: []string{"fake-drafter"},
+		Backend: drafter.BackendClaude,
 	})
 	document := validRoleDraftDocument("researcher", "researcher", "codex", nil)
 	document = strings.Replace(document, "Take live scope only", "For issue-665, take live scope only", 1)
@@ -217,8 +283,7 @@ func TestRunRoleDraftRejectsSessionBoundOutputWithoutStaging(t *testing.T) {
 
 func TestRunRoleDraftRefusesExistingPathBeforeInvokingDrafter(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
-		Backend: drafter.BackendCustom,
-		Command: []string{"fake-drafter"},
+		Backend: drafter.BackendClaude,
 	})
 	path := team.CustomRolePath(project, "researcher")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -322,6 +387,12 @@ func TestRoleCommandIsPublicAndCompletable(t *testing.T) {
 
 func setupRoleDraftTeam(t *testing.T, cfg *drafter.Config) (string, string, string) {
 	t.Helper()
+	oldResolver := resolveRoleDrafter
+	resolveRoleDrafter = func(profile *drafter.Config) (*drafter.Config, error) {
+		resolved, err := drafter.Resolve(profile, nil)
+		return resolved.Config, err
+	}
+	t.Cleanup(func() { resolveRoleDrafter = oldResolver })
 	project := t.TempDir()
 	const profile = "review"
 	const session = "issue-665"

--- a/internal/drafter/config.go
+++ b/internal/drafter/config.go
@@ -22,18 +22,24 @@ const (
 
 	DefaultTimeoutSeconds = 180
 	MaxTimeoutSeconds     = 3600
+
+	SourceProfile   = "profile"
+	SourceGlobal    = "global"
+	SourceInSession = "in_session"
 )
 
 var supportedTemplateTokens = []string{"{prompt}", "{out}", "{model}", "{effort}"}
 var templateTokenPattern = regexp.MustCompile(`\{[A-Za-z_][A-Za-z0-9_]*\}`)
 
-// Config is the profile-scoped external drafting policy. Command is an argv
-// template, never a shell string. The optional {prompt} and {out} tokens expand
-// to private temporary files; without them prompt input is sent on stdin and
-// the draft is read from stdout. {model} and {effort} expose the corresponding
-// knobs to custom templates.
+// Config is an external drafting policy. A profile may select preset backends
+// and knobs, while Command is trusted only when this config came from the
+// user-level global config. Command is an argv template, never a shell string.
+// The optional {prompt} and {out} tokens expand to private temporary files;
+// without them prompt input is sent on stdin and the draft is read from stdout.
+// {model} and {effort} expose the corresponding knobs to custom templates.
 type Config struct {
 	Backend        string   `json:"backend,omitempty"`
+	Chain          []string `json:"chain,omitempty"`
 	Command        []string `json:"command,omitempty"`
 	Model          string   `json:"model,omitempty"`
 	Effort         string   `json:"effort,omitempty"`
@@ -41,11 +47,35 @@ type Config struct {
 	OnFailure      string   `json:"on_failure,omitempty"`
 }
 
+// Resolution names which complete drafter block won precedence. Config is nil
+// only for the implicit in-session default.
+type Resolution struct {
+	Config *Config
+	Source string
+}
+
 func (c Config) EffectiveBackend() string {
+	if len(c.Chain) > 0 {
+		return strings.TrimSpace(c.Chain[0])
+	}
 	if backend := strings.TrimSpace(c.Backend); backend != "" {
 		return backend
 	}
 	return BackendInSession
+}
+
+// EffectiveBackends returns the configured external backends in attempt order.
+// The implicit in-session default is returned only when no external backend is
+// configured; it is never appended to an explicit chain.
+func (c Config) EffectiveBackends() []string {
+	if len(c.Chain) > 0 {
+		backends := make([]string, len(c.Chain))
+		for i, backend := range c.Chain {
+			backends[i] = strings.TrimSpace(backend)
+		}
+		return backends
+	}
+	return []string{c.EffectiveBackend()}
 }
 
 func (c Config) EffectiveTimeout() time.Duration {
@@ -63,18 +93,73 @@ func (c Config) EffectiveFailureMode() string {
 	return FailureInSession
 }
 
+// Resolve applies whole-block precedence. Profile fields are never merged with
+// the global block because doing so could accidentally import a user command
+// template into project-controlled policy.
+func Resolve(profile, global *Config) (Resolution, error) {
+	if profile != nil {
+		if err := ValidateProfile(profile); err != nil {
+			return Resolution{}, fmt.Errorf("profile drafter: %w", err)
+		}
+		return Resolution{Config: cloneConfig(profile), Source: SourceProfile}, nil
+	}
+	if global != nil {
+		if err := ValidateGlobal(global); err != nil {
+			return Resolution{}, fmt.Errorf("global drafter: %w", err)
+		}
+		return Resolution{Config: cloneConfig(global), Source: SourceGlobal}, nil
+	}
+	return Resolution{Source: SourceInSession}, nil
+}
+
+// ValidateProfile rejects executable argv from project-controlled team files.
+func ValidateProfile(c *Config) error {
+	if c == nil {
+		return nil
+	}
+	if len(c.Command) > 0 {
+		return fmt.Errorf("command: custom argv templates are allowed only in the user-level global config")
+	}
+	for _, backend := range c.EffectiveBackends() {
+		if backend == BackendCustom {
+			return fmt.Errorf("backend: custom is allowed only in the user-level global config")
+		}
+	}
+	return Validate(c)
+}
+
+// ValidateGlobal validates trusted user-level drafter policy, including custom
+// argv templates.
+func ValidateGlobal(c *Config) error { return Validate(c) }
+
 // Validate checks the persisted policy before any subprocess or temporary
 // file is created.
 func Validate(c *Config) error {
 	if c == nil {
 		return nil
 	}
-	backend := c.EffectiveBackend()
-	switch backend {
-	case BackendInSession, BackendYoetz, BackendClaude, BackendCodex, BackendCustom:
-	default:
-		return fmt.Errorf("backend: unsupported drafter backend %q: use %s, %s, %s, %s, or %s",
-			backend, BackendInSession, BackendYoetz, BackendClaude, BackendCodex, BackendCustom)
+	if strings.TrimSpace(c.Backend) != "" && len(c.Chain) > 0 {
+		return fmt.Errorf("backend and chain are mutually exclusive")
+	}
+	backends := c.EffectiveBackends()
+	seen := make(map[string]struct{}, len(backends))
+	for i, backend := range backends {
+		if backend == "" {
+			return fmt.Errorf("chain[%d]: backend cannot be empty", i)
+		}
+		switch backend {
+		case BackendInSession, BackendYoetz, BackendClaude, BackendCodex, BackendCustom:
+		default:
+			return fmt.Errorf("backend: unsupported drafter backend %q: use %s, %s, %s, %s, or %s",
+				backend, BackendInSession, BackendYoetz, BackendClaude, BackendCodex, BackendCustom)
+		}
+		if len(c.Chain) > 0 && backend == BackendInSession {
+			return fmt.Errorf("chain[%d]: %s is implicit after chain exhaustion and cannot be configured as a hop", i, BackendInSession)
+		}
+		if _, ok := seen[backend]; ok {
+			return fmt.Errorf("chain[%d]: duplicate backend %q", i, backend)
+		}
+		seen[backend] = struct{}{}
 	}
 	if c.TimeoutSeconds < 0 || c.TimeoutSeconds > MaxTimeoutSeconds {
 		return fmt.Errorf("timeout_seconds: must be between 1 and %d when set", MaxTimeoutSeconds)
@@ -85,14 +170,18 @@ func Validate(c *Config) error {
 		return fmt.Errorf("on_failure: invalid mode %q: use %s or %s", c.OnFailure, FailureInSession, FailureError)
 	}
 
-	if backend == BackendInSession {
+	if len(c.Chain) == 0 && backends[0] == BackendInSession {
 		if len(c.Command) > 0 || strings.TrimSpace(c.Model) != "" || strings.TrimSpace(c.Effort) != "" || c.TimeoutSeconds != 0 || strings.TrimSpace(c.OnFailure) != "" {
-			return fmt.Errorf("backend %s cannot set command, model, effort, timeout_seconds, or on_failure", BackendInSession)
+			return fmt.Errorf("backend %s cannot set chain, command, model, effort, timeout_seconds, or on_failure", BackendInSession)
 		}
 		return nil
 	}
-	if backend == BackendCustom && len(c.Command) == 0 {
+	_, hasCustom := seen[BackendCustom]
+	if hasCustom && len(c.Command) == 0 {
 		return fmt.Errorf("command: required for custom drafter backend")
+	}
+	if len(c.Chain) > 0 && len(c.Command) > 0 && !hasCustom {
+		return fmt.Errorf("command: with chain it applies only to a custom backend, but chain has no custom hop")
 	}
 	for i, arg := range c.Command {
 		if strings.TrimSpace(arg) == "" {
@@ -123,10 +212,30 @@ func Validate(c *Config) error {
 	if templateContains(c.Command, "{effort}") && strings.TrimSpace(c.Effort) == "" {
 		return fmt.Errorf("effort: required when command contains {effort}")
 	}
-	if len(c.Command) == 0 && backend == BackendYoetz && strings.TrimSpace(c.Effort) != "" {
+	if len(c.Command) == 0 && len(backends) == 1 && backends[0] == BackendYoetz && strings.TrimSpace(c.Effort) != "" {
 		return fmt.Errorf("effort: the yoetz preset has no effort flag; use a custom command template with {effort}")
 	}
 	return nil
+}
+
+func (c Config) forBackend(backend string) Config {
+	attempt := c
+	attempt.Backend = backend
+	attempt.Chain = nil
+	if len(c.Chain) > 0 && backend != BackendCustom {
+		attempt.Command = nil
+	}
+	return attempt
+}
+
+func cloneConfig(c *Config) *Config {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+	clone.Chain = append([]string(nil), c.Chain...)
+	clone.Command = append([]string(nil), c.Command...)
+	return &clone
 }
 
 func templateContains(command []string, token string) bool {

--- a/internal/drafter/config.go
+++ b/internal/drafter/config.go
@@ -225,6 +225,9 @@ func (c Config) forBackend(backend string) Config {
 	if len(c.Chain) > 0 && backend != BackendCustom {
 		attempt.Command = nil
 	}
+	if backend == BackendYoetz && len(attempt.Command) == 0 {
+		attempt.Effort = ""
+	}
 	return attempt
 }
 

--- a/internal/drafter/config_test.go
+++ b/internal/drafter/config_test.go
@@ -1,6 +1,7 @@
 package drafter
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,8 @@ func TestValidatePresetAndCustomConfigs(t *testing.T) {
 		{name: "codex", cfg: Config{Backend: BackendCodex, Model: "gpt-5.6-luna", Effort: "medium", OnFailure: FailureError}},
 		{name: "custom-stdio", cfg: Config{Backend: BackendCustom, Command: []string{"local-drafter", "--schema", `{"type":"string"}`}}},
 		{name: "custom-files", cfg: Config{Backend: BackendCustom, Command: []string{"local-drafter", "--in={prompt}", "--out={out}", "--model={model}", "--effort={effort}"}, Model: "fast", Effort: "low"}},
+		{name: "ordered-chain", cfg: Config{Chain: []string{BackendYoetz, BackendClaude, BackendCodex}, Model: "fast", Effort: "low"}},
+		{name: "chain-with-custom", cfg: Config{Chain: []string{BackendCustom, BackendClaude}, Command: []string{"local-drafter"}}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,6 +58,12 @@ func TestValidateRejectsInvalidConfig(t *testing.T) {
 		{name: "missing-model-token", cfg: Config{Backend: BackendCustom, Command: []string{"tool"}, Model: "x"}, want: "must include {model}"},
 		{name: "missing-model-value", cfg: Config{Backend: BackendCustom, Command: []string{"tool", "{model}"}}, want: "required when command contains {model}"},
 		{name: "yoetz-effort", cfg: Config{Backend: BackendYoetz, Effort: "low"}, want: "yoetz preset has no effort"},
+		{name: "backend-and-chain", cfg: Config{Backend: BackendClaude, Chain: []string{BackendCodex}}, want: "mutually exclusive"},
+		{name: "empty-chain-hop", cfg: Config{Chain: []string{BackendClaude, " "}}, want: "chain[1]"},
+		{name: "in-session-chain-hop", cfg: Config{Chain: []string{BackendClaude, BackendInSession}}, want: "implicit after chain exhaustion"},
+		{name: "duplicate-chain-hop", cfg: Config{Chain: []string{BackendClaude, BackendClaude}}, want: "duplicate backend"},
+		{name: "chain-command-without-custom", cfg: Config{Chain: []string{BackendClaude}, Command: []string{"claude"}}, want: "chain has no custom hop"},
+		{name: "chain-custom-without-command", cfg: Config{Chain: []string{BackendCustom, BackendClaude}}, want: "required for custom"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,5 +72,64 @@ func TestValidateRejectsInvalidConfig(t *testing.T) {
 				t.Fatalf("Validate error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestResolveUsesWholeBlockPrecedenceAndClones(t *testing.T) {
+	profile := &Config{Backend: BackendClaude, Model: "profile-model"}
+	global := &Config{Chain: []string{BackendYoetz, BackendCodex}, Model: "global-model"}
+	resolved, err := Resolve(profile, global)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Source != SourceProfile || resolved.Config == nil {
+		t.Fatalf("resolution = %+v", resolved)
+	}
+	if resolved.Config.Model != "profile-model" || len(resolved.Config.Chain) != 0 || resolved.Config.Backend != BackendClaude {
+		t.Fatalf("profile and global blocks were merged: %+v", resolved.Config)
+	}
+	resolved.Config.Model = "changed"
+	if profile.Model != "profile-model" {
+		t.Fatalf("Resolve returned profile alias: %+v", profile)
+	}
+
+	resolved, err = Resolve(nil, global)
+	if err != nil {
+		t.Fatalf("Resolve global: %v", err)
+	}
+	if resolved.Source != SourceGlobal || !reflect.DeepEqual(resolved.Config.Chain, global.Chain) {
+		t.Fatalf("global resolution = %+v", resolved)
+	}
+	resolved.Config.Chain[0] = BackendClaude
+	if global.Chain[0] != BackendYoetz {
+		t.Fatalf("Resolve returned global slice alias: %+v", global)
+	}
+
+	resolved, err = Resolve(nil, nil)
+	if err != nil || resolved.Source != SourceInSession || resolved.Config != nil {
+		t.Fatalf("in-session resolution = %+v, %v", resolved, err)
+	}
+}
+
+func TestValidateProfileRejectsExecutablePolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{name: "command", cfg: Config{Backend: BackendClaude, Command: []string{"attacker-command"}}, want: "only in the user-level global config"},
+		{name: "custom-backend", cfg: Config{Backend: BackendCustom}, want: "custom is allowed only"},
+		{name: "custom-chain", cfg: Config{Chain: []string{BackendClaude, BackendCustom}, Command: []string{"attacker-command"}}, want: "only in the user-level global config"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProfile(&tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ValidateProfile error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	if err := ValidateProfile(&Config{Chain: []string{BackendClaude, BackendCodex}, Model: "safe-preset"}); err != nil {
+		t.Fatalf("ValidateProfile preset chain: %v", err)
 	}
 }

--- a/internal/drafter/run.go
+++ b/internal/drafter/run.go
@@ -33,15 +33,17 @@ type Evidence struct {
 	DurationMillis int64     `json:"duration_millis,omitempty"`
 	ExitCode       int       `json:"exit_code"`
 	Stderr         string    `json:"stderr,omitempty"`
+	Failure        string    `json:"failure,omitempty"`
 }
 
 type Result struct {
-	Text         string   `json:"text,omitempty"`
-	UseInSession bool     `json:"use_in_session,omitempty"`
-	Fallback     bool     `json:"fallback,omitempty"`
-	Reason       string   `json:"reason,omitempty"`
-	Remedy       string   `json:"remedy,omitempty"`
-	Evidence     Evidence `json:"evidence"`
+	Text         string     `json:"text,omitempty"`
+	UseInSession bool       `json:"use_in_session,omitempty"`
+	Fallback     bool       `json:"fallback,omitempty"`
+	Reason       string     `json:"reason,omitempty"`
+	Remedy       string     `json:"remedy,omitempty"`
+	Evidence     Evidence   `json:"evidence"`
+	Attempts     []Evidence `json:"attempts,omitempty"`
 }
 
 // RunError is returned only when on_failure=error. Result still carries the
@@ -49,6 +51,7 @@ type Result struct {
 type RunError struct {
 	Cause    error
 	Evidence Evidence
+	Attempts []Evidence
 	Remedy   string
 }
 
@@ -82,15 +85,36 @@ func Run(ctx context.Context, config *Config, request Request) (Result, error) {
 		return Result{}, fmt.Errorf("create drafter temp directory: %w", err)
 	}
 	promptPath := tempDir + string(os.PathSeparator) + "prompt.md"
-	outputPath := tempDir + string(os.PathSeparator) + "draft.md"
-	defer cleanupTempFiles(promptPath, outputPath, tempDir)
+	cleanupPaths := []string{promptPath}
+	defer func() { cleanupTempFiles(append(cleanupPaths, tempDir)...) }()
 	if err := os.WriteFile(promptPath, []byte(request.Prompt), 0o600); err != nil {
 		return Result{}, fmt.Errorf("write drafter prompt: %w", err)
 	}
 
-	argv, promptFile, outputFile, err := buildCommand(*config, promptPath, outputPath)
+	backends := config.EffectiveBackends()
+	attempts := make([]Evidence, 0, len(backends))
+	failures := make([]error, 0, len(backends))
+	for i, backend := range backends {
+		outputPath := tempDir + string(os.PathSeparator) + fmt.Sprintf("draft-%d.md", i)
+		cleanupPaths = append(cleanupPaths, outputPath)
+		attempt := config.forBackend(backend)
+		text, evidence, cause := runAttempt(ctx, attempt, request, promptPath, outputPath)
+		if cause != nil {
+			evidence.Failure = cause.Error()
+			attempts = append(attempts, evidence)
+			failures = append(failures, fmt.Errorf("%s: %w", backend, cause))
+			continue
+		}
+		attempts = append(attempts, evidence)
+		return Result{Text: text, Evidence: evidence, Attempts: attempts}, nil
+	}
+	return failureResult(*config, attempts, failures)
+}
+
+func runAttempt(ctx context.Context, config Config, request Request, promptPath, outputPath string) (string, Evidence, error) {
+	argv, promptFile, outputFile, err := buildCommand(config, promptPath, outputPath)
 	if err != nil {
-		return Result{}, err
+		return "", Evidence{Backend: config.EffectiveBackend(), ExitCode: -1}, err
 	}
 	timeout := config.EffectiveTimeout()
 	started := time.Now()
@@ -120,31 +144,29 @@ func Run(ctx context.Context, config *Config, request Request) (Result, error) {
 	runErr := cmd.Run()
 	evidence.DurationMillis = time.Since(started).Milliseconds()
 	evidence.Stderr = strings.TrimSpace(stderr.String())
-	if runErr == nil {
-		evidence.ExitCode = 0
-	} else {
+	if runErr != nil {
 		var exitErr *exec.ExitError
 		if errors.As(runErr, &exitErr) {
 			evidence.ExitCode = exitErr.ExitCode()
 		}
-		cause := commandFailure(runCtx, runErr, evidence.Stderr)
-		return failureResult(*config, evidence, cause)
+		return "", evidence, commandFailure(runCtx, runErr, evidence.Stderr)
 	}
+	evidence.ExitCode = 0
 
 	var output []byte
 	if outputFile {
 		output, err = readFileLimited(outputPath, outputLimit)
 		if err != nil {
-			return failureResult(*config, evidence, fmt.Errorf("read configured {out} file: %w", err))
+			return "", evidence, fmt.Errorf("read configured {out} file: %w", err)
 		}
 	} else {
 		output = stdout.Bytes()
 	}
 	text := strings.TrimSpace(string(output))
 	if text == "" {
-		return failureResult(*config, evidence, fmt.Errorf("command produced an empty draft"))
+		return "", evidence, fmt.Errorf("command produced an empty draft")
 	}
-	return Result{Text: text, Evidence: evidence}, nil
+	return text, evidence, nil
 }
 
 func readFileLimited(path string, limit int) ([]byte, error) {
@@ -220,8 +242,16 @@ func buildCommand(config Config, promptPath, outputPath string) ([]string, bool,
 	return command, promptFile, outputFile, nil
 }
 
-func failureResult(config Config, evidence Evidence, cause error) (Result, error) {
-	remedy := fmt.Sprintf("check the %s command and provider credentials", config.EffectiveBackend())
+func failureResult(config Config, attempts []Evidence, failures []error) (Result, error) {
+	evidence := Evidence{Backend: BackendInSession, ExitCode: 0}
+	if len(attempts) > 0 {
+		evidence = attempts[len(attempts)-1]
+	}
+	cause := errors.Join(failures...)
+	if cause == nil {
+		cause = fmt.Errorf("configured drafter chain had no external attempts")
+	}
+	remedy := fmt.Sprintf("check the configured %s commands and provider credentials", strings.Join(config.EffectiveBackends(), ", "))
 	if config.EffectiveFailureMode() == FailureInSession {
 		remedy += ", then retry; this run may be completed from the generated prompt in the active session"
 		return Result{
@@ -230,10 +260,11 @@ func failureResult(config Config, evidence Evidence, cause error) (Result, error
 			Reason:       cause.Error(),
 			Remedy:       remedy,
 			Evidence:     evidence,
+			Attempts:     append([]Evidence(nil), attempts...),
 		}, nil
 	}
 	remedy += " or set drafter.on_failure to in_session"
-	return Result{Reason: cause.Error(), Remedy: remedy, Evidence: evidence}, &RunError{Cause: cause, Evidence: evidence, Remedy: remedy}
+	return Result{Reason: cause.Error(), Remedy: remedy, Evidence: evidence, Attempts: append([]Evidence(nil), attempts...)}, &RunError{Cause: cause, Evidence: evidence, Attempts: append([]Evidence(nil), attempts...), Remedy: remedy}
 }
 
 func commandFailure(ctx context.Context, runErr error, stderr string) error {

--- a/internal/drafter/run_test.go
+++ b/internal/drafter/run_test.go
@@ -164,6 +164,106 @@ printf x >> "$1"
 	}
 }
 
+func TestRunOrderedChainFallsThroughWithExactAttemptEvidence(t *testing.T) {
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendYoetz, `#!/bin/sh
+printf 'yoetz unavailable\n' >&2
+exit 17
+`)
+	writeNamedExecutable(t, bin, BackendClaude, `#!/bin/sh
+IFS= read -r line
+printf 'claude:%s\n' "$line"
+`)
+	t.Setenv("PATH", bin)
+	cfg := &Config{Chain: []string{BackendYoetz, BackendClaude}, Model: "fast-model", Effort: "low"}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "draft this"})
+	if err != nil {
+		t.Fatalf("Run chain: %v", err)
+	}
+	if result.Text != "claude:draft this" || result.UseInSession || result.Fallback {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(result.Attempts) != 2 {
+		t.Fatalf("attempts = %+v", result.Attempts)
+	}
+	first, second := result.Attempts[0], result.Attempts[1]
+	if first.Backend != BackendYoetz || first.ExitCode != 17 || !strings.Contains(first.Failure, "yoetz unavailable") {
+		t.Fatalf("first attempt = %+v", first)
+	}
+	if len(first.Command) == 0 || first.Command[0] != BackendYoetz || first.CommandDisplay == "" {
+		t.Fatalf("first exact command evidence = %+v", first)
+	}
+	if first.Effort != "" {
+		t.Fatalf("yoetz attempt inherited unsupported effort: %+v", first)
+	}
+	if second.Backend != BackendClaude || second.ExitCode != 0 || second.Failure != "" || second.Effort != "low" {
+		t.Fatalf("second attempt = %+v", second)
+	}
+	if !reflect.DeepEqual(result.Evidence, second) {
+		t.Fatalf("compatibility evidence = %+v, want final successful attempt %+v", result.Evidence, second)
+	}
+}
+
+func TestRunOrderedChainRecordsMissingBinaryThenSucceeds(t *testing.T) {
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendCodex, `#!/bin/sh
+IFS= read -r line
+printf 'codex:%s\n' "$line"
+`)
+	t.Setenv("PATH", bin)
+	cfg := &Config{Chain: []string{BackendYoetz, BackendCodex}}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "fallback"})
+	if err != nil {
+		t.Fatalf("Run chain: %v", err)
+	}
+	if result.Text != "codex:fallback" || len(result.Attempts) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.Attempts[0].ExitCode != -1 || !strings.Contains(result.Attempts[0].Failure, "executable file not found") {
+		t.Fatalf("missing binary evidence = %+v", result.Attempts[0])
+	}
+}
+
+func TestRunOrderedChainExhaustionFallsBackInSession(t *testing.T) {
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendYoetz, "#!/bin/sh\nexit 11\n")
+	writeNamedExecutable(t, bin, BackendClaude, "#!/bin/sh\nexit 12\n")
+	t.Setenv("PATH", bin)
+	cfg := &Config{Chain: []string{BackendYoetz, BackendClaude}}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "draft"})
+	if err != nil {
+		t.Fatalf("Run exhaustion: %v", err)
+	}
+	if !result.UseInSession || !result.Fallback || len(result.Attempts) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	if result.Attempts[0].ExitCode != 11 || result.Attempts[1].ExitCode != 12 || result.Evidence.ExitCode != 12 {
+		t.Fatalf("attempt evidence = %+v; compatibility=%+v", result.Attempts, result.Evidence)
+	}
+	if result.Attempts[0].Failure == "" || result.Attempts[1].Failure == "" || !strings.Contains(result.Reason, BackendYoetz) || !strings.Contains(result.Reason, BackendClaude) {
+		t.Fatalf("fall-through reasons missing: %+v", result)
+	}
+}
+
+func TestRunOrderedChainFailureModeErrorFailsAfterExhaustion(t *testing.T) {
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendClaude, "#!/bin/sh\nexit 21\n")
+	writeNamedExecutable(t, bin, BackendCodex, "#!/bin/sh\nexit 22\n")
+	t.Setenv("PATH", bin)
+	cfg := &Config{Chain: []string{BackendClaude, BackendCodex}, OnFailure: FailureError}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "draft"})
+	var runErr *RunError
+	if !errors.As(err, &runErr) {
+		t.Fatalf("Run error = %v, want RunError", err)
+	}
+	if result.UseInSession || len(result.Attempts) != 2 || len(runErr.Attempts) != 2 {
+		t.Fatalf("result=%+v runErr=%+v", result, runErr)
+	}
+	if result.Attempts[0].ExitCode != 21 || result.Attempts[1].ExitCode != 22 {
+		t.Fatalf("attempts = %+v", result.Attempts)
+	}
+}
+
 func TestBuildCommandPresets(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -208,6 +308,15 @@ func writeExecutable(t *testing.T, body string) string {
 	path := filepath.Join(t.TempDir(), "drafter-helper")
 	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
 		t.Fatalf("write helper: %v", err)
+	}
+	return path
+}
+
+func writeNamedExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write helper %s: %v", name, err)
 	}
 	return path
 }

--- a/internal/drafter/run_test.go
+++ b/internal/drafter/run_test.go
@@ -157,10 +157,44 @@ printf x >> "$1"
 			if result.Evidence.ExitCode != 0 {
 				t.Fatalf("exit code = %d, want successful command evidence", result.Evidence.ExitCode)
 			}
+			if len(result.Attempts) != 1 || result.Attempts[0].Failure == "" {
+				t.Fatalf("attempt evidence = %+v, want one recorded output-limit failure", result.Attempts)
+			}
 			if !strings.Contains(result.Reason, "read configured {out} file: output exceeds 4194304-byte limit") {
 				t.Fatalf("reason = %q, want explicit output limit failure", result.Reason)
 			}
 		})
+	}
+}
+
+func TestRunOrderedChainFallsThroughAfterOversizedOutputFile(t *testing.T) {
+	oversized := writeExecutable(t, `#!/bin/sh
+dd if=/dev/zero of="$1" bs=1048576 count=4 2>/dev/null
+printf x >> "$1"
+`)
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendClaude, `#!/bin/sh
+IFS= read -r line
+printf 'claude:%s\n' "$line"
+`)
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cfg := &Config{
+		Chain:   []string{BackendCustom, BackendClaude},
+		Command: []string{oversized, "{out}"},
+	}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "bounded fallback"})
+	if err != nil {
+		t.Fatalf("Run chain: %v", err)
+	}
+	if result.Text != "claude:bounded fallback" || len(result.Attempts) != 2 {
+		t.Fatalf("result = %+v", result)
+	}
+	first, second := result.Attempts[0], result.Attempts[1]
+	if first.Backend != BackendCustom || first.ExitCode != 0 || !strings.Contains(first.Failure, "output exceeds 4194304-byte limit") {
+		t.Fatalf("oversized attempt = %+v", first)
+	}
+	if second.Backend != BackendClaude || second.ExitCode != 0 || second.Failure != "" {
+		t.Fatalf("fallback attempt = %+v", second)
 	}
 }
 

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -1118,7 +1118,7 @@ func Validate(t Team) error {
 	if t.Drafter != nil && t.Schema > 0 && t.Schema < SchemaVersion {
 		return fmt.Errorf("drafter: requires team schema %d", SchemaVersion)
 	}
-	if err := drafter.Validate(t.Drafter); err != nil {
+	if err := drafter.ValidateProfile(t.Drafter); err != nil {
 		return fmt.Errorf("drafter: %w", err)
 	}
 	operatorHandle := ""

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -178,8 +178,13 @@ func TestDrafterConfigRequiresSchemaSixAndValidPolicy(t *testing.T) {
 	}
 
 	invalid := Team{Drafter: &drafter.Config{Backend: drafter.BackendCustom}}
-	if err := Write(t.TempDir(), invalid); err == nil || !strings.Contains(err.Error(), "required for custom") {
+	if err := Write(t.TempDir(), invalid); err == nil || !strings.Contains(err.Error(), "custom is allowed only") {
 		t.Fatalf("Write invalid drafter error = %v", err)
+	}
+
+	untrustedCommand := Team{Drafter: &drafter.Config{Backend: drafter.BackendClaude, Command: []string{"attacker-command"}}}
+	if err := Write(t.TempDir(), untrustedCommand); err == nil || !strings.Contains(err.Error(), "only in the user-level global config") {
+		t.Fatalf("Write untrusted drafter command error = %v", err)
 	}
 }
 

--- a/internal/userconfig/config.go
+++ b/internal/userconfig/config.go
@@ -1,0 +1,74 @@
+// Package userconfig owns the machine-scoped amq-squad configuration file.
+package userconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/drafter"
+)
+
+const ConfigEnv = "AMQ_SQUAD_CONFIG"
+
+// Config is the user-level machine configuration. Keep unrelated settings in
+// this shared top-level shape so setup can update drafter policy without
+// discarding model defaults used by existing installations.
+type Config struct {
+	Model       string            `json:"model,omitempty"`
+	CodexModel  string            `json:"codex_model,omitempty"`
+	ClaudeModel string            `json:"claude_model,omitempty"`
+	Models      map[string]string `json:"models,omitempty"`
+	Drafter     *drafter.Config   `json:"drafter,omitempty"`
+}
+
+// Path returns the canonical ~/.config/amq-squad/config.json path.
+// AMQ_SQUAD_CONFIG is an explicit whole-file override for non-interactive/CI
+// provisioning and tests; it never triggers path or backend auto-discovery.
+func Path() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(ConfigEnv)); override != "" {
+		return filepath.Clean(override), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for amq-squad user config: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve home directory for amq-squad user config: empty path")
+	}
+	return filepath.Join(home, ".config", "amq-squad", "config.json"), nil
+}
+
+// Read loads the canonical user config. A missing file is the empty config;
+// malformed or invalid policy fails closed instead of silently selecting a
+// different backend.
+func Read() (Config, error) {
+	path, err := Path()
+	if err != nil {
+		return Config{}, err
+	}
+	cfg, err := ReadFile(path)
+	if os.IsNotExist(err) {
+		return Config{}, nil
+	}
+	return cfg, err
+}
+
+// ReadFile strictly decodes one explicit user-config path. It is exported for
+// setup, deterministic tests, and callers that already resolved the path.
+func ReadFile(path string) (Config, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	var cfg Config
+	if err := json.Unmarshal(body, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse user config %s: %w", path, err)
+	}
+	if err := drafter.ValidateGlobal(cfg.Drafter); err != nil {
+		return Config{}, fmt.Errorf("validate user config %s: drafter: %w", path, err)
+	}
+	return cfg, nil
+}

--- a/internal/userconfig/config.go
+++ b/internal/userconfig/config.go
@@ -2,8 +2,10 @@
 package userconfig
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +66,16 @@ func ReadFile(path string) (Config, error) {
 		return Config{}, err
 	}
 	var cfg Config
-	if err := json.Unmarshal(body, &cfg); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("parse user config %s: %w", path, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Config{}, fmt.Errorf("parse user config %s: multiple JSON values", path)
+		}
 		return Config{}, fmt.Errorf("parse user config %s: %w", path, err)
 	}
 	if err := drafter.ValidateGlobal(cfg.Drafter); err != nil {

--- a/internal/userconfig/config_test.go
+++ b/internal/userconfig/config_test.go
@@ -1,0 +1,94 @@
+package userconfig
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/drafter"
+)
+
+func TestPathUsesCanonicalHomeAndExplicitOverride(t *testing.T) {
+	t.Setenv(ConfigEnv, "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	want := filepath.Join(home, ".config", "amq-squad", "config.json")
+	if path != want {
+		t.Fatalf("Path = %q, want %q", path, want)
+	}
+
+	override := filepath.Join(t.TempDir(), "ci-config.json")
+	t.Setenv(ConfigEnv, override)
+	path, err = Path()
+	if err != nil || path != override {
+		t.Fatalf("override Path = %q, %v, want %q", path, err, override)
+	}
+}
+
+func TestReadMissingConfigIsEmpty(t *testing.T) {
+	t.Setenv(ConfigEnv, filepath.Join(t.TempDir(), "missing.json"))
+	cfg, err := Read()
+	if err != nil {
+		t.Fatalf("Read missing: %v", err)
+	}
+	if !reflect.DeepEqual(cfg, Config{}) {
+		t.Fatalf("Read missing = %+v, want empty", cfg)
+	}
+}
+
+func TestReadPreservesExistingSettingsAndAcceptsTrustedCustomCommand(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	body := `{
+  "models": {"codex": "gpt-default"},
+  "drafter": {
+    "chain": ["custom", "claude"],
+    "command": ["local-drafter", "--out", "{out}"],
+    "timeout_seconds": 30
+  }
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if cfg.Models["codex"] != "gpt-default" || cfg.Drafter == nil {
+		t.Fatalf("config = %+v", cfg)
+	}
+	if !reflect.DeepEqual(cfg.Drafter.Chain, []string{drafter.BackendCustom, drafter.BackendClaude}) {
+		t.Fatalf("chain = %v", cfg.Drafter.Chain)
+	}
+	if !reflect.DeepEqual(cfg.Drafter.Command, []string{"local-drafter", "--out", "{out}"}) {
+		t.Fatalf("command = %v", cfg.Drafter.Command)
+	}
+}
+
+func TestReadFailsClosedOnMalformedOrInvalidDrafter(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "malformed", body: `{`, want: "parse user config"},
+		{name: "invalid-chain", body: `{"drafter":{"chain":["claude","in_session"]}}`, want: "implicit after chain exhaustion"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := ReadFile(path)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ReadFile error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/userconfig/config_test.go
+++ b/internal/userconfig/config_test.go
@@ -77,6 +77,9 @@ func TestReadFailsClosedOnMalformedOrInvalidDrafter(t *testing.T) {
 		want string
 	}{
 		{name: "malformed", body: `{`, want: "parse user config"},
+		{name: "unknown-top-level", body: `{"draftre":{"chain":["claude"]}}`, want: `unknown field "draftre"`},
+		{name: "unknown-nested-drafter", body: `{"drafter":{"chian":["claude"]}}`, want: `unknown field "chian"`},
+		{name: "multiple-json-values", body: `{} {}`, want: "multiple JSON values"},
 		{name: "invalid-chain", body: `{"drafter":{"chain":["claude","in_session"]}}`, want: "implicit after chain exhaustion"},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #696.

Global user-level drafter config with an ordered backend fallback chain.

## Changes
- `internal/userconfig`: canonical `~/.config/amq-squad/config.json` (`AMQ_SQUAD_CONFIG` whole-file override for CI/tests). Strict decoding — unknown top-level and nested fields rejected (`DisallowUnknownFields`), trailing JSON values rejected, invalid drafter policy fails closed.
- `drafter.Resolve`: whole-block precedence `profile > global > in_session` (no field merge), with source attribution and defensive cloning.
- Ordered fallback chain (`"chain": ["yoetz","claude","codex"]`): strict configured order, fall-through on missing binary or failed/oversized/empty attempt, `in_session` only after exhaustion. Explicit config only — no PATH auto-discovery. `backend`/`chain` mutually exclusive; `in_session` hops and duplicates rejected.
- Trust rule: custom argv templates and the `custom` backend are honored only from the user-level global config; profile/project files may select presets and knobs but never inject argv.
- Evidence: `Result.Attempts` records every hop's backend, exact argv/display, and fall-through failure; legacy `Result.Evidence` remains the final attempt. Fail-closed (`on_failure=error`) errors render every ordered attempt at the CLI boundary.
- `role draft` resolves the global layer and prints ordered attempt evidence.
- The 4 MiB bounded `{out}` read (#698) is preserved inside every chain attempt; a dedicated test proves an oversized hop falls through to the next.

## Evidence
- head: 7ddbc3606ae15f2e406da9466f8be2de45907b98 (base 92568db)
- make ci PASS; real-AMQ compatibility + wake matrices (pinned v0.60.0 + latest v0.60.1) all PASS; git diff --check clean
- Reviews: two independent exact-head reviews at this head (lead APPROVE, wizard-dev-v2294 APPROVE) after one REQUEST_CHANGES round (both blockers fixed with regression tests) — recorded on AMQ thread task/t2-gh696

Implemented by config-dev-v2294 (amq-squad session squad-v2-29-3/v2-29-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
