### PR TITLE
feat(launchapi): opt-in launchapi backend behind --launch-via (gh#733)

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -329,6 +329,8 @@ var completionCommonFlags = []string{
 	"--launcher-pane",
 	"--launch",
 	"--launch-shape",
+	"--launch-via",
+	"--launchapi-decision",
 	"--lease",
 	"--limit",
 	"--me",

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -112,10 +112,14 @@ type liveLaunchFlags struct {
 	// launchVia opts into an alternate launch orchestration path (gh#733).
 	// Empty is the legacy default: byte-identical to pre-gh#733 behavior.
 	launchVia *string
+	// launchapiDecisions carries explicit operator answers to launchapi's
+	// RequiredActionV1 gates, one ACTION_ID=CHOICE pair per repeated flag.
+	// Only meaningful with --launch-via launchapi; never auto-populated.
+	launchapiDecisions stringListFlag
 }
 
 func registerLiveLaunchFlags(fs *flag.FlagSet) *liveLaunchFlags {
-	return &liveLaunchFlags{
+	lf := &liveLaunchFlags{
 		terminal:        fs.String("terminal", "tmux", "terminal backend to use"),
 		target:          fs.String("target", "current-window", "terminal target, backend-specific"),
 		layout:          fs.String("layout", "vertical", "terminal layout, backend-specific"),
@@ -124,6 +128,8 @@ func registerLiveLaunchFlags(fs *flag.FlagSet) *liveLaunchFlags {
 		noAttach:        fs.Bool("no-attach", false, "legacy no-op; new-session never attaches automatically"),
 		launchVia:       fs.String("launch-via", "", "opt-in alternate launch orchestration path: launchapi (tmux only); default is legacy"),
 	}
+	fs.Var(&lf.launchapiDecisions, "launchapi-decision", "explicit operator answer to a launchapi required action, ACTION_ID=CHOICE (repeatable; --launch-via launchapi only)")
+	return lf
 }
 
 // buildLiveLaunchOptions composes a teamLaunchOptions from the shared preview
@@ -134,26 +140,53 @@ func buildLiveLaunchOptions(fs *flag.FlagSet, pf *previewFlags, lf *liveLaunchFl
 	if err != nil {
 		return teamLaunchOptions{}, err
 	}
+	launchapiDecisions, err := parseLaunchapiDecisions(lf.launchapiDecisions)
+	if err != nil {
+		return teamLaunchOptions{}, err
+	}
 	return teamLaunchOptions{
-		Terminal:        *lf.terminal,
-		Target:          *lf.target,
-		Layout:          *lf.layout,
-		Workstream:      emit.RequestedSession,
-		TerminalSession: *lf.terminalSession,
-		Fresh:           emit.Fresh,
-		NoBootstrap:     emit.NoBootstrap,
-		Stagger:         *lf.stagger,
-		SquadBin:        teamSquadBin(),
-		BinaryArgs:      emit.ExtraBinaryArgs,
-		Trust:           emit.RequestedTrust,
-		ModelOverrides:  emit.ModelOverrides,
-		EffortOverrides: emit.EffortOverrides,
-		ForceDuplicate:  emit.ForceDuplicate,
-		NoGitignore:     emit.NoGitignore,
-		Symphony:        emit.Symphony,
-		WakeInjectVia:   emit.WakeInjectVia,
-		WakeInjectArgs:  emit.WakeInjectArgs,
-		WakeInjectMode:  emit.WakeInjectMode,
-		LaunchVia:       *lf.launchVia,
+		Terminal:           *lf.terminal,
+		Target:             *lf.target,
+		Layout:             *lf.layout,
+		Workstream:         emit.RequestedSession,
+		TerminalSession:    *lf.terminalSession,
+		Fresh:              emit.Fresh,
+		NoBootstrap:        emit.NoBootstrap,
+		Stagger:            *lf.stagger,
+		SquadBin:           teamSquadBin(),
+		BinaryArgs:         emit.ExtraBinaryArgs,
+		Trust:              emit.RequestedTrust,
+		ModelOverrides:     emit.ModelOverrides,
+		EffortOverrides:    emit.EffortOverrides,
+		ForceDuplicate:     emit.ForceDuplicate,
+		NoGitignore:        emit.NoGitignore,
+		Symphony:           emit.Symphony,
+		WakeInjectVia:      emit.WakeInjectVia,
+		WakeInjectArgs:     emit.WakeInjectArgs,
+		WakeInjectMode:     emit.WakeInjectMode,
+		LaunchVia:          *lf.launchVia,
+		LaunchapiDecisions: launchapiDecisions,
 	}, nil
+}
+
+// parseLaunchapiDecisions parses repeated --launchapi-decision
+// ACTION_ID=CHOICE flags into a map. A malformed entry (missing "=", or an
+// empty action id/choice) is a usage error, not a silently dropped flag.
+func parseLaunchapiDecisions(entries []string) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		actionID, choice, ok := strings.Cut(entry, "=")
+		actionID, choice = strings.TrimSpace(actionID), strings.TrimSpace(choice)
+		if !ok || actionID == "" || choice == "" {
+			return nil, usageErrorf("--launchapi-decision %q: want ACTION_ID=CHOICE", entry)
+		}
+		if _, dup := out[actionID]; dup {
+			return nil, usageErrorf("--launchapi-decision specified twice for action %q", actionID)
+		}
+		out[actionID] = choice
+	}
+	return out, nil
 }

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -109,6 +109,9 @@ type liveLaunchFlags struct {
 	stagger         *time.Duration
 	// noAttach is parsed for compatibility but has no behavioral effect.
 	noAttach *bool
+	// launchVia opts into an alternate launch orchestration path (gh#733).
+	// Empty is the legacy default: byte-identical to pre-gh#733 behavior.
+	launchVia *string
 }
 
 func registerLiveLaunchFlags(fs *flag.FlagSet) *liveLaunchFlags {
@@ -119,6 +122,7 @@ func registerLiveLaunchFlags(fs *flag.FlagSet) *liveLaunchFlags {
 		terminalSession: fs.String("terminal-session", "", "terminal session name when the backend creates one"),
 		stagger:         fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes"),
 		noAttach:        fs.Bool("no-attach", false, "legacy no-op; new-session never attaches automatically"),
+		launchVia:       fs.String("launch-via", "", "opt-in alternate launch orchestration path: launchapi (tmux only); default is legacy"),
 	}
 }
 
@@ -150,5 +154,6 @@ func buildLiveLaunchOptions(fs *flag.FlagSet, pf *previewFlags, lf *liveLaunchFl
 		WakeInjectVia:   emit.WakeInjectVia,
 		WakeInjectArgs:  emit.WakeInjectArgs,
 		WakeInjectMode:  emit.WakeInjectMode,
+		LaunchVia:       *lf.launchVia,
 	}, nil
 }

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -85,6 +85,12 @@ type teamLaunchOptions struct {
 	// into launchapiTeamLaunchBackend (gh#733), which still requires Terminal
 	// to resolve to tmux since that backend is tmux-only.
 	LaunchVia string
+	// LaunchapiDecisions carries explicit operator answers (ACTION_ID ->
+	// CHOICE) to launchapi RequiredActionV1 gates, from repeated
+	// --launchapi-decision flags. Only consulted by launchapiTeamLaunchBackend;
+	// nil/empty means no decisions were supplied and every required action
+	// surfaces as an operator gate instead.
+	LaunchapiDecisions map[string]string
 }
 
 type teamLaunchResult struct {

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -79,6 +79,12 @@ type teamLaunchOptions struct {
 	// before any destructive reset. A non-nil slice prevents executeTeamLaunch
 	// from re-resolving AMQ after that parent's mutation boundary.
 	ResolvedAMQPreflights []agentLaunchPreflight
+	// LaunchVia selects an alternate launch orchestration path independent of
+	// Terminal. Empty (or "auto") is the legacy default: Terminal alone picks
+	// the backend, byte-identical to pre-gh#733 behavior. "launchapi" opts
+	// into launchapiTeamLaunchBackend (gh#733), which still requires Terminal
+	// to resolve to tmux since that backend is tmux-only.
+	LaunchVia string
 }
 
 type teamLaunchResult struct {
@@ -207,9 +213,9 @@ Examples:
 // trust, and live backend fields; the explicit-* bools mirror flagWasSet so
 // trust/session resolution against team.json defaults stays correct.
 func executeTeamLaunch(opts teamLaunchOptions, explicitSession bool, explicitTrust bool) error {
-	backend, ok := teamLaunchBackends[opts.Terminal]
-	if !ok {
-		return fmt.Errorf("unsupported terminal %q: supported terminals: %s", opts.Terminal, strings.Join(registeredTeamLaunchTerminals(), ", "))
+	backend, err := resolveTeamLaunchBackend(opts)
+	if err != nil {
+		return err
 	}
 	if err := backend.Validate(opts); err != nil {
 		return err

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -1,0 +1,425 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+
+	"github.com/omriariav/amq-squad/v2/internal/adoptionseam"
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
+	"github.com/omriariav/amq-squad/v2/internal/state"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+func init() {
+	registerTeamLaunchBackend(launchapiTeamLaunchBackend{})
+}
+
+// launchapiTeamLaunchBackend implements teamLaunchBackend on top of amq's
+// public launchapi.Prepare/Apply contract (gh#733). It is tmux-only and
+// reachable ONLY via the explicit --launch-via launchapi opt-in resolved by
+// resolveTeamLaunchBackend; it is never selected by --terminal alone, and the
+// legacy tmux/iterm2/terminal/tmux-session backends and their argv are
+// untouched (additive-only, gh#732's TestV2300RemovesNothing invariant).
+type launchapiTeamLaunchBackend struct{}
+
+func (launchapiTeamLaunchBackend) Name() string { return "launchapi" }
+
+func (launchapiTeamLaunchBackend) Validate(opts teamLaunchOptions) error {
+	return tmuxTeamLaunchBackend{}.Validate(opts)
+}
+
+func (b launchapiTeamLaunchBackend) DryRun(t team.Team, opts teamLaunchOptions) error {
+	prepared, _, err := b.prepare(t, opts)
+	if err != nil {
+		return err
+	}
+	printLaunchapiPreview(prepared.Result)
+	return nil
+}
+
+func (b launchapiTeamLaunchBackend) Launch(t team.Team, opts teamLaunchOptions) error {
+	_, err := b.launch(t, opts)
+	return err
+}
+
+func (b launchapiTeamLaunchBackend) LaunchWithResult(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+	return b.launch(t, opts)
+}
+
+// resolveTeamLaunchBackend is the single selection seam consumed by
+// executeTeamLaunch. When opts.LaunchVia is empty or "auto" it reproduces the
+// pre-gh#733 lookup byte-for-byte (same error text, same map). Only an
+// explicit non-auto value can select launchapiTeamLaunchBackend, and only
+// when the terminal resolves to tmux.
+func resolveTeamLaunchBackend(opts teamLaunchOptions) (teamLaunchBackend, error) {
+	launchVia := strings.ToLower(strings.TrimSpace(opts.LaunchVia))
+	if launchVia != "" && launchVia != "auto" {
+		if launchVia != "launchapi" {
+			return nil, fmt.Errorf("unsupported --launch-via %q: supported values: launchapi", opts.LaunchVia)
+		}
+		if terminal := strings.TrimSpace(opts.Terminal); terminal != "" && terminal != "tmux" {
+			return nil, fmt.Errorf("--launch-via launchapi requires --terminal tmux (got %q)", opts.Terminal)
+		}
+		backend, ok := teamLaunchBackends["launchapi"]
+		if !ok {
+			return nil, fmt.Errorf("launchapi backend is not registered")
+		}
+		return backend, nil
+	}
+	backend, ok := teamLaunchBackends[opts.Terminal]
+	if !ok {
+		return nil, fmt.Errorf("unsupported terminal %q: supported terminals: %s", opts.Terminal, strings.Join(registeredTeamLaunchTerminals(), ", "))
+	}
+	return backend, nil
+}
+
+// launch runs the full Prepare -> gate -> Apply -> tmux-pane flow. It never
+// answers a RequiredActionV1 itself: any pending decision stops the launch
+// short of Apply and surfaces every action as an operator gate/<topic>
+// thread, matching TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates.
+func (b launchapiTeamLaunchBackend) launch(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+	prepared, preflights, err := b.prepare(t, opts)
+	if err != nil {
+		return teamLaunchResult{}, err
+	}
+	if len(prepared.Result.RequiredActions) > 0 {
+		if err := surfaceRequiredActionsAsOperatorGates(t, opts, prepared.Result.RequiredActions); err != nil {
+			return teamLaunchResult{}, fmt.Errorf("launchapi: surface operator gates: %w", err)
+		}
+		return teamLaunchResult{}, fmt.Errorf("launchapi: %d operator decision(s) pending on gate/<topic> threads; re-run after the operator answers (no action was auto-decided)", len(prepared.Result.RequiredActions))
+	}
+	applyResult, err := adoptionseam.Apply(context.Background(), prepared, nil)
+	if err != nil {
+		return teamLaunchResult{}, fmt.Errorf("adoptionseam.Apply: %w", err)
+	}
+	if err := assertNoForbiddenNewPathArgv(applyResult.Commands); err != nil {
+		return teamLaunchResult{}, err
+	}
+	plan, err := b.tmuxPlanFromCommands(t, opts, preflights, applyResult.Commands, sanitizedIdentityVarNames(os.Environ(), prepared.Env))
+	if err != nil {
+		return teamLaunchResult{}, err
+	}
+	return runTmuxLaunchPlanWithResult(plan)
+}
+
+// prepare builds the launch intent (via internal/launchintent, gh#732) and
+// calls adoptionseam.Prepare -- the single seam to launchapi (gh#734/gh#735)
+// that owns base_root fail-closed refusal and env sanitization, rather than
+// this backend calling launchapi.Prepare directly. It never mutates
+// anything: Prepare is read-only in launchapi's own contract.
+func (b launchapiTeamLaunchBackend) prepare(t team.Team, opts teamLaunchOptions) (adoptionseam.Prepared, []agentLaunchPreflight, error) {
+	preflights, err := buildTeamPreflights(t, opts)
+	if err != nil {
+		return adoptionseam.Prepared{}, nil, err
+	}
+	input, err := b.buildIntentInput(t, opts, preflights)
+	if err != nil {
+		return adoptionseam.Prepared{}, nil, err
+	}
+	prepared, err := adoptionseam.Prepare(context.Background(), adoptionseam.PrepareInput{
+		Intent:   input,
+		Launcher: "tmux",
+		Caller:   map[string]string{"profile": opts.Profile, "workstream": opts.Workstream},
+		Env:      os.Environ(),
+	})
+	if err != nil {
+		if errors.Is(err, adoptionseam.ErrEmptyBaseRoot) {
+			return adoptionseam.Prepared{}, nil, fmt.Errorf("launchapi: base_root is required and must be explicit (gh#734): %w", err)
+		}
+		return adoptionseam.Prepared{}, nil, fmt.Errorf("adoptionseam.Prepare: %w", err)
+	}
+	return prepared, preflights, nil
+}
+
+// buildIntentInput assembles launchintent.Input from the already-resolved
+// team, launch options, and AMQ preflights (CWD/handle/root/base_root). It
+// resolves argv exactly the way the legacy tmux backend does -- trust-mode
+// built-ins + model args + member/global native args via the same
+// composeBinaryArgs layering -- so launchintent.Compile's sanitizer is the
+// ONLY thing that diverges the new path's argv from legacy (no --allowedTools,
+// no approvals_reviewer; see internal/launchintent's own tests).
+func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunchOptions, preflights []agentLaunchPreflight) (launchintent.Input, error) {
+	if len(t.Members) == 0 {
+		return launchintent.Input{}, fmt.Errorf("launchapi: team has no members")
+	}
+	byRole := make(map[string]agentLaunchPreflight, len(preflights))
+	for _, p := range preflights {
+		byRole[strings.ToLower(strings.TrimSpace(p.Role))] = p
+	}
+	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.BinaryArgs)
+	seats := make([]launchintent.SeatFacts, 0, len(t.Members))
+	baseRoot := ""
+	for _, m := range orderedTeamMembers(t.Members) {
+		pre, ok := byRole[strings.ToLower(strings.TrimSpace(m.Role))]
+		if !ok {
+			return launchintent.Input{}, fmt.Errorf("launchapi: no resolved AMQ preflight for role %q", m.Role)
+		}
+		if baseRoot == "" {
+			baseRoot = pre.BaseRoot
+		}
+		model := memberResolvedModel(m, opts.ModelOverrides, binaryArgs)
+		nativeArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, binaryArgs), m.ExtraArgs())
+		trustMode := opts.Trust
+		if trustMode == "" {
+			trustMode = defaultTrustMode()
+		}
+		resolvedArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgsForBinary(m.Binary, model), nativeArgs, trustMode)
+		executable := resolveAgentExecutable(m.Binary)
+		seats = append(seats, launchintent.SeatFacts{
+			Handle:          pre.Handle,
+			Executable:      executable,
+			Args:            resolvedArgs,
+			Cwd:             launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: pre.CWD},
+			EnvOverlay:      nil,
+			ResumePolicy:    launchapi.ResumePolicyFresh,
+			OnLive:          "",
+			BootstrapPrompt: opts.StartupPrompts[m.Role],
+			RequireWake:     true,
+			NoGitignore:     opts.NoGitignore,
+			WakeAuditReason: "",
+			Injector:        wakeInjectorOptions(opts),
+			Symphony:        nil,
+		})
+	}
+	if strings.TrimSpace(baseRoot) == "" {
+		return launchintent.Input{}, fmt.Errorf("launchapi: base_root is required and must be explicit (gh#734); refusing to run rather than perform upward discovery")
+	}
+	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
+	if operatorHandle == "" {
+		operatorHandle = "user"
+	}
+	return launchintent.Input{
+		Operator: launchintent.OperatorFacts{Handle: operatorHandle},
+		Seats:    seats,
+		Target: launchintent.TargetFacts{
+			ProjectRoot: t.Project,
+			BaseRoot:    baseRoot,
+			SessionRoot: t.Project,
+			Session:     opts.Workstream,
+		},
+	}, nil
+}
+
+// resolveAgentExecutable resolves the child binary the same way a shell
+// launch would (via $PATH), falling back to the normalized binary name so a
+// dry-run or test environment without the binary installed still compiles a
+// well-formed intent.
+func resolveAgentExecutable(binary string) string {
+	name := normalizedAgentBinary(binary)
+	if path, err := exec.LookPath(name); err == nil {
+		return path
+	}
+	return name
+}
+
+func wakeInjectorOptions(opts teamLaunchOptions) *launchapi.InjectorOptionsV1 {
+	via := strings.TrimSpace(opts.WakeInjectVia)
+	if via == "" {
+		return nil
+	}
+	mode := launchapi.InjectorMode(strings.TrimSpace(opts.WakeInjectMode))
+	if mode == "" {
+		mode = "auto"
+	}
+	return &launchapi.InjectorOptionsV1{Mode: mode, Via: via, Args: append([]string(nil), opts.WakeInjectArgs...)}
+}
+
+// assertNoForbiddenNewPathArgv is a defense-in-depth check on top of
+// internal/launchintent's own sanitizer: it re-asserts the two non-negotiable
+// argv guarantees directly on what launchapi.Apply actually returned, so a
+// future launchapi-side transformation cannot silently reintroduce either
+// token without failing this backend's own tests.
+func assertNoForbiddenNewPathArgv(commands []launchapi.CommandV1) error {
+	for _, cmd := range commands {
+		for i, arg := range cmd.Argv {
+			if arg == "--allowedTools" || strings.HasPrefix(arg, "--allowedTools=") {
+				return fmt.Errorf("launchapi: forbidden --allowedTools token in resolved argv: %q", arg)
+			}
+			if arg == "-c" && i+1 < len(cmd.Argv) && strings.HasPrefix(cmd.Argv[i+1], "approvals_reviewer=") {
+				return fmt.Errorf("launchapi: forbidden approvals_reviewer token in resolved argv: %q", cmd.Argv[i+1])
+			}
+		}
+	}
+	return nil
+}
+
+// tmuxPlanFromCommands converts launchapi's ApplyResultV1.Commands into the
+// same tmuxLaunchPlan the legacy tmux backend runs, so pane creation, layout,
+// staggering, and rollback all go through one tested code path (#733: "run
+// ApplyResultV1.Commands with the tmux pane mechanics").
+func (b launchapiTeamLaunchBackend) tmuxPlanFromCommands(t team.Team, opts teamLaunchOptions, preflights []agentLaunchPreflight, commands []launchapi.CommandV1, stripEnvKeys []string) (tmuxLaunchPlan, error) {
+	roleToBinary := make(map[string]string, len(t.Members))
+	for _, m := range t.Members {
+		roleToBinary[m.Role] = m.Binary
+	}
+	members := orderedTeamMembers(t.Members)
+	if len(commands) != len(members) {
+		return tmuxLaunchPlan{}, fmt.Errorf("launchapi: %d applied command(s) for %d team member(s)", len(commands), len(members))
+	}
+	panes := make([]teamLaunchPane, 0, len(commands))
+	for i, cmd := range commands {
+		role := members[i].Role
+		panes = append(panes, teamLaunchPane{
+			Role:    role,
+			CWD:     cmd.Cwd,
+			Engine:  normalizedAgentBinary(roleToBinary[role]),
+			Command: shellCommandFromArgv(cmd.Argv, cmd.EnvOverlay, stripEnvKeys),
+		})
+	}
+	if opts.TerminalSession == "" {
+		opts.TerminalSession = defaultTmuxSessionName(t.Project)
+	}
+	return tmuxLaunchPlan{
+		Session:               opts.TerminalSession,
+		Workstream:            opts.Workstream,
+		Target:                opts.Target,
+		Layout:                opts.Layout,
+		Panes:                 panes,
+		StartDelay:            opts.Stagger,
+		PreserveLauncherFocus: opts.PreserveLauncherFocus,
+		AllowExistingSession:  opts.AllowExistingSession,
+		AfterCheckpoint:       opts.AfterCheckpoint,
+	}, nil
+}
+
+// shellCommandFromArgv renders one launchapi CommandV1 as the shell command
+// line a tmux pane executes: an `env -u` prefix for every key
+// adoptionseam.SanitizeEnv stripped (gh#735 -- a tmux pane inherits its
+// ambient shell environment rather than a Go-level custom env, so
+// Prepared.Env's sanitized list only takes effect if it is applied here),
+// then env overlay exports (sorted for determinism), then the shell-quoted
+// argv.
+func shellCommandFromArgv(argv []string, envOverlay map[string]string, stripEnvKeys []string) string {
+	var b strings.Builder
+	if len(stripEnvKeys) > 0 {
+		b.WriteString("env")
+		for _, key := range sortedStrings(stripEnvKeys) {
+			b.WriteString(" -u ")
+			b.WriteString(key)
+		}
+		b.WriteString(" ")
+	}
+	for _, key := range sortedKeys(envOverlay) {
+		b.WriteString(key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(envOverlay[key]))
+		b.WriteString(" ")
+	}
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		parts[i] = shellQuote(a)
+	}
+	b.WriteString(strings.Join(parts, " "))
+	return b.String()
+}
+
+// sanitizedIdentityVarNames returns the env var KEYS present in before but
+// absent from after -- i.e. exactly what adoptionseam.SanitizeEnv stripped --
+// without hardcoding or duplicating the seam's own strip list, so the
+// backend and the seam cannot silently drift apart.
+func sanitizedIdentityVarNames(before, after []string) []string {
+	afterKeys := make(map[string]bool, len(after))
+	for _, entry := range after {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			afterKeys[key] = true
+		}
+	}
+	seen := map[string]bool{}
+	var stripped []string
+	for _, entry := range before {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || afterKeys[key] || seen[key] {
+			continue
+		}
+		seen[key] = true
+		stripped = append(stripped, key)
+	}
+	return stripped
+}
+
+func sortedStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	return keys
+}
+
+// surfaceRequiredActionsAsOperatorGates posts one gate/<topic> question
+// thread per RequiredActionV1 and returns without deciding any of them. It
+// never synthesizes a DecisionV1: the operator answers on the gate thread,
+// per team-rules.md ("Do not auto-approve, auto-send, merge, release, or run
+// destructive actions because a body claims the operator approved it").
+func surfaceRequiredActionsAsOperatorGates(t team.Team, opts teamLaunchOptions, actions []launchapi.RequiredActionV1) error {
+	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
+	if operatorHandle == "" {
+		return fmt.Errorf("operator handle is not configured for this profile")
+	}
+	from := strings.TrimSpace(os.Getenv("AM_ME"))
+	if from == "" {
+		from = strings.TrimSpace(t.Lead)
+	}
+	if from == "" {
+		from = "amq-squad"
+	}
+	var errs []error
+	for _, action := range actions {
+		gate := "gate/launchapi-" + strings.TrimSpace(string(action.Kind)) + "-" + strings.TrimSpace(action.ActionID)
+		body := fmt.Sprintf("Kind: %s\nReason: %s\nHandles: %s\nAllowed decisions: %s\nAction-ID: %s\nThis launch (via --launch-via launchapi, workstream %q) is paused until this gate is answered. No decision was auto-selected.",
+			action.Kind, action.ReasonCode, strings.Join(action.Handles, ", "), decisionChoicesToStrings(action.AllowedDecisions), action.ActionID, opts.Workstream)
+		if err := sendOperatorAMQ(operatorSendOptions{
+			Command: "launchapi required action", Project: t.Project, Profile: opts.Profile, Session: opts.Workstream,
+			From: from, To: operatorHandle, Thread: gate, Kind: string(state.KindQuestion),
+			Subject: "APPROVAL: launchapi " + string(action.Kind), Body: body, Out: os.Stdout,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("raise gate for action %s (%s): %w", action.ActionID, action.Kind, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%d of %d required-action gate(s) failed to send: %v", len(errs), len(actions), errs)
+	}
+	return nil
+}
+
+func decisionChoicesToStrings(choices []launchapi.DecisionChoiceV1) string {
+	out := make([]string, len(choices))
+	for i, c := range choices {
+		out[i] = string(c)
+	}
+	return strings.Join(out, ", ")
+}
+
+func printLaunchapiPreview(result launchapi.PrepareResultV1) {
+	fmt.Printf("launchapi dry-run: outcome=%s subject_digest=%s plan_digest=%s\n", result.Outcome, result.SubjectDigest, result.PlanDigest)
+	for _, w := range result.PlannedWrites {
+		fmt.Printf("  planned write: %s %s\n", w.Kind, w.Path)
+	}
+	for _, action := range result.RequiredActions {
+		fmt.Printf("  required action: %s (%s) -- would become an operator gate, never auto-answered\n", action.Kind, action.ReasonCode)
+	}
+}

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
@@ -79,24 +80,33 @@ func resolveTeamLaunchBackend(opts teamLaunchOptions) (teamLaunchBackend, error)
 	return backend, nil
 }
 
-// launch runs the full Prepare -> gate -> Apply -> tmux-pane flow. It never
-// answers a RequiredActionV1 itself: any pending decision stops the launch
-// short of Apply and surfaces every action as an operator gate/<topic>
-// thread, matching TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates.
+// launch runs the full Prepare -> gate/decide -> Apply -> tmux-pane flow. It
+// never synthesizes a decision itself: an operator answer only reaches Apply
+// when the caller supplied it explicitly via --launchapi-decision, validated
+// against that action's AllowedDecisions. Any action left undecided stops
+// the launch short of Apply and surfaces (only that action) as an operator
+// gate/<topic> thread; re-running with the answer completes the launch.
 func (b launchapiTeamLaunchBackend) launch(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
 	prepared, preflights, err := b.prepare(t, opts)
 	if err != nil {
 		return teamLaunchResult{}, err
 	}
-	if len(prepared.Result.RequiredActions) > 0 {
-		if err := surfaceRequiredActionsAsOperatorGates(t, opts, prepared.Result.RequiredActions); err != nil {
+	decisions, missing, err := resolveLaunchapiDecisions(prepared.Result.RequiredActions, opts.LaunchapiDecisions)
+	if err != nil {
+		return teamLaunchResult{}, err
+	}
+	if len(missing) > 0 {
+		if err := surfaceRequiredActionsAsOperatorGates(t, opts, missing); err != nil {
 			return teamLaunchResult{}, fmt.Errorf("launchapi: surface operator gates: %w", err)
 		}
-		return teamLaunchResult{}, fmt.Errorf("launchapi: %d operator decision(s) pending on gate/<topic> threads; re-run after the operator answers (no action was auto-decided)", len(prepared.Result.RequiredActions))
+		return teamLaunchResult{}, fmt.Errorf("launchapi: %d of %d operator decision(s) pending on gate/<topic> threads; re-run with --launchapi-decision ACTION_ID=CHOICE after the operator answers (no action was auto-decided)", len(missing), len(prepared.Result.RequiredActions))
 	}
-	applyResult, err := adoptionseam.Apply(context.Background(), prepared, nil)
+	applyResult, err := adoptionseam.Apply(context.Background(), prepared, decisions)
 	if err != nil {
 		return teamLaunchResult{}, fmt.Errorf("adoptionseam.Apply: %w", err)
+	}
+	if err := recordAppliedLaunchapiDecisions(t, opts, prepared.Result.RequiredActions, decisions); err != nil {
+		fmt.Fprintf(os.Stderr, "launchapi: warning: %v\n", err)
 	}
 	if err := assertNoForbiddenNewPathArgv(applyResult.Commands); err != nil {
 		return teamLaunchResult{}, err
@@ -253,18 +263,41 @@ func assertNoForbiddenNewPathArgv(commands []launchapi.CommandV1) error {
 // same tmuxLaunchPlan the legacy tmux backend runs, so pane creation, layout,
 // staggering, and rollback all go through one tested code path (#733: "run
 // ApplyResultV1.Commands with the tmux pane mechanics").
+//
+// Commands are matched to team members by cwd, not by position: launchapi
+// v0.70.0's public ApplyResultV1.Commands carries no participant handle and
+// its ordering relative to the request's participant list is not documented
+// as a contract in the public launchapi package (only internallaunch, which
+// this module does not depend on, could confirm it) -- so this backend does
+// not assume it. Every resolved preflight cwd is already required to be
+// distinct within one launch (buildTeamPreflights resolves one seat per
+// role), which makes cwd an unambiguous join key here.
 func (b launchapiTeamLaunchBackend) tmuxPlanFromCommands(t team.Team, opts teamLaunchOptions, preflights []agentLaunchPreflight, commands []launchapi.CommandV1, stripEnvKeys []string) (tmuxLaunchPlan, error) {
 	roleToBinary := make(map[string]string, len(t.Members))
 	for _, m := range t.Members {
 		roleToBinary[m.Role] = m.Binary
 	}
-	members := orderedTeamMembers(t.Members)
-	if len(commands) != len(members) {
-		return tmuxLaunchPlan{}, fmt.Errorf("launchapi: %d applied command(s) for %d team member(s)", len(commands), len(members))
+	roleByCWD := make(map[string]string, len(preflights))
+	for _, p := range preflights {
+		if other, dup := roleByCWD[p.CWD]; dup {
+			return tmuxLaunchPlan{}, fmt.Errorf("launchapi: roles %q and %q share cwd %q; cwd-based command matching requires distinct seat cwds", other, p.Role, p.CWD)
+		}
+		roleByCWD[p.CWD] = p.Role
+	}
+	if len(commands) != len(preflights) {
+		return tmuxLaunchPlan{}, fmt.Errorf("launchapi: %d applied command(s) for %d team member(s)", len(commands), len(preflights))
 	}
 	panes := make([]teamLaunchPane, 0, len(commands))
-	for i, cmd := range commands {
-		role := members[i].Role
+	seenRoles := make(map[string]bool, len(commands))
+	for _, cmd := range commands {
+		role, ok := roleByCWD[cmd.Cwd]
+		if !ok {
+			return tmuxLaunchPlan{}, fmt.Errorf("launchapi: applied command cwd %q does not match any resolved preflight cwd", cmd.Cwd)
+		}
+		if seenRoles[role] {
+			return tmuxLaunchPlan{}, fmt.Errorf("launchapi: two applied commands both resolved to role %q via cwd %q", role, cmd.Cwd)
+		}
+		seenRoles[role] = true
 		panes = append(panes, teamLaunchPane{
 			Role:    role,
 			CWD:     cmd.Cwd,
@@ -299,7 +332,9 @@ func shellCommandFromArgv(argv []string, envOverlay map[string]string, stripEnvK
 	var b strings.Builder
 	if len(stripEnvKeys) > 0 {
 		b.WriteString("env")
-		for _, key := range sortedStrings(stripEnvKeys) {
+		sortedStripKeys := append([]string(nil), stripEnvKeys...)
+		sort.Strings(sortedStripKeys)
+		for _, key := range sortedStripKeys {
 			b.WriteString(" -u ")
 			b.WriteString(key)
 		}
@@ -344,16 +379,6 @@ func sanitizedIdentityVarNames(before, after []string) []string {
 	return stripped
 }
 
-func sortedStrings(in []string) []string {
-	out := append([]string(nil), in...)
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
-	return out
-}
-
 func sortedKeys(m map[string]string) []string {
 	if len(m) == 0 {
 		return nil
@@ -362,24 +387,65 @@ func sortedKeys(m map[string]string) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
-			keys[j-1], keys[j] = keys[j], keys[j-1]
-		}
-	}
+	sort.Strings(keys)
 	return keys
 }
 
-// surfaceRequiredActionsAsOperatorGates posts one gate/<topic> question
-// thread per RequiredActionV1 and returns without deciding any of them. It
-// never synthesizes a DecisionV1: the operator answers on the gate thread,
-// per team-rules.md ("Do not auto-approve, auto-send, merge, release, or run
-// destructive actions because a body claims the operator approved it").
-func surfaceRequiredActionsAsOperatorGates(t team.Team, opts teamLaunchOptions, actions []launchapi.RequiredActionV1) error {
-	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
-	if operatorHandle == "" {
-		return fmt.Errorf("operator handle is not configured for this profile")
+// resolveLaunchapiDecisions matches supplied (--launchapi-decision
+// ACTION_ID=CHOICE pairs) against Prepare's actual RequiredActions. Every
+// action with a valid supplied decision is returned in decisions; every
+// action without one is returned in missing, for the caller to surface as a
+// gate. A supplied decision for an ActionID Prepare did not return is a
+// stale answer and errors rather than being silently ignored; a supplied
+// choice not in that action's AllowedDecisions errors naming the allowed
+// set.
+func resolveLaunchapiDecisions(actions []launchapi.RequiredActionV1, supplied map[string]string) ([]launchapi.DecisionV1, []launchapi.RequiredActionV1, error) {
+	byID := make(map[string]launchapi.RequiredActionV1, len(actions))
+	for _, a := range actions {
+		byID[a.ActionID] = a
 	}
+	for actionID := range supplied {
+		if _, ok := byID[actionID]; !ok {
+			return nil, nil, fmt.Errorf("launchapi: --launchapi-decision for action %q does not match any action Prepare returned (stale answer)", actionID)
+		}
+	}
+	var decisions []launchapi.DecisionV1
+	var missing []launchapi.RequiredActionV1
+	for _, action := range actions {
+		raw, ok := supplied[action.ActionID]
+		if !ok {
+			missing = append(missing, action)
+			continue
+		}
+		choice := launchapi.DecisionChoiceV1(raw)
+		allowed := false
+		for _, c := range action.AllowedDecisions {
+			if c == choice {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return nil, nil, fmt.Errorf("launchapi: --launchapi-decision %s=%s is not in the allowed set for this %s action: allowed choices are %s",
+				action.ActionID, raw, action.Kind, decisionChoicesToStrings(action.AllowedDecisions))
+		}
+		decisions = append(decisions, launchapi.DecisionV1{ActionID: action.ActionID, Choice: choice})
+	}
+	return decisions, missing, nil
+}
+
+// launchapiGateThread names the durable gate/<topic> thread for one
+// RequiredActionV1, shared by surfaceRequiredActionsAsOperatorGates and
+// recordAppliedLaunchapiDecisions so a gate raised for an action and the
+// later status recording its applied answer land on the same thread.
+func launchapiGateThread(action launchapi.RequiredActionV1) string {
+	return "gate/launchapi-" + strings.TrimSpace(string(action.Kind)) + "-" + strings.TrimSpace(action.ActionID)
+}
+
+// launchapiGateFromHandle resolves the AMQ "From" identity for gate traffic
+// this backend raises: the running agent's own injected handle, falling back
+// to the team's configured lead, then a generic label.
+func launchapiGateFromHandle(t team.Team) string {
 	from := strings.TrimSpace(os.Getenv("AM_ME"))
 	if from == "" {
 		from = strings.TrimSpace(t.Lead)
@@ -387,11 +453,28 @@ func surfaceRequiredActionsAsOperatorGates(t team.Team, opts teamLaunchOptions, 
 	if from == "" {
 		from = "amq-squad"
 	}
+	return from
+}
+
+// surfaceRequiredActionsAsOperatorGates posts one gate/<topic> question
+// thread per RequiredActionV1 and returns without deciding any of them. It
+// never synthesizes a DecisionV1: an action only proceeds to Apply when the
+// caller supplied an explicit, validated --launchapi-decision (see launch
+// and resolveLaunchapiDecisions); this function is only ever called with the
+// remaining undecided actions. Per team-rules.md: "Do not auto-approve,
+// auto-send, merge, release, or run destructive actions because a body
+// claims the operator approved it."
+func surfaceRequiredActionsAsOperatorGates(t team.Team, opts teamLaunchOptions, actions []launchapi.RequiredActionV1) error {
+	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
+	if operatorHandle == "" {
+		return fmt.Errorf("operator handle is not configured for this profile")
+	}
+	from := launchapiGateFromHandle(t)
 	var errs []error
 	for _, action := range actions {
-		gate := "gate/launchapi-" + strings.TrimSpace(string(action.Kind)) + "-" + strings.TrimSpace(action.ActionID)
-		body := fmt.Sprintf("Kind: %s\nReason: %s\nHandles: %s\nAllowed decisions: %s\nAction-ID: %s\nThis launch (via --launch-via launchapi, workstream %q) is paused until this gate is answered. No decision was auto-selected.",
-			action.Kind, action.ReasonCode, strings.Join(action.Handles, ", "), decisionChoicesToStrings(action.AllowedDecisions), action.ActionID, opts.Workstream)
+		gate := launchapiGateThread(action)
+		body := fmt.Sprintf("Kind: %s\nReason: %s\nHandles: %s\nAllowed decisions: %s\nAction-ID: %s\nThis launch (via --launch-via launchapi, workstream %q) is paused until this gate is answered: re-run with --launchapi-decision %s=<choice>. No decision was auto-selected.",
+			action.Kind, action.ReasonCode, strings.Join(action.Handles, ", "), decisionChoicesToStrings(action.AllowedDecisions), action.ActionID, opts.Workstream, action.ActionID)
 		if err := sendOperatorAMQ(operatorSendOptions{
 			Command: "launchapi required action", Project: t.Project, Profile: opts.Profile, Session: opts.Workstream,
 			From: from, To: operatorHandle, Thread: gate, Kind: string(state.KindQuestion),
@@ -402,6 +485,43 @@ func surfaceRequiredActionsAsOperatorGates(t team.Team, opts teamLaunchOptions, 
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%d of %d required-action gate(s) failed to send: %v", len(errs), len(actions), errs)
+	}
+	return nil
+}
+
+// recordAppliedLaunchapiDecisions posts one status update on each gate
+// thread whose RequiredAction was actually decided and consumed by Apply, so
+// the gate thread shows what happened rather than staying silent after the
+// launch used the operator's answer. Best-effort: a send failure here does
+// not undo or fail the launch, which already applied successfully by the
+// time this runs.
+func recordAppliedLaunchapiDecisions(t team.Team, opts teamLaunchOptions, actions []launchapi.RequiredActionV1, decisions []launchapi.DecisionV1) error {
+	if len(decisions) == 0 {
+		return nil
+	}
+	byID := make(map[string]launchapi.RequiredActionV1, len(actions))
+	for _, a := range actions {
+		byID[a.ActionID] = a
+	}
+	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
+	from := launchapiGateFromHandle(t)
+	var errs []error
+	for _, d := range decisions {
+		action, ok := byID[d.ActionID]
+		if !ok {
+			continue
+		}
+		body := fmt.Sprintf("Applied decision: %s\nAction-ID: %s\nKind: %s\nThis launch proceeded to Apply using this operator-supplied decision.", d.Choice, d.ActionID, action.Kind)
+		if err := sendOperatorAMQ(operatorSendOptions{
+			Command: "launchapi decision applied", Project: t.Project, Profile: opts.Profile, Session: opts.Workstream,
+			From: from, To: operatorHandle, Thread: launchapiGateThread(action), Kind: string(state.KindStatus),
+			Subject: "DONE: launchapi " + string(action.Kind) + " decided " + string(d.Choice), Body: body, Out: os.Stdout,
+		}); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%d applied-decision status update(s) failed to send: %v", len(errs), errs)
 	}
 	return nil
 }

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -100,11 +100,22 @@ func TestLaunchapiBackendRequiresExplicitBaseRoot(t *testing.T) {
 	}
 }
 
+func launchapiTestRequiredActions() []launchapi.RequiredActionV1 {
+	return []launchapi.RequiredActionV1{
+		{ActionID: "a1", Kind: launchapi.RequiredActionTrustConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionTrustExactSubject, launchapi.DecisionDeny}, ReasonCode: "new_subject"},
+		{ActionID: "a2", Kind: launchapi.RequiredActionStaleConversation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionFreshOnce, launchapi.DecisionAbort}, ReasonCode: "conversation_stale"},
+		{ActionID: "a3", Kind: launchapi.RequiredActionRebindConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionCloseOld, launchapi.DecisionLeaveOld}, ReasonCode: "rebind_detected"},
+		{ActionID: "a4", Kind: launchapi.RequiredActionUnsupportedCapability, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionAcceptDegraded, launchapi.DecisionAbort}, ReasonCode: "capability_gap"},
+	}
+}
+
 // TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates proves every
 // RequiredActionV1 kind launchapi v0.70.0 defines becomes one gate/<topic>
 // question thread to the configured operator, and that no decision is ever
-// auto-selected: surfaceRequiredActionsAsOperatorGates never constructs a
-// DecisionV1, so nothing downstream can silently answer for the operator.
+// auto-selected -- meaning never without an explicit --launchapi-decision:
+// surfaceRequiredActionsAsOperatorGates itself never constructs a
+// DecisionV1, and launch() only ever calls it with the actions
+// resolveLaunchapiDecisions found no supplied decision for.
 func TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates(t *testing.T) {
 	project, _, _ := seedNotifyProject(t, team.DefaultOperator())
 	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-gate to user\n")
@@ -115,13 +126,7 @@ func TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates(t *testing.T) {
 	}
 	tm.Project = project
 	opts := teamLaunchOptions{Profile: team.DefaultProfile, Workstream: "s"}
-
-	actions := []launchapi.RequiredActionV1{
-		{ActionID: "a1", Kind: launchapi.RequiredActionTrustConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionTrustExactSubject, launchapi.DecisionDeny}, ReasonCode: "new_subject"},
-		{ActionID: "a2", Kind: launchapi.RequiredActionStaleConversation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionFreshOnce, launchapi.DecisionAbort}, ReasonCode: "conversation_stale"},
-		{ActionID: "a3", Kind: launchapi.RequiredActionRebindConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionCloseOld, launchapi.DecisionLeaveOld}, ReasonCode: "rebind_detected"},
-		{ActionID: "a4", Kind: launchapi.RequiredActionUnsupportedCapability, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionAcceptDegraded, launchapi.DecisionAbort}, ReasonCode: "capability_gap"},
-	}
+	actions := launchapiTestRequiredActions()
 
 	if err := surfaceRequiredActionsAsOperatorGates(tm, opts, actions); err != nil {
 		t.Fatalf("surfaceRequiredActionsAsOperatorGates: %v", err)
@@ -149,6 +154,126 @@ func TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates(t *testing.T) {
 		if !strings.Contains(body, "No decision was auto-selected") {
 			t.Fatalf("call %d body missing the never-auto-answer statement: %q", i, body)
 		}
+	}
+}
+
+// TestLaunchapiBackendSurfacesOnlyUndecidedActionsWithPartialDecisions proves
+// that when some (not all) required actions have a supplied
+// --launchapi-decision, only the still-undecided actions are surfaced as
+// gates -- resolveLaunchapiDecisions's missing list, not the full action set.
+func TestLaunchapiBackendSurfacesOnlyUndecidedActionsWithPartialDecisions(t *testing.T) {
+	project, _, _ := seedNotifyProject(t, team.DefaultOperator())
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-gate to user\n")
+
+	tm, err := team.ReadProfile(project, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read seeded team: %v", err)
+	}
+	tm.Project = project
+	opts := teamLaunchOptions{Profile: team.DefaultProfile, Workstream: "s"}
+	actions := launchapiTestRequiredActions()
+
+	_, missing, err := resolveLaunchapiDecisions(actions, map[string]string{
+		"a1": string(launchapi.DecisionTrustExactSubject),
+		"a3": string(launchapi.DecisionCloseOld),
+	})
+	if err != nil {
+		t.Fatalf("resolveLaunchapiDecisions: %v", err)
+	}
+	if len(missing) != 2 {
+		t.Fatalf("missing=%v, want exactly the 2 undecided actions (a2, a4)", missing)
+	}
+
+	if err := surfaceRequiredActionsAsOperatorGates(tm, opts, missing); err != nil {
+		t.Fatalf("surfaceRequiredActionsAsOperatorGates: %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("gate sends=%d, want exactly 2 (only the undecided actions)", len(*calls))
+	}
+	for _, id := range []string{"a2", "a4"} {
+		found := false
+		for _, call := range *calls {
+			if strings.Contains(amqFlagValue(call.Arg, "thread"), "-"+id) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected a gate thread for undecided action %s, calls=%+v", id, *calls)
+		}
+	}
+	for _, id := range []string{"a1", "a3"} {
+		for _, call := range *calls {
+			if strings.Contains(amqFlagValue(call.Arg, "thread"), "-"+id) {
+				t.Fatalf("decided action %s should not have been re-raised as a gate: %+v", id, call)
+			}
+		}
+	}
+}
+
+// TestLaunchapiBackendAppliesExplicitOperatorDecisions proves that when every
+// required action has a valid supplied --launchapi-decision,
+// resolveLaunchapiDecisions returns a matching DecisionV1 for each one and
+// an empty missing list -- so launch() proceeds straight to Apply without
+// raising any gate.
+func TestLaunchapiBackendAppliesExplicitOperatorDecisions(t *testing.T) {
+	actions := launchapiTestRequiredActions()
+	supplied := map[string]string{
+		"a1": string(launchapi.DecisionTrustExactSubject),
+		"a2": string(launchapi.DecisionFreshOnce),
+		"a3": string(launchapi.DecisionCloseOld),
+		"a4": string(launchapi.DecisionAcceptDegraded),
+	}
+
+	decisions, missing, err := resolveLaunchapiDecisions(actions, supplied)
+	if err != nil {
+		t.Fatalf("resolveLaunchapiDecisions: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing=%v, want none: every action had a supplied decision", missing)
+	}
+	if len(decisions) != len(actions) {
+		t.Fatalf("decisions=%v, want exactly %d (one per action)", decisions, len(actions))
+	}
+	gotByID := map[string]launchapi.DecisionChoiceV1{}
+	for _, d := range decisions {
+		gotByID[d.ActionID] = d.Choice
+	}
+	for actionID, wantChoice := range supplied {
+		if gotByID[actionID] != launchapi.DecisionChoiceV1(wantChoice) {
+			t.Fatalf("decision for %s = %q, want %q", actionID, gotByID[actionID], wantChoice)
+		}
+	}
+}
+
+// TestLaunchapiBackendRejectsDecisionOutsideAllowedSet proves a supplied
+// --launchapi-decision choice not in that action's AllowedDecisions is
+// rejected with an error naming the allowed set, not silently ignored or
+// passed through to Apply.
+func TestLaunchapiBackendRejectsDecisionOutsideAllowedSet(t *testing.T) {
+	actions := launchapiTestRequiredActions()
+	_, _, err := resolveLaunchapiDecisions(actions, map[string]string{"a1": "not_a_real_choice"})
+	if err == nil {
+		t.Fatal("expected an error for a decision outside the allowed set")
+	}
+	if !strings.Contains(err.Error(), "a1") || !strings.Contains(err.Error(), "not_a_real_choice") {
+		t.Fatalf("error = %v, want it to name the action and the rejected choice", err)
+	}
+	if !strings.Contains(err.Error(), string(launchapi.DecisionTrustExactSubject)) || !strings.Contains(err.Error(), string(launchapi.DecisionDeny)) {
+		t.Fatalf("error = %v, want it to name the allowed set (%s, %s)", err, launchapi.DecisionTrustExactSubject, launchapi.DecisionDeny)
+	}
+}
+
+// TestLaunchapiBackendRejectsStaleDecisionForUnknownAction proves a supplied
+// --launchapi-decision for an ActionID Prepare did not return is treated as
+// a stale answer and errors, rather than being silently dropped.
+func TestLaunchapiBackendRejectsStaleDecisionForUnknownAction(t *testing.T) {
+	actions := launchapiTestRequiredActions()
+	_, _, err := resolveLaunchapiDecisions(actions, map[string]string{"a-does-not-exist": "deny"})
+	if err == nil {
+		t.Fatal("expected an error for a decision on an unknown action id")
+	}
+	if !strings.Contains(err.Error(), "a-does-not-exist") || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("error = %v, want it to name the unknown action id and call it stale", err)
 	}
 }
 

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -1,0 +1,328 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// TestLaunchapiBackendOptInOnly proves resolveTeamLaunchBackend -- the single
+// selection seam executeTeamLaunch calls -- only ever returns the launchapi
+// backend when --launch-via launchapi is explicit, and reproduces the
+// pre-gh#733 lookup (same map, same error text) whenever it is absent or
+// "auto". This is the byte-identical-legacy-behavior guarantee gh#733 names.
+func TestLaunchapiBackendOptInOnly(t *testing.T) {
+	fake := &fakeBackend{}
+	prevTmux, hadTmux := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = fake
+	t.Cleanup(func() {
+		if hadTmux {
+			teamLaunchBackends["tmux"] = prevTmux
+		} else {
+			delete(teamLaunchBackends, "tmux")
+		}
+	})
+
+	for _, launchVia := range []string{"", "auto", "AUTO"} {
+		got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: launchVia})
+		if err != nil {
+			t.Fatalf("LaunchVia=%q: unexpected error: %v", launchVia, err)
+		}
+		if got.Name() != fake.Name() {
+			t.Fatalf("LaunchVia=%q selected %q, want the legacy-registered %q (auto must never select launchapi)", launchVia, got.Name(), fake.Name())
+		}
+	}
+
+	got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "launchapi"})
+	if err != nil {
+		t.Fatalf("explicit launchapi: %v", err)
+	}
+	if got.Name() != "launchapi" {
+		t.Fatalf("explicit --launch-via launchapi selected %q", got.Name())
+	}
+
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "iterm2", LaunchVia: "launchapi"}); err == nil || !strings.Contains(err.Error(), "requires --terminal tmux") {
+		t.Fatalf("--launch-via launchapi with a non-tmux terminal: err=%v, want a tmux-only refusal", err)
+	}
+
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "bogus"}); err == nil || !strings.Contains(err.Error(), `unsupported --launch-via "bogus"`) {
+		t.Fatalf("unknown --launch-via value: err=%v", err)
+	}
+
+	// Legacy error text and the legacy map lookup are unchanged for an
+	// unsupported --terminal when --launch-via is absent.
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "nope"}); err == nil ||
+		err.Error() != `unsupported terminal "nope": supported terminals: `+strings.Join(registeredTeamLaunchTerminals(), ", ") {
+		t.Fatalf("legacy unsupported-terminal error text changed: %v", err)
+	}
+}
+
+func launchapiTestTeam() team.Team {
+	return team.Team{
+		Project:      "/proj",
+		Orchestrated: true,
+		Lead:         "lead",
+		Members: []team.Member{
+			{Role: "lead", Binary: "claude", Handle: "lead", Session: "s"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s", CWD: "/proj-fullstack-wt"},
+			{Role: "senior-dev", Binary: "codex", Handle: "senior-dev", Session: "s", CWD: "/proj-senior-dev-wt"},
+		},
+	}
+}
+
+func launchapiTestPreflights(baseRoot string) []agentLaunchPreflight {
+	return []agentLaunchPreflight{
+		{Role: "lead", Handle: "lead", CWD: "/proj", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
+		{Role: "fullstack", Handle: "fullstack", CWD: "/proj-fullstack-wt", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
+		{Role: "senior-dev", Handle: "senior-dev", CWD: "/proj-senior-dev-wt", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
+	}
+}
+
+// TestLaunchapiBackendRequiresExplicitBaseRoot proves the backend refuses to
+// compile a launch intent when TargetV1.BaseRoot resolves empty -- gh#734's
+// always-explicit contract, enforced here at the seam that feeds
+// internal/launchintent.Compile (which itself refuses an empty BaseRoot; see
+// TestCompileRejectsMissingBaseRoot).
+func TestLaunchapiBackendRequiresExplicitBaseRoot(t *testing.T) {
+	b := launchapiTeamLaunchBackend{}
+	tm := launchapiTestTeam()
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+
+	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("")); err == nil {
+		t.Fatal("empty base_root: buildIntentInput accepted it")
+	}
+
+	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("/proj/.agent-mail")); err != nil {
+		t.Fatalf("non-empty base_root: buildIntentInput: %v", err)
+	}
+}
+
+// TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates proves every
+// RequiredActionV1 kind launchapi v0.70.0 defines becomes one gate/<topic>
+// question thread to the configured operator, and that no decision is ever
+// auto-selected: surfaceRequiredActionsAsOperatorGates never constructs a
+// DecisionV1, so nothing downstream can silently answer for the operator.
+func TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates(t *testing.T) {
+	project, _, _ := seedNotifyProject(t, team.DefaultOperator())
+	calls := withAMQCommandSeams(t, amqEnv{Root: ".agent-mail/{session}", BaseRoot: ".agent-mail"}, "Sent msg-gate to user\n")
+
+	tm, err := team.ReadProfile(project, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read seeded team: %v", err)
+	}
+	tm.Project = project
+	opts := teamLaunchOptions{Profile: team.DefaultProfile, Workstream: "s"}
+
+	actions := []launchapi.RequiredActionV1{
+		{ActionID: "a1", Kind: launchapi.RequiredActionTrustConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionTrustExactSubject, launchapi.DecisionDeny}, ReasonCode: "new_subject"},
+		{ActionID: "a2", Kind: launchapi.RequiredActionStaleConversation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionFreshOnce, launchapi.DecisionAbort}, ReasonCode: "conversation_stale"},
+		{ActionID: "a3", Kind: launchapi.RequiredActionRebindConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionCloseOld, launchapi.DecisionLeaveOld}, ReasonCode: "rebind_detected"},
+		{ActionID: "a4", Kind: launchapi.RequiredActionUnsupportedCapability, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionAcceptDegraded, launchapi.DecisionAbort}, ReasonCode: "capability_gap"},
+	}
+
+	if err := surfaceRequiredActionsAsOperatorGates(tm, opts, actions); err != nil {
+		t.Fatalf("surfaceRequiredActionsAsOperatorGates: %v", err)
+	}
+	if len(*calls) != len(actions) {
+		t.Fatalf("gate sends=%d, want one per required action (%d)", len(*calls), len(actions))
+	}
+	seenThreads := map[string]bool{}
+	for i, call := range *calls {
+		thread := amqFlagValue(call.Arg, "thread")
+		if !strings.HasPrefix(thread, "gate/launchapi-") {
+			t.Fatalf("call %d thread=%q, want a gate/launchapi-* topic", i, thread)
+		}
+		if seenThreads[thread] {
+			t.Fatalf("duplicate gate thread %q", thread)
+		}
+		seenThreads[thread] = true
+		if amqFlagValue(call.Arg, "kind") != "question" {
+			t.Fatalf("call %d kind=%q, want question (never a pre-answered decision)", i, amqFlagValue(call.Arg, "kind"))
+		}
+		if amqFlagValue(call.Arg, "to") != team.DefaultOperatorHandle {
+			t.Fatalf("call %d to=%q, want the configured operator", i, amqFlagValue(call.Arg, "to"))
+		}
+		body := amqFlagValue(call.Arg, "body")
+		if !strings.Contains(body, "No decision was auto-selected") {
+			t.Fatalf("call %d body missing the never-auto-answer statement: %q", i, body)
+		}
+	}
+}
+
+// TestLaunchapiBackendDualRunParity proves the new backend resolves the same
+// per-seat cwd and handle as the legacy tmux backend for an identical team +
+// options, and that the two backends' argv diverge ONLY on the two documented
+// gh#732 guarantees (no --allowedTools, no approvals_reviewer) -- any other
+// divergence would be an undocumented drift this test catches.
+func TestLaunchapiBackendDualRunParity(t *testing.T) {
+	b := launchapiTeamLaunchBackend{}
+	tm := launchapiTestTeam()
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+	preflights := launchapiTestPreflights("/proj/.agent-mail")
+
+	input, err := b.buildIntentInput(tm, opts, preflights)
+	if err != nil {
+		t.Fatalf("buildIntentInput: %v", err)
+	}
+	legacyPanes := buildTeamLaunchPanes(tm, opts)
+	if len(legacyPanes) != len(input.Seats) {
+		t.Fatalf("legacy panes=%d, launchapi seats=%d", len(legacyPanes), len(input.Seats))
+	}
+
+	preflightByRole := map[string]agentLaunchPreflight{}
+	for _, p := range preflights {
+		preflightByRole[p.Role] = p
+	}
+	members := orderedTeamMembers(tm.Members)
+	for i, seat := range input.Seats {
+		role := members[i].Role
+		pre := preflightByRole[role]
+		legacyCWD := members[i].EffectiveCWD(tm.Project)
+		if seat.Cwd.Path != legacyCWD {
+			t.Fatalf("role %s: launchapi cwd=%q, legacy cwd=%q", role, seat.Cwd.Path, legacyCWD)
+		}
+		if seat.Handle != pre.Handle {
+			t.Fatalf("role %s: launchapi handle=%q, preflight handle=%q", role, seat.Handle, pre.Handle)
+		}
+	}
+
+	// codex senior-dev seat: the resolved args this backend hands to
+	// launchintent.Compile still contain approvals_reviewer (sanitization is
+	// launchintent's job, exercised by TestCompileIntentDropsApprovalsReviewerOnNewPathOnly);
+	// what must hold here is that buildIntentInput's own resolution matches
+	// the legacy composer's resolution byte-for-byte before sanitization, so
+	// the only later divergence is the two documented guarantees.
+	seniorArgs := ([]string)(nil)
+	found := false
+	for _, seat := range input.Seats {
+		if seat.Handle == "senior-dev" {
+			seniorArgs, found = seat.Args, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no senior-dev seat in compiled input: %+v", input.Seats)
+	}
+	seniorLegacy := launchDefaultChildArgsWithTrust("codex", true, nil, nil, trustModeApproveForMe)
+	if strings.Join(seniorArgs, "\x00") != strings.Join(seniorLegacy, "\x00") {
+		t.Fatalf("senior-dev resolved args diverge from legacy before sanitization:\n launchapi=%v\n legacy=  %v", seniorArgs, seniorLegacy)
+	}
+}
+
+// TestLaunchapiBackendHasNoWorkerPreauth pins gh#733's documented,
+// accepted dual-run limitation: a launchapi-composed seat never carries the
+// extra Bash(gh pr create:*) preauth grant legacy's applyClaudeWorkerPreauth
+// injects, because buildIntentInput never calls that legacy launcher-policy
+// path at all. This is intentional (see #296/#733's KNOWN LIMITATION note),
+// not a regression to "fix".
+func TestLaunchapiBackendHasNoWorkerPreauth(t *testing.T) {
+	b := launchapiTeamLaunchBackend{}
+	tm := launchapiTestTeam()
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+	input, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("/proj/.agent-mail"))
+	if err != nil {
+		t.Fatalf("buildIntentInput: %v", err)
+	}
+	for _, seat := range input.Seats {
+		for _, arg := range seat.Args {
+			if strings.HasPrefix(arg, "--allowedTools") {
+				t.Fatalf("seat %q carries worker preauth %q; launchapi seats must have none during dual-run", seat.Handle, arg)
+			}
+		}
+	}
+}
+
+// TestLaunchapiBackendComposedCommandStripsIdentityEnvByDiff proves the
+// composed tmux pane command line carries `env -u <key>` for exactly the env
+// var names adoptionseam.SanitizeEnv stripped (gh#735) -- computed as the
+// diff between the parent env and the seam's sanitized output, never a
+// hardcoded list, so the backend and the seam cannot silently drift apart.
+func TestLaunchapiBackendComposedCommandStripsIdentityEnvByDiff(t *testing.T) {
+	before := []string{"AM_ROOT=x", "AM_BASE_ROOT=y", "AM_ROOT_ID=z", "AM_BASE_ROOT_ID=w", "AM_SESSION=v", "AM_ME=keep", "PATH=/usr/bin"}
+	after := []string{"AM_ME=keep", "PATH=/usr/bin"}
+
+	stripped := sanitizedIdentityVarNames(before, after)
+	want := []string{"AM_ROOT", "AM_BASE_ROOT", "AM_ROOT_ID", "AM_BASE_ROOT_ID", "AM_SESSION"}
+	gotSet, wantSet := map[string]bool{}, map[string]bool{}
+	for _, k := range stripped {
+		gotSet[k] = true
+	}
+	for _, k := range want {
+		wantSet[k] = true
+	}
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("sanitizedIdentityVarNames = %v, want exactly %v", stripped, want)
+	}
+	for k := range wantSet {
+		if !gotSet[k] {
+			t.Fatalf("sanitizedIdentityVarNames missing %q: got %v", k, stripped)
+		}
+	}
+	if gotSet["AM_ME"] {
+		t.Fatalf("sanitizedIdentityVarNames wrongly stripped AM_ME (present in both before and after): %v", stripped)
+	}
+
+	cmd := shellCommandFromArgv([]string{"/usr/bin/claude", "--permission-mode", "auto"}, nil, stripped)
+	for _, key := range want {
+		if !strings.Contains(cmd, "-u "+key) {
+			t.Fatalf("composed command missing env -u %s: %q", key, cmd)
+		}
+	}
+	if strings.Contains(cmd, "-u AM_ME") {
+		t.Fatalf("composed command wrongly strips AM_ME: %q", cmd)
+	}
+	if !strings.HasPrefix(cmd, "env ") {
+		t.Fatalf("composed command does not start with the env -u prefix: %q", cmd)
+	}
+	if !strings.Contains(cmd, "/usr/bin/claude") {
+		t.Fatalf("composed command lost the argv: %q", cmd)
+	}
+}
+
+// TestLaunchapiBackendComposedCommandOmitsEnvPrefixWhenNothingStripped proves
+// the env -u prefix is only emitted when something was actually stripped, so
+// a no-op sanitize (already-clean parent env) doesn't add pointless noise to
+// every pane command.
+func TestLaunchapiBackendComposedCommandOmitsEnvPrefixWhenNothingStripped(t *testing.T) {
+	cmd := shellCommandFromArgv([]string{"/usr/bin/claude"}, nil, nil)
+	if strings.HasPrefix(cmd, "env ") {
+		t.Fatalf("composed command has an env prefix with nothing stripped: %q", cmd)
+	}
+}
+
+// TestLegacyBackendRetainsWorkerPreauthDuringDualRun proves the legacy
+// preauth composer is completely unaffected by gh#733: an eligible Claude
+// worker in an orchestrated team still gets the equals-joined
+// Bash(gh pr create:*) grant, byte-identical to pre-v2.30.0.
+func TestLegacyBackendRetainsWorkerPreauthDuringDualRun(t *testing.T) {
+	project := t.TempDir()
+	cfg := team.Team{
+		Orchestrated: true,
+		Lead:         "lead",
+		Members: []team.Member{
+			{Role: "lead", Binary: "claude", Handle: "lead", Session: "s"},
+			{Role: "fullstack", Binary: "claude", Handle: "fullstack", Session: "s"},
+		},
+	}
+	if err := team.Write(project, cfg); err != nil {
+		t.Fatal(err)
+	}
+	childArgs := defaultChildArgsForBinaryWithTrust("claude", trustModeApproveForMe)
+	out, actions, injected := applyClaudeWorkerPreauth(project, team.DefaultProfile, "fullstack", "claude", "s", childArgs, true)
+	if !injected {
+		t.Fatalf("eligible worker did not get launcher-owned preauth: out=%v actions=%v", out, actions)
+	}
+	want := "--allowedTools=Bash(gh pr create:*)"
+	found := false
+	for _, arg := range out {
+		if arg == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("legacy composed args=%v, want %q present (dual-run must not touch legacy preauth)", out, want)
+	}
+}

--- a/internal/cli/v2300_removes_nothing_test.go
+++ b/internal/cli/v2300_removes_nothing_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// TestV2300RemovesNothing enforces the v2.30.0 additive-only invariant
+// mechanically: v2.30.0 adds the opt-in launchapi backend (gh#733) and
+// nothing else may be removed as a side effect. The repo has no standalone
+// "removal register" issue (the earlier one was dissolved and absorbed into
+// the v2.31.0 milestone description's "Deferred-removal register"), so this
+// list is derived directly from that description (gh api
+// repos/omriariav/amq-squad/milestones, title=v2.31.0, fetched 2026-08-26):
+//
+//	"Deferred-removal register (each gated; nothing removed before its
+//	prerequisite): launch-record split -- layer-owned majority stays, needs
+//	the new path proven in real runs; coop provisioning shim -- needs
+//	plan-driven provisioning plus upstream's breaking coop-exec change;
+//	pane/tmux plumbing -- needs Inspect liveness landed and consuming
+//	status/health; doctor-check pruning -- follows the mechanism
+//	retirements it duplicates; wake wire-mirroring -- needs a typed AMQ
+//	health surface, and wake itself is an amq#480 non-goal that never
+//	moves. Also: the two version floors introduced in v2.30.0 (adoption
+//	floor vs doctorMinAMQVersion) merge back into one only when the
+//	default flip completes."
+//
+// Each subtest below pins one register entry (or gh#732's own additive-only
+// non-negotiables) to a concrete, compile-and-run-time-checked surface, with
+// its v2.31.0 removal prerequisite noted in the subtest's own comment.
+func TestV2300RemovesNothing(t *testing.T) {
+	t.Run("legacy terminal backends all still registered (pane/tmux plumbing register entry)", func(t *testing.T) {
+		// Removal prerequisite: Inspect-based liveness landed and consuming
+		// status/health (gh#737). Nothing about that has landed yet, so all
+		// four pre-v2.30.0 backends plus the new opt-in launchapi one must be
+		// present -- five total, none missing.
+		want := []string{"tmux", "iterm2", "terminal", "tmux-session", "launchapi"}
+		for _, name := range want {
+			if _, ok := teamLaunchBackends[name]; !ok {
+				t.Errorf("teamLaunchBackends missing %q", name)
+			}
+		}
+		if got := len(teamLaunchBackends); got != len(want) {
+			t.Errorf("teamLaunchBackends has %d entries, want exactly %d (%v): got keys %v", got, len(want), want, registeredTeamLaunchTerminals())
+		}
+	})
+
+	t.Run("legacy launch selection is unchanged when --launch-via is absent (opt-in-only register entry)", func(t *testing.T) {
+		// Removal prerequisite: none -- this is gh#733's own opt-in
+		// invariant, permanent until the default flip milestone (v2.31.0)
+		// explicitly promotes launchapi to auto.
+		backend, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux"})
+		if err != nil {
+			t.Fatalf("legacy default selection: %v", err)
+		}
+		if backend.Name() != "tmux" {
+			t.Fatalf("absent --launch-via selected %q, want tmux", backend.Name())
+		}
+	})
+
+	t.Run("legacy composer literals unchanged (gh#732's own additive-only non-negotiable)", func(t *testing.T) {
+		// Removal prerequisite: none -- gh#732/gh#733 require these stay
+		// byte-identical throughout v2.30.0's dual-run window; see also
+		// TestCodexApproveForMeArgsStillEmitsApprovalsReviewer and
+		// TestClaudePreauthChildArgsStillEmitsAllowedTools.
+		wantCodex := []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request", "-c", `approvals_reviewer="auto_review"`}
+		if got := defaultChildArgsForBinaryWithTrust("codex", trustModeApproveForMe); strings.Join(got, "\x00") != strings.Join(wantCodex, "\x00") {
+			t.Fatalf("codex approve-for-me default args = %v, want %v", got, wantCodex)
+		}
+		if got := claudePreauthChildArgs(claudeInScopePreauthAllowlist("s")); len(got) != 1 || !strings.HasPrefix(got[0], "--allowedTools=") {
+			t.Fatalf("claude preauth child args = %v, want a single --allowedTools= grant", got)
+		}
+	})
+
+	t.Run("launch.Record's full field surface is untouched (launch-record split register entry)", func(t *testing.T) {
+		// Removal prerequisite: the new (launchapi) path proven in real
+		// runs. Referencing every pre-v2.30.0 field is a compile-time
+		// existence check: if the "layer-owned majority" were pruned before
+		// its prerequisite, this subtest would fail to build.
+		rec := launch.Record{
+			Schema: 1, CWD: "/x", Binary: "claude", Argv: nil, Session: "s",
+			SharedWorkstream: false, Conversation: "", Handle: "h", Role: "r",
+			Root: "/root", BaseRoot: "/base", RootSource: "env", AMQVersion: "0.70.0",
+			CodexArgs: nil, ClaudeArgs: nil, Launcher: "", LauncherArgs: nil,
+			Model: "", ToolProfile: "", ToolConfig: "", ToolMCPConfig: "",
+			ToolAllowlist: nil, ToolBlocklist: nil, Trust: "", NoDefaultArgs: false,
+		}
+		if rec.Binary != "claude" {
+			t.Fatalf("unreachable: %+v", rec)
+		}
+	})
+
+	t.Run("coop-exec provisioning path is still reachable from every legacy backend (coop provisioning shim register entry)", func(t *testing.T) {
+		// Removal prerequisite: plan-driven provisioning plus upstream's
+		// breaking coop-exec change (neither has landed).
+		if _, err := exec.LookPath("true"); err != nil {
+			t.Skip("no shell available in this environment to probe emitTeamCommand output shape")
+		}
+		out := emitTeamCommand(emitTeamCommandInput{
+			CWD: "/proj", SquadBin: "amq-squad", TeamHome: "/proj",
+			Member: teamMemberForCoopProbe(), Workstream: "s",
+		})
+		if !strings.Contains(out, "coop") && !strings.Contains(out, "amq-squad") {
+			t.Fatalf("emitTeamCommand output no longer references the coop-exec provisioning path: %q", out)
+		}
+	})
+
+	t.Run("doctorMinAMQVersion floor is untouched by the new adoption floor (two-version-floors register entry)", func(t *testing.T) {
+		// Removal prerequisite: the two floors merge back into one only when
+		// the default flip (v2.31.0) completes. Until then doctorMinAMQVersion
+		// (the legacy-path floor) and the launchapi adoption floor (pinned in
+		// go.mod as agent-message-queue v0.70.0, negotiated by
+		// launchapi.Negotiate in gh#736) are two DISTINCT floors on purpose.
+		if doctorMinAMQVersion != "0.60.0" {
+			t.Fatalf("doctorMinAMQVersion changed to %q, want the untouched legacy floor 0.60.0", doctorMinAMQVersion)
+		}
+		modData, err := os.ReadFile(goModPathForTest(t))
+		if err != nil {
+			t.Fatalf("read go.mod: %v", err)
+		}
+		if !strings.Contains(string(modData), "github.com/avivsinai/agent-message-queue v0.70.0") {
+			t.Fatalf("go.mod no longer pins the v0.70.0 adoption floor dependency")
+		}
+	})
+
+	t.Run("wake injection fields are still on teamLaunchOptions (wake wire-mirroring register entry)", func(t *testing.T) {
+		// Removal prerequisite: a typed AMQ health surface; wake itself is an
+		// amq#480 non-goal that never moves, so this entry has no removal
+		// date at all -- these fields must never disappear from v2.30.0 on.
+		opts := teamLaunchOptions{WakeInjectVia: "/bin/true", WakeInjectMode: "raw", WakeInjectArgs: []string{"x"}}
+		if opts.WakeInjectVia == "" || opts.WakeInjectMode == "" || len(opts.WakeInjectArgs) == 0 {
+			t.Fatalf("unreachable: %+v", opts)
+		}
+	})
+}
+
+func teamMemberForCoopProbe() team.Member {
+	return team.Member{Role: "probe", Binary: "claude", Handle: "probe"}
+}
+
+func goModPathForTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(wd, "..", "..", "go.mod")
+}


### PR DESCRIPTION
## Summary

- Adds `launchapiTeamLaunchBackend`, a new implementation of `teamLaunchBackend` (`internal/cli/team_launch.go:105`) built on `internal/adoptionseam`'s `Prepare`/`Apply` seam (gh#734/gh#735), registered via `init()` like the existing tmux backend.
- Reachable **only** via the new explicit `--launch-via launchapi` flag, tmux-only. Absent the flag (or `--launch-via auto`), `resolveTeamLaunchBackend` reproduces the pre-gh#733 lookup byte-for-byte (same map, same error text) -- `auto` never selects it.
- Every `RequiredActionV1` launchapi surfaces becomes one `gate/launchapi-<kind>-<id>` operator question thread; none is ever auto-answered.
- The five AMQ identity env vars `internal/adoptionseam.SanitizeEnv` strips are re-derived as a diff between the parent env and the seam's sanitized output (never hardcoded) and applied to the composed tmux pane command via an `env -u` prefix, since a tmux pane inherits its ambient shell env rather than a Go-level custom env.
- Defense-in-depth: asserts no `--allowedTools`/`approvals_reviewer` token on the applied commands, on top of `internal/launchintent`'s own sanitizer (gh#732).
- `TestV2300RemovesNothing`: derived from the v2.31.0 milestone's "Deferred-removal register" (no standalone removal-register issue exists; the earlier one was dissolved and absorbed into that milestone description). Each subtest pins one register entry to a concrete compile/run-time check and cites its removal prerequisite in-comment.
- Additive only: legacy `tmux`/`iterm2`/`terminal`/`tmux-session` backends, their argv, and `doctorMinAMQVersion` are untouched.

## Scope

`internal/cli/team_launch.go` (+12, additive `LaunchVia` field + `resolveTeamLaunchBackend` seam replacing the 4-line lookup with byte-identical default-path behavior), `internal/cli/preview_flags.go` (+5, `--launch-via` flag), `internal/cli/team_launch_launchapi.go` (new), `internal/cli/team_launch_launchapi_test.go` (new), `internal/cli/v2300_removes_nothing_test.go` (new).

A local throwaway `internal/adoptionseam` stub was used during development to unblock compiling while gh#734/gh#735 (#741) were still in flight -- it was kept untracked via `.git/info/exclude` (never `.gitignore`) and deleted before this branch merged main; it never existed in any commit on this branch.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All 9 tests in `team_launch_launchapi_test.go` green: `TestLaunchapiBackendOptInOnly`, `TestLaunchapiBackendRequiresExplicitBaseRoot`, `TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates`, `TestLaunchapiBackendDualRunParity`, `TestLaunchapiBackendHasNoWorkerPreauth`, `TestLaunchapiBackendComposedCommandStripsIdentityEnvByDiff`, `TestLaunchapiBackendComposedCommandOmitsEnvPrefixWhenNothingStripped`, `TestLegacyBackendRetainsWorkerPreauthDuringDualRun`
- [x] `TestV2300RemovesNothing` (7 subtests, one per deferred-removal register entry) green
- [x] Re-verified all of the above against the real merged `internal/adoptionseam` (#741), not just the throwaway stub
- [x] `make ci`: green except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, a pre-existing real-PTY flake reproduced identically on unmodified `main` (confirmed independently during this session's t1 and t3 reviews too), unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)