### PR TITLE
feat(adoptionseam): bump adoption floor to amq v0.72.0, pin go.mod v0.73.0 (gh#746)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
   # (internal/adoptionseam.AdoptionFloorAMQVersion), not matrixed like the
   # general-operation lanes above: there is exactly one floor to prove here.
   adoption-floor-compatibility:
-    name: adoption floor compatibility (v0.70.0)
+    name: adoption floor compatibility (v0.72.0)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -173,14 +173,14 @@ jobs:
           set -euo pipefail
           export GOBIN="$RUNNER_TEMP/amq-bin"
           mkdir -p "$GOBIN"
-          go install github.com/avivsinai/agent-message-queue/cmd/amq@v0.70.0
+          go install github.com/avivsinai/agent-message-queue/cmd/amq@v0.72.0
           "$GOBIN/amq" version
 
       - name: Run adoption-floor lane
         shell: bash
         env:
           AMQ_SQUAD_REAL_AMQ: ${{ runner.temp }}/amq-bin/amq
-          AMQ_SQUAD_REAL_AMQ_VERSION: v0.70.0
+          AMQ_SQUAD_REAL_AMQ_VERSION: v0.72.0
           AMQ_NO_UPDATE_CHECK: "1"
           # TestLaunchapiBackendDualRunParity (gh#733) needs no real floor
           # binary itself (it compares legacy vs launchapi seat resolution

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/omriariav/amq-squad/v2
 go 1.25.12
 
 require (
-	github.com/avivsinai/agent-message-queue v0.70.0
+	github.com/avivsinai/agent-message-queue v0.73.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/avivsinai/agent-message-queue v0.70.0 h1:53LtUoY40poW6EwRKZ/PGwWACj6O68wR+D0LpTPqlg8=
-github.com/avivsinai/agent-message-queue v0.70.0/go.mod h1:E/TJeNt+rzXF/yiBPKp8INj8SYjWF0fCCeaj48dxnFA=
+github.com/avivsinai/agent-message-queue v0.73.0 h1:2oNIrebXUjRMgI2TBfR+Sd04ZPknj3FvipCToBh/fzQ=
+github.com/avivsinai/agent-message-queue v0.73.0/go.mod h1:E/TJeNt+rzXF/yiBPKp8INj8SYjWF0fCCeaj48dxnFA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/adoptionseam/floor.go
+++ b/internal/adoptionseam/floor.go
@@ -8,11 +8,11 @@ import (
 
 // AdoptionFloorAMQVersion documents the released amq version
 // AdoptionFloorContractSemver was verified against (launchapi.Compatibility()
-// on v0.70.0). It is not itself compared at runtime: Negotiate checks the
-// compiled-in launchapi contract this binary was built against, not an
-// on-disk amq version, since this seam never shells out to the amq CLI (see
-// the package doc comment).
-const AdoptionFloorAMQVersion = "v0.70.0"
+// on v0.72.0, go.mod pinned to v0.73.0 -- gh#746). It is not itself compared
+// at runtime: Negotiate checks the compiled-in launchapi contract this
+// binary was built against, not an on-disk amq version, since this seam
+// never shells out to the amq CLI (see the package doc comment).
+const AdoptionFloorAMQVersion = "v0.72.0"
 
 // AdoptionFloorContractSemver is the minimum launchapi contract semver this
 // backend requires. Deliberately distinct from internal/cli's
@@ -21,6 +21,29 @@ const AdoptionFloorAMQVersion = "v0.70.0"
 // every user who never touches it would tax them for zero benefit — the
 // wake/mail path is proven on amq 0.60.x. The two floors merge only when
 // the launchapi backend becomes the auto default (gh#733's v2.31.0+ line).
+//
+// gh#746: the launchapi package's negotiable contract is unchanged since
+// v0.70.0. launchapi.ContractSemverV1 is still "0.61.1" on both v0.72.0 and
+// v0.73.0 -- verified byte-identical to v0.70.0 (md5 of every non-test .go
+// file in the launchapi package matches exactly across v0.70.0 and v0.73.0).
+// No launchapi.Feature* constant, and no raw string in
+// platformCompatibilityFeaturesV1, names scoped grants, approvals_reviewer,
+// or project-root authority on either version -- upstream's #648 asks landed
+// as changes to the module's internals and to Prepare's RUNTIME output
+// instead (PrepareResultV1.Preview.Capabilities[].GrammarVersion bumped 1 ->
+// 2, .AllowedArgumentForms gained "-n"/"--name"), not as anything
+// Compatibility()/Negotiate() can see ahead of time.
+//
+// So this adoption floor is enforced two ways, neither of which is
+// Negotiate: (a) the go.mod pin itself, since launchapi and its internals
+// run inside this binary -- TestPinnedAMQModuleAtOrAboveAdoptionFloor proves
+// the linked module version is >= AdoptionFloorAMQVersion via
+// runtime/debug.ReadBuildInfo(); (b) a runtime check on the observed
+// GrammarVersion in Prepare's own PreviewV1.Capabilities, added in t10.
+// TestNegotiateRejectsBelowAdoptionFloor below still exercises Negotiate's
+// real refusal paths (an ahead-of-compiled-in semver, a missing feature, an
+// unsupported intent version) -- those remain true refusal mechanisms, just
+// not ones gh#746's version bump itself changes anything about.
 const AdoptionFloorContractSemver = ">=0.61.1"
 
 // AdoptionFloorFeatures are the launchapi features this backend actually
@@ -36,7 +59,8 @@ const AdoptionFloorContractSemver = ">=0.61.1"
 //     being honored, not just accepted.
 //
 // Not required here: on_live, placement, executable_identity, wrapper,
-// lifecycle_v1, plan_only_commands_v1 — real features on v0.70.0, but
+// lifecycle_v1, plan_only_commands_v1 — real features on v0.70.0 through
+// v0.73.0 (unchanged, see AdoptionFloorContractSemver's doc comment), but
 // nothing in this package calls the paths that need them yet. Extending
 // this list is a one-line change when that changes.
 var AdoptionFloorFeatures = []string{

--- a/internal/adoptionseam/floor_test.go
+++ b/internal/adoptionseam/floor_test.go
@@ -3,10 +3,113 @@ package adoptionseam
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
 )
+
+const adoptionFloorModulePath = "github.com/avivsinai/agent-message-queue"
+
+var adoptionFloorRequireLine = regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(adoptionFloorModulePath) + `\s+(v\S+)\s*$`)
+
+// TestPinnedAMQModuleAtOrAboveAdoptionFloor is the real gh#746 floor guard.
+// launchapi's negotiable Compatibility()/Negotiate() contract did not move
+// between v0.70.0 and v0.73.0 (see AdoptionFloorContractSemver's doc
+// comment), so Negotiate cannot detect an older pinned module -- the actual
+// floor for this in-process path is the go.mod pin itself, since launchapi
+// and its internals run inside this binary.
+//
+// This reads go.mod directly rather than runtime/debug.ReadBuildInfo():
+// verified empirically that `go test -c` binaries in this toolchain
+// (go1.25.12 darwin/arm64) embed zero dependency entries at all -- confirmed
+// systemic (internal/cli's test binary has the same empty Deps), not
+// specific to this package, by comparing against `go version -m` on a
+// regular `go build` binary, which correctly lists all 23 deps including
+// this one. ReadBuildInfo would make this test either always fail or
+// silently prove nothing; go.mod is the actual, unambiguous source of truth
+// for what's pinned regardless of that quirk.
+func TestPinnedAMQModuleAtOrAboveAdoptionFloor(t *testing.T) {
+	pinned := adoptionFloorPinnedVersion(t)
+	got, ok := parseAdoptionFloorSemver(pinned)
+	if !ok {
+		t.Fatalf("could not parse pinned module version %q as semver", pinned)
+	}
+	want, ok := parseAdoptionFloorSemver(AdoptionFloorAMQVersion)
+	if !ok {
+		t.Fatalf("could not parse AdoptionFloorAMQVersion %q as semver", AdoptionFloorAMQVersion)
+	}
+	if compareAdoptionFloorSemver(got, want) < 0 {
+		t.Fatalf("pinned %s version %s is below the documented adoption floor %s", adoptionFloorModulePath, pinned, AdoptionFloorAMQVersion)
+	}
+}
+
+// adoptionFloorPinnedVersion locates the repo-root go.mod relative to this
+// test file's own source location (robust to the package moving, and to
+// where `go test` happens to set its working directory) and extracts the
+// pinned agent-message-queue require-line version.
+func adoptionFloorPinnedVersion(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed to resolve this test file's path")
+	}
+	dir := filepath.Dir(thisFile)
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "go.mod")
+		data, err := os.ReadFile(candidate)
+		if err == nil {
+			m := adoptionFloorRequireLine.FindSubmatch(data)
+			if m == nil {
+				t.Fatalf("%s has no require line for %s", candidate, adoptionFloorModulePath)
+			}
+			return string(m[1])
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("could not locate the repo-root go.mod by walking up from this test file")
+	return ""
+}
+
+func parseAdoptionFloorSemver(v string) ([3]int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	v, _, _ = strings.Cut(v, "-") // drop any pre-release/pseudo-version suffix
+	v, _, _ = strings.Cut(v, "+") // drop any build-metadata suffix
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+func compareAdoptionFloorSemver(a, b [3]int) int {
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
 
 // TestNegotiateAdoptionFloorSatisfiedByPinnedAMQ is the positive control:
 // the floor this package declares must actually be satisfied by the

--- a/internal/cli/v2300_removes_nothing_test.go
+++ b/internal/cli/v2300_removes_nothing_test.go
@@ -115,8 +115,15 @@ func TestV2300RemovesNothing(t *testing.T) {
 		// Removal prerequisite: the two floors merge back into one only when
 		// the default flip (v2.31.0) completes. Until then doctorMinAMQVersion
 		// (the legacy-path floor) and the launchapi adoption floor (pinned in
-		// go.mod as agent-message-queue v0.70.0, negotiated by
-		// launchapi.Negotiate in gh#736) are two DISTINCT floors on purpose.
+		// go.mod, negotiated/guarded in internal/adoptionseam -- gh#736,
+		// gh#746) are two DISTINCT floors on purpose. This does not hardcode
+		// the adoption-floor pin's exact version: gh#746 moved it from
+		// v0.70.0 to v0.73.0 with doctorMinAMQVersion correctly untouched,
+		// proving the two floors really are independent. Whether the pinned
+		// version actually meets the documented floor is
+		// internal/adoptionseam.TestPinnedAMQModuleAtOrAboveAdoptionFloor's
+		// job, not this test's; this one only proves the dependency itself
+		// was not removed.
 		if doctorMinAMQVersion != "0.60.0" {
 			t.Fatalf("doctorMinAMQVersion changed to %q, want the untouched legacy floor 0.60.0", doctorMinAMQVersion)
 		}
@@ -124,8 +131,8 @@ func TestV2300RemovesNothing(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read go.mod: %v", err)
 		}
-		if !strings.Contains(string(modData), "github.com/avivsinai/agent-message-queue v0.70.0") {
-			t.Fatalf("go.mod no longer pins the v0.70.0 adoption floor dependency")
+		if !strings.Contains(string(modData), "github.com/avivsinai/agent-message-queue ") {
+			t.Fatalf("go.mod no longer pins the adoption floor dependency github.com/avivsinai/agent-message-queue at all")
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `go.mod`/`go.sum`: `agent-message-queue` v0.70.0 -> v0.73.0.
- `internal/adoptionseam/floor.go`: `AdoptionFloorAMQVersion` -> v0.72.0 (doc-only, not compared at runtime). `AdoptionFloorContractSemver`/`AdoptionFloorFeatures` deliberately **unchanged**, with the investigation documented in-comment: verified by md5 that every non-test `.go` file in the `launchapi` package is byte-identical across v0.70.0/v0.72.0/v0.73.0. `launchapi.ContractSemverV1` is still `"0.61.1"`; no `launchapi.Feature*` constant and no raw string in `platformCompatibilityFeaturesV1` names scoped grants, `approvals_reviewer`, or project-root authority on any of these versions. Upstream's #648 asks landed as module-internal changes and as `Prepare`'s runtime `PreviewV1.Capabilities[].GrammarVersion` (1 -> 2) instead -- data `Negotiate` cannot see ahead of time.
- `.github/workflows/ci.yml`: the `adoption-floor-compatibility` lane installs and names v0.72.0.
- New test `TestPinnedAMQModuleAtOrAboveAdoptionFloor` replaces a DoD line that assumed a negotiable feature which turned out not to exist (flagged to lead, confirmed, redirected to this design). It reads `go.mod` directly rather than `runtime/debug.ReadBuildInfo()`: verified empirically that `go test -c` binaries in this toolchain (go1.25.12 darwin/arm64) embed **zero** dependency entries at all -- confirmed systemic (not package-specific) by comparing against a working `go build` binary that correctly lists all 23 deps. `ReadBuildInfo` here would make the test either always fail or silently prove nothing regardless of what's actually pinned.
- `internal/cli/v2300_removes_nothing_test.go`: the two-version-floors subtest no longer hardcodes the adoption-floor pin's exact version (previously `"v0.70.0"` -- broken by this very PR's bump, so it's fixed here). Whether the pin meets the documented floor is now `TestPinnedAMQModuleAtOrAboveAdoptionFloor`'s job; this test only proves the dependency itself was not removed.
- `doctorMinAMQVersion` untouched (`TestGeneralOperationFloorUnchanged` stays green).

Cross-checked against senior-dev's t8 in-process measurement (task/t8) before opening this PR: `GrammarVersion` 1->2 confirmed as a deterministic per-call gate computed from static grammar tables, not provider-probed -- matches this PR's own claim.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `TestPinnedAMQModuleAtOrAboveAdoptionFloor` green against the v0.73.0 pin; verified it actually fails when the documented floor is raised past the pin (manual sabotage test, reverted)
- [x] `TestNegotiateAdoptionFloorSatisfiedByPinnedAMQ`, `TestNegotiateRejectsBelowAdoptionFloor` (3 existing subtests, unchanged), `TestGeneralOperationFloorUnchanged`, `TestPrepareFailsClosedBelowAdoptionFloor` all green
- [x] `TestV2300RemovesNothing` green (fixed the collateral break its hardcoded v0.70.0 string hit from this bump)
- [x] Floor CI lane invocation run locally against the real installed v0.72.0 `amq` binary: `TestCompiledIntentAcceptedByReleasedAMQ` and `TestLaunchapiBackendDualRunParity` both pass
- [x] Full `make ci`: green, zero `FAIL` lines anywhere in the log (grepped exhaustively, not tail-read)

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)