### PR TITLE
Release v2.29.4 — drafter config maturation: global config, chain fallback, setup command, drafter-backed generation

### DIFF
--- a/README.html
+++ b/README.html
@@ -354,11 +354,14 @@ implicit <code>in_session</code> default — and an ordered fallback chain
 in configured order, records exact command evidence for every attempt
 and fall-through, and lands on the in-session prompt only after
 exhaustion. Trust stays explicit: custom argv templates are honored only
-from the user-level global config, never from project or profile files,
-and unknown or typoed config keys fail closed instead of silently
-changing backend selection. The new <code>amq-squad setup</code> command
-(#697) owns that global layer interactively — probing PATH for backends
-with versions, prompting for chain and knobs, and writing the config
+from the user-level global config, never from project or profile files —
+a breaking change for v2.29.3 profiles that carried a
+<code>custom</code> drafter block, which now fails closed; move that
+block to the global config (or run <code>amq-squad setup</code>).
+Unknown or typoed config keys fail closed instead of silently changing
+backend selection. The new <code>amq-squad setup</code> command (#697)
+owns that global layer interactively — probing PATH for backends with
+versions, prompting for chain and knobs, and writing the config
 atomically at mode 0600 — with <code>--drafter-*</code> flags for
 non-interactive CI provisioning. The binary's own generation surfaces
 now route through the configured drafter (#700): <code>--goal</code>

--- a/README.html
+++ b/README.html
@@ -356,12 +356,12 @@ and fall-through, and lands on the in-session prompt only after
 exhaustion. Trust stays explicit: custom argv templates are honored only
 from the user-level global config, never from project or profile files —
 a breaking change for v2.29.3 profiles that carried a
-<code>custom</code> drafter block, which now fails closed; move that
-block to the global config (or run <code>amq-squad setup</code>).
-Unknown or typoed config keys fail closed instead of silently changing
-backend selection. The new <code>amq-squad setup</code> command (#697)
-owns that global layer interactively — probing PATH for backends with
-versions, prompting for chain and knobs, and writing the config
+<code>custom</code> drafter block, which now fails closed; remove that
+block from the team profile and move it unchanged into the global
+config. Unknown or typoed config keys fail closed instead of silently
+changing backend selection. The new <code>amq-squad setup</code> command
+(#697) owns that global layer interactively — probing PATH for backends
+with versions, prompting for chain and knobs, and writing the config
 atomically at mode 0600 — with <code>--drafter-*</code> flags for
 non-interactive CI provisioning. The binary's own generation surfaces
 now route through the configured drafter (#700): <code>--goal</code>

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2293" id="toc-whats-new-in-v2293">What's new
-in v2.29.3</a></li>
+<li><a href="#whats-new-in-v2294" id="toc-whats-new-in-v2294">What's new
+in v2.29.4</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2293">What's new in v2.29.3</a></li>
+<li><a href="#whats-new-in-v2294">What's new in v2.29.4</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,30 +342,36 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2293">What's new in v2.29.3</h2>
-<p>v2.29.3 ships the drafter theme plus two run-friction fixes from the
-v2.29.2 live run. Team profiles gain an optional schema-6
-<code>drafter</code> block (#679) selecting a headless LLM backend for
-cli/wizard prose generation — presets for <code>yoetz</code>,
-<code>claude -p</code>, and <code>codex exec</code>, plus argv-only
-<code>custom</code> templates with validated
-<code>{prompt}</code>/<code>{out}</code>/<code>{model}</code>/<code>{effort}</code>
-tokens, bounded captured stdout/stderr, context timeouts, and an
-explicit keyless-environment fallback that returns the filled prompt
-with exact command evidence instead of failing. On top of it, the new
-<code>amq-squad role draft</code> command (#665) generates a reusable
-custom role.md, deterministically validates shape and
-session/version/task/branch neutrality, and stages it atomically without
-ever adding or launching a member (see <a
-href="docs/drafter-backends.md">drafter backends</a>).
-<code>send --role</code> now resolves worktree-cwd members through the
-canonical team-home launch record, matching dispatch and status (#686,
-the #681/#682 resolver family). CI now runs the VERSION-bound
-<code>make release-check</code> on release pull requests — detected via
-<code>release/*</code> head refs or a plugin-manifest version change
-against the PR base — so invalid release metadata can no longer ride a
-green pipeline (#687, found live on release PR #685). Full detail in <a
-href="docs/v2.29.3-release-notes.md">the v2.29.3 release notes</a>.</p>
+<h2 id="whats-new-in-v2294">What's new in v2.29.4</h2>
+<p>v2.29.4 matures the drafter configuration story shipped in v2.29.3.
+The drafter block graduates from profile-only to a layered model (#696):
+a user-level global config at
+<code>~/.config/amq-squad/config.json</code> (override with
+<code>AMQ_SQUAD_CONFIG</code>) carries machine-scoped defaults, resolved
+with whole-block precedence — profile block over global config over the
+implicit <code>in_session</code> default — and an ordered fallback chain
+(<code>"chain": ["yoetz", "claude", "codex"]</code>) tries each backend
+in configured order, records exact command evidence for every attempt
+and fall-through, and lands on the in-session prompt only after
+exhaustion. Trust stays explicit: custom argv templates are honored only
+from the user-level global config, never from project or profile files,
+and unknown or typoed config keys fail closed instead of silently
+changing backend selection. The new <code>amq-squad setup</code> command
+(#697) owns that global layer interactively — probing PATH for backends
+with versions, prompting for chain and knobs, and writing the config
+atomically at mode 0600 — with <code>--drafter-*</code> flags for
+non-interactive CI provisioning. The binary's own generation surfaces
+now route through the configured drafter (#700): <code>--goal</code>
+brief drafting with exact six-section validation staged for operator
+review before write, per-seat personas reusing the
+<code>role draft</code> path end to end, and team-rules charter prose
+wrapped in deterministic structure validation — with config source plus
+the complete ordered attempt chain reported on every success, fallback,
+and failure path. A safety fix (#698) bounds configured
+<code>{out}</code> file reads to the same 4 MiB budget as captured
+stdout/stderr, failing oversized drafts through the normal failure
+policy. Full detail in <a href="docs/v2.29.4-release-notes.md">the
+v2.29.4 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
 Releases</a> and <a href="docs/">docs/</a> (per-release notes
@@ -376,7 +382,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.3</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.4</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.3](#whats-new-in-v2293)
+- [What's new in v2.29.4](#whats-new-in-v2294)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,27 +38,33 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.3
+## What's new in v2.29.4
 
-v2.29.3 ships the drafter theme plus two run-friction fixes from the v2.29.2
-live run. Team profiles gain an optional schema-6 `drafter` block (#679)
-selecting a headless LLM backend for cli/wizard prose generation — presets
-for `yoetz`, `claude -p`, and `codex exec`, plus argv-only `custom`
-templates with validated `{prompt}`/`{out}`/`{model}`/`{effort}` tokens,
-bounded captured stdout/stderr, context timeouts, and an explicit
-keyless-environment fallback that returns the filled prompt with exact
-command evidence instead of failing. On top of it, the new `amq-squad role draft` command (#665)
-generates a reusable custom role.md, deterministically validates shape and
-session/version/task/branch neutrality, and stages it atomically without
-ever adding or launching a member (see
-[drafter backends](docs/drafter-backends.md)). `send --role` now resolves
-worktree-cwd members through the canonical team-home launch record, matching
-dispatch and status (#686, the #681/#682 resolver family). CI now runs the
-VERSION-bound `make release-check` on release pull requests — detected via
-`release/*` head refs or a plugin-manifest version change against the PR
-base — so invalid release metadata can no longer ride a green pipeline
-(#687, found live on release PR #685). Full detail in
-[the v2.29.3 release notes](docs/v2.29.3-release-notes.md).
+v2.29.4 matures the drafter configuration story shipped in v2.29.3. The
+drafter block graduates from profile-only to a layered model (#696): a
+user-level global config at `~/.config/amq-squad/config.json` (override with
+`AMQ_SQUAD_CONFIG`) carries machine-scoped defaults, resolved with
+whole-block precedence — profile block over global config over the implicit
+`in_session` default — and an ordered fallback chain
+(`"chain": ["yoetz", "claude", "codex"]`) tries each backend in configured
+order, records exact command evidence for every attempt and fall-through,
+and lands on the in-session prompt only after exhaustion. Trust stays
+explicit: custom argv templates are honored only from the user-level global
+config, never from project or profile files, and unknown or typoed config
+keys fail closed instead of silently changing backend selection. The new
+`amq-squad setup` command (#697) owns that global layer interactively —
+probing PATH for backends with versions, prompting for chain and knobs, and
+writing the config atomically at mode 0600 — with `--drafter-*` flags for
+non-interactive CI provisioning. The binary's own generation surfaces now
+route through the configured drafter (#700): `--goal` brief drafting with
+exact six-section validation staged for operator review before write,
+per-seat personas reusing the `role draft` path end to end, and team-rules
+charter prose wrapped in deterministic structure validation — with config
+source plus the complete ordered attempt chain reported on every success,
+fallback, and failure path. A safety fix (#698) bounds configured `{out}`
+file reads to the same 4 MiB budget as captured stdout/stderr, failing
+oversized drafts through the normal failure policy. Full detail in
+[the v2.29.4 release notes](docs/v2.29.4-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -76,7 +82,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.3
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.4
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ whole-block precedence — profile block over global config over the implicit
 order, records exact command evidence for every attempt and fall-through,
 and lands on the in-session prompt only after exhaustion. Trust stays
 explicit: custom argv templates are honored only from the user-level global
-config, never from project or profile files, and unknown or typoed config
-keys fail closed instead of silently changing backend selection. The new
+config, never from project or profile files — a breaking change for
+v2.29.3 profiles that carried a `custom` drafter block, which now fails
+closed; move that block to the global config (or run `amq-squad setup`).
+Unknown or typoed config keys fail closed instead of silently changing
+backend selection. The new
 `amq-squad setup` command (#697) owns that global layer interactively —
 probing PATH for backends with versions, prompting for chain and knobs, and
 writing the config atomically at mode 0600 — with `--drafter-*` flags for

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ and lands on the in-session prompt only after exhaustion. Trust stays
 explicit: custom argv templates are honored only from the user-level global
 config, never from project or profile files — a breaking change for
 v2.29.3 profiles that carried a `custom` drafter block, which now fails
-closed; move that block to the global config (or run `amq-squad setup`).
-Unknown or typoed config keys fail closed instead of silently changing
-backend selection. The new
+closed; remove that block from the team profile and move it unchanged into
+the global config. Unknown or typoed config keys fail closed instead of
+silently changing backend selection. The new
 `amq-squad setup` command (#697) owns that global layer interactively —
 probing PATH for backends with versions, prompting for chain and knobs, and
 writing the config atomically at mode 0600 — with `--drafter-*` flags for

--- a/docs/v2.29.4-release-notes.md
+++ b/docs/v2.29.4-release-notes.md
@@ -54,8 +54,9 @@ not project truth. v2.29.4 adds a user-level global config so committed
   `--drafter-effort`, `--drafter-timeout`, `--drafter-on-failure`.
 - Setup owns the global layer only; team profiles keep per-team overrides.
   Writes validate through the same global policy validation before an
-  atomic same-directory temp-and-rename persist at file mode 0600
-  (directory 0700), preserving unrelated machine settings and trusted
+  atomic same-directory temp-and-rename persist at file mode 0600 (a newly
+  created config directory is 0700; an existing directory's mode is left
+  unchanged), preserving unrelated machine settings and trusted
   custom argv on knob-only updates. Configured presets missing from PATH
   warn without changing explicit policy.
 - The command is the extension point for future machine-level settings.
@@ -77,7 +78,9 @@ without a live agent session gets drafted prose, not stubs:
   the `role draft` path end to end — no parallel implementation — and emits
   actionable `role draft` commands for proposed seats. (There is no
   `wizard` CLI command; "wizard" in issue #700 refers to these goal-first
-  surfaces and the `wizard` plugin skill.)
+  surfaces and the `wizard` plugin skill. The old interactive wizard launch
+  path was removed in the v2.28 simple-mode cutover, PR #650, and is not
+  restored here — #700 routes its successor surfaces through the drafter.)
 - **Team-rules prose**: custom charter and role-scope fragments are drafter
   generated inside the deterministic safety/lifecycle/operator wrapper with
   exact structure validation.
@@ -104,8 +107,17 @@ every chain attempt.
   release time).
 - Team profile schema stays 6. Profiles without a `drafter` block now fall
   through to the user-level global config before the `in_session` default.
-- No breaking CLI changes. `amq-squad setup` is a new command; existing
-  profile drafter blocks keep their exact v2.29.3 behavior.
+- **Breaking config change (trust rule)**: profile drafter blocks using the
+  `custom` backend or a `command` argv template — valid in v2.29.3 — now
+  fail closed. Preset-only profile blocks (`yoetz`/`claude`/`codex` plus
+  knobs) keep their exact v2.29.3 behavior. Migration: move the whole
+  custom drafter block from the team profile to the user-level global
+  config (`~/.config/amq-squad/config.json`, or run `amq-squad setup`),
+  where custom argv remains fully supported. This is deliberate: a cloned
+  repository must not be able to execute attacker-chosen commands via
+  `role draft`.
+- No breaking changes to command syntax. `amq-squad setup` is a new
+  command; all existing verbs and flags keep their v2.29.3 signatures.
 
 ## Dogfood note
 

--- a/docs/v2.29.4-release-notes.md
+++ b/docs/v2.29.4-release-notes.md
@@ -110,10 +110,13 @@ every chain attempt.
 - **Breaking config change (trust rule)**: profile drafter blocks using the
   `custom` backend or a `command` argv template — valid in v2.29.3 — now
   fail closed. Preset-only profile blocks (`yoetz`/`claude`/`codex` plus
-  knobs) keep their exact v2.29.3 behavior. Migration: move the whole
-  custom drafter block from the team profile to the user-level global
-  config (`~/.config/amq-squad/config.json`, or run `amq-squad setup`),
-  where custom argv remains fully supported. This is deliberate: a cloned
+  knobs) keep their exact v2.29.3 behavior. Migration: remove the custom
+  drafter block from the team profile and move it unchanged into the
+  user-level global config (`~/.config/amq-squad/config.json`), where
+  custom argv remains fully supported — `amq-squad setup` cannot do this
+  for you (it writes preset chains only and never edits team profiles),
+  though after removing the profile block you may run `setup` to configure
+  a supported preset chain instead. This is deliberate: a cloned
   repository must not be able to execute attacker-chosen commands via
   `role draft`.
 - No breaking changes to command syntax. `amq-squad setup` is a new

--- a/docs/v2.29.4-release-notes.md
+++ b/docs/v2.29.4-release-notes.md
@@ -1,0 +1,117 @@
+# amq-squad v2.29.4
+
+Drafter configuration maturation: a user-level global config layer with an
+ordered backend fallback chain, an interactive `amq-squad setup` command,
+the binary's own generation surfaces routed through the configured drafter,
+and a bounded-read safety fix. Milestone issues: #696, #697, #698, #700.
+PRs: #702, #703, #704, #705.
+
+## Global user-level drafter config with ordered fallback chain (#696)
+
+The drafter block is machine-scoped preference (which CLIs are installed),
+not project truth. v2.29.4 adds a user-level global config so committed
+`teams/<profile>.json` files no longer need to carry personal settings:
+
+- **Canonical path**: `~/.config/amq-squad/config.json`. The
+  `AMQ_SQUAD_CONFIG` environment variable pins an alternate file for
+  provisioning and tests; it never triggers path or backend auto-discovery.
+- **Whole-block precedence**: a non-nil profile `drafter` block wins over
+  the global block, which wins over the implicit `in_session` default.
+  Blocks never field-merge, so a project file can never combine with a user
+  command template. Every resolution reports its winning source.
+- **Ordered fallback chain**: `"chain": ["yoetz", "claude", "codex"]` tries
+  each backend strictly in configured order — a missing binary, failed,
+  timed-out, oversized, or empty attempt falls through to the next hop —
+  landing on the in-session prompt only after exhaustion. The chain is
+  explicit configuration, never silent auto-discovery. `backend` and
+  `chain` are mutually exclusive; `in_session` hops and duplicate backends
+  are rejected.
+- **Per-attempt evidence**: `Result.Attempts` records every hop's backend,
+  exact argv/display, and fall-through failure reason; the legacy
+  `Result.Evidence` remains the final attempt. Fail-closed errors and
+  generated-output validation failures render the resolved config source
+  plus the complete ordered attempt chain at the CLI boundary.
+- **Trust rule**: custom argv templates and the `custom` backend are
+  honored only from the user-level global config. Profile and project files
+  may select preset backends and knobs but can never inject argv, so a
+  cloned repository cannot execute attacker-chosen commands via
+  `role draft`.
+- **Fail-closed decoding**: unknown top-level or nested config keys (for
+  example a typoed `chian`) and trailing JSON values are rejected instead
+  of silently selecting a different backend.
+- Credentials remain entirely each backend CLI's own concern.
+
+## `amq-squad setup`: interactive machine-level configuration (#697)
+
+`doctor` diagnoses but nothing configured — until now:
+
+- Interactive mode probes PATH for `yoetz`, `claude`, and `codex` with
+  versions (bounded 2s probes), then prompts for the drafter chain, model,
+  effort, timeout, and failure policy, defaulting to the current config or
+  detected backends.
+- Any `--drafter-*` flag selects non-interactive mode for scripted setup
+  and CI images: `--drafter-chain yoetz,claude,codex`, `--drafter-model`,
+  `--drafter-effort`, `--drafter-timeout`, `--drafter-on-failure`.
+- Setup owns the global layer only; team profiles keep per-team overrides.
+  Writes validate through the same global policy validation before an
+  atomic same-directory temp-and-rename persist at file mode 0600
+  (directory 0700), preserving unrelated machine settings and trusted
+  custom argv on knob-only updates. Configured presets missing from PATH
+  warn without changing explicit policy.
+- The command is the extension point for future machine-level settings.
+
+## Binary generation surfaces route through the drafter (#700)
+
+The plugin skill already drafts in-session; v2.29.4 converges the binary's
+own headless generation surfaces on the same drafter path, so an operator
+without a live agent session gets drafted prose, not stubs:
+
+- **Brief drafting**: `goal draft` and `new`/`start --goal` draft a missing
+  workstream brief through the configured drafter, validate the exact
+  six-section structure (Goal / Source / Scope / Out of scope / Team shape /
+  Acceptance, injection-hardened prompt, 128 KiB cap, no code fences),
+  preview it with a default-No confirmation, lock the reviewed bytes across
+  the pre-launch recheck (refusing if the on-disk brief changed), and stage
+  atomically without overwriting existing briefs.
+- **Personas**: the goal-first setup flow (`new`, `start --goal`) reuses
+  the `role draft` path end to end — no parallel implementation — and emits
+  actionable `role draft` commands for proposed seats. (There is no
+  `wizard` CLI command; "wizard" in issue #700 refers to these goal-first
+  surfaces and the `wizard` plugin skill.)
+- **Team-rules prose**: custom charter and role-scope fragments are drafter
+  generated inside the deterministic safety/lifecycle/operator wrapper with
+  exact structure validation.
+- **Contract unchanged**: the LLM writes prose only; deterministic code
+  owns structure validation, staging, and lifecycle. With no backend
+  configured, the filled prompt is printed and the command stops before any
+  brief, session, role, or rules mutation. Config source and the complete
+  ordered attempt chain are reported on every surface — success, manual
+  fallback, fail-closed error, and validation failure.
+
+## Bounded `{out}` file reads (#698)
+
+`internal/drafter` capped captured stdout/stderr at 4 MiB but read
+configured `{out}` files unbounded — and the default yoetz preset uses
+`{out}`. The read is now bounded to the same 4 MiB budget with an explicit
+over-limit failure through the normal failure policy (fallback or
+fail-closed), restoring the stronger guarantee across every output path and
+every chain attempt.
+
+## Compatibility
+
+- AMQ supported series stays 0.60.x with the fail-closed minimum at 0.60.0;
+  CI validates pinned `v0.60.0` plus the `latest` canary (v0.60.1 at
+  release time).
+- Team profile schema stays 6. Profiles without a `drafter` block now fall
+  through to the user-level global config before the `in_session` default.
+- No breaking CLI changes. `amq-squad setup` is a new command; existing
+  profile drafter blocks keep their exact v2.29.3 behavior.
+
+## Dogfood note
+
+This release was built by an amq-squad lead-orchestrated team whose three
+implementation-seat personas were all generated through the v2.29.3
+`role draft` drafter path (one structural-validation retry, zero hand-drafted
+prose), and whose review process caught and fixed two evidence-contract
+gaps before merge — the same evidence discipline #696 and #700 now enforce
+in code.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.3",
+  "version": "2.29.4",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.3",
+  "version": "2.29.4",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.3"  # x-release-please-version
+version: "2.29.4"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release PR for milestone v2.29.4. Closes no issues (all four milestone issues #696 #697 #698 #700 already closed via PRs #702-#705).

## Contents
- Plugin manifests (claude + codex) 2.29.3 → 2.29.4; skill mirrors restamped via make skills-generate
- README: single What's-new section REPLACING v2.29.3 (per RELEASING.md step 0), install tag → v2.29.4, README.html regenerated
- docs/v2.29.4-release-notes.md (first heading exactly '# amq-squad v2.29.4')
- AMQ floor unchanged: 0.60.x series, minimum 0.60.0

## Evidence
- Clean-worktree make ci: PASS at ca43f8a
- make release-check VERSION=v2.29.4: PASS at ca43f8a ('release metadata matches v2.29.4')
- Release-check CI (#687) will also run on this PR via the release/* head ref

Authored by lead (release-PR mechanics per team precedent); two independent worker reviews to follow on AMQ thread task/release-v2-29-4. Lead does NOT merge this PR — operator merges lead-authored PRs per team rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)