### PR TITLE
chore(release): prepare v2.29.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,29 @@
 > [v2.22.0](docs/v2.22.0-release-notes.md),
 > [v2.23.0](docs/v2.23.0-release-notes.md),
 > [v2.23.1](docs/v2.23.1-release-notes.md),
-> [v2.24.0](docs/v2.24.0-release-notes.md), and
-> [v2.25.0](docs/v2.25.0-release-notes.md).
+> [v2.24.0](docs/v2.24.0-release-notes.md),
+> [v2.25.0](docs/v2.25.0-release-notes.md),
+> [v2.25.1](docs/v2.25.1-release-notes.md),
+> [v2.26.0](docs/v2.26.0-release-notes.md),
+> [v2.27.0](docs/v2.27.0-release-notes.md),
+> [v2.28.0](docs/v2.28.0-release-notes.md),
+> [v2.28.1](docs/v2.28.1-release-notes.md),
+> [v2.29.0](docs/v2.29.0-release-notes.md),
+> [v2.29.1](docs/v2.29.1-release-notes.md),
+> [v2.29.2](docs/v2.29.2-release-notes.md),
+> [v2.29.3](docs/v2.29.3-release-notes.md),
+> [v2.29.4](docs/v2.29.4-release-notes.md),
+> [v2.29.5](docs/v2.29.5-release-notes.md), and
+> [v2.29.6](docs/v2.29.6-release-notes.md).
 >
 > **v2.23.1 reconciliation index:** the canonical note records the exact Go
 > 1.25.12 requirement; lead-only staged admission/replacement; exact-authorizer,
 > single-use reserved launches; the idempotent one-repeat `control_continue`
 > recovery documented by the [#505 harness](docs/issue-505-staged-iterm2-harness.md);
 > and Git/Go `-C` option-boundary parsing with unknown wrappers failing closed.
+>
+> **v2.29.6 reconciliation index:** the canonical note records the
+> deterministic in-binary `amq-squad wizard` and its #709 companion changes;
+> `resume --last`, bounded slow-boot verification, quieter expected diagnostics,
+> and complete per-role health output for #722; and AMQ 0.60.5 compatibility for
+> coop mailbox provisioning plus fail-closed `machine_id` wake-lock handling.

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2295" id="toc-whats-new-in-v2295">What's new
-in v2.29.5</a></li>
+<li><a href="#whats-new-in-v2296" id="toc-whats-new-in-v2296">What's new
+in v2.29.6</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2295">What's new in v2.29.5</a></li>
+<li><a href="#whats-new-in-v2296">What's new in v2.29.6</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,42 +342,32 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2295">What's new in v2.29.5</h2>
-<p>v2.29.5 removes the run frictions that forced operator workarounds
-during the v2.29.2–v2.29.4 dogfood runs.
-<code>worktree cleanup --decision accepted</code> now accepts the two
-end states every normal multi-task run produces (#690): sequential task
-branches in one seat worktree are adopted when branch mismatch is the
-sole drift on a clean tree, and worktree-local <code>.agent-mail</code>
-bootstrap residue is classified removable — re-verified at deletion
-time, per-entry removal, with symlinks and unique local state still
-failing closed. Scoped <code>resume --exec</code> no longer declares a
-false <code>launch record missing</code> partial failure while a member
-is still booting (#688): a bounded 30s startup budget extends the 5s
-base window only while every outstanding record is boot-resolvable,
-identity mismatches stay terminal, and stale-record pane-title adoption
-runs at the base deadline so adoptable panes resolve in seconds.
-<code>start --yes</code> reconciles its own live session from canonical
-launch records instead of volatile pane titles (#692), so an agent
-rewriting its title no longer kills the documented
-rerun-<code>start</code> roll-forward path. Winding down a finished seat
-works (#689): verifiably dead panes (<code>pane_dead=1</code>, exact
-pane, identity match, re-verified at close) close under
-<code>--close-panes</code> without operator review, retries after a
-manual <code>kill-pane</code> converge to <code>already_gone</code>, and
-<code>team member rm</code> is idempotent with unambiguous roster
-outcomes — with the dead-pane evidence channel hardened across four
-review rounds (explicit format provenance, row-integrity validation, raw
-canonical payload gate). Wizard friction shrinks (#710):
-<code>setup --show [--json]</code> gives a strictly read-only view of
-the effective global drafter config, <code>--actor-mode</code> is
-documented and echoed per member in the <code>--dry-run --json</code>
-plan, and the wizard skill states that isolation materializes per task
-at dispatch time. Lead doctrine gains mandatory local-input supervision
-(#719): every status pass inspects <code>records[].local_input</code>
-and <code>local_input_blocked</code> warnings, and a detected permission
-prompt is a blocker — never authority. Full detail in <a
-href="docs/v2.29.5-release-notes.md">the v2.29.5 release notes</a>.</p>
+<h2 id="whats-new-in-v2296">What's new in v2.29.6</h2>
+<p>v2.29.6 restores guided squad setup as a deterministic binary-owned
+flow and removes the manual reconstruction around resuming an existing
+profile.</p>
+<ul>
+<li><code>amq-squad wizard</code> now owns readiness, new/existing
+profile selection, optional custom seats, rules and brief staging, and
+one combined launch review that defaults to No (#709). It snapshots
+every reviewed artifact, rejects drift before mutation, and delegates an
+accepted plan to the locked <code>start --yes</code> path. The release
+also carries the companion <code>setup --show</code>,
+<code>--actor-mode</code>, and task-scoped worktree-isolation
+improvements.</li>
+<li><code>resume --last</code> selects the profile's most recently
+active session (#722). Slow-but-live <code>resume --exec</code> launches
+may verify for up to 90 seconds, expected context/bootstrap noise moves
+behind <code>--verbose</code>, and the success epilogue covers every
+role — relaunched, skipped-live, or all-live.</li>
+<li>Fresh launches work with AMQ 0.60.5's stricter coop provisioning
+contract, and wake-lock compatibility now treats AMQ's
+<code>machine_id</code> field strictly and refuses local-PID conclusions
+for another or unverifiable machine. The supported minimum remains AMQ
+0.60.0.</li>
+</ul>
+<p>Full detail in <a href="docs/v2.29.6-release-notes.md">the v2.29.6
+release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
 Releases</a> and <a href="docs/">docs/</a> (per-release notes
@@ -388,7 +378,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.5</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.6</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.5](#whats-new-in-v2295)
+- [What's new in v2.29.6](#whats-new-in-v2296)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,38 +38,27 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.5
+## What's new in v2.29.6
 
-v2.29.5 removes the run frictions that forced operator workarounds during
-the v2.29.2–v2.29.4 dogfood runs. `worktree cleanup --decision accepted`
-now accepts the two end states every normal multi-task run produces (#690):
-sequential task branches in one seat worktree are adopted when branch
-mismatch is the sole drift on a clean tree, and worktree-local `.agent-mail`
-bootstrap residue is classified removable — re-verified at deletion time,
-per-entry removal, with symlinks and unique local state still failing
-closed. Scoped `resume --exec` no longer declares a false
-`launch record missing` partial failure while a member is still booting
-(#688): a bounded 30s startup budget extends the 5s base window only while
-every outstanding record is boot-resolvable, identity mismatches stay
-terminal, and stale-record pane-title adoption runs at the base deadline so
-adoptable panes resolve in seconds. `start --yes` reconciles its own live
-session from canonical launch records instead of volatile pane titles
-(#692), so an agent rewriting its title no longer kills the documented
-rerun-`start` roll-forward path. Winding down a finished seat works (#689):
-verifiably dead panes (`pane_dead=1`, exact pane, identity match,
-re-verified at close) close under `--close-panes` without operator review,
-retries after a manual `kill-pane` converge to `already_gone`, and
-`team member rm` is idempotent with unambiguous roster outcomes — with the
-dead-pane evidence channel hardened across four review rounds (explicit
-format provenance, row-integrity validation, raw canonical payload gate).
-Wizard friction shrinks (#710): `setup --show [--json]` gives a strictly
-read-only view of the effective global drafter config, `--actor-mode` is
-documented and echoed per member in the `--dry-run --json` plan, and the
-wizard skill states that isolation materializes per task at dispatch time.
-Lead doctrine gains mandatory local-input supervision (#719): every status
-pass inspects `records[].local_input` and `local_input_blocked` warnings,
-and a detected permission prompt is a blocker — never authority. Full
-detail in [the v2.29.5 release notes](docs/v2.29.5-release-notes.md).
+v2.29.6 restores guided squad setup as a deterministic binary-owned flow and
+removes the manual reconstruction around resuming an existing profile.
+
+- `amq-squad wizard` now owns readiness, new/existing profile selection,
+  optional custom seats, rules and brief staging, and one combined launch
+  review that defaults to No (#709). It snapshots every reviewed artifact,
+  rejects drift before mutation, and delegates an accepted plan to the locked
+  `start --yes` path. The release also carries the companion `setup --show`,
+  `--actor-mode`, and task-scoped worktree-isolation improvements.
+- `resume --last` selects the profile's most recently active session (#722).
+  Slow-but-live `resume --exec` launches may verify for up to 90 seconds,
+  expected context/bootstrap noise moves behind `--verbose`, and the success
+  epilogue covers every role — relaunched, skipped-live, or all-live.
+- Fresh launches work with AMQ 0.60.5's stricter coop provisioning contract,
+  and wake-lock compatibility now treats AMQ's `machine_id` field strictly and
+  refuses local-PID conclusions for another or unverifiable machine. The
+  supported minimum remains AMQ 0.60.0.
+
+Full detail in [the v2.29.6 release notes](docs/v2.29.6-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -87,7 +76,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.5
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.6
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.29.6-release-notes.md
+++ b/docs/v2.29.6-release-notes.md
@@ -1,0 +1,96 @@
+# amq-squad v2.29.6
+
+Deterministic guided setup and lower-friction resume: the in-binary
+`amq-squad wizard` required by #709, the existing-profile startup improvements
+from #722, and compatibility fixes for AMQ 0.60.5's coop-provisioning and
+wake-lock identity contracts. Milestone issues: #709 and #722.
+PRs: #724, #723, and #726.
+
+## Deterministic in-binary wizard (#709, PR #724)
+
+Guided setup is a real CLI state machine again rather than a long sequence an
+LLM must simulate:
+
+- `amq-squad wizard "GOAL"` owns the ordered flow from machine and drafter
+  readiness through new-profile creation or existing-profile reuse, optional
+  custom seats, team rules, root pointers, brief drafting, and launch review.
+- The final output is one combined review of the exact artifacts and launch
+  plan. Confirmation defaults to No; cancellation and `--json` preview do not
+  mutate the project.
+- The wizard snapshots every reviewed path and re-verifies it after approval.
+  A file that appears or changes while the prompt is open aborts before any
+  write, so approval cannot be replayed onto a different plan.
+- Accepted plans stage only the reviewed bytes and delegate launch to the
+  current locked `start --yes` path. A failed start leaves a rerunnable recovery
+  path rather than inventing a second launch implementation.
+- The wizard skill now delegates to one binary invocation. The release train
+  also includes #709's companion improvements: read-only
+  `setup --show [--json]`, documented and planned `--actor-mode`, and explicit
+  task-scoped worktree-isolation guidance.
+
+Known residual #727 is tracked separately: an existing-profile preview can
+defer its worktree-isolation rejection until `start`; the accepted launch still
+fails closed rather than silently using an unsafe layout.
+
+## Low-friction resume and new-session startup (#722, PR #723)
+
+Returning to an existing profile no longer requires reconstructing context by
+hand:
+
+- `resume --last` selects the profile's most recently active session using the
+  same activity signal as the status board. It rejects combination with an
+  explicit session instead of silently choosing one source.
+- The first `--last` resolution pass now stops after project/profile selection.
+  It does not ask session-dependent handle/root/namespace fields to resolve
+  before `--last` has chosen the session; the selected session is then fed
+  through full context resolution for normal diagnostics and safety checks.
+- `resume --exec` keeps its original 30-second failure point for a dead or
+  never-spawned pane, but a slow boot may continue to a 90-second hard ceiling
+  while every outstanding member's exact tmux pane remains alive.
+- Expected higher-priority context wins and mailbox-bootstrap creation details
+  move behind `--verbose`. Genuine equal-rank ambiguity still warns, and the
+  explicit `doctor --fix-amq-root` repair trail remains visible.
+- Successful resumes print a compact `role state pane-id` epilogue for all
+  roles, including already-live skipped roles and the all-live/no-launch case.
+
+## AMQ 0.60.5 compatibility (#726 and release-train follow-up)
+
+The latest-AMQ compatibility lane exposed two upstream contract changes. Both
+are handled without raising the supported minimum above AMQ 0.60.0:
+
+- AMQ 0.60.5 no longer lets `coop exec` self-provision a root that has
+  `meta/config.json` but no `agents/` directory. `agent up` now repairs root
+  authority and runs the idempotent mailbox fix before coop execution, so a
+  fresh launch materializes `agents/<handle>/inbox` on AMQ 0.60.5 and remains
+  compatible with 0.60.0–0.60.4.
+- AMQ 0.60.4 made `machine_id` a strict, trust-bearing wake-lock field.
+  amq-squad now matches the strict decode surface (wrong type, duplicate, and
+  null values refuse) and never uses local PID state to declare a writer dead
+  when a recorded machine is different or unverifiable. Legacy locks without
+  `machine_id` retain the hostname fallback.
+
+Together these changes prevent fresh-launch refusal on AMQ 0.60.5 and prevent
+a foreign-machine wake lock from being discounted using an unrelated local
+PID, which could otherwise permit a duplicate launch.
+
+## Verification
+
+- `make release-check VERSION=v2.29.6`
+- `make ci`
+- Real-AMQ compatibility coverage against latest AMQ 0.60.5, including root
+  authority, wake compatibility, and environment sanitization; the minimum
+  compatibility lane remains pinned at AMQ 0.60.0.
+- The #709 and #722 implementations were reviewed at exact heads and merged
+  with their regression suites and CI green.
+
+## Tracked follow-ups
+
+- #725: the optional evidence wrapper can break tmuxharness socket-identity
+  tests even when the underlying direct tests pass.
+- #727: existing-profile wizard preview defers the worktree-isolation check to
+  `start`.
+- #728: the production-cleanup wake test has a control-socket
+  connection-refused teardown race.
+- #730: the real-PTY wait-posture test can inherit an unexpected
+  `shell-setup` failure from the host environment; GitHub CI remains the
+  substantive release gate while the shell-init interaction is investigated.

--- a/internal/cli/context_resolution.go
+++ b/internal/cli/context_resolution.go
@@ -65,7 +65,7 @@ type contextResolveOptions struct {
 	BaseRootExplicit  bool
 	AllowMalformedEnv bool
 
-	// SkipSessionResolution resolves project/profile/root only and leaves
+	// SkipSessionResolution resolves project/profile only and leaves
 	// Session/Sources["session"] empty instead of selecting (or erroring on
 	// an ambiguous) session candidate. For a caller that picks its own
 	// session afterward (e.g. 'resume --last' choosing the most recently

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.5",
+  "version": "2.29.6",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.5",
+  "version": "2.29.6",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.29.5"  # x-release-please-version
+version: "2.29.6"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
## Summary

Prepare the v2.29.6 release from current `main` (`9386477`):

- bump both plugin manifests and all 14 generated Claude/Codex skill versions to 2.29.6
- add canonical v2.29.6 release notes and refresh the retired CHANGELOG index
- replace the README What's-new section and pinned install example, then regenerate README.html
- cover the deterministic in-binary wizard and #709 companion changes, #722 resume/new-session UX, and AMQ 0.60.5 compatibility for coop provisioning plus strict `machine_id` wake-lock handling
- correct the one-line `SkipSessionResolution` comment to match its project/profile-only behavior
- record tracked residuals #725, #727, #728, and #730

## Why

v2.29.6 closes the two milestone outcomes already merged through #724 and #723 and packages the AMQ 0.60.5 compatibility work from #726 plus its release-train follow-up. The supported AMQ minimum remains 0.60.0.

## User and developer impact

Operators regain a deterministic, default-No binary wizard; existing profiles can resume the latest session with quieter expected diagnostics and complete health output; and fresh launches remain safe across AMQ 0.60.0–0.60.5, including foreign-machine wake-lock evidence.

## Validation

- PASS: `make release-check VERSION=v2.29.6`
- PASS: `readme-html-check docs-html-check skills-check skill-routing-check skill-command-check skill-invocation-check release-validator-test go-files-scope-test`
- PASS: `go test -timeout 20m -skip '^TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout$' ./...`
- Local unfiltered `make ci` and a focused count=1 rerun fail only the named real-PTY host-environment case with `fake amq: unsupported command: shell-setup`; this is tracked in #730. GitHub CI at the exact base `9386477` is green after rerun (run 31793749157) and remains the substantive release gate.
- `git diff --check 9386477..c862e70` passes.

## Release gate

This PR is intentionally draft. No tag or GitHub release has been created. The remaining sequence is fullstack exact-head review, operator release approval, merge, then lead-owned tag/publish and release smoke verification.
