### PR TITLE
fix(start): reconcile owned tmux session from records, not volatile pane titles

### DIFF
--- a/internal/cli/simple_start.go
+++ b/internal/cli/simple_start.go
@@ -636,12 +636,11 @@ func buildSimpleStartPlan(req simpleStartRequest, deps simpleStartDependencies) 
 	if err := backend.Validate(opts); err != nil {
 		return simpleStartPlan{}, err
 	}
-	if err := validateSimpleStartTmuxTarget(opts, session); err != nil {
-		return simpleStartPlan{}, err
-	}
-
 	records, err := readSimpleStartRecords(req.Project, root, req.Profile, session)
 	if err != nil {
+		return simpleStartPlan{}, err
+	}
+	if err := validateSimpleStartTmuxTarget(opts, session, records, deps.RuntimeProbe); err != nil {
 		return simpleStartPlan{}, err
 	}
 	roles, removed, err := reconcileSimpleStartRoles(t, req.Profile, session, root, records, opts, deps.RuntimeProbe)
@@ -881,7 +880,7 @@ func simpleStartAuthorityHandles(plan simpleStartPlan) []string {
 	return normalizeAMQAuthorityHandles(handles)
 }
 
-func validateSimpleStartTmuxTarget(opts teamLaunchOptions, session string) error {
+func validateSimpleStartTmuxTarget(opts teamLaunchOptions, session string, records []simpleStartRecord, probe launchRuntimeProbe) error {
 	switch opts.Target {
 	case "current-window":
 		if strings.TrimSpace(os.Getenv("TMUX")) == "" || strings.TrimSpace(os.Getenv("TMUX_PANE")) == "" {
@@ -891,16 +890,41 @@ func validateSimpleStartTmuxTarget(opts teamLaunchOptions, session string) error
 		if !tmuxSessionExists(opts.TerminalSession) {
 			return nil
 		}
-		out, err := tmuxOutputCommand("tmux", "list-panes", "-t", opts.TerminalSession, "-F", "#{pane_title}\t#{@amq_squad_title}")
+		out, err := tmuxOutputCommand("tmux", "list-panes", "-s", "-t", opts.TerminalSession, "-F", "#{pane_id}\t#{pane_title}\t#{@amq_squad_title}")
 		if err != nil {
 			return &simpleStartConflictError{Class: "unmanaged", Detail: fmt.Sprintf("cannot verify existing tmux session %s: %v", opts.TerminalSession, err)}
 		}
-		prefix := "amq:" + session + ":"
+		panes := make(map[string]bool)
+		var titleFields []string
 		for _, line := range strings.Split(out, "\n") {
-			for _, title := range strings.Split(line, "\t") {
-				if strings.HasPrefix(strings.TrimSpace(title), prefix) {
-					return nil
+			fields := strings.Split(line, "\t")
+			if len(fields) > 0 {
+				if paneID := strings.TrimSpace(fields[0]); paneID != "" {
+					panes[paneID] = true
 				}
+			}
+			if len(fields) > 1 {
+				titleFields = append(titleFields, fields[1:]...)
+			}
+		}
+		for _, item := range records {
+			rec := item.Record
+			if rec.Tmux == nil || strings.TrimSpace(rec.Tmux.Session) != strings.TrimSpace(opts.TerminalSession) {
+				continue
+			}
+			paneID := strings.TrimSpace(rec.Tmux.PaneID)
+			if paneID == "" || !panes[paneID] {
+				continue
+			}
+			identity := classifyLaunchRuntimeIdentity(rec, "", paneID, probe)
+			if identity.PaneLive && simpleStartRuntimeLive(rec, identity) {
+				return nil
+			}
+		}
+		prefix := "amq:" + session + ":"
+		for _, title := range titleFields {
+			if strings.HasPrefix(strings.TrimSpace(title), prefix) {
+				return nil
 			}
 		}
 		return &simpleStartConflictError{Class: "unmanaged", Detail: fmt.Sprintf("tmux session %s exists without a pane owned by workstream %s", opts.TerminalSession, session)}

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -406,6 +406,127 @@ func (f *simpleStartRunFixture) seedRecord(t *testing.T, role, handle string, pi
 	return agentDir
 }
 
+func TestSimpleStartNewSessionAcceptsOwnedLivePaneAfterTitleRewrite(t *testing.T) {
+	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
+	const (
+		terminalSession = "owned-session"
+		paneID          = "%281"
+	)
+	agentDir := f.seedRecord(t, "dev", "dev", 4281, paneID, true, false)
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Tmux.Session = terminalSession
+	rec.Tmux.Target = "new-session"
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	f.titles[paneID] = "codex: working"
+	f.deps.RuntimeProbe.PaneTTY = func(got string) (string, bool) {
+		if got != paneID {
+			t.Fatalf("PaneTTY(%q), want %q", got, paneID)
+		}
+		return "/dev/ttys-test", true
+	}
+
+	oldExists, oldOutput := tmuxSessionExists, tmuxOutputCommand
+	tmuxSessionExists = func(got string) bool { return got == terminalSession }
+	tmuxOutputCommand = func(_ string, args ...string) (string, error) {
+		joined := strings.Join(args, " ")
+		if !strings.Contains(joined, "list-panes -s -t "+terminalSession) {
+			t.Fatalf("tmux list-panes args = %v, want all panes in target %s", args, terminalSession)
+		}
+		return paneID + "\tcodex: working\t\n", nil
+	}
+	t.Cleanup(func() {
+		tmuxSessionExists = oldExists
+		tmuxOutputCommand = oldOutput
+	})
+
+	plan, err := buildSimpleStartPlan(simpleStartRequest{
+		Project: f.project, Profile: f.profile, Session: f.session, SessionExplicit: true,
+		Options: teamLaunchOptions{Terminal: "tmux", Target: "new-session", TerminalSession: terminalSession},
+	}, f.deps)
+	if err != nil {
+		t.Fatalf("owned live target rejected after pane title rewrite: %v", err)
+	}
+	if len(plan.Roles) != 1 || !strings.HasPrefix(plan.Roles[0].State, "live") || len(plan.SpawnTeam.Members) != 0 {
+		t.Fatalf("plan roles=%+v spawn=%+v, want one retained live role and no spawn", plan.Roles, plan.SpawnTeam.Members)
+	}
+}
+
+func TestValidateSimpleStartTmuxTargetRequiresCorroboratedRecordInTargetSession(t *testing.T) {
+	const (
+		terminalSession = "owned-session"
+		paneID          = "%282"
+	)
+	started := time.Unix(2_000, 0).UTC()
+	record := simpleStartRecord{AgentDir: "/root/agents/dev", Record: launch.Record{
+		Schema: launch.SchemaVersion, Session: "work", Role: "dev", Handle: "dev", Binary: "codex",
+		AgentPID: 4282, AgentTTY: "/dev/ttys-test", StartedAt: started,
+		Tmux: &launch.TmuxInfo{Session: terminalSession, PaneID: paneID, Target: "new-session"},
+	}}
+	probe := launchRuntimeProbe{
+		PIDAlive:         func(int) bool { return true },
+		ProcessMatch:     func(int, func(string) bool) bool { return true },
+		ProcessTTY:       func(int) (string, bool) { return "/dev/ttys-test", true },
+		ProcessStartTime: func(int) (time.Time, bool) { return started, true },
+		PaneTitle:        func(string) (string, bool) { return "codex: working", true },
+		PaneTTY:          func(string) (string, bool) { return "/dev/ttys-test", true },
+	}
+
+	oldExists, oldOutput := tmuxSessionExists, tmuxOutputCommand
+	tmuxSessionExists = func(string) bool { return true }
+	var listOutput string
+	tmuxOutputCommand = func(string, ...string) (string, error) { return listOutput, nil }
+	t.Cleanup(func() {
+		tmuxSessionExists = oldExists
+		tmuxOutputCommand = oldOutput
+	})
+
+	tests := []struct {
+		name   string
+		output string
+		mutate func(*launch.Record, *launchRuntimeProbe)
+	}{
+		{name: "recorded pane absent from target", output: "%999\tcodex: working\t\n"},
+		{name: "record names another session", output: paneID + "\tcodex: working\t\n", mutate: func(rec *launch.Record, _ *launchRuntimeProbe) {
+			rec.Tmux.Session = "other-session"
+		}},
+		{name: "recorded process is dead", output: paneID + "\tcodex: working\t\n", mutate: func(_ *launch.Record, got *launchRuntimeProbe) {
+			got.PIDAlive = func(int) bool { return false }
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRecord, gotProbe := record, probe
+			gotRecord.Record.Tmux = &launch.TmuxInfo{
+				Session: record.Record.Tmux.Session, PaneID: record.Record.Tmux.PaneID, Target: record.Record.Tmux.Target,
+			}
+			if tc.mutate != nil {
+				tc.mutate(&gotRecord.Record, &gotProbe)
+			}
+			listOutput = tc.output
+			err := validateSimpleStartTmuxTarget(
+				teamLaunchOptions{Target: "new-session", TerminalSession: terminalSession},
+				"work", []simpleStartRecord{gotRecord}, gotProbe,
+			)
+			var conflict *simpleStartConflictError
+			if !errors.As(err, &conflict) || conflict.Class != "unmanaged" {
+				t.Fatalf("error = %v, want unmanaged conflict", err)
+			}
+		})
+	}
+
+	listOutput = "%999\tcodex: working\tamq:work:dev\n"
+	if err := validateSimpleStartTmuxTarget(
+		teamLaunchOptions{Target: "new-session", TerminalSession: terminalSession}, "work", nil, probe,
+	); err != nil {
+		t.Fatalf("durable pane-title fallback rejected: %v", err)
+	}
+}
+
 func simpleStartLaunchResult(role, paneID string) teamLaunchResult {
 	return teamLaunchResult{Panes: []teamLaunchResultPane{{Role: role, PaneID: paneID, WindowID: "@1"}}}
 }


### PR DESCRIPTION
Fixes #692.

`start --yes` (target `new-session`) permanently classified its own live session as `conflict unmanaged` the moment a launched agent rewrote its pane title, because `validateSimpleStartTmuxTarget` decided ownership by scanning `#{pane_title}`/`#{@amq_squad_title}` for the `amq:<session>:` prefix. This killed the documented rerun-`start` roll-forward path for the whole run.

## Changes

- Canonical launch records are read before existing-session validation; ownership acceptance is record-first: a record whose recorded tmux session matches the target, whose `pane_id` is present in the session (`list-panes -s`, all windows), and whose runtime identity classifier corroborates managed PID+pane (or external pane) ownership marks the session owned.
- Rewritten titles are recovered via PID/TTY identity; the stamped-title prefix scan remains as fallback only.
- Falsifiers stay fail-closed: absent recorded pane, wrong recorded session, and dead recorded PID still return `unmanaged`.

## Evidence

- Regression: `TestSimpleStartNewSessionAcceptsOwnedLivePaneAfterTitleRewrite` fails pre-fix with the exact issue error (`start conflict unmanaged: tmux session owned-session exists without a pane owned by workstream work`) and passes at head — verified independently by the lead in a detached worktree at `35fafb6` (record-first path neutralized in place, then restored).
- Full `go test ./internal/cli` green (201s); task-bound `make ci` green at exact head (evidence attempt `t4-gh692-35fafb6-ci`, summary sha256 `f6b6d328e0be9a17b46f2c991a714964fa8ac5e2aed8b989d11d45b77b2589e5`).

Squad: senior-dev (implementation), lead (exact-head review). Merge pending second independent review + `amq-squad verify merge` + operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)