### PR TITLE
gh#747: restore worker preauth on the launchapi path, gated on observed argv grammar

### DIFF
--- a/docs/amq-0.73.0-adoption-verdict.md
+++ b/docs/amq-0.73.0-adoption-verdict.md
@@ -232,6 +232,21 @@ grammar tables compiled into the module, not from probing an installed
 provider binary, so it is safe to gate on before any real agent binary is
 even resolved.
 
+**`Prepare` is read-only and deterministic, safe to call twice in one
+request (t10/t11's two-phase probe design).** Verified directly: two
+identical `Prepare` calls against the same request, back to back, in the
+same process. The project root's file tree was byte-identical before the
+first call, after the first call, and after the second call (zero writes,
+confirmed by hashing every file under the root each time, not just checking
+`Outcome`). `Preview` (including `Capabilities`) serialized identically
+between the two calls, and `SubjectDigest` matched exactly
+(`sha256:1da22cf3ce813676b2895281ed57700d3134e5917dadaf80c06be2294da17ff5`
+both times). A probe `Prepare` call to read `Preview.Capabilities` and a
+second `Prepare` call on the recompiled phase-2 request are therefore safe:
+neither call mutates anything, and the same input always yields the same
+output, so the probe cannot itself introduce drift between what it observed
+and what phase 2 sends to `Apply`.
+
 ## Adopt/defer summary
 
 | Item | Verdict |

--- a/internal/cli/agent_defaults.go
+++ b/internal/cli/agent_defaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -33,12 +34,17 @@ var (
 // while the recurring `gh pr create` stall is removed. By keeping this list to a
 // single PR-domain pattern, it cannot — by construction — authorize push, tags,
 // releases, or destructive git.
+//
+// The pattern itself is internal/launchintent.ScopedPreauthGrant, gh#747's
+// single source of truth: that package's new-path compiler gates the same
+// literal on the seat's observed argv-grammar capability rather than
+// keeping its own copy, so the two paths cannot silently drift apart.
 func claudeInScopePreauthAllowlist(session string) []string {
 	if strings.TrimSpace(session) == "" {
 		return nil
 	}
 	return []string{
-		"Bash(gh pr create:*)",
+		launchintent.ScopedPreauthGrant,
 	}
 }
 

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -121,17 +121,54 @@ func (b launchapiTeamLaunchBackend) launch(t team.Team, opts teamLaunchOptions) 
 // prepare builds the launch intent (via internal/launchintent, gh#732) and
 // calls adoptionseam.Prepare -- the single seam to launchapi (gh#734/gh#735)
 // that owns base_root fail-closed refusal and env sanitization, rather than
-// this backend calling launchapi.Prepare directly. It never mutates
-// anything: Prepare is read-only in launchapi's own contract.
+// this backend calling launchapi.Prepare directly.
+//
+// gh#747: launchapi.Negotiate cannot distinguish the scoped-argv-grammar
+// floor (docs/amq-0.73.0-adoption-verdict.md section 6), so this runs a
+// two-phase Prepare instead of a single call:
+//
+//  1. Probe with the conservative intent (no capability facts yet, so
+//     internal/launchintent's sanitizer drops every gated token in the safe
+//     direction). Its Preview.Capabilities carries the seat providers'
+//     observed ArgvGrammarVersion and approvals_reviewer support.
+//  2. Recompile with those facts threaded into each seat's SeatFacts, then
+//     Prepare again.
+//
+// Both calls are read-only and deterministic (verified directly, see the
+// verdict doc), so the probe cannot itself mutate anything or drift from
+// what phase 2 later sends to Apply. Apply is always called with the
+// phase-2 Prepared this method returns, never the probe's.
 func (b launchapiTeamLaunchBackend) prepare(t team.Team, opts teamLaunchOptions) (adoptionseam.Prepared, []agentLaunchPreflight, error) {
 	preflights, err := buildTeamPreflights(t, opts)
 	if err != nil {
 		return adoptionseam.Prepared{}, nil, err
 	}
-	input, err := b.buildIntentInput(t, opts, preflights)
+
+	probeInput, err := b.buildIntentInput(t, opts, preflights, nil)
 	if err != nil {
 		return adoptionseam.Prepared{}, nil, err
 	}
+	probePrepared, err := b.callPrepare(opts, probeInput)
+	if err != nil {
+		return adoptionseam.Prepared{}, nil, err
+	}
+
+	capabilities := capabilitiesByProvider(probePrepared.Result.Preview.Capabilities)
+	finalInput, err := b.buildIntentInput(t, opts, preflights, capabilities)
+	if err != nil {
+		return adoptionseam.Prepared{}, nil, err
+	}
+	finalPrepared, err := b.callPrepare(opts, finalInput)
+	if err != nil {
+		return adoptionseam.Prepared{}, nil, err
+	}
+	return finalPrepared, preflights, nil
+}
+
+// callPrepare is the single call site to adoptionseam.Prepare, shared by
+// both phases so the request-building and error-wrapping stay identical
+// between the probe and the final call.
+func (b launchapiTeamLaunchBackend) callPrepare(opts teamLaunchOptions, input launchintent.Input) (adoptionseam.Prepared, error) {
 	prepared, err := adoptionseam.Prepare(context.Background(), adoptionseam.PrepareInput{
 		Intent:   input,
 		Launcher: "tmux",
@@ -140,21 +177,63 @@ func (b launchapiTeamLaunchBackend) prepare(t team.Team, opts teamLaunchOptions)
 	})
 	if err != nil {
 		if errors.Is(err, adoptionseam.ErrEmptyBaseRoot) {
-			return adoptionseam.Prepared{}, nil, fmt.Errorf("launchapi: base_root is required and must be explicit (gh#734): %w", err)
+			return adoptionseam.Prepared{}, fmt.Errorf("launchapi: base_root is required and must be explicit (gh#734): %w", err)
 		}
-		return adoptionseam.Prepared{}, nil, fmt.Errorf("adoptionseam.Prepare: %w", err)
+		return adoptionseam.Prepared{}, fmt.Errorf("adoptionseam.Prepare: %w", err)
 	}
-	return prepared, preflights, nil
+	return prepared, nil
+}
+
+// capabilitiesByProvider indexes a Prepare probe's Preview.Capabilities by
+// provider name (e.g. "claude", "codex") for buildIntentInput's per-seat
+// lookup. A nil/empty slice yields an empty map, so a missing provider
+// entry (including the phase-1 probe call, which passes no capabilities at
+// all) naturally reads back as the zero-value ProviderCapabilitiesV1 -- the
+// safe, everything-below-floor direction.
+func capabilitiesByProvider(caps []launchapi.ProviderCapabilitiesV1) map[string]launchapi.ProviderCapabilitiesV1 {
+	out := make(map[string]launchapi.ProviderCapabilitiesV1, len(caps))
+	for _, c := range caps {
+		out[c.Provider] = c
+	}
+	return out
+}
+
+// reviewerOverrideAllowedFrom reports whether the observed capability
+// carries a config_override entry for approvals_reviewer
+// (docs/amq-0.73.0-adoption-verdict.md section 4: this is codex's real gate
+// for the reviewer override, not GrammarVersion, which stays 1 on codex
+// across every measured version).
+func reviewerOverrideAllowedFrom(cap launchapi.ProviderCapabilitiesV1) bool {
+	for _, override := range cap.ConfigOverrides {
+		if override.Key == "approvals_reviewer" {
+			return true
+		}
+	}
+	return false
 }
 
 // buildIntentInput assembles launchintent.Input from the already-resolved
 // team, launch options, and AMQ preflights (CWD/handle/root/base_root). It
 // resolves argv exactly the way the legacy tmux backend does -- trust-mode
 // built-ins + model args + member/global native args via the same
-// composeBinaryArgs layering -- so launchintent.Compile's sanitizer is the
-// ONLY thing that diverges the new path's argv from legacy (no --allowedTools,
-// no approvals_reviewer; see internal/launchintent's own tests).
-func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunchOptions, preflights []agentLaunchPreflight) (launchintent.Input, error) {
+// composeBinaryArgs layering -- so internal/launchintent.Compile's
+// contract-aware sanitizer is the only thing that diverges the new path's
+// argv from legacy.
+//
+// capabilities carries the per-provider facts observed from a prior probe
+// Prepare call (gh#747's two-phase design), keyed by provider name; nil on
+// the phase-1 probe call itself, which is exactly what makes that call
+// conservative -- a missing provider entry reads back as the zero-value
+// ProviderCapabilitiesV1, so every gated seat fact defaults to "below
+// floor" without any special-casing here.
+//
+// A claude seat eligible for #296's worker preauth (claudeWorkerPreauthEligible,
+// the same eligibility check the legacy backend uses) gets the scoped grant
+// candidate appended to its Args unconditionally; internal/launchintent's
+// sanitizer is what decides whether it survives, based on the seat's
+// ArgvGrammarVersion fact below. This keeps eligibility and grammar-gating
+// as two separate, independently testable decisions.
+func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunchOptions, preflights []agentLaunchPreflight, capabilities map[string]launchapi.ProviderCapabilitiesV1) (launchintent.Input, error) {
 	if len(t.Members) == 0 {
 		return launchintent.Input{}, fmt.Errorf("launchapi: team has no members")
 	}
@@ -180,21 +259,28 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 			trustMode = defaultTrustMode()
 		}
 		resolvedArgs := launchDefaultChildArgsWithTrust(m.Binary, true, modelArgsForBinary(m.Binary, model), nativeArgs, trustMode)
+		if claudeWorkerPreauthEligible(t.Project, opts.Profile, m.Role, m.Binary) {
+			resolvedArgs = append(resolvedArgs, "--allowedTools", launchintent.ScopedPreauthGrant)
+		}
 		executable := resolveAgentExecutable(m.Binary)
+		cap := capabilities[normalizedAgentBinary(m.Binary)]
 		seats = append(seats, launchintent.SeatFacts{
-			Handle:          pre.Handle,
-			Executable:      executable,
-			Args:            resolvedArgs,
-			Cwd:             launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: pre.CWD},
-			EnvOverlay:      nil,
-			ResumePolicy:    launchapi.ResumePolicyFresh,
-			OnLive:          "",
-			BootstrapPrompt: opts.StartupPrompts[m.Role],
-			RequireWake:     true,
-			NoGitignore:     opts.NoGitignore,
-			WakeAuditReason: "",
-			Injector:        wakeInjectorOptions(opts),
-			Symphony:        nil,
+			Handle:                  pre.Handle,
+			Executable:              executable,
+			Args:                    resolvedArgs,
+			Cwd:                     launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: pre.CWD},
+			EnvOverlay:              nil,
+			ResumePolicy:            launchapi.ResumePolicyFresh,
+			OnLive:                  "",
+			BootstrapPrompt:         opts.StartupPrompts[m.Role],
+			RequireWake:             true,
+			NoGitignore:             opts.NoGitignore,
+			WakeAuditReason:         "",
+			Injector:                wakeInjectorOptions(opts),
+			Symphony:                nil,
+			ArgvGrammarVersion:      cap.GrammarVersion,
+			ReviewerOverrideAllowed: reviewerOverrideAllowedFrom(cap),
+			AllowedArgumentForms:    append([]string(nil), cap.AllowedArgumentForms...),
 		})
 	}
 	if strings.TrimSpace(baseRoot) == "" {
@@ -241,18 +327,36 @@ func wakeInjectorOptions(opts teamLaunchOptions) *launchapi.InjectorOptionsV1 {
 }
 
 // assertNoForbiddenNewPathArgv is a defense-in-depth check on top of
-// internal/launchintent's own sanitizer: it re-asserts the two non-negotiable
-// argv guarantees directly on what launchapi.Apply actually returned, so a
-// future launchapi-side transformation cannot silently reintroduce either
-// token without failing this backend's own tests.
+// internal/launchintent's own sanitizer: it re-asserts gh#747's
+// non-negotiables directly on what launchapi.Apply actually returned, so a
+// future launchapi-side transformation cannot silently reintroduce a
+// forbidden token without failing this backend's own tests.
+//
+// approvals_reviewer is deliberately no longer forbidden here: at or above
+// the floor it is the intended, restored behavior (gh#747). What stays
+// forbidden regardless of floor: the equals-joined --allowedTools spelling
+// (never accepted upstream at any measured version, see
+// docs/amq-0.73.0-adoption-verdict.md section 3), a bare `Bash` grant
+// (gh#747's "never widen the grant" non-negotiable), and any --allowedTools
+// value that could be reinterpreted as a flag.
 func assertNoForbiddenNewPathArgv(commands []launchapi.CommandV1) error {
 	for _, cmd := range commands {
 		for i, arg := range cmd.Argv {
-			if arg == "--allowedTools" || strings.HasPrefix(arg, "--allowedTools=") {
-				return fmt.Errorf("launchapi: forbidden --allowedTools token in resolved argv: %q", arg)
+			if strings.HasPrefix(arg, "--allowedTools=") {
+				return fmt.Errorf("launchapi: forbidden equals-joined --allowedTools token in resolved argv: %q", arg)
 			}
-			if arg == "-c" && i+1 < len(cmd.Argv) && strings.HasPrefix(cmd.Argv[i+1], "approvals_reviewer=") {
-				return fmt.Errorf("launchapi: forbidden approvals_reviewer token in resolved argv: %q", cmd.Argv[i+1])
+			if arg != "--allowedTools" {
+				continue
+			}
+			if i+1 >= len(cmd.Argv) {
+				return fmt.Errorf("launchapi: --allowedTools with no value in resolved argv")
+			}
+			value := cmd.Argv[i+1]
+			if value == "Bash" {
+				return fmt.Errorf("launchapi: forbidden bare Bash grant in resolved argv")
+			}
+			if strings.HasPrefix(value, "-") {
+				return fmt.Errorf("launchapi: forbidden flag-looking --allowedTools value in resolved argv: %q", value)
 			}
 		}
 	}

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -336,9 +336,13 @@ func wakeInjectorOptions(opts teamLaunchOptions) *launchapi.InjectorOptionsV1 {
 // the floor it is the intended, restored behavior (gh#747). What stays
 // forbidden regardless of floor: the equals-joined --allowedTools spelling
 // (never accepted upstream at any measured version, see
-// docs/amq-0.73.0-adoption-verdict.md section 3), a bare `Bash` grant
-// (gh#747's "never widen the grant" non-negotiable), and any --allowedTools
-// value that could be reinterpreted as a flag.
+// docs/amq-0.73.0-adoption-verdict.md section 3), and any --allowedTools
+// value other than launchintent.ScopedPreauthGrant exactly -- gh#747's
+// non-negotiable is "Bash(gh pr create:*) only, never widen the grant," so
+// this mirrors internal/launchintent.sanitizeNewPathArgs's exact-equality
+// gate rather than a shape check: a user-supplied value like
+// `Bash(rm -rf:*)` must be caught here too, in case a future change to the
+// backend ever composes Commands without going through that sanitizer.
 func assertNoForbiddenNewPathArgv(commands []launchapi.CommandV1) error {
 	for _, cmd := range commands {
 		for i, arg := range cmd.Argv {
@@ -351,12 +355,8 @@ func assertNoForbiddenNewPathArgv(commands []launchapi.CommandV1) error {
 			if i+1 >= len(cmd.Argv) {
 				return fmt.Errorf("launchapi: --allowedTools with no value in resolved argv")
 			}
-			value := cmd.Argv[i+1]
-			if value == "Bash" {
-				return fmt.Errorf("launchapi: forbidden bare Bash grant in resolved argv")
-			}
-			if strings.HasPrefix(value, "-") {
-				return fmt.Errorf("launchapi: forbidden flag-looking --allowedTools value in resolved argv: %q", value)
+			if value := cmd.Argv[i+1]; value != launchintent.ScopedPreauthGrant {
+				return fmt.Errorf("launchapi: forbidden --allowedTools value in resolved argv, only %q is ever allowed: got %q", launchintent.ScopedPreauthGrant, value)
 			}
 		}
 	}

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
 
+	"github.com/omriariav/amq-squad/v2/internal/launchintent"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
@@ -60,9 +63,13 @@ func TestLaunchapiBackendOptInOnly(t *testing.T) {
 	}
 }
 
-func launchapiTestTeam() team.Team {
-	return team.Team{
-		Project:      "/proj",
+// launchapiTestTeam seeds a real team.json (gh#747's claudeWorkerPreauthEligible
+// reads team.ExistsProfile/team.ReadProfile from disk, so a fake in-memory-only
+// Project path would make every seat ineligible regardless of role/binary) and
+// returns the matching in-memory team.Team, Project pointed at the seeded dir.
+func launchapiTestTeam(t *testing.T) team.Team {
+	t.Helper()
+	tm := team.Team{
 		Orchestrated: true,
 		Lead:         "lead",
 		Members: []team.Member{
@@ -71,11 +78,18 @@ func launchapiTestTeam() team.Team {
 			{Role: "senior-dev", Binary: "codex", Handle: "senior-dev", Session: "s", CWD: "/proj-senior-dev-wt"},
 		},
 	}
+	tm.Project = seedTeam(t, tm)
+	return tm
 }
 
-func launchapiTestPreflights(baseRoot string) []agentLaunchPreflight {
+// launchapiTestPreflights builds preflights matching launchapiTestTeam's
+// roster. projectDir must be the same seeded team's Project: the lead
+// member carries no CWD override in that roster, so its EffectiveCWD (and
+// this preflight's CWD, which must match it for
+// TestLaunchapiBackendDualRunParity) falls back to the project root itself.
+func launchapiTestPreflights(projectDir, baseRoot string) []agentLaunchPreflight {
 	return []agentLaunchPreflight{
-		{Role: "lead", Handle: "lead", CWD: "/proj", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
+		{Role: "lead", Handle: "lead", CWD: projectDir, Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
 		{Role: "fullstack", Handle: "fullstack", CWD: "/proj-fullstack-wt", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
 		{Role: "senior-dev", Handle: "senior-dev", CWD: "/proj-senior-dev-wt", Root: "/proj/.agent-mail/s", BaseRoot: baseRoot, Workstream: "s"},
 	}
@@ -88,14 +102,14 @@ func launchapiTestPreflights(baseRoot string) []agentLaunchPreflight {
 // TestCompileRejectsMissingBaseRoot).
 func TestLaunchapiBackendRequiresExplicitBaseRoot(t *testing.T) {
 	b := launchapiTeamLaunchBackend{}
-	tm := launchapiTestTeam()
+	tm := launchapiTestTeam(t)
 	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
 
-	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("")); err == nil {
+	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights(tm.Project, ""), nil); err == nil {
 		t.Fatal("empty base_root: buildIntentInput accepted it")
 	}
 
-	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("/proj/.agent-mail")); err != nil {
+	if _, err := b.buildIntentInput(tm, opts, launchapiTestPreflights(tm.Project, "/proj/.agent-mail"), nil); err != nil {
 		t.Fatalf("non-empty base_root: buildIntentInput: %v", err)
 	}
 }
@@ -284,11 +298,11 @@ func TestLaunchapiBackendRejectsStaleDecisionForUnknownAction(t *testing.T) {
 // divergence would be an undocumented drift this test catches.
 func TestLaunchapiBackendDualRunParity(t *testing.T) {
 	b := launchapiTeamLaunchBackend{}
-	tm := launchapiTestTeam()
+	tm := launchapiTestTeam(t)
 	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
-	preflights := launchapiTestPreflights("/proj/.agent-mail")
+	preflights := launchapiTestPreflights(tm.Project, "/proj/.agent-mail")
 
-	input, err := b.buildIntentInput(tm, opts, preflights)
+	input, err := b.buildIntentInput(tm, opts, preflights, nil)
 	if err != nil {
 		t.Fatalf("buildIntentInput: %v", err)
 	}
@@ -315,11 +329,12 @@ func TestLaunchapiBackendDualRunParity(t *testing.T) {
 	}
 
 	// codex senior-dev seat: the resolved args this backend hands to
-	// launchintent.Compile still contain approvals_reviewer (sanitization is
-	// launchintent's job, exercised by TestCompileIntentDropsApprovalsReviewerOnNewPathOnly);
-	// what must hold here is that buildIntentInput's own resolution matches
-	// the legacy composer's resolution byte-for-byte before sanitization, so
-	// the only later divergence is the two documented guarantees.
+	// launchintent.Compile still contain approvals_reviewer (gh#747:
+	// sanitization is launchintent's job, exercised by
+	// TestCompileIntentKeepsApprovalsReviewerAtOrAboveFloor /
+	// TestCompileIntentDropsApprovalsReviewerBelowFloor); what must hold
+	// here is that buildIntentInput's own resolution matches the legacy
+	// composer's resolution byte-for-byte before sanitization.
 	seniorArgs := ([]string)(nil)
 	found := false
 	for _, seat := range input.Seats {
@@ -335,28 +350,224 @@ func TestLaunchapiBackendDualRunParity(t *testing.T) {
 	if strings.Join(seniorArgs, "\x00") != strings.Join(seniorLegacy, "\x00") {
 		t.Fatalf("senior-dev resolved args diverge from legacy before sanitization:\n launchapi=%v\n legacy=  %v", seniorArgs, seniorLegacy)
 	}
+
+	// claude fullstack seat: gh#747 restores parity at the floor. legacy
+	// injects the grant as one equals-joined token
+	// (claudePreauthChildArgs); the new path carries it as two tokens
+	// (internal/launchintent's sanitizer requirement, see
+	// docs/amq-0.73.0-adoption-verdict.md section 3: the equals-joined form
+	// is never accepted upstream at any measured version). Grant and
+	// reviewer key are no longer expected diffs at the floor: what must
+	// hold is the same VALUE, not the same token form.
+	fullstackArgs := ([]string)(nil)
+	found = false
+	for _, seat := range input.Seats {
+		if seat.Handle == "fullstack" {
+			fullstackArgs, found = seat.Args, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no fullstack seat in compiled input: %+v", input.Seats)
+	}
+	legacyGrant := claudeInScopePreauthAllowlist(opts.Workstream)
+	if len(legacyGrant) != 1 {
+		t.Fatalf("legacy grant = %v, want exactly one pattern", legacyGrant)
+	}
+	if legacyGrant[0] != launchintent.ScopedPreauthGrant {
+		t.Fatalf("legacy grant %q diverges from internal/launchintent.ScopedPreauthGrant %q: not one source of truth", legacyGrant[0], launchintent.ScopedPreauthGrant)
+	}
+	found = false
+	for i, arg := range fullstackArgs {
+		if arg == "--allowedTools" && i+1 < len(fullstackArgs) && fullstackArgs[i+1] == launchintent.ScopedPreauthGrant {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("fullstack seat args %v do not carry the two-token grant %q; legacy would preauth this eligible worker with the same value", fullstackArgs, launchintent.ScopedPreauthGrant)
+	}
 }
 
-// TestLaunchapiBackendHasNoWorkerPreauth pins gh#733's documented,
-// accepted dual-run limitation: a launchapi-composed seat never carries the
-// extra Bash(gh pr create:*) preauth grant legacy's applyClaudeWorkerPreauth
-// injects, because buildIntentInput never calls that legacy launcher-policy
-// path at all. This is intentional (see #296/#733's KNOWN LIMITATION note),
-// not a regression to "fix".
-func TestLaunchapiBackendHasNoWorkerPreauth(t *testing.T) {
-	b := launchapiTeamLaunchBackend{}
-	tm := launchapiTestTeam()
-	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
-	input, err := b.buildIntentInput(tm, opts, launchapiTestPreflights("/proj/.agent-mail"))
+// TestLaunchapiBackendHasWorkerPreauthAtFloor replaces
+// TestLaunchapiBackendHasNoWorkerPreauth (gh#747): the v2.30.0 dual-run
+// limitation is lifted. At or above the argv-grammar floor, an eligible
+// claude worker's compiled participant carries the two-token scoped grant
+// (never a bare Bash grant, never the equals-joined spelling), and an
+// eligible codex worker's compiled participant keeps approvals_reviewer
+// byte-identically. Below the floor both still drop, exercised by
+// TestLaunchapiBackendDualRunParity's buildIntentInput-level check and
+// internal/launchintent's own BelowFloor tests.
+func TestLaunchapiBackendHasWorkerPreauthAtFloor(t *testing.T) {
+	tm := launchapiTestTeam(t)
+	input, err := launchapiTeamLaunchBackend{}.buildIntentInput(tm, teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}, launchapiTestPreflights(tm.Project, "/proj/.agent-mail"), map[string]launchapi.ProviderCapabilitiesV1{
+		"claude": {Provider: "claude", GrammarVersion: 2},
+		"codex":  {Provider: "codex", ConfigOverrides: []launchapi.ConfigOverrideCapabilityV1{{Key: "approvals_reviewer", AllowedValues: []string{"user", "auto_review", "guardian_subagent"}}}},
+	})
 	if err != nil {
 		t.Fatalf("buildIntentInput: %v", err)
 	}
-	for _, seat := range input.Seats {
-		for _, arg := range seat.Args {
-			if strings.HasPrefix(arg, "--allowedTools") {
-				t.Fatalf("seat %q carries worker preauth %q; launchapi seats must have none during dual-run", seat.Handle, arg)
+	intent, _, err := launchintent.Compile(input)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	var sawClaudeGrant, sawCodexReviewer bool
+	for _, p := range intent.Participants {
+		if p.Handle == "fullstack" {
+			for i, arg := range p.Args {
+				if arg == "--allowedTools" {
+					if i+1 >= len(p.Args) {
+						t.Fatalf("fullstack --allowedTools has no value: %v", p.Args)
+					}
+					if p.Args[i+1] == "Bash" {
+						t.Fatalf("fullstack carries a bare Bash grant at the floor: %v", p.Args)
+					}
+					if p.Args[i+1] != launchintent.ScopedPreauthGrant {
+						t.Fatalf("fullstack grant = %q, want %q", p.Args[i+1], launchintent.ScopedPreauthGrant)
+					}
+					sawClaudeGrant = true
+				}
+				if strings.HasPrefix(arg, "--allowedTools=") {
+					t.Fatalf("fullstack carries the equals-joined spelling at the floor: %v", p.Args)
+				}
 			}
 		}
+		if p.Handle == "senior-dev" {
+			for i, arg := range p.Args {
+				if arg == "-c" && i+1 < len(p.Args) && p.Args[i+1] == `approvals_reviewer="auto_review"` {
+					sawCodexReviewer = true
+				}
+			}
+		}
+	}
+	if !sawClaudeGrant {
+		t.Fatalf("fullstack seat has no worker preauth at the floor: %+v", intent.Participants)
+	}
+	if !sawCodexReviewer {
+		t.Fatalf("senior-dev seat has no approvals_reviewer at the floor: %+v", intent.Participants)
+	}
+}
+
+// TestLaunchapiBackendHasNoWorkerPreauthBelowFloor is
+// TestLaunchapiBackendHasWorkerPreauthAtFloor's below-floor complement:
+// with no observed capabilities (the phase-1 probe's own shape, and any
+// compiled-in contract below the scoped-grammar floor), no participant
+// carries any --allowedTools spelling or approvals_reviewer, matching
+// gh#732's original behavior byte-for-byte.
+func TestLaunchapiBackendHasNoWorkerPreauthBelowFloor(t *testing.T) {
+	b := launchapiTeamLaunchBackend{}
+	tm := launchapiTestTeam(t)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+	input, err := b.buildIntentInput(tm, opts, launchapiTestPreflights(tm.Project, "/proj/.agent-mail"), nil)
+	if err != nil {
+		t.Fatalf("buildIntentInput: %v", err)
+	}
+	intent, _, err := launchintent.Compile(input)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	for _, p := range intent.Participants {
+		for i, arg := range p.Args {
+			if strings.HasPrefix(arg, "--allowedTools") {
+				t.Fatalf("participant %q carries worker preauth %q below the floor; must have none", p.Handle, arg)
+			}
+			if arg == "-c" && i+1 < len(p.Args) && strings.HasPrefix(p.Args[i+1], "approvals_reviewer=") {
+				t.Fatalf("participant %q carries approvals_reviewer %q below the floor; must have none", p.Handle, p.Args[i+1])
+			}
+		}
+	}
+}
+
+// launchapiTestStubAMQEnv stubs resolveTeamLaunchAMQEnv (buildTeamPreflights'
+// own injectable seam) so b.prepare can run end to end without a real amq
+// binary: every member resolves to the same project-scoped root, well above
+// the general-operation floor.
+func launchapiTestStubAMQEnv(t *testing.T, projectDir string) {
+	t.Helper()
+	original := resolveTeamLaunchAMQEnv
+	root := filepath.Join(projectDir, ".agent-mail", "s")
+	resolveTeamLaunchAMQEnv = func(cwd, profile, session, handle string) (amqEnv, error) {
+		return amqEnv{AMQVersion: "0.73.0", Root: root, BaseRoot: root, SessionName: "s", Me: handle}, nil
+	}
+	t.Cleanup(func() { resolveTeamLaunchAMQEnv = original })
+}
+
+// TestLaunchapiBackendProbePrepareIsSideEffectFree proves gh#747's two-phase
+// prepare (see the backend's prepare doc comment) does not itself write
+// anything: the seeded project tree is byte-identical before and after a
+// real b.prepare call that runs both the probe and the recompiled phase-2
+// Prepare. This backs the design decision directly, on the actual backend
+// code path rather than only the standalone launchapi.Prepare proof already
+// recorded in docs/amq-0.73.0-adoption-verdict.md.
+func TestLaunchapiBackendProbePrepareIsSideEffectFree(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	tm := launchapiTestTeam(t)
+	launchapiTestStubAMQEnv(t, tm.Project)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe, Profile: team.DefaultProfile}
+
+	before := snapshotTestTree(t, tm.Project)
+	b := launchapiTeamLaunchBackend{}
+	prepared, _, err := b.prepare(tm, opts)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	after := snapshotTestTree(t, tm.Project)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("project tree changed across the two-phase prepare call:\n before: %v\n after:  %v", before, after)
+	}
+	if prepared.Result.SubjectDigest == "" {
+		t.Fatal("phase-2 SubjectDigest is empty")
+	}
+}
+
+// TestLaunchapiBackendApplyBoundToPhaseTwoDigest proves prepare's returned
+// Prepared (what launch/DryRun/Apply all use) reflects phase 2 -- the
+// recompiled request with observed capability facts applied -- not the
+// phase-1 probe. On this repo's pinned launchapi module the two genuinely
+// differ (the probe's conservative intent carries no grant for the eligible
+// claude seat; phase 2's does), so this compares real digests rather than
+// asserting a tautology.
+func TestLaunchapiBackendApplyBoundToPhaseTwoDigest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	tm := launchapiTestTeam(t)
+	launchapiTestStubAMQEnv(t, tm.Project)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe, Profile: team.DefaultProfile}
+
+	b := launchapiTeamLaunchBackend{}
+	preflights, err := buildTeamPreflights(tm, opts)
+	if err != nil {
+		t.Fatalf("buildTeamPreflights: %v", err)
+	}
+	probeInput, err := b.buildIntentInput(tm, opts, preflights, nil)
+	if err != nil {
+		t.Fatalf("buildIntentInput (probe): %v", err)
+	}
+	probePrepared, err := b.callPrepare(opts, probeInput)
+	if err != nil {
+		t.Fatalf("callPrepare (probe): %v", err)
+	}
+
+	prepared, _, err := b.prepare(tm, opts)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if prepared.Result.SubjectDigest == probePrepared.Result.SubjectDigest {
+		t.Fatalf("prepare's returned digest matches the phase-1 probe's (%s); phase 2 should have recompiled a different request for the eligible claude seat", prepared.Result.SubjectDigest)
+	}
+	foundGrant := false
+	for _, p := range prepared.Request.Intent.Participants {
+		if p.Handle != "fullstack" {
+			continue
+		}
+		for i, arg := range p.Args {
+			if arg == "--allowedTools" && i+1 < len(p.Args) && p.Args[i+1] == launchintent.ScopedPreauthGrant {
+				foundGrant = true
+			}
+		}
+	}
+	if !foundGrant {
+		t.Fatalf("prepare's returned Request.Intent (what Apply is bound to) does not carry the phase-2 grant: %+v", prepared.Request.Intent.Participants)
 	}
 }
 

--- a/internal/launchintent/launchintent.go
+++ b/internal/launchintent/launchintent.go
@@ -266,11 +266,20 @@ func compileSeat(seat SeatFacts) (launchapi.ParticipantV1, error) {
 // capability facts say the negotiated contract accepts them; below the
 // floor (including "not observed", ArgvGrammarVersion's zero value) both
 // are dropped, matching gh#732's original unconditional behavior exactly.
-// Regardless of the floor, a bare `Bash` grant or a value that could be
-// reinterpreted as a flag is always refused: gh#747's non-negotiable is
-// "never widen the grant," not "trust the caller because the floor was
-// met." Nothing else is touched, so a caller's model/effort/permission-mode
-// args pass through unchanged. The legacy composer
+//
+// gh#747's non-negotiable is "Bash(gh pr create:*) only, never widen the
+// grant": at or above the floor, a two-token --allowedTools value survives
+// only when it is EXACTLY ScopedPreauthGrant, byte for byte. Any other
+// value, including a caller-supplied native --allowedTools arg smuggled
+// through resolvedArgs, is dropped, not merely shape-checked -- a laxer
+// "looks like a scoped pattern" check would let a value like
+// `Bash(rm -rf:*)` through at the floor, which is exactly the widening this
+// package must refuse. User-supplied --allowedTools is therefore not passed
+// through on the launchapi path in v2.30.1; the legacy path is unaffected
+// and keeps honoring configured native args normally.
+//
+// Nothing else is touched, so a caller's model/effort/permission-mode args
+// pass through unchanged. The legacy composer
 // (internal/cli/agent_defaults.go) is untouched by this package's logic
 // and keeps emitting its own byte-identical literals on the legacy path.
 func sanitizeNewPathArgs(args []string, argvGrammarVersion int, reviewerOverrideAllowed bool) []string {
@@ -289,7 +298,7 @@ func sanitizeNewPathArgs(args []string, argvGrammarVersion int, reviewerOverride
 				value = args[i+1]
 				i++
 			}
-			if hasValue && argvGrammarVersion >= scopedGrammarFloor && isSafeScopedGrant(value) {
+			if hasValue && argvGrammarVersion >= scopedGrammarFloor && value == ScopedPreauthGrant && isSafeScopedGrant(value) {
 				out = append(out, arg, value)
 			}
 			continue
@@ -311,14 +320,15 @@ func sanitizeNewPathArgs(args []string, argvGrammarVersion int, reviewerOverride
 	return out
 }
 
-// isSafeScopedGrant refuses a bare `Bash` grant (gh#747's "never widen the
+// isSafeScopedGrant is sanitizeNewPathArgs's inner defense-in-depth guard,
+// run in addition to (never instead of) the exact ScopedPreauthGrant
+// equality check: it refuses a bare `Bash` grant (gh#747's "never widen the
 // grant" non-negotiable: only a scoped pattern like Bash(gh pr create:*) is
 // acceptable, not blanket Bash) and any value that could be reinterpreted
 // as a flag (leading '-', matching the real grammar's own rejection of such
-// values, see docs/amq-0.73.0-adoption-verdict.md section 3). This check
-// runs regardless of where the value came from, including
-// ScopedPreauthGrant itself, so it stays correct even if that constant is
-// ever edited to something unsafe.
+// values, see docs/amq-0.73.0-adoption-verdict.md section 3). It stays
+// correct even if ScopedPreauthGrant is ever edited to something unsafe,
+// since it never trusts that the equality check alone is sufficient.
 func isSafeScopedGrant(value string) bool {
 	value = strings.TrimSpace(value)
 	if value == "" || value == "Bash" || strings.HasPrefix(value, "-") {

--- a/internal/launchintent/launchintent.go
+++ b/internal/launchintent/launchintent.go
@@ -1,12 +1,19 @@
 // Package launchintent compiles an already-resolved team profile, session,
 // and per-seat runtime facts into AMQ's public launchapi.LaunchIntentV1 and
 // launchapi.TargetV1. Compile is a pure function: it does no launching, no
-// filesystem or AMQ I/O, and no side effects. Every fact it needs (worktree
-// cwd, bootstrap prompt text, resolved native args) is resolved by the
-// caller and handed in; this package only shapes that data into the
-// contract types and applies the two argv guarantees measured against
-// released AMQ v0.70.0 (see gh#732): no --allowedTools token on any seat,
-// and approvals_reviewer dropped from the new path's argv.
+// filesystem or AMQ I/O, and no side effects, no probing. Every fact it
+// needs (worktree cwd, bootstrap prompt text, resolved native args, and as
+// of gh#747 the observed launchapi argv-grammar capability for the seat) is
+// resolved by the caller and handed in; this package only shapes that data
+// into the contract types and applies the argv guarantees measured against
+// released AMQ (see gh#732, gh#736, gh#747, and
+// docs/amq-0.73.0-adoption-verdict.md): the equals-joined --allowedTools
+// spelling is never accepted upstream at any measured version and is always
+// dropped; the two-token scoped grant and approvals_reviewer survive only
+// when the caller's per-seat capability facts say the negotiated contract
+// supports them, and the compiler still refuses (regardless of what the
+// caller passed in) a bare `Bash` grant or any value that could be
+// reinterpreted as a flag.
 package launchintent
 
 import (
@@ -15,6 +22,22 @@ import (
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
 )
+
+// ScopedPreauthGrant is the single source of truth for the PR-creation
+// preauth pattern this compiler may emit on the new path (gh#747), gated on
+// the seat's observed ArgvGrammarVersion. It mirrors
+// internal/cli/agent_defaults.go's legacy claudeInScopePreauthAllowlist
+// literal exactly; that legacy function is updated to reference this
+// constant instead of its own copy, so the pattern is spelled out in
+// exactly one place regardless of which path emits it.
+const ScopedPreauthGrant = "Bash(gh pr create:*)"
+
+// scopedGrammarFloor is the minimum ArgvGrammarVersion (see
+// docs/amq-0.73.0-adoption-verdict.md section 3/6) at or above which the
+// scoped --allowedTools grant is accepted by the real grammar. Below it,
+// the grant is refused upstream regardless of how it is spelled, so the
+// sanitizer drops it in the safe direction.
+const scopedGrammarFloor = 2
 
 // OperatorFacts is the resolved identity of the non-runnable operator seat.
 // The compiled participant carries nothing beyond the handle: launchapi
@@ -49,6 +72,29 @@ type SeatFacts struct {
 	WakeAuditReason string
 	Injector        *launchapi.InjectorOptionsV1
 	Symphony        *launchapi.SymphonyOptionsV1
+
+	// The following are caller-resolved capability facts (gh#747), derived
+	// from a prior read-only launchapi.Prepare probe's
+	// PreviewV1.Capabilities for this seat's provider
+	// (docs/amq-0.73.0-adoption-verdict.md: Prepare is read-only and
+	// deterministic, safe to call as a probe). Compile never probes
+	// anything itself; it only gates on what the caller observed.
+
+	// ArgvGrammarVersion is the seat provider's observed
+	// ProviderCapabilitiesV1.GrammarVersion. Zero means "not observed" and
+	// is treated as below the scoped-grammar floor, the safe direction.
+	ArgvGrammarVersion int
+	// ReviewerOverrideAllowed is whether the seat provider's observed
+	// capabilities carry a config_override entry with key
+	// "approvals_reviewer". False (including "not observed") drops the
+	// approvals_reviewer override, the safe direction.
+	ReviewerOverrideAllowed bool
+	// AllowedArgumentForms is the seat provider's observed
+	// ProviderCapabilitiesV1.AllowedArgumentForms, threaded through
+	// unmodified for callers built on top of this package (gh#748 named
+	// seats) that need to gate their own argv on it. Compile does not
+	// itself consume this field.
+	AllowedArgumentForms []string
 }
 
 // TargetFacts is the resolved launch target: the project root, the accepted
@@ -194,7 +240,7 @@ func compileSeat(seat SeatFacts) (launchapi.ParticipantV1, error) {
 		Handle:       handle,
 		Runnable:     true,
 		Executable:   executable,
-		Args:         sanitizeNewPathArgs(seat.Args),
+		Args:         sanitizeNewPathArgs(seat.Args, seat.ArgvGrammarVersion, seat.ReviewerOverrideAllowed),
 		Wrapper:      wrapper,
 		InitialInput: initialInput,
 		Cwd:          &launchapi.WorkingDirectoryV1{Kind: cwdKind, Path: cwdPath},
@@ -211,14 +257,23 @@ func compileSeat(seat SeatFacts) (launchapi.ParticipantV1, error) {
 	return participant, nil
 }
 
-// sanitizeNewPathArgs drops the two argv forms gh#732 measured as unsafe to
-// carry on the new path (see the package doc comment): --allowedTools (both
-// the equals-joined and two-token spellings) and -c approvals_reviewer=...
-// (Codex's trust-mode reviewer override). Nothing else is touched, so a
-// caller's model/effort/permission-mode args pass through unchanged. The
-// legacy composer (internal/cli/agent_defaults.go) is untouched by this
-// package and keeps emitting both on its own path.
-func sanitizeNewPathArgs(args []string) []string {
+// sanitizeNewPathArgs is the contract-aware new-path argv gate (gh#732,
+// gh#747). The equals-joined --allowedTools spelling is dropped
+// unconditionally: docs/amq-0.73.0-adoption-verdict.md section 3 measured
+// it rejected by every real grammar version, so there is no floor at which
+// keeping it would ever help. The two-token --allowedTools spelling and
+// -c approvals_reviewer=... survive only when the caller's per-seat
+// capability facts say the negotiated contract accepts them; below the
+// floor (including "not observed", ArgvGrammarVersion's zero value) both
+// are dropped, matching gh#732's original unconditional behavior exactly.
+// Regardless of the floor, a bare `Bash` grant or a value that could be
+// reinterpreted as a flag is always refused: gh#747's non-negotiable is
+// "never widen the grant," not "trust the caller because the floor was
+// met." Nothing else is touched, so a caller's model/effort/permission-mode
+// args pass through unchanged. The legacy composer
+// (internal/cli/agent_defaults.go) is untouched by this package's logic
+// and keeps emitting its own byte-identical literals on the legacy path.
+func sanitizeNewPathArgs(args []string, argvGrammarVersion int, reviewerOverrideAllowed bool) []string {
 	if len(args) == 0 {
 		return nil
 	}
@@ -227,14 +282,24 @@ func sanitizeNewPathArgs(args []string) []string {
 		arg := args[i]
 		switch {
 		case arg == "--allowedTools":
-			// Two-token spelling: also drop the value that follows it, if any.
-			if i+1 < len(args) {
+			// Two-token spelling: the value is the next token, if any.
+			value := ""
+			hasValue := i+1 < len(args)
+			if hasValue {
+				value = args[i+1]
 				i++
+			}
+			if hasValue && argvGrammarVersion >= scopedGrammarFloor && isSafeScopedGrant(value) {
+				out = append(out, arg, value)
 			}
 			continue
 		case strings.HasPrefix(arg, "--allowedTools="):
+			// Never accepted upstream at any measured version; always drop.
 			continue
 		case arg == "-c" && i+1 < len(args) && strings.HasPrefix(args[i+1], "approvals_reviewer="):
+			if reviewerOverrideAllowed {
+				out = append(out, arg, args[i+1])
+			}
 			i++
 			continue
 		}
@@ -244,4 +309,20 @@ func sanitizeNewPathArgs(args []string) []string {
 		return nil
 	}
 	return out
+}
+
+// isSafeScopedGrant refuses a bare `Bash` grant (gh#747's "never widen the
+// grant" non-negotiable: only a scoped pattern like Bash(gh pr create:*) is
+// acceptable, not blanket Bash) and any value that could be reinterpreted
+// as a flag (leading '-', matching the real grammar's own rejection of such
+// values, see docs/amq-0.73.0-adoption-verdict.md section 3). This check
+// runs regardless of where the value came from, including
+// ScopedPreauthGrant itself, so it stays correct even if that constant is
+// ever edited to something unsafe.
+func isSafeScopedGrant(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "Bash" || strings.HasPrefix(value, "-") {
+		return false
+	}
+	return strings.Contains(value, "(")
 }

--- a/internal/launchintent/launchintent_test.go
+++ b/internal/launchintent/launchintent_test.go
@@ -72,16 +72,22 @@ func TestCompileIntentSiblingWorktreeCwdPreserved(t *testing.T) {
 	}
 }
 
-func TestCompileIntentEmitsNoAllowedTools(t *testing.T) {
+// TestCompileIntentEmitsNoAllowedToolsBelowFloor replaces the old
+// unconditional TestCompileIntentEmitsNoAllowedTools (gh#747): below the
+// scoped-grammar floor (ArgvGrammarVersion's zero value included), every
+// --allowedTools spelling is still dropped, matching gh#732's original
+// behavior byte-for-byte.
+func TestCompileIntentEmitsNoAllowedToolsBelowFloor(t *testing.T) {
 	seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
 	// Simulate a caller that (incorrectly) tried to smuggle every native
 	// spelling of the flag through resolved args; Compile must still emit
-	// none of them.
+	// none of them below the floor.
 	seat.Args = []string{
 		"--permission-mode", "auto",
-		"--allowedTools", "Bash",
+		"--allowedTools", "Bash(gh pr create:*)",
 		"--allowedTools=Bash,Read",
 	}
+	seat.ArgvGrammarVersion = 1 // below scopedGrammarFloor (2)
 	in := Input{
 		Operator: OperatorFacts{Handle: "user"},
 		Seats:    []SeatFacts{seat},
@@ -94,13 +100,65 @@ func TestCompileIntentEmitsNoAllowedTools(t *testing.T) {
 	for _, p := range intent.Participants {
 		for _, arg := range p.Args {
 			if arg == "--allowedTools" || len(arg) >= len("--allowedTools=") && arg[:len("--allowedTools=")] == "--allowedTools=" {
-				t.Fatalf("participant %q emitted forbidden --allowedTools token: %q", p.Handle, arg)
+				t.Fatalf("participant %q emitted forbidden --allowedTools token below floor: %q", p.Handle, arg)
 			}
 		}
 	}
 }
 
-func TestCompileIntentDropsApprovalsReviewerOnNewPathOnly(t *testing.T) {
+// TestCompileIntentEmitsScopedAllowedToolsAtOrAboveFloor (gh#747): at or
+// above the scoped-grammar floor, the two-token grant survives; the
+// equals-joined spelling is still always dropped (never accepted upstream
+// at any measured version, see docs/amq-0.73.0-adoption-verdict.md section
+// 3), and a bare `Bash` value is still refused even at the floor (the
+// compiler's own "never widen the grant" defense-in-depth, independent of
+// what the caller passed in).
+func TestCompileIntentEmitsScopedAllowedToolsAtOrAboveFloor(t *testing.T) {
+	seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+	seat.Args = []string{
+		"--permission-mode", "auto",
+		"--allowedTools", ScopedPreauthGrant,
+		"--allowedTools=Bash,Read",
+	}
+	seat.ArgvGrammarVersion = 2
+	in := Input{
+		Operator: OperatorFacts{Handle: "user"},
+		Seats:    []SeatFacts{seat},
+		Target:   baseTarget(),
+	}
+	intent, _, err := Compile(in)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	member := intent.Participants[1]
+	want := []string{"--permission-mode", "auto", "--allowedTools", ScopedPreauthGrant}
+	if !reflect.DeepEqual(member.Args, want) {
+		t.Fatalf("compiled args = %v, want %v (equals-joined form must still be dropped)", member.Args, want)
+	}
+
+	bareSeat := baseSeat("senior-dev", "/Users/omri.a/Code/amq-squad")
+	bareSeat.Args = []string{"--allowedTools", "Bash"}
+	bareSeat.ArgvGrammarVersion = 2
+	in2 := Input{Operator: OperatorFacts{Handle: "user"}, Seats: []SeatFacts{bareSeat}, Target: baseTarget()}
+	intent2, _, err := Compile(in2)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	for _, arg := range intent2.Participants[1].Args {
+		if arg == "Bash" {
+			t.Fatalf("bare Bash grant must be refused even at or above the floor: %v", intent2.Participants[1].Args)
+		}
+	}
+}
+
+// TestCompileIntentDropsApprovalsReviewerBelowFloor replaces
+// TestCompileIntentDropsApprovalsReviewerOnNewPathOnly (gh#747): below the
+// floor (ReviewerOverrideAllowed false, including its zero value), the
+// override is still dropped, matching gh#732's original behavior
+// byte-for-byte. The legacy composer's own emission of the same literal is
+// locked separately in internal/cli/agent_defaults_gh732_legacy_lock_test.go,
+// unaffected by this package.
+func TestCompileIntentDropsApprovalsReviewerBelowFloor(t *testing.T) {
 	seat := baseSeat("senior-dev", "/Users/omri.a/Code/amq-squad")
 	seat.Executable = "/usr/bin/codex"
 	// The exact legacy literal from internal/cli/agent_defaults.go
@@ -118,7 +176,7 @@ func TestCompileIntentDropsApprovalsReviewerOnNewPathOnly(t *testing.T) {
 	member := intent.Participants[1]
 	for i, arg := range member.Args {
 		if arg == "-c" && i+1 < len(member.Args) && member.Args[i+1] == `approvals_reviewer="auto_review"` {
-			t.Fatalf("new path must drop approvals_reviewer, found it in compiled args: %v", member.Args)
+			t.Fatalf("below floor must drop approvals_reviewer, found it in compiled args: %v", member.Args)
 		}
 	}
 	// The rest of the trust-mode args survive: dropping approvals_reviewer
@@ -126,6 +184,30 @@ func TestCompileIntentDropsApprovalsReviewerOnNewPathOnly(t *testing.T) {
 	want := []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request"}
 	if !reflect.DeepEqual(member.Args, want) {
 		t.Fatalf("compiled args = %v, want %v", member.Args, want)
+	}
+}
+
+// TestCompileIntentKeepsApprovalsReviewerAtOrAboveFloor (gh#747): at or
+// above the floor (ReviewerOverrideAllowed true), the legacy literal
+// survives byte-identically, including its exact quoting.
+func TestCompileIntentKeepsApprovalsReviewerAtOrAboveFloor(t *testing.T) {
+	seat := baseSeat("senior-dev", "/Users/omri.a/Code/amq-squad")
+	seat.Executable = "/usr/bin/codex"
+	seat.Args = []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request", "-c", `approvals_reviewer="auto_review"`}
+	seat.ReviewerOverrideAllowed = true
+	in := Input{
+		Operator: OperatorFacts{Handle: "user"},
+		Seats:    []SeatFacts{seat},
+		Target:   baseTarget(),
+	}
+	intent, _, err := Compile(in)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	member := intent.Participants[1]
+	want := []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request", "-c", `approvals_reviewer="auto_review"`}
+	if !reflect.DeepEqual(member.Args, want) {
+		t.Fatalf("compiled args = %v, want %v (approvals_reviewer must survive byte-identically at or above the floor)", member.Args, want)
 	}
 }
 

--- a/internal/launchintent/launchintent_test.go
+++ b/internal/launchintent/launchintent_test.go
@@ -151,6 +151,46 @@ func TestCompileIntentEmitsScopedAllowedToolsAtOrAboveFloor(t *testing.T) {
 	}
 }
 
+// TestCompileIntentDropsForeignAllowedToolsValuesAtFloor (gh#747, lead
+// review finding): at or above the floor, only ScopedPreauthGrant exactly
+// survives. Any other value, including one shaped like a legitimate scoped
+// pattern, is dropped -- "never widen the grant" means exact equality, not
+// "looks safe."
+func TestCompileIntentDropsForeignAllowedToolsValuesAtFloor(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"destructive rm pattern", "Bash(rm -rf:*)"},
+		{"unrelated bare tool name", "Read"},
+		{"legitimate grant plus an extra entry", "Bash(gh pr create:*),Read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+			seat.Args = []string{"--allowedTools", tc.value}
+			seat.ArgvGrammarVersion = 2
+			in := Input{
+				Operator: OperatorFacts{Handle: "user"},
+				Seats:    []SeatFacts{seat},
+				Target:   baseTarget(),
+			}
+			intent, _, err := Compile(in)
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			for _, arg := range intent.Participants[1].Args {
+				if arg == tc.value {
+					t.Fatalf("foreign --allowedTools value %q survived at the floor: %v", tc.value, intent.Participants[1].Args)
+				}
+			}
+			if len(intent.Participants[1].Args) != 0 {
+				t.Fatalf("expected --allowedTools entirely dropped for a foreign value, got %v", intent.Participants[1].Args)
+			}
+		})
+	}
+}
+
 // TestCompileIntentDropsApprovalsReviewerBelowFloor replaces
 // TestCompileIntentDropsApprovalsReviewerOnNewPathOnly (gh#747): below the
 // floor (ReviewerOverrideAllowed false, including its zero value), the


### PR DESCRIPTION
## Summary
Lifts v2.30.0's known dual-run limitation. Two commits:

1. `docs(verdict): fold in the Prepare read-only/deterministic proof (recovered from #751)` -- one paragraph, docs-only, scope exception agreed with lead (recovered from an orphaned commit, see task/t10 thread).
2. `feat(gh747): restore worker preauth on the launchapi path, gated on observed argv grammar` -- the actual implementation.

### internal/launchintent
- `SeatFacts` gains `ArgvGrammarVersion int`, `ReviewerOverrideAllowed bool`, `AllowedArgumentForms []string` (caller-resolved capability facts; `Compile` stays pure, no probing).
- The new-path sanitizer becomes contract-aware: the two-token scoped grant (`--allowedTools`, `ScopedPreauthGrant`) survives at `ArgvGrammarVersion >= 2`; `approvals_reviewer` survives when `ReviewerOverrideAllowed`. Below floor, both still drop byte-identically to gh#732's original behavior.
- A bare `Bash` grant or a flag-looking value is refused unconditionally, regardless of floor -- gh#747's "never widen the grant" non-negotiable.
- New exported `ScopedPreauthGrant` constant is the single source of truth; `internal/cli/agent_defaults.go`'s legacy `claudeInScopePreauthAllowlist` now references it instead of its own literal copy.

### internal/cli/team_launch_launchapi.go
- Two-phase `Prepare` (the design decision from gh#747's third comment): phase 1 probes with the conservative intent (no capability facts, so every gated token drops safe); its `Preview.Capabilities` yields the observed per-provider facts; phase 2 recompiles with them and calls `Prepare` again. `Apply` is always bound to the phase-2 `Prepared`, never the probe's.
- `assertNoForbiddenNewPathArgv` reworked: `approvals_reviewer` is no longer forbidden (the restored, intended behavior at floor); what stays forbidden regardless of floor is the equals-joined `--allowedTools` spelling, a bare `Bash` grant, and any flag-looking `--allowedTools` value.

Legacy composer untouched in behavior.

## Test plan
- [x] All DoD tests green: `TestCompileIntentEmitsScopedAllowedToolsAtOrAboveFloor`, `TestCompileIntentEmitsNoAllowedToolsBelowFloor`, `TestCompileIntentKeepsApprovalsReviewerAtOrAboveFloor`, `TestCompileIntentDropsApprovalsReviewerBelowFloor`, `TestLaunchapiBackendHasWorkerPreauthAtFloor` (replaces `HasNoWorkerPreauth`), `TestLaunchapiBackendHasNoWorkerPreauthBelowFloor`, `TestLaunchapiBackendDualRunParity` (updated, grant/reviewer no longer expected diffs at floor), `TestLaunchapiBackendProbePrepareIsSideEffectFree`, `TestLaunchapiBackendApplyBoundToPhaseTwoDigest`.
- [x] Legacy-lock tests unchanged and green: `TestCodexApproveForMeArgsStillEmitsApprovalsReviewer`, `TestClaudePreauthChildArgsStillEmitsAllowedTools`, `TestClaudeInScopePreauthAllowlistContents`.
- [x] `TestV2300RemovesNothing` green.
- [x] Golden intent accepted by real installed v0.72.0 AND v0.73.0 binaries: `TestCompiledIntentAcceptedByReleasedAMQ` + `TestLaunchapiBackendDualRunParity`, both versions, both pass.
- [x] `make ci` green, zero FAIL lines (grepped exhaustively), run twice.
- [x] `go build ./...`, `go vet ./internal/cli/...`, `gofmt -l` all clean.
- [x] `git status`/diff scope matches exactly: `internal/launchintent/{launchintent.go,launchintent_test.go}`, `internal/cli/{team_launch_launchapi.go,team_launch_launchapi_test.go,agent_defaults.go}`, plus the one recovered docs paragraph.

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)