### PR TITLE
release: amq-squad v2.30.1

### DIFF
--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2300" id="toc-whats-new-in-v2300">What's new
-in v2.30.0</a></li>
+<li><a href="#whats-new-in-v2301" id="toc-whats-new-in-v2301">What's new
+in v2.30.1</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2300">What's new in v2.30.0</a></li>
+<li><a href="#whats-new-in-v2301">What's new in v2.30.1</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,49 +342,45 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2300">What's new in v2.30.0</h2>
-<p>amq-squad becomes an opt-in layer above amq's public
-<code>launchapi</code> Go package. Strictly additive: the legacy
-tmux-pane launch path is unchanged and remains the default;
-<code>TestV2300RemovesNothing</code> enforces that mechanically.</p>
+<h2 id="whats-new-in-v2301">What's new in v2.30.1</h2>
+<p>Re-verifies and adopts amq v0.72.0/v0.73.0 on the opt-in launchapi
+path. Strictly additive: the legacy tmux-pane launch path is unchanged
+and remains the default; the general-operation AMQ floor stays
+0.60.0.</p>
 <ul>
-<li>A new pure intent compiler (<code>internal/launchintent</code>)
-turns a resolved team profile into amq's public
-<code>LaunchIntentV1</code>/<code>TargetV1</code>: no launching, no side
-effects (#732). Two argv decisions are enforced at compile time on the
-new path only, measured against released amq v0.70.0: no
-<code>--allowedTools</code> token on any seat, and
-<code>approvals_reviewer</code> dropped from Codex's trust-mode args.
-The legacy composer keeps emitting both, byte-identically.</li>
-<li>A new opt-in <code>--launch-via launchapi</code> team-launch
-backend, tmux only, never selected by <code>auto</code> or an absent
-flag (#733). Every required action <code>launchapi.Prepare</code>
-surfaces becomes an operator gate on a
-<code>gate/launchapi-&lt;kind&gt;-&lt;id&gt;</code> thread: the backend
-never answers a decision without an explicit, repeatable
-<code>--launchapi-decision ACTION_ID=CHOICE</code> (validated against
-the action's allowed choices; a decision for an action Prepare did not
-return is rejected as stale). Re-running with the answer surfaces only
-the still-undecided actions and completes the launch once every action
-has a valid decision. <strong>Known limitation, not a bug:</strong>
-launchapi seats have no worker preauth during dual-run; the legacy
-backend's preauth is unchanged, and legacy remains the default launch
-path.</li>
-<li>A new Go-API-only adoption seam (<code>internal/adoptionseam</code>)
-talks to <code>launchapi</code> exclusively: no shelling out to the amq
-CLI, no upward root discovery (#734). <code>Prepare</code> fails closed
-before any <code>launchapi</code> call if the target's base root is
-missing, closing the bug class that let AMQ's own <code>.amqrc</code>
-discovery retarget writes into a parent repo's live base root from a
-nested task-worktree cwd. The five inherited AMQ root/session identity
-variables are stripped before any child sees them (#735).</li>
-<li>The launchapi backend gets its own adoption floor (amq v0.70.0),
-deliberately separate from the general-operation floor
-(<code>doctor</code> minimum stays 0.60.0), negotiated at runtime via
-<code>launchapi.Negotiate</code> and a new pinned CI lane, not enforced
-by <code>doctor</code> (#736).</li>
+<li>Measured re-verification of amq v0.71.0/v0.72.0/v0.73.0 against the
+launchapi path (#745). The gh#734 nested-worktree project-root bug still
+reproduces identically on every version at read time, so the fail-closed
+<code>base_root</code> seam stays as defense in depth, not redundant.
+<code>launchapi</code>'s contract (<code>Compatibility()</code>) is
+unchanged across every measured version; the internal grammar changes
+below surface only at <code>Prepare</code>'s per-call
+<code>Capabilities</code>. <code>Prepare</code> itself is confirmed
+read-only and deterministic.</li>
+<li>The launchapi backend's adoption floor moves to v0.72.0, module
+pinned to v0.73.0 (#746). The floor is enforced by the go.mod pin plus a
+runtime <code>GrammarVersion</code> check, since
+<code>launchapi.Negotiate</code> cannot see it.</li>
+<li><strong>The launchapi path now carries the same scoped worker
+preauth as legacy, at amq &gt;= v0.72.0: v2.30.0's known dual-run
+limitation is lifted</strong> (#747). An eligible claude worker gets the
+exact two-token scoped grant (<code>--allowedTools</code>,
+<code>Bash(gh pr create:*)</code>, literal only, never widened), and an
+eligible codex worker keeps <code>approvals_reviewer</code>. Below
+floor, both still drop, byte-identical to v2.30.0. The backend runs a
+two-phase <code>Prepare</code> to derive these facts safely: a
+side-effect-free probe, then a recompile before the real
+<code>Apply</code>.</li>
+<li>Named seats from amq v0.73.0 (#748): an eligible claude worker's
+launch now carries its <code>&lt;workstream&gt;/&lt;handle&gt;</code>
+label as a managed <code>-n</code> argv token, validated at compile time
+against a byte-identical mirror of the real grammar's label rules. Codex
+seats never receive it.</li>
+<li>The launchapi path is still opt-in via
+<code>--launch-via launchapi</code>; the default flip to launchapi is
+tracked separately in the v2.31.0 milestone, not this release.</li>
 </ul>
-<p>Full detail in <a href="docs/v2.30.0-release-notes.md">the v2.30.0
+<p>Full detail in <a href="docs/v2.30.1-release-notes.md">the v2.30.1
 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
@@ -396,7 +392,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.0</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.1</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.30.0](#whats-new-in-v2300)
+- [What's new in v2.30.1](#whats-new-in-v2301)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,45 +38,40 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.30.0
+## What's new in v2.30.1
 
-amq-squad becomes an opt-in layer above amq's public `launchapi` Go package.
+Re-verifies and adopts amq v0.72.0/v0.73.0 on the opt-in launchapi path.
 Strictly additive: the legacy tmux-pane launch path is unchanged and remains
-the default; `TestV2300RemovesNothing` enforces that mechanically.
+the default; the general-operation AMQ floor stays 0.60.0.
 
-- A new pure intent compiler (`internal/launchintent`) turns a resolved team
-  profile into amq's public `LaunchIntentV1`/`TargetV1`: no launching, no
-  side effects (#732). Two argv decisions are enforced at compile time on
-  the new path only, measured against released amq v0.70.0: no
-  `--allowedTools` token on any seat, and `approvals_reviewer` dropped from
-  Codex's trust-mode args. The legacy composer keeps emitting both,
-  byte-identically.
-- A new opt-in `--launch-via launchapi` team-launch backend, tmux only,
-  never selected by `auto` or an absent flag (#733). Every required action
-  `launchapi.Prepare` surfaces becomes an operator gate on a
-  `gate/launchapi-<kind>-<id>` thread: the backend never answers a decision
-  without an explicit, repeatable `--launchapi-decision ACTION_ID=CHOICE`
-  (validated against the action's allowed choices; a decision for an action
-  Prepare did not return is rejected as stale). Re-running with the answer
-  surfaces only the still-undecided actions and completes the launch once
-  every action has a valid decision. **Known limitation, not a bug:**
-  launchapi seats have no worker preauth during dual-run; the legacy
-  backend's preauth is unchanged, and legacy remains the default launch
-  path.
-- A new Go-API-only adoption seam (`internal/adoptionseam`) talks to
-  `launchapi` exclusively: no shelling out to the amq CLI, no upward root
-  discovery (#734). `Prepare` fails closed before any `launchapi` call if
-  the target's base root is missing, closing the bug class that let AMQ's
-  own `.amqrc` discovery retarget writes into a parent repo's live base
-  root from a nested task-worktree cwd. The five inherited AMQ
-  root/session identity variables are stripped before any child sees them
-  (#735).
-- The launchapi backend gets its own adoption floor (amq v0.70.0),
-  deliberately separate from the general-operation floor (`doctor` minimum
-  stays 0.60.0), negotiated at runtime via `launchapi.Negotiate` and a new
-  pinned CI lane, not enforced by `doctor` (#736).
+- Measured re-verification of amq v0.71.0/v0.72.0/v0.73.0 against the
+  launchapi path (#745). The gh#734 nested-worktree project-root bug still
+  reproduces identically on every version at read time, so the fail-closed
+  `base_root` seam stays as defense in depth, not redundant. `launchapi`'s
+  contract (`Compatibility()`) is unchanged across every measured version;
+  the internal grammar changes below surface only at
+  `Prepare`'s per-call `Capabilities`. `Prepare` itself is confirmed
+  read-only and deterministic.
+- The launchapi backend's adoption floor moves to v0.72.0, module pinned to
+  v0.73.0 (#746). The floor is enforced by the go.mod pin plus a runtime
+  `GrammarVersion` check, since `launchapi.Negotiate` cannot see it.
+- **The launchapi path now carries the same scoped worker preauth as
+  legacy, at amq >= v0.72.0: v2.30.0's known dual-run limitation is
+  lifted** (#747). An eligible claude worker gets the exact two-token
+  scoped grant (`--allowedTools`, `Bash(gh pr create:*)`, literal only,
+  never widened), and an eligible codex worker keeps `approvals_reviewer`.
+  Below floor, both still drop, byte-identical to v2.30.0. The backend runs
+  a two-phase `Prepare` to derive these facts safely: a side-effect-free
+  probe, then a recompile before the real `Apply`.
+- Named seats from amq v0.73.0 (#748): an eligible claude worker's launch
+  now carries its `<workstream>/<handle>` label as a managed `-n` argv
+  token, validated at compile time against a byte-identical mirror of the
+  real grammar's label rules. Codex seats never receive it.
+- The launchapi path is still opt-in via `--launch-via launchapi`; the
+  default flip to launchapi is tracked separately in the v2.31.0 milestone,
+  not this release.
 
-Full detail in [the v2.30.0 release notes](docs/v2.30.0-release-notes.md).
+Full detail in [the v2.30.1 release notes](docs/v2.30.1-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -94,7 +89,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.0
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.1
 ```
 
 Install the skills from the plugin marketplace when agents should use the

--- a/docs/v2.30.1-release-notes.md
+++ b/docs/v2.30.1-release-notes.md
@@ -1,0 +1,114 @@
+# amq-squad v2.30.1
+
+Re-verifies and adopts amq v0.72.0/v0.73.0 on the opt-in launchapi path.
+Upstream shipped all three of the v2.30.0 #648 asks in v0.72.0 (project-root
+authority, scoped `--allowedTools` grammar, an `approvals_reviewer`
+allowlist) and named seats in v0.73.0. Strictly additive: the legacy launch
+path is untouched and remains the default; the general-operation AMQ floor
+stays 0.60.0. Milestone issues: #745, #746, #747, #748.
+PRs: #750, #751, #752, #753.
+
+## Verification verdict (#745, PR #751)
+
+Measured re-verification of amq v0.71.0, v0.72.0, v0.73.0 against the
+launchapi path, in the style of the v0.70.0 diff-verdict:
+`docs/amq-0.73.0-adoption-verdict.md`.
+
+- All real-AMQ compatibility and wake lanes pass on all three versions.
+- The gh#734 nested-worktree project-root bug still reproduces identically
+  on every version at read time: `amq env`'s upward `.amqrc` discovery is
+  unchanged. `amq setup --project-root` fixes it only when explicitly
+  invoked, which amq-squad's own worktree creation never does. **The
+  fail-closed `base_root` seam stays as defense in depth, not redundant.**
+- The scoped `--allowedTools` grammar and the `approvals_reviewer`
+  allowlist both landed as changes to amq's internal grammar tables, not to
+  the `launchapi` package contract itself: `launchapi.Compatibility()` is
+  byte-identical from v0.70.0 through v0.73.0. The real per-call gate is
+  `PrepareResultV1.Preview.Capabilities[].GrammarVersion`, confirmed
+  deterministic and available without a real provider binary present.
+- `Prepare` is confirmed read-only and deterministic: two identical calls
+  in one process produce a byte-identical project tree and an identical
+  `SubjectDigest`, the basis for the two-phase probe design #747 and #748
+  both use.
+
+## Adoption floor: v0.72.0, module pinned to v0.73.0 (#746, PR #750)
+
+- `internal/adoptionseam.AdoptionFloorAMQVersion` moves to v0.72.0; go.mod
+  pins the `agent-message-queue` module to v0.73.0.
+- Since `launchapi.Negotiate`'s contract cannot see the internal grammar
+  changes, the floor is enforced two ways instead: the go.mod pin itself
+  (`TestPinnedAMQModuleAtOrAboveAdoptionFloor`, reading go.mod directly
+  since `go test` binaries in this toolchain embed no dependency info), and
+  the runtime `GrammarVersion` check #747 wires into `Prepare`.
+- The CI adoption-floor lane moves to v0.72.0. `TestV2300RemovesNothing`'s
+  go.mod check is relaxed from an exact version string to a presence check,
+  so it keeps proving the two floors are independent without hardcoding a
+  version that future floor bumps would immediately go stale against.
+
+## Worker preauth restored on the launchapi path (#747, PR #752)
+
+Lifts v2.30.0's known dual-run limitation.
+
+- `internal/launchintent.SeatFacts` gains `ArgvGrammarVersion`,
+  `ReviewerOverrideAllowed`, and `AllowedArgumentForms`: caller-resolved
+  capability facts. `Compile` stays pure and probes nothing itself.
+- At `ArgvGrammarVersion >= 2`, the two-token scoped grant
+  (`--allowedTools`, `Bash(gh pr create:*)`) survives, exact literal only:
+  any other value, including one shaped like a legitimate scoped pattern
+  the real grammar would itself accept, is dropped. A bare `Bash` grant is
+  refused unconditionally. `approvals_reviewer` survives when
+  `ReviewerOverrideAllowed` is true (gated on the codex capability's
+  `config_overrides` entry, not on `GrammarVersion`, which stays 1 for
+  codex across every measured version). Below floor, both still drop,
+  byte-identical to the original v2.30.0 behavior.
+- The backend runs a two-phase `Prepare`: phase 1 probes with the
+  conservative intent (no capability facts, so every gated token drops
+  safe); its `Preview.Capabilities` yields the observed per-provider
+  facts; phase 2 recompiles with them and calls `Prepare` again. `Apply` is
+  always bound to the phase-2 result, never the probe's.
+- The scoped grant's pattern (`internal/launchintent.ScopedPreauthGrant`)
+  is now the single source of truth the legacy composer's
+  `claudeInScopePreauthAllowlist` references too, so the two paths cannot
+  drift apart.
+
+## Named seats (#748, PR #753)
+
+- `internal/launchintent.SeatFacts` gains `SessionName`, the caller-resolved
+  `<workstream>/<handle>` managed-plan label. `buildIntentInput` sets it for
+  every claude seat unconditionally; whether it is ever emitted is a
+  separate, later decision made inside `Compile`, the same
+  eligibility-vs-gating split #747 already established for the scoped
+  preauth grant.
+- `Compile` emits the label as two argv tokens, `-n <label>`, only when the
+  seat's observed `AllowedArgumentForms` (from `Preview.Capabilities`)
+  includes `-n` or `--name`. Across every measured version this holds for
+  claude seats and never for codex, so a codex seat never receives `-n` even
+  if a capability probe falsely claimed support for it.
+- The label is validated at compile time against
+  `validManagedSessionLabel`, a byte-identical mirror of the real grammar's
+  own `validSessionLabel`: at most two `/`-separated parts, each matching
+  `^[a-z0-9_][a-z0-9_-]*$` and not leading with a dash. A malformed non-empty
+  `SessionName` fails `Compile` with a clear error instead of surfacing as
+  an opaque downstream argv rejection; an empty `SessionName`, or a seat
+  whose `AllowedArgumentForms` lacks the naming forms, safely emits nothing.
+- Proven accepted by the real, released v0.73.0 `amq` binary via the
+  existing golden round-trip test
+  (`TestCompiledIntentAcceptedByReleasedAMQ`), extended with a named lead
+  seat fixture.
+
+## Compatibility
+
+- Additive only. The legacy tmux-pane launch path is untouched and remains
+  the default.
+- The general-operation AMQ floor stays at 0.60.0. The launchapi backend's
+  own adoption floor moves to v0.72.0 (module pinned to v0.73.0).
+
+## Known follow-ups
+
+- #739: `amq-squad worktree plan`/`materialize` can reject a re-plan onto a
+  newer accepted base with a false "base drift" error. Workaround in use
+  throughout this milestone: materialize at the session-pinned base, then
+  `git reset --hard` to the intended base.
+- #740: `amq-squad worktree cleanup` cannot reconcile its plan-store entry
+  after a worktree was removed directly with `git worktree remove` instead
+  of going through `cleanup`.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.30.0"  # x-release-please-version
+version: "2.30.1"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
## Summary
- docs/v2.30.1-release-notes.md: verification verdict (#745), adoption floor bump to v0.72.0/pin v0.73.0 (#746), worker preauth restored on the launchapi path (#747), named seats (#748).
- Both plugin manifests (Claude, Codex) bumped 2.30.0 -> 2.30.1; `make skills-generate` regenerated the skill mirrors' frontmatter.
- README What's-new section replaced with the v2.30.1 summary (Contents entry, install tag, and full-detail link updated to match); states plainly that launchapi's worker preauth now matches legacy at amq >= v0.72.0, and that the default-path flip is still tracked separately in v2.31.0.
- Added #739/#740 (known worktree-plan follow-ups) and the project-root read-time finding to the release notes' Known follow-ups section.

Task t12, worktree pinned to main @ 49ba45e (post-#753 merge). Milestone issues #745-#748 all closed by prior PRs (#750, #751, #752, #753).

## Test plan
- [x] `make ci` green locally (fmt, vet, test, readme-html-check, docs-html-check, skills-check, skill-routing-check, skill-command-check, skill-invocation-check, release-validator-test, go-files-scope-test) - zero FAIL lines.
- [x] `make readme-html` regenerated and committed alongside the README.md What's-new swap.
- [x] `gh pr view` state/head check performed immediately before this push.

Per RELEASING.md: does not merge, tag, or publish here. Tag/GitHub release/smoke test wait for the operator gate lead raises after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)