### PR TITLE
feat(launchintent): single compile path via Compile, legacy composer isolation test (gh#763)

### DIFF
--- a/internal/cli/legacy_composer_isolation_test.go
+++ b/internal/cli/legacy_composer_isolation_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyArgvComposerSymbols is agent_defaults.go's legacy Claude preauth
+// argv-splicing surface (gh#763): claudeInScopePreauthAllowlist plus the
+// "friends" that shape it into launch argv. claudeWorkerPreauthEligible is
+// deliberately excluded -- it is a shared eligibility check both the legacy
+// backend and launchapiTeamLaunchBackend call (team_launch_launchapi.go
+// documents this explicitly), not argv-composition, so its presence on the
+// new path is intentional and not a leak.
+var legacyArgvComposerSymbols = []string{
+	"claudeInScopePreauthAllowlist",
+	"claudeLauncherPreauthActions",
+	"applyClaudeWorkerPreauth",
+	"applyClaudeWorkerPreauthActions",
+	"claudePreauthChildArgs",
+	"collectClaudeAllowedTools",
+	"replaceClaudeAllowedTools",
+	"stripRecordedLauncherPreauth",
+	"configuredClaudePermissionAllowlist",
+	"childArgsAllowedTools",
+}
+
+// TestLegacyComposerReferencedOnlyByLegacyBackend is gh#763's named
+// acceptance test. Its literal wording ("only --launch-via legacy
+// references it") does not hold as stated: gh#755 only flipped
+// executeTeamLaunch's backend selection (resolveTeamLaunchBackend), and two
+// other call sites reach this same composer with no --launch-via gate at
+// all, because they never go through resolveTeamLaunchBackend in the first
+// place --
+//   - internal/cli/simple_start.go (the `amq-squad start` single-session
+//     planner) resolves its backend via a bare teamLaunchBackends[opts.Terminal]
+//     lookup and always calls buildTeamLaunchPanes, which composes legacy
+//     pane commands (composer included) unconditionally.
+//   - internal/cli/launch.go (single-agent `agent up`/launch) has no
+//     --launch-via concept at all; LaunchVia is a team-launch-only flag.
+//
+// Migrating simple_start and single-agent launch onto internal/launchintent
+// or the launchapi path is out of gh#763's scope (and not in the v2.31.0
+// milestone as read); until it happens, v2.32.0's planned deletion of this
+// composer is not a plain file removal. That resizing is tracked in a
+// release-time follow-up (see t14's deprecation table), not fixed here.
+//
+// What this test proves instead, honestly: the composer is never referenced
+// from the launchapi-path files -- team_launch_launchapi.go and every file
+// in internal/launchintent. That is the provable invariant gh#763 actually
+// needs: the new path must never silently reabsorb the old argv-splicing
+// logic, regardless of what the rest of the legacy surface still does.
+// fileIdentifiers parses a Go source file and returns the set of all
+// identifier names appearing in its code (declarations, calls, expressions).
+// Comments are not part of the AST, so a symbol named only in a doc comment
+// (e.g. launchintent.go's own doc comment cross-referencing
+// claudeInScopePreauthAllowlist by name to explain where its literal is
+// mirrored from) is correctly excluded -- this test cares about actual code
+// references, not prose mentioning a name.
+func fileIdentifiers(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	idents := make(map[string]bool)
+	ast.Inspect(f, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok {
+			idents[ident.Name] = true
+		}
+		return true
+	})
+	return idents
+}
+
+func TestLegacyComposerReferencedOnlyByLegacyBackend(t *testing.T) {
+	checkFileForbidsSymbols := func(readPath, label string) {
+		idents := fileIdentifiers(t, readPath)
+		for _, symbol := range legacyArgvComposerSymbols {
+			if idents[symbol] {
+				t.Fatalf("%s references legacy argv composer symbol %q in code; the launchapi path must never reabsorb legacy argv-splicing logic", label, symbol)
+			}
+		}
+	}
+
+	checkFileForbidsSymbols("team_launch_launchapi.go", "internal/cli/team_launch_launchapi.go")
+
+	launchintentEntries, err := os.ReadDir("../launchintent")
+	if err != nil {
+		t.Fatalf("read internal/launchintent: %v", err)
+	}
+	sawLaunchintentFile := false
+	for _, entry := range launchintentEntries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".go" || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawLaunchintentFile = true
+		checkFileForbidsSymbols(filepath.Join("../launchintent", name), "internal/launchintent/"+name)
+	}
+	if !sawLaunchintentFile {
+		t.Fatal("found no non-test .go files under internal/launchintent; test fixture is stale")
+	}
+
+	// Guard against a vacuous test: every symbol above must still be
+	// referenced somewhere in internal/cli (its legacy callers), so a typo
+	// or a symbol rename can never silently make this pass by checking
+	// nothing.
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	legacyIdents := make(map[string]bool)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".go" || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		for ident := range fileIdentifiers(t, name) {
+			legacyIdents[ident] = true
+		}
+	}
+	for _, symbol := range legacyArgvComposerSymbols {
+		if !legacyIdents[symbol] {
+			t.Fatalf("legacy argv composer symbol %q is not referenced anywhere in internal/cli; test fixture is stale", symbol)
+		}
+	}
+}

--- a/internal/launchintent/golden_amq_test.go
+++ b/internal/launchintent/golden_amq_test.go
@@ -11,12 +11,14 @@ import (
 )
 
 // TestCompiledIntentAcceptedByReleasedAMQ proves the compiled golden intent
-// for this repo's real 3-seat profile (lead, senior-dev, fullstack, plus the
-// non-runnable operator) passes launchapi's own strict decode — the same
-// decode path the pinned v0.70.0 adoption floor performs on an intent it
-// receives. It follows the same real-binary-gated convention already used
-// by internal/cli/real_amq_compatibility_test.go: set AMQ_SQUAD_REAL_AMQ to
-// a real amq binary to prove the floor is genuinely available in this
+// for amq-squad's real default profile (cto: codex lead, fullstack: claude,
+// plus the non-runnable operator -- see internal/cli/simple_wizard.go's
+// `--lead cto` default and `--roles cto,fullstack --binary cto=codex`
+// example) passes launchapi's own strict decode — the same decode path the
+// pinned v0.70.0 adoption floor performs on an intent it receives. It
+// follows the same real-binary-gated convention already used by
+// internal/cli/real_amq_compatibility_test.go: set AMQ_SQUAD_REAL_AMQ to a
+// real amq binary to prove the floor is genuinely available in this
 // environment; the test skips (not fails) when that floor binary is absent,
 // since the round trip through the imported launchapi package below already
 // exercises the same v0.70.0 contract code the binary embeds.
@@ -36,12 +38,21 @@ func TestCompiledIntentAcceptedByReleasedAMQ(t *testing.T) {
 		Operator: OperatorFacts{Handle: "user"},
 		Seats: []SeatFacts{
 			{
-				Handle:          "lead",
-				Executable:      "/usr/bin/claude",
-				Args:            []string{"--permission-mode", "auto", "--model", "claude-fable-5"},
+				Handle:          "cto",
+				Executable:      "/usr/bin/codex",
+				Args:            []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request"},
 				Cwd:             SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: "/Users/omri.a/Code/amq-squad"},
 				ResumePolicy:    launchapi.ResumePolicyResume,
-				BootstrapPrompt: "You are lead. Orchestrate the v2.30.0 milestone.",
+				BootstrapPrompt: "You are cto. Orchestrate the v2.31.0 milestone.",
+				RequireWake:     true,
+			},
+			{
+				Handle:          "fullstack",
+				Executable:      "/usr/bin/claude",
+				Args:            []string{"--permission-mode", "auto", "--model", "claude-fable-5"},
+				Cwd:             SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: "/Users/omri.a/Code/amq-squad-wt-fable-squad-v2-31-0-fullstack"},
+				ResumePolicy:    launchapi.ResumePolicyFresh,
+				BootstrapPrompt: "You are fullstack. Wait for a task on AMQ.",
 				RequireWake:     true,
 				// gh#748: a named seat, gated on the pinned module's real
 				// argv grammar the same way the scoped grant and
@@ -55,32 +66,14 @@ func TestCompiledIntentAcceptedByReleasedAMQ(t *testing.T) {
 				// like docs/amq-0.73.0-adoption-verdict.md section 3/5's own
 				// measurements were.
 				AllowedArgumentForms: []string{"-n", "--name"},
-				SessionName:          "v2-30-0/lead",
-			},
-			{
-				Handle:          "senior-dev",
-				Executable:      "/usr/bin/codex",
-				Args:            []string{"--sandbox", "workspace-write", "--ask-for-approval", "on-request"},
-				Cwd:             SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: "/Users/omri.a/Code/amq-squad-wt-squad-v2-30-0-v2-30-0-senior-dev"},
-				ResumePolicy:    launchapi.ResumePolicyFresh,
-				BootstrapPrompt: "You are senior-dev. Wait for a task on AMQ.",
-				RequireWake:     true,
-			},
-			{
-				Handle:          "fullstack",
-				Executable:      "/usr/bin/claude",
-				Args:            []string{"--permission-mode", "auto"},
-				Cwd:             SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: "/Users/omri.a/Code/amq-squad-wt-squad-v2-30-0-v2-30-0-fullstack"},
-				ResumePolicy:    launchapi.ResumePolicyFresh,
-				BootstrapPrompt: "You are fullstack. Wait for a task on AMQ.",
-				RequireWake:     true,
+				SessionName:          "v2-31-0/fullstack",
 			},
 		},
 		Target: TargetFacts{
 			ProjectRoot: "/Users/omri.a/Code/amq-squad",
-			BaseRoot:    "/Users/omri.a/Code/amq-squad/.agent-mail/squad-v2-30-0/v2-30-0",
+			BaseRoot:    "/Users/omri.a/Code/amq-squad/.agent-mail/fable-squad/v2-31-0",
 			SessionRoot: "/Users/omri.a/Code/amq-squad",
-			Session:     "v2-30-0",
+			Session:     "v2-31-0",
 		},
 	}
 

--- a/internal/launchintent/launchintent.go
+++ b/internal/launchintent/launchintent.go
@@ -111,13 +111,49 @@ type SeatCWD struct {
 
 // SeatFacts is the fully resolved runtime shape of one runnable participant:
 // a team member's binary/args resolution, its placement, and its bootstrap
-// text, all assembled by the caller before Compile runs.
+// text, all assembled by the caller before Compile runs. This is the single
+// compile-path contract (gh#763): worktree cwd resolution belongs in Cwd,
+// per-seat process environment overrides belong in EnvOverlay, and trust
+// posture / model selection / preauth grants all resolve to native argv in
+// Args -- Compile shapes these into the ParticipantV1 contract fields of the
+// same name and otherwise passes Args and EnvOverlay through unchanged (Args
+// only has its new-path argv gated by sanitizeNewPathArgs below; EnvOverlay
+// is never inspected or mutated by Compile itself).
+//
+// EnvOverlay is NOT where AM_* identity goes: launchapi's own committed-env
+// allowlist (every provider, v0.73.0) accepts only COLORTERM/LANG/LC_ALL/
+// NO_COLOR/TERM and rejects any other key with "committed environment key
+// %q is not allowed by adapter" (internal/launch/adapter_env.go in the
+// pinned module), so a caller that puts AM_ROOT et al. here fails
+// intent.Validate() inside Compile. AM_* identity reaches the launched
+// process through ambient environment inheritance instead: the caller's
+// launch mechanism (see internal/cli/team_launch_launchapi.go's
+// buildIntentInput, which always passes EnvOverlay: nil) launches the seat
+// into a pane/shell that already has AM_* set, and adoptionseam.SanitizeEnv
+// plus the backend's own strip list (see sanitizedIdentityVarNames) decide
+// what ambient identity to keep or scrub -- that inheritance path, not
+// EnvOverlay, is the caller's AM_* mechanism.
 type SeatFacts struct {
-	Handle          string
-	Executable      string
-	Args            []string
-	Wrapper         *launchapi.WrapperV1
-	Cwd             SeatCWD
+	// Handle is the participant handle. Must be unique across all seats and
+	// distinct from the operator handle; Compile rejects otherwise.
+	Handle string
+	// Executable is the resolved binary path or name to run. Required.
+	Executable string
+	// Args is the seat's resolved native argv (trust-mode built-ins, model
+	// selection, preauth grants, and any other per-seat native flags) as the
+	// caller composed them. Compile applies only the new-path argv gate
+	// (sanitizeNewPathArgs) on top; it never adds trust/model/preauth
+	// semantics of its own.
+	Args    []string
+	Wrapper *launchapi.WrapperV1
+	// Cwd is the caller-resolved worktree/session working directory. Compile
+	// never touches the filesystem to produce or validate it (see SeatCWD).
+	Cwd SeatCWD
+	// EnvOverlay is the caller-resolved per-seat committed environment
+	// override, passed through to ParticipantV1.EnvOverlay unchanged. Only
+	// COLORTERM/LANG/LC_ALL/NO_COLOR/TERM survive launchapi's own adapter
+	// allowlist (see the SeatFacts doc comment above); it is not a channel
+	// for AM_* identity or arbitrary per-seat env.
 	EnvOverlay      map[string]string
 	ResumePolicy    launchapi.ResumePolicy
 	OnLive          launchapi.OnLivePolicyV1

--- a/internal/launchintent/launchintent_test.go
+++ b/internal/launchintent/launchintent_test.go
@@ -27,7 +27,7 @@ func baseTarget() TargetFacts {
 	}
 }
 
-func TestCompileIntentOperatorIsHandleOnly(t *testing.T) {
+func TestCompileIntentOperatorSeatIsNonRunnableHandleOnly(t *testing.T) {
 	in := Input{
 		Operator: OperatorFacts{Handle: "user"},
 		Seats:    []SeatFacts{baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")},
@@ -47,7 +47,7 @@ func TestCompileIntentOperatorIsHandleOnly(t *testing.T) {
 	}
 }
 
-func TestCompileIntentSiblingWorktreeCwdPreserved(t *testing.T) {
+func TestCompileIntentWorktreeSeatCarriesCwd(t *testing.T) {
 	worktreeCWD := "/Users/omri.a/Code/amq-squad-wt-squad-v2-30-0-v2-30-0-senior-dev"
 	in := Input{
 		Operator: OperatorFacts{Handle: "user"},

--- a/internal/launchintent/launchintent_test.go
+++ b/internal/launchintent/launchintent_test.go
@@ -406,6 +406,36 @@ func TestCompileIntentBootstrapPromptGoesToInitialInput(t *testing.T) {
 	}
 }
 
+// TestCompileIntentEnvOverlayPassesThroughUnchanged proves gh#763's
+// contract that Compile never inspects or mutates a seat's caller-resolved
+// EnvOverlay -- it lands on the compiled participant byte-for-byte. Keys
+// here are drawn from launchapi's own committed-env allowlist (every
+// provider, v0.73.0: COLORTERM/LANG/LC_ALL/NO_COLOR/TERM only --
+// internal/launch/adapter_env.go in the pinned module); AM_* identity is
+// deliberately not exercised here since it is rejected by intent.Validate()
+// (see the SeatFacts.EnvOverlay doc comment) and reaches the launched
+// process via ambient environment inheritance instead, not EnvOverlay.
+func TestCompileIntentEnvOverlayPassesThroughUnchanged(t *testing.T) {
+	seat := baseSeat("fullstack", "/Users/omri.a/Code/amq-squad")
+	seat.EnvOverlay = map[string]string{
+		"TERM":     "xterm-256color",
+		"NO_COLOR": "1",
+	}
+	in := Input{
+		Operator: OperatorFacts{Handle: "user"},
+		Seats:    []SeatFacts{seat},
+		Target:   baseTarget(),
+	}
+	intent, _, err := Compile(in)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	member := intent.Participants[1]
+	if !reflect.DeepEqual(member.EnvOverlay, seat.EnvOverlay) {
+		t.Fatalf("EnvOverlay not passed through unchanged: got %+v, want %+v", member.EnvOverlay, seat.EnvOverlay)
+	}
+}
+
 func TestCompileRejectsMissingBaseRoot(t *testing.T) {
 	target := baseTarget()
 	target.BaseRoot = ""


### PR DESCRIPTION
## Summary
- Makes `internal/launchintent.Compile` the single, documented compile path from a resolved team profile to `launchapi.LaunchIntentV1`/`TargetV1`: operator seat compiles to a `runnable:false` handle-only `ParticipantV1` (already the case), worktree cwd resolves through `SeatCWD`/`Cwd`, and trust/model/preauth resolve to native argv in `Args` -- all now documented explicitly in `SeatFacts`' doc comments.
- Renames the two Compile unit tests to gh#763's named acceptance tests (`TestCompileIntentOperatorSeatIsNonRunnableHandleOnly`, `TestCompileIntentWorktreeSeatCarriesCwd`); no behavior change, both already covered the claim.
- Refreshes the golden fixture in `golden_amq_test.go` from the retired squad-v2-30-0 3-seat shape to amq-squad's actual default profile (cto: codex lead, fullstack: claude, operator), per `simple_wizard.go`'s `--lead cto` default.
- Adds `TestCompileIntentEnvOverlayPassesThroughUnchanged` and adds `TestLegacyComposerReferencedOnlyByLegacyBackend` (see Deviations below for both).

## Deviations from gh#763's text
Two places where gh#763's literal wording doesn't hold against the real contract, found and corrected while implementing (both discussed with cto on the task thread before landing):

1. **"AM_\* and per-seat env -> EnvOverlay" is not possible.** launchapi's committed-env allowlist (every provider, pinned v0.73.0: `internal/launch/adapter_env.go`/`adapter_claude.go`/`adapter_codex.go`/etc.) accepts only `COLORTERM`/`LANG`/`LC_ALL`/`NO_COLOR`/`TERM` and rejects any other key with `committed environment key %q is not allowed by adapter`, confirmed empirically for both `AM_ROOT` and `AM_ME`. AM_\* identity reaches the launched process via ambient environment inheritance instead (`team_launch_launchapi.go`'s `buildIntentInput` always passes `EnvOverlay: nil`), not via `ParticipantV1.EnvOverlay`. Documented this in `SeatFacts`' doc comments and added `TestCompileIntentEnvOverlayPassesThroughUnchanged` using allowlisted keys (`TERM`/`NO_COLOR`) instead of asserting something false with AM_\* keys. (Also found `internal/adoptionseam.go`'s own doc comment at lines 107-120 makes the same incorrect claim about AM_ME round-tripping through EnvOverlay -- out of scope for this PR since that file isn't part of t1's scope; flagged for a follow-up fix when t6 next touches that package.)

2. **"Isolate the legacy argv composer so only `--launch-via legacy` references it" is not fully achievable today.** `--launch-via`/`resolveTeamLaunchBackend` (gh#755, just merged) only gates `executeTeamLaunch`'s backend selection (the `team launch`/`up` command). Two other call sites reach the same composer (`claudeInScopePreauthAllowlist` and the argv-splicing "friends" in `agent_defaults.go`) with **no** `--launch-via` gate at all, because they never go through `resolveTeamLaunchBackend`:
   - `internal/cli/simple_start.go` (the `amq-squad start` single-session planner) resolves its backend via a bare `teamLaunchBackends[opts.Terminal]` lookup and always calls `buildTeamLaunchPanes`, composing legacy pane commands unconditionally.
   - `internal/cli/launch.go` (single-agent `agent up`/launch) has no `--launch-via` concept at all.

   `TestLegacyComposerReferencedOnlyByLegacyBackend` therefore asserts the honest, provable invariant instead: the composer is never referenced (as an actual `go/parser`-verified code identifier, not a doc-comment mention) from the launchapi-path files -- `team_launch_launchapi.go` and every file in `internal/launchintent`. That's what gh#763 actually needs: the new path must never silently reabsorb the old argv-splicing logic.

   **Architecture consequence for v2.32.0:** the milestone's planned deletion of this composer is *not* a plain file removal until `simple_start` and single-agent launch are migrated onto `internal/launchintent.Compile` or the launchapi path. cto is carrying this into a release-time follow-up issue via t14's deprecation table.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/launchintent/... ./internal/cli/...` -- all pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing and identical on unmodified main @ 18f7474 (unrelated PTY/sandbox flake).
- [x] `AMQ_SQUAD_REAL_AMQ=<real amq binary>` run of `TestCompiledIntentAcceptedByReleasedAMQ` (golden intent decode against the real launchapi contract).

Closes #763.
