### PR TITLE
feat(launch): flip default launch backend to launchapi on tmux (gh#755)

### DIFF
--- a/README.html
+++ b/README.html
@@ -376,9 +376,14 @@ launch now carries its <code>&lt;workstream&gt;/&lt;handle&gt;</code>
 label as a managed <code>-n</code> argv token, validated at compile time
 against a byte-identical mirror of the real grammar's label rules. Codex
 seats never receive it.</li>
-<li>The launchapi path is still opt-in via
-<code>--launch-via launchapi</code>; the default flip to launchapi is
-tracked separately in the v2.31.0 milestone, not this release.</li>
+<li><strong>launchapi is now the default launch backend</strong>
+whenever the terminal resolves to tmux (gh#755): plain
+<code>start</code>/<code>up</code> with no <code>--launch-via</code>
+uses it. The legacy tmux pane driver stays reachable for one release via
+the explicit opt-out <code>--launch-via legacy</code>, and is deleted in
+v2.32.0. A terminal that is not tmux (<code>iterm2</code>,
+<code>terminal</code>, <code>tmux-session</code>) is unaffected and
+keeps using its own legacy backend.</li>
 </ul>
 <p>Full detail in <a href="docs/v2.30.1-release-notes.md">the v2.30.1
 release notes</a>.</p>

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ the default; the general-operation AMQ floor stays 0.60.0.
   now carries its `<workstream>/<handle>` label as a managed `-n` argv
   token, validated at compile time against a byte-identical mirror of the
   real grammar's label rules. Codex seats never receive it.
-- The launchapi path is still opt-in via `--launch-via launchapi`; the
-  default flip to launchapi is tracked separately in the v2.31.0 milestone,
-  not this release.
+- **launchapi is now the default launch backend** whenever the terminal
+  resolves to tmux (gh#755): plain `start`/`up` with no `--launch-via` uses
+  it. The legacy tmux pane driver stays reachable for one release via the
+  explicit opt-out `--launch-via legacy`, and is deleted in v2.32.0. A
+  terminal that is not tmux (`iterm2`, `terminal`, `tmux-session`) is
+  unaffected and keeps using its own legacy backend.
 
 Full detail in [the v2.30.1 release notes](docs/v2.30.1-release-notes.md).
 

--- a/internal/cli/preview_flags.go
+++ b/internal/cli/preview_flags.go
@@ -109,8 +109,9 @@ type liveLaunchFlags struct {
 	stagger         *time.Duration
 	// noAttach is parsed for compatibility but has no behavioral effect.
 	noAttach *bool
-	// launchVia opts into an alternate launch orchestration path (gh#733).
-	// Empty is the legacy default: byte-identical to pre-gh#733 behavior.
+	// launchVia selects the launch orchestration path (gh#733, gh#755).
+	// Empty is now the launchapi default on tmux; "legacy" opts out to the
+	// deprecated pre-gh#755 pane driver.
 	launchVia *string
 	// launchapiDecisions carries explicit operator answers to launchapi's
 	// RequiredActionV1 gates, one ACTION_ID=CHOICE pair per repeated flag.
@@ -126,7 +127,7 @@ func registerLiveLaunchFlags(fs *flag.FlagSet) *liveLaunchFlags {
 		terminalSession: fs.String("terminal-session", "", "terminal session name when the backend creates one"),
 		stagger:         fs.Duration("stagger", 750*time.Millisecond, "delay between starting agent panes"),
 		noAttach:        fs.Bool("no-attach", false, "legacy no-op; new-session never attaches automatically"),
-		launchVia:       fs.String("launch-via", "", "opt-in alternate launch orchestration path: launchapi (tmux only); default is legacy"),
+		launchVia:       fs.String("launch-via", "", "launch orchestration path: launchapi (tmux only) is the default since v2.31.0; legacy opts out to the deprecated pre-v2.31.0 pane driver, removed in v2.32.0"),
 	}
 	fs.Var(&lf.launchapiDecisions, "launchapi-decision", "explicit operator answer to a launchapi required action, ACTION_ID=CHOICE (repeatable; --launch-via launchapi only)")
 	return lf

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -79,11 +79,14 @@ type teamLaunchOptions struct {
 	// before any destructive reset. A non-nil slice prevents executeTeamLaunch
 	// from re-resolving AMQ after that parent's mutation boundary.
 	ResolvedAMQPreflights []agentLaunchPreflight
-	// LaunchVia selects an alternate launch orchestration path independent of
-	// Terminal. Empty (or "auto") is the legacy default: Terminal alone picks
-	// the backend, byte-identical to pre-gh#733 behavior. "launchapi" opts
-	// into launchapiTeamLaunchBackend (gh#733), which still requires Terminal
-	// to resolve to tmux since that backend is tmux-only.
+	// LaunchVia selects the launch orchestration path independent of
+	// Terminal. As of v2.31.0 (gh#755), empty (or "auto") defaults to
+	// launchapiTeamLaunchBackend whenever Terminal resolves to tmux; a
+	// non-tmux Terminal still falls back to the legacy per-terminal lookup.
+	// "launchapi" opts in explicitly (same selection, same tmux-only
+	// requirement). "legacy" opts out to the pre-gh#755 tmux pane driver,
+	// byte-identical to v2.30.1's empty/"auto" behavior; deprecated and
+	// deleted in v2.32.0.
 	LaunchVia string
 	// LaunchapiDecisions carries explicit operator answers (ACTION_ID ->
 	// CHOICE) to launchapi RequiredActionV1 gates, from repeated

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -22,11 +22,13 @@ func init() {
 }
 
 // launchapiTeamLaunchBackend implements teamLaunchBackend on top of amq's
-// public launchapi.Prepare/Apply contract (gh#733). It is tmux-only and
-// reachable ONLY via the explicit --launch-via launchapi opt-in resolved by
-// resolveTeamLaunchBackend; it is never selected by --terminal alone, and the
-// legacy tmux/iterm2/terminal/tmux-session backends and their argv are
-// untouched (additive-only, gh#732's TestV2300RemovesNothing invariant).
+// public launchapi.Prepare/Apply contract (gh#733). It is tmux-only. As of
+// v2.31.0 (gh#755) it is the default resolveTeamLaunchBackend selects
+// whenever the terminal resolves to tmux and --launch-via is empty, "auto",
+// or the explicit "launchapi" opt-in; the legacy tmux/iterm2/terminal/
+// tmux-session backends and their argv remain untouched and stay reachable
+// for one release via the explicit "--launch-via legacy" opt-out (deleted in
+// v2.32.0).
 type launchapiTeamLaunchBackend struct{}
 
 func (launchapiTeamLaunchBackend) Name() string { return "launchapi" }
@@ -54,25 +56,59 @@ func (b launchapiTeamLaunchBackend) LaunchWithResult(t team.Team, opts teamLaunc
 }
 
 // resolveTeamLaunchBackend is the single selection seam consumed by
-// executeTeamLaunch. When opts.LaunchVia is empty or "auto" it reproduces the
-// pre-gh#733 lookup byte-for-byte (same error text, same map). Only an
-// explicit non-auto value can select launchapiTeamLaunchBackend, and only
-// when the terminal resolves to tmux.
+// executeTeamLaunch (gh#755: v2.31.0's default flip). When opts.LaunchVia is
+// empty or "auto" and the terminal resolves to tmux, it now selects
+// launchapiTeamLaunchBackend by default. A terminal that does not resolve to
+// tmux (iterm2, terminal, tmux-session) still falls back to the legacy
+// per-terminal lookup, since the launchapi backend is tmux-only. The legacy
+// tmux pane driver stays reachable for one release (v2.31.x) via the
+// explicit opt-out "--launch-via legacy", byte-identical to v2.30.1's
+// empty/"auto" behavior; it is deleted in v2.32.0. An explicit
+// "--launch-via launchapi" keeps working exactly as before. The
+// unsupported-terminal error text (legacyTeamLaunchBackend) is unchanged.
 func resolveTeamLaunchBackend(opts teamLaunchOptions) (teamLaunchBackend, error) {
 	launchVia := strings.ToLower(strings.TrimSpace(opts.LaunchVia))
-	if launchVia != "" && launchVia != "auto" {
-		if launchVia != "launchapi" {
-			return nil, fmt.Errorf("unsupported --launch-via %q: supported values: launchapi", opts.LaunchVia)
+	switch launchVia {
+	case "legacy":
+		return legacyTeamLaunchBackend(opts)
+	case "", "auto":
+		if terminalResolvesToTmux(opts.Terminal) {
+			return registeredLaunchapiBackend()
 		}
-		if terminal := strings.TrimSpace(opts.Terminal); terminal != "" && terminal != "tmux" {
+		return legacyTeamLaunchBackend(opts)
+	case "launchapi":
+		if !terminalResolvesToTmux(opts.Terminal) {
 			return nil, fmt.Errorf("--launch-via launchapi requires --terminal tmux (got %q)", opts.Terminal)
 		}
-		backend, ok := teamLaunchBackends["launchapi"]
-		if !ok {
-			return nil, fmt.Errorf("launchapi backend is not registered")
-		}
-		return backend, nil
+		return registeredLaunchapiBackend()
+	default:
+		return nil, fmt.Errorf("unsupported --launch-via %q: supported values: launchapi, legacy", opts.LaunchVia)
 	}
+}
+
+// terminalResolvesToTmux reports whether opts.Terminal selects (or, if
+// empty, defaults to) the tmux terminal backend. Preserves the pre-gh#755
+// tolerance of an empty Terminal value.
+func terminalResolvesToTmux(terminal string) bool {
+	t := strings.TrimSpace(terminal)
+	return t == "" || t == "tmux"
+}
+
+// registeredLaunchapiBackend looks up the launchapi backend in
+// teamLaunchBackends, shared by both the new default path and the explicit
+// "--launch-via launchapi" opt-in so they resolve identically.
+func registeredLaunchapiBackend() (teamLaunchBackend, error) {
+	backend, ok := teamLaunchBackends["launchapi"]
+	if !ok {
+		return nil, fmt.Errorf("launchapi backend is not registered")
+	}
+	return backend, nil
+}
+
+// legacyTeamLaunchBackend reproduces the pre-gh#733 terminal-map lookup
+// byte-for-byte (same error text, same map), reachable now only via the
+// explicit "--launch-via legacy" opt-in or a non-tmux terminal.
+func legacyTeamLaunchBackend(opts teamLaunchOptions) (teamLaunchBackend, error) {
 	backend, ok := teamLaunchBackends[opts.Terminal]
 	if !ok {
 		return nil, fmt.Errorf("unsupported terminal %q: supported terminals: %s", opts.Terminal, strings.Join(registeredTeamLaunchTerminals(), ", "))

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -12,12 +12,46 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
-// TestLaunchapiBackendOptInOnly proves resolveTeamLaunchBackend -- the single
-// selection seam executeTeamLaunch calls -- only ever returns the launchapi
-// backend when --launch-via launchapi is explicit, and reproduces the
-// pre-gh#733 lookup (same map, same error text) whenever it is absent or
-// "auto". This is the byte-identical-legacy-behavior guarantee gh#733 names.
-func TestLaunchapiBackendOptInOnly(t *testing.T) {
+// TestResolveTeamLaunchBackendDefaultsToLaunchapiOnTmux proves
+// resolveTeamLaunchBackend -- the single selection seam executeTeamLaunch
+// calls -- selects the launchapi backend by default (LaunchVia empty,
+// "auto", or the explicit "launchapi" opt-in) whenever the terminal resolves
+// to tmux. This is v2.31.0's default flip (gh#755): pre-v2.31.0, only the
+// explicit "launchapi" value ever selected this backend.
+func TestResolveTeamLaunchBackendDefaultsToLaunchapiOnTmux(t *testing.T) {
+	for _, launchVia := range []string{"", "auto", "AUTO", "launchapi"} {
+		got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: launchVia})
+		if err != nil {
+			t.Fatalf("LaunchVia=%q: unexpected error: %v", launchVia, err)
+		}
+		if got.Name() != "launchapi" {
+			t.Fatalf("LaunchVia=%q on tmux selected %q, want launchapi (v2.31.0 default)", launchVia, got.Name())
+		}
+	}
+
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "iterm2", LaunchVia: "launchapi"}); err == nil || !strings.Contains(err.Error(), "requires --terminal tmux") {
+		t.Fatalf("--launch-via launchapi with a non-tmux terminal: err=%v, want a tmux-only refusal", err)
+	}
+
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "bogus"}); err == nil || !strings.Contains(err.Error(), `unsupported --launch-via "bogus"`) {
+		t.Fatalf("unknown --launch-via value: err=%v", err)
+	}
+
+	// A non-tmux terminal with LaunchVia empty/"auto" still falls back to
+	// the legacy per-terminal lookup (launchapi is tmux-only); the
+	// unsupported-terminal error text is unchanged.
+	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "nope"}); err == nil ||
+		err.Error() != `unsupported terminal "nope": supported terminals: `+strings.Join(registeredTeamLaunchTerminals(), ", ") {
+		t.Fatalf("legacy unsupported-terminal error text changed: %v", err)
+	}
+}
+
+// TestResolveTeamLaunchBackendLegacyRequiresExplicitOptIn proves the legacy
+// tmux pane driver is reachable ONLY via the explicit "--launch-via legacy"
+// opt-out, never via empty/"auto" any more, and that it then selects the
+// same backend the pre-gh#755 map lookup (v2.30.1's "auto" behavior) would
+// have selected -- byte-identical, same map, same backend.
+func TestResolveTeamLaunchBackendLegacyRequiresExplicitOptIn(t *testing.T) {
 	fake := &fakeBackend{}
 	prevTmux, hadTmux := teamLaunchBackends["tmux"]
 	teamLaunchBackends["tmux"] = fake
@@ -29,37 +63,30 @@ func TestLaunchapiBackendOptInOnly(t *testing.T) {
 		}
 	})
 
-	for _, launchVia := range []string{"", "auto", "AUTO"} {
+	got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "legacy"})
+	if err != nil {
+		t.Fatalf("--launch-via legacy: unexpected error: %v", err)
+	}
+	if got.Name() != fake.Name() {
+		t.Fatalf("--launch-via legacy selected %q, want the legacy-registered %q", got.Name(), fake.Name())
+	}
+
+	wantLegacy, err := legacyTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux"})
+	if err != nil {
+		t.Fatalf("legacyTeamLaunchBackend: %v", err)
+	}
+	if got != wantLegacy {
+		t.Fatalf("--launch-via legacy backend diverges from v2.30.1's auto map lookup")
+	}
+
+	for _, launchVia := range []string{"", "auto"} {
 		got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: launchVia})
 		if err != nil {
 			t.Fatalf("LaunchVia=%q: unexpected error: %v", launchVia, err)
 		}
-		if got.Name() != fake.Name() {
-			t.Fatalf("LaunchVia=%q selected %q, want the legacy-registered %q (auto must never select launchapi)", launchVia, got.Name(), fake.Name())
+		if got.Name() == fake.Name() {
+			t.Fatalf("LaunchVia=%q selected the legacy backend; v2.31.0 requires the explicit --launch-via legacy opt-out", launchVia)
 		}
-	}
-
-	got, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "launchapi"})
-	if err != nil {
-		t.Fatalf("explicit launchapi: %v", err)
-	}
-	if got.Name() != "launchapi" {
-		t.Fatalf("explicit --launch-via launchapi selected %q", got.Name())
-	}
-
-	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "iterm2", LaunchVia: "launchapi"}); err == nil || !strings.Contains(err.Error(), "requires --terminal tmux") {
-		t.Fatalf("--launch-via launchapi with a non-tmux terminal: err=%v, want a tmux-only refusal", err)
-	}
-
-	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "bogus"}); err == nil || !strings.Contains(err.Error(), `unsupported --launch-via "bogus"`) {
-		t.Fatalf("unknown --launch-via value: err=%v", err)
-	}
-
-	// Legacy error text and the legacy map lookup are unchanged for an
-	// unsupported --terminal when --launch-via is absent.
-	if _, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "nope"}); err == nil ||
-		err.Error() != `unsupported terminal "nope": supported terminals: `+strings.Join(registeredTeamLaunchTerminals(), ", ") {
-		t.Fatalf("legacy unsupported-terminal error text changed: %v", err)
 	}
 }
 

--- a/internal/cli/team_launch_test.go
+++ b/internal/cli/team_launch_test.go
@@ -190,7 +190,7 @@ func TestRunTeamLaunchDryRunDefaultsToCurrentWindow(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -248,7 +248,7 @@ func TestRunTeamLaunchDryRunUsesExplicitSharedWorkstream(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -294,7 +294,7 @@ func TestRunTeamLaunchDryRunUsesBinaryArgs(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--dry-run", "--no-bootstrap", "--trust", "trusted", "--codex-args=--enable goals", "--claude-args=--chrome"})
+		return runTeamLaunch([]string{"--dry-run", "--launch-via", "legacy", "--no-bootstrap", "--trust", "trusted", "--codex-args=--enable goals", "--claude-args=--chrome"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -373,7 +373,7 @@ func TestRunTeamLaunchDryRunUsesSharedWorkstreamAcrossMemberCWDs(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -412,7 +412,7 @@ func TestRunTeamLaunchDryRunNewSessionDoesNotAutoAttach(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--target", "new-session", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--target", "new-session", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -600,7 +600,7 @@ func TestRunTeamLaunchDryRunMixedSessionFiltersOutCrossSessionMembers(t *testing
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)
@@ -643,7 +643,7 @@ func TestRunTeamLaunchDryRunMixedSessionIncludesUnpinnedMembers(t *testing.T) {
 	}
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--session", "v2-3-0", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("runTeamLaunch: %v\nstderr:\n%s", err, stderr)

--- a/internal/cli/team_lead_test.go
+++ b/internal/cli/team_lead_test.go
@@ -1860,7 +1860,7 @@ func TestTeamLaunchDryRunSkipsRegisteredExternalLead(t *testing.T) {
 	t.Cleanup(func() { currentPaneIdentity = prev; statusPaneInspector = prevInspector })
 
 	stdout, stderr, err := captureOutput(t, func() error {
-		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--no-bootstrap"})
+		return runTeamLaunch([]string{"--session", "issue-96", "--dry-run", "--launch-via", "legacy", "--no-bootstrap"})
 	})
 	if err != nil {
 		t.Fatalf("team launch dry-run: %v\nstderr:\n%s", err, stderr)

--- a/internal/cli/v2310_legacy_still_reachable_test.go
+++ b/internal/cli/v2310_legacy_still_reachable_test.go
@@ -11,12 +11,16 @@ import (
 	"github.com/omriariav/amq-squad/v2/internal/team"
 )
 
-// TestV2300RemovesNothing enforces the v2.30.0 additive-only invariant
-// mechanically: v2.30.0 adds the opt-in launchapi backend (gh#733) and
-// nothing else may be removed as a side effect. The repo has no standalone
-// "removal register" issue (the earlier one was dissolved and absorbed into
-// the v2.31.0 milestone description's "Deferred-removal register"), so this
-// list is derived directly from that description (gh api
+// TestV2310LegacyStillReachable enforces the additive-only invariant
+// mechanically across the v2.31.0 default flip (gh#755): v2.30.0 added the
+// opt-in launchapi backend (gh#733), and v2.31.0 makes it the default on
+// tmux, but the legacy tmux pane driver and every other register entry below
+// stay reachable and untouched. Formerly TestV2300RemovesNothing; renamed
+// for gh#755 since its central assertion is now "legacy still reachable
+// under the explicit opt-out", not "legacy is still the default". The repo
+// has no standalone "removal register" issue (the earlier one was dissolved
+// and absorbed into the v2.31.0 milestone description's "Deferred-removal
+// register"), so this list is derived directly from that description (gh api
 // repos/omriariav/amq-squad/milestones, title=v2.31.0, fetched 2026-08-26):
 //
 //	"Deferred-removal register (each gated; nothing removed before its
@@ -33,13 +37,13 @@ import (
 //
 // Each subtest below pins one register entry (or gh#732's own additive-only
 // non-negotiables) to a concrete, compile-and-run-time-checked surface, with
-// its v2.31.0 removal prerequisite noted in the subtest's own comment.
-func TestV2300RemovesNothing(t *testing.T) {
+// its removal prerequisite noted in the subtest's own comment.
+func TestV2310LegacyStillReachable(t *testing.T) {
 	t.Run("legacy terminal backends all still registered (pane/tmux plumbing register entry)", func(t *testing.T) {
 		// Removal prerequisite: Inspect-based liveness landed and consuming
 		// status/health (gh#737). Nothing about that has landed yet, so all
-		// four pre-v2.30.0 backends plus the new opt-in launchapi one must be
-		// present -- five total, none missing.
+		// four pre-v2.30.0 backends plus the launchapi one must be present --
+		// five total, none missing.
 		want := []string{"tmux", "iterm2", "terminal", "tmux-session", "launchapi"}
 		for _, name := range want {
 			if _, ok := teamLaunchBackends[name]; !ok {
@@ -51,16 +55,38 @@ func TestV2300RemovesNothing(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy launch selection is unchanged when --launch-via is absent (opt-in-only register entry)", func(t *testing.T) {
-		// Removal prerequisite: none -- this is gh#733's own opt-in
-		// invariant, permanent until the default flip milestone (v2.31.0)
-		// explicitly promotes launchapi to auto.
+	t.Run("default launch selection is launchapi when --launch-via is absent (v2.31.0 default flip register entry)", func(t *testing.T) {
+		// gh#755: the default flip itself. Absent --launch-via now selects
+		// launchapi on tmux, not the legacy backend.
 		backend, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux"})
 		if err != nil {
-			t.Fatalf("legacy default selection: %v", err)
+			t.Fatalf("default selection: %v", err)
+		}
+		if backend.Name() != "launchapi" {
+			t.Fatalf("absent --launch-via selected %q, want launchapi (v2.31.0 default)", backend.Name())
+		}
+	})
+
+	t.Run("legacy backend and its argv are reachable only under the explicit --launch-via legacy opt-out", func(t *testing.T) {
+		// Removal prerequisite: none until v2.32.0, which deletes the legacy
+		// pane driver entirely (gh#755's own deprecation window). Until then
+		// the legacy backend must still resolve, and must resolve to exactly
+		// the pre-gh#755 map lookup, but ONLY when explicitly requested.
+		backend, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: "legacy"})
+		if err != nil {
+			t.Fatalf("--launch-via legacy: %v", err)
 		}
 		if backend.Name() != "tmux" {
-			t.Fatalf("absent --launch-via selected %q, want tmux", backend.Name())
+			t.Fatalf("--launch-via legacy selected %q, want tmux", backend.Name())
+		}
+		for _, launchVia := range []string{"", "auto"} {
+			backend, err := resolveTeamLaunchBackend(teamLaunchOptions{Terminal: "tmux", LaunchVia: launchVia})
+			if err != nil {
+				t.Fatalf("LaunchVia=%q: %v", launchVia, err)
+			}
+			if backend.Name() == "tmux" {
+				t.Fatalf("LaunchVia=%q selected the legacy tmux backend without the explicit opt-out", launchVia)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Summary
- `resolveTeamLaunchBackend` now selects `launchapi` by default whenever the terminal resolves to tmux; the legacy tmux pane driver stays reachable for one release via the explicit `--launch-via legacy` opt-out, deprecated and deleted in v2.32.0. A non-tmux terminal (`iterm2`, `terminal`, `tmux-session`) is unaffected. Unsupported-value error texts are unchanged.
- Renames `TestV2300RemovesNothing` to `TestV2310LegacyStillReachable` (file renamed to match) and adds a subtest proving the legacy backend/argv is reachable only under the explicit opt-out.
- Adds the two named acceptance tests: `TestResolveTeamLaunchBackendDefaultsToLaunchapiOnTmux`, `TestResolveTeamLaunchBackendLegacyRequiresExplicitOptIn`.
- Updates dry-run tests asserting legacy composed-pane output (`TestRunTeamLaunchDryRun*`, `TestTeamLaunchDryRunSkipsRegisteredExternalLead`) to opt in explicitly via `--launch-via legacy`, since they exercise legacy-specific pane rendering, not the new default.
- Updates the README What's-new bullet so launchapi is documented as the default, and regenerates README.html.

Closes #755.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l .` clean
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing/failing identically on the unmodified base commit (unrelated PTY/sandbox flake, not touched by this change).
- [x] `make ci` targets other than `test` (fmt-check, vet, readme-html-check, docs-html-check, skills-check, skill-routing-check, skill-command-check, skill-invocation-check, release-validator-test, go-files-scope-test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)