### PR TITLE
feat(710): setup --show, --actor-mode help + plan echo, wizard isolation docs

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -424,6 +424,8 @@ var completionCommonFlags = []string{
 	"--session",
 	"--sha",
 	"--shared-cwd-exception",
+	// gh#710: setup --show, the read-only effective-config view.
+	"--show",
 	"--since",
 	"--sink",
 	"--set",

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -220,7 +220,9 @@ Usage:
 
 This delegates to 'amq-squad team init --profile NAME'. It is the named-profile
 counterpart to 'amq-squad new team', so it inherits role selection, --binary,
---model, --effort, --dry-run, --json, --project, and --sync.
+--model, --effort, --actor-mode (role=implementation|review execution
+capability, echoed per member in the --dry-run plan), --dry-run, --json,
+--project, and --sync.
 
 Pass --no-session-pin to create an unpinned template profile instead of a
 session-pinned one: members carry no session, so 'run start --profile NAME
@@ -232,6 +234,7 @@ Examples:
   amq-squad new profile review --roles cto,qa
   amq-squad new profile review --sync --roles cto,qa
   amq-squad new profile review --dry-run --json --roles 2,9
+  amq-squad new profile review --roles dev,reviewer --actor-mode reviewer=review
   amq-squad new profile --project ~/Code/app review --roles cto
   amq-squad new profile pm-squad --no-session-pin --roles cto,fullstack
 `)

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -221,8 +221,8 @@ Usage:
 This delegates to 'amq-squad team init --profile NAME'. It is the named-profile
 counterpart to 'amq-squad new team', so it inherits role selection, --binary,
 --model, --effort, --actor-mode (role=implementation|review execution
-capability, echoed per member in the --dry-run plan), --dry-run, --json,
---project, and --sync.
+capability, echoed per member as actor_mode in the --dry-run --json plan),
+--dry-run, --json, --project, and --sync.
 
 Pass --no-session-pin to create an unpinned template profile instead of a
 session-pinned one: members carry no session, so 'run start --profile NAME

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -39,6 +39,7 @@ type setupDependencies struct {
 	Version     func(string) (string, error)
 	ReadConfig  func() (userconfig.Config, error)
 	WriteConfig func(userconfig.Config) (string, error)
+	ConfigPath  func() (string, error)
 }
 
 type setupOptions struct {
@@ -63,6 +64,7 @@ func runSetup(args []string) error {
 		Version:     setupCommandVersion,
 		ReadConfig:  userconfig.Read,
 		WriteConfig: userconfig.Write,
+		ConfigPath:  userconfig.Path,
 	})
 }
 
@@ -75,16 +77,21 @@ func runSetupWithDependencies(args []string, deps setupDependencies) error {
 	fs.StringVar(&opts.effort, "drafter-effort", "", "drafter reasoning effort passed to configured backends")
 	fs.IntVar(&opts.timeoutSeconds, "drafter-timeout", 0, "drafter timeout in seconds (0 uses the default)")
 	fs.StringVar(&opts.onFailure, "drafter-on-failure", "", "failure policy: in_session or error")
+	showFlag := fs.Bool("show", false, "print the effective global drafter config and exit without writing")
+	jsonFlag := fs.Bool("json", false, "with --show, emit a schema-versioned setup_show envelope")
 	fs.Usage = func() {
 		fmt.Fprint(deps.Err, `amq-squad setup - configure machine-level amq-squad defaults
 
 Usage:
   amq-squad setup
   amq-squad setup --drafter-chain yoetz,claude,codex [options]
+  amq-squad setup --show [--json]
 
 Without setup flags the command probes PATH and prompts interactively. Any
 setup flag selects non-interactive mode for scripts and CI images. Setup writes
 only the user-level global config; team profiles keep their own overrides.
+--show is read-only: it prints the effective global drafter config and never
+prompts, probes, or writes.
 
 Options:
 `)
@@ -92,6 +99,7 @@ Options:
 		fmt.Fprint(deps.Err, `
 Examples:
   amq-squad setup
+  amq-squad setup --show --json
   amq-squad setup --drafter-chain yoetz,claude,codex --drafter-timeout 180 --drafter-on-failure in_session
   AMQ_SQUAD_CONFIG=/tmp/amq-squad-config.json amq-squad setup --drafter-chain codex
 `)
@@ -107,6 +115,15 @@ Examples:
 	opts.effortSet = flagWasSet(fs, "drafter-effort")
 	opts.timeoutSet = flagWasSet(fs, "drafter-timeout")
 	opts.onFailureSet = flagWasSet(fs, "drafter-on-failure")
+	if *jsonFlag && !*showFlag {
+		return usageErrorf("--json requires --show")
+	}
+	if *showFlag {
+		if opts.chainSet || opts.modelSet || opts.effortSet || opts.timeoutSet || opts.onFailureSet {
+			return usageErrorf("--show is read-only and cannot be combined with drafter mutation flags")
+		}
+		return runSetupShow(deps, *jsonFlag)
+	}
 
 	current, err := deps.ReadConfig()
 	if err != nil {
@@ -132,6 +149,63 @@ Examples:
 	}
 	fmt.Fprintf(deps.Out, "Configured drafter: %s\n", setupDrafterSelection(next.Drafter))
 	fmt.Fprintf(deps.Out, "Wrote user config: %s\n", path)
+	return nil
+}
+
+// setupShowData is the `setup --show --json` payload: the stored drafter
+// block plus the resolved effective values, so scripts need no client-side
+// defaulting logic.
+type setupShowData struct {
+	Path               string          `json:"path"`
+	Exists             bool            `json:"exists"`
+	Drafter            *drafter.Config `json:"drafter,omitempty"`
+	EffectiveSelection string          `json:"effective_selection"`
+	EffectiveChain     []string        `json:"effective_chain"`
+	EffectiveTimeout   int             `json:"effective_timeout_seconds"`
+	EffectiveOnFailure string          `json:"effective_on_failure"`
+}
+
+// runSetupShow prints the effective global drafter config. Strictly read-only:
+// no prompts, no PATH probing, no config writes.
+func runSetupShow(deps setupDependencies, jsonOut bool) error {
+	current, err := deps.ReadConfig()
+	if err != nil {
+		return fmt.Errorf("read user-level config: %w", err)
+	}
+	path := ""
+	if deps.ConfigPath != nil {
+		if p, pathErr := deps.ConfigPath(); pathErr == nil {
+			path = p
+		}
+	}
+	cfg := drafter.Config{}
+	if current.Drafter != nil {
+		cfg = *current.Drafter
+	}
+	data := setupShowData{
+		Path:               path,
+		Exists:             current.Drafter != nil,
+		Drafter:            current.Drafter,
+		EffectiveSelection: setupDrafterSelection(current.Drafter),
+		EffectiveChain:     cfg.EffectiveBackends(),
+		EffectiveTimeout:   int(cfg.EffectiveTimeout() / time.Second),
+		EffectiveOnFailure: cfg.EffectiveFailureMode(),
+	}
+	if jsonOut {
+		return writeJSONEnvelope(deps.Out, "setup_show", data)
+	}
+	fmt.Fprintf(deps.Out, "Global config: %s\n", orDash(path))
+	if !data.Exists {
+		fmt.Fprintln(deps.Out, "Drafter: not configured (implicit in_session default)")
+	}
+	fmt.Fprintf(deps.Out, "Effective selection:  %s\n", data.EffectiveSelection)
+	fmt.Fprintf(deps.Out, "Effective chain:      %s\n", strings.Join(data.EffectiveChain, " -> "))
+	if data.Exists {
+		fmt.Fprintf(deps.Out, "Model:                %s\n", orDash(cfg.Model))
+		fmt.Fprintf(deps.Out, "Effort:               %s\n", orDash(cfg.Effort))
+	}
+	fmt.Fprintf(deps.Out, "Timeout (seconds):    %d\n", data.EffectiveTimeout)
+	fmt.Fprintf(deps.Out, "On failure:           %s\n", data.EffectiveOnFailure)
 	return nil
 }
 

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -211,3 +211,111 @@ func TestSetupIsPublicAndCompletable(t *testing.T) {
 		}
 	}
 }
+
+// gh#710 slice 1: `setup --show [--json]` is a read-only view of the effective
+// global drafter config — no prompts, no PATH probes, no writes.
+func TestSetupShowPrintsEffectiveDrafterConfigWithoutWriting(t *testing.T) {
+	current := userconfig.Config{Drafter: &drafter.Config{
+		Chain:  []string{drafter.BackendYoetz, drafter.BackendClaude},
+		Model:  "opus",
+		Effort: "high",
+	}}
+	var stdout, stderr bytes.Buffer
+	deps := setupDependencies{
+		In:  strings.NewReader(""),
+		Out: &stdout,
+		Err: &stderr,
+		LookPath: func(string) (string, error) {
+			t.Fatal("--show must not probe PATH")
+			return "", nil
+		},
+		Version: func(string) (string, error) {
+			t.Fatal("--show must not probe versions")
+			return "", nil
+		},
+		ReadConfig: func() (userconfig.Config, error) { return current, nil },
+		WriteConfig: func(userconfig.Config) (string, error) {
+			t.Fatal("--show must not write config")
+			return "", nil
+		},
+		ConfigPath: func() (string, error) { return "/home/user/.config/amq-squad/config.json", nil },
+	}
+	if err := runSetupWithDependencies([]string{"--show"}, deps); err != nil {
+		t.Fatalf("setup --show: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"/home/user/.config/amq-squad/config.json",
+		"yoetz -> claude",
+		"opus",
+		"high",
+		"180",        // default timeout surfaces as effective
+		"in_session", // default failure mode surfaces as effective
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("setup --show output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSetupShowJSONEmitsEffectiveEnvelope(t *testing.T) {
+	current := userconfig.Config{Drafter: &drafter.Config{
+		Chain:          []string{drafter.BackendCodex},
+		TimeoutSeconds: 60,
+		OnFailure:      drafter.FailureError,
+	}}
+	var stdout, stderr bytes.Buffer
+	deps := setupDependencies{
+		In: strings.NewReader(""), Out: &stdout, Err: &stderr,
+		ReadConfig: func() (userconfig.Config, error) { return current, nil },
+		WriteConfig: func(userconfig.Config) (string, error) {
+			t.Fatal("--show --json must not write config")
+			return "", nil
+		},
+		ConfigPath: func() (string, error) { return "/cfg.json", nil },
+	}
+	if err := runSetupWithDependencies([]string{"--show", "--json"}, deps); err != nil {
+		t.Fatalf("setup --show --json: %v", err)
+	}
+	env := decodeJSONEnvelope[setupShowData](t, stdout.String())
+	if env.Kind != "setup_show" {
+		t.Errorf("kind = %q, want setup_show", env.Kind)
+	}
+	d := env.Data
+	if !d.Exists || d.Path != "/cfg.json" || d.EffectiveSelection != drafter.BackendCodex {
+		t.Errorf("show data = %+v", d)
+	}
+	if d.EffectiveTimeout != 60 || d.EffectiveOnFailure != drafter.FailureError {
+		t.Errorf("effective timeout/on_failure = %d/%q, want 60/error", d.EffectiveTimeout, d.EffectiveOnFailure)
+	}
+}
+
+func TestSetupShowUnconfiguredReportsInSessionDefault(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := setupDependencies{
+		In: strings.NewReader(""), Out: &stdout, Err: &stderr,
+		ReadConfig:  func() (userconfig.Config, error) { return userconfig.Config{}, nil },
+		WriteConfig: func(userconfig.Config) (string, error) { t.Fatal("no write"); return "", nil },
+		ConfigPath:  func() (string, error) { return "/cfg.json", nil },
+	}
+	if err := runSetupWithDependencies([]string{"--show"}, deps); err != nil {
+		t.Fatalf("setup --show: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "not configured") || !strings.Contains(stdout.String(), "in_session") {
+		t.Errorf("unconfigured --show must state the in_session default:\n%s", stdout.String())
+	}
+}
+
+func TestSetupShowRejectsMutationFlagsAndBareJSON(t *testing.T) {
+	deps := setupDependencies{
+		In: strings.NewReader(""), Out: &bytes.Buffer{}, Err: &bytes.Buffer{},
+		ReadConfig:  func() (userconfig.Config, error) { return userconfig.Config{}, nil },
+		WriteConfig: func(userconfig.Config) (string, error) { t.Fatal("no write"); return "", nil },
+	}
+	if err := runSetupWithDependencies([]string{"--show", "--drafter-chain", "codex"}, deps); err == nil || !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("--show with mutation flags must refuse, got %v", err)
+	}
+	if err := runSetupWithDependencies([]string{"--json"}, deps); err == nil || !strings.Contains(err.Error(), "--json requires --show") {
+		t.Fatalf("bare --json must refuse, got %v", err)
+	}
+}

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -180,8 +180,9 @@ Execution capability: --actor-mode role=implementation|review pins what each
 member may DO (mutate code vs review-only), independent of its persona title,
 e.g. --actor-mode dev=implementation,reviewer=review. Unset roles default to
 implementation, except a lead under --lead-mode planner which defaults to
-review. The resolved mode per member is echoed in the --dry-run plan and its
---json envelope (actor_mode).
+review. The resolved mode per member is echoed as actor_mode in the
+--dry-run --json team_profile_plan member entries (the human --dry-run
+table does not show it).
 
 Operator interaction: --operator-mode accepts lead_pane, separate_terminal,
 noc, or self_operator. Fresh self_operator profiles require an exact

--- a/internal/cli/team.go
+++ b/internal/cli/team.go
@@ -176,6 +176,13 @@ also be referenced inline, e.g. --roles cto,./roles/researcher.md. The file's
 The authored document is staged under .amq-squad/roles/<id>.md and seeds that
 agent's role.md at launch.
 
+Execution capability: --actor-mode role=implementation|review pins what each
+member may DO (mutate code vs review-only), independent of its persona title,
+e.g. --actor-mode dev=implementation,reviewer=review. Unset roles default to
+implementation, except a lead under --lead-mode planner which defaults to
+review. The resolved mode per member is echoed in the --dry-run plan and its
+--json envelope (actor_mode).
+
 Operator interaction: --operator-mode accepts lead_pane, separate_terminal,
 noc, or self_operator. Fresh self_operator profiles require an exact
 --self-operator-lead and explicit --self-operator-allow merge. Spawn remains
@@ -212,6 +219,7 @@ Examples:
   amq-squad team init --roles cto,fullstack --operator operator
   amq-squad team init --roles cto,fullstack --no-operator
   amq-squad team init --roles cto,fullstack,qa --orchestrated --lead cto
+  amq-squad team init --roles dev,reviewer --actor-mode dev=implementation,reviewer=review
   amq-squad team init --project ~/Code/app --roles cto,qa
   amq-squad team init --roles 2,9
   amq-squad team init --roles all
@@ -685,6 +693,7 @@ type teamProfilePlanMember struct {
 	Model                string   `json:"model,omitempty"`
 	CWD                  string   `json:"cwd"`
 	Session              string   `json:"session"`
+	ActorMode            string   `json:"actor_mode"`
 	ToolProfile          string   `json:"tool_profile"`
 	ToolConfig           string   `json:"tool_config,omitempty"`
 	ToolMCPConfig        string   `json:"tool_mcp_config,omitempty"`
@@ -800,6 +809,7 @@ func buildTeamProfilePlan(p teamInitDryRun) teamProfilePlan {
 			Model:                m.Model,
 			CWD:                  m.EffectiveCWD(p.Team.Project),
 			Session:              m.Session,
+			ActorMode:            team.EffectiveActorMode(p.Team, m),
 			ToolProfile:          m.EffectiveToolProfile(),
 			ToolConfig:           m.ToolConfig,
 			ToolMCPConfig:        m.ToolMCPConfig,

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -2531,3 +2531,48 @@ func TestEffectiveCWDFallback(t *testing.T) {
 		t.Errorf("EffectiveCWD set: got %q, want /other", got)
 	}
 }
+
+// gh#710 slice 2: the dry-run plan JSON echoes each member's resolved
+// actor mode so operators can verify execution capability before writing.
+func TestTeamInitDryRunJSONEchoesActorModes(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(old); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	stdout, stderr, err := captureOutput(t, func() error {
+		return runTeamInit([]string{
+			"--roles", "cto,fullstack",
+			"--session", "issue-710",
+			"--actor-mode", "cto=review",
+			"--dry-run",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("team init --dry-run --json: %v\nstderr:\n%s", err, stderr)
+	}
+	env := decodeJSONEnvelope[teamProfilePlan](t, stdout)
+	modes := map[string]string{}
+	for _, m := range env.Data.Plan {
+		modes[m.Role] = m.ActorMode
+	}
+	if modes["cto"] != team.ActorModeReview {
+		t.Errorf("cto actor_mode = %q, want %q", modes["cto"], team.ActorModeReview)
+	}
+	if modes["fullstack"] != team.ActorModeImplementation {
+		t.Errorf("fullstack actor_mode = %q, want %q (unset default)", modes["fullstack"], team.ActorModeImplementation)
+	}
+	if !strings.Contains(stdout, `"actor_mode"`) {
+		t.Error("plan JSON must carry the actor_mode field")
+	}
+}

--- a/internal/cli/team_test.go
+++ b/internal/cli/team_test.go
@@ -2575,4 +2575,18 @@ func TestTeamInitDryRunJSONEchoesActorModes(t *testing.T) {
 	if !strings.Contains(stdout, `"actor_mode"`) {
 		t.Error("plan JSON must carry the actor_mode field")
 	}
+
+	// PR #718 review: help must not overstate where the echo appears — the
+	// human dry-run table does not show actor mode, only the JSON plan does.
+	// --help prints usage to stderr and returns flag.ErrHelp; only the
+	// printed text matters here.
+	_, helpErr, _ := captureOutput(t, func() error {
+		return runTeamInit([]string{"--help"})
+	})
+	if !strings.Contains(helpErr, "--dry-run --json team_profile_plan member entries") {
+		t.Error("team init help must scope the actor_mode echo to the --dry-run --json plan")
+	}
+	if strings.Contains(helpErr, "echoed in the --dry-run plan and its --json envelope") {
+		t.Error("team init help must not claim the human dry-run table echoes actor mode")
+	}
 }

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -82,8 +82,11 @@ verbatim, state the validation result, and name the next operator decision.
    Use `amq-squad new team` instead for the default profile. For a profile meant
    to serve many future sessions, use `--no-session-pin` instead of `--session`.
    Two implementation actors need distinct worktrees or an explicit recorded
-   shared-CWD exception. Verify the previewed roster matches the written profile,
-   then rerun `doctor --project P --profile R --session S`.
+   shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
+   task-scoped worktrees materialize per task at dispatch time via
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   followed by `worktree materialize`. Verify the previewed roster matches the
+   written profile, then rerun `doctor --project P --profile R --session S`.
 
 3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
    a richer custom seat, run the shared drafter path, review the staged file, and

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -84,7 +84,7 @@ verbatim, state the validation result, and name the next operator decision.
    Two implementation actors need distinct worktrees or an explicit recorded
    shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
    task-scoped worktrees materialize per task at dispatch time via
-   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --session S --scope ...`
    followed by `worktree materialize`. Verify the previewed roster matches the
    written profile, then rerun `doctor --project P --profile R --session S`.
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -78,8 +78,11 @@ verbatim, state the validation result, and name the next operator decision.
    Use `amq-squad new team` instead for the default profile. For a profile meant
    to serve many future sessions, use `--no-session-pin` instead of `--session`.
    Two implementation actors need distinct worktrees or an explicit recorded
-   shared-CWD exception. Verify the previewed roster matches the written profile,
-   then rerun `doctor --project P --profile R --session S`.
+   shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
+   task-scoped worktrees materialize per task at dispatch time via
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   followed by `worktree materialize`. Verify the previewed roster matches the
+   written profile, then rerun `doctor --project P --profile R --session S`.
 
 3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
    a richer custom seat, run the shared drafter path, review the staged file, and

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -80,7 +80,7 @@ verbatim, state the validation result, and name the next operator decision.
    Two implementation actors need distinct worktrees or an explicit recorded
    shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
    task-scoped worktrees materialize per task at dispatch time via
-   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --session S --scope ...`
    followed by `worktree materialize`. Verify the previewed roster matches the
    written profile, then rerun `doctor --project P --profile R --session S`.
 

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -78,8 +78,11 @@ verbatim, state the validation result, and name the next operator decision.
    Use `amq-squad new team` instead for the default profile. For a profile meant
    to serve many future sessions, use `--no-session-pin` instead of `--session`.
    Two implementation actors need distinct worktrees or an explicit recorded
-   shared-CWD exception. Verify the previewed roster matches the written profile,
-   then rerun `doctor --project P --profile R --session S`.
+   shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
+   task-scoped worktrees materialize per task at dispatch time via
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   followed by `worktree materialize`. Verify the previewed roster matches the
+   written profile, then rerun `doctor --project P --profile R --session S`.
 
 3. **Draft and add each custom seat.** Built-in seats need no persona draft. For
    a richer custom seat, run the shared drafter path, review the staged file, and

--- a/plugins/skills-src/wizard/SKILL.md
+++ b/plugins/skills-src/wizard/SKILL.md
@@ -80,7 +80,7 @@ verbatim, state the validation result, and name the next operator decision.
    Two implementation actors need distinct worktrees or an explicit recorded
    shared-CWD exception. Do not invent per-role `--cwd` paths for isolation:
    task-scoped worktrees materialize per task at dispatch time via
-   `amq-squad worktree plan --role <role> --task <id> --base <sha> --scope ...`
+   `amq-squad worktree plan --role <role> --task <id> --base <sha> --session S --scope ...`
    followed by `worktree materialize`. Verify the previewed roster matches the
    written profile, then rerun `doctor --project P --profile R --session S`.
 


### PR DESCRIPTION
Fixes #710.

Three friction subfixes split from #709 per the sprint decision, each removing a real `--help`/config-file detour found in the v2.29.4 Flow A dogfood run:

1. **`setup --show [--json]`** — strictly read-only view of the effective global drafter config (path, stored block, effective selection/chain/timeout/on-failure). Never prompts, probes PATH, or writes — all three enforced by injected-dependency tests. `--json` emits a `setup_show` envelope with stored + resolved values; `--json` without `--show` and `--show` with mutation flags both refuse.
2. **`--actor-mode` documented and echoed** — `team init` help gains an execution-capability paragraph (unset defaults to implementation, except a planner-mode lead which defaults to review — verified against `team.EffectiveActorMode`) with examples; `new profile` help names the flag; `team_profile_plan --dry-run --json` now carries resolved `actor_mode` per member.
3. **Wizard skill isolation guidance** — Flow A step 2 now states that task-scoped worktrees materialize per task at dispatch time (`worktree plan --role --task --base --session --scope` + materialize), so operators don't invent per-role `--cwd` paths. Source + both generated mirrors, `make skills-generate` drift-free.

Also: one mechanical `completion.go` registry entry for `--show` (forced by `TestCompletionFlagsCoverDispatcher`).

## Evidence

- Slice 1 fail-before: a binary at base `ea4e17a` errors `flag provided but not defined: -show`; head works end to end including missing-config read as unconfigured/in_session.
- Slice 2 fail-before: neutralizing the `actor_mode` echo fails `TestTeamInitDryRunJSONEchoesActorModes` — lead-verified in place at exact head.
- 5 new tests; `make ci` exit 0 at head.

Squad: fullstack (implementation), lead (exact-head review). Merge pending second independent review + `amq-squad verify merge` + operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)