### PR TITLE
docs(wizard): stepped Flow A/B on the v2.29.4 command set (#707)

### DIFF
--- a/docs/skills.html
+++ b/docs/skills.html
@@ -506,33 +506,45 @@ mutation.</li>
 may draft that same six-section brief in-session, show it for approval,
 save it at the canonical profile/session path, and let
 <code>start</code> reuse it. That preserves the live-agent path without
-duplicating the prose through another LLM call.</p>
+duplicating the prose through another LLM call. The named path is
+<code>P/.amq-squad/briefs/R/S.md</code>; the default path is
+<code>P/.amq-squad/briefs/S.md</code>. Show the entire saved file with
+<code>cat PATH</code>, then require the start plan's <code>brief:</code>
+line to match it.</p>
 <h3 id="flow-b-start-a-session-from-an-existing-profile">Flow B: start a
 session from an existing profile</h3>
 <ol type="1">
-<li>Pick a reusable unpinned profile and fresh session; run
+<li><p>Pick a reusable unpinned profile and fresh session; run
 <code>amq-squad doctor --project P --profile R --session S</code>, then
 <code>amq-squad status --project P --profile R --session S --json</code>.
 Doctor checks project/profile health and uses the session only for
 additive plan diagnostics; status and the start plan expose namespace
-conflicts.</li>
-<li>Either leave <code>P/.amq-squad/briefs/R/S.md</code> absent for
+conflicts. Extract the canonical path mechanically with
+<code>amq-squad status --project P --profile R --session S --json | jq '.data.namespace.paths.brief'</code>;
+<code>data.goal_binding.brief_path</code> should agree.</p></li>
+<li><p>Either leave <code>P/.amq-squad/briefs/R/S.md</code> absent for
 configured <code>start --goal</code> drafting, or safely reuse a named
-profile's <code>OLD</code> session with
-<code>test ! -e P/.amq-squad/briefs/R/S.md</code>,
-<code>mkdir -p P/.amq-squad/briefs/R</code>, and
-<code>cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md</code>.
-The default-profile path omits <code>/R</code>. Edit and display the
-saved six-section result; require the start plan's <code>brief:</code>
-line to match. A live in-session draft is written to that same path only
-after review. A raw ticket, wrong default/named path, or stale copied
-brief is not accepted scope.</li>
-<li>Run
+profile's <code>OLD</code> session with one fail-closed chain:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="bu">test</span> <span class="at">-f</span> P/.amq-squad/briefs/R/OLD.md <span class="kw">&amp;&amp;</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>  <span class="fu">mkdir</span> <span class="at">-p</span> P/.amq-squad/briefs/R <span class="kw">&amp;&amp;</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="bu">test</span> ! <span class="at">-e</span> P/.amq-squad/briefs/R/S.md <span class="kw">&amp;&amp;</span></span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">(</span><span class="bu">set</span> <span class="at">-C</span> <span class="kw">&amp;&amp;</span> <span class="fu">cat</span> P/.amq-squad/briefs/R/OLD.md <span class="op">&gt;</span> P/.amq-squad/briefs/R/S.md<span class="kw">)</span> <span class="kw">&amp;&amp;</span></span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">cmp</span> <span class="at">-s</span> P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md <span class="kw">&amp;&amp;</span></span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">cat</span> P/.amq-squad/briefs/R/S.md</span></code></pre></div>
+<p><code>set -C</code> makes publication itself refuse an existing
+target even if one appears after the precheck; any nonzero command stops
+the chain. The default profile uses the same chain with both
+<code>/R</code> components omitted. Edit and show the entire saved
+six-section result with <code>cat PATH</code>; require the start plan's
+<code>brief:</code> line to match. A live in-session draft is written to
+that same path only after review. A raw ticket, wrong default/named
+path, or stale copied brief is not accepted scope.</p></li>
+<li><p>Run
 <code>amq-squad start --project P --profile R --session S --goal "..."</code>
 interactively. With no brief, use Flow A's same-invocation draft
 approval. With a reviewed brief, inspect the reused path and launch
 plan. Use <code>--yes</code> for automation only when that reviewed
-brief already exists and inputs are unchanged.</li>
+brief already exists and inputs are unchanged.</p></li>
 </ol>
 <p>After either flow, trust <code>started</code> only after every pane
 owns its verified live child. If start prints an attach command for a
@@ -848,9 +860,9 @@ plain prose because the caller shell expands it before execution. Bare
 <code>amq send</code> instead uses <code>--body -</code> or
 <code>--body @file</code>; raw AMQ does not accept
 <code>--body-file</code>.</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto                       <span class="co"># bring a pane into view</span></span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body-file</span> ./prompt.md <span class="co"># deliver a prompt + submit</span></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="fu">cat</span> prompt.md <span class="kw">|</span> <span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body-file</span> <span class="at">-</span></span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto                       <span class="co"># bring a pane into view</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body-file</span> ./prompt.md <span class="co"># deliver a prompt + submit</span></span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="fu">cat</span> prompt.md <span class="kw">|</span> <span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body-file</span> <span class="at">-</span></span></code></pre></div>
 <p><code>send</code> stages text in a tmux paste buffer (multi-line and
 shell metacharacters arrive verbatim) and has a <strong>built-in
 busy-guard</strong>: it refuses to deliver into a mid-turn pane unless
@@ -862,9 +874,9 @@ post an inter-agent message, use
 <code>amq send ... --kind &lt;kind&gt;</code> (see below).</p>
 </blockquote>
 <h3 id="routing-messages-over-amq">Routing messages over AMQ</h3>
-<div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> review_request <span class="dt">\</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Review: rate limiter&quot;</span> <span class="at">--body</span> @review.md</span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--include-body</span>            <span class="co"># read your inbox</span></span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> review_request <span class="dt">\</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Review: rate limiter&quot;</span> <span class="at">--body</span> @review.md</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--include-body</span>            <span class="co"># read your inbox</span></span></code></pre></div>
 <p>Valid kinds (enforced):
 <code>brainstorm, review_request, review_response, question, answer, decision, status, todo</code>.
 <strong>There is no <code>handoff</code> kind</strong> — send a handoff
@@ -1030,10 +1042,10 @@ request must carry measured idle age, evidence that active task linkage
 was checked, and proof that no active task remains linked.</p>
 <p>Pause, resume, inspect, or permanently disable the policy without
 editing the profile directly:</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
-<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
 <p>Autonomous composition grants no authority to merge, push, tag,
 release, perform destructive filesystem operations, send externally,
 invoke provider side effects, or delegate child self-spawn. Those
@@ -1041,27 +1053,27 @@ actions retain their normal lead/operator gates and verification
 preflights.</p>
 <h3 id="the-loop-start--dispatch--status--drain--recover">The loop:
 start → dispatch → status → drain → recover</h3>
-<div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. START — preview and reconcile one window per agent</span></span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--target</span> new-window</span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
-<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
-<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
-<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
-<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
-<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
-<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
-<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
-<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
-<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
-<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. INSPECT — use one bounded status snapshot when needed</span></span>
-<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
-<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead performs one rooted drain</span></span>
-<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. START — preview and reconcile one window per agent</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--target</span> new-window</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. INSPECT — use one bounded status snapshot when needed</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead performs one rooted drain</span></span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span></code></pre></div>
 <p>Do not hand-roll an unbounded polling loop in the visible lead pane.
 Read one <code>status --json</code> snapshot, act on a bounded item,
 drain the exact-root mailbox once when the notifier wakes pending work,
@@ -1095,7 +1107,7 @@ in each child's brief:</p>
 </tbody>
 </table>
 <p>The lead consumes child reports with one exact-root command:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> <span class="op">&lt;</span>lead<span class="op">&gt;</span> --include-body</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> <span class="op">&lt;</span>lead<span class="op">&gt;</span> --include-body</span></code></pre></div>
 <p><code>drain</code> moves unread messages to <code>cur</code>, so
 persist or act on the displayed result before draining again. The pinned
 root and actor are mandatory in agent instructions; repository-cwd
@@ -1121,8 +1133,8 @@ directive does not clear <code>gate/&lt;topic&gt;</code> threads.
 Orchestrated teams carry the convention as a generated line in their
 <code>## Orchestration</code> norm.</p>
 <h3 id="recover">Recover</h3>
-<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># PLAN ONLY; add --exec to reopen panes</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># PLAN ONLY; add --exec to reopen panes</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
 <hr />
 <h2 id="role-authoring-with-amq-squadwizard">Role Authoring With
 <code>amq-squad:wizard</code></h2>
@@ -1136,7 +1148,7 @@ bootstrap prompt, and status/launch exactly like built-ins.</p>
 <p>Three ways, by how much role guidance you want:</p>
 <p><strong>A. Inline (quick, minimal <code>role.md</code>)</strong> —
 just an id + CLI:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
 <p>A custom role must be a valid slug and <strong>must</strong> carry an
 explicit <code>--binary &lt;role&gt;=&lt;cli&gt;</code> (there is no
 catalog default to fall back to).</p>
@@ -1145,9 +1157,10 @@ catalog default to fall back to).</p>
 the reusable prose to the shared configured drafter. If the active brief
 exists it is attached as untrusted context; otherwise the persona defers
 live scope to the future brief and durable task:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> role draft researcher <span class="at">--binary</span> codex <span class="dt">\</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--purpose</span> <span class="st">&quot;Investigate ambiguous product behavior&quot;</span> <span class="dt">\</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> P <span class="at">--profile</span> R <span class="at">--session</span> S</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> role draft researcher <span class="at">--binary</span> codex <span class="dt">\</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--purpose</span> <span class="st">&quot;Investigate ambiguous product behavior&quot;</span> <span class="dt">\</span></span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> P <span class="at">--profile</span> R <span class="at">--session</span> S</span></code></pre></div>
 <p>The binary owns the template, validates exact frontmatter and the
 Mission/Boundaries/Protocol shape, enforces fewer than 45 lines, rejects
 active session/task/version/branch names, and stages without
@@ -1162,19 +1175,19 @@ Claude, Codex, and custom argv settings.</p>
 <p><strong>C. From a role file (rich, authored
 <code>role.md</code>)</strong> — Markdown with optional YAML
 frontmatter, <code>.yaml</code>, or <code>.json</code>:</p>
-<div class="sourceCode" id="cb10"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
 <div class="sourceCode" id="cb11"><pre
-class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
-<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
-<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
-<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
-<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
-<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
-<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
 <p>The id comes from the file (<code>id:</code>, a <code># Role:</code>
 heading, or the filename); the binary from the file's
 <code>binary:</code> field (<code>--binary</code> overrides). The
@@ -1186,9 +1199,9 @@ Preview with <code>--dry-run --json</code> before writing.</p>
 <h2 id="end-to-end-walkthrough">End-to-end walkthrough</h2>
 <p>Shipping GitHub issue #96 with an orchestrated squad, start to
 finish.</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
-<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
 <ol type="1">
 <li><p><strong>Set up and start</strong> — invoke
 <code>/amq-squad:wizard</code> and say <em>"the goal is GitHub issue
@@ -1197,18 +1210,18 @@ named roster, creates it after approval, refreshes team rules, and runs
 goal-first start. The configured drafter turns the fetched issue context
 into the exact six-section brief, prints source/attempt evidence, and
 shows the brief and launch plan at one default-No approval:</p>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> setup</span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--dry-run</span> <span class="at">--json</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
-<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team rules init <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--template</span> auto <span class="at">--force</span></span>
-<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> setup</span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--dry-run</span> <span class="at">--json</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb14-8"><a href="#cb14-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
+<span id="cb14-9"><a href="#cb14-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb14-10"><a href="#cb14-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team rules init <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--template</span> auto <span class="at">--force</span></span>
+<span id="cb14-11"><a href="#cb14-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span></code></pre></div>
 <p>Answer Yes in that final invocation only after reviewing the
 generated brief and plan. Do not cancel it and later use
 <code>--yes</code> against a newly generated draft.</p></li>
@@ -1216,19 +1229,19 @@ generated brief and plan. Do not cancel it and later use
 <code>team-rules.md</code> now carries the orchestration norm, so it
 loads <code>/amq-squad:orchestrator</code>) dispatches to
 <code>fullstack</code>, monitors, and drains pushed reports:</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> @task.md</span>
-<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span>
-<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> @review-task.md</span></code></pre></div></li>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> @task.md</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> @review-task.md</span></code></pre></div></li>
 <li><p><strong>Converge and stop</strong> — the lead verifies the
 artifacts, owns the merge and lifecycle-action path after the human
 gates align, reports up to the human, then:</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb16"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span></code></pre></div></li>
 </ol>
 <h2 id="troubleshooting">Troubleshooting</h2>
 <table>

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -516,10 +516,17 @@ session from an existing profile</h3>
 Doctor checks project/profile health and uses the session only for
 additive plan diagnostics; status and the start plan expose namespace
 conflicts.</li>
-<li>Either leave the new brief absent for configured
-<code>start --goal</code> drafting, or copy/reuse a brief and review its
-new title, source, scope, Team shape, and acceptance. A raw ticket or
-stale copied brief is not accepted scope.</li>
+<li>Either leave <code>P/.amq-squad/briefs/R/S.md</code> absent for
+configured <code>start --goal</code> drafting, or safely reuse a named
+profile's <code>OLD</code> session with
+<code>test ! -e P/.amq-squad/briefs/R/S.md</code>,
+<code>mkdir -p P/.amq-squad/briefs/R</code>, and
+<code>cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md</code>.
+The default-profile path omits <code>/R</code>. Edit and display the
+saved six-section result; require the start plan's <code>brief:</code>
+line to match. A live in-session draft is written to that same path only
+after review. A raw ticket, wrong default/named path, or stale copied
+brief is not accepted scope.</li>
 <li>Run
 <code>amq-squad start --project P --profile R --session S --goal "..."</code>
 interactively. With no brief, use Flow A's same-invocation draft

--- a/docs/skills.html
+++ b/docs/skills.html
@@ -462,108 +462,77 @@ omits them).</p>
 <code>$wizard</code> (Codex). <strong>Use when:</strong> no team exists
 yet, or you are starting a new piece of work and want a real goal/brief
 in place before launch.</p>
-<p>It is a <strong>wizard</strong>: it walks five steps and confirms
-with you at each gate. Setup stays read-only until the final create step
-(no live launch).</p>
-<h3 id="the-five-steps">The five steps</h3>
+<p>It is a <strong>wizard with two explicit flows</strong>. Each step
+names the exact command, the operator decision, and the evidence that
+must be preserved.</p>
+<h3 id="flow-a-create-and-start-a-new-team-profile">Flow A: create and
+start a new team profile</h3>
 <ol type="1">
-<li><p><strong>Capture the goal (any source).</strong> Tell the skill
-where the goal lives and it fetches it with whatever tool the agent has,
-detecting the source type:</p>
-<table>
-<thead>
-<tr>
-<th>You give it</th>
-<th>It fetches with</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>a one-line prompt / inline text</td>
-<td>the text itself</td>
-</tr>
-<tr>
-<td>a local file / path (<code>./design.md</code>)</td>
-<td>reads the file</td>
-</tr>
-<tr>
-<td>a GitHub issue (<code>#96</code>, a URL,
-<code>owner/repo#96</code>)</td>
-<td><code>gh issue view</code></td>
-</tr>
-<tr>
-<td>a GitHub PR</td>
-<td><code>gh pr view</code></td>
-</tr>
-<tr>
-<td>a Jira key (<code>PROJ-123</code>)</td>
-<td>the Atlassian MCP / a <code>jira</code> CLI</td>
-</tr>
-<tr>
-<td>a URL (Confluence / doc)</td>
-<td>the Atlassian MCP / a fetch tool</td>
-</tr>
-</tbody>
-</table>
-<p>Tracker integrations live <strong>in the skill</strong>, never in the
-amq-squad binary — the core stays tracker-neutral. If no integration is
-available, the skill asks you to paste rather than inventing
-content.</p></li>
-<li><p><strong>Draft and confirm the brief.</strong> The skill
-normalizes whatever it fetched into one canonical shape and
-<strong>shows it to you to edit before saving</strong> (a raw ticket
-description is not a brief):</p>
-<div class="sourceCode" id="cb1"><pre
-class="sourceCode md"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="fu"># &lt;session&gt; brief</span></span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="fu">## Goal          # the outcome, 1-2 sentences</span></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="fu">## Source        # JIRA PROJ-123 / gh#96 / URL / file: / &quot;operator prompt&quot;</span></span>
-<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="fu">## Scope</span></span>
-<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="fu">## Out of scope</span></span>
-<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="fu">## Acceptance     # how we know it&#39;s done; who signs off</span></span></code></pre></div></li>
-<li><p><strong>Roles, profile, and tool policy.</strong> Pick the roster
-(built-in personas or custom roles), the binary behind each
-(<code>codex</code>/<code>claude</code>), the team-home, and whether to
-use the default profile or a named one. The recommended tool policy
-keeps the visible lead broad and assigns every worker its built-in
-catalog minimum (for example <code>coding</code>, <code>browser</code>,
-<code>data</code>, or <code>minimal</code>). <code>full_all</code> is an
-explicit opt-in, never the default. With two or more <code>full</code>
-members, review warns that each broad agent duplicates MCP/plugin
-context and increases memory and concurrency pressure; keep the
-recommended split unless the work actually requires broad access for
-every member.</p></li>
-<li><p><strong>Orchestrated? Who leads?</strong> Default is
-<strong>no</strong> (a flat, peer-to-peer squad). Say yes and name
-exactly one lead role to run an orchestrated squad.</p></li>
-<li><p><strong>Review and create.</strong> The skill prints a summary,
-then on your confirmation creates <code>team.json</code> +
-<code>team-rules.md</code>, saves the brief, writes the pointer stubs,
-validates, and prints the next commands. For a squad with two or more
-Claude members it also asks whether the <strong>workers</strong> should
-run with a trimmed plugin/hook surface and, if so, generates + wires the
-context overlays in one command
-(<code>amq-squad team overlay init --workers ...</code>, v1.9.0+) — the
-lead keeps the full configuration.</p></li>
+<li><strong>Machine readiness.</strong> If machine-level drafter
+defaults are missing or must change, run <code>amq-squad setup</code>;
+then run <code>amq-squad doctor --project P</code>. <code>setup</code>
+probes yoetz/Claude/Codex and writes only the global user config. A
+complete profile <code>drafter</code> block overrides the complete
+global block; fields never merge. Missing/invalid configured backends or
+blocking doctor findings stop the flow.</li>
+<li><strong>Profile.</strong> Preview
+<code>amq-squad new profile R --project P --session S --roles ... --binary ... --model ... --effort ... --dry-run --json</code>,
+review actor modes and worktree isolation, then repeat without
+<code>--dry-run</code> and add <code>--sync</code>. Use
+<code>new team</code> for the default profile and
+<code>--no-session-pin</code> for a roster intended for future
+sessions.</li>
+<li><strong>Custom personas.</strong> For each rich custom seat, run
+<code>amq-squad role draft &lt;id&gt; --binary ... --purpose ... --project P --profile R --session S</code>,
+review the validated staged file, then run the printed
+<code>team member add</code> command. Record the config source and every
+ordered attempt/fall-through. Manual fallback stages nothing; the draft
+command never adds or launches.</li>
+<li><strong>Team rules.</strong> After the roster is final, run
+<code>amq-squad team rules init --project P --profile R --template auto --force</code>.
+Custom charter/scope prose is drafter-backed and validated before
+deterministic safety, lifecycle, and operator sections wrap it.
+In-session fallback writes nothing.</li>
+<li><strong>Brief and launch.</strong> Run
+<code>amq-squad start --project P --profile R --session S --goal "..."</code>
+without <code>--yes</code>. With no brief, the configured drafter
+reports its source and ordered attempts, then the binary validates and
+prints exactly Goal, Source, Scope, Out of scope, Team shape, and
+Acceptance. Review and answer Yes in that same invocation so the written
+bytes are the bytes shown. No, invalid output, or fallback stops before
+mutation.</li>
 </ol>
-<h3 id="what-it-runs">What it runs</h3>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co"># flat team</span></span>
-<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--binary</span> cto=codex <span class="at">--sync</span></span>
-<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a><span class="co"># orchestrated team (step 4 said yes, cto leads)</span></span>
-<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
-<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb2-7"><a href="#cb2-7" aria-hidden="true" tabindex="-1"></a><span class="co"># preview anything first</span></span>
-<span id="cb2-8"><a href="#cb2-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--dry-run</span> <span class="at">--json</span> <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto</span></code></pre></div>
-<p><code>--orchestrated [--lead ROLE]</code> records the lead in
-<code>team.json</code> and writes a generated
-<code>## Orchestration</code> reporting norm into
-<code>team-rules.md</code> when that file is first seeded — a structured
-flag, not pasted prose, so it can't drift. (An existing
-<code>team-rules.md</code> is left untouched; regenerate with
-<code>amq-squad team rules init --force</code>.) Default off; exactly
-one lead; the lead is a team member, never the operator.</p>
-<p>After setup, the wizard previews one complete <code>start</code> plan
-with a default-No launch approval.</p>
+<p>When the wizard itself is already running in a live LLM session, it
+may draft that same six-section brief in-session, show it for approval,
+save it at the canonical profile/session path, and let
+<code>start</code> reuse it. That preserves the live-agent path without
+duplicating the prose through another LLM call.</p>
+<h3 id="flow-b-start-a-session-from-an-existing-profile">Flow B: start a
+session from an existing profile</h3>
+<ol type="1">
+<li>Pick a reusable unpinned profile and fresh session; run
+<code>amq-squad doctor --project P --profile R --session S</code>, then
+<code>amq-squad status --project P --profile R --session S --json</code>.
+Doctor checks project/profile health and uses the session only for
+additive plan diagnostics; status and the start plan expose namespace
+conflicts.</li>
+<li>Either leave the new brief absent for configured
+<code>start --goal</code> drafting, or copy/reuse a brief and review its
+new title, source, scope, Team shape, and acceptance. A raw ticket or
+stale copied brief is not accepted scope.</li>
+<li>Run
+<code>amq-squad start --project P --profile R --session S --goal "..."</code>
+interactively. With no brief, use Flow A's same-invocation draft
+approval. With a reviewed brief, inspect the reused path and launch
+plan. Use <code>--yes</code> for automation only when that reviewed
+brief already exists and inputs are unchanged.</li>
+</ol>
+<p>After either flow, trust <code>started</code> only after every pane
+owns its verified live child. If start prints an attach command for a
+detached tmux session, run it, then require
+<code>amq-squad status --project P --profile R --session S --json</code>
+to show live records and no visible-lead invariant before routing that
+lead to <code>amq-squad:orchestrator</code>.</p>
 <hr />
 <h2
 id="amq-squadcli--direct-live-team-operations"><code>amq-squad:cli</code>
@@ -872,9 +841,9 @@ plain prose because the caller shell expands it before execution. Bare
 <code>amq send</code> instead uses <code>--body -</code> or
 <code>--body @file</code>; raw AMQ does not accept
 <code>--body-file</code>.</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto                       <span class="co"># bring a pane into view</span></span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body-file</span> ./prompt.md <span class="co"># deliver a prompt + submit</span></span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="fu">cat</span> prompt.md <span class="kw">|</span> <span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body-file</span> <span class="at">-</span></span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> cto                       <span class="co"># bring a pane into view</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> send  <span class="at">--session</span> issue-96 <span class="at">--role</span> cto <span class="at">--body-file</span> ./prompt.md <span class="co"># deliver a prompt + submit</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="fu">cat</span> prompt.md <span class="kw">|</span> <span class="ex">amq-squad</span> send <span class="at">--session</span> issue-96 <span class="at">--role</span> qa <span class="at">--body-file</span> <span class="at">-</span></span></code></pre></div>
 <p><code>send</code> stages text in a tmux paste buffer (multi-line and
 shell metacharacters arrive verbatim) and has a <strong>built-in
 busy-guard</strong>: it refuses to deliver into a mid-turn pane unless
@@ -886,9 +855,9 @@ post an inter-agent message, use
 <code>amq send ... --kind &lt;kind&gt;</code> (see below).</p>
 </blockquote>
 <h3 id="routing-messages-over-amq">Routing messages over AMQ</h3>
-<div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> review_request <span class="dt">\</span></span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Review: rate limiter&quot;</span> <span class="at">--body</span> @review.md</span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--include-body</span>            <span class="co"># read your inbox</span></span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> review_request <span class="dt">\</span></span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Review: rate limiter&quot;</span> <span class="at">--body</span> @review.md</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--include-body</span>            <span class="co"># read your inbox</span></span></code></pre></div>
 <p>Valid kinds (enforced):
 <code>brainstorm, review_request, review_response, question, answer, decision, status, todo</code>.
 <strong>There is no <code>handoff</code> kind</strong> — send a handoff
@@ -1054,10 +1023,10 @@ request must carry measured idle age, evidence that active task linkage
 was checked, and proof that no active task remains linked.</p>
 <p>Pause, resume, inspect, or permanently disable the policy without
 editing the profile directly:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
-<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
-<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
-<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous show <span class="at">--json</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous pause</span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous resume</span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team autonomous disable</span></code></pre></div>
 <p>Autonomous composition grants no authority to merge, push, tag,
 release, perform destructive filesystem operations, send externally,
 invoke provider side effects, or delegate child self-spawn. Those
@@ -1065,27 +1034,27 @@ actions retain their normal lead/operator gates and verification
 preflights.</p>
 <h3 id="the-loop-start--dispatch--status--drain--recover">The loop:
 start → dispatch → status → drain → recover</h3>
-<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. START — preview and reconcile one window per agent</span></span>
-<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--target</span> new-window</span>
-<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
-<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
-<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
-<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
-<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
-<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
-<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
-<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
-<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
-<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
-<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. INSPECT — use one bounded status snapshot when needed</span></span>
-<span id="cb7-18"><a href="#cb7-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
-<span id="cb7-19"><a href="#cb7-19" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb7-20"><a href="#cb7-20" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead performs one rooted drain</span></span>
-<span id="cb7-21"><a href="#cb7-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 1. START — preview and reconcile one window per agent</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--target</span> new-window</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co"># 2. CONFIRM the children are live before dispatching</span></span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96 <span class="at">--json</span> <span class="dt">\</span></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">|</span> <span class="ex">jq</span> <span class="st">&#39;.data.records[] | {role, status, pane_alive: .tmux.pane_alive}&#39;</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="co"># 3. DISPATCH — over durable AMQ (queues, survives pane death; the busy-guarded</span></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a><span class="co">#    `amq-squad send` pane injection is the fallback/nudge only)</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="dt">\</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: rate-limiter&quot;</span> <span class="at">--body</span> <span class="at">-</span> <span class="at">--wait-for</span> drained <span class="at">--wait-timeout</span> 60s <span class="op">&lt;&lt;&#39;EOF&#39;</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="st">Implement the rate-limiter per the brief. When the diff is ready, push a</span></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="st">review_request to me (cto) over AMQ. Report any blocker as a question.</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a><span class="op">EOF</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="co"># 4. INSPECT — use one bounded status snapshot when needed</span></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> focus <span class="at">--session</span> issue-96 <span class="at">--role</span> fullstack   <span class="co"># watch live when needed</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a><span class="co"># 5. COORDINATE — children PUSH reports; the lead performs one rooted drain</span></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span></code></pre></div>
 <p>Do not hand-roll an unbounded polling loop in the visible lead pane.
 Read one <code>status --json</code> snapshot, act on a bounded item,
 drain the exact-root mailbox once when the notifier wakes pending work,
@@ -1119,7 +1088,7 @@ in each child's brief:</p>
 </tbody>
 </table>
 <p>The lead consumes child reports with one exact-root command:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> <span class="op">&lt;</span>lead<span class="op">&gt;</span> --include-body</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> <span class="op">&lt;</span>lead<span class="op">&gt;</span> --include-body</span></code></pre></div>
 <p><code>drain</code> moves unread messages to <code>cur</code>, so
 persist or act on the displayed result before draining again. The pinned
 root and actor are mandatory in agent instructions; repository-cwd
@@ -1145,8 +1114,8 @@ directive does not clear <code>gate/&lt;topic&gt;</code> threads.
 Orchestrated teams carry the convention as a generated line in their
 <code>## Orchestration</code> norm.</p>
 <h3 id="recover">Recover</h3>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># PLAN ONLY; add --exec to reopen panes</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96      <span class="co"># PLAN ONLY; add --exec to reopen panes</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> agent resume fullstack         <span class="co"># revive one child from its saved record</span></span></code></pre></div>
 <hr />
 <h2 id="role-authoring-with-amq-squadwizard">Role Authoring With
 <code>amq-squad:wizard</code></h2>
@@ -1160,18 +1129,18 @@ bootstrap prompt, and status/launch exactly like built-ins.</p>
 <p>Three ways, by how much role guidance you want:</p>
 <p><strong>A. Inline (quick, minimal <code>role.md</code>)</strong> —
 just an id + CLI:</p>
-<div class="sourceCode" id="cb10"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> researcher <span class="at">--binary</span> researcher=codex</span></code></pre></div>
 <p>A custom role must be a valid slug and <strong>must</strong> carry an
 explicit <code>--binary &lt;role&gt;=&lt;cli&gt;</code> (there is no
 catalog default to fall back to).</p>
 <p><strong>B. Built-in fast draft (rich, reviewed
-<code>role.md</code>)</strong> — after the profile and active brief
-exist, delegate only the prose to the profile's configured drafter:</p>
-<div class="sourceCode" id="cb11"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> role draft researcher <span class="at">--binary</span> codex <span class="dt">\</span></span>
-<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--purpose</span> <span class="st">&quot;Investigate ambiguous product behavior&quot;</span> <span class="dt">\</span></span>
-<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> P <span class="at">--profile</span> R <span class="at">--session</span> S</span></code></pre></div>
+<code>role.md</code>)</strong> — after the profile exists, delegate only
+the reusable prose to the shared configured drafter. If the active brief
+exists it is attached as untrusted context; otherwise the persona defers
+live scope to the future brief and durable task:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> role draft researcher <span class="at">--binary</span> codex <span class="dt">\</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--purpose</span> <span class="st">&quot;Investigate ambiguous product behavior&quot;</span> <span class="dt">\</span></span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--project</span> P <span class="at">--profile</span> R <span class="at">--session</span> S</span></code></pre></div>
 <p>The binary owns the template, validates exact frontmatter and the
 Mission/Boundaries/Protocol shape, enforces fewer than 45 lines, rejects
 active session/task/version/branch names, and stages without
@@ -1186,19 +1155,19 @@ Claude, Codex, and custom argv settings.</p>
 <p><strong>C. From a role file (rich, authored
 <code>role.md</code>)</strong> — Markdown with optional YAML
 frontmatter, <code>.yaml</code>, or <code>.json</code>:</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
-<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
-<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
-<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
-<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
-<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
-<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
-<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
-<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--role-file</span> ./roles/researcher.md <span class="at">--roles</span> cto</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre
+class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a><span class="an">id:</span><span class="co"> researcher</span></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="an">label:</span><span class="co"> Research Engineer</span></span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="an">binary:</span><span class="co"> codex</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a><span class="an">peers:</span><span class="co"> [cto, qa]</span></span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a><span class="an">skills:</span><span class="co"> [/deep-research]</span></span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a><span class="co">---</span></span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a><span class="fu"># Role: Research Engineer</span></span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="fu">## Description</span></span>
+<span id="cb11-10"><a href="#cb11-10" aria-hidden="true" tabindex="-1"></a>Owns deep technical investigation, prototypes, and written findings.</span></code></pre></div>
 <p>The id comes from the file (<code>id:</code>, a <code># Role:</code>
 heading, or the filename); the binary from the file's
 <code>binary:</code> field (<code>--binary</code> overrides). The
@@ -1210,41 +1179,49 @@ Preview with <code>--dry-run --json</code> before writing.</p>
 <h2 id="end-to-end-walkthrough">End-to-end walkthrough</h2>
 <p>Shipping GitHub issue #96 with an orchestrated squad, start to
 finish.</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="co"># 0. (once) install the marketplace, then in your project:</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span></code></pre></div>
 <ol type="1">
 <li><p><strong>Set up and start</strong> — invoke
 <code>/amq-squad:wizard</code> and say <em>"the goal is GitHub issue
-#96."</em> The wizard runs <code>gh issue view 96</code>, drafts a
-canonical brief, shows it for your edit, asks for roles
-(<code>cto</code>, <code>fullstack</code>, <code>qa</code>), asks
-<em>"orchestrated? who leads?"</em> (yes, <code>cto</code>), and writes
-the reviewed team inputs. <code>start</code> then renders one complete
-plan and asks for a default-No launch approval:</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Automation may use --yes only after the displayed plan is approved.</span></span>
-<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="at">--yes</span></span></code></pre></div></li>
+#96."</em> The wizard selects Flow A, checks setup/doctor, previews the
+named roster, creates it after approval, refreshes team rules, and runs
+goal-first start. The configured drafter turns the fetched issue context
+into the exact six-section brief, prints source/attempt evidence, and
+shows the brief and launch plan at one default-No approval:</p>
+<div class="sourceCode" id="cb13"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> setup</span>
+<span id="cb13-2"><a href="#cb13-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb13-3"><a href="#cb13-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb13-4"><a href="#cb13-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
+<span id="cb13-5"><a href="#cb13-5" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--dry-run</span> <span class="at">--json</span></span>
+<span id="cb13-6"><a href="#cb13-6" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new profile delivery <span class="at">--project</span> . <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb13-7"><a href="#cb13-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--roles</span> cto,fullstack,qa <span class="dt">\</span></span>
+<span id="cb13-8"><a href="#cb13-8" aria-hidden="true" tabindex="-1"></a>  <span class="at">--actor-mode</span> cto=review,fullstack=implementation,qa=review <span class="dt">\</span></span>
+<span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a>  <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team rules init <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--template</span> auto <span class="at">--force</span></span>
+<span id="cb13-11"><a href="#cb13-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--profile</span> delivery <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span></code></pre></div>
+<p>Answer Yes in that final invocation only after reviewing the
+generated brief and plan. Do not cancel it and later use
+<code>--yes</code> against a newly generated draft.</p></li>
 <li><p><strong>Lead the work</strong> — the <code>cto</code> agent (its
 <code>team-rules.md</code> now carries the orchestration norm, so it
 loads <code>/amq-squad:orchestrator</code>) dispatches to
 <code>fullstack</code>, monitors, and drains pushed reports:</p>
-<div class="sourceCode" id="cb16"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> @task.md</span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> @review-task.md</span></code></pre></div></li>
+<div class="sourceCode" id="cb14"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> fullstack <span class="at">--thread</span> p2p/cto__fullstack <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: #96&quot;</span> <span class="at">--body</span> @task.md</span>
+<span id="cb14-4"><a href="#cb14-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> drain <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="at">--include-body</span></span>
+<span id="cb14-5"><a href="#cb14-5" aria-hidden="true" tabindex="-1"></a><span class="ex">amq</span> send <span class="at">--root</span> /absolute/path/to/session-root <span class="at">--me</span> cto <span class="dt">\</span></span>
+<span id="cb14-6"><a href="#cb14-6" aria-hidden="true" tabindex="-1"></a>  <span class="at">--to</span> qa <span class="at">--thread</span> p2p/cto__qa <span class="at">--kind</span> todo <span class="at">--wait-for</span> drained <span class="dt">\</span></span>
+<span id="cb14-7"><a href="#cb14-7" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Task: review #96&quot;</span> <span class="at">--body</span> @review-task.md</span></code></pre></div></li>
 <li><p><strong>Converge and stop</strong> — the lead verifies the
 artifacts, owns the merge and lifecycle-action path after the human
 gates align, reports up to the human, then:</p>
-<div class="sourceCode" id="cb17"><pre
-class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span></code></pre></div></li>
+<div class="sourceCode" id="cb15"><pre
+class="sourceCode sh"><code class="sourceCode bash"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span></code></pre></div></li>
 </ol>
 <h2 id="troubleshooting">Troubleshooting</h2>
 <table>
@@ -1257,8 +1234,8 @@ class="sourceCode sh"><code class="sourceCode bash"><span id="cb17-1"><a href="#
 <tbody>
 <tr>
 <td>"no team configured"</td>
-<td>No <code>team.json</code> yet — use the <code>amq-squad</code> Setup
-section (or <code>amq-squad new team</code>) first.</td>
+<td>No selected profile exists yet — use <code>amq-squad:wizard</code>
+Flow A (or <code>amq-squad new team</code>) first.</td>
 </tr>
 <tr>
 <td><code>start</code> reports a conflict</td>
@@ -1329,7 +1306,7 @@ them:</p>
 <tr>
 <td><code>amq-squad:wizard</code></td>
 <td><code>plugins/skills-src/wizard/SKILL.md</code></td>
-<td><code>references/{stages,readiness,roles,worktrees}.md</code>,
+<td><code>references/{stages,readiness,briefs-template,roles,worktrees}.md</code>,
 <code>LEARNINGS.md</code></td>
 </tr>
 <tr>

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -124,9 +124,15 @@ live-agent path without duplicating the prose through another LLM call.
    --profile R --session S --json`. Doctor checks project/profile health and
    uses the session only for additive plan diagnostics; status and the start
    plan expose namespace conflicts.
-2. Either leave the new brief absent for configured `start --goal` drafting, or
-   copy/reuse a brief and review its new title, source, scope, Team shape, and
-   acceptance. A raw ticket or stale copied brief is not accepted scope.
+2. Either leave `P/.amq-squad/briefs/R/S.md` absent for configured `start
+   --goal` drafting, or safely reuse a named profile's `OLD` session with `test
+   ! -e P/.amq-squad/briefs/R/S.md`, `mkdir -p
+   P/.amq-squad/briefs/R`, and `cp P/.amq-squad/briefs/R/OLD.md
+   P/.amq-squad/briefs/R/S.md`. The default-profile path omits `/R`. Edit and
+   display the saved six-section result; require the start plan's `brief:` line
+   to match. A live in-session draft is written to that same path only after
+   review. A raw ticket, wrong default/named path, or stale copied brief is not
+   accepted scope.
 3. Run `amq-squad start --project P --profile R --session S --goal "..."`
    interactively.
    With no brief, use Flow A's same-invocation draft approval. With a reviewed

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -80,83 +80,64 @@ metadata differs (a Claude skill carries `trigger` / `allowed-tools` /
 **Invoke:** `/amq-squad:wizard` (Claude) · `$wizard` (Codex). **Use when:** no team exists yet, or you are starting a
 new piece of work and want a real goal/brief in place before launch.
 
-It is a **wizard**: it walks five steps and confirms with you at each gate.
-Setup stays read-only until the final create step (no live launch).
+It is a **wizard with two explicit flows**. Each step names the exact command,
+the operator decision, and the evidence that must be preserved.
 
-### The five steps
+### Flow A: create and start a new team profile
 
-1. **Capture the goal (any source).** Tell the skill where the goal lives and it
-   fetches it with whatever tool the agent has, detecting the source type:
+1. **Machine readiness.** If machine-level drafter defaults are missing or must
+   change, run `amq-squad setup`; then run `amq-squad doctor --project P`.
+   `setup` probes yoetz/Claude/Codex and writes only the global user config.
+   A complete profile `drafter` block overrides the complete global block;
+   fields never merge. Missing/invalid configured backends or blocking doctor
+   findings stop the flow.
+2. **Profile.** Preview `amq-squad new profile R --project P --session S
+   --roles ... --binary ... --model ... --effort ... --dry-run --json`, review
+   actor modes and worktree isolation, then repeat without `--dry-run` and add
+   `--sync`. Use `new team` for the default profile and `--no-session-pin` for
+   a roster intended for future sessions.
+3. **Custom personas.** For each rich custom seat, run `amq-squad role draft
+   <id> --binary ... --purpose ... --project P --profile R --session S`, review
+   the validated staged file, then run the printed `team member add` command.
+   Record the config source and every ordered attempt/fall-through. Manual
+   fallback stages nothing; the draft command never adds or launches.
+4. **Team rules.** After the roster is final, run `amq-squad team rules init
+   --project P --profile R --template auto --force`. Custom charter/scope prose
+   is drafter-backed and validated before deterministic safety, lifecycle, and
+   operator sections wrap it. In-session fallback writes nothing.
+5. **Brief and launch.** Run `amq-squad start --project P --profile R --session
+   S --goal "..."` without `--yes`. With no brief, the configured drafter reports its
+   source and ordered attempts, then the binary validates and prints exactly
+   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. Review and
+   answer Yes in that same invocation so the written bytes are the bytes shown.
+   No, invalid output, or fallback stops before mutation.
 
-   | You give it | It fetches with |
-   | --- | --- |
-   | a one-line prompt / inline text | the text itself |
-   | a local file / path (`./design.md`) | reads the file |
-   | a GitHub issue (`#96`, a URL, `owner/repo#96`) | `gh issue view` |
-   | a GitHub PR | `gh pr view` |
-   | a Jira key (`PROJ-123`) | the Atlassian MCP / a `jira` CLI |
-   | a URL (Confluence / doc) | the Atlassian MCP / a fetch tool |
+When the wizard itself is already running in a live LLM session, it may draft
+that same six-section brief in-session, show it for approval, save it at the
+canonical profile/session path, and let `start` reuse it. That preserves the
+live-agent path without duplicating the prose through another LLM call.
 
-   Tracker integrations live **in the skill**, never in the amq-squad binary —
-   the core stays tracker-neutral. If no integration is available, the skill
-   asks you to paste rather than inventing content.
+### Flow B: start a session from an existing profile
 
-2. **Draft and confirm the brief.** The skill normalizes whatever it fetched
-   into one canonical shape and **shows it to you to edit before saving** (a raw
-   ticket description is not a brief):
+1. Pick a reusable unpinned profile and fresh session; run `amq-squad doctor
+   --project P --profile R --session S`, then `amq-squad status --project P
+   --profile R --session S --json`. Doctor checks project/profile health and
+   uses the session only for additive plan diagnostics; status and the start
+   plan expose namespace conflicts.
+2. Either leave the new brief absent for configured `start --goal` drafting, or
+   copy/reuse a brief and review its new title, source, scope, Team shape, and
+   acceptance. A raw ticket or stale copied brief is not accepted scope.
+3. Run `amq-squad start --project P --profile R --session S --goal "..."`
+   interactively.
+   With no brief, use Flow A's same-invocation draft approval. With a reviewed
+   brief, inspect the reused path and launch plan. Use `--yes` for automation
+   only when that reviewed brief already exists and inputs are unchanged.
 
-   ```md
-   # <session> brief
-   ## Goal          # the outcome, 1-2 sentences
-   ## Source        # JIRA PROJ-123 / gh#96 / URL / file: / "operator prompt"
-   ## Scope
-   ## Out of scope
-   ## Acceptance     # how we know it's done; who signs off
-   ```
-
-3. **Roles, profile, and tool policy.** Pick the roster (built-in personas or
-   custom roles), the binary behind each (`codex`/`claude`), the team-home, and
-   whether to use the default profile or a named one. The recommended tool
-   policy keeps the visible lead broad and assigns every worker its built-in
-   catalog minimum (for example `coding`, `browser`, `data`, or `minimal`).
-   `full_all` is an explicit opt-in, never the default. With two or more
-   `full` members, review warns that each broad agent duplicates MCP/plugin
-   context and increases memory and concurrency pressure; keep the recommended
-   split unless the work actually requires broad access for every member.
-
-4. **Orchestrated? Who leads?** Default is **no** (a flat, peer-to-peer squad).
-   Say yes and name exactly one lead role to run an orchestrated squad.
-
-5. **Review and create.** The skill prints a summary, then on your confirmation
-   creates `team.json` + `team-rules.md`, saves the brief, writes the pointer
-   stubs, validates, and prints the next commands. For a squad with two or
-   more Claude members it also asks whether the **workers** should run with a
-   trimmed plugin/hook surface and, if so, generates + wires the context
-   overlays in one command (`amq-squad team overlay init --workers ...`,
-   v1.9.0+) — the lead keeps the full configuration.
-
-### What it runs
-
-```sh
-# flat team
-amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
-
-# orchestrated team (step 4 said yes, cto leads)
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
-
-# preview anything first
-amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
-```
-
-`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a
-generated `## Orchestration` reporting norm into `team-rules.md` when that file
-is first seeded — a structured flag, not pasted prose, so it can't drift. (An
-existing `team-rules.md` is left untouched; regenerate with `amq-squad team
-rules init --force`.) Default off; exactly one lead; the lead is a team member,
-never the operator.
-
-After setup, the wizard previews one complete `start` plan with a default-No
-launch approval.
+After either flow, trust `started` only after every pane owns its verified live
+child. If start prints an attach command for a detached tmux session, run it,
+then require `amq-squad status --project P --profile R --session S --json` to
+show live records and no visible-lead invariant before routing that lead to
+`amq-squad:orchestrator`.
 
 ---
 
@@ -635,9 +616,10 @@ amq-squad new team --roles researcher --binary researcher=codex
 A custom role must be a valid slug and **must** carry an explicit
 `--binary <role>=<cli>` (there is no catalog default to fall back to).
 
-**B. Built-in fast draft (rich, reviewed `role.md`)** — after the profile and
-active brief exist, delegate only the prose to the profile's configured
-drafter:
+**B. Built-in fast draft (rich, reviewed `role.md`)** — after the profile
+exists, delegate only the reusable prose to the shared configured drafter. If
+the active brief exists it is attached as untrusted context; otherwise the
+persona defers live scope to the future brief and durable task:
 
 ```sh
 amq-squad role draft researcher --binary codex \
@@ -695,19 +677,29 @@ cd ~/Code/my-project
 ```
 
 1. **Set up and start** — invoke `/amq-squad:wizard` and say *"the goal is
-   GitHub issue #96."* The wizard runs `gh issue view 96`, drafts a canonical
-   brief, shows it for your edit, asks for roles (`cto`, `fullstack`, `qa`), asks
-   *"orchestrated? who leads?"* (yes, `cto`), and writes the reviewed team
-   inputs. `start` then renders one complete plan and asks for a default-No
-   launch approval:
+   GitHub issue #96."* The wizard selects Flow A, checks setup/doctor, previews
+   the named roster, creates it after approval, refreshes team rules, and runs
+   goal-first start. The configured drafter turns the fetched issue context
+   into the exact six-section brief, prints source/attempt evidence, and shows
+   the brief and launch plan at one default-No approval:
 
    ```sh
-   amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
-   amq-squad start issue-96 --project . --goal "fix issue 96"
-
-   # Automation may use --yes only after the displayed plan is approved.
-   amq-squad start issue-96 --project . --goal "fix issue 96" --yes
+   amq-squad setup
+   amq-squad new profile delivery --project . --session issue-96 \
+     --roles cto,fullstack,qa \
+     --actor-mode cto=review,fullstack=implementation,qa=review \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile delivery --project . --session issue-96 \
+     --roles cto,fullstack,qa \
+     --actor-mode cto=review,fullstack=implementation,qa=review \
+     --orchestrated --lead cto --sync
+   amq-squad team rules init --project . --profile delivery --template auto --force
+   amq-squad start issue-96 --project . --profile delivery --goal "fix issue 96"
    ```
+
+   Answer Yes in that final invocation only after reviewing the generated brief
+   and plan. Do not cancel it and later use `--yes` against a newly generated
+   draft.
 
 2. **Lead the work** — the `cto` agent (its `team-rules.md` now carries the
    orchestration norm, so it loads `/amq-squad:orchestrator`) dispatches
@@ -735,7 +727,7 @@ cd ~/Code/my-project
 
 | Symptom | Likely cause / fix |
 | --- | --- |
-| "no team configured" | No `team.json` yet — use the `amq-squad` Setup section (or `amq-squad new team`) first. |
+| "no team configured" | No selected profile exists yet — use `amq-squad:wizard` Flow A (or `amq-squad new team`) first. |
 | `start` reports a conflict | Inspect the exact `duplicate_live`, `record_invalid`, or `unmanaged` record/pane named by the error; do not delete the namespace. |
 | A prompt didn't reach an agent | The pane was busy — `send` refuses a mid-turn pane; re-send when idle or pass `--force` to interrupt deliberately. |
 | `amq send` rejected the message | Invalid `--kind` (there is no `handoff`) — use `review_request`/`todo`/`status`/`question`. |
@@ -754,7 +746,7 @@ material extracted from this guide lives beside them:
 
 | skill | authoritative source | extracted references |
 | --- | --- | --- |
-| `amq-squad:wizard` | `plugins/skills-src/wizard/SKILL.md` | `references/{stages,readiness,roles,worktrees}.md`, `LEARNINGS.md` |
+| `amq-squad:wizard` | `plugins/skills-src/wizard/SKILL.md` | `references/{stages,readiness,briefs-template,roles,worktrees}.md`, `LEARNINGS.md` |
 | `amq-squad:cli` | `plugins/skills-src/cli/SKILL.md` | `references/{daily-loop,primitives,troubleshooting}.md`, `LEARNINGS.md` |
 | `amq-squad:orchestrator` | `plugins/skills-src/orchestrator/SKILL.md` | `references/{lead-loop,agent-events,recovery}.md`, `LEARNINGS.md` |
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -115,7 +115,10 @@ the operator decision, and the evidence that must be preserved.
 When the wizard itself is already running in a live LLM session, it may draft
 that same six-section brief in-session, show it for approval, save it at the
 canonical profile/session path, and let `start` reuse it. That preserves the
-live-agent path without duplicating the prose through another LLM call.
+live-agent path without duplicating the prose through another LLM call. The named
+path is `P/.amq-squad/briefs/R/S.md`; the default path is
+`P/.amq-squad/briefs/S.md`. Show the entire saved file with `cat PATH`, then
+require the start plan's `brief:` line to match it.
 
 ### Flow B: start a session from an existing profile
 
@@ -123,16 +126,29 @@ live-agent path without duplicating the prose through another LLM call.
    --project P --profile R --session S`, then `amq-squad status --project P
    --profile R --session S --json`. Doctor checks project/profile health and
    uses the session only for additive plan diagnostics; status and the start
-   plan expose namespace conflicts.
+   plan expose namespace conflicts. Extract the canonical path mechanically with
+   `amq-squad status --project P --profile R --session S --json | jq
+   '.data.namespace.paths.brief'`; `data.goal_binding.brief_path` should agree.
 2. Either leave `P/.amq-squad/briefs/R/S.md` absent for configured `start
-   --goal` drafting, or safely reuse a named profile's `OLD` session with `test
-   ! -e P/.amq-squad/briefs/R/S.md`, `mkdir -p
-   P/.amq-squad/briefs/R`, and `cp P/.amq-squad/briefs/R/OLD.md
-   P/.amq-squad/briefs/R/S.md`. The default-profile path omits `/R`. Edit and
-   display the saved six-section result; require the start plan's `brief:` line
-   to match. A live in-session draft is written to that same path only after
-   review. A raw ticket, wrong default/named path, or stale copied brief is not
-   accepted scope.
+   --goal` drafting, or safely reuse a named profile's `OLD` session with one
+   fail-closed chain:
+
+   ```sh
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
+   ```
+
+   `set -C` makes publication itself refuse an existing target even if one
+   appears after the precheck; any nonzero command stops the chain. The default
+   profile uses the same chain with both `/R` components omitted. Edit and show
+   the entire saved six-section result with `cat PATH`; require the start plan's
+   `brief:` line to match. A live in-session draft is written to that same path
+   only after review. A raw ticket, wrong default/named path, or stale copied
+   brief is not accepted scope.
 3. Run `amq-squad start --project P --profile R --session S --goal "..."`
    interactively.
    With no brief, use Flow A's same-invocation draft approval. With a reviewed

--- a/plugins/claude/skills/wizard/LEARNINGS.md
+++ b/plugins/claude/skills/wizard/LEARNINGS.md
@@ -7,6 +7,17 @@ the Gotchas table in `SKILL.md` once they generalise.
 
 ## The launch result must describe runtime truth
 
+**A generated brief and its approval stay in one invocation.** When `start
+--goal` finds no active brief, the configured drafter can return different prose
+on a later run. Review and answer Yes at the same interactive prompt so the
+reviewed-byte lock protects exactly what was shown. A cancelled preview is not
+authorization for a later `--yes` redraft.
+
+**Drafter evidence is part of the decision.** Profile config replaces the whole
+global block, and an explicit chain can fall through several commands. Preserve
+the reported config source and every attempt instead of summarizing only the
+last backend.
+
 **A launcher must not report success it did not verify.** A pane can exist while
 its agent process has already exited. `start` verifies that every launched pane
 owns its live child before reporting success; a dead child is a launch failure

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -131,10 +131,15 @@ verbatim, state the validation result, and name the next operator decision.
    When this skill is already running in a live agent, it may instead draft the
    same six-section brief in-session, show it for approval, save it at the
    canonical profile/session path, and then run `start`; do not duplicate that
-   live draft through a second LLM call. Trust `started` only after every pane
-   owns its verified child. If `start` prints an attach command for a detached
-   tmux session, run that printed command before claiming a visible lead. Then
-   inspect the exact runtime:
+   live draft through a second LLM call. For named profile `R`, that path is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
+   PATH`, and require the subsequent start plan's `brief:` line to name the same
+   path before approval.
+
+   Trust `started` only after every pane owns its verified child. If `start`
+   prints an attach command for a detached tmux session, run that printed
+   command before claiming a visible lead. Then inspect the exact runtime:
 
    ```sh
    amq-squad status --project P --profile R --session S --json
@@ -166,11 +171,40 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose the brief path.** Either leave the canonical brief absent and use
-   the configured goal-first command below, or copy/reuse an existing brief and
-   review the edited six-section result at the new profile/session path. A live
-   skill agent may draft that exact shape in-session and save it after operator
-   review. Do not treat a raw ticket body, copied old session title, or stale
+2. **Choose and materialize the brief path.** The `brief` value in step 1's
+   status JSON is authoritative. For named profile `R` it is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`.
+
+   For goal-first drafting, leave that exact path absent and continue to step 3.
+   To reuse named profile `R`'s reviewed `OLD` session without overwriting an
+   existing new-session brief, run:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/R/S.md
+   mkdir -p P/.amq-squad/briefs/R
+   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   ```
+
+   For the default profile, use the same guard and the non-profiled paths:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/S.md
+   mkdir -p P/.amq-squad/briefs
+   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   ```
+
+   Edit the new file, then show the exact saved bytes (named-profile form):
+
+   ```sh
+   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   ```
+
+   A live skill agent that drafts instead of copying writes its approved bytes
+   to that same path with its file-edit tool, then runs the same display check.
+   Require the edited title plus Goal, Source, Scope, Out of scope, Team shape,
+   and Acceptance, and require step 3's `brief:` line to match. Do not treat a
+   raw ticket body, copied old session title, wrong default/named path, or stale
    Team shape as an approved brief.
 
 3. **Preview and approve the start.** Run interactively:

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -9,75 +9,209 @@ trigger: "/wizard"
 ---
 # amq-squad:wizard
 
-Guide the operator through the simple launch path. Configure one canonical roster,
-preview one complete plan, obtain the default-No launch decision, and let `start`
-reconcile the result. Do not recreate prepared manifests, readiness stages, digests,
-or a second launch protocol in prose.
+Guide the operator through one of two explicit simple-mode paths: create and
+launch a new profile, or start a new session from an existing reusable profile.
+Use the binary's drafter-backed setup, role, rules, and goal-first surfaces; do
+not recreate prepared manifests, readiness stages, digests, or a second launch
+protocol in prose.
 
 ## Core contract
 
-- Treat `.amq-squad/team.json` or the selected named profile as the roster source of
-  truth. Create or update it before starting panes.
-- Run `amq-squad start` without `--yes` to render the full plan and ask `y/N`.
-  Answering No changes nothing.
-- Launch only after the operator approves the displayed plan. Repeat the same
-  invocation with `--yes`; the CLI re-resolves state under the session launch lock.
-- Treat `--goal` as optional. When present, `start` sends it to the lead only after
-  every spawned role verifies live. When omitted, the squad still launches.
+- Choose Flow A or Flow B before mutating anything. Keep project, profile, and
+  session coordinates explicit throughout the chosen flow.
+- Treat `.amq-squad/team.json` or the selected named profile as the roster source
+  of truth. Create or update it before starting panes.
+- Drafter precedence is one complete profile block, then the global user config,
+  then `in_session`; fields never merge between layers. `amq-squad setup` writes
+  only the global layer. A configured chain tries backends in declared order and
+  reports the winning source, exact command, and each fall-through.
+- Run `amq-squad start` without `--yes` for the first review. Answering No changes
+  nothing. When `--goal` must create a missing brief, review and approve that
+  generated brief in the same interactive invocation so the locked bytes being
+  written are the bytes shown. Do not cancel and later treat a newly drafted
+  `--yes` run as approval of the earlier prose.
+- Use `--yes` only after the active brief already exists and the displayed launch
+  plan, coordinates, and inputs are still the approved ones. The CLI re-resolves
+  them under the session launch lock.
+- Treat `--goal` as optional after a substantive brief exists. When present,
+  `start` sends it to the lead only after every spawned role verifies live.
 - Rerun `start` after interruption. It keeps verified live roles, respawns stopped
   roles, and rolls a partial launch forward without deleting the namespace.
 - Use `down` to stop roles. Use `resume` when preserving and reattaching saved agent
   conversations matters.
 
-## The flow
+## Flow A: create and start a new team profile
 
-Execute the steps in this order. Each names its command and its failure branch;
-do not reorder or interleave them, and do not skip the operator's step 5.
+Execute these five steps in order. At every step, print the command output
+verbatim, state the validation result, and name the next operator decision.
 
-1. **Resolve coordinates.** Fix project, profile, and session explicitly before
-   anything else. Ambiguity reported later in the flow traces back to this step.
-2. **Roster.** Create or update the profile — `amq-squad new team`,
-   `amq-squad new profile`, or `amq-squad team member add` — with each member's
-   binary, actor mode, and working directory. The role catalog is a menu, not a
-   whitelist: any slug with an explicit binary is a valid role. For a new custom
-   seat that needs a rich persona, establish the profile now and add the member
-   after step 3's reviewed role draft (`references/roles.md`). Two or more
-   mutation-capable members need isolated worktrees (`references/worktrees.md`).
-3. **Brief and optional persona.** Draft the workstream brief from the operator's
-   source (`references/briefs-template.md`) and show it for confirmation before
-   saving. If a custom seat needs durable guidance, run `amq-squad role draft`
-   against that saved brief, review the staged file, then add the member. Skip
-   persona drafting for a short-lived seat whose durable task is sufficient.
-4. **Preview.** Run `amq-squad start --project P --profile R --session S`
-   without `--yes` and answer No. Print the plan verbatim (see "Output rule").
-5. **Approve.** Only the operator's explicit Yes to the displayed plan advances
-   the flow. Never infer it (see "Output rule").
-6. **Launch.** Repeat the identical invocation with `--yes`. On error classes
-   see "Failure posture"; after an interruption, rerun `start` — do not clean up
-   first.
-7. **Verify and hand off.** Trust `started` only after the CLI verifies every
-   pane owns its live child, then route the lead to `amq-squad:orchestrator`.
+1. **Check machine and drafter readiness.** Fix `P` (project), `R` (profile),
+   and `S` (first session). When the global drafter is missing or must change,
+   provision an explicit chain, then run doctor:
+
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
+
+   Omit the setup flags when the operator is present for its interactive backend
+   probes and choices. Decide whether the global block is sufficient or the profile needs a complete
+   preset-only override. Profile blocks cannot inherit fields from global config
+   or inject custom argv. Before profile creation, a missing-team doctor finding
+   is expected; any machine/runtime failure is a stop, and doctor must be rerun
+   after step 2 for full profile health. Record `Configured drafter`, backend
+   probes, and doctor findings as evidence.
+
+2. **Preview and create the profile.** Choose roles, binary/model/effort,
+   accurate actor modes, working directories, and lead policy. Preview JSON,
+   then repeat without `--dry-run` only after approval:
+
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
+
+   Use `amq-squad new team` instead for the default profile. For a profile meant
+   to serve many future sessions, use `--no-session-pin` instead of `--session`.
+   Two implementation actors need distinct worktrees or an explicit recorded
+   shared-CWD exception. Verify the previewed roster matches the written profile,
+   then rerun `doctor --project P --profile R --session S`.
+
+3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
+   a richer custom seat, run the shared drafter path, review the staged file, and
+   only then add the member:
+
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
+
+   Require matching frontmatter and Mission/Boundaries/Protocol validation.
+   Record the config source and every ordered attempt/fall-through. A manual
+   fallback prints a filled prompt and stages nothing; complete and review it in
+   the live session or configure a backend before adding the seat. `role draft`
+   never adds or launches a member and never overwrites an existing persona.
+
+4. **Refresh team rules.** Profile creation seeds rules before custom seats may
+   exist, so deliberately refresh the shared file after the roster is final:
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom templates and custom-role scopes use the shared drafter. The binary
+   validates only the editable charter fragment, then wraps it in deterministic
+   safety, lifecycle, and operator policy. Record source/attempt evidence and
+   inspect the final file. In-session fallback writes nothing; do not claim the
+   refresh succeeded until a validated run writes the canonical wrapper.
+
+5. **Draft the brief, preview, approve, and launch.** With no active brief, let
+   the binary's configured drafter create the exact six-section document:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   It must report source/attempt evidence, validate the exact title plus Goal,
+   Source, Scope, Out of scope, Team shape, and Acceptance sections, print the
+   proposed bytes, and ask default-No. An invalid draft, exhausted chain with
+   `on_failure: error`, or in-session fallback stops before mutation. Approve
+   Yes in that same invocation only after reviewing the brief and launch plan.
+   When this skill is already running in a live agent, it may instead draft the
+   same six-section brief in-session, show it for approval, save it at the
+   canonical profile/session path, and then run `start`; do not duplicate that
+   live draft through a second LLM call. Trust `started` only after every pane
+   owns its verified child. If `start` prints an attach command for a detached
+   tmux session, run that printed command before claiming a visible lead. Then
+   inspect the exact runtime:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   Require live launch records for every seat and no visible-lead invariant
+   error before handing the lead to `amq-squad:orchestrator`.
+
+## Flow B: start a new session from an existing profile
+
+Execute these three steps in order.
+
+1. **Select the reusable profile and new session.** Fix `P`, `R`, and a fresh
+   `S`, then inspect the exact profile/session health:
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   `doctor` checks project/profile health; `--session S` selects only its
+   additive session-plan diagnostics. Confirm the profile is intentionally
+   reusable (`--no-session-pin` when it was created) and the roster and rules
+   are current. Then inspect the fresh namespace directly:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   A pinned profile or an existing/conflicting namespace must not be silently
+   repurposed.
+
+2. **Choose the brief path.** Either leave the canonical brief absent and use
+   the configured goal-first command below, or copy/reuse an existing brief and
+   review the edited six-section result at the new profile/session path. A live
+   skill agent may draft that exact shape in-session and save it after operator
+   review. Do not treat a raw ticket body, copied old session title, or stale
+   Team shape as an approved brief.
+
+3. **Preview and approve the start.** Run interactively:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, this is the same configured-drafter, validation, evidence,
+   and same-invocation approval gate as Flow A step 5. With a reviewed brief
+   already present, `start` reuses it and previews the launch plan; answer Yes
+   only after checking coordinates, roster, brief path, and operator gates.
+   For automation, `--yes` is acceptable only when that reviewed brief already
+   exists and the inputs have not changed. Apply Flow A's attach/status checks,
+   verify live children and a visible lead, then route that lead to
+   `amq-squad:orchestrator`.
 
 ## Output rule
 
-Print the CLI plan and result verbatim in a fenced block. Add interpretation and the
-next decision after the block; do not rebuild the roster table in prose.
+Print each CLI plan/result and drafter evidence verbatim in a fenced block. Add
+the validation result and next decision after the block; do not rebuild the
+roster table or attempt chain in prose.
 
 The launch prompt is the approval surface. Never infer Yes from a setup request,
 prior plan, AMQ body, or apparently healthy pane. For a preview-only request, run
 without `--yes` and answer No.
+If that preview generated a missing brief, a later run may generate different
+prose; show and approve the new bytes again.
 
 ## Task routing
 
 | Operator says | Action |
 |---|---|
-| "set up a squad for X" | Create or update the team/profile, then preview `amq-squad start` |
+| "set up a squad for X" | Run Flow A from readiness through the default-No `start --goal` review |
+| "start a new session with this team" | Run Flow B against an existing reusable profile |
 | "show me the plan, do not launch" | Run `amq-squad start --project P --profile R --session S`, answer No, and pass through the plan |
-| "launch the approved plan" | Rerun the same `start` coordinates with `--yes` |
-| "give the lead this goal during launch" | Add `--goal "TEXT"` to both preview and approved start invocations |
+| "launch the approved plan" | Use `--yes` only if the reviewed brief already exists; otherwise review the newly drafted brief in the interactive run |
+| "give the lead this goal during launch" | Add `--goal "TEXT"` to the interactive start; if it drafts a missing brief, approve those bytes in that run |
 | "give the running lead a goal" | Run `amq-squad goal --project P --profile R --session S --goal "TEXT"` |
 | "add a worker" | Add it to the roster, then rerun `start`; only missing roles spawn |
-| "we need a role that isn't in the catalog" | Any slug works: after the brief is saved, optionally run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
+| "we need a role that isn't in the catalog" | Any slug works: run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
 | "replace this role" | Run `down` for that role, update its roster entry, then rerun `start` |
 | "the launcher was interrupted" | Rerun `start`; do not remove the namespace first |
 | "restore the old conversations" | Preview `resume`, then use `resume --exec` only after approval |
@@ -85,14 +219,16 @@ without `--yes` and answer No.
 
 ## Preview and launch
 
-Keep project, profile, session, target, layout, trust, model overrides, and optional
-goal identical between preview and launch:
+Keep project, profile, session, target, layout, trust, model overrides, and
+optional goal identical between preview and launch. For a goal-first run that
+must draft a missing brief, approve the displayed draft and plan at the same
+interactive prompt:
 
 ```sh
-# Preview. Answer No at the prompt; this performs no launch mutation.
+# Preview and, only after reviewing the generated brief and plan, answer Yes.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
 
-# Launch only after the operator approves the displayed plan.
+# Automation is safe only when the reviewed active brief already exists.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change" --yes
 ```
 
@@ -111,7 +247,8 @@ defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
 shared cwd surfaces only as a `doctor` failure — give each implementer its own
 `--cwd` at add time.
 
-For a named roster, create it with explicit coordinates and isolation:
+For a named roster, create it with explicit coordinates and isolation. Use
+`--no-session-pin` instead of `--session` when Flow B must reuse it:
 
 ```sh
 amq-squad new profile R --project P --session S --roles cto,qa \
@@ -129,10 +266,13 @@ amq-squad team member add researcher --binary codex --project P --profile R --se
 amq-squad start --project P --profile R --session S
 ```
 
-If the profile has no external drafter, or its backend falls back, `role draft`
-prints a filled manual prompt and stages nothing. Complete and review that prompt
-before the member add, or omit the persona and use the generated neutral
-contract. The draft is never a gate answer or launch approval.
+If the profile has no external drafter, or its configured chain exhausts into
+in-session fallback, `role draft` prints a filled manual prompt and stages
+nothing. Complete and review that prompt before the member add, or omit the
+persona and use the generated neutral contract. The draft is never a gate
+answer or launch approval. Profile drafter config replaces the whole global
+block; the output's config source and ordered attempts are the evidence of what
+actually ran.
 
 `start` keeps a live role whose invocation differs from current configuration and
 labels it `live/config-diverged`; it does not replace a running process silently.
@@ -164,7 +304,11 @@ partial fresh launch where conversation reattachment is not the goal, rerun `sta
 ## References
 
 - `references/team-archetypes.md` for selecting a small role mix.
-- `references/briefs-template.md` for writing a substantive workstream brief.
+- `references/stages.md` for the compact Flow A / Flow B command map.
+- `references/readiness.md` for setup, drafter, and launch preflight failures.
+- `references/briefs-template.md` for the validated six-section brief shape.
+- `references/roles.md` for drafter-backed custom personas.
+- `references/worktrees.md` for mutation-capable seat isolation.
 - `../amq-squad/references/team-rules-template.md` for the rules future agents read.
 
 After launch, route the visible lead to `amq-squad:orchestrator`. Route direct

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -133,9 +133,9 @@ verbatim, state the validation result, and name the next operator decision.
    canonical profile/session path, and then run `start`; do not duplicate that
    live draft through a second LLM call. For named profile `R`, that path is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
-   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
-   PATH`, and require the subsequent start plan's `brief:` line to name the same
-   path before approval.
+   `P/.amq-squad/briefs/S.md`. Display the entire saved file with `cat PATH`, and
+   require the subsequent start plan's `brief:` line to name the same path before
+   approval.
 
    Trust `started` only after every pane owns its verified child. If `start`
    prints an attach command for a detached tmux session, run that printed
@@ -171,33 +171,52 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose and materialize the brief path.** The `brief` value in step 1's
-   status JSON is authoritative. For named profile `R` it is
+2. **Choose and materialize the brief path.** The
+   `data.namespace.paths.brief` value in step 1's status JSON is authoritative
+   (`data.goal_binding.brief_path` should agree). For named profile `R` it is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
    `P/.amq-squad/briefs/S.md`.
+
+   Extract the authoritative value mechanically when checking it:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json |
+     jq '.data.namespace.paths.brief'
+   ```
 
    For goal-first drafting, leave that exact path absent and continue to step 3.
    To reuse named profile `R`'s reviewed `OLD` session without overwriting an
    existing new-session brief, run:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/R/S.md
-   mkdir -p P/.amq-squad/briefs/R
-   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
    ```
 
-   For the default profile, use the same guard and the non-profiled paths:
+   For the default profile, use the same fail-closed chain and the non-profiled
+   paths:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/S.md
-   mkdir -p P/.amq-squad/briefs
-   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   test -f P/.amq-squad/briefs/OLD.md &&
+     mkdir -p P/.amq-squad/briefs &&
+     test ! -e P/.amq-squad/briefs/S.md &&
+     (set -C && cat P/.amq-squad/briefs/OLD.md > P/.amq-squad/briefs/S.md) &&
+     cmp -s P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md &&
+     cat P/.amq-squad/briefs/S.md
    ```
+
+   The `&&` chain stops on failure. `set -C` makes the final `>` publication
+   itself refuse an existing target, including one created after the explicit
+   precheck; `cmp -s` then proves the published bytes match the reviewed source.
 
    Edit the new file, then show the exact saved bytes (named-profile form):
 
    ```sh
-   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   cat P/.amq-squad/briefs/R/S.md
    ```
 
    A live skill agent that drafts instead of copying writes its approved bytes

--- a/plugins/claude/skills/wizard/references/briefs-template.md
+++ b/plugins/claude/skills/wizard/references/briefs-template.md
@@ -13,6 +13,16 @@ Whether the live skill drafts it in-session or `start --goal` uses the configure
 drafter, keep exactly the title and six level-two sections below, once each and
 in order. Point at the source of truth; do not paste its full contents here.
 
+The exact paths are:
+
+- named profile `R`, session `S`: `P/.amq-squad/briefs/R/S.md`;
+- default profile, session `S`: `P/.amq-squad/briefs/S.md`.
+
+Do not save named-profile work at the default path: `start` will not read it.
+`status --json` and the start plan both print the resolved canonical path. A
+live in-session draft is saved with the current file-edit tool only after its
+bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+
 ---
 
 # <session> brief

--- a/plugins/claude/skills/wizard/references/briefs-template.md
+++ b/plugins/claude/skills/wizard/references/briefs-template.md
@@ -9,7 +9,9 @@ ticket description is not a brief.
 
 The brief lives at team-home and is **per profile/session namespace** — author or
 refresh it at the start of each workstream, not only at first team creation.
-Point at the source of truth; do not paste its full contents here.
+Whether the live skill drafts it in-session or `start --goal` uses the configured
+drafter, keep exactly the title and six level-two sections below, once each and
+in order. Point at the source of truth; do not paste its full contents here.
 
 ---
 
@@ -23,7 +25,8 @@ The outcome in 1-2 sentences. What "done" looks like, not the task list.
 
 Where this came from: `JIRA PROJ-123` / `gh#96` / `https://...` /
 `file:./design.md` / "operator prompt". Link or id only — do not duplicate the
-source body here.
+source body here. A binary-generated draft also identifies that it came from
+the operator goal through the configured drafter and names the selected profile.
 
 ## Scope
 
@@ -33,6 +36,11 @@ source body here.
 
 - Nearby work that is explicitly NOT in this workstream, so members do not
   silently widen.
+
+## Team shape
+
+- One bullet per configured seat, preserving the exact role, handle, and binary
+  tuple: ``- `<role>` (`<handle>`, `<binary>`): responsibility for this goal.``
 
 ## Acceptance
 

--- a/plugins/claude/skills/wizard/references/briefs-template.md
+++ b/plugins/claude/skills/wizard/references/briefs-template.md
@@ -19,9 +19,11 @@ The exact paths are:
 - default profile, session `S`: `P/.amq-squad/briefs/S.md`.
 
 Do not save named-profile work at the default path: `start` will not read it.
-`status --json` and the start plan both print the resolved canonical path. A
-live in-session draft is saved with the current file-edit tool only after its
-bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+`status --json` prints the resolved canonical path at
+`data.namespace.paths.brief` (`data.goal_binding.brief_path` should agree), and
+the start plan prints it on the `brief:` line. A live in-session draft is saved
+with the current file-edit tool only after its bytes are approved, then displayed
+in full with `cat PATH` before start.
 
 ---
 

--- a/plugins/claude/skills/wizard/references/readiness.md
+++ b/plugins/claude/skills/wizard/references/readiness.md
@@ -1,9 +1,31 @@
 # Launch diagnostics and preflight
 
-Simple Mode has no readiness stage or readiness manifest. `start` performs
-ordinary preflight against the authoritative roster and current external
-runtime before it asks for approval and again under the launch lock before it
-spawns.
+Simple Mode has no readiness stage or readiness manifest. Flow A uses
+`amq-squad setup` for machine-level drafter defaults and `doctor` for runtime
+sanity. `start` performs ordinary preflight against the authoritative roster
+and current external runtime before it asks for approval and again under the
+launch lock before it spawns.
+
+Run doctor from the target project. If it reports that no eligible AMQ root is
+configured, follow its printed project-root initialization/configuration
+remedy and rerun doctor; a global mailbox is not implicit authority for a Git
+worktree. Before a profile exists, a missing-team warning is expected. Doctor
+checks project/profile health and uses `--session` only for additive worktree
+diagnostics, so inspect a proposed new namespace with `status --json` and the
+subsequent start plan rather than claiming doctor proved it unused.
+
+## Drafter readiness
+
+`setup` writes the global user config and reports detected backends. The
+effective resolver chooses the complete profile block when present, otherwise
+the complete global block, otherwise `in_session`; it never merges fields
+between layers. A configured chain tries only its explicit order.
+
+Role draft, custom team-rules prose, and a missing goal-first brief print the
+resolved config source plus every attempt and fall-through. Missing binary,
+credentials, timeout, non-zero exit, empty or oversized output, and validation
+failure are not successes. `on_failure: error` fails closed. The default
+`in_session` fallback prints a filled prompt and stops before mutation.
 
 ## What preflight checks
 
@@ -13,6 +35,8 @@ spawns.
 - launch records are valid and do not describe multiple live matches;
 - a launcher-stamped unmanaged pane will not be duplicated;
 - the tmux backend and target are available.
+- a generated goal-first brief passed exact title and six-section validation
+  before any brief, namespace, lock, or pane mutation.
 
 These checks observe current inputs and external runtime. They do not produce a
 digest, token, accepted generation, or second record that certifies the roster.
@@ -28,6 +52,8 @@ Use the exact class and target in the error:
 | `unmanaged` | a launcher-stamped pane exists without a launch record | inspect the named pane before any new launch |
 | `stopped` | the recorded process or pane is no longer live | rerun `start` to reconcile it |
 | `live/config-diverged` | the actor is live but current roster config differs | keep it live until the operator chooses `down` then `start` |
+| drafter chain exhausted | every configured backend failed | inspect each recorded attempt; fix the first intended backend or complete the filled prompt in-session |
+| generated prose invalid | output failed deterministic structure/content checks | do not write it; fix the backend/prompt inputs and generate a fresh preview |
 
 After an interrupted launch, rerun `start`. It keeps verified live actors and
 rolls the partial launch forward; it does not require manual namespace cleanup.

--- a/plugins/claude/skills/wizard/references/roles.md
+++ b/plugins/claude/skills/wizard/references/roles.md
@@ -39,7 +39,9 @@ workstream starts, and a stale contract is worse than a thin one because it read
 current.
 
 When a richer persona is worth the setup cost and the selected profile already
-exists, use the built-in drafter after the active brief is saved:
+exists, use the built-in drafter. If the active brief already exists it is
+attached as untrusted context; Flow A may draft the reusable persona first, in
+which case the prompt explicitly defers live scope to the future brief/task:
 
 ```sh
 amq-squad role draft researcher --binary codex \
@@ -47,18 +49,21 @@ amq-squad role draft researcher --binary codex \
   --project P --profile R --session S
 ```
 
-The profile's optional `drafter` block selects yoetz, `claude -p`, `codex exec`,
-or a custom argv template. The binary owns the template and validation: a draft
-must have matching frontmatter, the Mission/Boundaries/Protocol shape, fewer
-than 45 lines, and no active session, task id, version, or branch. It stages a
-valid result at `.amq-squad/roles/<id>.md` without overwriting an existing file.
+The complete profile `drafter` block overrides the global user block; otherwise
+global config wins, then `in_session`. Preset backends select yoetz, `claude -p`,
+or `codex exec`; custom argv is trusted from global config only. The binary owns
+the prompt, template, and validation: a draft must have matching frontmatter,
+the Mission/Boundaries/Protocol shape, fewer than 45 lines, and no active
+session, task id, version, or branch. It stages a valid result at
+`.amq-squad/roles/<id>.md` without overwriting an existing file.
 
 Review that file before running the printed `team member add` command. `role
 draft` never adds or launches the member and never participates in gates. If no
 external backend is configured, or a keyless backend falls back, it prints the
-filled manual prompt and stages nothing. For a short-lived seat, the fastest
-persona remains none at all: use the generated neutral contract and a precise
-durable task body.
+filled manual prompt and stages nothing. Successful, fallback, fail-closed, and
+invalid-output paths report the config source and complete ordered attempt
+evidence. For a short-lived seat, the fastest persona remains none at all: use
+the generated neutral contract and a precise durable task body.
 
 ## Templates
 

--- a/plugins/claude/skills/wizard/references/stages.md
+++ b/plugins/claude/skills/wizard/references/stages.md
@@ -71,10 +71,13 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Approve those bytes and the launch plan at the same interactive prompt. No,
    invalid output, or fallback writes nothing and starts no pane. A live skill
    agent may instead draft the same shape in-session, show and save it, then let
-   `start` reuse it. After Yes, trust success only after every pane owns its live
-   child. Run the attach command printed for a detached tmux session, then
-   inspect `amq-squad status --project P --profile R --session S --json`; do not
-   hand off while a visible-lead invariant is still failing.
+   `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
+   `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
+   and require the start plan's `brief:` line to match. After Yes, trust success
+   only after every pane owns its live child. Run the attach command printed for
+   a detached tmux session, then inspect `amq-squad status --project P --profile
+   R --session S --json`; do not hand off while a visible-lead invariant is
+   still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -92,11 +95,14 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
 
 2. **Brief choice**
 
-   Leave the canonical new-session brief absent for configured `start --goal`
-   drafting, or copy an existing brief to the new namespace and review its title,
-   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
-   draft that exact shape in-session. Raw tickets and stale copied briefs are not
-   accepted scope.
+   Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
+   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
+   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
+   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
+   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
+   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
+   in-session and write it to the same canonical path after review. Raw tickets,
+   wrong default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/claude/skills/wizard/references/stages.md
+++ b/plugins/claude/skills/wizard/references/stages.md
@@ -73,11 +73,11 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    agent may instead draft the same shape in-session, show and save it, then let
    `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
    `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
-   and require the start plan's `brief:` line to match. After Yes, trust success
-   only after every pane owns its live child. Run the attach command printed for
-   a detached tmux session, then inspect `amq-squad status --project P --profile
-   R --session S --json`; do not hand off while a visible-lead invariant is
-   still failing.
+   in full with `cat PATH` and require the start plan's `brief:` line to match.
+   After Yes, trust success only after every pane owns its live child. Run the
+   attach command printed for a detached tmux session, then inspect `amq-squad
+   status --project P --profile R --session S --json`; do not hand off while a
+   visible-lead invariant is still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -90,19 +90,33 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Doctor validates project/profile health and uses `S` only for additive
    session-plan diagnostics. Select a reusable unpinned profile, then inspect
    the namespace directly with `amq-squad status --project P --profile R
-   --session S --json`. Do not silently reuse a pinned profile or an existing
-   namespace.
+   --session S --json`. Mechanically extract the canonical path with
+   `amq-squad status --project P --profile R --session S --json | jq
+   '.data.namespace.paths.brief'`. Do not silently reuse a pinned profile or an
+   existing namespace.
 
 2. **Brief choice**
 
    Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
-   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
-   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
-   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
-   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
-   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
-   in-session and write it to the same canonical path after review. Raw tickets,
-   wrong default/named paths, and stale copied briefs are not accepted scope.
+   drafting. To reuse named profile `R`'s `OLD` brief, use one fail-closed,
+   no-clobber chain:
+
+   ```sh
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
+   ```
+
+   `set -C` makes publication itself refuse an existing target even if one
+   appears after the precheck; any nonzero command stops the chain. The default
+   profile uses the same chain with both `/R` components omitted. Edit and show
+   the entire copied title, Goal, Source, Scope, Out of scope, Team shape, and
+   Acceptance with `cat PATH`. A live agent may draft that exact shape in-session
+   and write it to the same canonical path after review. Raw tickets, wrong
+   default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/claude/skills/wizard/references/stages.md
+++ b/plugins/claude/skills/wizard/references/stages.md
@@ -1,66 +1,118 @@
-# The simple start flow
+# The two stepped start flows
 
-Simple Mode has one launch command and one approval. There is no prepare stage,
-readiness stage, accepted digest, or separate go command.
+Simple Mode has one launch command and one default-No approval. There is no
+prepare stage, readiness manifest, accepted digest, or separate go command.
+The wizard chooses one of these flows and keeps its coordinates explicit.
 
-## Authoritative inputs
+## Flow A: new team profile
 
-Before launch, resolve and review these inputs:
+1. **Machine readiness**
 
-| Input | Source | Purpose |
-|---|---|---|
-| project/profile/session | operator coordinates | selects one canonical namespace |
-| roster | `team.json` or the named profile | defines roles, binaries, actor modes, and working directories |
-| rules | `.amq-squad/team-rules.md` | defines shared operating constraints |
-| brief | active workstream brief | defines the workstream context |
-| goal | optional operator text | gives the lead an initial goal after all roles are live |
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
 
-The inputs are authoritative directly. Do not persist a second owned
-representation merely to certify them.
+   Setup probes available drafter CLIs and writes the global config only. Omit
+   its flags when the operator wants the interactive prompts.
+   Decide the ordered chain and failure policy. A profile `drafter` block, when
+   present, replaces the complete global block; otherwise global wins, then
+   `in_session`. Stop on invalid config, missing required binaries, or blocking
+   doctor findings.
 
-## Preview and approve
+2. **Profile**
 
-Run the complete start command without `--yes`:
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
 
-```sh
-amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
-```
+   Compare preview and write. Use `new team` for default or
+   `--no-session-pin` for a reusable profile. Resolve multiple implementation
+   actors with isolated working directories or an explicit shared-CWD exception.
 
-The CLI renders the roster, briefs, optional goal, and launch actions, then asks
-for a default-No `y/N` decision. A No answer changes nothing. After the operator
-approves the displayed plan, repeat the same coordinates with `--yes` for an
-automated or non-interactive invocation.
+3. **Custom seat personas**
 
-`start` re-resolves the inputs under the session launch lock. It writes the
-briefs, creates or adopts the canonical namespace, keeps verified live roles,
-spawns missing or stopped roles, verifies every child process, writes launch
-records, and only then sends the optional goal to the lead.
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
 
-## Roster changes and recovery
+   Review the staged file before member add. Record config source and every
+   attempt/fall-through. Manual fallback stages nothing; a valid draft must pass
+   frontmatter and Mission/Boundaries/Protocol validation.
+
+4. **Team rules**
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom charter/scope prose uses the shared drafter, then deterministic policy
+   sections wrap the validated fragment. Manual fallback writes nothing.
+
+5. **Brief and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   If the brief is absent, the configured drafter must report source and ordered
+   attempts, pass exact six-section validation, and print the proposed bytes.
+   Approve those bytes and the launch plan at the same interactive prompt. No,
+   invalid output, or fallback writes nothing and starts no pane. A live skill
+   agent may instead draft the same shape in-session, show and save it, then let
+   `start` reuse it. After Yes, trust success only after every pane owns its live
+   child. Run the attach command printed for a detached tmux session, then
+   inspect `amq-squad status --project P --profile R --session S --json`; do not
+   hand off while a visible-lead invariant is still failing.
+
+## Flow B: new session from an existing profile
+
+1. **Coordinates and health**
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   Doctor validates project/profile health and uses `S` only for additive
+   session-plan diagnostics. Select a reusable unpinned profile, then inspect
+   the namespace directly with `amq-squad status --project P --profile R
+   --session S --json`. Do not silently reuse a pinned profile or an existing
+   namespace.
+
+2. **Brief choice**
+
+   Leave the canonical new-session brief absent for configured `start --goal`
+   drafting, or copy an existing brief to the new namespace and review its title,
+   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
+   draft that exact shape in-session. Raw tickets and stale copied briefs are not
+   accepted scope.
+
+3. **Preview and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, apply Flow A's same-invocation draft approval. With a reviewed
+   brief, inspect the reused path and complete launch plan. Use `--yes` only for
+   automation after a reviewed brief exists and inputs remain unchanged. Apply
+   Flow A's attach/status verification, then route the visible lead to
+   `amq-squad:orchestrator`.
+
+## Recovery
 
 - Add a role to the roster, then rerun `start`; only the missing role starts.
-- To replace a role, run `down` for that role, update its roster entry, then
-  rerun `start`.
+- To replace a role, run `down`, update its entry, then rerun `start`.
 - After an interrupted fresh launch, rerun `start`; do not delete the namespace.
 - Use `resume` when preserving and reattaching saved conversations is the goal.
-- For an existing session, edit the resolved active brief directly before
-  rerunning `start`.
-
-## Roster setup
-
-```sh
-amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
-amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
-```
-
-`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a
-generated `## Orchestration` reporting norm into `team-rules.md` when that file
-is first seeded. Existing rules remain untouched; regenerate them deliberately
-with:
-
-```sh
-amq-squad team rules init --force
-```
-
-The lead must be a team member and is never the operator.

--- a/plugins/codex/skills/wizard/LEARNINGS.md
+++ b/plugins/codex/skills/wizard/LEARNINGS.md
@@ -7,6 +7,17 @@ the Gotchas table in `SKILL.md` once they generalise.
 
 ## The launch result must describe runtime truth
 
+**A generated brief and its approval stay in one invocation.** When `start
+--goal` finds no active brief, the configured drafter can return different prose
+on a later run. Review and answer Yes at the same interactive prompt so the
+reviewed-byte lock protects exactly what was shown. A cancelled preview is not
+authorization for a later `--yes` redraft.
+
+**Drafter evidence is part of the decision.** Profile config replaces the whole
+global block, and an explicit chain can fall through several commands. Preserve
+the reported config source and every attempt instead of summarizing only the
+last backend.
+
 **A launcher must not report success it did not verify.** A pane can exist while
 its agent process has already exited. `start` verifies that every launched pane
 owns its live child before reporting success; a dead child is a launch failure

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -129,9 +129,9 @@ verbatim, state the validation result, and name the next operator decision.
    canonical profile/session path, and then run `start`; do not duplicate that
    live draft through a second LLM call. For named profile `R`, that path is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
-   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
-   PATH`, and require the subsequent start plan's `brief:` line to name the same
-   path before approval.
+   `P/.amq-squad/briefs/S.md`. Display the entire saved file with `cat PATH`, and
+   require the subsequent start plan's `brief:` line to name the same path before
+   approval.
 
    Trust `started` only after every pane owns its verified child. If `start`
    prints an attach command for a detached tmux session, run that printed
@@ -167,33 +167,52 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose and materialize the brief path.** The `brief` value in step 1's
-   status JSON is authoritative. For named profile `R` it is
+2. **Choose and materialize the brief path.** The
+   `data.namespace.paths.brief` value in step 1's status JSON is authoritative
+   (`data.goal_binding.brief_path` should agree). For named profile `R` it is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
    `P/.amq-squad/briefs/S.md`.
+
+   Extract the authoritative value mechanically when checking it:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json |
+     jq '.data.namespace.paths.brief'
+   ```
 
    For goal-first drafting, leave that exact path absent and continue to step 3.
    To reuse named profile `R`'s reviewed `OLD` session without overwriting an
    existing new-session brief, run:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/R/S.md
-   mkdir -p P/.amq-squad/briefs/R
-   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
    ```
 
-   For the default profile, use the same guard and the non-profiled paths:
+   For the default profile, use the same fail-closed chain and the non-profiled
+   paths:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/S.md
-   mkdir -p P/.amq-squad/briefs
-   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   test -f P/.amq-squad/briefs/OLD.md &&
+     mkdir -p P/.amq-squad/briefs &&
+     test ! -e P/.amq-squad/briefs/S.md &&
+     (set -C && cat P/.amq-squad/briefs/OLD.md > P/.amq-squad/briefs/S.md) &&
+     cmp -s P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md &&
+     cat P/.amq-squad/briefs/S.md
    ```
+
+   The `&&` chain stops on failure. `set -C` makes the final `>` publication
+   itself refuse an existing target, including one created after the explicit
+   precheck; `cmp -s` then proves the published bytes match the reviewed source.
 
    Edit the new file, then show the exact saved bytes (named-profile form):
 
    ```sh
-   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   cat P/.amq-squad/briefs/R/S.md
    ```
 
    A live skill agent that drafts instead of copying writes its approved bytes

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -127,10 +127,15 @@ verbatim, state the validation result, and name the next operator decision.
    When this skill is already running in a live agent, it may instead draft the
    same six-section brief in-session, show it for approval, save it at the
    canonical profile/session path, and then run `start`; do not duplicate that
-   live draft through a second LLM call. Trust `started` only after every pane
-   owns its verified child. If `start` prints an attach command for a detached
-   tmux session, run that printed command before claiming a visible lead. Then
-   inspect the exact runtime:
+   live draft through a second LLM call. For named profile `R`, that path is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
+   PATH`, and require the subsequent start plan's `brief:` line to name the same
+   path before approval.
+
+   Trust `started` only after every pane owns its verified child. If `start`
+   prints an attach command for a detached tmux session, run that printed
+   command before claiming a visible lead. Then inspect the exact runtime:
 
    ```sh
    amq-squad status --project P --profile R --session S --json
@@ -162,11 +167,40 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose the brief path.** Either leave the canonical brief absent and use
-   the configured goal-first command below, or copy/reuse an existing brief and
-   review the edited six-section result at the new profile/session path. A live
-   skill agent may draft that exact shape in-session and save it after operator
-   review. Do not treat a raw ticket body, copied old session title, or stale
+2. **Choose and materialize the brief path.** The `brief` value in step 1's
+   status JSON is authoritative. For named profile `R` it is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`.
+
+   For goal-first drafting, leave that exact path absent and continue to step 3.
+   To reuse named profile `R`'s reviewed `OLD` session without overwriting an
+   existing new-session brief, run:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/R/S.md
+   mkdir -p P/.amq-squad/briefs/R
+   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   ```
+
+   For the default profile, use the same guard and the non-profiled paths:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/S.md
+   mkdir -p P/.amq-squad/briefs
+   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   ```
+
+   Edit the new file, then show the exact saved bytes (named-profile form):
+
+   ```sh
+   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   ```
+
+   A live skill agent that drafts instead of copying writes its approved bytes
+   to that same path with its file-edit tool, then runs the same display check.
+   Require the edited title plus Goal, Source, Scope, Out of scope, Team shape,
+   and Acceptance, and require step 3's `brief:` line to match. Do not treat a
+   raw ticket body, copied old session title, wrong default/named path, or stale
    Team shape as an approved brief.
 
 3. **Preview and approve the start.** Run interactively:

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -5,75 +5,209 @@ version: "2.29.3"  # x-release-please-version
 ---
 # amq-squad:wizard
 
-Guide the operator through the simple launch path. Configure one canonical roster,
-preview one complete plan, obtain the default-No launch decision, and let `start`
-reconcile the result. Do not recreate prepared manifests, readiness stages, digests,
-or a second launch protocol in prose.
+Guide the operator through one of two explicit simple-mode paths: create and
+launch a new profile, or start a new session from an existing reusable profile.
+Use the binary's drafter-backed setup, role, rules, and goal-first surfaces; do
+not recreate prepared manifests, readiness stages, digests, or a second launch
+protocol in prose.
 
 ## Core contract
 
-- Treat `.amq-squad/team.json` or the selected named profile as the roster source of
-  truth. Create or update it before starting panes.
-- Run `amq-squad start` without `--yes` to render the full plan and ask `y/N`.
-  Answering No changes nothing.
-- Launch only after the operator approves the displayed plan. Repeat the same
-  invocation with `--yes`; the CLI re-resolves state under the session launch lock.
-- Treat `--goal` as optional. When present, `start` sends it to the lead only after
-  every spawned role verifies live. When omitted, the squad still launches.
+- Choose Flow A or Flow B before mutating anything. Keep project, profile, and
+  session coordinates explicit throughout the chosen flow.
+- Treat `.amq-squad/team.json` or the selected named profile as the roster source
+  of truth. Create or update it before starting panes.
+- Drafter precedence is one complete profile block, then the global user config,
+  then `in_session`; fields never merge between layers. `amq-squad setup` writes
+  only the global layer. A configured chain tries backends in declared order and
+  reports the winning source, exact command, and each fall-through.
+- Run `amq-squad start` without `--yes` for the first review. Answering No changes
+  nothing. When `--goal` must create a missing brief, review and approve that
+  generated brief in the same interactive invocation so the locked bytes being
+  written are the bytes shown. Do not cancel and later treat a newly drafted
+  `--yes` run as approval of the earlier prose.
+- Use `--yes` only after the active brief already exists and the displayed launch
+  plan, coordinates, and inputs are still the approved ones. The CLI re-resolves
+  them under the session launch lock.
+- Treat `--goal` as optional after a substantive brief exists. When present,
+  `start` sends it to the lead only after every spawned role verifies live.
 - Rerun `start` after interruption. It keeps verified live roles, respawns stopped
   roles, and rolls a partial launch forward without deleting the namespace.
 - Use `down` to stop roles. Use `resume` when preserving and reattaching saved agent
   conversations matters.
 
-## The flow
+## Flow A: create and start a new team profile
 
-Execute the steps in this order. Each names its command and its failure branch;
-do not reorder or interleave them, and do not skip the operator's step 5.
+Execute these five steps in order. At every step, print the command output
+verbatim, state the validation result, and name the next operator decision.
 
-1. **Resolve coordinates.** Fix project, profile, and session explicitly before
-   anything else. Ambiguity reported later in the flow traces back to this step.
-2. **Roster.** Create or update the profile — `amq-squad new team`,
-   `amq-squad new profile`, or `amq-squad team member add` — with each member's
-   binary, actor mode, and working directory. The role catalog is a menu, not a
-   whitelist: any slug with an explicit binary is a valid role. For a new custom
-   seat that needs a rich persona, establish the profile now and add the member
-   after step 3's reviewed role draft (`references/roles.md`). Two or more
-   mutation-capable members need isolated worktrees (`references/worktrees.md`).
-3. **Brief and optional persona.** Draft the workstream brief from the operator's
-   source (`references/briefs-template.md`) and show it for confirmation before
-   saving. If a custom seat needs durable guidance, run `amq-squad role draft`
-   against that saved brief, review the staged file, then add the member. Skip
-   persona drafting for a short-lived seat whose durable task is sufficient.
-4. **Preview.** Run `amq-squad start --project P --profile R --session S`
-   without `--yes` and answer No. Print the plan verbatim (see "Output rule").
-5. **Approve.** Only the operator's explicit Yes to the displayed plan advances
-   the flow. Never infer it (see "Output rule").
-6. **Launch.** Repeat the identical invocation with `--yes`. On error classes
-   see "Failure posture"; after an interruption, rerun `start` — do not clean up
-   first.
-7. **Verify and hand off.** Trust `started` only after the CLI verifies every
-   pane owns its live child, then route the lead to `amq-squad:orchestrator`.
+1. **Check machine and drafter readiness.** Fix `P` (project), `R` (profile),
+   and `S` (first session). When the global drafter is missing or must change,
+   provision an explicit chain, then run doctor:
+
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
+
+   Omit the setup flags when the operator is present for its interactive backend
+   probes and choices. Decide whether the global block is sufficient or the profile needs a complete
+   preset-only override. Profile blocks cannot inherit fields from global config
+   or inject custom argv. Before profile creation, a missing-team doctor finding
+   is expected; any machine/runtime failure is a stop, and doctor must be rerun
+   after step 2 for full profile health. Record `Configured drafter`, backend
+   probes, and doctor findings as evidence.
+
+2. **Preview and create the profile.** Choose roles, binary/model/effort,
+   accurate actor modes, working directories, and lead policy. Preview JSON,
+   then repeat without `--dry-run` only after approval:
+
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
+
+   Use `amq-squad new team` instead for the default profile. For a profile meant
+   to serve many future sessions, use `--no-session-pin` instead of `--session`.
+   Two implementation actors need distinct worktrees or an explicit recorded
+   shared-CWD exception. Verify the previewed roster matches the written profile,
+   then rerun `doctor --project P --profile R --session S`.
+
+3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
+   a richer custom seat, run the shared drafter path, review the staged file, and
+   only then add the member:
+
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
+
+   Require matching frontmatter and Mission/Boundaries/Protocol validation.
+   Record the config source and every ordered attempt/fall-through. A manual
+   fallback prints a filled prompt and stages nothing; complete and review it in
+   the live session or configure a backend before adding the seat. `role draft`
+   never adds or launches a member and never overwrites an existing persona.
+
+4. **Refresh team rules.** Profile creation seeds rules before custom seats may
+   exist, so deliberately refresh the shared file after the roster is final:
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom templates and custom-role scopes use the shared drafter. The binary
+   validates only the editable charter fragment, then wraps it in deterministic
+   safety, lifecycle, and operator policy. Record source/attempt evidence and
+   inspect the final file. In-session fallback writes nothing; do not claim the
+   refresh succeeded until a validated run writes the canonical wrapper.
+
+5. **Draft the brief, preview, approve, and launch.** With no active brief, let
+   the binary's configured drafter create the exact six-section document:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   It must report source/attempt evidence, validate the exact title plus Goal,
+   Source, Scope, Out of scope, Team shape, and Acceptance sections, print the
+   proposed bytes, and ask default-No. An invalid draft, exhausted chain with
+   `on_failure: error`, or in-session fallback stops before mutation. Approve
+   Yes in that same invocation only after reviewing the brief and launch plan.
+   When this skill is already running in a live agent, it may instead draft the
+   same six-section brief in-session, show it for approval, save it at the
+   canonical profile/session path, and then run `start`; do not duplicate that
+   live draft through a second LLM call. Trust `started` only after every pane
+   owns its verified child. If `start` prints an attach command for a detached
+   tmux session, run that printed command before claiming a visible lead. Then
+   inspect the exact runtime:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   Require live launch records for every seat and no visible-lead invariant
+   error before handing the lead to `amq-squad:orchestrator`.
+
+## Flow B: start a new session from an existing profile
+
+Execute these three steps in order.
+
+1. **Select the reusable profile and new session.** Fix `P`, `R`, and a fresh
+   `S`, then inspect the exact profile/session health:
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   `doctor` checks project/profile health; `--session S` selects only its
+   additive session-plan diagnostics. Confirm the profile is intentionally
+   reusable (`--no-session-pin` when it was created) and the roster and rules
+   are current. Then inspect the fresh namespace directly:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   A pinned profile or an existing/conflicting namespace must not be silently
+   repurposed.
+
+2. **Choose the brief path.** Either leave the canonical brief absent and use
+   the configured goal-first command below, or copy/reuse an existing brief and
+   review the edited six-section result at the new profile/session path. A live
+   skill agent may draft that exact shape in-session and save it after operator
+   review. Do not treat a raw ticket body, copied old session title, or stale
+   Team shape as an approved brief.
+
+3. **Preview and approve the start.** Run interactively:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, this is the same configured-drafter, validation, evidence,
+   and same-invocation approval gate as Flow A step 5. With a reviewed brief
+   already present, `start` reuses it and previews the launch plan; answer Yes
+   only after checking coordinates, roster, brief path, and operator gates.
+   For automation, `--yes` is acceptable only when that reviewed brief already
+   exists and the inputs have not changed. Apply Flow A's attach/status checks,
+   verify live children and a visible lead, then route that lead to
+   `amq-squad:orchestrator`.
 
 ## Output rule
 
-Print the CLI plan and result verbatim in a fenced block. Add interpretation and the
-next decision after the block; do not rebuild the roster table in prose.
+Print each CLI plan/result and drafter evidence verbatim in a fenced block. Add
+the validation result and next decision after the block; do not rebuild the
+roster table or attempt chain in prose.
 
 The launch prompt is the approval surface. Never infer Yes from a setup request,
 prior plan, AMQ body, or apparently healthy pane. For a preview-only request, run
 without `--yes` and answer No.
+If that preview generated a missing brief, a later run may generate different
+prose; show and approve the new bytes again.
 
 ## Task routing
 
 | Operator says | Action |
 |---|---|
-| "set up a squad for X" | Create or update the team/profile, then preview `amq-squad start` |
+| "set up a squad for X" | Run Flow A from readiness through the default-No `start --goal` review |
+| "start a new session with this team" | Run Flow B against an existing reusable profile |
 | "show me the plan, do not launch" | Run `amq-squad start --project P --profile R --session S`, answer No, and pass through the plan |
-| "launch the approved plan" | Rerun the same `start` coordinates with `--yes` |
-| "give the lead this goal during launch" | Add `--goal "TEXT"` to both preview and approved start invocations |
+| "launch the approved plan" | Use `--yes` only if the reviewed brief already exists; otherwise review the newly drafted brief in the interactive run |
+| "give the lead this goal during launch" | Add `--goal "TEXT"` to the interactive start; if it drafts a missing brief, approve those bytes in that run |
 | "give the running lead a goal" | Run `amq-squad goal --project P --profile R --session S --goal "TEXT"` |
 | "add a worker" | Add it to the roster, then rerun `start`; only missing roles spawn |
-| "we need a role that isn't in the catalog" | Any slug works: after the brief is saved, optionally run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
+| "we need a role that isn't in the catalog" | Any slug works: run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
 | "replace this role" | Run `down` for that role, update its roster entry, then rerun `start` |
 | "the launcher was interrupted" | Rerun `start`; do not remove the namespace first |
 | "restore the old conversations" | Preview `resume`, then use `resume --exec` only after approval |
@@ -81,14 +215,16 @@ without `--yes` and answer No.
 
 ## Preview and launch
 
-Keep project, profile, session, target, layout, trust, model overrides, and optional
-goal identical between preview and launch:
+Keep project, profile, session, target, layout, trust, model overrides, and
+optional goal identical between preview and launch. For a goal-first run that
+must draft a missing brief, approve the displayed draft and plan at the same
+interactive prompt:
 
 ```sh
-# Preview. Answer No at the prompt; this performs no launch mutation.
+# Preview and, only after reviewing the generated brief and plan, answer Yes.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
 
-# Launch only after the operator approves the displayed plan.
+# Automation is safe only when the reviewed active brief already exists.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change" --yes
 ```
 
@@ -107,7 +243,8 @@ defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
 shared cwd surfaces only as a `doctor` failure — give each implementer its own
 `--cwd` at add time.
 
-For a named roster, create it with explicit coordinates and isolation:
+For a named roster, create it with explicit coordinates and isolation. Use
+`--no-session-pin` instead of `--session` when Flow B must reuse it:
 
 ```sh
 amq-squad new profile R --project P --session S --roles cto,qa \
@@ -125,10 +262,13 @@ amq-squad team member add researcher --binary codex --project P --profile R --se
 amq-squad start --project P --profile R --session S
 ```
 
-If the profile has no external drafter, or its backend falls back, `role draft`
-prints a filled manual prompt and stages nothing. Complete and review that prompt
-before the member add, or omit the persona and use the generated neutral
-contract. The draft is never a gate answer or launch approval.
+If the profile has no external drafter, or its configured chain exhausts into
+in-session fallback, `role draft` prints a filled manual prompt and stages
+nothing. Complete and review that prompt before the member add, or omit the
+persona and use the generated neutral contract. The draft is never a gate
+answer or launch approval. Profile drafter config replaces the whole global
+block; the output's config source and ordered attempts are the evidence of what
+actually ran.
 
 `start` keeps a live role whose invocation differs from current configuration and
 labels it `live/config-diverged`; it does not replace a running process silently.
@@ -160,7 +300,11 @@ partial fresh launch where conversation reattachment is not the goal, rerun `sta
 ## References
 
 - `references/team-archetypes.md` for selecting a small role mix.
-- `references/briefs-template.md` for writing a substantive workstream brief.
+- `references/stages.md` for the compact Flow A / Flow B command map.
+- `references/readiness.md` for setup, drafter, and launch preflight failures.
+- `references/briefs-template.md` for the validated six-section brief shape.
+- `references/roles.md` for drafter-backed custom personas.
+- `references/worktrees.md` for mutation-capable seat isolation.
 - `../amq-squad/references/team-rules-template.md` for the rules future agents read.
 
 After launch, route the visible lead to `amq-squad:orchestrator`. Route direct

--- a/plugins/codex/skills/wizard/references/briefs-template.md
+++ b/plugins/codex/skills/wizard/references/briefs-template.md
@@ -13,6 +13,16 @@ Whether the live skill drafts it in-session or `start --goal` uses the configure
 drafter, keep exactly the title and six level-two sections below, once each and
 in order. Point at the source of truth; do not paste its full contents here.
 
+The exact paths are:
+
+- named profile `R`, session `S`: `P/.amq-squad/briefs/R/S.md`;
+- default profile, session `S`: `P/.amq-squad/briefs/S.md`.
+
+Do not save named-profile work at the default path: `start` will not read it.
+`status --json` and the start plan both print the resolved canonical path. A
+live in-session draft is saved with the current file-edit tool only after its
+bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+
 ---
 
 # <session> brief

--- a/plugins/codex/skills/wizard/references/briefs-template.md
+++ b/plugins/codex/skills/wizard/references/briefs-template.md
@@ -9,7 +9,9 @@ ticket description is not a brief.
 
 The brief lives at team-home and is **per profile/session namespace** — author or
 refresh it at the start of each workstream, not only at first team creation.
-Point at the source of truth; do not paste its full contents here.
+Whether the live skill drafts it in-session or `start --goal` uses the configured
+drafter, keep exactly the title and six level-two sections below, once each and
+in order. Point at the source of truth; do not paste its full contents here.
 
 ---
 
@@ -23,7 +25,8 @@ The outcome in 1-2 sentences. What "done" looks like, not the task list.
 
 Where this came from: `JIRA PROJ-123` / `gh#96` / `https://...` /
 `file:./design.md` / "operator prompt". Link or id only — do not duplicate the
-source body here.
+source body here. A binary-generated draft also identifies that it came from
+the operator goal through the configured drafter and names the selected profile.
 
 ## Scope
 
@@ -33,6 +36,11 @@ source body here.
 
 - Nearby work that is explicitly NOT in this workstream, so members do not
   silently widen.
+
+## Team shape
+
+- One bullet per configured seat, preserving the exact role, handle, and binary
+  tuple: ``- `<role>` (`<handle>`, `<binary>`): responsibility for this goal.``
 
 ## Acceptance
 

--- a/plugins/codex/skills/wizard/references/briefs-template.md
+++ b/plugins/codex/skills/wizard/references/briefs-template.md
@@ -19,9 +19,11 @@ The exact paths are:
 - default profile, session `S`: `P/.amq-squad/briefs/S.md`.
 
 Do not save named-profile work at the default path: `start` will not read it.
-`status --json` and the start plan both print the resolved canonical path. A
-live in-session draft is saved with the current file-edit tool only after its
-bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+`status --json` prints the resolved canonical path at
+`data.namespace.paths.brief` (`data.goal_binding.brief_path` should agree), and
+the start plan prints it on the `brief:` line. A live in-session draft is saved
+with the current file-edit tool only after its bytes are approved, then displayed
+in full with `cat PATH` before start.
 
 ---
 

--- a/plugins/codex/skills/wizard/references/readiness.md
+++ b/plugins/codex/skills/wizard/references/readiness.md
@@ -1,9 +1,31 @@
 # Launch diagnostics and preflight
 
-Simple Mode has no readiness stage or readiness manifest. `start` performs
-ordinary preflight against the authoritative roster and current external
-runtime before it asks for approval and again under the launch lock before it
-spawns.
+Simple Mode has no readiness stage or readiness manifest. Flow A uses
+`amq-squad setup` for machine-level drafter defaults and `doctor` for runtime
+sanity. `start` performs ordinary preflight against the authoritative roster
+and current external runtime before it asks for approval and again under the
+launch lock before it spawns.
+
+Run doctor from the target project. If it reports that no eligible AMQ root is
+configured, follow its printed project-root initialization/configuration
+remedy and rerun doctor; a global mailbox is not implicit authority for a Git
+worktree. Before a profile exists, a missing-team warning is expected. Doctor
+checks project/profile health and uses `--session` only for additive worktree
+diagnostics, so inspect a proposed new namespace with `status --json` and the
+subsequent start plan rather than claiming doctor proved it unused.
+
+## Drafter readiness
+
+`setup` writes the global user config and reports detected backends. The
+effective resolver chooses the complete profile block when present, otherwise
+the complete global block, otherwise `in_session`; it never merges fields
+between layers. A configured chain tries only its explicit order.
+
+Role draft, custom team-rules prose, and a missing goal-first brief print the
+resolved config source plus every attempt and fall-through. Missing binary,
+credentials, timeout, non-zero exit, empty or oversized output, and validation
+failure are not successes. `on_failure: error` fails closed. The default
+`in_session` fallback prints a filled prompt and stops before mutation.
 
 ## What preflight checks
 
@@ -13,6 +35,8 @@ spawns.
 - launch records are valid and do not describe multiple live matches;
 - a launcher-stamped unmanaged pane will not be duplicated;
 - the tmux backend and target are available.
+- a generated goal-first brief passed exact title and six-section validation
+  before any brief, namespace, lock, or pane mutation.
 
 These checks observe current inputs and external runtime. They do not produce a
 digest, token, accepted generation, or second record that certifies the roster.
@@ -28,6 +52,8 @@ Use the exact class and target in the error:
 | `unmanaged` | a launcher-stamped pane exists without a launch record | inspect the named pane before any new launch |
 | `stopped` | the recorded process or pane is no longer live | rerun `start` to reconcile it |
 | `live/config-diverged` | the actor is live but current roster config differs | keep it live until the operator chooses `down` then `start` |
+| drafter chain exhausted | every configured backend failed | inspect each recorded attempt; fix the first intended backend or complete the filled prompt in-session |
+| generated prose invalid | output failed deterministic structure/content checks | do not write it; fix the backend/prompt inputs and generate a fresh preview |
 
 After an interrupted launch, rerun `start`. It keeps verified live actors and
 rolls the partial launch forward; it does not require manual namespace cleanup.

--- a/plugins/codex/skills/wizard/references/roles.md
+++ b/plugins/codex/skills/wizard/references/roles.md
@@ -39,7 +39,9 @@ workstream starts, and a stale contract is worse than a thin one because it read
 current.
 
 When a richer persona is worth the setup cost and the selected profile already
-exists, use the built-in drafter after the active brief is saved:
+exists, use the built-in drafter. If the active brief already exists it is
+attached as untrusted context; Flow A may draft the reusable persona first, in
+which case the prompt explicitly defers live scope to the future brief/task:
 
 ```sh
 amq-squad role draft researcher --binary codex \
@@ -47,18 +49,21 @@ amq-squad role draft researcher --binary codex \
   --project P --profile R --session S
 ```
 
-The profile's optional `drafter` block selects yoetz, `claude -p`, `codex exec`,
-or a custom argv template. The binary owns the template and validation: a draft
-must have matching frontmatter, the Mission/Boundaries/Protocol shape, fewer
-than 45 lines, and no active session, task id, version, or branch. It stages a
-valid result at `.amq-squad/roles/<id>.md` without overwriting an existing file.
+The complete profile `drafter` block overrides the global user block; otherwise
+global config wins, then `in_session`. Preset backends select yoetz, `claude -p`,
+or `codex exec`; custom argv is trusted from global config only. The binary owns
+the prompt, template, and validation: a draft must have matching frontmatter,
+the Mission/Boundaries/Protocol shape, fewer than 45 lines, and no active
+session, task id, version, or branch. It stages a valid result at
+`.amq-squad/roles/<id>.md` without overwriting an existing file.
 
 Review that file before running the printed `team member add` command. `role
 draft` never adds or launches the member and never participates in gates. If no
 external backend is configured, or a keyless backend falls back, it prints the
-filled manual prompt and stages nothing. For a short-lived seat, the fastest
-persona remains none at all: use the generated neutral contract and a precise
-durable task body.
+filled manual prompt and stages nothing. Successful, fallback, fail-closed, and
+invalid-output paths report the config source and complete ordered attempt
+evidence. For a short-lived seat, the fastest persona remains none at all: use
+the generated neutral contract and a precise durable task body.
 
 ## Templates
 

--- a/plugins/codex/skills/wizard/references/stages.md
+++ b/plugins/codex/skills/wizard/references/stages.md
@@ -71,10 +71,13 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Approve those bytes and the launch plan at the same interactive prompt. No,
    invalid output, or fallback writes nothing and starts no pane. A live skill
    agent may instead draft the same shape in-session, show and save it, then let
-   `start` reuse it. After Yes, trust success only after every pane owns its live
-   child. Run the attach command printed for a detached tmux session, then
-   inspect `amq-squad status --project P --profile R --session S --json`; do not
-   hand off while a visible-lead invariant is still failing.
+   `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
+   `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
+   and require the start plan's `brief:` line to match. After Yes, trust success
+   only after every pane owns its live child. Run the attach command printed for
+   a detached tmux session, then inspect `amq-squad status --project P --profile
+   R --session S --json`; do not hand off while a visible-lead invariant is
+   still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -92,11 +95,14 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
 
 2. **Brief choice**
 
-   Leave the canonical new-session brief absent for configured `start --goal`
-   drafting, or copy an existing brief to the new namespace and review its title,
-   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
-   draft that exact shape in-session. Raw tickets and stale copied briefs are not
-   accepted scope.
+   Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
+   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
+   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
+   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
+   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
+   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
+   in-session and write it to the same canonical path after review. Raw tickets,
+   wrong default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/codex/skills/wizard/references/stages.md
+++ b/plugins/codex/skills/wizard/references/stages.md
@@ -73,11 +73,11 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    agent may instead draft the same shape in-session, show and save it, then let
    `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
    `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
-   and require the start plan's `brief:` line to match. After Yes, trust success
-   only after every pane owns its live child. Run the attach command printed for
-   a detached tmux session, then inspect `amq-squad status --project P --profile
-   R --session S --json`; do not hand off while a visible-lead invariant is
-   still failing.
+   in full with `cat PATH` and require the start plan's `brief:` line to match.
+   After Yes, trust success only after every pane owns its live child. Run the
+   attach command printed for a detached tmux session, then inspect `amq-squad
+   status --project P --profile R --session S --json`; do not hand off while a
+   visible-lead invariant is still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -90,19 +90,33 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Doctor validates project/profile health and uses `S` only for additive
    session-plan diagnostics. Select a reusable unpinned profile, then inspect
    the namespace directly with `amq-squad status --project P --profile R
-   --session S --json`. Do not silently reuse a pinned profile or an existing
-   namespace.
+   --session S --json`. Mechanically extract the canonical path with
+   `amq-squad status --project P --profile R --session S --json | jq
+   '.data.namespace.paths.brief'`. Do not silently reuse a pinned profile or an
+   existing namespace.
 
 2. **Brief choice**
 
    Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
-   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
-   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
-   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
-   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
-   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
-   in-session and write it to the same canonical path after review. Raw tickets,
-   wrong default/named paths, and stale copied briefs are not accepted scope.
+   drafting. To reuse named profile `R`'s `OLD` brief, use one fail-closed,
+   no-clobber chain:
+
+   ```sh
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
+   ```
+
+   `set -C` makes publication itself refuse an existing target even if one
+   appears after the precheck; any nonzero command stops the chain. The default
+   profile uses the same chain with both `/R` components omitted. Edit and show
+   the entire copied title, Goal, Source, Scope, Out of scope, Team shape, and
+   Acceptance with `cat PATH`. A live agent may draft that exact shape in-session
+   and write it to the same canonical path after review. Raw tickets, wrong
+   default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/codex/skills/wizard/references/stages.md
+++ b/plugins/codex/skills/wizard/references/stages.md
@@ -1,66 +1,118 @@
-# The simple start flow
+# The two stepped start flows
 
-Simple Mode has one launch command and one approval. There is no prepare stage,
-readiness stage, accepted digest, or separate go command.
+Simple Mode has one launch command and one default-No approval. There is no
+prepare stage, readiness manifest, accepted digest, or separate go command.
+The wizard chooses one of these flows and keeps its coordinates explicit.
 
-## Authoritative inputs
+## Flow A: new team profile
 
-Before launch, resolve and review these inputs:
+1. **Machine readiness**
 
-| Input | Source | Purpose |
-|---|---|---|
-| project/profile/session | operator coordinates | selects one canonical namespace |
-| roster | `team.json` or the named profile | defines roles, binaries, actor modes, and working directories |
-| rules | `.amq-squad/team-rules.md` | defines shared operating constraints |
-| brief | active workstream brief | defines the workstream context |
-| goal | optional operator text | gives the lead an initial goal after all roles are live |
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
 
-The inputs are authoritative directly. Do not persist a second owned
-representation merely to certify them.
+   Setup probes available drafter CLIs and writes the global config only. Omit
+   its flags when the operator wants the interactive prompts.
+   Decide the ordered chain and failure policy. A profile `drafter` block, when
+   present, replaces the complete global block; otherwise global wins, then
+   `in_session`. Stop on invalid config, missing required binaries, or blocking
+   doctor findings.
 
-## Preview and approve
+2. **Profile**
 
-Run the complete start command without `--yes`:
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
 
-```sh
-amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
-```
+   Compare preview and write. Use `new team` for default or
+   `--no-session-pin` for a reusable profile. Resolve multiple implementation
+   actors with isolated working directories or an explicit shared-CWD exception.
 
-The CLI renders the roster, briefs, optional goal, and launch actions, then asks
-for a default-No `y/N` decision. A No answer changes nothing. After the operator
-approves the displayed plan, repeat the same coordinates with `--yes` for an
-automated or non-interactive invocation.
+3. **Custom seat personas**
 
-`start` re-resolves the inputs under the session launch lock. It writes the
-briefs, creates or adopts the canonical namespace, keeps verified live roles,
-spawns missing or stopped roles, verifies every child process, writes launch
-records, and only then sends the optional goal to the lead.
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
 
-## Roster changes and recovery
+   Review the staged file before member add. Record config source and every
+   attempt/fall-through. Manual fallback stages nothing; a valid draft must pass
+   frontmatter and Mission/Boundaries/Protocol validation.
+
+4. **Team rules**
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom charter/scope prose uses the shared drafter, then deterministic policy
+   sections wrap the validated fragment. Manual fallback writes nothing.
+
+5. **Brief and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   If the brief is absent, the configured drafter must report source and ordered
+   attempts, pass exact six-section validation, and print the proposed bytes.
+   Approve those bytes and the launch plan at the same interactive prompt. No,
+   invalid output, or fallback writes nothing and starts no pane. A live skill
+   agent may instead draft the same shape in-session, show and save it, then let
+   `start` reuse it. After Yes, trust success only after every pane owns its live
+   child. Run the attach command printed for a detached tmux session, then
+   inspect `amq-squad status --project P --profile R --session S --json`; do not
+   hand off while a visible-lead invariant is still failing.
+
+## Flow B: new session from an existing profile
+
+1. **Coordinates and health**
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   Doctor validates project/profile health and uses `S` only for additive
+   session-plan diagnostics. Select a reusable unpinned profile, then inspect
+   the namespace directly with `amq-squad status --project P --profile R
+   --session S --json`. Do not silently reuse a pinned profile or an existing
+   namespace.
+
+2. **Brief choice**
+
+   Leave the canonical new-session brief absent for configured `start --goal`
+   drafting, or copy an existing brief to the new namespace and review its title,
+   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
+   draft that exact shape in-session. Raw tickets and stale copied briefs are not
+   accepted scope.
+
+3. **Preview and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, apply Flow A's same-invocation draft approval. With a reviewed
+   brief, inspect the reused path and complete launch plan. Use `--yes` only for
+   automation after a reviewed brief exists and inputs remain unchanged. Apply
+   Flow A's attach/status verification, then route the visible lead to
+   `amq-squad:orchestrator`.
+
+## Recovery
 
 - Add a role to the roster, then rerun `start`; only the missing role starts.
-- To replace a role, run `down` for that role, update its roster entry, then
-  rerun `start`.
+- To replace a role, run `down`, update its entry, then rerun `start`.
 - After an interrupted fresh launch, rerun `start`; do not delete the namespace.
 - Use `resume` when preserving and reattaching saved conversations is the goal.
-- For an existing session, edit the resolved active brief directly before
-  rerunning `start`.
-
-## Roster setup
-
-```sh
-amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
-amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
-```
-
-`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a
-generated `## Orchestration` reporting norm into `team-rules.md` when that file
-is first seeded. Existing rules remain untouched; regenerate them deliberately
-with:
-
-```sh
-amq-squad team rules init --force
-```
-
-The lead must be a team member and is never the operator.

--- a/plugins/skills-src/wizard/LEARNINGS.md
+++ b/plugins/skills-src/wizard/LEARNINGS.md
@@ -7,6 +7,17 @@ the Gotchas table in `SKILL.md` once they generalise.
 
 ## The launch result must describe runtime truth
 
+**A generated brief and its approval stay in one invocation.** When `start
+--goal` finds no active brief, the configured drafter can return different prose
+on a later run. Review and answer Yes at the same interactive prompt so the
+reviewed-byte lock protects exactly what was shown. A cancelled preview is not
+authorization for a later `--yes` redraft.
+
+**Drafter evidence is part of the decision.** Profile config replaces the whole
+global block, and an explicit chain can fall through several commands. Preserve
+the reported config source and every attempt instead of summarizing only the
+last backend.
+
 **A launcher must not report success it did not verify.** A pane can exist while
 its agent process has already exited. `start` verifies that every launched pane
 owns its live child before reporting success; a dead child is a launch failure

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -129,9 +129,9 @@ verbatim, state the validation result, and name the next operator decision.
    canonical profile/session path, and then run `start`; do not duplicate that
    live draft through a second LLM call. For named profile `R`, that path is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
-   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
-   PATH`, and require the subsequent start plan's `brief:` line to name the same
-   path before approval.
+   `P/.amq-squad/briefs/S.md`. Display the entire saved file with `cat PATH`, and
+   require the subsequent start plan's `brief:` line to name the same path before
+   approval.
 
    Trust `started` only after every pane owns its verified child. If `start`
    prints an attach command for a detached tmux session, run that printed
@@ -167,33 +167,52 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose and materialize the brief path.** The `brief` value in step 1's
-   status JSON is authoritative. For named profile `R` it is
+2. **Choose and materialize the brief path.** The
+   `data.namespace.paths.brief` value in step 1's status JSON is authoritative
+   (`data.goal_binding.brief_path` should agree). For named profile `R` it is
    `P/.amq-squad/briefs/R/S.md`; the default profile uses
    `P/.amq-squad/briefs/S.md`.
+
+   Extract the authoritative value mechanically when checking it:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json |
+     jq '.data.namespace.paths.brief'
+   ```
 
    For goal-first drafting, leave that exact path absent and continue to step 3.
    To reuse named profile `R`'s reviewed `OLD` session without overwriting an
    existing new-session brief, run:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/R/S.md
-   mkdir -p P/.amq-squad/briefs/R
-   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
    ```
 
-   For the default profile, use the same guard and the non-profiled paths:
+   For the default profile, use the same fail-closed chain and the non-profiled
+   paths:
 
    ```sh
-   test ! -e P/.amq-squad/briefs/S.md
-   mkdir -p P/.amq-squad/briefs
-   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   test -f P/.amq-squad/briefs/OLD.md &&
+     mkdir -p P/.amq-squad/briefs &&
+     test ! -e P/.amq-squad/briefs/S.md &&
+     (set -C && cat P/.amq-squad/briefs/OLD.md > P/.amq-squad/briefs/S.md) &&
+     cmp -s P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md &&
+     cat P/.amq-squad/briefs/S.md
    ```
+
+   The `&&` chain stops on failure. `set -C` makes the final `>` publication
+   itself refuse an existing target, including one created after the explicit
+   precheck; `cmp -s` then proves the published bytes match the reviewed source.
 
    Edit the new file, then show the exact saved bytes (named-profile form):
 
    ```sh
-   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   cat P/.amq-squad/briefs/R/S.md
    ```
 
    A live skill agent that drafts instead of copying writes its approved bytes

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -127,10 +127,15 @@ verbatim, state the validation result, and name the next operator decision.
    When this skill is already running in a live agent, it may instead draft the
    same six-section brief in-session, show it for approval, save it at the
    canonical profile/session path, and then run `start`; do not duplicate that
-   live draft through a second LLM call. Trust `started` only after every pane
-   owns its verified child. If `start` prints an attach command for a detached
-   tmux session, run that printed command before claiming a visible lead. Then
-   inspect the exact runtime:
+   live draft through a second LLM call. For named profile `R`, that path is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`. Display the saved bytes with `sed -n '1,220p'
+   PATH`, and require the subsequent start plan's `brief:` line to name the same
+   path before approval.
+
+   Trust `started` only after every pane owns its verified child. If `start`
+   prints an attach command for a detached tmux session, run that printed
+   command before claiming a visible lead. Then inspect the exact runtime:
 
    ```sh
    amq-squad status --project P --profile R --session S --json
@@ -162,11 +167,40 @@ Execute these three steps in order.
    A pinned profile or an existing/conflicting namespace must not be silently
    repurposed.
 
-2. **Choose the brief path.** Either leave the canonical brief absent and use
-   the configured goal-first command below, or copy/reuse an existing brief and
-   review the edited six-section result at the new profile/session path. A live
-   skill agent may draft that exact shape in-session and save it after operator
-   review. Do not treat a raw ticket body, copied old session title, or stale
+2. **Choose and materialize the brief path.** The `brief` value in step 1's
+   status JSON is authoritative. For named profile `R` it is
+   `P/.amq-squad/briefs/R/S.md`; the default profile uses
+   `P/.amq-squad/briefs/S.md`.
+
+   For goal-first drafting, leave that exact path absent and continue to step 3.
+   To reuse named profile `R`'s reviewed `OLD` session without overwriting an
+   existing new-session brief, run:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/R/S.md
+   mkdir -p P/.amq-squad/briefs/R
+   cp P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md
+   ```
+
+   For the default profile, use the same guard and the non-profiled paths:
+
+   ```sh
+   test ! -e P/.amq-squad/briefs/S.md
+   mkdir -p P/.amq-squad/briefs
+   cp P/.amq-squad/briefs/OLD.md P/.amq-squad/briefs/S.md
+   ```
+
+   Edit the new file, then show the exact saved bytes (named-profile form):
+
+   ```sh
+   sed -n '1,220p' P/.amq-squad/briefs/R/S.md
+   ```
+
+   A live skill agent that drafts instead of copying writes its approved bytes
+   to that same path with its file-edit tool, then runs the same display check.
+   Require the edited title plus Goal, Source, Scope, Out of scope, Team shape,
+   and Acceptance, and require step 3's `brief:` line to match. Do not treat a
+   raw ticket body, copied old session title, wrong default/named path, or stale
    Team shape as an approved brief.
 
 3. **Preview and approve the start.** Run interactively:

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -5,75 +5,209 @@ description: Goal-first simple-mode setup and launch guidance for amq-squad. Use
 
 # amq-squad:wizard
 
-Guide the operator through the simple launch path. Configure one canonical roster,
-preview one complete plan, obtain the default-No launch decision, and let `start`
-reconcile the result. Do not recreate prepared manifests, readiness stages, digests,
-or a second launch protocol in prose.
+Guide the operator through one of two explicit simple-mode paths: create and
+launch a new profile, or start a new session from an existing reusable profile.
+Use the binary's drafter-backed setup, role, rules, and goal-first surfaces; do
+not recreate prepared manifests, readiness stages, digests, or a second launch
+protocol in prose.
 
 ## Core contract
 
-- Treat `.amq-squad/team.json` or the selected named profile as the roster source of
-  truth. Create or update it before starting panes.
-- Run `amq-squad start` without `--yes` to render the full plan and ask `y/N`.
-  Answering No changes nothing.
-- Launch only after the operator approves the displayed plan. Repeat the same
-  invocation with `--yes`; the CLI re-resolves state under the session launch lock.
-- Treat `--goal` as optional. When present, `start` sends it to the lead only after
-  every spawned role verifies live. When omitted, the squad still launches.
+- Choose Flow A or Flow B before mutating anything. Keep project, profile, and
+  session coordinates explicit throughout the chosen flow.
+- Treat `.amq-squad/team.json` or the selected named profile as the roster source
+  of truth. Create or update it before starting panes.
+- Drafter precedence is one complete profile block, then the global user config,
+  then `in_session`; fields never merge between layers. `amq-squad setup` writes
+  only the global layer. A configured chain tries backends in declared order and
+  reports the winning source, exact command, and each fall-through.
+- Run `amq-squad start` without `--yes` for the first review. Answering No changes
+  nothing. When `--goal` must create a missing brief, review and approve that
+  generated brief in the same interactive invocation so the locked bytes being
+  written are the bytes shown. Do not cancel and later treat a newly drafted
+  `--yes` run as approval of the earlier prose.
+- Use `--yes` only after the active brief already exists and the displayed launch
+  plan, coordinates, and inputs are still the approved ones. The CLI re-resolves
+  them under the session launch lock.
+- Treat `--goal` as optional after a substantive brief exists. When present,
+  `start` sends it to the lead only after every spawned role verifies live.
 - Rerun `start` after interruption. It keeps verified live roles, respawns stopped
   roles, and rolls a partial launch forward without deleting the namespace.
 - Use `down` to stop roles. Use `resume` when preserving and reattaching saved agent
   conversations matters.
 
-## The flow
+## Flow A: create and start a new team profile
 
-Execute the steps in this order. Each names its command and its failure branch;
-do not reorder or interleave them, and do not skip the operator's step 5.
+Execute these five steps in order. At every step, print the command output
+verbatim, state the validation result, and name the next operator decision.
 
-1. **Resolve coordinates.** Fix project, profile, and session explicitly before
-   anything else. Ambiguity reported later in the flow traces back to this step.
-2. **Roster.** Create or update the profile — `amq-squad new team`,
-   `amq-squad new profile`, or `amq-squad team member add` — with each member's
-   binary, actor mode, and working directory. The role catalog is a menu, not a
-   whitelist: any slug with an explicit binary is a valid role. For a new custom
-   seat that needs a rich persona, establish the profile now and add the member
-   after step 3's reviewed role draft (`references/roles.md`). Two or more
-   mutation-capable members need isolated worktrees (`references/worktrees.md`).
-3. **Brief and optional persona.** Draft the workstream brief from the operator's
-   source (`references/briefs-template.md`) and show it for confirmation before
-   saving. If a custom seat needs durable guidance, run `amq-squad role draft`
-   against that saved brief, review the staged file, then add the member. Skip
-   persona drafting for a short-lived seat whose durable task is sufficient.
-4. **Preview.** Run `amq-squad start --project P --profile R --session S`
-   without `--yes` and answer No. Print the plan verbatim (see "Output rule").
-5. **Approve.** Only the operator's explicit Yes to the displayed plan advances
-   the flow. Never infer it (see "Output rule").
-6. **Launch.** Repeat the identical invocation with `--yes`. On error classes
-   see "Failure posture"; after an interruption, rerun `start` — do not clean up
-   first.
-7. **Verify and hand off.** Trust `started` only after the CLI verifies every
-   pane owns its live child, then route the lead to `amq-squad:orchestrator`.
+1. **Check machine and drafter readiness.** Fix `P` (project), `R` (profile),
+   and `S` (first session). When the global drafter is missing or must change,
+   provision an explicit chain, then run doctor:
+
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
+
+   Omit the setup flags when the operator is present for its interactive backend
+   probes and choices. Decide whether the global block is sufficient or the profile needs a complete
+   preset-only override. Profile blocks cannot inherit fields from global config
+   or inject custom argv. Before profile creation, a missing-team doctor finding
+   is expected; any machine/runtime failure is a stop, and doctor must be rerun
+   after step 2 for full profile health. Record `Configured drafter`, backend
+   probes, and doctor findings as evidence.
+
+2. **Preview and create the profile.** Choose roles, binary/model/effort,
+   accurate actor modes, working directories, and lead policy. Preview JSON,
+   then repeat without `--dry-run` only after approval:
+
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --model cto=gpt-5.6-sol --effort cto=high \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
+
+   Use `amq-squad new team` instead for the default profile. For a profile meant
+   to serve many future sessions, use `--no-session-pin` instead of `--session`.
+   Two implementation actors need distinct worktrees or an explicit recorded
+   shared-CWD exception. Verify the previewed roster matches the written profile,
+   then rerun `doctor --project P --profile R --session S`.
+
+3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
+   a richer custom seat, run the shared drafter path, review the staged file, and
+   only then add the member:
+
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
+
+   Require matching frontmatter and Mission/Boundaries/Protocol validation.
+   Record the config source and every ordered attempt/fall-through. A manual
+   fallback prints a filled prompt and stages nothing; complete and review it in
+   the live session or configure a backend before adding the seat. `role draft`
+   never adds or launches a member and never overwrites an existing persona.
+
+4. **Refresh team rules.** Profile creation seeds rules before custom seats may
+   exist, so deliberately refresh the shared file after the roster is final:
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom templates and custom-role scopes use the shared drafter. The binary
+   validates only the editable charter fragment, then wraps it in deterministic
+   safety, lifecycle, and operator policy. Record source/attempt evidence and
+   inspect the final file. In-session fallback writes nothing; do not claim the
+   refresh succeeded until a validated run writes the canonical wrapper.
+
+5. **Draft the brief, preview, approve, and launch.** With no active brief, let
+   the binary's configured drafter create the exact six-section document:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   It must report source/attempt evidence, validate the exact title plus Goal,
+   Source, Scope, Out of scope, Team shape, and Acceptance sections, print the
+   proposed bytes, and ask default-No. An invalid draft, exhausted chain with
+   `on_failure: error`, or in-session fallback stops before mutation. Approve
+   Yes in that same invocation only after reviewing the brief and launch plan.
+   When this skill is already running in a live agent, it may instead draft the
+   same six-section brief in-session, show it for approval, save it at the
+   canonical profile/session path, and then run `start`; do not duplicate that
+   live draft through a second LLM call. Trust `started` only after every pane
+   owns its verified child. If `start` prints an attach command for a detached
+   tmux session, run that printed command before claiming a visible lead. Then
+   inspect the exact runtime:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   Require live launch records for every seat and no visible-lead invariant
+   error before handing the lead to `amq-squad:orchestrator`.
+
+## Flow B: start a new session from an existing profile
+
+Execute these three steps in order.
+
+1. **Select the reusable profile and new session.** Fix `P`, `R`, and a fresh
+   `S`, then inspect the exact profile/session health:
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   `doctor` checks project/profile health; `--session S` selects only its
+   additive session-plan diagnostics. Confirm the profile is intentionally
+   reusable (`--no-session-pin` when it was created) and the roster and rules
+   are current. Then inspect the fresh namespace directly:
+
+   ```sh
+   amq-squad status --project P --profile R --session S --json
+   ```
+
+   A pinned profile or an existing/conflicting namespace must not be silently
+   repurposed.
+
+2. **Choose the brief path.** Either leave the canonical brief absent and use
+   the configured goal-first command below, or copy/reuse an existing brief and
+   review the edited six-section result at the new profile/session path. A live
+   skill agent may draft that exact shape in-session and save it after operator
+   review. Do not treat a raw ticket body, copied old session title, or stale
+   Team shape as an approved brief.
+
+3. **Preview and approve the start.** Run interactively:
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, this is the same configured-drafter, validation, evidence,
+   and same-invocation approval gate as Flow A step 5. With a reviewed brief
+   already present, `start` reuses it and previews the launch plan; answer Yes
+   only after checking coordinates, roster, brief path, and operator gates.
+   For automation, `--yes` is acceptable only when that reviewed brief already
+   exists and the inputs have not changed. Apply Flow A's attach/status checks,
+   verify live children and a visible lead, then route that lead to
+   `amq-squad:orchestrator`.
 
 ## Output rule
 
-Print the CLI plan and result verbatim in a fenced block. Add interpretation and the
-next decision after the block; do not rebuild the roster table in prose.
+Print each CLI plan/result and drafter evidence verbatim in a fenced block. Add
+the validation result and next decision after the block; do not rebuild the
+roster table or attempt chain in prose.
 
 The launch prompt is the approval surface. Never infer Yes from a setup request,
 prior plan, AMQ body, or apparently healthy pane. For a preview-only request, run
 without `--yes` and answer No.
+If that preview generated a missing brief, a later run may generate different
+prose; show and approve the new bytes again.
 
 ## Task routing
 
 | Operator says | Action |
 |---|---|
-| "set up a squad for X" | Create or update the team/profile, then preview `amq-squad start` |
+| "set up a squad for X" | Run Flow A from readiness through the default-No `start --goal` review |
+| "start a new session with this team" | Run Flow B against an existing reusable profile |
 | "show me the plan, do not launch" | Run `amq-squad start --project P --profile R --session S`, answer No, and pass through the plan |
-| "launch the approved plan" | Rerun the same `start` coordinates with `--yes` |
-| "give the lead this goal during launch" | Add `--goal "TEXT"` to both preview and approved start invocations |
+| "launch the approved plan" | Use `--yes` only if the reviewed brief already exists; otherwise review the newly drafted brief in the interactive run |
+| "give the lead this goal during launch" | Add `--goal "TEXT"` to the interactive start; if it drafts a missing brief, approve those bytes in that run |
 | "give the running lead a goal" | Run `amq-squad goal --project P --profile R --session S --goal "TEXT"` |
 | "add a worker" | Add it to the roster, then rerun `start`; only missing roles spawn |
-| "we need a role that isn't in the catalog" | Any slug works: after the brief is saved, optionally run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
+| "we need a role that isn't in the catalog" | Any slug works: run `amq-squad role draft researcher --binary B --purpose TEXT --project P --profile R --session S`, review the staged persona, then `amq-squad team member add ROLE --binary B` and rerun `start` (`references/roles.md`) |
 | "replace this role" | Run `down` for that role, update its roster entry, then rerun `start` |
 | "the launcher was interrupted" | Rerun `start`; do not remove the namespace first |
 | "restore the old conversations" | Preview `resume`, then use `resume --exec` only after approval |
@@ -81,14 +215,16 @@ without `--yes` and answer No.
 
 ## Preview and launch
 
-Keep project, profile, session, target, layout, trust, model overrides, and optional
-goal identical between preview and launch:
+Keep project, profile, session, target, layout, trust, model overrides, and
+optional goal identical between preview and launch. For a goal-first run that
+must draft a missing brief, approve the displayed draft and plan at the same
+interactive prompt:
 
 ```sh
-# Preview. Answer No at the prompt; this performs no launch mutation.
+# Preview and, only after reviewing the generated brief and plan, answer Yes.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
 
-# Launch only after the operator approves the displayed plan.
+# Automation is safe only when the reviewed active brief already exists.
 amq-squad start --project P --profile R --session S --goal "Ship the reviewed change" --yes
 ```
 
@@ -107,7 +243,8 @@ defaults to `--actor-mode review`, and a deliberate `implementation` grant on a
 shared cwd surfaces only as a `doctor` failure — give each implementer its own
 `--cwd` at add time.
 
-For a named roster, create it with explicit coordinates and isolation:
+For a named roster, create it with explicit coordinates and isolation. Use
+`--no-session-pin` instead of `--session` when Flow B must reuse it:
 
 ```sh
 amq-squad new profile R --project P --session S --roles cto,qa \
@@ -125,10 +262,13 @@ amq-squad team member add researcher --binary codex --project P --profile R --se
 amq-squad start --project P --profile R --session S
 ```
 
-If the profile has no external drafter, or its backend falls back, `role draft`
-prints a filled manual prompt and stages nothing. Complete and review that prompt
-before the member add, or omit the persona and use the generated neutral
-contract. The draft is never a gate answer or launch approval.
+If the profile has no external drafter, or its configured chain exhausts into
+in-session fallback, `role draft` prints a filled manual prompt and stages
+nothing. Complete and review that prompt before the member add, or omit the
+persona and use the generated neutral contract. The draft is never a gate
+answer or launch approval. Profile drafter config replaces the whole global
+block; the output's config source and ordered attempts are the evidence of what
+actually ran.
 
 `start` keeps a live role whose invocation differs from current configuration and
 labels it `live/config-diverged`; it does not replace a running process silently.
@@ -160,7 +300,11 @@ partial fresh launch where conversation reattachment is not the goal, rerun `sta
 ## References
 
 - `references/team-archetypes.md` for selecting a small role mix.
-- `references/briefs-template.md` for writing a substantive workstream brief.
+- `references/stages.md` for the compact Flow A / Flow B command map.
+- `references/readiness.md` for setup, drafter, and launch preflight failures.
+- `references/briefs-template.md` for the validated six-section brief shape.
+- `references/roles.md` for drafter-backed custom personas.
+- `references/worktrees.md` for mutation-capable seat isolation.
 - `../amq-squad/references/team-rules-template.md` for the rules future agents read.
 
 After launch, route the visible lead to `amq-squad:orchestrator`. Route direct

--- a/plugins/skills-src/wizard/references/briefs-template.md
+++ b/plugins/skills-src/wizard/references/briefs-template.md
@@ -13,6 +13,16 @@ Whether the live skill drafts it in-session or `start --goal` uses the configure
 drafter, keep exactly the title and six level-two sections below, once each and
 in order. Point at the source of truth; do not paste its full contents here.
 
+The exact paths are:
+
+- named profile `R`, session `S`: `P/.amq-squad/briefs/R/S.md`;
+- default profile, session `S`: `P/.amq-squad/briefs/S.md`.
+
+Do not save named-profile work at the default path: `start` will not read it.
+`status --json` and the start plan both print the resolved canonical path. A
+live in-session draft is saved with the current file-edit tool only after its
+bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+
 ---
 
 # <session> brief

--- a/plugins/skills-src/wizard/references/briefs-template.md
+++ b/plugins/skills-src/wizard/references/briefs-template.md
@@ -9,7 +9,9 @@ ticket description is not a brief.
 
 The brief lives at team-home and is **per profile/session namespace** — author or
 refresh it at the start of each workstream, not only at first team creation.
-Point at the source of truth; do not paste its full contents here.
+Whether the live skill drafts it in-session or `start --goal` uses the configured
+drafter, keep exactly the title and six level-two sections below, once each and
+in order. Point at the source of truth; do not paste its full contents here.
 
 ---
 
@@ -23,7 +25,8 @@ The outcome in 1-2 sentences. What "done" looks like, not the task list.
 
 Where this came from: `JIRA PROJ-123` / `gh#96` / `https://...` /
 `file:./design.md` / "operator prompt". Link or id only — do not duplicate the
-source body here.
+source body here. A binary-generated draft also identifies that it came from
+the operator goal through the configured drafter and names the selected profile.
 
 ## Scope
 
@@ -33,6 +36,11 @@ source body here.
 
 - Nearby work that is explicitly NOT in this workstream, so members do not
   silently widen.
+
+## Team shape
+
+- One bullet per configured seat, preserving the exact role, handle, and binary
+  tuple: ``- `<role>` (`<handle>`, `<binary>`): responsibility for this goal.``
 
 ## Acceptance
 

--- a/plugins/skills-src/wizard/references/briefs-template.md
+++ b/plugins/skills-src/wizard/references/briefs-template.md
@@ -19,9 +19,11 @@ The exact paths are:
 - default profile, session `S`: `P/.amq-squad/briefs/S.md`.
 
 Do not save named-profile work at the default path: `start` will not read it.
-`status --json` and the start plan both print the resolved canonical path. A
-live in-session draft is saved with the current file-edit tool only after its
-bytes are approved, then displayed with `sed -n '1,220p' PATH` before start.
+`status --json` prints the resolved canonical path at
+`data.namespace.paths.brief` (`data.goal_binding.brief_path` should agree), and
+the start plan prints it on the `brief:` line. A live in-session draft is saved
+with the current file-edit tool only after its bytes are approved, then displayed
+in full with `cat PATH` before start.
 
 ---
 

--- a/plugins/skills-src/wizard/references/readiness.md
+++ b/plugins/skills-src/wizard/references/readiness.md
@@ -1,9 +1,31 @@
 # Launch diagnostics and preflight
 
-Simple Mode has no readiness stage or readiness manifest. `start` performs
-ordinary preflight against the authoritative roster and current external
-runtime before it asks for approval and again under the launch lock before it
-spawns.
+Simple Mode has no readiness stage or readiness manifest. Flow A uses
+`amq-squad setup` for machine-level drafter defaults and `doctor` for runtime
+sanity. `start` performs ordinary preflight against the authoritative roster
+and current external runtime before it asks for approval and again under the
+launch lock before it spawns.
+
+Run doctor from the target project. If it reports that no eligible AMQ root is
+configured, follow its printed project-root initialization/configuration
+remedy and rerun doctor; a global mailbox is not implicit authority for a Git
+worktree. Before a profile exists, a missing-team warning is expected. Doctor
+checks project/profile health and uses `--session` only for additive worktree
+diagnostics, so inspect a proposed new namespace with `status --json` and the
+subsequent start plan rather than claiming doctor proved it unused.
+
+## Drafter readiness
+
+`setup` writes the global user config and reports detected backends. The
+effective resolver chooses the complete profile block when present, otherwise
+the complete global block, otherwise `in_session`; it never merges fields
+between layers. A configured chain tries only its explicit order.
+
+Role draft, custom team-rules prose, and a missing goal-first brief print the
+resolved config source plus every attempt and fall-through. Missing binary,
+credentials, timeout, non-zero exit, empty or oversized output, and validation
+failure are not successes. `on_failure: error` fails closed. The default
+`in_session` fallback prints a filled prompt and stops before mutation.
 
 ## What preflight checks
 
@@ -13,6 +35,8 @@ spawns.
 - launch records are valid and do not describe multiple live matches;
 - a launcher-stamped unmanaged pane will not be duplicated;
 - the tmux backend and target are available.
+- a generated goal-first brief passed exact title and six-section validation
+  before any brief, namespace, lock, or pane mutation.
 
 These checks observe current inputs and external runtime. They do not produce a
 digest, token, accepted generation, or second record that certifies the roster.
@@ -28,6 +52,8 @@ Use the exact class and target in the error:
 | `unmanaged` | a launcher-stamped pane exists without a launch record | inspect the named pane before any new launch |
 | `stopped` | the recorded process or pane is no longer live | rerun `start` to reconcile it |
 | `live/config-diverged` | the actor is live but current roster config differs | keep it live until the operator chooses `down` then `start` |
+| drafter chain exhausted | every configured backend failed | inspect each recorded attempt; fix the first intended backend or complete the filled prompt in-session |
+| generated prose invalid | output failed deterministic structure/content checks | do not write it; fix the backend/prompt inputs and generate a fresh preview |
 
 After an interrupted launch, rerun `start`. It keeps verified live actors and
 rolls the partial launch forward; it does not require manual namespace cleanup.

--- a/plugins/skills-src/wizard/references/roles.md
+++ b/plugins/skills-src/wizard/references/roles.md
@@ -39,7 +39,9 @@ workstream starts, and a stale contract is worse than a thin one because it read
 current.
 
 When a richer persona is worth the setup cost and the selected profile already
-exists, use the built-in drafter after the active brief is saved:
+exists, use the built-in drafter. If the active brief already exists it is
+attached as untrusted context; Flow A may draft the reusable persona first, in
+which case the prompt explicitly defers live scope to the future brief/task:
 
 ```sh
 amq-squad role draft researcher --binary codex \
@@ -47,18 +49,21 @@ amq-squad role draft researcher --binary codex \
   --project P --profile R --session S
 ```
 
-The profile's optional `drafter` block selects yoetz, `claude -p`, `codex exec`,
-or a custom argv template. The binary owns the template and validation: a draft
-must have matching frontmatter, the Mission/Boundaries/Protocol shape, fewer
-than 45 lines, and no active session, task id, version, or branch. It stages a
-valid result at `.amq-squad/roles/<id>.md` without overwriting an existing file.
+The complete profile `drafter` block overrides the global user block; otherwise
+global config wins, then `in_session`. Preset backends select yoetz, `claude -p`,
+or `codex exec`; custom argv is trusted from global config only. The binary owns
+the prompt, template, and validation: a draft must have matching frontmatter,
+the Mission/Boundaries/Protocol shape, fewer than 45 lines, and no active
+session, task id, version, or branch. It stages a valid result at
+`.amq-squad/roles/<id>.md` without overwriting an existing file.
 
 Review that file before running the printed `team member add` command. `role
 draft` never adds or launches the member and never participates in gates. If no
 external backend is configured, or a keyless backend falls back, it prints the
-filled manual prompt and stages nothing. For a short-lived seat, the fastest
-persona remains none at all: use the generated neutral contract and a precise
-durable task body.
+filled manual prompt and stages nothing. Successful, fallback, fail-closed, and
+invalid-output paths report the config source and complete ordered attempt
+evidence. For a short-lived seat, the fastest persona remains none at all: use
+the generated neutral contract and a precise durable task body.
 
 ## Templates
 

--- a/plugins/skills-src/wizard/references/stages.md
+++ b/plugins/skills-src/wizard/references/stages.md
@@ -71,10 +71,13 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Approve those bytes and the launch plan at the same interactive prompt. No,
    invalid output, or fallback writes nothing and starts no pane. A live skill
    agent may instead draft the same shape in-session, show and save it, then let
-   `start` reuse it. After Yes, trust success only after every pane owns its live
-   child. Run the attach command printed for a detached tmux session, then
-   inspect `amq-squad status --project P --profile R --session S --json`; do not
-   hand off while a visible-lead invariant is still failing.
+   `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
+   `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
+   and require the start plan's `brief:` line to match. After Yes, trust success
+   only after every pane owns its live child. Run the attach command printed for
+   a detached tmux session, then inspect `amq-squad status --project P --profile
+   R --session S --json`; do not hand off while a visible-lead invariant is
+   still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -92,11 +95,14 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
 
 2. **Brief choice**
 
-   Leave the canonical new-session brief absent for configured `start --goal`
-   drafting, or copy an existing brief to the new namespace and review its title,
-   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
-   draft that exact shape in-session. Raw tickets and stale copied briefs are not
-   accepted scope.
+   Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
+   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
+   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
+   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
+   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
+   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
+   in-session and write it to the same canonical path after review. Raw tickets,
+   wrong default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/skills-src/wizard/references/stages.md
+++ b/plugins/skills-src/wizard/references/stages.md
@@ -73,11 +73,11 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    agent may instead draft the same shape in-session, show and save it, then let
    `start` reuse it at `P/.amq-squad/briefs/R/S.md` (or
    `P/.amq-squad/briefs/S.md` for the default profile). Display the saved bytes
-   and require the start plan's `brief:` line to match. After Yes, trust success
-   only after every pane owns its live child. Run the attach command printed for
-   a detached tmux session, then inspect `amq-squad status --project P --profile
-   R --session S --json`; do not hand off while a visible-lead invariant is
-   still failing.
+   in full with `cat PATH` and require the start plan's `brief:` line to match.
+   After Yes, trust success only after every pane owns its live child. Run the
+   attach command printed for a detached tmux session, then inspect `amq-squad
+   status --project P --profile R --session S --json`; do not hand off while a
+   visible-lead invariant is still failing.
 
 ## Flow B: new session from an existing profile
 
@@ -90,19 +90,33 @@ The wizard chooses one of these flows and keeps its coordinates explicit.
    Doctor validates project/profile health and uses `S` only for additive
    session-plan diagnostics. Select a reusable unpinned profile, then inspect
    the namespace directly with `amq-squad status --project P --profile R
-   --session S --json`. Do not silently reuse a pinned profile or an existing
-   namespace.
+   --session S --json`. Mechanically extract the canonical path with
+   `amq-squad status --project P --profile R --session S --json | jq
+   '.data.namespace.paths.brief'`. Do not silently reuse a pinned profile or an
+   existing namespace.
 
 2. **Brief choice**
 
    Leave `P/.amq-squad/briefs/R/S.md` absent for configured `start --goal`
-   drafting. To reuse named profile `R`'s `OLD` brief, first run `test ! -e
-   P/.amq-squad/briefs/R/S.md`, then `mkdir -p P/.amq-squad/briefs/R` and `cp
-   P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md`. The default-profile
-   path omits `/R`. Edit and display the copied title, Goal, Source, Scope, Out
-   of scope, Team shape, and Acceptance. A live agent may draft that exact shape
-   in-session and write it to the same canonical path after review. Raw tickets,
-   wrong default/named paths, and stale copied briefs are not accepted scope.
+   drafting. To reuse named profile `R`'s `OLD` brief, use one fail-closed,
+   no-clobber chain:
+
+   ```sh
+   test -f P/.amq-squad/briefs/R/OLD.md &&
+     mkdir -p P/.amq-squad/briefs/R &&
+     test ! -e P/.amq-squad/briefs/R/S.md &&
+     (set -C && cat P/.amq-squad/briefs/R/OLD.md > P/.amq-squad/briefs/R/S.md) &&
+     cmp -s P/.amq-squad/briefs/R/OLD.md P/.amq-squad/briefs/R/S.md &&
+     cat P/.amq-squad/briefs/R/S.md
+   ```
+
+   `set -C` makes publication itself refuse an existing target even if one
+   appears after the precheck; any nonzero command stops the chain. The default
+   profile uses the same chain with both `/R` components omitted. Edit and show
+   the entire copied title, Goal, Source, Scope, Out of scope, Team shape, and
+   Acceptance with `cat PATH`. A live agent may draft that exact shape in-session
+   and write it to the same canonical path after review. Raw tickets, wrong
+   default/named paths, and stale copied briefs are not accepted scope.
 
 3. **Preview and launch**
 

--- a/plugins/skills-src/wizard/references/stages.md
+++ b/plugins/skills-src/wizard/references/stages.md
@@ -1,66 +1,118 @@
-# The simple start flow
+# The two stepped start flows
 
-Simple Mode has one launch command and one approval. There is no prepare stage,
-readiness stage, accepted digest, or separate go command.
+Simple Mode has one launch command and one default-No approval. There is no
+prepare stage, readiness manifest, accepted digest, or separate go command.
+The wizard chooses one of these flows and keeps its coordinates explicit.
 
-## Authoritative inputs
+## Flow A: new team profile
 
-Before launch, resolve and review these inputs:
+1. **Machine readiness**
 
-| Input | Source | Purpose |
-|---|---|---|
-| project/profile/session | operator coordinates | selects one canonical namespace |
-| roster | `team.json` or the named profile | defines roles, binaries, actor modes, and working directories |
-| rules | `.amq-squad/team-rules.md` | defines shared operating constraints |
-| brief | active workstream brief | defines the workstream context |
-| goal | optional operator text | gives the lead an initial goal after all roles are live |
+   ```sh
+   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-on-failure in_session
+   amq-squad doctor --project P
+   ```
 
-The inputs are authoritative directly. Do not persist a second owned
-representation merely to certify them.
+   Setup probes available drafter CLIs and writes the global config only. Omit
+   its flags when the operator wants the interactive prompts.
+   Decide the ordered chain and failure policy. A profile `drafter` block, when
+   present, replaces the complete global block; otherwise global wins, then
+   `in_session`. Stop on invalid config, missing required binaries, or blocking
+   doctor findings.
 
-## Preview and approve
+2. **Profile**
 
-Run the complete start command without `--yes`:
+   ```sh
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --dry-run --json
+   amq-squad new profile R --project P --session S \
+     --roles cto,fullstack --binary cto=codex,fullstack=claude \
+     --actor-mode cto=review,fullstack=implementation \
+     --orchestrated --lead cto --sync
+   ```
 
-```sh
-amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
-```
+   Compare preview and write. Use `new team` for default or
+   `--no-session-pin` for a reusable profile. Resolve multiple implementation
+   actors with isolated working directories or an explicit shared-CWD exception.
 
-The CLI renders the roster, briefs, optional goal, and launch actions, then asks
-for a default-No `y/N` decision. A No answer changes nothing. After the operator
-approves the displayed plan, repeat the same coordinates with `--yes` for an
-automated or non-interactive invocation.
+3. **Custom seat personas**
 
-`start` re-resolves the inputs under the session launch lock. It writes the
-briefs, creates or adopts the canonical namespace, keeps verified live roles,
-spawns missing or stopped roles, verifies every child process, writes launch
-records, and only then sends the optional goal to the lead.
+   ```sh
+   amq-squad role draft researcher --binary codex \
+     --purpose "Investigate ambiguous product behavior" \
+     --project P --profile R --session S
+   amq-squad team member add researcher --binary codex --actor-mode review \
+     --project P --profile R --session S
+   ```
 
-## Roster changes and recovery
+   Review the staged file before member add. Record config source and every
+   attempt/fall-through. Manual fallback stages nothing; a valid draft must pass
+   frontmatter and Mission/Boundaries/Protocol validation.
+
+4. **Team rules**
+
+   ```sh
+   amq-squad team rules init --project P --profile R --template auto --force
+   ```
+
+   Custom charter/scope prose uses the shared drafter, then deterministic policy
+   sections wrap the validated fragment. Manual fallback writes nothing.
+
+5. **Brief and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   If the brief is absent, the configured drafter must report source and ordered
+   attempts, pass exact six-section validation, and print the proposed bytes.
+   Approve those bytes and the launch plan at the same interactive prompt. No,
+   invalid output, or fallback writes nothing and starts no pane. A live skill
+   agent may instead draft the same shape in-session, show and save it, then let
+   `start` reuse it. After Yes, trust success only after every pane owns its live
+   child. Run the attach command printed for a detached tmux session, then
+   inspect `amq-squad status --project P --profile R --session S --json`; do not
+   hand off while a visible-lead invariant is still failing.
+
+## Flow B: new session from an existing profile
+
+1. **Coordinates and health**
+
+   ```sh
+   amq-squad doctor --project P --profile R --session S
+   ```
+
+   Doctor validates project/profile health and uses `S` only for additive
+   session-plan diagnostics. Select a reusable unpinned profile, then inspect
+   the namespace directly with `amq-squad status --project P --profile R
+   --session S --json`. Do not silently reuse a pinned profile or an existing
+   namespace.
+
+2. **Brief choice**
+
+   Leave the canonical new-session brief absent for configured `start --goal`
+   drafting, or copy an existing brief to the new namespace and review its title,
+   Goal, Source, Scope, Out of scope, Team shape, and Acceptance. A live agent may
+   draft that exact shape in-session. Raw tickets and stale copied briefs are not
+   accepted scope.
+
+3. **Preview and launch**
+
+   ```sh
+   amq-squad start --project P --profile R --session S --goal "Ship the reviewed change"
+   ```
+
+   With no brief, apply Flow A's same-invocation draft approval. With a reviewed
+   brief, inspect the reused path and complete launch plan. Use `--yes` only for
+   automation after a reviewed brief exists and inputs remain unchanged. Apply
+   Flow A's attach/status verification, then route the visible lead to
+   `amq-squad:orchestrator`.
+
+## Recovery
 
 - Add a role to the roster, then rerun `start`; only the missing role starts.
-- To replace a role, run `down` for that role, update its roster entry, then
-  rerun `start`.
+- To replace a role, run `down`, update its entry, then rerun `start`.
 - After an interrupted fresh launch, rerun `start`; do not delete the namespace.
 - Use `resume` when preserving and reattaching saved conversations is the goal.
-- For an existing session, edit the resolved active brief directly before
-  rerunning `start`.
-
-## Roster setup
-
-```sh
-amq-squad new team --roles cto,fullstack,qa --binary cto=codex --sync
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
-amq-squad new team --dry-run --json --roles cto,fullstack,qa --orchestrated --lead cto
-```
-
-`--orchestrated [--lead ROLE]` records the lead in `team.json` and writes a
-generated `## Orchestration` reporting norm into `team-rules.md` when that file
-is first seeded. Existing rules remain untouched; regenerate them deliberately
-with:
-
-```sh
-amq-squad team rules init --force
-```
-
-The lead must be a team member and is never the operator.


### PR DESCRIPTION
Closes #707.

Restructure the `/amq-squad:wizard` skill into explicit stepped flows — the guided shape of the old CLI wizard (removed in the v2.28 cutover, #650) rebuilt on the v2.29.4 command set.

## Flows
- **Flow A — create and start a new team profile** (5 steps): machine/drafter readiness (`setup`, `doctor`, whole-block precedence explained) → profile preview/create → `role draft` per custom seat (drafter-backed, ordered fall-through evidence) → team-rules refresh → `start --goal` brief drafting with six-section validation, preview, same-invocation approval, launch.
- **Flow B — start a new session from an existing profile** (3 steps): profile/session selection → brief path choice (goal-first drafting or fail-closed no-clobber reuse with byte comparison) → preview and approved start, with attach/status verification and handoff boundaries.

## Constraints honored
- Skill/docs only (canonical `plugins/skills-src/wizard` + generated Claude/Codex mirrors + guides); no binary changes.
- Routing contract and compatibility redirects preserved; live in-session brief drafting kept per the #700 scoping split.
- Exact canonical brief paths with wrong-path rejection; status selectors pinned to `data.namespace.paths.brief` / `data.goal_binding.brief_path`.

## Evidence
- head: 365cc13e152cd59917d0ff65af2b7eca96ab9fab (base 7e41c09)
- make ci PASS; skill command gate (31 paths), invocation gate (88 invocations) PASS; real-AMQ compatibility + real-PTY wake PASS on pinned v0.60.0 and latest v0.60.1
- Scratch dogfood of both flows end to end with real AMQ 0.60.0, including full yoetz→claude→codex fall-through evidence and no-clobber first-write/raced-target checks
- Reviews (exact-head, independent): fixes-dev-v2294 APPROVE; config-dev-v2294 APPROVE (one transient PTY deadline retained, exact rerun green) — recorded on AMQ thread task/t5-gh707; two earlier heads corrected through worker-driven review rounds

Implemented by wizard-dev-v2294 (amq-squad session squad-v2-29-3/v2-29-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
