### PR TITLE
Release v2.29.5 — run-friction fixes and lead local-input supervision

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2294" id="toc-whats-new-in-v2294">What's new
-in v2.29.4</a></li>
+<li><a href="#whats-new-in-v2295" id="toc-whats-new-in-v2295">What's new
+in v2.29.5</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2294">What's new in v2.29.4</a></li>
+<li><a href="#whats-new-in-v2295">What's new in v2.29.5</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,39 +342,42 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2294">What's new in v2.29.4</h2>
-<p>v2.29.4 matures the drafter configuration story shipped in v2.29.3.
-The drafter block graduates from profile-only to a layered model (#696):
-a user-level global config at
-<code>~/.config/amq-squad/config.json</code> (override with
-<code>AMQ_SQUAD_CONFIG</code>) carries machine-scoped defaults, resolved
-with whole-block precedence — profile block over global config over the
-implicit <code>in_session</code> default — and an ordered fallback chain
-(<code>"chain": ["yoetz", "claude", "codex"]</code>) tries each backend
-in configured order, records exact command evidence for every attempt
-and fall-through, and lands on the in-session prompt only after
-exhaustion. Trust stays explicit: custom argv templates are honored only
-from the user-level global config, never from project or profile files —
-a breaking change for v2.29.3 profiles that carried a
-<code>custom</code> drafter block, which now fails closed; remove that
-block from the team profile and move it unchanged into the global
-config. Unknown or typoed config keys fail closed instead of silently
-changing backend selection. The new <code>amq-squad setup</code> command
-(#697) owns that global layer interactively — probing PATH for backends
-with versions, prompting for chain and knobs, and writing the config
-atomically at mode 0600 — with <code>--drafter-*</code> flags for
-non-interactive CI provisioning. The binary's own generation surfaces
-now route through the configured drafter (#700): <code>--goal</code>
-brief drafting with exact six-section validation staged for operator
-review before write, per-seat personas reusing the
-<code>role draft</code> path end to end, and team-rules charter prose
-wrapped in deterministic structure validation — with config source plus
-the complete ordered attempt chain reported on every success, fallback,
-and failure path. A safety fix (#698) bounds configured
-<code>{out}</code> file reads to the same 4 MiB budget as captured
-stdout/stderr, failing oversized drafts through the normal failure
-policy. Full detail in <a href="docs/v2.29.4-release-notes.md">the
-v2.29.4 release notes</a>.</p>
+<h2 id="whats-new-in-v2295">What's new in v2.29.5</h2>
+<p>v2.29.5 removes the run frictions that forced operator workarounds
+during the v2.29.2–v2.29.4 dogfood runs.
+<code>worktree cleanup --decision accepted</code> now accepts the two
+end states every normal multi-task run produces (#690): sequential task
+branches in one seat worktree are adopted when branch mismatch is the
+sole drift on a clean tree, and worktree-local <code>.agent-mail</code>
+bootstrap residue is classified removable — re-verified at deletion
+time, per-entry removal, with symlinks and unique local state still
+failing closed. Scoped <code>resume --exec</code> no longer declares a
+false <code>launch record missing</code> partial failure while a member
+is still booting (#688): a bounded 30s startup budget extends the 5s
+base window only while every outstanding record is boot-resolvable,
+identity mismatches stay terminal, and stale-record pane-title adoption
+runs at the base deadline so adoptable panes resolve in seconds.
+<code>start --yes</code> reconciles its own live session from canonical
+launch records instead of volatile pane titles (#692), so an agent
+rewriting its title no longer kills the documented
+rerun-<code>start</code> roll-forward path. Winding down a finished seat
+works (#689): verifiably dead panes (<code>pane_dead=1</code>, exact
+pane, identity match, re-verified at close) close under
+<code>--close-panes</code> without operator review, retries after a
+manual <code>kill-pane</code> converge to <code>already_gone</code>, and
+<code>team member rm</code> is idempotent with unambiguous roster
+outcomes — with the dead-pane evidence channel hardened across four
+review rounds (explicit format provenance, row-integrity validation, raw
+canonical payload gate). Wizard friction shrinks (#710):
+<code>setup --show [--json]</code> gives a strictly read-only view of
+the effective global drafter config, <code>--actor-mode</code> is
+documented and echoed per member in the <code>--dry-run --json</code>
+plan, and the wizard skill states that isolation materializes per task
+at dispatch time. Lead doctrine gains mandatory local-input supervision
+(#719): every status pass inspects <code>records[].local_input</code>
+and <code>local_input_blocked</code> warnings, and a detected permission
+prompt is a blocker — never authority. Full detail in <a
+href="docs/v2.29.5-release-notes.md">the v2.29.5 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
 Releases</a> and <a href="docs/">docs/</a> (per-release notes

--- a/README.html
+++ b/README.html
@@ -385,7 +385,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.4</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.5</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.4
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.5
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.4](#whats-new-in-v2294)
+- [What's new in v2.29.5](#whats-new-in-v2295)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,36 +38,38 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.4
+## What's new in v2.29.5
 
-v2.29.4 matures the drafter configuration story shipped in v2.29.3. The
-drafter block graduates from profile-only to a layered model (#696): a
-user-level global config at `~/.config/amq-squad/config.json` (override with
-`AMQ_SQUAD_CONFIG`) carries machine-scoped defaults, resolved with
-whole-block precedence — profile block over global config over the implicit
-`in_session` default — and an ordered fallback chain
-(`"chain": ["yoetz", "claude", "codex"]`) tries each backend in configured
-order, records exact command evidence for every attempt and fall-through,
-and lands on the in-session prompt only after exhaustion. Trust stays
-explicit: custom argv templates are honored only from the user-level global
-config, never from project or profile files — a breaking change for
-v2.29.3 profiles that carried a `custom` drafter block, which now fails
-closed; remove that block from the team profile and move it unchanged into
-the global config. Unknown or typoed config keys fail closed instead of
-silently changing backend selection. The new
-`amq-squad setup` command (#697) owns that global layer interactively —
-probing PATH for backends with versions, prompting for chain and knobs, and
-writing the config atomically at mode 0600 — with `--drafter-*` flags for
-non-interactive CI provisioning. The binary's own generation surfaces now
-route through the configured drafter (#700): `--goal` brief drafting with
-exact six-section validation staged for operator review before write,
-per-seat personas reusing the `role draft` path end to end, and team-rules
-charter prose wrapped in deterministic structure validation — with config
-source plus the complete ordered attempt chain reported on every success,
-fallback, and failure path. A safety fix (#698) bounds configured `{out}`
-file reads to the same 4 MiB budget as captured stdout/stderr, failing
-oversized drafts through the normal failure policy. Full detail in
-[the v2.29.4 release notes](docs/v2.29.4-release-notes.md).
+v2.29.5 removes the run frictions that forced operator workarounds during
+the v2.29.2–v2.29.4 dogfood runs. `worktree cleanup --decision accepted`
+now accepts the two end states every normal multi-task run produces (#690):
+sequential task branches in one seat worktree are adopted when branch
+mismatch is the sole drift on a clean tree, and worktree-local `.agent-mail`
+bootstrap residue is classified removable — re-verified at deletion time,
+per-entry removal, with symlinks and unique local state still failing
+closed. Scoped `resume --exec` no longer declares a false
+`launch record missing` partial failure while a member is still booting
+(#688): a bounded 30s startup budget extends the 5s base window only while
+every outstanding record is boot-resolvable, identity mismatches stay
+terminal, and stale-record pane-title adoption runs at the base deadline so
+adoptable panes resolve in seconds. `start --yes` reconciles its own live
+session from canonical launch records instead of volatile pane titles
+(#692), so an agent rewriting its title no longer kills the documented
+rerun-`start` roll-forward path. Winding down a finished seat works (#689):
+verifiably dead panes (`pane_dead=1`, exact pane, identity match,
+re-verified at close) close under `--close-panes` without operator review,
+retries after a manual `kill-pane` converge to `already_gone`, and
+`team member rm` is idempotent with unambiguous roster outcomes — with the
+dead-pane evidence channel hardened across four review rounds (explicit
+format provenance, row-integrity validation, raw canonical payload gate).
+Wizard friction shrinks (#710): `setup --show [--json]` gives a strictly
+read-only view of the effective global drafter config, `--actor-mode` is
+documented and echoed per member in the `--dry-run --json` plan, and the
+wizard skill states that isolation materializes per task at dispatch time.
+Lead doctrine gains mandatory local-input supervision (#719): every status
+pass inspects `records[].local_input` and `local_input_blocked` warnings,
+and a detected permission prompt is a blocker — never authority. Full
+detail in [the v2.29.5 release notes](docs/v2.29.5-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and

--- a/docs/v2.29.5-release-notes.md
+++ b/docs/v2.29.5-release-notes.md
@@ -1,0 +1,141 @@
+# amq-squad v2.29.5
+
+Run-friction fixes: the five failure modes that forced operator workarounds
+during the v2.29.2–v2.29.4 dogfood runs — false launch-record negatives, dead
+panes that refused to close, sanctioned worktree cleanup that refused normal
+end states, `start` disowning its own live session, and wizard-flow config
+detours — plus mandatory lead supervision of local permission prompts.
+Milestone issues: #688, #689, #690, #692, #710, #719.
+PRs: #711, #712, #713, #716, #718, #720.
+
+## Sanctioned worktree cleanup after normal runs (#690, PR #711)
+
+`worktree cleanup --decision accepted` no longer refuses the two end states
+every normal multi-task run produces:
+
+- **Sequential-task branch adoption**: when `branch mismatch` is the *sole*
+  drift, the tree is clean, no other role's non-cleaned plan owns the current
+  branch, and the handoff SHA still matches, cleanup adopts the current branch
+  instead of refusing. Dirty trees, base-ancestry drift, duplicate ownership,
+  and stale handoffs still fail closed.
+- **Removable coordination residue**: a worktree-local `.agent-mail` tree
+  containing only bootstrap skeleton (`meta/config.json` shape) and
+  byte-identical canonical copies (including inbox `new`/`cur` moves) is
+  classified removable residue, not divergence. Removal re-verifies
+  removability at deletion time and deletes per-entry (never a recursive
+  force delete); symlinks, non-regular files, and any unique local state
+  refuse and preserve the tree.
+- `MemberStatus` gains `current_branch` and `removable_coordination_residue`
+  for observability.
+
+## Bounded startup budget for `resume --exec` launch records (#688, PR #712)
+
+Scoped `resume --exec --role <member>` no longer declares
+`partial launch failure: launch record missing` while the member binary is
+still booting:
+
+- After the 5s base verify window, the check keeps polling within a bounded
+  30s startup budget — but only while every outstanding result is one a
+  booting member can resolve (`missing` / `stale-record`). Identity
+  mismatches stay terminal at the base deadline.
+- Stale-record pane-title adoption runs *at the base deadline*, before any
+  extended polling, so an already-adoptable pane resolves in ~5s instead of
+  paying the full budget (timing pinned by an elapsed-assertion regression).
+- On timeout the error states the boot-timing possibility and how to confirm
+  (`amq-squad status --json`; live + launched means no relaunch needed).
+
+## `start` reconciles its own session from records, not pane titles (#692, PR #713)
+
+`start --yes` (target `new-session`) no longer classifies its own live
+session `conflict unmanaged` after an agent rewrites its pane title:
+
+- Ownership validation reads the workstream's canonical launch records first:
+  a record whose tmux session matches the target, whose exact `pane_id` is
+  live in that session (`list-panes -s`, all windows), and whose runtime
+  identity corroborates (PID liveness with reuse/TTY guards) marks the
+  session owned. The volatile `amq:<session>:` title prefix survives as
+  fallback only.
+- Falsifiers stay fail-closed: absent recorded pane, wrong recorded session,
+  and dead recorded PID still return `unmanaged`.
+- The rerun-`start` roll-forward path documented for interrupted launches
+  works again.
+
+## Dead panes close under `--close-panes`; `member rm` is idempotent (#689, PR #716)
+
+Winding down a finished seat no longer aborts on its own dead pane:
+
+- **AgentGone contract**: when the lifecycle caller attests the recorded
+  agent runtime is gone (pid dead, PID reuse, or no-pid + stale presence),
+  pane closure switches authority from live process-lineage attestation to
+  tmux's own dead-pane evidence: exact recorded pane, identity match, and
+  affirmative `pane_dead=1`, re-verified at close (a revived pane is
+  preserved). Live processes, identity mismatches, and unavailable
+  inspection stay preserved.
+- **`already_gone` convergence**: a recorded pane id tmux affirmatively no
+  longer knows reports `already_gone` instead of double-reporting
+  `preserved` on retry after a manual `kill-pane`.
+- **Idempotent rm with unambiguous outcomes**: `team member rm` proceeds
+  past a PARTIAL stop and reports both outcomes explicitly; hard refusals
+  still abort before roster mutation; removing an absent role is a clean
+  no-op (`already_absent`).
+- **Hardened evidence channel** (four adversarial review rounds): dead-pane
+  evidence is consumed only under explicit modern-format provenance (the two
+  call sites that own `paneListFormat`), combined with row-integrity
+  validation of the returned row (12-field minimum, fixed `amqmeta:`
+  neighbor) and raw canonical payload validation (no whitespace
+  normalization, digits-or-empty status/signal). Legacy parsing never
+  content-detects the field, so user-controlled titles and tabbed window
+  names can never mint the destructive close signal.
+
+## Wizard friction subfixes (#710, PR #718)
+
+The cheap first slice of #709, so the deterministic-wizard core can move to
+v2.29.6 without losing immediately fixable friction:
+
+- **`setup --show [--json]`**: strictly read-only view of the effective
+  global drafter config (path, stored block, effective
+  selection/chain/timeout/on-failure). Never prompts, probes PATH, or
+  writes; `--json` emits a `setup_show` envelope; invalid flag combinations
+  refuse.
+- **`--actor-mode` documented and echoed**: `team init` and `new profile`
+  help document execution capability (unset defaults to implementation,
+  except a planner-mode lead which defaults to review), and
+  `team_profile_plan --dry-run --json` member entries carry the resolved
+  `actor_mode`. Help wording is scoped to the JSON plan (the human table
+  does not show it) and pinned by a help assertion.
+- **Task-scoped isolation guidance**: the wizard skill's Flow A step 2 now
+  states isolation materializes per task at dispatch time via
+  `worktree plan --role <role> --task <id> ...` + materialize, so operators
+  do not invent per-role `--cwd` paths at profile creation.
+
+## Lead local-input supervision (#719, PR #720)
+
+Operator-approved scope addition from this release's own dogfood run: the
+orchestrator doctrine now makes local permission prompts part of every lead
+status pass.
+
+- Inspect `records[].local_input` and `warnings[]` entries with
+  `kind=local_input_blocked` before treating child silence as idle or
+  parking; `status --json` performs the bounded managed-child pane-tail
+  scan, and absence means *not observed*, never proven clear.
+- A detected prompt is a blocker, never authority: inspect the exact action
+  and target, never nudge or type into an unresolved modal, raise the
+  matching typed gate when the action is not already authorized, and rerun
+  status after operator-directed recovery to verify the prompt cleared.
+- Ships as generated team-rule norm, orchestrator skill doctrine (source and
+  both mirrors), lead-loop reference, and a regression extending the
+  generated-norm assertion.
+
+## Verification
+
+- Every fix carries a regression test independently proven
+  failing-before/passing-after by the lead in exact-commit detached
+  worktrees.
+- Two independent exact-head reviews per PR; the cross-review process caught
+  and repaired seven real defects before merge.
+- `make ci` green at every PR head and after every merge to main
+  (push-triggered runs verified before each subsequent merge-train step).
+- Follow-ups tracked, not shipped: #714 (flaky real-PTY wait-posture test
+  under full-suite load), #715 (worktree plan store serializes lanes against
+  merge latency), #717 (wind-down close-by-default semantics, window seats,
+  team-rm classifier path).

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.4",
+  "version": "2.29.5",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.4",
+  "version": "2.29.5",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first simple-mode setup and launch guidance for amq-squad. Use when turning a request into a team/profile, previewing or approving a start, adding or replacing roles, supplying an optional lead goal, or recovering a partially started squad. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", \"add a worker\", \"replace this role\", and \"bring the squad back\". NOT for the live lead loop after launch (use amq-squad:orchestrator) and NOT for one-off status, task, or evidence commands (use amq-squad:cli)."
-version: "2.29.4"  # x-release-please-version
+version: "2.29.5"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
Release cut operator-approved on gate/release-v2-29-5 from exact main `8e62726`.

Milestone v2.29.5: #688 #689 #690 #692 #710 closed via PRs #711/#712/#713/#716/#718; operator-approved addition #719 closed via PR #720.

## Contents (release mechanics only)

- Version 2.29.4 → 2.29.5 in both plugin manifests; SKILL.md frontmatter via `make skills-generate`
- `docs/v2.29.5-release-notes.md` (canonical notes)
- README install pin → `@v2.29.5`; README.html/docs regenerated

## Validation at head

- `make release-check VERSION=v2.29.5`: release metadata matches v2.29.5
- `make ci`: green in the release worktree
- Diff scope: exactly the 19 release-mechanics files, no source changes

Merge → tag `v2.29.5` → GitHub release, all bound to the operator's release-gate approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)