### PR TITLE
fix(down): close verifiably dead panes under --close-panes; make member rm idempotent

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -695,6 +695,16 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 		request.Attestation = att
 		return PreparePaneCleanup(request, paneDeps)
 	}
+	// closeGoneAgentPane completes an AgentGone preparation: a Ready result
+	// means the exact recorded pane was re-attested and tmux reports it dead,
+	// so it is safe to close without operator review (#689). Anything not
+	// Ready keeps its fail-closed preparation outcome.
+	closeGoneAgentPane := func(prepared PaneCleanupPreparation, deps PaneCleanupDependencies) PaneCleanupResult {
+		if !prepared.Ready {
+			return prepared.Result
+		}
+		return ClosePreparedPane(prepared, deps)
+	}
 	strictWakeRoot := exactDownScope != nil
 	if recordIsExternal(rec) {
 		report.Pane = prepare(PaneCleanupAgentAttestation{}).Result
@@ -707,15 +717,18 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 		return report
 	}
 	if rec.AgentPID <= 0 {
-		report.Pane = prepare(PaneCleanupAgentAttestation{}).Result
 		// No pid was captured at launch (e.g. codex seats never recorded one).
 		// There is nothing to signal, so consult presence before implying the
 		// member is gone: a fresh heartbeat means it may well still be running.
 		if lastSeen, fresh := presenceFreshFor(report.AgentDir, handle, probe); fresh {
+			report.Pane = prepare(PaneCleanupAgentAttestation{}).Result
 			report.Status = downStatusMaybeLive
 			report.Detail = fmt.Sprintf("no pid captured at launch — may still be live (fresh presence, last seen %s); cannot signal", lastSeen.UTC().Format(time.RFC3339))
 			return report
 		}
+		// Stale presence with no recorded pid is the gone-agent shape: pane
+		// closure switches to tmux dead-pane evidence (#689).
+		report.Pane = closeGoneAgentPane(prepare(PaneCleanupAgentAttestation{AgentGone: true}), paneDeps)
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
@@ -737,7 +750,9 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 	}
 	runtimeIdentity := classifyLaunchPIDRuntimeIdentity(rec, binary, probe)
 	if !runtimeIdentity.PIDAlive {
-		report.Pane = prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: rec.Binary, Live: false}).Result
+		// The recorded pid is affirmatively dead: a lingering pane can only be
+		// a dead pane (or foreign content the dead-pane contract preserves).
+		report.Pane = closeGoneAgentPane(prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: rec.Binary, Live: false, AgentGone: true}), paneDeps)
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed
@@ -754,7 +769,11 @@ func terminateMember(t team.Team, projectDir, profile string, m team.Member, wor
 		return report
 	}
 	if !runtimeIdentity.PIDLive {
-		report.Pane = prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: binary, Live: true, BinaryMatch: runtimeIdentity.BinaryMatch}).Result
+		// The recorded runtime identity is gone (pid reused by some other
+		// process): the recorded agent no longer exists, so pane closure is
+		// gated on tmux dead-pane evidence, which a reused-pid process
+		// occupying the pane can never satisfy.
+		report.Pane = closeGoneAgentPane(prepare(PaneCleanupAgentAttestation{PID: rec.AgentPID, Binary: binary, Live: true, BinaryMatch: runtimeIdentity.BinaryMatch, AgentGone: true}), paneDeps)
 		cleaned := reapStaleArtifacts(report.AgentDir, handle, report.Root, strictWakeRoot, rec, term, probe, wakeCheck)
 		if cleaned.failed() {
 			report.Status = downStatusFailed

--- a/internal/cli/pane_cleanup.go
+++ b/internal/cli/pane_cleanup.go
@@ -53,6 +53,15 @@ type PaneCleanupAgentAttestation struct {
 	Binary      string `json:"binary"`
 	Live        bool   `json:"live"`
 	BinaryMatch bool   `json:"binary_match"`
+	// AgentGone is the lifecycle caller's affirmative attestation that the
+	// recorded agent runtime no longer exists: the recorded PID is not alive,
+	// its identity failed live verification (PID reuse), or no PID was ever
+	// recorded and presence is stale. It switches pane-closure authority from
+	// live process-lineage attestation to tmux dead-pane evidence: the pane
+	// may then be closed only when tmux itself reports pane_dead for the
+	// exact recorded pane id (#689). It never authorizes closing a pane whose
+	// process is still running.
+	AgentGone bool `json:"agent_gone,omitempty"`
 }
 
 type PaneCleanupRequest struct {
@@ -113,6 +122,11 @@ type PaneCleanupPreparation struct {
 	Identity PaneCleanupIdentity     `json:"identity"`
 	Initial  PaneCleanupPaneEvidence `json:"initial_pane"`
 	Result   PaneCleanupResult       `json:"result,omitempty"`
+	// DeadPane marks a preparation made under the AgentGone contract: the
+	// pane was attested via tmux dead-pane evidence rather than live process
+	// lineage. ClosePreparedPane must re-verify the pane is STILL dead before
+	// closing; a pane that came alive in between is preserved.
+	DeadPane bool `json:"dead_pane,omitempty"`
 }
 
 type PaneCleanupDependencies struct {
@@ -155,7 +169,17 @@ func PreparePaneCleanup(req PaneCleanupRequest, deps PaneCleanupDependencies) Pa
 	if recordIsExternal(req.Record) {
 		return finish(PaneCleanupPreservedExternal, "external/operator-owned pane is never closed")
 	}
+	if req.Attestation.AgentGone {
+		return prepareGoneAgentPaneCleanup(req, identity, recovery, deps, finish)
+	}
 	if mismatches := validatePaneCleanupRecord(req, deps.CanonicalDir); len(mismatches) > 0 {
+		// A recorded pane id that affirmatively no longer exists is
+		// already_gone regardless of the unconfirmed identity: reporting
+		// "preserved" for a nonexistent pane sends the operator to review
+		// nothing (#689). Only exact-id Gone evidence short-circuits here.
+		if gone, detail := recordedPaneAffirmativelyGone(identity.PaneID, deps); gone {
+			return finish(PaneCleanupAlreadyGone, detail)
+		}
 		return finish(PaneCleanupPreservedIdentityUnconfirmed, "launch identity is not fully confirmed", mismatches...)
 	}
 
@@ -192,6 +216,62 @@ func PreparePaneCleanup(req PaneCleanupRequest, deps PaneCleanupDependencies) Pa
 	}
 
 	return PaneCleanupPreparation{Ready: true, Identity: identity, Initial: initial}
+}
+
+// prepareGoneAgentPaneCleanup is the AgentGone contract (#689): the lifecycle
+// caller attested the recorded agent runtime no longer exists, so live
+// process-lineage attestation is impossible by definition. Pane closure is
+// instead authorized by tmux's own dead-pane evidence: the exact recorded pane
+// must exist, match the recorded identity, and be reported pane_dead. A pane
+// with a live process, an identity mismatch, or unavailable inspection is
+// preserved; a pane id tmux affirmatively no longer knows is already_gone.
+func prepareGoneAgentPaneCleanup(req PaneCleanupRequest, identity PaneCleanupIdentity, recovery *PaneCleanupRecovery, deps PaneCleanupDependencies, finish func(PaneCleanupOutcome, string, ...PaneCleanupMismatch) PaneCleanupPreparation) PaneCleanupPreparation {
+	mismatches := validatePaneCleanupRecordScoped(req, deps.CanonicalDir, false)
+	// Inspect before judging identity: a nonexistent pane is already_gone
+	// even when the durable record cannot be fully confirmed, so a retry
+	// after a manual kill-pane converges instead of re-reporting preserved.
+	if gone, detail := recordedPaneAffirmativelyGone(identity.PaneID, deps); gone {
+		return finish(PaneCleanupAlreadyGone, detail)
+	}
+	if len(mismatches) > 0 {
+		return finish(PaneCleanupPreservedIdentityUnconfirmed, "launch identity is not fully confirmed", mismatches...)
+	}
+	inspection := deps.Inspect(identity.PaneID)
+	switch inspection.State {
+	case tmuxpane.PaneInspectionGone:
+		return finish(PaneCleanupAlreadyGone, inspection.Detail)
+	case tmuxpane.PaneInspectionFound:
+		// Continue below.
+	default:
+		return finish(PaneCleanupInspectionUnavailable, inspection.Detail,
+			PaneCleanupMismatch{Field: "inspection", Expected: string(tmuxpane.PaneInspectionFound), Actual: string(inspection.State)})
+	}
+	initial, paneMismatches := attestInspectedPaneScoped(identity, req.Record.CWD, inspection.Pane, deps.CanonicalDir, false)
+	recovery.InitialPane = &initial
+	if len(paneMismatches) > 0 {
+		return finish(PaneCleanupPreservedIdentityUnconfirmed, "inspected pane identity is not fully confirmed", paneMismatches...)
+	}
+	if !inspection.Pane.Dead {
+		return finish(PaneCleanupPreservedIdentityUnconfirmed,
+			"agent runtime is gone but tmux reports the pane process still running; pane preserved for operator review",
+			PaneCleanupMismatch{Field: "pane_dead", Expected: "1", Actual: "0"})
+	}
+	return PaneCleanupPreparation{Ready: true, Identity: identity, Initial: initial, DeadPane: true}
+}
+
+// recordedPaneAffirmativelyGone reports whether an exact recorded pane id no
+// longer names a pane. Only affirmative Gone evidence counts; malformed ids
+// and unavailable inspection return false so callers keep their fail-closed
+// classification.
+func recordedPaneAffirmativelyGone(paneID string, deps PaneCleanupDependencies) (bool, string) {
+	if _, err := exactTmuxPaneID(paneID); err != nil {
+		return false, ""
+	}
+	inspection := deps.Inspect(paneID)
+	if inspection.State == tmuxpane.PaneInspectionGone {
+		return true, inspection.Detail
+	}
+	return false, ""
 }
 
 // paneProcessOrDescendant is the process-shape contract for managed panes:
@@ -251,10 +331,37 @@ func ClosePreparedPane(prepared PaneCleanupPreparation, deps PaneCleanupDependen
 		return PaneCleanupResult{Outcome: PaneCleanupPreservedIdentityUnconfirmed,
 			Detail: "pane identity changed during immediate revalidation", Mismatches: mismatches, Recovery: recovery}
 	}
+	if prepared.DeadPane {
+		// The dead-pane contract closes only what tmux still reports dead: a
+		// pane that came alive between preparation and close hosts a live
+		// process the gone-agent attestation never covered.
+		if !inspection.Pane.Dead {
+			return PaneCleanupResult{Outcome: PaneCleanupPreservedIdentityUnconfirmed,
+				Detail:     "pane came alive during immediate revalidation; preserved for operator review",
+				Mismatches: []PaneCleanupMismatch{{Field: "pane_dead", Expected: "1", Actual: "0"}}, Recovery: recovery}
+		}
+		if err := deps.Close(prepared.Identity.PaneID); err != nil {
+			return PaneCleanupResult{Outcome: PaneCleanupCloseFailed, Detail: err.Error(), Recovery: recovery}
+		}
+		return PaneCleanupResult{Outcome: PaneCleanupClosed, Detail: deadPaneClosedDetail(inspection.Pane), Recovery: recovery}
+	}
 	if err := deps.Close(prepared.Identity.PaneID); err != nil {
 		return PaneCleanupResult{Outcome: PaneCleanupCloseFailed, Detail: err.Error(), Recovery: recovery}
 	}
 	return PaneCleanupResult{Outcome: PaneCleanupClosed, Detail: "tmux pane closed", Recovery: recovery}
+}
+
+// deadPaneClosedDetail records the tmux dead-pane evidence that authorized the
+// close, so manifests and operators can audit why no review was required.
+func deadPaneClosedDetail(pane tmuxpane.TmuxPane) string {
+	detail := "dead tmux pane closed (pane_dead=1"
+	if strings.TrimSpace(pane.DeadStatus) != "" {
+		detail += " status=" + strings.TrimSpace(pane.DeadStatus)
+	}
+	if strings.TrimSpace(pane.DeadSignal) != "" {
+		detail += " signal=" + strings.TrimSpace(pane.DeadSignal)
+	}
+	return detail + ")"
 }
 
 func identityForCleanup(req PaneCleanupRequest) PaneCleanupIdentity {
@@ -292,6 +399,14 @@ func paneCleanupBinaryIdentityMatches(configured, observed string) bool {
 }
 
 func validatePaneCleanupRecord(req PaneCleanupRequest, canonicalDir func(string) (string, error)) []PaneCleanupMismatch {
+	return validatePaneCleanupRecordScoped(req, canonicalDir, true)
+}
+
+// validatePaneCleanupRecordScoped runs the durable-record identity checks.
+// requireLiveAttestation additionally demands the live PID/binary attestation;
+// the AgentGone contract passes false because a gone agent has no live process
+// to attest — pane closure is then gated on tmux dead-pane evidence instead.
+func validatePaneCleanupRecordScoped(req PaneCleanupRequest, canonicalDir func(string) (string, error), requireLiveAttestation bool) []PaneCleanupMismatch {
 	rec, scope, att := req.Record, req.Scope, req.Attestation
 	var out []PaneCleanupMismatch
 	match := func(field, expected, actual string) {
@@ -329,16 +444,18 @@ func validatePaneCleanupRecord(req PaneCleanupRequest, canonicalDir func(string)
 		out = append(out, PaneCleanupMismatch{Field: "binary", Expected: scope.Binary, Actual: rec.Binary})
 	}
 
-	if rec.AgentPID <= 0 || att.PID != rec.AgentPID {
-		out = append(out, PaneCleanupMismatch{Field: "agent_pid", Expected: fmt.Sprintf("%d", rec.AgentPID), Actual: fmt.Sprintf("%d", att.PID)})
-	}
-	if !att.Live {
-		out = append(out, PaneCleanupMismatch{Field: "agent_live", Expected: "true", Actual: "false"})
-	}
-	if !att.BinaryMatch ||
-		!paneCleanupBinaryIdentityMatches(scope.Binary, att.Binary) ||
-		!paneCleanupBinaryIdentityMatches(rec.Binary, att.Binary) {
-		out = append(out, PaneCleanupMismatch{Field: "agent_binary", Expected: scope.Binary, Actual: att.Binary})
+	if requireLiveAttestation {
+		if rec.AgentPID <= 0 || att.PID != rec.AgentPID {
+			out = append(out, PaneCleanupMismatch{Field: "agent_pid", Expected: fmt.Sprintf("%d", rec.AgentPID), Actual: fmt.Sprintf("%d", att.PID)})
+		}
+		if !att.Live {
+			out = append(out, PaneCleanupMismatch{Field: "agent_live", Expected: "true", Actual: "false"})
+		}
+		if !att.BinaryMatch ||
+			!paneCleanupBinaryIdentityMatches(scope.Binary, att.Binary) ||
+			!paneCleanupBinaryIdentityMatches(rec.Binary, att.Binary) {
+			out = append(out, PaneCleanupMismatch{Field: "agent_binary", Expected: scope.Binary, Actual: att.Binary})
+		}
 	}
 
 	if rec.Tmux == nil {
@@ -402,6 +519,14 @@ func paneCleanupBaseRootMatches(scope PaneCleanupScope, rec launch.Record, canon
 }
 
 func attestInspectedPane(identity PaneCleanupIdentity, recordedCWD string, pane tmuxpane.TmuxPane, canonicalDir func(string) (string, error)) (PaneCleanupPaneEvidence, []PaneCleanupMismatch) {
+	return attestInspectedPaneScoped(identity, recordedCWD, pane, canonicalDir, true)
+}
+
+// attestInspectedPaneScoped compares the inspected pane against the recorded
+// identity. requirePanePID demands a positive foreground pane process; the
+// dead-pane contract passes false because a pane tmux reports dead has, by
+// definition, no live foreground process left to attest.
+func attestInspectedPaneScoped(identity PaneCleanupIdentity, recordedCWD string, pane tmuxpane.TmuxPane, canonicalDir func(string) (string, error), requirePanePID bool) (PaneCleanupPaneEvidence, []PaneCleanupMismatch) {
 	canonicalCWD, cwdErr := canonicalDir(pane.CWD)
 	evidence := paneEvidence(pane, canonicalCWD)
 	var out []PaneCleanupMismatch
@@ -413,7 +538,7 @@ func attestInspectedPane(identity PaneCleanupIdentity, recordedCWD string, pane 
 	check("pane.id", identity.PaneID, pane.PaneID)
 	check("pane.session", identity.TmuxSession, pane.Session)
 	check("pane.window_id", identity.WindowID, pane.WindowID)
-	if pane.PID <= 0 {
+	if requirePanePID && pane.PID <= 0 {
 		out = append(out, PaneCleanupMismatch{Field: "pane.pid", Expected: "positive", Actual: fmt.Sprintf("%d", pane.PID)})
 	}
 	recordedCanonical, recErr := canonicalDir(recordedCWD)
@@ -424,7 +549,7 @@ func attestInspectedPane(identity PaneCleanupIdentity, recordedCWD string, pane 
 }
 
 func revalidatePreparedPane(prepared PaneCleanupPreparation, pane tmuxpane.TmuxPane, canonicalDir func(string) (string, error)) (PaneCleanupPaneEvidence, []PaneCleanupMismatch) {
-	current, out := attestInspectedPane(prepared.Identity, prepared.Initial.CWD, pane, canonicalDir)
+	current, out := attestInspectedPaneScoped(prepared.Identity, prepared.Initial.CWD, pane, canonicalDir, !prepared.DeadPane)
 	if pane.PID != prepared.Initial.PanePID {
 		out = append(out, PaneCleanupMismatch{Field: "pane.pid", Expected: fmt.Sprintf("%d", prepared.Initial.PanePID), Actual: fmt.Sprintf("%d", pane.PID)})
 	}

--- a/internal/cli/pane_cleanup_dead_pane_689_test.go
+++ b/internal/cli/pane_cleanup_dead_pane_689_test.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
+)
+
+// #689 regression: winding down a member whose process already exited must
+// close its lingering dead pane under --close-panes instead of fail-closing it
+// into "preserved" (operator review) and aborting the removal.
+
+// deadPaneFixture returns the standard down fixture with the recorded pane
+// reported dead by tmux (signal recorded), as after the agent process exits
+// under remain-on-exit.
+func deadPaneFixture(t *testing.T) (team.Team, team.Member, tmuxpane.TmuxPane, string) {
+	t.Helper()
+	configured, member, _, pane, project := completeDownPaneFixture(t)
+	pane.Dead = true
+	pane.DeadStatus = "0"
+	pane.DeadSignal = "15"
+	return configured, member, pane, project
+}
+
+func TestDownClosePanesClosesDeadPaneOfDeadAgent(t *testing.T) {
+	configured, member, pane, project := deadPaneFixture(t)
+	closed := []string{}
+	deps := PaneCleanupDependencies{
+		Inspect: func(string) tmuxpane.PaneInspection {
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+		},
+		Close: func(id string) error { closed = append(closed, id); return nil },
+	}
+	// Recorded pid 4242 is affirmatively not alive.
+	probe := downFakeProbe(map[int]bool{}, map[int]bool{})
+	report := terminateMember(configured, project, team.DefaultProfile, member, "issue-465", eventTerminator{events: &[]string{}}, probe, nil, true, deps, fakeMissingWakeCheck)
+	if report.Pane.Outcome != PaneCleanupClosed {
+		t.Fatalf("dead agent + dead pane must close under --close-panes, got %s (%s) mismatches=%v", report.Pane.Outcome, report.Pane.Detail, report.Pane.Mismatches)
+	}
+	if !strings.Contains(report.Pane.Detail, "pane_dead=1") || !strings.Contains(report.Pane.Detail, "signal=15") {
+		t.Fatalf("closed detail must carry the dead-pane evidence, got %q", report.Pane.Detail)
+	}
+	if len(closed) != 1 || closed[0] != "%9" {
+		t.Fatalf("expected exactly the recorded pane %%9 closed, got %v", closed)
+	}
+}
+
+func TestDownClosePanesPreservesLivePaneOfDeadAgent(t *testing.T) {
+	configured, member, pane, project := deadPaneFixture(t)
+	pane.Dead = false // pane process still running; agent record dead
+	deps := PaneCleanupDependencies{
+		Inspect: func(string) tmuxpane.PaneInspection {
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+		},
+		Close: func(string) error {
+			t.Fatal("live pane must never be closed under the gone-agent contract")
+			return nil
+		},
+	}
+	probe := downFakeProbe(map[int]bool{}, map[int]bool{})
+	report := terminateMember(configured, project, team.DefaultProfile, member, "issue-465", eventTerminator{events: &[]string{}}, probe, nil, true, deps, fakeMissingWakeCheck)
+	if report.Pane.Outcome != PaneCleanupPreservedIdentityUnconfirmed {
+		t.Fatalf("live pane with gone agent must be preserved, got %s (%s)", report.Pane.Outcome, report.Pane.Detail)
+	}
+	found := false
+	for _, m := range report.Pane.Mismatches {
+		if m.Field == "pane_dead" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("preservation must carry the pane_dead mismatch, got %v", report.Pane.Mismatches)
+	}
+}
+
+func TestDownClosePanesReportsAlreadyGoneForVanishedDeadAgentPane(t *testing.T) {
+	configured, member, _, project := deadPaneFixture(t)
+	deps := PaneCleanupDependencies{
+		Inspect: func(id string) tmuxpane.PaneInspection {
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionGone, Detail: "tmux returned fallback pane %0 for requested pane " + id}
+		},
+		Close: func(string) error { t.Fatal("gone pane must not be closed"); return nil },
+	}
+	probe := downFakeProbe(map[int]bool{}, map[int]bool{})
+	report := terminateMember(configured, project, team.DefaultProfile, member, "issue-465", eventTerminator{events: &[]string{}}, probe, nil, true, deps, fakeMissingWakeCheck)
+	if report.Pane.Outcome != PaneCleanupAlreadyGone {
+		t.Fatalf("vanished recorded pane must report already_gone, got %s (%s)", report.Pane.Outcome, report.Pane.Detail)
+	}
+}
+
+// The v2.29.3 double-report: after a manual kill-pane, a follow-up cleanup
+// re-reported "preserved" for the nonexistent pane id because the durable
+// record failed identity validation before live tmux was ever consulted. A
+// gone pane must now win over unconfirmed identity even on the live path.
+func TestPreparePaneCleanupUnconfirmedIdentityStillReportsGonePane(t *testing.T) {
+	_, _, record, _, project := completeDownPaneFixture(t)
+	record.Role = "someone-else" // force an identity mismatch
+	req := PaneCleanupRequest{
+		Requested: true,
+		Record:    record,
+		Scope: PaneCleanupScope{
+			ProjectDir: project, TeamHome: project, Profile: team.DefaultProfile,
+			Root: record.Root, BaseRoot: record.BaseRoot, Session: "issue-465",
+			Role: "cto", Handle: "cto", Binary: "codex", CWD: project,
+		},
+	}
+	deps := PaneCleanupDependencies{
+		Inspect: func(id string) tmuxpane.PaneInspection {
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionGone, Detail: "no such pane " + id}
+		},
+	}
+	prepared := PreparePaneCleanup(req, deps)
+	if prepared.Result.Outcome != PaneCleanupAlreadyGone {
+		t.Fatalf("gone pane must report already_gone despite unconfirmed identity, got %s (%s) mismatches=%v",
+			prepared.Result.Outcome, prepared.Result.Detail, prepared.Result.Mismatches)
+	}
+}
+
+func TestClosePreparedDeadPanePreservesWhenPaneComesAlive(t *testing.T) {
+	_, _, record, pane, project := completeDownPaneFixture(t)
+	pane.Dead = true
+	pane.DeadSignal = "15"
+	inspections := 0
+	alive := pane
+	alive.Dead = false
+	deps := PaneCleanupDependencies{
+		Inspect: func(string) tmuxpane.PaneInspection {
+			inspections++
+			if inspections <= 2 {
+				// preparation inspections see the dead pane
+				return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: pane}
+			}
+			// close-time revalidation sees it alive again
+			return tmuxpane.PaneInspection{State: tmuxpane.PaneInspectionFound, Pane: alive}
+		},
+		Close: func(string) error { t.Fatal("revived pane must not be closed"); return nil },
+	}
+	req := PaneCleanupRequest{
+		Requested:   true,
+		Record:      record,
+		Attestation: PaneCleanupAgentAttestation{AgentGone: true},
+		Scope: PaneCleanupScope{
+			ProjectDir: project, TeamHome: project, Profile: team.DefaultProfile,
+			Root: record.Root, BaseRoot: record.BaseRoot, Session: "issue-465",
+			Role: "cto", Handle: "cto", Binary: "codex", CWD: project,
+		},
+	}
+	prepared := PreparePaneCleanup(req, deps)
+	if !prepared.Ready || !prepared.DeadPane {
+		t.Fatalf("dead pane preparation must be Ready+DeadPane, got %+v", prepared.Result)
+	}
+	result := ClosePreparedPane(prepared, deps)
+	if result.Outcome != PaneCleanupPreservedIdentityUnconfirmed {
+		t.Fatalf("revived pane must be preserved at close time, got %s (%s)", result.Outcome, result.Detail)
+	}
+}
+
+// #689 (b): a partial stop (pane cleanups incomplete) no longer aborts the
+// roster removal; the command removes the entry and reports both outcomes.
+func TestTeamMemberRmRemovesDespitePartialPaneCleanup(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-96"},
+		},
+	})
+	prev := teamMemberStop
+	teamMemberStop = func([]string) error {
+		return &PartialError{Message: "down: 1 pane cleanup(s) were not completed"}
+	}
+	t.Cleanup(func() { teamMemberStop = prev })
+
+	out, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"rm", "qa", "--stop", "--close-panes"})
+	})
+	if err == nil {
+		t.Fatal("partial stop must surface as a partial error, not silent success")
+	}
+	if _, ok := err.(*PartialError); !ok {
+		t.Fatalf("want *PartialError, got %T: %v", err, err)
+	}
+	for _, want := range []string{"removed qa from the team roster", "pane cleanup"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("partial error must state the roster outcome, missing %q in %v", want, err)
+		}
+	}
+	if !strings.Contains(out, "removed qa from the team.") {
+		t.Fatalf("stdout must state the roster outcome, got:\n%s", out)
+	}
+	if got := len(teamMembers(t, dir)); got != 1 {
+		t.Fatalf("roster must be mutated despite partial stop, members=%d", got)
+	}
+}
+
+// Hard stop refusals (not partial) still abort before any roster mutation.
+func TestTeamMemberRmHardStopRefusalStillPreservesRoster(t *testing.T) {
+	dir := seedTeam(t, team.Team{
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "qa", Binary: "codex", Handle: "qa", Session: "issue-96"},
+		},
+	})
+	prev := teamMemberStop
+	teamMemberStop = func([]string) error {
+		return errString("launch record failed exact named-profile identity validation")
+	}
+	t.Cleanup(func() { teamMemberStop = prev })
+
+	_, _, err := captureOutput(t, func() error {
+		return runTeamMember([]string{"rm", "qa", "--stop", "--close-panes"})
+	})
+	if err == nil || !strings.Contains(err.Error(), "stop before remove") {
+		t.Fatalf("hard refusal must abort with 'stop before remove', got %v", err)
+	}
+	if got := len(teamMembers(t, dir)); got != 2 {
+		t.Fatalf("roster must be preserved on hard refusal, members=%d", got)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/cli/team_member.go
+++ b/internal/cli/team_member.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"crypto/sha256"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -728,7 +729,20 @@ func runTeamMemberRemove(args []string) error {
 	}
 	removedMember, ok := teamMemberByRole(t, role)
 	if !ok {
-		return fmt.Errorf("role %q is not a team member", role)
+		// rm is idempotent (#689): a retry after a partially-failed removal
+		// must converge with an unambiguous roster answer, not an error that
+		// reads like the removal may have failed.
+		if *jsonOut {
+			return printJSONEnvelope("team_member_rm", mutationResult{
+				Command: "team member rm",
+				Status:  "already_absent",
+				Project: projectDir,
+				Profile: profile,
+				Role:    role,
+			})
+		}
+		fmt.Printf("role %q is not a team member; roster unchanged (already removed or never added).\n", role)
+		return nil
 	}
 	if *dryRunFlag {
 		if *stopFlag {
@@ -737,9 +751,22 @@ func runTeamMemberRemove(args []string) error {
 		fmt.Printf("# preview: would remove %s from profile %s\n", role, profile)
 		return nil
 	}
+	// A PARTIAL stop (progress made, but e.g. pane cleanups incomplete) no
+	// longer aborts the removal: the operator asked for the roster mutation,
+	// and bailing out here left the roster outcome ambiguous (#689). The
+	// partial error is carried through and reported next to the definitive
+	// roster answer instead. Hard refusals (namespace conflicts, identity
+	// validation) still abort: they mean the stop request itself was unsafe,
+	// so the roster must not mutate on top of that uncertainty.
+	var stopErr error
 	if *stopFlag {
 		if err := teamMemberStop(teamMemberStopArgs(projectDir, profile, role, removedMember.Session, *forceFlag, *closePanesFlag)); err != nil {
-			return fmt.Errorf("stop before remove: %w", err)
+			var partial *PartialError
+			if !errors.As(err, &partial) {
+				return fmt.Errorf("stop before remove: %w", err)
+			}
+			stopErr = err
+			fmt.Fprintf(os.Stderr, "stop before remove was only partially completed: %v\nproceeding with the roster removal; its outcome is reported explicitly below.\n", err)
 		}
 	}
 
@@ -782,11 +809,14 @@ func runTeamMemberRemove(args []string) error {
 		})
 	}
 	if err := mutateRosterWithProfileCAS(projectDir, profile, mutation); err != nil {
+		if stopErr != nil {
+			return fmt.Errorf("%w (roster NOT removed; stop before remove had also failed: %v)", err, stopErr)
+		}
 		return err
 	}
 
 	if *jsonOut {
-		return printJSONEnvelope("team_member_rm", mutationResult{
+		if err := printJSONEnvelope("team_member_rm", mutationResult{
 			Command: "team member rm",
 			Status:  "removed",
 			Project: projectDir,
@@ -795,9 +825,21 @@ func runTeamMemberRemove(args []string) error {
 			Actions: []mutationAction{
 				followUp("down", "close live pane", "amq-squad down --project "+shellQuote(projectDir)+" --profile "+shellQuote(profile)+" --role "+shellQuote(role)+" --close-panes"),
 			},
-		})
+		}); err != nil {
+			return err
+		}
+		if stopErr != nil {
+			return &PartialError{Message: fmt.Sprintf("removed %s from the team roster, but stop/pane cleanup was incomplete: %v", role, stopErr), Cause: stopErr}
+		}
+		return nil
 	}
 	fmt.Printf("removed %s from the team.\n", role)
+	if stopErr != nil {
+		// The roster answer is definitive even though the stop was partial;
+		// the partial exit code says "roster removed, runtime cleanup needs
+		// attention", never "the removal may not have happened".
+		return &PartialError{Message: fmt.Sprintf("removed %s from the team roster, but stop/pane cleanup was incomplete: %v", role, stopErr), Cause: stopErr}
+	}
 	// rm is roster-only; it never touches the agent's tmux pane. Point at the
 	// pane-closing teardown so a pruned worker's window doesn't linger as an
 	// orphan (down keeps the pane by default; --close-panes closes it).

--- a/internal/cli/team_member_test.go
+++ b/internal/cli/team_member_test.go
@@ -267,12 +267,21 @@ func TestTeamMemberRmRemovesAndPersists(t *testing.T) {
 	}
 }
 
-func TestTeamMemberRmUnknownRoleErrors(t *testing.T) {
+// TestTeamMemberRmAbsentRoleIsIdempotentNoOp: rm of a role that is not in the
+// roster succeeds with an unambiguous "roster unchanged" answer (#689), so a
+// retry after a partially-failed removal converges instead of erroring.
+func TestTeamMemberRmAbsentRoleIsIdempotentNoOp(t *testing.T) {
 	seedTeam(t, team.Team{Members: []team.Member{{Role: "cto", Binary: "claude", Handle: "cto", Session: "s"}}})
-	if _, _, err := captureOutput(t, func() error {
+	out, _, err := captureOutput(t, func() error {
 		return runTeamMember([]string{"rm", "ghost"})
-	}); err == nil || !strings.Contains(err.Error(), "not a team member") {
-		t.Fatalf("want 'not a team member', got %v", err)
+	})
+	if err != nil {
+		t.Fatalf("absent-role rm must be a clean no-op, got %v", err)
+	}
+	for _, want := range []string{"not a team member", "roster unchanged"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("absent-role rm output missing %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -88,6 +88,15 @@ type TmuxPane struct {
 	// production lister always requests them.
 	PaneID   string
 	WindowID string
+	// Dead reports #{pane_dead}: the pane's process has exited but the pane
+	// itself remains (remain-on-exit). Only an affirmative "1" from tmux sets
+	// it; absent or unparseable evidence stays false so destructive policy
+	// fails closed. DeadStatus and DeadSignal carry #{pane_dead_status} and
+	// #{pane_dead_signal} verbatim when tmux recorded them (older tmux may
+	// leave either empty).
+	Dead       bool
+	DeadStatus string
+	DeadSignal string
 }
 
 // TmuxTarget identifies a single pane for the jump action. Title carries the
@@ -213,7 +222,13 @@ func PaneIdentityFor(paneID string) (*PaneIdentity, error) {
 // never shift the ids. window_name remains the last field so the parser can
 // absorb any embedded tabs into it; an empty pane_title (older/non-amq panes)
 // leaves a trailing tab the parser tolerates.
-const paneListFormat = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_id}\t#{window_id}\tamqmeta:#{@amq_squad_title}\t#{pane_title}\t#{window_name}"
+//
+// amqdead carries the pane's dead-state evidence (#{pane_dead} plus the exit
+// status/signal tmux recorded) as one prefix-guarded colon-joined field so the
+// parser can splice it out without shifting the legacy field positions. Older
+// tmux renders unsupported format variables as empty strings, which the parser
+// treats as absent evidence (never as dead).
+const paneListFormat = "#{session_name}\t#{window_index}\t#{pane_index}\t#{pane_pid}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_id}\t#{window_id}\tamqdead:#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}\tamqmeta:#{@amq_squad_title}\t#{pane_title}\t#{window_name}"
 
 // DefaultPaneLister shells `tmux list-panes -a` with a tab-separated format and
 // parses each row into a TmuxPane. It is strictly READ-ONLY. A missing tmux
@@ -543,6 +558,22 @@ func parsePanes(out string) []TmuxPane {
 		}
 		if len(fields) >= 8 {
 			pane.WindowID = strings.TrimSpace(fields[7])
+		}
+		// The prefix-guarded dead-state field is spliced out before the legacy
+		// positional logic so its presence never shifts the older shapes. Only
+		// an affirmative "1" marks the pane dead; anything else (older tmux,
+		// empty render, malformed row) stays alive-by-default so destructive
+		// consumers fail closed.
+		if len(fields) >= 9 && strings.HasPrefix(fields[8], "amqdead:") {
+			parts := strings.SplitN(strings.TrimPrefix(fields[8], "amqdead:"), ":", 3)
+			pane.Dead = len(parts) > 0 && strings.TrimSpace(parts[0]) == "1"
+			if len(parts) > 1 {
+				pane.DeadStatus = strings.TrimSpace(parts[1])
+			}
+			if len(parts) > 2 {
+				pane.DeadSignal = strings.TrimSpace(parts[2])
+			}
+			fields = append(fields[:8], fields[9:]...)
 		}
 		// D6 (#505 review, accepted low risk): this shift assumes field 8 only
 		// starts with "amqmeta:" when it really is the launcher-set

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -248,7 +248,7 @@ func DefaultPaneLister() ([]TmuxPane, error) {
 			// An empty list with no error is a genuine "no panes", not a -CC
 			// stutter, so it returns immediately. Only an error (exit 1, the
 			// pause shape) is retried.
-			return parsePanes(out), nil
+			return parsePanesModernFormat(out), nil
 		}
 		lastErr = err
 		// A permission denial (sandboxed agent) is not transient — don't burn
@@ -318,7 +318,7 @@ func InspectPaneExactByID(paneID string) PaneInspection {
 			// reports pane_alive:true for a pane that has been closed (the #156
 			// false positive). Only accept the row when its pane_id matches the
 			// id we asked for; a mismatch means the original pane is gone.
-			panes := parsePanes(out)
+			panes := parsePanesModernFormat(out)
 			if len(panes) != 1 {
 				return PaneInspection{State: PaneInspectionMalformed, Detail: fmt.Sprintf("unexpected tmux display-message output %q", out)}
 			}
@@ -528,7 +528,27 @@ const tmuxNoServerRunningMarker = "no server running"
 
 // parsePanes parses the tab-separated `tmux list-panes` output. Malformed rows
 // (too few fields) are skipped rather than failing the whole parse.
+// parsePanes parses rows of UNKNOWN or legacy origin. It never consumes the
+// amqdead dead-evidence field: pane titles and window names are user- and
+// agent-controlled text, and window_name legally absorbs tabs, so no width or
+// prefix heuristic on an ambiguous row can prove which format produced it.
+// Dead-pane evidence is only trusted with explicit format provenance — see
+// parsePanesModernFormat.
 func parsePanes(out string) []TmuxPane {
+	return parsePaneRows(out, false)
+}
+
+// parsePanesModernFormat parses rows the CALLER produced with paneListFormat,
+// which emits the amqdead field at position 8 by construction. That explicit
+// provenance — not content inspection — is what authorizes consuming
+// dead-pane evidence, because Dead feeds the destructive AgentGone close
+// path. The payload itself still passes the raw canonical gate before it can
+// read dead.
+func parsePanesModernFormat(out string) []TmuxPane {
+	return parsePaneRows(out, true)
+}
+
+func parsePaneRows(out string, modernFormat bool) []TmuxPane {
 	var panes []TmuxPane
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimRight(line, "\r")
@@ -559,25 +579,19 @@ func parsePanes(out string) []TmuxPane {
 		if len(fields) >= 8 {
 			pane.WindowID = strings.TrimSpace(fields[7])
 		}
-		// The prefix-guarded dead-state field is spliced out before the legacy
-		// positional logic so its presence never shifts the older shapes. Dead
-		// feeds the destructive AgentGone close path, so the gate is strictly
-		// fail-closed: the payload must have the exact canonical shape (three
-		// colon-separated components; flag exactly "", "0", or "1"; status and
-		// signal digits-or-empty as tmux renders them) AND the NEXT field must
-		// carry the launcher-controlled amqmeta: prefix that corroborates the
-		// modern row format. Anything else — truncated, overlong, or a legacy
-		// pane title that merely starts with "amqdead:" — is left in place as
-		// ordinary text with Dead=false and legacy positions untouched.
-		// A modern row carries at least 12 fields before the splice (8 base
-		// fields, amqdead, amqmeta, title, window_name). Anything shorter is a
-		// legacy shape whose field 8/9 are title/window text, where matching
-		// prefixes are coincidence or injection, never launcher provenance.
-		if len(fields) >= 12 && strings.HasPrefix(fields[8], "amqdead:") && strings.HasPrefix(fields[9], "amqmeta:") {
+		// Dead-pane evidence is consumed ONLY under explicit modern-format
+		// provenance: the caller invoked tmux with paneListFormat, which puts
+		// the amqdead field at position 8 by construction. The field is then
+		// spliced out unconditionally to keep downstream positions canonical
+		// (its content comes from tab-free tmux variables), while Dead itself
+		// additionally requires the raw canonical payload gate. Legacy parsing
+		// never auto-detects the prefix — a title or window label that merely
+		// looks like "amqdead:..." stays ordinary text with Dead=false.
+		if modernFormat && len(fields) >= 9 && strings.HasPrefix(fields[8], "amqdead:") {
 			if dead, status, signal, ok := parseDeadPaneField(strings.TrimPrefix(fields[8], "amqdead:")); ok {
 				pane.Dead, pane.DeadStatus, pane.DeadSignal = dead, status, signal
-				fields = append(fields[:8], fields[9:]...)
 			}
+			fields = append(fields[:8], fields[9:]...)
 		}
 		// D6 (#505 review, accepted low risk): this shift assumes field 8 only
 		// starts with "amqmeta:" when it really is the launcher-set

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -569,7 +569,11 @@ func parsePanes(out string) []TmuxPane {
 		// modern row format. Anything else — truncated, overlong, or a legacy
 		// pane title that merely starts with "amqdead:" — is left in place as
 		// ordinary text with Dead=false and legacy positions untouched.
-		if len(fields) >= 10 && strings.HasPrefix(fields[8], "amqdead:") && strings.HasPrefix(fields[9], "amqmeta:") {
+		// A modern row carries at least 12 fields before the splice (8 base
+		// fields, amqdead, amqmeta, title, window_name). Anything shorter is a
+		// legacy shape whose field 8/9 are title/window text, where matching
+		// prefixes are coincidence or injection, never launcher provenance.
+		if len(fields) >= 12 && strings.HasPrefix(fields[8], "amqdead:") && strings.HasPrefix(fields[9], "amqmeta:") {
 			if dead, status, signal, ok := parseDeadPaneField(strings.TrimPrefix(fields[8], "amqdead:")); ok {
 				pane.Dead, pane.DeadStatus, pane.DeadSignal = dead, status, signal
 				fields = append(fields[:8], fields[9:]...)
@@ -611,11 +615,14 @@ func parseDeadPaneField(payload string) (dead bool, status, signal string, ok bo
 	if len(parts) != 3 {
 		return false, "", "", false
 	}
-	flag := strings.TrimSpace(parts[0])
+	// RAW comparison throughout: real tmux output cannot contain whitespace
+	// in these variables, so whitespace anywhere is disqualifying evidence of
+	// a non-canonical source, never something to normalize away.
+	flag := parts[0]
 	if flag != "" && flag != "0" && flag != "1" {
 		return false, "", "", false
 	}
-	status, signal = strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])
+	status, signal = parts[1], parts[2]
 	if !deadFieldDigitsOrEmpty(status) || !deadFieldDigitsOrEmpty(signal) {
 		return false, "", "", false
 	}

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -560,20 +560,20 @@ func parsePanes(out string) []TmuxPane {
 			pane.WindowID = strings.TrimSpace(fields[7])
 		}
 		// The prefix-guarded dead-state field is spliced out before the legacy
-		// positional logic so its presence never shifts the older shapes. Only
-		// an affirmative "1" marks the pane dead; anything else (older tmux,
-		// empty render, malformed row) stays alive-by-default so destructive
-		// consumers fail closed.
-		if len(fields) >= 9 && strings.HasPrefix(fields[8], "amqdead:") {
-			parts := strings.SplitN(strings.TrimPrefix(fields[8], "amqdead:"), ":", 3)
-			pane.Dead = len(parts) > 0 && strings.TrimSpace(parts[0]) == "1"
-			if len(parts) > 1 {
-				pane.DeadStatus = strings.TrimSpace(parts[1])
+		// positional logic so its presence never shifts the older shapes. Dead
+		// feeds the destructive AgentGone close path, so the gate is strictly
+		// fail-closed: the payload must have the exact canonical shape (three
+		// colon-separated components; flag exactly "", "0", or "1"; status and
+		// signal digits-or-empty as tmux renders them) AND the NEXT field must
+		// carry the launcher-controlled amqmeta: prefix that corroborates the
+		// modern row format. Anything else — truncated, overlong, or a legacy
+		// pane title that merely starts with "amqdead:" — is left in place as
+		// ordinary text with Dead=false and legacy positions untouched.
+		if len(fields) >= 10 && strings.HasPrefix(fields[8], "amqdead:") && strings.HasPrefix(fields[9], "amqmeta:") {
+			if dead, status, signal, ok := parseDeadPaneField(strings.TrimPrefix(fields[8], "amqdead:")); ok {
+				pane.Dead, pane.DeadStatus, pane.DeadSignal = dead, status, signal
+				fields = append(fields[:8], fields[9:]...)
 			}
-			if len(parts) > 2 {
-				pane.DeadSignal = strings.TrimSpace(parts[2])
-			}
-			fields = append(fields[:8], fields[9:]...)
 		}
 		// D6 (#505 review, accepted low risk): this shift assumes field 8 only
 		// starts with "amqmeta:" when it really is the launcher-set
@@ -598,6 +598,37 @@ func parsePanes(out string) []TmuxPane {
 		panes = append(panes, pane)
 	}
 	return panes
+}
+
+// parseDeadPaneField validates and parses the canonical amqdead payload
+// (#{pane_dead}:#{pane_dead_status}:#{pane_dead_signal}). ok is false for any
+// non-canonical shape so callers refuse to treat the field as dead-state
+// evidence: exactly three components (full Split, so extra colons are
+// overlong, not absorbed), flag strictly "", "0", or "1", and status/signal
+// digits-or-empty (tmux renders unset variables as empty strings).
+func parseDeadPaneField(payload string) (dead bool, status, signal string, ok bool) {
+	parts := strings.Split(payload, ":")
+	if len(parts) != 3 {
+		return false, "", "", false
+	}
+	flag := strings.TrimSpace(parts[0])
+	if flag != "" && flag != "0" && flag != "1" {
+		return false, "", "", false
+	}
+	status, signal = strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])
+	if !deadFieldDigitsOrEmpty(status) || !deadFieldDigitsOrEmpty(signal) {
+		return false, "", "", false
+	}
+	return flag == "1", status, signal, true
+}
+
+func deadFieldDigitsOrEmpty(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // ResolveTmuxTarget matches a running agent to the tmux pane hosting it.

--- a/internal/tmuxpane/tmux.go
+++ b/internal/tmuxpane/tmux.go
@@ -581,13 +581,19 @@ func parsePaneRows(out string, modernFormat bool) []TmuxPane {
 		}
 		// Dead-pane evidence is consumed ONLY under explicit modern-format
 		// provenance: the caller invoked tmux with paneListFormat, which puts
-		// the amqdead field at position 8 by construction. The field is then
-		// spliced out unconditionally to keep downstream positions canonical
-		// (its content comes from tab-free tmux variables), while Dead itself
-		// additionally requires the raw canonical payload gate. Legacy parsing
-		// never auto-detects the prefix — a title or window label that merely
-		// looks like "amqdead:..." stays ordinary text with Dead=false.
-		if modernFormat && len(fields) >= 9 && strings.HasPrefix(fields[8], "amqdead:") {
+		// the amqdead field at position 8 by construction. Provenance proves
+		// which format was REQUESTED, not that tmux returned a complete row,
+		// so it is combined with ROW-INTEGRITY validation of what actually
+		// came back before Dead may read true: the complete modern minimum
+		// (12 fields) and the fixed amqmeta field that must follow at
+		// position 9. These are integrity checks inside declared-modern
+		// parsing, not provenance heuristics — legacy parsing never reaches
+		// this block, so a title or window label that merely looks like
+		// "amqdead:..." stays ordinary text with Dead=false. A structurally
+		// invalid modern row is likewise left unspliced as text (still listed
+		// read-only via its ids), and Dead itself additionally requires the
+		// raw canonical payload gate.
+		if modernFormat && len(fields) >= 12 && strings.HasPrefix(fields[8], "amqdead:") && strings.HasPrefix(fields[9], "amqmeta:") {
 			if dead, status, signal, ok := parseDeadPaneField(strings.TrimPrefix(fields[8], "amqdead:")); ok {
 				pane.Dead, pane.DeadStatus, pane.DeadSignal = dead, status, signal
 			}

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -332,3 +332,37 @@ func swapTmuxEnv(fn func() string) func() {
 	tmuxEnv = fn
 	return func() { tmuxEnv = prev }
 }
+
+// TestParsePanesDeadPaneEvidence covers the #689 prefix-guarded amqdead field:
+// affirmative pane_dead=1 with the recorded status/signal parses into the
+// TmuxPane dead-evidence fields, and its presence never shifts the id, token,
+// title, or window-name positions.
+func TestParsePanesDeadPaneEvidence(t *testing.T) {
+	out := "squad\t1\t0\t0\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:15\tamqmeta:amq:issue-465:cto\tcto-title\tcto-win\n"
+	panes := parsePanes(out)
+	if len(panes) != 1 {
+		t.Fatalf("panes = %d, want 1", len(panes))
+	}
+	p := panes[0]
+	if !p.Dead || p.DeadStatus != "0" || p.DeadSignal != "15" {
+		t.Fatalf("dead evidence = %v/%q/%q, want true/0/15", p.Dead, p.DeadStatus, p.DeadSignal)
+	}
+	if p.PaneID != "%9" || p.WindowID != "@7" || p.DiscoveryToken != "amq:issue-465:cto" || p.WindowName != "cto-win" {
+		t.Fatalf("dead field shifted positional parsing: %+v", p)
+	}
+
+	// A live pane parses Dead=false; an empty/older render never reads dead.
+	for _, row := range []string{
+		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:0::\tamqmeta:tok\ttitle\twin\n",
+		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:::\tamqmeta:tok\ttitle\twin\n",
+		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqmeta:tok\ttitle\twin\n", // legacy: no dead field
+	} {
+		got := parsePanes(row)
+		if len(got) != 1 || got[0].Dead {
+			t.Fatalf("row %q must parse one live pane, got %+v", row, got)
+		}
+		if got[0].PaneID != "%9" || got[0].WindowID != "@7" {
+			t.Fatalf("row %q shifted ids: %+v", row, got[0])
+		}
+	}
+}

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -366,3 +366,47 @@ func TestParsePanesDeadPaneEvidence(t *testing.T) {
 		}
 	}
 }
+
+// TestParsePanesDeadPaneFieldFailsClosed covers the PR #716 review probes: a
+// non-canonical amqdead payload (truncated or overlong), or ordinary pane-title
+// text that merely starts with "amqdead:" in a legacy row, must never read as
+// dead-pane evidence and must never shift positional parsing. Dead feeds the
+// destructive AgentGone close path, so every one of these fails closed.
+func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
+	// Truncated and overlong payloads in modern-format position: refused as
+	// dead evidence; the un-spliced field then reads as legacy title text.
+	for _, tc := range []struct{ name, row string }{
+		{"truncated payload", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1\tamqmeta:tok\ttitle\twin\n"},
+		{"overlong payload", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:15:extra\tamqmeta:tok\ttitle\twin\n"},
+		{"non-numeric flag", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:yes:0:15\tamqmeta:tok\ttitle\twin\n"},
+		{"non-numeric signal", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:TERM;rm\tamqmeta:tok\ttitle\twin\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePanes(tc.row)
+			if len(got) != 1 {
+				t.Fatalf("panes = %d, want 1", len(got))
+			}
+			if got[0].Dead || got[0].DeadStatus != "" || got[0].DeadSignal != "" {
+				t.Fatalf("non-canonical payload must not read dead: %+v", got[0])
+			}
+			if got[0].PaneID != "%9" || got[0].WindowID != "@7" {
+				t.Fatalf("refused payload shifted ids: %+v", got[0])
+			}
+		})
+	}
+
+	// Legacy row whose FIELD-8 PANE TITLE is attacker-influenceable text that
+	// starts with "amqdead:": no amqmeta corroboration follows, so it stays an
+	// ordinary title, Dead stays false, and window_name keeps its position.
+	row := "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tlegacy-win\n"
+	got := parsePanes(row)
+	if len(got) != 1 {
+		t.Fatalf("panes = %d, want 1", len(got))
+	}
+	if got[0].Dead {
+		t.Fatalf("legacy title collision must not read dead: %+v", got[0])
+	}
+	if got[0].Title != "amqdead:1::" || got[0].WindowName != "legacy-win" {
+		t.Fatalf("legacy title collision shifted title/window parsing: %+v", got[0])
+	}
+}

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -339,7 +339,7 @@ func swapTmuxEnv(fn func() string) func() {
 // title, or window-name positions.
 func TestParsePanesDeadPaneEvidence(t *testing.T) {
 	out := "squad\t1\t0\t0\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:15\tamqmeta:amq:issue-465:cto\tcto-title\tcto-win\n"
-	panes := parsePanes(out)
+	panes := parsePanesModernFormat(out)
 	if len(panes) != 1 {
 		t.Fatalf("panes = %d, want 1", len(panes))
 	}
@@ -355,9 +355,9 @@ func TestParsePanesDeadPaneEvidence(t *testing.T) {
 	for _, row := range []string{
 		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:0::\tamqmeta:tok\ttitle\twin\n",
 		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:::\tamqmeta:tok\ttitle\twin\n",
-		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqmeta:tok\ttitle\twin\n", // legacy: no dead field
+		"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqmeta:tok\ttitle\twin\n", // older binary output: no dead field
 	} {
-		got := parsePanes(row)
+		got := parsePanesModernFormat(row)
 		if len(got) != 1 || got[0].Dead {
 			t.Fatalf("row %q must parse one live pane, got %+v", row, got)
 		}
@@ -367,14 +367,15 @@ func TestParsePanesDeadPaneEvidence(t *testing.T) {
 	}
 }
 
-// TestParsePanesDeadPaneFieldFailsClosed covers the PR #716 review probes: a
-// non-canonical amqdead payload (truncated or overlong), or ordinary pane-title
-// text that merely starts with "amqdead:" in a legacy row, must never read as
-// dead-pane evidence and must never shift positional parsing. Dead feeds the
-// destructive AgentGone close path, so every one of these fails closed.
+// TestParsePanesDeadPaneFieldFailsClosed covers the PR #716 review probes.
+// Dead feeds the destructive AgentGone close path, so it is consumed only
+// under explicit modern-format provenance AND a canonical raw payload; the
+// legacy parser never auto-detects dead evidence from content, because pane
+// titles and window names are user-controlled and window_name legally absorbs
+// tabs, making every width or prefix heuristic spoofable.
 func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
-	// Truncated and overlong payloads in modern-format position: refused as
-	// dead evidence; the un-spliced field then reads as legacy title text.
+	// Modern provenance, non-canonical payloads: the structural field is
+	// spliced (position is format-guaranteed) but Dead stays false.
 	for _, tc := range []struct{ name, row string }{
 		{"truncated payload", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1\tamqmeta:tok\ttitle\twin\n"},
 		{"overlong payload", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:15:extra\tamqmeta:tok\ttitle\twin\n"},
@@ -382,49 +383,58 @@ func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
 		{"non-numeric signal", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:TERM;rm\tamqmeta:tok\ttitle\twin\n"},
 		{"whitespace-padded flag", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead: 1 ::\tamqmeta:tok\ttitle\twin\n"},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := parsePanes(tc.row)
+		t.Run("modern "+tc.name, func(t *testing.T) {
+			got := parsePanesModernFormat(tc.row)
 			if len(got) != 1 {
 				t.Fatalf("panes = %d, want 1", len(got))
 			}
 			if got[0].Dead || got[0].DeadStatus != "" || got[0].DeadSignal != "" {
 				t.Fatalf("non-canonical payload must not read dead: %+v", got[0])
 			}
-			if got[0].PaneID != "%9" || got[0].WindowID != "@7" {
-				t.Fatalf("refused payload shifted ids: %+v", got[0])
+			if got[0].PaneID != "%9" || got[0].WindowID != "@7" || got[0].DiscoveryToken != "tok" || got[0].WindowName != "win" {
+				t.Fatalf("refused payload corrupted positional parsing: %+v", got[0])
 			}
 		})
 	}
 
-	// Legacy row whose FIELD-8 PANE TITLE is attacker-influenceable text that
-	// starts with "amqdead:": no amqmeta corroboration follows, so it stays an
-	// ordinary title, Dead stays false, and window_name keeps its position.
-	row := "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tlegacy-win\n"
-	got := parsePanes(row)
-	if len(got) != 1 {
-		t.Fatalf("panes = %d, want 1", len(got))
-	}
-	if got[0].Dead {
-		t.Fatalf("legacy title collision must not read dead: %+v", got[0])
-	}
-	if got[0].Title != "amqdead:1::" || got[0].WindowName != "legacy-win" {
-		t.Fatalf("legacy title collision shifted title/window parsing: %+v", got[0])
-	}
-
-	// Dual-prefix legacy collision (PR #716 round 2): a standard 10-field
-	// legacy row whose title is "amqdead:1::" AND whose window name starts
-	// with "amqmeta:" satisfies both prefix checks but not the 12-field
-	// modern minimum. It must stay a plain legacy row: not dead, title and
-	// window name in their legacy positions, nothing spliced or lost.
-	row = "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tamqmeta:legacy-win\n"
-	got = parsePanes(row)
-	if len(got) != 1 {
-		t.Fatalf("panes = %d, want 1", len(got))
-	}
-	if got[0].Dead {
-		t.Fatalf("dual-prefix legacy collision must not read dead: %+v", got[0])
-	}
-	if got[0].Title != "amqdead:1::" || got[0].WindowName != "amqmeta:legacy-win" {
-		t.Fatalf("dual-prefix legacy collision shifted title/window parsing: %+v", got[0])
+	// Legacy provenance: rows whose user-controlled labels imitate the
+	// modern fields must stay ordinary legacy rows regardless of shape —
+	// single-prefix title, dual-prefix title+window, and the tabbed-window
+	// variant whose legal window-name tabs make it exactly as wide as a
+	// modern row.
+	for _, tc := range []struct {
+		name, row, title, window string
+	}{
+		{
+			"title collision",
+			"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tlegacy-win\n",
+			"amqdead:1::", "legacy-win",
+		},
+		{
+			"dual-prefix collision",
+			"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tamqmeta:legacy-win\n",
+			"amqdead:1::", "amqmeta:legacy-win",
+		},
+		{
+			"dual-prefix tabbed-window collision",
+			"squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tamqmeta:legacy-win\textra\tchunks\n",
+			"amqdead:1::", "amqmeta:legacy-win\textra\tchunks",
+		},
+	} {
+		t.Run("legacy "+tc.name, func(t *testing.T) {
+			got := parsePanes(tc.row)
+			if len(got) != 1 {
+				t.Fatalf("panes = %d, want 1", len(got))
+			}
+			if got[0].Dead {
+				t.Fatalf("legacy parsing must never read dead: %+v", got[0])
+			}
+			if got[0].DiscoveryToken != "" {
+				t.Fatalf("legacy collision must not mint a discovery token: %+v", got[0])
+			}
+			if got[0].Title != tc.title || got[0].WindowName != tc.window {
+				t.Fatalf("legacy collision shifted title/window parsing: %+v", got[0])
+			}
+		})
 	}
 }

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -380,6 +380,7 @@ func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
 		{"overlong payload", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:15:extra\tamqmeta:tok\ttitle\twin\n"},
 		{"non-numeric flag", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:yes:0:15\tamqmeta:tok\ttitle\twin\n"},
 		{"non-numeric signal", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1:0:TERM;rm\tamqmeta:tok\ttitle\twin\n"},
+		{"whitespace-padded flag", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead: 1 ::\tamqmeta:tok\ttitle\twin\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := parsePanes(tc.row)
@@ -408,5 +409,22 @@ func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
 	}
 	if got[0].Title != "amqdead:1::" || got[0].WindowName != "legacy-win" {
 		t.Fatalf("legacy title collision shifted title/window parsing: %+v", got[0])
+	}
+
+	// Dual-prefix legacy collision (PR #716 round 2): a standard 10-field
+	// legacy row whose title is "amqdead:1::" AND whose window name starts
+	// with "amqmeta:" satisfies both prefix checks but not the 12-field
+	// modern minimum. It must stay a plain legacy row: not dead, title and
+	// window name in their legacy positions, nothing spliced or lost.
+	row = "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tamqmeta:legacy-win\n"
+	got = parsePanes(row)
+	if len(got) != 1 {
+		t.Fatalf("panes = %d, want 1", len(got))
+	}
+	if got[0].Dead {
+		t.Fatalf("dual-prefix legacy collision must not read dead: %+v", got[0])
+	}
+	if got[0].Title != "amqdead:1::" || got[0].WindowName != "amqmeta:legacy-win" {
+		t.Fatalf("dual-prefix legacy collision shifted title/window parsing: %+v", got[0])
 	}
 }

--- a/internal/tmuxpane/tmux_test.go
+++ b/internal/tmuxpane/tmux_test.go
@@ -397,6 +397,29 @@ func TestParsePanesDeadPaneFieldFailsClosed(t *testing.T) {
 		})
 	}
 
+	// Modern provenance with a structurally invalid RESPONSE (PR #716 round
+	// 4): provenance proves the request, not the returned row. A truncated
+	// row ending right after the amqdead field, or a row whose fixed field-9
+	// amqmeta position carries something else, must never authorize Dead —
+	// the row survives for read-only listing but the field stays text.
+	for _, tc := range []struct{ name, row string }{
+		{"truncated after amqdead", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\n"},
+		{"not-meta at fixed amqmeta position", "squad\t1\t0\t100\tcodex\t/tmp/proj\t%9\t@7\tamqdead:1::\tnot-meta\ttitle\twin\n"},
+	} {
+		t.Run("modern malformed row "+tc.name, func(t *testing.T) {
+			got := parsePanesModernFormat(tc.row)
+			if len(got) != 1 {
+				t.Fatalf("panes = %d, want 1 (structurally invalid modern rows stay listed read-only)", len(got))
+			}
+			if got[0].Dead || got[0].DeadStatus != "" || got[0].DeadSignal != "" {
+				t.Fatalf("structurally invalid modern row must not read dead: %+v", got[0])
+			}
+			if got[0].PaneID != "%9" || got[0].WindowID != "@7" {
+				t.Fatalf("structurally invalid modern row corrupted ids: %+v", got[0])
+			}
+		})
+	}
+
 	// Legacy provenance: rows whose user-controlled labels imitate the
 	// modern fields must stay ordinary legacy rows regardless of shape —
 	// single-prefix title, dual-prefix title+window, and the tabbed-window


### PR DESCRIPTION
Fixes #689.

`team member rm <role> --stop --close-panes` fail-closed dead panes into `preserved` (operator review) and aborted the removal, leaving the roster outcome ambiguous; a retry after a manual `kill-pane` still double-reported `preserved` for the nonexistent pane.

## Changes

- **tmuxpane**: `#{pane_dead}`/`#{pane_dead_status}`/`#{pane_dead_signal}` evidence via a prefix-guarded `amqdead:` field spliced out before legacy positional parsing. Only an affirmative `1` reads dead; absent/malformed evidence stays alive-by-default.
- **pane_cleanup**: new `AgentGone` contract — when the lifecycle caller attests the recorded agent runtime is gone, pane closure switches authority from live process-lineage attestation to tmux dead-pane evidence: exact recorded pane, identity match, `pane_dead=1`, re-verified at close (a revived pane is preserved). Live processes, identity mismatches, and unavailable inspection stay preserved. A recorded pane id tmux affirmatively no longer knows reports `already_gone` (fixes the retry double-report). Closed detail carries the dead status/signal for manifests.
- **down**: `AgentGone` wired on the pid-not-alive, PID-reuse, and no-pid+stale-presence branches; fresh-presence and external branches unchanged.
- **team member rm**: proceeds past a PARTIAL stop and reports both outcomes unambiguously (`removed X from the team roster, but stop/pane cleanup was incomplete`); hard refusals still abort before mutation; absent-role rm is an idempotent no-op (`already_absent`).

## Out of scope (split to follow-up)

The operator requirement on #689 (close-by-default on kill/stop/rm incl. full-window seats) and the `attestAndStopRmAgents` team-rm path — tracked in a follow-up issue.

## Evidence

- Regression: `TestDownClosePanesClosesDeadPaneOfDeadAgent` fails on the old wiring with exactly the gh#689 outcome (`preserved_identity_unconfirmed`, `agent_live` mismatch) and passes at head — verified independently by the lead in a detached worktree at `97ca925`.
- 8 further tests: live-pane preserve, vanished-pane already_gone (two paths), revived-pane preserve at close, rm-partial-removes-and-reports, rm-hard-refusal-preserves-roster, absent-role idempotent no-op, dead-evidence parsing incl. legacy shapes.
- `make ci` exit 0 at head in the task worktree; tmuxpane + focused cli suites green on lead re-run.

Squad: fullstack (implementation), lead (exact-head review). Merge pending second independent review + `amq-squad verify merge` + operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)