### PR TITLE
gh#734/gh#735: Go-API-only adoption seam with explicit base_root + env sanitization

### DIFF
--- a/internal/adoptionseam/adoptionseam.go
+++ b/internal/adoptionseam/adoptionseam.go
@@ -1,0 +1,141 @@
+// Package adoptionseam is the single call site through which amq-squad talks
+// to launchapi. It never shells out to the amq CLI and never performs its own
+// root discovery: every target coordinate comes from the caller's already-
+// resolved internal/launchintent.Input, and a missing base root is refused
+// before launchapi is ever called (gh#734) — the same bug class that let
+// AMQ's own upward .amqrc discovery retarget writes into a parent repo's
+// live base root from a nested worktree cwd. Identity env vars inherited
+// from a live parent AMQ seat are stripped before any child sees them
+// (gh#735).
+package adoptionseam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
+)
+
+// ErrEmptyBaseRoot is returned by Prepare before launchapi is ever called
+// when the caller's intent carries no explicit base root. There is no
+// fallback and no discovery: an empty base root is refused, not resolved.
+var ErrEmptyBaseRoot = errors.New("adoptionseam: target base_root is required")
+
+// PrepareInput is Prepare's complete input. Intent is already-resolved by
+// internal/launchintent, so its Target carries an explicit BaseRoot; this
+// package adds no lookups of its own on top of it.
+type PrepareInput struct {
+	Intent    launchintent.Input
+	Launcher  string
+	Placement *launchapi.PlacementV1
+	Caller    map[string]string
+	// Env is the parent process environment. SanitizeEnv strips inherited
+	// AMQ identity before it is attached to Prepared for any child command.
+	Env []string
+}
+
+// Prepared bundles a successful Prepare call: the exact request that was
+// sent to launchapi (so Apply can be built from it without re-deriving
+// anything), the result launchapi returned, and the sanitized environment
+// for whatever launches a child from this seam.
+type Prepared struct {
+	Request launchapi.PrepareRequestV1
+	Result  launchapi.PrepareResultV1
+	Env     []string
+}
+
+// Prepare compiles in.Intent and calls launchapi.Prepare with it. It never
+// shells out: no os/exec, no amq CLI invocation, no upward root discovery.
+// A missing base root fails closed with ErrEmptyBaseRoot before launchapi
+// (or internal/launchintent) is ever touched.
+func Prepare(ctx context.Context, in PrepareInput) (Prepared, error) {
+	if strings.TrimSpace(in.Intent.Target.BaseRoot) == "" {
+		return Prepared{}, ErrEmptyBaseRoot
+	}
+
+	intent, target, err := launchintent.Compile(in.Intent)
+	if err != nil {
+		return Prepared{}, err
+	}
+
+	request := launchapi.PrepareRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target:         target,
+		Launcher:       in.Launcher,
+		Placement:      in.Placement,
+		CallerContext:  in.Caller,
+		Intent:         intent,
+	}
+
+	result, err := launchapi.Prepare(ctx, request)
+	if err != nil {
+		return Prepared{}, err
+	}
+
+	return Prepared{
+		Request: request,
+		Result:  result,
+		Env:     SanitizeEnv(in.Env),
+	}, nil
+}
+
+// Apply calls launchapi.Apply against a previously Prepared bundle and the
+// operator/caller's decisions for any required actions Prepare surfaced.
+func Apply(ctx context.Context, p Prepared, decisions []launchapi.DecisionV1) (launchapi.ApplyResultV1, error) {
+	request := launchapi.ApplyRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Prepare:        p.Request,
+		SubjectDigest:  p.Result.SubjectDigest,
+		Decisions:      decisions,
+	}
+	return launchapi.Apply(ctx, request)
+}
+
+// sanitizedIdentityVars are the five AMQ root/session-pinning variables a
+// live parent agent seat has injected into its own environment (gh#735).
+// They must never reach a child this seam launches; everything else passes
+// through untouched.
+//
+// AM_ME is deliberately NOT in this set, despite also being AMQ identity.
+// gh#735's evidence is specifically about root/session PINNING failures
+// ("evidence from AM_ROOT_ID, AM_BASE_ROOT_ID requires an exact
+// AM_BASE_ROOT"), not about which handle a child acts as. Verified directly
+// against the pinned launchapi v0.70.0 + internal/launch sources: neither
+// package reads or sets AM_ME anywhere -- Prepare/Apply never touch it, and
+// a child's effective handle is carried explicitly through each
+// ParticipantV1.EnvOverlay (compiled by internal/launchintent), then
+// surfaced back out as CommandV1.EnvOverlay for whatever launches the
+// child. An inherited AM_ME in the parent's OS environment is therefore
+// inert to launchapi either way: stripping it here would be a no-op for
+// correctness, and keeping the set to exactly gh#735's five named
+// variables keeps this table an honest match for its acceptance test
+// rather than a superset nobody asked for.
+var sanitizedIdentityVars = map[string]bool{
+	"AM_ROOT":         true,
+	"AM_BASE_ROOT":    true,
+	"AM_ROOT_ID":      true,
+	"AM_BASE_ROOT_ID": true,
+	"AM_SESSION":      true,
+}
+
+// SanitizeEnv strips the five inherited AMQ root/session-pinning variables
+// from env, leaving every other entry -- including AM_ME, see above --
+// untouched. It is the seam's own dedicated contract (gh#735): it does not
+// read or modify internal/cli/amq_env.go's envWithoutAMQIdentity, which
+// strips a broader, CLI-specific set for a different call site.
+func SanitizeEnv(env []string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && sanitizedIdentityVars[key] {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/internal/adoptionseam/adoptionseam_test.go
+++ b/internal/adoptionseam/adoptionseam_test.go
@@ -1,0 +1,138 @@
+package adoptionseam
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
+)
+
+func baseIntentInput(t *testing.T, projectRoot string) launchintent.Input {
+	t.Helper()
+	return launchintent.Input{
+		Operator: launchintent.OperatorFacts{Handle: "user"},
+		Seats: []launchintent.SeatFacts{
+			{
+				Handle:      "fullstack",
+				Executable:  "/usr/bin/claude",
+				Args:        []string{"--permission-mode", "auto"},
+				Cwd:         launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: projectRoot},
+				RequireWake: true,
+			},
+		},
+		Target: launchintent.TargetFacts{
+			ProjectRoot: projectRoot,
+			BaseRoot:    filepath.Join(projectRoot, ".agent-mail", "squad-v2-30-0", "v2-30-0"),
+			SessionRoot: projectRoot,
+			Session:     "v2-30-0",
+		},
+	}
+}
+
+// TestAdoptionSeamRefusesEmptyBaseRoot proves Prepare fails closed with
+// ErrEmptyBaseRoot, and does so before touching internal/launchintent or
+// launchapi at all: no AMQ call, no compile, no network, no filesystem I/O.
+func TestAdoptionSeamRefusesEmptyBaseRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	intent := baseIntentInput(t, projectRoot)
+	intent.Target.BaseRoot = ""
+
+	_, err := Prepare(context.Background(), PrepareInput{Intent: intent, Launcher: "tmux"})
+	if err == nil {
+		t.Fatal("expected Prepare to refuse an empty base root")
+	}
+	if !errors.Is(err, ErrEmptyBaseRoot) {
+		t.Fatalf("err = %v, want ErrEmptyBaseRoot", err)
+	}
+}
+
+// TestAdoptionSeamNeverInvokesLaunchCLI is a source-level guard: the seam's
+// own .go files must never import os/exec or reference the amq CLI by
+// exec-style string, so a future change cannot silently reintroduce a shell
+// dependency on the CLI whose --plan path cannot express an explicit
+// base_root at all.
+func TestAdoptionSeamNeverInvokesLaunchCLI(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".go" || hasTestSuffix(name) {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		content := string(data)
+		if containsImport(content, `"os/exec"`) {
+			t.Fatalf("%s imports os/exec; the adoption seam must call launchapi exclusively", name)
+		}
+		for _, needle := range []string{`"amq"`, "exec.Command", "exec.CommandContext"} {
+			if contains(content, needle) {
+				t.Fatalf("%s references %q; the adoption seam must never shell out to the amq CLI", name, needle)
+			}
+		}
+	}
+}
+
+func hasTestSuffix(name string) bool {
+	return len(name) > len("_test.go") && name[len(name)-len("_test.go"):] == "_test.go"
+}
+
+func containsImport(content, importPath string) bool {
+	return contains(content, importPath)
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) > 0 && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+// TestAdoptionSeamStripsInheritedAMQIdentity locks the five variables a live
+// parent AMQ seat injects into its own environment (gh#735): none of them
+// may reach a child this seam launches.
+func TestAdoptionSeamStripsInheritedAMQIdentity(t *testing.T) {
+	cases := []string{"AM_ROOT", "AM_BASE_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT_ID", "AM_SESSION"}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			env := []string{key + "=inherited-value", "PATH=/usr/bin"}
+			got := SanitizeEnv(env)
+			for _, entry := range got {
+				if entry == key || len(entry) > len(key) && entry[:len(key)+1] == key+"=" {
+					t.Fatalf("SanitizeEnv did not strip %s: %v", key, got)
+				}
+			}
+		})
+	}
+}
+
+// TestAdoptionSeamPreservesNonAMQEnv proves the strip is targeted: unrelated
+// environment entries, including ones with an AM_/AMQ_ prefix that are not
+// one of the five identity variables, pass through untouched.
+func TestAdoptionSeamPreservesNonAMQEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/Users/senior-dev",
+		"AM_ME=senior-dev",          // not one of the five, must survive
+		"AMQ_NO_UPDATE_CHECK=1",     // not one of the five, must survive
+		"AMQSESSION_UNRELATED=keep", // prefix collision, must survive
+	}
+	got := SanitizeEnv(env)
+	want := append([]string(nil), env...)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SanitizeEnv(%v) = %v, want unchanged %v", env, got, want)
+	}
+}

--- a/internal/adoptionseam/nested_worktree_test.go
+++ b/internal/adoptionseam/nested_worktree_test.go
@@ -1,0 +1,144 @@
+package adoptionseam
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
+)
+
+// hashTree returns a stable digest of every regular file under root (path
+// relative to root, plus content), so the test can prove a directory tree
+// is byte-identical before and after a call without depending on mtimes.
+func hashTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return out
+	}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		out[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// TestAdoptionSeamTargetsNestedWorktreeWithoutParentEscape reproduces the
+// exact hazard gh#734 exists to close: a task worktree nested INSIDE a
+// parent repo, where AMQ's own upward .amqrc discovery would otherwise
+// retarget writes into the parent's live base root. This seam takes no
+// discovery path at all -- every root is the explicit one the caller
+// resolved -- so the parent's .agent-mail tree must be byte-identical
+// before and after, and the resolved roots must live under the nested
+// project's own explicit base, never the parent's.
+func TestAdoptionSeamTargetsNestedWorktreeWithoutParentEscape(t *testing.T) {
+	// Keep the trust store this seam opens fully inside the test's temp
+	// dir; DefaultLaunchStateDir honors XDG_STATE_HOME. Otherwise Prepare
+	// would touch the real machine's global AMQ state directory.
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	parentRepo := t.TempDir()
+	parentAgentMail := filepath.Join(parentRepo, ".agent-mail")
+	if err := os.MkdirAll(filepath.Join(parentAgentMail, "live-profile", "live-session"), 0o755); err != nil {
+		t.Fatalf("seed parent .agent-mail: %v", err)
+	}
+	liveSentinel := filepath.Join(parentAgentMail, "live-profile", "live-session", "sentinel.txt")
+	if err := os.WriteFile(liveSentinel, []byte("parent live session, must not move\n"), 0o644); err != nil {
+		t.Fatalf("seed parent sentinel: %v", err)
+	}
+
+	// A task worktree nested INSIDE the parent repo -- our real layout
+	// (amq-squad-wt-*) and the default hazard, not an edge case.
+	nestedProject := filepath.Join(parentRepo, "task-worktree")
+	if err := os.MkdirAll(nestedProject, 0o755); err != nil {
+		t.Fatalf("create nested project: %v", err)
+	}
+	nestedBaseRoot := filepath.Join(nestedProject, ".agent-mail", "squad-v2-30-0", "v2-30-0")
+
+	before := hashTree(t, parentAgentMail)
+
+	intent := launchintent.Input{
+		Operator: launchintent.OperatorFacts{Handle: "user"},
+		Seats: []launchintent.SeatFacts{
+			{
+				Handle:      "senior-dev",
+				Executable:  "/usr/bin/claude",
+				Args:        []string{"--permission-mode", "auto"},
+				Cwd:         launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: nestedProject},
+				RequireWake: true,
+			},
+		},
+		Target: launchintent.TargetFacts{
+			ProjectRoot: nestedProject,
+			BaseRoot:    nestedBaseRoot,
+			SessionRoot: nestedProject,
+			Session:     "v2-30-0",
+		},
+	}
+
+	prepared, err := Prepare(context.Background(), PrepareInput{
+		Intent:   intent,
+		Launcher: "tmux",
+		Env:      []string{"AM_ROOT=" + filepath.Join(parentRepo, ".agent-mail", "live-profile", "live-session"), "PATH=/usr/bin"},
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	after := hashTree(t, parentAgentMail)
+	if len(before) != len(after) {
+		t.Fatalf("parent .agent-mail tree changed: before had %d files, after has %d", len(before), len(after))
+	}
+	for path, contentBefore := range before {
+		contentAfter, ok := after[path]
+		if !ok {
+			t.Fatalf("parent .agent-mail file %s disappeared", path)
+		}
+		if contentAfter != contentBefore {
+			t.Fatalf("parent .agent-mail file %s changed content", path)
+		}
+	}
+	for path := range after {
+		if _, ok := before[path]; !ok {
+			t.Fatalf("parent .agent-mail gained a new file %s -- discovery escaped into the parent repo", path)
+		}
+	}
+
+	resolvedBase := prepared.Request.Target.BaseRoot
+	resolvedProject := prepared.Request.Target.ProjectRoot
+	if resolvedBase != nestedBaseRoot {
+		t.Fatalf("resolved base_root = %q, want the explicit nested base %q (no upward discovery)", resolvedBase, nestedBaseRoot)
+	}
+	if resolvedProject != nestedProject {
+		t.Fatalf("resolved project_root = %q, want the explicit nested project %q", resolvedProject, nestedProject)
+	}
+	if rel, err := filepath.Rel(nestedProject, resolvedBase); err != nil || len(rel) >= 2 && rel[:2] == ".." {
+		t.Fatalf("resolved base_root %q is not under the nested project %q", resolvedBase, nestedProject)
+	}
+	for _, entry := range prepared.Env {
+		if len(entry) >= 8 && entry[:8] == "AM_ROOT=" {
+			t.Fatalf("Prepared.Env still carries inherited AM_ROOT: %v", prepared.Env)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New package `internal/adoptionseam`: the single call site through which amq-squad talks to `launchapi`. `Prepare`/`Apply` never shell out to the amq CLI and never perform upward root discovery — every target coordinate comes from the caller's already-resolved `internal/launchintent.Input`.
- `Prepare` fails closed with `ErrEmptyBaseRoot` before `launchapi` is ever called if the base root is missing (gh#734) — closes the same bug class that let AMQ's own `.amqrc` upward discovery retarget writes into a parent repo's live base root from a nested task-worktree cwd (our default layout, not an edge case).
- `SanitizeEnv` formalizes stripping the five inherited AMQ root/session-pinning identity vars (`AM_ROOT`, `AM_BASE_ROOT`, `AM_ROOT_ID`, `AM_BASE_ROOT_ID`, `AM_SESSION`) as a tested seam contract (gh#735). Does not touch `internal/cli/amq_env.go`'s existing `envWithoutAMQIdentity` — additive, separate contract for a separate call site.
- `AM_ME` deliberately excluded from the strip set: verified directly against pinned launchapi v0.70.0 + its `internal/launch` dependency that neither reads nor sets it anywhere; a child's handle rides `ParticipantV1.EnvOverlay` explicitly, not ambient env inheritance. Reasoning documented in the `SanitizeEnv` doc comment.
- Contract signatures match what fullstack's t2 launchapi backend codes against (`PrepareInput{Intent, Launcher string, Placement *launchapi.PlacementV1, Caller map[string]string, Env []string}`, `Prepared{Request, Result, Env}`), corrected from the original dispatch to match launchapi v0.70.0's real field types (`Launcher string`, not a nonexistent `LauncherV1`; `Caller map[string]string`, not a nonexistent `CallerContextV1`) — confirmed with lead before implementing.

Additive only: no existing file touched.

## Test plan
- [x] `go test ./internal/adoptionseam/...` — all 6 named acceptance tests green: `TestAdoptionSeamRefusesEmptyBaseRoot`, `TestAdoptionSeamNeverInvokesLaunchCLI` (source-level guard: no `os/exec` import, no amq-CLI exec strings), `TestAdoptionSeamTargetsNestedWorktreeWithoutParentEscape` (real nested-worktree fixture, byte-compares the parent repo's `.agent-mail` tree before/after a real `launchapi.Prepare` call), `TestAdoptionSeamStripsInheritedAMQIdentity` (table over the five vars), `TestAdoptionSeamPreservesNonAMQEnv`.
- [x] `go build ./...` and `go vet ./internal/adoptionseam/...` clean.
- [x] `make ci`: diff scope confirmed clean (only `internal/adoptionseam/*`). One pre-existing flaky test — `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout` — reproduced identically on an unmodified `main` checkout right now (real-PTY timing test, environmental, unrelated to this diff; same flake independently confirmed on t1 by both reviewers).
- [x] `git diff` / `git status` confirms only the new `internal/adoptionseam/` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)