### PR TITLE
feat(launchintent): named seats from amq v0.73.0 on the launchapi path (gh#748)

### DIFF
--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -264,6 +264,16 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 		}
 		executable := resolveAgentExecutable(m.Binary)
 		cap := capabilities[normalizedAgentBinary(m.Binary)]
+		// gh#748: SessionName is only ever set for claude seats. Codex has
+		// no -n/--name argRules entry on any measured version (t8's own
+		// finding), so leaving it empty there is belt-and-suspenders on top
+		// of AllowedArgumentForms naturally never containing "-n" for
+		// codex; naming still only actually reaches argv when
+		// internal/launchintent.Compile also sees that capability fact.
+		sessionName := ""
+		if normalizedAgentBinary(m.Binary) == "claude" {
+			sessionName = opts.Workstream + "/" + pre.Handle
+		}
 		seats = append(seats, launchintent.SeatFacts{
 			Handle:                  pre.Handle,
 			Executable:              executable,
@@ -281,6 +291,7 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 			ArgvGrammarVersion:      cap.GrammarVersion,
 			ReviewerOverrideAllowed: reviewerOverrideAllowedFrom(cap),
 			AllowedArgumentForms:    append([]string(nil), cap.AllowedArgumentForms...),
+			SessionName:             sessionName,
 		})
 	}
 	if strings.TrimSpace(baseRoot) == "" {

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -387,6 +387,29 @@ func TestLaunchapiBackendDualRunParity(t *testing.T) {
 	if !found {
 		t.Fatalf("fullstack seat args %v do not carry the two-token grant %q; legacy would preauth this eligible worker with the same value", fullstackArgs, launchintent.ScopedPreauthGrant)
 	}
+
+	// gh#748: SessionName is an expected new-path-only diff, not a parity
+	// gap. Legacy has no concept of managed-plan naming at all (no field,
+	// no argv it ever emits for it) -- unlike CWD/Handle/Args above, which
+	// all have a direct legacy equivalent this test holds to the same
+	// value, SessionName's "legacy equivalent" is simply absent by design.
+	// buildIntentInput still resolves it deterministically for every claude
+	// seat regardless of whether naming ends up in compiled argv (that
+	// gate is AllowedArgumentForms, exercised by
+	// TestLaunchapiBackendRequestsNamedSeatsOnlyWhenAllowedArgumentFormsIncludeName).
+	for _, seat := range input.Seats {
+		switch seat.Handle {
+		case "fullstack", "lead":
+			want := opts.Workstream + "/" + seat.Handle
+			if seat.SessionName != want {
+				t.Fatalf("claude seat %q SessionName = %q, want %q (new-path-only, no legacy equivalent)", seat.Handle, seat.SessionName, want)
+			}
+		case "senior-dev":
+			if seat.SessionName != "" {
+				t.Fatalf("codex seat %q SessionName = %q, want empty: codex never gets managed-plan naming", seat.Handle, seat.SessionName)
+			}
+		}
+	}
 }
 
 // TestLaunchapiBackendHasWorkerPreauthAtFloor replaces
@@ -476,6 +499,99 @@ func TestLaunchapiBackendHasNoWorkerPreauthBelowFloor(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestLaunchapiBackendRequestsNamedSeatsOnlyWhenAllowedArgumentFormsIncludeName
+// (gh#748): buildIntentInput sets SessionName for every claude seat
+// unconditionally (the same "eligibility and gating are separate decisions"
+// pattern gh#747 established for the scoped grant), but naming only
+// actually reaches compiled argv when the observed capability says the
+// negotiated contract accepts it. A codex seat never gets -n even when its
+// own capability facts happen to include naming-adjacent forms, because
+// buildIntentInput never sets SessionName for a non-claude seat at all.
+func TestLaunchapiBackendRequestsNamedSeatsOnlyWhenAllowedArgumentFormsIncludeName(t *testing.T) {
+	tm := launchapiTestTeam(t)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+	preflights := launchapiTestPreflights(tm.Project, "/proj/.agent-mail")
+	b := launchapiTeamLaunchBackend{}
+
+	t.Run("claude gets -n when AllowedArgumentForms includes it", func(t *testing.T) {
+		input, err := b.buildIntentInput(tm, opts, preflights, map[string]launchapi.ProviderCapabilitiesV1{
+			"claude": {Provider: "claude", AllowedArgumentForms: []string{"-n", "--name"}},
+		})
+		if err != nil {
+			t.Fatalf("buildIntentInput: %v", err)
+		}
+		intent, _, err := launchintent.Compile(input)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		found := false
+		for _, p := range intent.Participants {
+			if p.Handle != "fullstack" {
+				continue
+			}
+			for i, arg := range p.Args {
+				if arg == "-n" && i+1 < len(p.Args) && p.Args[i+1] == "s/fullstack" {
+					found = true
+				}
+				if strings.HasPrefix(arg, "--name=") {
+					t.Fatalf("fullstack used the equals-joined --name= spelling: %v", p.Args)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("fullstack seat did not get -n s/fullstack with AllowedArgumentForms including it")
+		}
+	})
+
+	t.Run("claude does not get -n when AllowedArgumentForms lacks it", func(t *testing.T) {
+		input, err := b.buildIntentInput(tm, opts, preflights, nil)
+		if err != nil {
+			t.Fatalf("buildIntentInput: %v", err)
+		}
+		intent, _, err := launchintent.Compile(input)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		for _, p := range intent.Participants {
+			if p.Handle != "fullstack" {
+				continue
+			}
+			for _, arg := range p.Args {
+				if arg == "-n" || arg == "--name" {
+					t.Fatalf("fullstack seat carries naming with no observed AllowedArgumentForms: %v", p.Args)
+				}
+			}
+		}
+	})
+
+	t.Run("codex never gets -n even if its own capability facts include naming forms", func(t *testing.T) {
+		input, err := b.buildIntentInput(tm, opts, preflights, map[string]launchapi.ProviderCapabilitiesV1{
+			// Not a real upstream shape (t8/t10 confirmed codex has no
+			// -n/--name argRules entry on any measured version) -- exists
+			// only to prove buildIntentInput's own claude-only SessionName
+			// gate holds even if a capability probe ever reported this.
+			"codex": {Provider: "codex", AllowedArgumentForms: []string{"-n", "--name"}},
+		})
+		if err != nil {
+			t.Fatalf("buildIntentInput: %v", err)
+		}
+		intent, _, err := launchintent.Compile(input)
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+		for _, p := range intent.Participants {
+			if p.Handle != "senior-dev" {
+				continue
+			}
+			for _, arg := range p.Args {
+				if arg == "-n" || arg == "--name" {
+					t.Fatalf("codex seat carries naming, must never: %v", p.Args)
+				}
+			}
+		}
+	})
 }
 
 // launchapiTestStubAMQEnv stubs resolveTeamLaunchAMQEnv (buildTeamPreflights'

--- a/internal/launchintent/golden_amq_test.go
+++ b/internal/launchintent/golden_amq_test.go
@@ -43,6 +43,19 @@ func TestCompiledIntentAcceptedByReleasedAMQ(t *testing.T) {
 				ResumePolicy:    launchapi.ResumePolicyResume,
 				BootstrapPrompt: "You are lead. Orchestrate the v2.30.0 milestone.",
 				RequireWake:     true,
+				// gh#748: a named seat, gated on the pinned module's real
+				// argv grammar the same way the scoped grant and
+				// approvals_reviewer already are in this fixture --
+				// intent.Validate() below (called inside Compile) enforces
+				// the real per-provider argRules against whatever launchapi
+				// version is pinned, so this seat's -n token round-tripping
+				// through Marshal/Decode below is the "accepted by the real
+				// v0.73.0 binary" proof this issue's acceptance criteria asks
+				// for, exercised in-process against the pinned module exactly
+				// like docs/amq-0.73.0-adoption-verdict.md section 3/5's own
+				// measurements were.
+				AllowedArgumentForms: []string{"-n", "--name"},
+				SessionName:          "v2-30-0/lead",
 			},
 			{
 				Handle:          "senior-dev",

--- a/internal/launchintent/launchintent.go
+++ b/internal/launchintent/launchintent.go
@@ -6,18 +6,21 @@
 // of gh#747 the observed launchapi argv-grammar capability for the seat) is
 // resolved by the caller and handed in; this package only shapes that data
 // into the contract types and applies the argv guarantees measured against
-// released AMQ (see gh#732, gh#736, gh#747, and
+// released AMQ (see gh#732, gh#736, gh#747, gh#748, and
 // docs/amq-0.73.0-adoption-verdict.md): the equals-joined --allowedTools
 // spelling is never accepted upstream at any measured version and is always
 // dropped; the two-token scoped grant and approvals_reviewer survive only
 // when the caller's per-seat capability facts say the negotiated contract
 // supports them, and the compiler still refuses (regardless of what the
 // caller passed in) a bare `Bash` grant or any value that could be
-// reinterpreted as a flag.
+// reinterpreted as a flag. A seat's managed-plan naming (-n <session>/
+// <handle>, gh#748) is likewise gated on the caller's observed
+// AllowedArgumentForms, never assumed.
 package launchintent
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
@@ -38,6 +41,58 @@ const ScopedPreauthGrant = "Bash(gh pr create:*)"
 // the grant is refused upstream regardless of how it is spelled, so the
 // sanitizer drops it in the safe direction.
 const scopedGrammarFloor = 2
+
+// namedSeatArgumentForms are the argv forms gh#748's measured facts (see
+// docs/amq-0.73.0-adoption-verdict.md section 5) confirm accept a managed
+// session/handle label on Claude: "-n" and "--name", both two-token only
+// (no "--name=" inline special-case exists for either, matching the two-
+// token-only pattern already established for --allowedTools in gh#747).
+// Codex has no such argRules entry on any measured version, so a codex
+// seat's AllowedArgumentForms never contains either and naming is skipped
+// -- Compile does not special-case the provider, only what the caller
+// observed.
+var namedSeatArgumentForms = map[string]bool{"-n": true, "--name": true}
+
+// canonicalSessionLabelPattern mirrors the real grammar's own
+// canonicalSessionPattern exactly (internal/launch/config.go in the pinned
+// module): lowercase alphanumeric/underscore, starting with one of those,
+// then any run of lowercase alphanumeric/underscore/hyphen.
+var canonicalSessionLabelPattern = regexp.MustCompile(`^[a-z0-9_][a-z0-9_-]*$`)
+
+// validManagedSessionLabel mirrors the real grammar's own validSessionLabel
+// exactly (internal/launch/adapter.go in the pinned module): split on '/',
+// at most two parts, each matching canonicalSessionLabelPattern and not
+// leading with '-' (redundant with the pattern, kept for parity with
+// upstream's own belt-and-suspenders check), and the whole value non-empty.
+// Compile validates locally before ever emitting -n so a malformed
+// SessionName fails closed here with a clear error, not as an opaque
+// Prepare/launchapi refusal downstream.
+func validManagedSessionLabel(value string) bool {
+	if value == "" {
+		return false
+	}
+	parts := strings.Split(value, "/")
+	if len(parts) > 2 {
+		return false
+	}
+	for _, part := range parts {
+		if !canonicalSessionLabelPattern.MatchString(part) || strings.HasPrefix(part, "-") {
+			return false
+		}
+	}
+	return true
+}
+
+// allowsManagedName reports whether the seat's observed AllowedArgumentForms
+// includes either accepted spelling of the naming flag.
+func allowsManagedName(forms []string) bool {
+	for _, f := range forms {
+		if namedSeatArgumentForms[f] {
+			return true
+		}
+	}
+	return false
+}
 
 // OperatorFacts is the resolved identity of the non-runnable operator seat.
 // The compiled participant carries nothing beyond the handle: launchapi
@@ -90,11 +145,20 @@ type SeatFacts struct {
 	// approvals_reviewer override, the safe direction.
 	ReviewerOverrideAllowed bool
 	// AllowedArgumentForms is the seat provider's observed
-	// ProviderCapabilitiesV1.AllowedArgumentForms, threaded through
-	// unmodified for callers built on top of this package (gh#748 named
-	// seats) that need to gate their own argv on it. Compile does not
-	// itself consume this field.
+	// ProviderCapabilitiesV1.AllowedArgumentForms. gh#748: Compile now
+	// consumes this itself to gate whether SessionName below is ever
+	// emitted (previously threaded through unconsumed for a future caller;
+	// that caller is this package, now).
 	AllowedArgumentForms []string
+	// SessionName is the caller-resolved "<session>/<handle>" managed-plan
+	// label (gh#748). Compile emits it as -n <SessionName> (two argv
+	// tokens, never --name=) only when AllowedArgumentForms says the
+	// negotiated contract accepts the naming flag; empty means "do not
+	// attempt naming for this seat" (the default, and always the case for
+	// a provider gh#748's measured facts say never accepts it, such as
+	// codex). A non-empty value that fails local validation is a caller
+	// bug and errors rather than silently launching unnamed.
+	SessionName string
 }
 
 // TargetFacts is the resolved launch target: the project root, the accepted
@@ -236,11 +300,26 @@ func compileSeat(seat SeatFacts) (launchapi.ParticipantV1, error) {
 		wrapper = &w
 	}
 
+	args := sanitizeNewPathArgs(seat.Args, seat.ArgvGrammarVersion, seat.ReviewerOverrideAllowed)
+	if seat.SessionName != "" {
+		if !allowsManagedName(seat.AllowedArgumentForms) {
+			// Below the floor (including "not observed"): drop naming
+			// silently, the same safe direction gh#747 established for the
+			// scoped grant and approvals_reviewer -- this is an expected,
+			// routine outcome (e.g. a codex seat, or a claude seat on a
+			// pre-v0.73.0 pin), not a caller error.
+		} else if !validManagedSessionLabel(seat.SessionName) {
+			return launchapi.ParticipantV1{}, fmt.Errorf("invalid SessionName %q for managed naming", seat.SessionName)
+		} else {
+			args = append(args, "-n", seat.SessionName)
+		}
+	}
+
 	participant := launchapi.ParticipantV1{
 		Handle:       handle,
 		Runnable:     true,
 		Executable:   executable,
-		Args:         sanitizeNewPathArgs(seat.Args, seat.ArgvGrammarVersion, seat.ReviewerOverrideAllowed),
+		Args:         args,
 		Wrapper:      wrapper,
 		InitialInput: initialInput,
 		Cwd:          &launchapi.WorkingDirectoryV1{Kind: cwdKind, Path: cwdPath},

--- a/internal/launchintent/launchintent_test.go
+++ b/internal/launchintent/launchintent_test.go
@@ -2,6 +2,7 @@ package launchintent
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
@@ -248,6 +249,130 @@ func TestCompileIntentKeepsApprovalsReviewerAtOrAboveFloor(t *testing.T) {
 	want := []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request", "-c", `approvals_reviewer="auto_review"`}
 	if !reflect.DeepEqual(member.Args, want) {
 		t.Fatalf("compiled args = %v, want %v (approvals_reviewer must survive byte-identically at or above the floor)", member.Args, want)
+	}
+}
+
+// TestCompileIntentNamedSeatCarriesSessionHandleName (gh#748): a seat whose
+// observed AllowedArgumentForms includes "-n" and whose SessionName is set
+// gets -n <SessionName> appended as two argv tokens, in "<session>/<handle>"
+// shape (docs/amq-0.73.0-adoption-verdict.md section 5), never --name=.
+func TestCompileIntentNamedSeatCarriesSessionHandleName(t *testing.T) {
+	seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+	seat.AllowedArgumentForms = []string{"-n", "--name"}
+	seat.SessionName = "v2-30-0/fullstack"
+	in := Input{
+		Operator: OperatorFacts{Handle: "user"},
+		Seats:    []SeatFacts{seat},
+		Target:   baseTarget(),
+	}
+	intent, _, err := Compile(in)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	member := intent.Participants[1]
+	want := []string{"--permission-mode", "auto", "-n", "v2-30-0/fullstack"}
+	if !reflect.DeepEqual(member.Args, want) {
+		t.Fatalf("compiled args = %v, want %v", member.Args, want)
+	}
+	for _, arg := range member.Args {
+		if strings.HasPrefix(arg, "--name=") {
+			t.Fatalf("named seat used the equals-joined --name= spelling, never allowed: %v", member.Args)
+		}
+	}
+}
+
+// TestCompileIntentUnnamedSeatIsByteIdenticalToV1 (gh#748): a seat with an
+// empty SessionName (the default) compiles identically whether or not
+// AllowedArgumentForms includes naming forms -- naming is opt-in per seat
+// via SessionName, not auto-applied whenever the capability is present.
+func TestCompileIntentUnnamedSeatIsByteIdenticalToV1(t *testing.T) {
+	withForms := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+	withForms.AllowedArgumentForms = []string{"-n", "--name"}
+	withoutForms := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+
+	for name, seat := range map[string]SeatFacts{"forms present, SessionName empty": withForms, "forms absent, SessionName empty": withoutForms} {
+		t.Run(name, func(t *testing.T) {
+			intent, _, err := Compile(Input{
+				Operator: OperatorFacts{Handle: "user"},
+				Seats:    []SeatFacts{seat},
+				Target:   baseTarget(),
+			})
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			want := []string{"--permission-mode", "auto"}
+			if !reflect.DeepEqual(intent.Participants[1].Args, want) {
+				t.Fatalf("compiled args = %v, want %v (byte-identical to the pre-gh#748 V1 shape)", intent.Participants[1].Args, want)
+			}
+		})
+	}
+}
+
+// TestCompileIntentDropsNameWhenArgumentFormsLackIt (gh#748): SessionName
+// set but AllowedArgumentForms does not include "-n"/"--name" (a codex
+// seat's actual shape on every measured version, or a claude seat below the
+// naming floor) -- naming is silently skipped, matching gh#747's established
+// safe-direction default, not an error.
+func TestCompileIntentDropsNameWhenArgumentFormsLackIt(t *testing.T) {
+	cases := []struct {
+		name  string
+		forms []string
+	}{
+		{"no forms observed at all", nil},
+		{"codex-shaped forms (no -n/--name entry)", []string{"--sandbox", "--ask-for-approval"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seat := baseSeat("senior-dev", "/Users/omri.a/Code/amq-squad")
+			seat.AllowedArgumentForms = tc.forms
+			seat.SessionName = "v2-30-0/senior-dev"
+			intent, _, err := Compile(Input{
+				Operator: OperatorFacts{Handle: "user"},
+				Seats:    []SeatFacts{seat},
+				Target:   baseTarget(),
+			})
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			for _, arg := range intent.Participants[1].Args {
+				if arg == "-n" || arg == "--name" || strings.HasPrefix(arg, "--name=") {
+					t.Fatalf("naming form emitted despite AllowedArgumentForms lacking it: %v", intent.Participants[1].Args)
+				}
+			}
+		})
+	}
+}
+
+// TestCompileIntentRejectsMalformedSessionName (gh#748): a non-empty
+// SessionName that fails the same local shape check the real grammar uses
+// (validManagedSessionLabel, mirroring upstream's validSessionLabel) errors
+// at Compile time rather than silently launching unnamed or deferring the
+// failure to an opaque Prepare/launchapi refusal.
+func TestCompileIntentRejectsMalformedSessionName(t *testing.T) {
+	cases := []string{
+		"",                 // handled separately (empty means "no naming"), included for contrast
+		"a/b/c",            // more than 2 parts
+		"-leading-dash",    // leading '-'
+		"Has/Upper",        // canonical pattern is lowercase only
+		"has space/handle", // space not in canonical pattern
+	}
+	for _, value := range cases {
+		if value == "" {
+			continue // empty SessionName means "skip naming", covered elsewhere, not a malformed-value case
+		}
+		t.Run(value, func(t *testing.T) {
+			seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+			seat.AllowedArgumentForms = []string{"-n"}
+			seat.SessionName = value
+			_, _, err := Compile(Input{
+				Operator: OperatorFacts{Handle: "user"},
+				Seats:    []SeatFacts{seat},
+				Target:   baseTarget(),
+			})
+			if err == nil {
+				t.Fatalf("Compile accepted malformed SessionName %q", value)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `internal/launchintent`: `SeatFacts` gains `SessionName` (the caller-resolved `"<session>/<handle>"` managed-plan label) and `Compile` now consumes `AllowedArgumentForms` itself (previously threaded through unused, per t10's own doc comment). `compileSeat` emits `-n <SessionName>` as two argv tokens, **never** `--name=`, only when `AllowedArgumentForms` includes `"-n"` or `"--name"` and `SessionName` is non-empty -- the same "eligibility and gating are separate decisions" pattern gh#747 established for the scoped grant.
- A non-empty `SessionName` is validated locally before ever emitting `-n`: `validManagedSessionLabel` mirrors the pinned module's own `validSessionLabel` exactly (split on `/`, max 2 parts, canonical lowercase pattern, no leading `-`) and errors at `Compile` time on a malformed value rather than deferring to an opaque `Prepare` refusal.
- `internal/cli/team_launch_launchapi.go`: `buildIntentInput` sets `SessionName = workstream/handle` for every claude seat unconditionally; codex seats always get an empty `SessionName` (t8/t10 confirmed codex has no `-n`/`--name` argRules entry on any measured version, so this is belt-and-suspenders on top of `AllowedArgumentForms` naturally excluding it too). `AllowedArgumentForms` already flowed from t10's two-phase probe.
- `golden_amq_test.go`: the lead seat now carries `AllowedArgumentForms` + `SessionName`, so the existing real-pinned-module `Validate()`/round-trip proof also covers a named seat -- verified locally against the real v0.72.0 and v0.73.0 binaries (this is the same test the CI floor lane already runs, no `ci.yml` change needed).
- `TestLaunchapiBackendDualRunParity` updated: `SessionName` is asserted as an expected new-path-only diff (no legacy equivalent to compare against), distinct from the CWD/Handle/Args facts that do have one.

Legacy path untouched; legacy-lock tests unaffected. No schema or version-gate changes (`LaunchIntentV1`/`ParticipantV1` are byte-identical through v0.73.0, per t8's own finding).

## Scope note

`internal/launchintent/golden_amq_test.go` was touched in addition to the declared worktree scope (`launchintent.go`/`launchintent_test.go`, `team_launch_launchapi.go`/`team_launch_launchapi_test.go`) -- necessary to satisfy the DoD's "golden intent with a named seat accepted by the real v0.73.0 binary" against the same test the CI floor lane runs, flagging for visibility.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `TestCompileIntentNamedSeatCarriesSessionHandleName`, `TestCompileIntentUnnamedSeatIsByteIdenticalToV1`, `TestCompileIntentDropsNameWhenArgumentFormsLackIt`, `TestCompileIntentRejectsMalformedSessionName` (bonus) all green
- [x] `TestLaunchapiBackendRequestsNamedSeatsOnlyWhenAllowedArgumentFormsIncludeName` green (claude gets `-n`, codex never, even when a synthetic capability probe claims otherwise)
- [x] `TestLaunchapiBackendDualRunParity` green with the new `SessionName` assertion
- [x] `TestCompiledIntentAcceptedByReleasedAMQ` (the golden test, now with a named seat) verified locally against real v0.72.0 and v0.73.0 `amq` binaries, not just skip-gated
- [x] All legacy-lock tests (`TestCodexApproveForMeArgsStillEmitsApprovalsReviewer`, `TestClaudePreauthChildArgsStillEmitsAllowedTools`) unchanged and green
- [x] Full `make ci`: green except the same pre-existing `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout` flake confirmed unrelated throughout this whole workstream

Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)