### PR TITLE
fix(worktree): allow sanctioned cleanup after normal runs

### DIFF
--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -48,8 +48,9 @@ Usage:
   amq-squad worktree exception clear --session S [--profile P] --yes [--json]
 
 plan is read-only. Mutating commands are explicit --yes operations. cleanup only
-removes a clean, registered worktree whose exact path and branch match the
-durable session plan; it never deletes an unknown directory or branch.
+removes a clean worktree at the exact registered path; it may adopt a clean
+sequential-task branch and remove verified bootstrap/canonical-copy AMQ residue,
+but it never deletes an unknown directory or branch.
 `)
 		if len(args) == 0 {
 			return usageErrorf("worktree requires a subcommand")

--- a/internal/worktreeplan/model.go
+++ b/internal/worktreeplan/model.go
@@ -105,26 +105,29 @@ type CleanupRequest struct {
 }
 
 type MemberStatus struct {
-	Role                     string   `json:"role"`
-	Handle                   string   `json:"handle"`
-	CWD                      string   `json:"cwd"`
-	Worktree                 string   `json:"worktree,omitempty"`
-	Branch                   string   `json:"branch,omitempty"`
-	BaseSHA                  string   `json:"base_sha,omitempty"`
-	CurrentHEAD              string   `json:"current_head,omitempty"`
-	Clean                    bool     `json:"clean"`
-	Dirty                    bool     `json:"dirty"`
-	Drifted                  bool     `json:"drifted"`
-	Scope                    []string `json:"scope,omitempty"`
-	TaskID                   string   `json:"task_id,omitempty"`
-	State                    State    `json:"state,omitempty"`
-	HandoffSHA               string   `json:"handoff_sha,omitempty"`
-	HandoffValid             bool     `json:"handoff_valid"`
-	Registered               bool     `json:"registered"`
-	Index                    string   `json:"index,omitempty"`
-	Detail                   string   `json:"detail,omitempty"`
-	CoordinationRootDiverged bool     `json:"coordination_root_diverged"`
-	Orphaned                 bool     `json:"orphaned"`
+	Role                         string   `json:"role"`
+	Handle                       string   `json:"handle"`
+	CWD                          string   `json:"cwd"`
+	Worktree                     string   `json:"worktree,omitempty"`
+	Branch                       string   `json:"branch,omitempty"`
+	CurrentBranch                string   `json:"current_branch,omitempty"`
+	BaseSHA                      string   `json:"base_sha,omitempty"`
+	CurrentHEAD                  string   `json:"current_head,omitempty"`
+	Clean                        bool     `json:"clean"`
+	Dirty                        bool     `json:"dirty"`
+	Drifted                      bool     `json:"drifted"`
+	Scope                        []string `json:"scope,omitempty"`
+	TaskID                       string   `json:"task_id,omitempty"`
+	State                        State    `json:"state,omitempty"`
+	HandoffSHA                   string   `json:"handoff_sha,omitempty"`
+	HandoffValid                 bool     `json:"handoff_valid"`
+	Registered                   bool     `json:"registered"`
+	Index                        string   `json:"index,omitempty"`
+	Detail                       string   `json:"detail,omitempty"`
+	CoordinationRootDiverged     bool     `json:"coordination_root_diverged"`
+	RemovableCoordinationResidue []string `json:"removable_coordination_residue,omitempty"`
+	Orphaned                     bool     `json:"orphaned"`
+	driftKinds                   []string
 }
 
 type DiagnosticStatus string

--- a/internal/worktreeplan/residue.go
+++ b/internal/worktreeplan/residue.go
@@ -1,0 +1,206 @@
+package worktreeplan
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func inspectCoordinationState(set Set, worktree string) (bool, []string) {
+	worktree = filepath.Clean(worktree)
+	for _, root := range []string{set.TeamHome, set.ControlRoot, set.AMQRoot} {
+		if pathWithin(filepath.Clean(root), worktree) {
+			return true, nil
+		}
+	}
+	for _, local := range []string{filepath.Join(worktree, ".amqrc"), filepath.Join(worktree, team.DirName, DirName)} {
+		if pathExists(local) {
+			return true, nil
+		}
+	}
+	localAMQ := filepath.Join(worktree, ".agent-mail")
+	if !pathExists(localAMQ) {
+		return false, nil
+	}
+	if !removableAgentMailTree(set, localAMQ) {
+		return true, nil
+	}
+	return false, []string{localAMQ}
+}
+
+func removableAgentMailTree(set Set, root string) bool {
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	canonicalBase := filepath.Join(set.TeamHome, ".agent-mail")
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root || entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink residue")
+		}
+		entryInfo, err := entry.Info()
+		if err != nil || !entryInfo.Mode().IsRegular() {
+			return fmt.Errorf("non-regular residue")
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("residue escaped root")
+		}
+		if bootstrapConfig(path, rel) || canonicalCopy(set, canonicalBase, rel, path) {
+			return nil
+		}
+		return fmt.Errorf("unique coordination state")
+	})
+	return err == nil
+}
+
+func bootstrapConfig(path, rel string) bool {
+	if !strings.HasSuffix(filepath.ToSlash(rel), "/meta/config.json") && filepath.ToSlash(rel) != "meta/config.json" {
+		return false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return false
+	}
+	agents, ok := document["agents"]
+	if !ok {
+		return false
+	}
+	var handles []string
+	return json.Unmarshal(agents, &handles) == nil
+}
+
+func canonicalCopy(set Set, canonicalBase, rel, localPath string) bool {
+	candidates := []string{filepath.Join(canonicalBase, rel)}
+	if alternate := alternateInboxState(rel); alternate != rel {
+		candidates = append(candidates, filepath.Join(canonicalBase, alternate))
+	}
+	for _, prefix := range localAMQPrefixes(set) {
+		suffix, ok := trimPathPrefix(rel, prefix)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(set.AMQRoot, suffix))
+		if alternate := alternateInboxState(suffix); alternate != suffix {
+			candidates = append(candidates, filepath.Join(set.AMQRoot, alternate))
+		}
+	}
+	for _, candidate := range candidates {
+		if sameRegularFile(localPath, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func localAMQPrefixes(set Set) []string {
+	prefixes := []string{filepath.Join(normalizedProfile(set.Profile), set.Session), set.Session}
+	if prefixes[0] == prefixes[1] {
+		return prefixes[:1]
+	}
+	return prefixes
+}
+
+func trimPathPrefix(path, prefix string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Clean(prefix), filepath.Clean(path))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	if rel == "." {
+		return "", true
+	}
+	return rel, true
+}
+
+func alternateInboxState(path string) string {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1] != "inbox" {
+			continue
+		}
+		switch parts[i] {
+		case "new":
+			parts[i] = "cur"
+		case "cur":
+			parts[i] = "new"
+		default:
+			continue
+		}
+		return filepath.FromSlash(strings.Join(parts, "/"))
+	}
+	return path
+}
+
+func sameRegularFile(left, right string) bool {
+	leftInfo, err := os.Lstat(left)
+	if err != nil || !leftInfo.Mode().IsRegular() {
+		return false
+	}
+	rightInfo, err := os.Lstat(right)
+	if err != nil || !rightInfo.Mode().IsRegular() || leftInfo.Size() != rightInfo.Size() {
+		return false
+	}
+	leftDigest, leftOK := fileDigest(left)
+	rightDigest, rightOK := fileDigest(right)
+	return leftOK && rightOK && leftDigest == rightDigest
+}
+
+func fileDigest(path string) ([sha256.Size]byte, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return [sha256.Size]byte{}, false
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return [sha256.Size]byte{}, false
+	}
+	var result [sha256.Size]byte
+	copy(result[:], digest.Sum(nil))
+	return result, true
+}
+
+func removeCoordinationResidue(set Set, record Record, paths []string) error {
+	for _, path := range paths {
+		expected := filepath.Join(record.Path, ".agent-mail")
+		if filepath.Clean(path) != filepath.Clean(expected) || !removableAgentMailTree(set, path) {
+			return fmt.Errorf("refuse cleanup: coordination residue at %s is no longer removable", path)
+		}
+		var entries []string
+		if err := filepath.WalkDir(path, func(current string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refuse symlink in coordination residue %s", current)
+			}
+			entries = append(entries, current)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("inspect removable coordination residue %s: %w", path, err)
+		}
+		for i := len(entries) - 1; i >= 0; i-- {
+			if err := os.Remove(entries[i]); err != nil {
+				return fmt.Errorf("remove coordination residue %s: %w", entries[i], err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/worktreeplan/service.go
+++ b/internal/worktreeplan/service.go
@@ -270,7 +270,13 @@ func (s *Service) Cleanup(req CleanupRequest) (Record, error) {
 				return fmt.Errorf("refuse cleanup of dirty worktree %s", record.Path)
 			}
 			if status.Drifted {
-				return fmt.Errorf("refuse cleanup of drifted worktree: %s", status.Detail)
+				if !cleanupMayAdoptCurrentBranch(status) {
+					return fmt.Errorf("refuse cleanup of drifted worktree: %s", status.Detail)
+				}
+				if owner := branchOwner(set, status.CurrentBranch, record.Role); owner != "" {
+					return fmt.Errorf("refuse cleanup of drifted worktree: current branch %s belongs to %s", status.CurrentBranch, owner)
+				}
+				record.Branch = status.CurrentBranch
 			}
 			if record.HandoffSHA != "" && status.CurrentHEAD != record.HandoffSHA {
 				return fmt.Errorf("refuse cleanup: current HEAD %s differs from handoff %s", status.CurrentHEAD, record.HandoffSHA)
@@ -293,6 +299,9 @@ func (s *Service) Cleanup(req CleanupRequest) (Record, error) {
 			return err
 		}
 		if status.Registered {
+			if err := removeCoordinationResidue(set, *record, status.RemovableCoordinationResidue); err != nil {
+				return err
+			}
 			if _, err := s.git.Run(record.RepoRoot, "worktree", "remove", record.Path); err != nil {
 				return fmt.Errorf("remove registered worktree: %w", err)
 			}
@@ -700,21 +709,26 @@ func (s *Service) inspectRecord(set Set, record Record) (MemberStatus, error) {
 	}
 	status.CurrentHEAD, _ = currentHEAD(s.git, record.Path)
 	actualBranch, branchErr := currentBranch(s.git, record.Path)
+	status.CurrentBranch = actualBranch
 	status.Index, _ = indexPath(s.git, record.Path)
 	status.Clean, _ = worktreeClean(s.git, record.Path)
 	status.Dirty = !status.Clean
-	status.CoordinationRootDiverged = coordinationDiverged(set, record.Path)
+	status.CoordinationRootDiverged, status.RemovableCoordinationResidue = inspectCoordinationState(set, record.Path)
 	var drift []string
 	if branchErr != nil || actualBranch != record.Branch || atPath.BranchRef != branchRef(record.Branch) {
+		status.driftKinds = append(status.driftKinds, "branch mismatch")
 		drift = append(drift, "branch mismatch")
 	}
 	if branchAt != nil && filepath.Clean(branchAt.Path) != filepath.Clean(record.Path) {
+		status.driftKinds = append(status.driftKinds, "branch registered at duplicate path")
 		drift = append(drift, "branch registered at duplicate path")
 	}
 	if status.CurrentHEAD == "" || !baseIsAncestor(s.git, record.Path, record.BaseSHA, status.CurrentHEAD) {
+		status.driftKinds = append(status.driftKinds, "accepted base is not an ancestor of HEAD")
 		drift = append(drift, "accepted base is not an ancestor of HEAD")
 	}
 	if status.CoordinationRootDiverged {
+		status.driftKinds = append(status.driftKinds, "coordination root diverged into worktree")
 		drift = append(drift, "coordination root diverged into worktree")
 	}
 	status.Drifted = len(drift) > 0
@@ -820,19 +834,17 @@ func duplicateIdentityFindings(plans []Record) []string {
 	return findings
 }
 
-func coordinationDiverged(set Set, worktree string) bool {
-	worktree = filepath.Clean(worktree)
-	for _, root := range []string{set.TeamHome, set.ControlRoot, set.AMQRoot} {
-		if pathWithin(filepath.Clean(root), worktree) {
-			return true
+func cleanupMayAdoptCurrentBranch(status MemberStatus) bool {
+	return status.CurrentBranch != "" && len(status.driftKinds) == 1 && status.driftKinds[0] == "branch mismatch"
+}
+
+func branchOwner(set Set, branch, exceptRole string) string {
+	for _, plan := range set.Plans {
+		if plan.Role != exceptRole && plan.State != StateCleaned && plan.Branch == branch {
+			return plan.Role
 		}
 	}
-	for _, local := range []string{filepath.Join(worktree, ".agent-mail"), filepath.Join(worktree, ".amqrc"), filepath.Join(worktree, team.DirName, DirName)} {
-		if pathExists(local) {
-			return true
-		}
-	}
-	return false
+	return ""
 }
 
 func pathWithin(path, parent string) bool {

--- a/internal/worktreeplan/service_test.go
+++ b/internal/worktreeplan/service_test.go
@@ -89,6 +89,101 @@ func TestMaterializeHandoffAndCleanupLifecycle(t *testing.T) {
 	}
 }
 
+func TestCleanupAcceptsSequentialTaskBranchAndRemovableCoordinationResidue(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, ".git", "info", "exclude"), []byte(".agent-mail/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
+	service := newTestService(t, configured, team.DefaultProfile, "release-24")
+	req := Request{Role: "worker", TaskID: "t1", Base: "HEAD", Scope: []string{"internal/runtime/**"}, AMQRoot: filepath.Join(repo, ".agent-mail", "release-24")}
+	_, record, err := service.Materialize(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nextBranch := record.Branch + "-t2"
+	runGit(t, record.Path, "switch", "-c", nextBranch)
+	localRoot := filepath.Join(record.Path, ".agent-mail", "release-24")
+	if err := os.MkdirAll(filepath.Join(localRoot, "meta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localRoot, "meta", "config.json"), []byte(`{"agents":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const message = "superseded message copy\n"
+	localMessage := filepath.Join(localRoot, "agents", "worker", "inbox", "new", "msg-1.md")
+	canonicalMessage := filepath.Join(repo, ".agent-mail", "release-24", "agents", "worker", "inbox", "cur", "msg-1.md")
+	for _, path := range []string{localMessage, canonicalMessage} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(message), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inspection, err := service.Inspect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := memberStatus(t, inspection, "worker")
+	if !status.Drifted || status.CurrentBranch != nextBranch || status.CoordinationRootDiverged {
+		t.Fatalf("sequential branch/residue classification = %+v", status)
+	}
+	if len(status.RemovableCoordinationResidue) != 1 || status.RemovableCoordinationResidue[0] != filepath.Join(record.Path, ".agent-mail") {
+		t.Fatalf("removable coordination residue = %v", status.RemovableCoordinationResidue)
+	}
+
+	cleaned, err := service.Cleanup(CleanupRequest{Role: "worker", Decision: "accepted"})
+	if err != nil {
+		t.Fatalf("cleanup refused a clean sequential-task worktree with removable AMQ residue: %v", err)
+	}
+	if cleaned.State != StateCleaned || cleaned.Branch != nextBranch {
+		t.Fatalf("cleaned record = %+v, want branch %s", cleaned, nextBranch)
+	}
+	if pathExists(record.Path) {
+		t.Fatalf("cleanup left worktree path %s", record.Path)
+	}
+}
+
+func TestCleanupRefusesUniqueWorktreeLocalCoordinationState(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, ".git", "info", "exclude"), []byte(".agent-mail/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
+	service := newTestService(t, configured, team.DefaultProfile, "release-24")
+	_, record, err := service.Materialize(Request{
+		Role: "worker", TaskID: "t1", Base: "HEAD", Scope: []string{"internal/runtime/**"},
+		AMQRoot: filepath.Join(repo, ".agent-mail", "release-24"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unique := filepath.Join(record.Path, ".agent-mail", "release-24", "agents", "worker", "inbox", "new", "unique.md")
+	if err := os.MkdirAll(filepath.Dir(unique), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unique, []byte("unique local message\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := service.Inspect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := memberStatus(t, inspection, "worker")
+	if !status.CoordinationRootDiverged || len(status.RemovableCoordinationResidue) != 0 {
+		t.Fatalf("unique coordination state classification = %+v", status)
+	}
+
+	if _, err := service.Cleanup(CleanupRequest{Role: "worker", Decision: "accepted"}); err == nil || !strings.Contains(err.Error(), "coordination root diverged") {
+		t.Fatalf("unique coordination state cleanup error = %v", err)
+	}
+	if !pathExists(unique) || !pathExists(record.Path) {
+		t.Fatal("refused cleanup removed unique coordination state or its worktree")
+	}
+}
+
 func TestPlanPreviewIsDeterministicAndTimestampFree(t *testing.T) {
 	repo := newTestRepo(t)
 	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
@@ -242,7 +337,11 @@ func TestInspectionDiagnosesSharedIndexAndCoordinationDivergence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(record.Path, ".agent-mail"), 0o755); err != nil {
+	localAMQ := filepath.Join(record.Path, ".agent-mail")
+	if err := os.MkdirAll(localAMQ, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localAMQ, "unique-state.md"), []byte("not present in the canonical root\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	inspection, err = service.Inspect()


### PR DESCRIPTION
Fixes #690.

After a normal run, `worktree cleanup --decision accepted` refused both sanctioned end states:

- a seat that worked sequential task branches in one worktree (`branch mismatch`)
- worktree-local `.agent-mail` bootstrap residue from the pre-#682 mid-run launch path (`coordination root diverged into worktree`)

## Changes

- Cleanup may adopt the current branch when `branch mismatch` is the **sole** drift, the tree is clean, no other role's plan owns that branch, and the handoff SHA still matches.
- `inspectCoordinationState` classifies a worktree-local `.agent-mail` tree containing only bootstrap skeleton (`meta/config.json`) and byte-identical canonical copies (incl. inbox `new`/`cur` moves) as removable residue instead of divergence; unique local state, symlinks, dirty trees, unrelated history, duplicate plan ownership, and stale handoffs still fail closed.
- Residue removal re-verifies removability at deletion time and removes per-entry (no recursive force delete).
- `MemberStatus` gains `current_branch` and `removable_coordination_residue` for observability.

## Evidence

- Regression: `TestCleanupAcceptsSequentialTaskBranchAndRemovableCoordinationResidue` fails on base `ea4e17a` with the exact gh#690 error (`refuse cleanup of drifted worktree: branch mismatch; coordination root diverged into worktree`) and passes at head — verified independently by the lead in detached worktrees at both SHAs.
- `make ci` green at head (task-bound evidence attempt `t3-gh690-f1e1a00-ci5`, summary sha256 `79bbc474754ce2fa77a438fe76798af063546eed4f7ba3ac1b17f90ab568a964`).

Squad: senior-dev (implementation), lead (exact-head review). Merge pending second independent review + `amq-squad verify merge` + operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)