### PR TITLE
Release v2.30.0: launchapi opt-in layer (intent compiler, backend, adoption seam, floor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,13 @@ jobs:
           AMQ_SQUAD_REAL_AMQ: ${{ runner.temp }}/amq-bin/amq
           AMQ_SQUAD_REAL_AMQ_VERSION: v0.70.0
           AMQ_NO_UPDATE_CHECK: "1"
-          # One-line extension point: once gh#733's launchapi backend lands,
-          # add its parity test name here, e.g.
-          # '^(TestCompiledIntentAcceptedByReleasedAMQ|TestTeamLaunchLaunchapiBackendParity)$'.
-          TEST_PATTERN: "^TestCompiledIntentAcceptedByReleasedAMQ$"
+          # TestLaunchapiBackendDualRunParity (gh#733) needs no real floor
+          # binary itself (it compares legacy vs launchapi seat resolution
+          # in-process, no AMQ_SQUAD_REAL_AMQ gating), so it already runs in
+          # the normal make ci sweep; it is included here too for visibility
+          # alongside the golden test that does exercise the floor binary.
+          TEST_PATTERN: "^(TestCompiledIntentAcceptedByReleasedAMQ|TestLaunchapiBackendDualRunParity)$"
         run: |
           set -euo pipefail
           "$AMQ_SQUAD_REAL_AMQ" version
-          go test ./internal/launchintent -run "$TEST_PATTERN" -count=1 -v -timeout=10m
+          go test ./internal/launchintent ./internal/cli -run "$TEST_PATTERN" -count=1 -v -timeout=10m

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2296" id="toc-whats-new-in-v2296">What's new
-in v2.29.6</a></li>
+<li><a href="#whats-new-in-v2300" id="toc-whats-new-in-v2300">What's new
+in v2.30.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2296">What's new in v2.29.6</a></li>
+<li><a href="#whats-new-in-v2300">What's new in v2.30.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,31 +342,49 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2296">What's new in v2.29.6</h2>
-<p>v2.29.6 restores guided squad setup as a deterministic binary-owned
-flow and removes the manual reconstruction around resuming an existing
-profile.</p>
+<h2 id="whats-new-in-v2300">What's new in v2.30.0</h2>
+<p>amq-squad becomes an opt-in layer above amq's public
+<code>launchapi</code> Go package. Strictly additive: the legacy
+tmux-pane launch path is unchanged and remains the default;
+<code>TestV2300RemovesNothing</code> enforces that mechanically.</p>
 <ul>
-<li><code>amq-squad wizard</code> now owns readiness, new/existing
-profile selection, optional custom seats, rules and brief staging, and
-one combined launch review that defaults to No (#709). It snapshots
-every reviewed artifact, rejects drift before mutation, and delegates an
-accepted plan to the locked <code>start --yes</code> path. The release
-also carries the companion <code>setup --show</code>,
-<code>--actor-mode</code>, and task-scoped worktree-isolation
-improvements.</li>
-<li><code>resume --last</code> selects the profile's most recently
-active session (#722). Slow-but-live <code>resume --exec</code> launches
-may verify for up to 90 seconds, expected context/bootstrap noise moves
-behind <code>--verbose</code>, and the success epilogue covers every
-role — relaunched, skipped-live, or all-live.</li>
-<li>Fresh launches work with AMQ 0.60.5's stricter coop provisioning
-contract, and wake-lock compatibility now treats AMQ's
-<code>machine_id</code> field strictly and refuses local-PID conclusions
-for another or unverifiable machine. The supported minimum remains AMQ
-0.60.0.</li>
+<li>A new pure intent compiler (<code>internal/launchintent</code>)
+turns a resolved team profile into amq's public
+<code>LaunchIntentV1</code>/<code>TargetV1</code>: no launching, no side
+effects (#732). Two argv decisions are enforced at compile time on the
+new path only, measured against released amq v0.70.0: no
+<code>--allowedTools</code> token on any seat, and
+<code>approvals_reviewer</code> dropped from Codex's trust-mode args.
+The legacy composer keeps emitting both, byte-identically.</li>
+<li>A new opt-in <code>--launch-via launchapi</code> team-launch
+backend, tmux only, never selected by <code>auto</code> or an absent
+flag (#733). Every required action <code>launchapi.Prepare</code>
+surfaces becomes an operator gate on a
+<code>gate/launchapi-&lt;kind&gt;-&lt;id&gt;</code> thread: the backend
+never answers a decision without an explicit, repeatable
+<code>--launchapi-decision ACTION_ID=CHOICE</code> (validated against
+the action's allowed choices; a decision for an action Prepare did not
+return is rejected as stale). Re-running with the answer surfaces only
+the still-undecided actions and completes the launch once every action
+has a valid decision. <strong>Known limitation, not a bug:</strong>
+launchapi seats have no worker preauth during dual-run; the legacy
+backend's preauth is unchanged, and legacy remains the default launch
+path.</li>
+<li>A new Go-API-only adoption seam (<code>internal/adoptionseam</code>)
+talks to <code>launchapi</code> exclusively: no shelling out to the amq
+CLI, no upward root discovery (#734). <code>Prepare</code> fails closed
+before any <code>launchapi</code> call if the target's base root is
+missing, closing the bug class that let AMQ's own <code>.amqrc</code>
+discovery retarget writes into a parent repo's live base root from a
+nested task-worktree cwd. The five inherited AMQ root/session identity
+variables are stripped before any child sees them (#735).</li>
+<li>The launchapi backend gets its own adoption floor (amq v0.70.0),
+deliberately separate from the general-operation floor
+(<code>doctor</code> minimum stays 0.60.0), negotiated at runtime via
+<code>launchapi.Negotiate</code> and a new pinned CI lane, not enforced
+by <code>doctor</code> (#736).</li>
 </ul>
-<p>Full detail in <a href="docs/v2.29.6-release-notes.md">the v2.29.6
+<p>Full detail in <a href="docs/v2.30.0-release-notes.md">the v2.30.0
 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
@@ -378,7 +396,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.6</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.29.6](#whats-new-in-v2296)
+- [What's new in v2.30.0](#whats-new-in-v2300)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,27 +38,45 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.29.6
+## What's new in v2.30.0
 
-v2.29.6 restores guided squad setup as a deterministic binary-owned flow and
-removes the manual reconstruction around resuming an existing profile.
+amq-squad becomes an opt-in layer above amq's public `launchapi` Go package.
+Strictly additive: the legacy tmux-pane launch path is unchanged and remains
+the default; `TestV2300RemovesNothing` enforces that mechanically.
 
-- `amq-squad wizard` now owns readiness, new/existing profile selection,
-  optional custom seats, rules and brief staging, and one combined launch
-  review that defaults to No (#709). It snapshots every reviewed artifact,
-  rejects drift before mutation, and delegates an accepted plan to the locked
-  `start --yes` path. The release also carries the companion `setup --show`,
-  `--actor-mode`, and task-scoped worktree-isolation improvements.
-- `resume --last` selects the profile's most recently active session (#722).
-  Slow-but-live `resume --exec` launches may verify for up to 90 seconds,
-  expected context/bootstrap noise moves behind `--verbose`, and the success
-  epilogue covers every role — relaunched, skipped-live, or all-live.
-- Fresh launches work with AMQ 0.60.5's stricter coop provisioning contract,
-  and wake-lock compatibility now treats AMQ's `machine_id` field strictly and
-  refuses local-PID conclusions for another or unverifiable machine. The
-  supported minimum remains AMQ 0.60.0.
+- A new pure intent compiler (`internal/launchintent`) turns a resolved team
+  profile into amq's public `LaunchIntentV1`/`TargetV1`: no launching, no
+  side effects (#732). Two argv decisions are enforced at compile time on
+  the new path only, measured against released amq v0.70.0: no
+  `--allowedTools` token on any seat, and `approvals_reviewer` dropped from
+  Codex's trust-mode args. The legacy composer keeps emitting both,
+  byte-identically.
+- A new opt-in `--launch-via launchapi` team-launch backend, tmux only,
+  never selected by `auto` or an absent flag (#733). Every required action
+  `launchapi.Prepare` surfaces becomes an operator gate on a
+  `gate/launchapi-<kind>-<id>` thread: the backend never answers a decision
+  without an explicit, repeatable `--launchapi-decision ACTION_ID=CHOICE`
+  (validated against the action's allowed choices; a decision for an action
+  Prepare did not return is rejected as stale). Re-running with the answer
+  surfaces only the still-undecided actions and completes the launch once
+  every action has a valid decision. **Known limitation, not a bug:**
+  launchapi seats have no worker preauth during dual-run; the legacy
+  backend's preauth is unchanged, and legacy remains the default launch
+  path.
+- A new Go-API-only adoption seam (`internal/adoptionseam`) talks to
+  `launchapi` exclusively: no shelling out to the amq CLI, no upward root
+  discovery (#734). `Prepare` fails closed before any `launchapi` call if
+  the target's base root is missing, closing the bug class that let AMQ's
+  own `.amqrc` discovery retarget writes into a parent repo's live base
+  root from a nested task-worktree cwd. The five inherited AMQ
+  root/session identity variables are stripped before any child sees them
+  (#735).
+- The launchapi backend gets its own adoption floor (amq v0.70.0),
+  deliberately separate from the general-operation floor (`doctor` minimum
+  stays 0.60.0), negotiated at runtime via `launchapi.Negotiate` and a new
+  pinned CI lane, not enforced by `doctor` (#736).
 
-Full detail in [the v2.29.6 release notes](docs/v2.29.6-release-notes.md).
+Full detail in [the v2.30.0 release notes](docs/v2.30.0-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -76,7 +94,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.29.6
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,11 @@ version.
 
 ## Minor release checklist
 
+Since v2.0.0, a minor release (for example v2.30.0) follows the same
+numbered Patch Release Checklist above: there is one release procedure,
+not two. The v1.3.0-era guidance below predates the `/v2` module path and is
+kept for historical reference only.
+
 For a minor release such as v1.3.0, keep the module path on
 `github.com/omriariav/amq-squad`, update README install examples to the new tag,
 run `make ci`, and smoke test with `make release-smoke VERSION=<tag>`.

--- a/docs/v2.30.0-release-notes.md
+++ b/docs/v2.30.0-release-notes.md
@@ -1,0 +1,131 @@
+# amq-squad v2.30.0
+
+amq-squad becomes an opt-in layer above amq's public `launchapi` Go
+package: a new intent compiler, an opt-in `launchapi` team-launch backend
+(tmux only), a Go-API-only adoption seam with an explicit `base_root` on
+every call, and the backend's own adoption floor with a `launchapi.Negotiate`
+guard. Strictly additive: the legacy tmux-pane launch path is untouched and
+stays the default; `TestV2300RemovesNothing` enforces that mechanically.
+Milestone issues: #732, #733, #734, #735, #736.
+PRs: #738, #741, #742, #743.
+
+## Intent compiler: team.json -> LaunchIntentV1 (#732, PR #738)
+
+New pure package `internal/launchintent` compiles a resolved team profile,
+session, and per-seat runtime facts into `launchapi`'s public
+`LaunchIntentV1` and `TargetV1`. No launching, no side effects, no AMQ
+calls.
+
+- The operator seat compiles to exactly `{handle, runnable: false}`; every
+  runnable seat carries an absolute cwd (sibling worktrees preserved
+  verbatim), resume policy, and bootstrap text riding `initial_input`, never
+  argv.
+- Two argv decisions are enforced at compile time, each measured against
+  released amq v0.70.0: the new path emits no `--allowedTools` token on any
+  seat, and drops `approvals_reviewer` from Codex's trust-mode args, on the
+  new path only. The legacy composer (`internal/cli/agent_defaults.go`)
+  keeps emitting both, byte-identically, locked by a dedicated legacy-side
+  test so the "new path only" claim is proven on both sides, not just
+  asserted on one.
+
+## Opt-in launchapi team-launch backend (#733, PR #743)
+
+A new `teamLaunchBackend` implementation, selected only by explicit
+`--launch-via launchapi`, never by `auto` or an absent flag. tmux only.
+
+- Every `RequiredActionV1` `Prepare` surfaces becomes an operator gate on a
+  `gate/launchapi-<kind>-<action_id>` thread. The backend never answers a
+  decision itself: it only proceeds to `Apply` once the operator supplies
+  an explicit, repeatable `--launchapi-decision ACTION_ID=CHOICE`, validated
+  against that action's allowed choices. A decision naming an action ID
+  `Prepare` did not return is rejected as stale, not silently dropped. A
+  partial set of decisions surfaces gates for only the still-undecided
+  actions on re-run, and once every action has a valid decision the launch
+  proceeds to `Apply`; the gate thread then gets a status update recording
+  which decision was applied.
+- The composed tmux pane command strips the adoption seam's sanitized
+  identity env vars via `env -u`, computed as a diff against the parent
+  environment rather than hardcoded, so the backend and the seam's strip set
+  cannot silently drift apart.
+- `ApplyResultV1.Commands` are matched to team members by cwd, not by
+  position: launchapi's public package documents no ordering contract
+  between `Commands` and the request's participant list.
+- Known limitation, not a bug: launchapi seats have no worker preauth during
+  dual-run. The legacy `--allowedTools` preauth path (#296) has no
+  equivalent yet on the new path (see #732's argv-safety finding for why).
+  The legacy backend keeps its preauth unchanged.
+- `TestV2300RemovesNothing` is the mechanical enforcement of this release's
+  additive-only contract, derived from the v2.31.0 milestone's
+  deferred-removal register.
+
+## Go-API-only adoption seam (#734, #735, PR #741)
+
+New package `internal/adoptionseam` is the single call site through which
+amq-squad talks to `launchapi`. It never shells out to the amq CLI and never
+performs upward root discovery.
+
+- `Prepare` fails closed with `ErrEmptyBaseRoot` before `launchapi` is ever
+  called if the caller's intent carries no explicit base root, closing the
+  exact bug class that let AMQ's own upward `.amqrc` discovery retarget
+  writes into a parent repo's live base root from a nested task-worktree
+  cwd, amq-squad's default layout, not an edge case. Proven against a real
+  nested-worktree fixture that byte-compares the parent repo's `.agent-mail`
+  tree before and after a real `Prepare` call.
+- `SanitizeEnv` formalizes stripping the five inherited AMQ root/session
+  identity variables (`AM_ROOT`, `AM_BASE_ROOT`, `AM_ROOT_ID`,
+  `AM_BASE_ROOT_ID`, `AM_SESSION`) as a tested seam contract, distinct from
+  `internal/cli`'s existing `envWithoutAMQIdentity` (a different, broader
+  set for a different call site). `AM_ME` is deliberately excluded,
+  verified against the pinned launchapi dependency that neither reads nor
+  sets it anywhere; a child's handle rides `EnvOverlay` explicitly.
+
+## Adoption floor and CI lane (#736, PR #742)
+
+The launchapi backend gets its own adoption floor, deliberately separate
+from `internal/cli`'s general-operation floor (`doctorMinAMQVersion`,
+unchanged at 0.60.0, proven by a dedicated test). Raising the
+general-operation floor for every user who never touches `launchapi` would
+tax them for zero benefit; the wake/mail path is proven on amq 0.60.x. The
+two floors merge only when the launchapi backend becomes the `auto` default
+(tracked in the v2.31.0 milestone).
+
+- `internal/adoptionseam.NegotiateAdoptionFloor` calls `launchapi.Negotiate`
+  against an explicit required-feature list (`launch_intent_v1`,
+  `prepare_apply_v1`, `base_root`, `initial_input`, `managed_tmux_v1`,
+  `caller_context`), each justified against the call site that needs it.
+  Wired into `Prepare`, right after the empty-base-root guard: an older
+  compiled-in contract, or one missing a required feature, refuses before
+  `launchintent.Compile` or `launchapi.Prepare` ever run.
+- CI gains a new `adoption floor compatibility (v0.70.0)` lane, pinned (not
+  matrixed like the general-operation real-AMQ lanes, since there is exactly
+  one floor to prove), running the intent-compiler golden test and the
+  launchapi backend parity test (`TestLaunchapiBackendDualRunParity`).
+
+## Compatibility
+
+- Additive only. The legacy tmux-pane launch path is untouched and remains
+  the default; nothing described above changes behavior unless
+  `--launch-via launchapi` is passed explicitly.
+- The general-operation AMQ floor stays at 0.60.0. The new launchapi
+  backend's own floor is v0.70.0, negotiated at runtime via
+  `launchapi.Negotiate`, not enforced by `doctor`.
+
+## Known issues / follow-ups
+
+Both found during this release's implementation, filed for a later
+milestone, not blocking:
+
+- #739: `amq-squad worktree plan`/`materialize` can refuse an explicit
+  `--base` with an "accepted base drift" error when it does not match the
+  session's originally pinned base, even when the requested base is the
+  correct, current one. Workaround used throughout this milestone:
+  materialize at the session-pinned base, then `git reset --hard` to the
+  intended base inside the worktree.
+- #740: `amq-squad worktree cleanup` cannot reconcile a plan-store entry
+  whose registered path was already removed by a raw `git worktree remove`
+  (as opposed to going through `cleanup` itself); it refuses with
+  "role already has a different materialized worktree plan" on the next
+  `plan`/`materialize` for that role. Workaround used: recreate a
+  throwaway placeholder worktree at the exact stale path and branch so
+  `cleanup --decision accepted` can see it as registered and reconcile the
+  store, then remove the placeholder.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.29.6",
+  "version": "2.30.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.29.6",
+  "version": "2.30.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.29.6"  # x-release-please-version
+version: "2.30.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
## Summary
Release PR for v2.30.0. Closes milestone `v2.30.0` (gh#732, gh#733, gh#734, gh#735, gh#736). Three commits, in order:

1. `ci: wire the launchapi backend parity test into the adoption-floor lane` -- gh#736's one-line TEST_PATTERN extension, word-checked against merged #743's `TestLaunchapiBackendDualRunParity`.
2. `docs(releasing): clarify the numbered checklist is the one release procedure since v2.0.0` -- additive-only fix to RELEASING.md's stale "Minor release checklist" section (found while reading it for this release).
3. `chore(release): prepare v2.30.0` -- plugin manifest bumps (2.29.6 -> 2.30.0) + skill mirror regeneration, README What's-new swap + install tag, README.html regeneration, `docs/v2.30.0-release-notes.md`.

Full detail in [docs/v2.30.0-release-notes.md](docs/v2.30.0-release-notes.md).

Strictly additive: the legacy tmux-pane launch path is untouched and remains the default (`TestV2300RemovesNothing`). General-operation AMQ floor stays 0.60.0.

## Test plan
- [x] `make ci` green at this exact head, locally.
- [x] New CI lane (`adoption floor compatibility (v0.70.0)`) verified locally with the real installed amq binary: both `TestCompiledIntentAcceptedByReleasedAMQ` and `TestLaunchapiBackendDualRunParity` pass under the exact `go test ./internal/launchintent ./internal/cli -run "$TEST_PATTERN"` invocation the workflow runs.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` validates the ci.yml diff.
- [x] `make skills-generate` diff confirmed to be exactly the 16 skill-mirror frontmatter version stamps + 2 plugin manifests, nothing else.
- [x] `make readme-html` regenerated README.html; `make ci`'s `readme-html-check` step confirms it's in sync.
- [x] No em dashes in any of the three commits' prose (repo docs style).
- [x] `git status` confirms scope matches the three commit messages exactly.

Not merging. Tag, GitHub release publish, and smoke test wait for the operator gate lead will raise separately, per RELEASING.md steps 3-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)