### PR TITLE
docs: v2.31.0 plan — align amq-squad with amq launchapi (#755-#768)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -5,6 +5,13 @@ the open issues by theme + status so the near-term path is legible at a glance.
 
 ## Release state
 
+- **v2.31.0 — align with amq `launchapi` (planned).** `launchapi` becomes the
+  default launch backend; amq-squad's own gates collapse onto amq's
+  `Prepare -> subject_digest -> Apply(decisions)` contract via new `plan` /
+  `start --apply` / `init` / `brief` verbs; resume and goal delivery ride
+  `ResumePolicy`/`OnLive`/`InitialInput`; legacy pane driver and trust flags
+  deprecated with redirects (deleted v2.32.0). Plan: `docs/v2.31.0-plan.md`,
+  issues #755-#768; amq floor v0.74.1, pin v0.75.0.
 - **v2.0.0 — shipped (goal-first dynamic teams).** A binary-neutral lead
   composes its team from a goal (Codex can lead, not just be led); manual setup
   stays the floor; spectrum manual → seeded (default) → autonomous (2.1). Full

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,7 +11,7 @@ the open issues by theme + status so the near-term path is legible at a glance.
   `start --apply` / `init` / `brief` verbs; resume and goal delivery ride
   `ResumePolicy`/`OnLive`/`InitialInput`; legacy pane driver and trust flags
   deprecated with redirects (deleted v2.32.0). Plan: `docs/v2.31.0-plan.md`,
-  issues #755-#768, #770; amq floor v0.74.1, pin v0.75.0.
+  issues #737 #739 #740 #755-#772; amq floor v0.74.1, pin v0.75.0.
 - **v2.0.0 — shipped (goal-first dynamic teams).** A binary-neutral lead
   composes its team from a goal (Codex can lead, not just be led); manual setup
   stays the floor; spectrum manual → seeded (default) → autonomous (2.1). Full

--- a/PLAN.md
+++ b/PLAN.md
@@ -11,7 +11,7 @@ the open issues by theme + status so the near-term path is legible at a glance.
   `start --apply` / `init` / `brief` verbs; resume and goal delivery ride
   `ResumePolicy`/`OnLive`/`InitialInput`; legacy pane driver and trust flags
   deprecated with redirects (deleted v2.32.0). Plan: `docs/v2.31.0-plan.md`,
-  issues #755-#768; amq floor v0.74.1, pin v0.75.0.
+  issues #755-#768, #770; amq floor v0.74.1, pin v0.75.0.
 - **v2.0.0 — shipped (goal-first dynamic teams).** A binary-neutral lead
   composes its team from a goal (Codex can lead, not just be led); manual setup
   stays the floor; spectrum manual → seeded (default) → autonomous (2.1). Full

--- a/docs/v2.31.0-plan.md
+++ b/docs/v2.31.0-plan.md
@@ -1,0 +1,117 @@
+# amq-squad v2.31.0 — align with amq `launchapi`
+
+Milestone: [v2.31.0](https://github.com/omriariav/amq-squad/milestone/51).
+Issues: #755 #756 #757 #758 #759 #760 #761 #762 #763 #765 #766 #767 #768.
+(#764 decided: the GUI-terminal track moved to v2.32.0.)
+
+## Thesis
+
+amq v0.72.0+ ships the exact pattern amq-squad reinvented three times:
+**zero-write `Prepare` -> digest-gated `Apply` with enumerated decisions.**
+
+```
+PrepareRequestV1{target, launcher, placement, intent: LaunchIntentV1{participants[]}}
+  -> PrepareResultV1{subject_digest, plan_digest, planned_writes[], required_actions[], preview}
+ApplyRequestV1{prepare, subject_digest, decisions[{action_id, choice}]}
+  -> ApplyResultV1{outcome, disposition, roster, observations[], commands[], follow_ups[]}
+```
+
+`amq setup --preview` / `--apply <digest>` already exposes the same shape on the
+CLI. amq-squad today owns its own default-No prompt + `--yes`, a `wizard` state
+machine, a `resume` planner with a bespoke live/restore/fresh/blocked classifier,
+a `goal draft/apply/deliver/claim/retry-attempt` chain, and per-flag trust
+overrides (`--trust`, `--force-duplicate`, `--skip-lead-check`, `--rebind`,
+`--launchapi-decision`, `--allow-fresh-fallback`). v2.30.x proved the
+`launchapi` path works end to end (#732-#736, #745-#748). v2.31.0 makes it the
+only path and turns amq-squad into a **compiler from roles/policy into
+`LaunchIntentV1`** plus the things amq does not model: roles, rules, briefs,
+tasks, gates, evidence, worktrees, operator notifications.
+
+## Verb surface after v2.31.0
+
+| Verb | Replaces | Backed by |
+|---|---|---|
+| `setup` | unchanged | global config |
+| `init [--profile] [--roles] [--binary]` (#762) | `new team`, `new profile`, `team init`, `team rules init`, `team sync --apply` | preview / `--apply <digest>` like `amq setup` |
+| `brief [--goal \| --seed-from]` (#759) | drafting inside `wizard`, `start --goal`, `new session --goal`, `goal draft` | configured drafter; **the only LLM step** |
+| `plan SESSION [--json]` (#756) | `start` preview, `wizard --json`, `resume` plan-only, `goal draft`, `new session` | `launchapi.Prepare` (zero-write); `--json` emits the exact `PrepareRequestV1` |
+| `start SESSION --apply <digest> [--decision ID=CHOICE]` (#757, #758) | `start --yes`, `resume --exec`, `wizard` approval, `goal apply/deliver/start`, `up` | `launchapi.Apply`; resume via `ResumePolicy`/`OnLive` |
+| `goal --goal TEXT` (#761) | itself; legacy `goal *` deleted | one AMQ todo operator -> lead |
+| `down`, `status`, `doctor` (#766), `task`, `gate`, `evidence`, `verify`, `worktree`, `broadcast`, `operator`, `roles`, `role`, `team member/overlay/profiles/rm` | unchanged | |
+| `wizard "GOAL"` | itself, minus its state machine | sugar: `brief` -> `init` -> `plan` -> confirm -> `start --apply` |
+| `resume` | `resume`, `team resume` | alias: `plan` (no `--exec`) / `start --apply` (`--exec`) |
+
+Deprecated with redirects in v2.31.x, deleted in v2.32.0: `--launch-via legacy`
+and the iterm2 / terminal / tmux-session backends (#755, #764), `--yes`,
+`--trust`, `--launchapi-decision`, `--force-duplicate`, `--skip-lead-check`,
+`--rebind`, `--allow-fresh-fallback` (#757), `new team|profile|session`, `up`,
+`team init|rules init|sync|resume` (#762, #758), `goal claim|deliver|retry-attempt|start|apply` (#761).
+
+## Data-model alignment (#763)
+
+| team profile | `ParticipantV1` |
+|---|---|
+| member `handle` | `handle` |
+| member `binary` | `executable` |
+| trust posture, `--model`, scoped preauth (`ScopedPreauthGrant`), `-n <session>/<handle>` | `args` |
+| bootstrap prompt + goal (lead only) | `initial_input` (#761) |
+| worktree | `cwd` |
+| `AM_*`, per-seat env | `env_overlay` |
+| launch record / live seat | `resume_policy`, `on_live` (#758) |
+| operator seat | `runnable:false` handle-only participant |
+
+`internal/launchintent.Compile` is the single pure function from profile to
+intent. The legacy argv composer is isolated behind the legacy backend so
+v2.32.0's deletion is a file removal.
+
+## amq version line (#768)
+
+v2.31.0 targets the latest amq, not v0.73.0. Measured 2026-08-30:
+
+| amq | launchapi contract | launch-relevant change |
+|---|---|---|
+| v0.73.0 | baseline (`Compatibility()` unchanged since v0.70.0) | named seats |
+| v0.74.0 | byte-identical | upstream #676: nested-worktree root discovery gets a git ceiling (the gh#734 bug behind the `base_root` seam) |
+| v0.74.1 | byte-identical | #692: `tmux new-session` retried once after server-exit race |
+| v0.75.0 | byte-identical | bridge envelope v2 only |
+
+Floor moves to v0.74.1, go.mod pin to v0.75.0; general-operation floor stays
+0.60.0. If gh#734 no longer reproduces on v0.74.0+, the `base_root` seam is
+downgraded to advisory at or above the floor.
+
+## Sequencing
+
+1. **Decision #764** — move the GUI-terminal track (#670-673, #330, #376, #378)
+   to v2.32.0 as `PlacementV1` / upstream work, or keep and accept the conflict.
+2. **#759 + #760** — `brief` verb and drafter fixes. Independent; land first so
+   launch stops depending on an LLM (root cause of the 2026-08-27 wizard failure).
+3. **#755 + #768** — default flip and the amq v0.75.0 floor/pin bump with the re-verification verdict. Gates everything below.
+4. **#756 -> #757 -> #758** — `plan`, `start --apply`, resume folded in.
+5. **#763 -> #761** — single compile path, goal as `initial_input`.
+6. **#762** — `init` verb (independent; can run parallel to 4-5).
+7. **#766** — doctor/status on `Compatibility()` + `Observations` (with #737).
+8. **#767** — release.
+
+Parallel: **#765** upstream asks to amq.
+
+## Upstream asks (#765)
+
+| Ask | Why | Status |
+|---|---|---|
+| Grammar version + `config_overrides` via `Compatibility()`/`Negotiate` | removes two-phase probe Prepare (#747/#748) | to file |
+| gh#734 nested-worktree root discovery fixed at read time | retires `base_root` seam | **shipped v0.74.0 (#676)**; verify in #768 |
+| `amq launch` provisions unknown sessions like `launchapi.Apply` | `amq launch --plan --apply` can stand in for `start --apply` in CI | to file |
+| Codex argv grammar v2 | scoped preauth + named seats for codex seats | to file |
+
+## Invariants
+
+- No amq-squad verb owns a mutation gate that is not `subject_digest` + `decisions`.
+- `plan --json` is reproducible by `amq launch --plan - --prepare --json` with amq-squad absent.
+- General-operation AMQ floor stays 0.60.0; launch floor v0.74.1, module pin v0.75.0 (#768).
+- Additive in v2.31.0 (redirects), deletions only in v2.32.0.
+
+## What amq-squad keeps
+
+Roles and personas, team rules, briefs, task store, typed gates, evidence,
+`verify merge/release`, worktree planning, operator notifications, `status` board.
+Everything about *starting and resuming processes* is amq's.

--- a/docs/v2.31.0-plan.md
+++ b/docs/v2.31.0-plan.md
@@ -1,7 +1,7 @@
 # amq-squad v2.31.0 — align with amq `launchapi`
 
 Milestone: [v2.31.0](https://github.com/omriariav/amq-squad/milestone/51).
-Issues: #755 #756 #757 #758 #759 #760 #761 #762 #763 #765 #766 #767 #768.
+Issues: #755 #756 #757 #758 #759 #760 #761 #762 #763 #765 #766 #767 #768 #770.
 (#764 decided: the GUI-terminal track moved to v2.32.0.)
 
 ## Thesis
@@ -35,7 +35,7 @@ tasks, gates, evidence, worktrees, operator notifications.
 | `init [--profile] [--roles] [--binary]` (#762) | `new team`, `new profile`, `team init`, `team rules init`, `team sync --apply` | preview / `--apply <digest>` like `amq setup` |
 | `brief [--goal \| --seed-from]` (#759) | drafting inside `wizard`, `start --goal`, `new session --goal`, `goal draft` | configured drafter; **the only LLM step** |
 | `plan SESSION [--json]` (#756) | `start` preview, `wizard --json`, `resume` plan-only, `goal draft`, `new session` | `launchapi.Prepare` (zero-write); `--json` emits the exact `PrepareRequestV1` |
-| `start SESSION --apply <digest> [--decision ID=CHOICE]` (#757, #758) | `start --yes`, `resume --exec`, `wizard` approval, `goal apply/deliver/start`, `up` | `launchapi.Apply`; resume via `ResumePolicy`/`OnLive` |
+| `start SESSION --apply <digest> [--decision ID=CHOICE]` (#757, #758, #770) | `start --yes`, `resume --exec`, `wizard` approval, `goal apply/deliver/start`, `up`, manual `git worktree add` + `team member update --cwd` for shared-cwd rosters | `launchapi.Apply`; resume via `ResumePolicy`/`OnLive`; per-member worktrees as `planned_writes` → `ParticipantV1.Cwd` |
 | `goal --goal TEXT` (#761) | itself; legacy `goal *` deleted | one AMQ todo operator -> lead |
 | `down`, `status`, `doctor` (#766), `task`, `gate`, `evidence`, `verify`, `worktree`, `broadcast`, `operator`, `roles`, `role`, `team member/overlay/profiles/rm` | unchanged | |
 | `wizard "GOAL"` | itself, minus its state machine | sugar: `brief` -> `init` -> `plan` -> confirm -> `start --apply` |
@@ -55,7 +55,7 @@ and the iterm2 / terminal / tmux-session backends (#755, #764), `--yes`,
 | member `binary` | `executable` |
 | trust posture, `--model`, scoped preauth (`ScopedPreauthGrant`), `-n <session>/<handle>` | `args` |
 | bootstrap prompt + goal (lead only) | `initial_input` (#761) |
-| worktree | `cwd` |
+| worktree (auto-materialized for shared-cwd implementation seats, #770) | `cwd` |
 | `AM_*`, per-seat env | `env_overlay` |
 | launch record / live seat | `resume_policy`, `on_live` (#758) |
 | operator seat | `runnable:false` handle-only participant |
@@ -86,7 +86,7 @@ downgraded to advisory at or above the floor.
 2. **#759 + #760** — `brief` verb and drafter fixes. Independent; land first so
    launch stops depending on an LLM (root cause of the 2026-08-27 wizard failure).
 3. **#755 + #768** — default flip and the amq v0.75.0 floor/pin bump with the re-verification verdict. Gates everything below.
-4. **#756 -> #757 -> #758** — `plan`, `start --apply`, resume folded in.
+4. **#756 -> #757 -> #758 -> #770** — `plan`, `start --apply`, resume folded in, per-member worktrees materialized inside the approved plan instead of a manual recipe (supersedes #727 ordering).
 5. **#763 -> #761** — single compile path, goal as `initial_input`.
 6. **#762** — `init` verb (independent; can run parallel to 4-5).
 7. **#766** — doctor/status on `Compatibility()` + `Observations` (with #737).

--- a/docs/v2.31.0-plan.md
+++ b/docs/v2.31.0-plan.md
@@ -1,8 +1,15 @@
 # amq-squad v2.31.0 — align with amq `launchapi`
 
 Milestone: [v2.31.0](https://github.com/omriariav/amq-squad/milestone/51).
-Issues: #755 #756 #757 #758 #759 #760 #761 #762 #763 #765 #766 #767 #768 #770.
+Issues: #737 #739 #740 #755 #756 #757 #758 #759 #760 #761 #762 #763 #765 #766 #767 #768 #770 #771 #772.
 (#764 decided: the GUI-terminal track moved to v2.32.0.)
+
+## Milestone goal
+
+**Launching a squad from a bare shell is as easy as `amq launch`, and the LLM
+work (roster, rules, brief) is done headlessly by yoetz / claude / codex.**
+Two halves: the launch half rides amq's `launchapi` contract; the drafting half
+becomes reliable enough to be the default (#771, #772).
 
 ## Thesis
 
@@ -33,12 +40,13 @@ tasks, gates, evidence, worktrees, operator notifications.
 |---|---|---|
 | `setup` | unchanged | global config |
 | `init [--profile] [--roles] [--binary]` (#762) | `new team`, `new profile`, `team init`, `team rules init`, `team sync --apply` | preview / `--apply <digest>` like `amq setup` |
-| `brief [--goal \| --seed-from]` (#759) | drafting inside `wizard`, `start --goal`, `new session --goal`, `goal draft` | configured drafter; **the only LLM step** |
-| `plan SESSION [--json]` (#756) | `start` preview, `wizard --json`, `resume` plan-only, `goal draft`, `new session` | `launchapi.Prepare` (zero-write); `--json` emits the exact `PrepareRequestV1` |
+| `launch "GOAL" [--profile] [--session]` (#771) | `wizard` (kept as alias), `new session --goal`, `start --goal` | the one drafter-invoking verb: `brief` -> `init` -> `plan` -> review -> `start --apply`; headless outside an agent session; first-run drafter probe |
+| `brief [--goal \| --seed-from]` (#759, #772) | drafting inside `wizard`, `start --goal`, `new session --goal`, `goal draft` | configured drafter; **the only LLM step** |
+| `plan SESSION [--json]` (#756) — never drafts | `start` preview, `wizard --json`, `resume` plan-only, `goal draft`, `new session` | `launchapi.Prepare` (zero-write); `--json` emits the exact `PrepareRequestV1` |
 | `start SESSION --apply <digest> [--decision ID=CHOICE]` (#757, #758, #770) | `start --yes`, `resume --exec`, `wizard` approval, `goal apply/deliver/start`, `up`, manual `git worktree add` + `team member update --cwd` for shared-cwd rosters | `launchapi.Apply`; resume via `ResumePolicy`/`OnLive`; per-member worktrees as `planned_writes` → `ParticipantV1.Cwd` |
 | `goal --goal TEXT` (#761) | itself; legacy `goal *` deleted | one AMQ todo operator -> lead |
 | `down`, `status`, `doctor` (#766), `task`, `gate`, `evidence`, `verify`, `worktree`, `broadcast`, `operator`, `roles`, `role`, `team member/overlay/profiles/rm` | unchanged | |
-| `wizard "GOAL"` | itself, minus its state machine | sugar: `brief` -> `init` -> `plan` -> confirm -> `start --apply` |
+| `wizard "GOAL"` | itself | alias of `launch` |
 | `resume` | `resume`, `team resume` | alias: `plan` (no `--exec`) / `start --apply` (`--exec`) |
 
 Deprecated with redirects in v2.31.x, deleted in v2.32.0: `--launch-via legacy`
@@ -83,13 +91,15 @@ downgraded to advisory at or above the floor.
 
 1. **Decision #764** — move the GUI-terminal track (#670-673, #330, #376, #378)
    to v2.32.0 as `PlacementV1` / upstream work, or keep and accept the conflict.
-2. **#759 + #760** — `brief` verb and drafter fixes. Independent; land first so
-   launch stops depending on an LLM (root cause of the 2026-08-27 wizard failure).
+2. **#759 + #760 + #772** — `brief` verb, drafter fixes, schema-constrained drafter
+   outputs. Independent; land first so headless drafting is reliable (root cause of
+   the 2026-08-27 and 2026-08-30 wizard failures).
 3. **#755 + #768** — default flip and the amq v0.75.0 floor/pin bump with the re-verification verdict. Gates everything below.
 4. **#756 -> #757 -> #758 -> #770** — `plan`, `start --apply`, resume folded in, per-member worktrees materialized inside the approved plan instead of a manual recipe (supersedes #727 ordering).
 5. **#763 -> #761** — single compile path, goal as `initial_input`.
 6. **#762** — `init` verb (independent; can run parallel to 4-5).
-7. **#766** — doctor/status on `Compatibility()` + `Observations` (with #737).
+7. **#737 -> #766** — Inspect-based liveness, then doctor/status on `Compatibility()` + `Observations`.
+7b. **#771** — `launch` front door composed from the verbs above; first-run drafter probe; drafter-proposed roster. **#739 / #740** worktree store fixes land alongside #770.
 8. **#767** — release.
 
 Parallel: **#765** upstream asks to amq.
@@ -106,6 +116,8 @@ Parallel: **#765** upstream asks to amq.
 ## Invariants
 
 - No amq-squad verb owns a mutation gate that is not `subject_digest` + `decisions`.
+- Only `launch` (and its `brief` step) invokes a drafter; `plan`/`start` are deterministic.
+- From a bare shell (no `AM_ME`), drafter exhaustion is an error with attempt evidence, never an in-session prompt.
 - `plan --json` is reproducible by `amq launch --plan - --prepare --json` with amq-squad absent.
 - General-operation AMQ floor stays 0.60.0; launch floor v0.74.1, module pin v0.75.0 (#768).
 - Additive in v2.31.0 (redirects), deletions only in v2.32.0.


### PR DESCRIPTION
Milestone plan for v2.31.0: launchapi becomes the default launch path; amq-squad's own gates collapse onto amq's Prepare -> subject_digest -> Apply(decisions) contract via new plan / start --apply / init / brief verbs; resume and goal delivery ride ResumePolicy / OnLive / InitialInput; floor v0.74.1, pin v0.75.0 (#768). Issues #755-#768; #764 decided (GUI terminal track -> v2.32.0).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)