### PR TITLE
fix(drafter): yoetz envelope, in_session evidence, missing-model, bullet markers (gh#760)

### DIFF
--- a/internal/cli/goal_test.go
+++ b/internal/cli/goal_test.go
@@ -1984,7 +1984,7 @@ func TestGoalDraftCustomLeadCarriesThroughPlan(t *testing.T) {
 
 func TestGoalDraftUsesConfiguredDrafterAndValidatesBrief(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(configPath, []byte(`{"drafter":{"chain":["yoetz","claude"]}}`), 0o600); err != nil {
+	if err := os.WriteFile(configPath, []byte(`{"drafter":{"chain":["yoetz","claude"],"model":"gemini/flash"}}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("AMQ_SQUAD_CONFIG", configPath)

--- a/internal/cli/role_draft_test.go
+++ b/internal/cli/role_draft_test.go
@@ -144,6 +144,7 @@ func TestRunRoleDraftBackendFallbackReportsEvidenceWithoutStaging(t *testing.T) 
 func TestRunRoleDraftChainFallbackReportsEveryAttempt(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
 		Chain: []string{drafter.BackendYoetz, drafter.BackendClaude},
+		Model: "fast-model",
 	})
 	installRoleDraftRunner(t, func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
 		attempts := []drafter.Evidence{
@@ -182,6 +183,7 @@ func TestRunRoleDraftChainFallbackReportsEveryAttempt(t *testing.T) {
 func TestRunRoleDraftFailureModeErrorReportsEveryAttempt(t *testing.T) {
 	project, profile, session := setupRoleDraftTeam(t, &drafter.Config{
 		Chain:     []string{drafter.BackendYoetz, drafter.BackendClaude},
+		Model:     "fast-model",
 		OnFailure: drafter.FailureError,
 	})
 	installRoleDraftRunner(t, func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -198,6 +198,34 @@ func TestSetupRejectsInvalidNonInteractiveChainBeforeWrite(t *testing.T) {
 	}
 }
 
+// TestSetupRejectsYoetzHopWithoutModel proves setup refuses a yoetz preset
+// hop with no --drafter-model up front (gh#760), via the same
+// drafter.ValidateGlobal call every non-interactive setup already runs
+// before writing -- not only at yoetz's own later "provider is required"
+// invocation failure.
+func TestSetupRejectsYoetzHopWithoutModel(t *testing.T) {
+	writes := 0
+	deps := setupDependencies{
+		In:         strings.NewReader(""),
+		Out:        &bytes.Buffer{},
+		Err:        &bytes.Buffer{},
+		LookPath:   func(string) (string, error) { return "", errors.New("not found") },
+		Version:    func(string) (string, error) { return "", nil },
+		ReadConfig: func() (userconfig.Config, error) { return userconfig.Config{}, nil },
+		WriteConfig: func(userconfig.Config) (string, error) {
+			writes++
+			return "/config.json", nil
+		},
+	}
+	err := runSetupWithDependencies([]string{"--drafter-chain", "yoetz"}, deps)
+	if err == nil || !strings.Contains(err.Error(), "model: required for the yoetz preset backend") {
+		t.Fatalf("setup error = %v, want yoetz-without-model refusal", err)
+	}
+	if writes != 0 {
+		t.Fatalf("invalid setup performed %d writes", writes)
+	}
+}
+
 func TestSetupIsPublicAndCompletable(t *testing.T) {
 	if _, ok := lookupCommand("setup", "v-test"); !ok {
 		t.Fatal("setup is not dispatchable")

--- a/internal/cli/simple_start_brief_draft.go
+++ b/internal/cli/simple_start_brief_draft.go
@@ -187,10 +187,23 @@ func nonEmptyTrimmedLines(lines []string) []string {
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
 		if line = strings.TrimSpace(line); line != "" {
-			out = append(out, line)
+			out = append(out, normalizeMarkdownBulletMarker(line))
 		}
 	}
 	return out
+}
+
+// normalizeMarkdownBulletMarker rewrites a leading CommonMark "* " or "+ "
+// bullet marker to "- " (gh#760: some drafters, e.g. gemini-2.5-flash, emit
+// those instead of "- ", and both allMarkdownBullets and
+// validateSimpleStartTeamShape's exact-prefix match only ever accepted
+// "- "). Only a two-character marker-plus-space prefix qualifies, so prose
+// starting with "**bold**" or a bare "+" is left untouched.
+func normalizeMarkdownBulletMarker(line string) string {
+	if strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "+ ") {
+		return "- " + line[2:]
+	}
+	return line
 }
 
 func allMarkdownBullets(lines []string) bool {

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -1080,6 +1080,57 @@ func TestValidateSimpleStartBriefDraftExactShape(t *testing.T) {
 	}
 }
 
+// TestAllMarkdownBulletsAcceptsAsteriskAndPlusMarkers proves gh#760's fix:
+// a drafter that emits valid CommonMark "* " or "+ " bullets (e.g. the
+// gemini-2.5-flash repro from the issue's 2026-08-30 comment) instead of
+// "- " is no longer rejected, in both allMarkdownBullets' generic
+// bullet-only sections and validateSimpleStartTeamShape's exact-prefix
+// roster match -- the same nonEmptyTrimmedLines normalization feeds both.
+func TestAllMarkdownBulletsAcceptsAsteriskAndPlusMarkers(t *testing.T) {
+	member := team.Member{Role: "dev", Handle: "dev", Binary: "codex"}
+	valid := validSimpleStartBriefDraft("work", "ship it", member)
+	body := valid
+	body = strings.Replace(body, "- Implement the reviewed change.", "* Implement the reviewed change.", 1)
+	body = strings.Replace(body, "- Do not release or send externally.", "+ Do not release or send externally.", 1)
+	body = strings.Replace(body, "- Focused and full validation pass.", "* Focused and full validation pass.", 1)
+	body = strings.Replace(body, "- `dev` (`dev`, `codex`)", "* `dev` (`dev`, `codex`)", 1)
+	if body == valid {
+		t.Fatal("test setup did not actually swap any bullet markers")
+	}
+	got, err := validateSimpleStartBriefDraft(body, "work", "ship it", []team.Member{member})
+	if err != nil {
+		t.Fatalf("validateSimpleStartBriefDraft with */+ bullets: %v", err)
+	}
+	if got != body {
+		t.Fatalf("validateSimpleStartBriefDraft returned a rewritten document; want the reviewed input returned verbatim")
+	}
+}
+
+// TestNormalizeMarkdownBulletMarkerLeavesNonBulletProseUntouched proves the
+// gh#760 normalization only rewrites an exact "* "/"+ " leading marker, so
+// the Goal and Source sections (never bullet-constrained, and not always
+// starting with a bullet at all) are byte-identical afterward -- including
+// prose that starts with a marker-like character with no following space.
+func TestNormalizeMarkdownBulletMarkerLeavesNonBulletProseUntouched(t *testing.T) {
+	for _, line := range []string{
+		"ship it",
+		"Generated from the operator goal through the configured drafter.",
+		"**bold** starts the line",
+		"+1 to this idea",
+		"*emphasis* at the start",
+	} {
+		if got := normalizeMarkdownBulletMarker(line); got != line {
+			t.Fatalf("normalizeMarkdownBulletMarker(%q) = %q, want unchanged", line, got)
+		}
+	}
+	if got := normalizeMarkdownBulletMarker("* bullet"); got != "- bullet" {
+		t.Fatalf("normalizeMarkdownBulletMarker(asterisk marker) = %q", got)
+	}
+	if got := normalizeMarkdownBulletMarker("+ bullet"); got != "- bullet" {
+		t.Fatalf("normalizeMarkdownBulletMarker(plus marker) = %q", got)
+	}
+}
+
 func TestEnsureSimpleStartBriefPublishesWithoutOverwrite(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "briefs", "work.md")
 	const reviewed = "# reviewed brief\n"

--- a/internal/cli/simple_wizard.go
+++ b/internal/cli/simple_wizard.go
@@ -395,11 +395,18 @@ func wizardNewProfileFlagsSet(req simpleWizardRequest) bool {
 }
 
 func preflightSimpleWizardReadiness(deps simpleWizardDependencies) error {
-	if _, err := deps.ReadConfig(); err != nil {
+	cfg, err := deps.ReadConfig()
+	if err != nil {
 		return fmt.Errorf("wizard read global config: %w", err)
 	}
 	if _, err := deps.ConfigPath(); err != nil {
 		return fmt.Errorf("wizard global config path: %w", err)
+	}
+	// gh#760: catch a yoetz-preset drafter with no model here, before the
+	// drafter ever runs, rather than only at yoetz's own opaque invocation
+	// failure. Same rule setup.go already enforces via ValidateGlobal.
+	if err := drafter.ValidateGlobal(cfg.Drafter); err != nil {
+		return fmt.Errorf("wizard readiness: drafter config: %w", err)
 	}
 	for _, name := range []string{"amq", "tmux"} {
 		if _, err := deps.LookPath(name); err != nil {
@@ -445,7 +452,8 @@ func buildNewSimpleWizardPlan(plan *simpleWizardPlan, req simpleWizardRequest, v
 		return err
 	}
 	if goalData.BriefDraft != nil && goalData.BriefDraft.Manual {
-		return fmt.Errorf("wizard stopped before mutation: configured brief drafting requires in-session completion; rerun after configuring a headless drafter. Prompt:\n%s", goalData.BriefDraft.Prompt)
+		return fmt.Errorf("wizard stopped before mutation: configured brief drafting requires in-session completion; rerun after configuring a headless drafter. %s\nPrompt:\n%s",
+			cliDrafterErrorEvidence(goalData.BriefDraft.ConfigSource, goalData.BriefDraft.Attempts, goalData.BriefDraft.Evidence), goalData.BriefDraft.Prompt)
 	}
 	brief := goalData.BriefSkeleton
 	plan.Team = tm
@@ -503,7 +511,8 @@ func buildExistingSimpleWizardPlan(plan *simpleWizardPlan, deps simpleWizardDepe
 			return draftErr
 		}
 		if draft.Manual {
-			return fmt.Errorf("wizard stopped before mutation: configured brief drafting requires in-session completion; rerun after configuring a headless drafter. Prompt:\n%s", draft.Prompt)
+			return fmt.Errorf("wizard stopped before mutation: configured brief drafting requires in-session completion; rerun after configuring a headless drafter. %s\nPrompt:\n%s",
+				cliDrafterErrorEvidence(draft.ConfigSource, draft.Attempts, draft.Evidence), draft.Prompt)
 		}
 		briefBytes = append([]byte(nil), draft.Document...)
 		evidence = &simpleWizardDraftEvidence{Source: draft.ConfigSource, Evidence: draft.Evidence, Attempts: draft.Attempts}

--- a/internal/cli/simple_wizard_test.go
+++ b/internal/cli/simple_wizard_test.go
@@ -156,6 +156,30 @@ func TestWizardReadinessFailsBeforeDrafterRuns(t *testing.T) {
 	}
 }
 
+// TestWizardReadinessFailsOnYoetzWithoutModel proves wizard readiness
+// refuses a global yoetz-preset drafter config with no model up front
+// (gh#760), before the drafter ever runs, instead of only surfacing yoetz's
+// own opaque "provider is required" failure at invocation time.
+func TestWizardReadinessFailsOnYoetzWithoutModel(t *testing.T) {
+	project := t.TempDir()
+	deps := simpleWizardTestDependencies(t, project)
+	deps.ReadConfig = func() (userconfig.Config, error) {
+		return userconfig.Config{Drafter: &drafter.Config{Backend: drafter.BackendYoetz}}, nil
+	}
+	drafterCalled := false
+	deps.RunGoalDraft = func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
+		drafterCalled = true
+		return drafter.Result{}, nil
+	}
+	err := runWizardWithDependencies([]string{"Ship it", "--project", project}, "test", deps, strings.NewReader(""), io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "model: required for the yoetz preset backend") {
+		t.Fatalf("wizard readiness error = %v, want yoetz-without-model refusal", err)
+	}
+	if drafterCalled {
+		t.Fatal("wizard invoked the drafter before core readiness passed")
+	}
+}
+
 func TestWizardImplicitProfileCollisionUsesExistingFlow(t *testing.T) {
 	project := t.TempDir()
 	op := team.DefaultOperator()
@@ -265,6 +289,58 @@ func TestWizardCustomSeatUsesDrafterInsideBinaryPlan(t *testing.T) {
 	if team.ExistsProfile(project, "research-team") {
 		t.Fatal("custom-seat JSON preview mutated the profile")
 	}
+}
+
+// TestInSessionFallthroughIncludesAttemptEvidence proves the wizard's
+// stopped-before-mutation error (gh#760) surfaces the per-attempt drafter
+// evidence -- backend, exact command, and fall-through reason -- for both
+// the new-profile brief draft path (simple_wizard.go's
+// buildNewSimpleWizardPlan) and the existing-profile brief draft path
+// (buildExistingSimpleWizardPlan), instead of silently dropping it like the
+// validation-error path never did.
+func TestInSessionFallthroughIncludesAttemptEvidence(t *testing.T) {
+	fallThroughDraft := func(context.Context, *drafter.Config, drafter.Request) (drafter.Result, error) {
+		return drafter.Result{
+			UseInSession: true,
+			Attempts: []drafter.Evidence{
+				{Backend: drafter.BackendYoetz, CommandDisplay: "yoetz ask --prompt-file *** --format text", Failure: "exit 17: missing provider API key"},
+			},
+		}, nil
+	}
+
+	t.Run("new profile", func(t *testing.T) {
+		project := t.TempDir()
+		deps := simpleWizardTestDependencies(t, project)
+		deps.RunGoalDraft = fallThroughDraft
+		err := runWizardWithDependencies([]string{"Ship the reviewed change", "--project", project, "--profile", "review", "--session", "issue-709", "--yes"}, "test", deps, strings.NewReader(""), io.Discard, io.Discard)
+		if err == nil {
+			t.Fatal("expected the in-session fallthrough error")
+		}
+		if !strings.Contains(err.Error(), "attempt[1] backend=yoetz") || !strings.Contains(err.Error(), "fall-through=") {
+			t.Fatalf("new-profile fallthrough error dropped attempt evidence: %v", err)
+		}
+	})
+
+	t.Run("existing profile", func(t *testing.T) {
+		project := t.TempDir()
+		op := team.DefaultOperator()
+		tm := team.Team{Operator: &op, Orchestrated: true, Lead: "cto", LeadMode: team.LeadModePlanner, ExecutionMode: executionModeProjectLead, Members: []team.Member{{Role: "cto", Handle: "cto", Binary: "codex", ActorMode: team.ActorModeReview}}}
+		if err := team.WriteProfile(project, "reusable", tm); err != nil {
+			t.Fatal(err)
+		}
+		if err := rules.Write(project, "# Existing reviewed rules\n"); err != nil {
+			t.Fatal(err)
+		}
+		deps := simpleWizardTestDependenciesForMembers(t, project, tm.Members)
+		deps.RunGoalDraft = fallThroughDraft
+		err := runWizardWithDependencies([]string{"A fresh workstream", "--project", project, "--profile", "reusable", "--session", "fresh", "--yes"}, "test", deps, strings.NewReader(""), io.Discard, io.Discard)
+		if err == nil {
+			t.Fatal("expected the in-session fallthrough error")
+		}
+		if !strings.Contains(err.Error(), "attempt[1] backend=yoetz") || !strings.Contains(err.Error(), "fall-through=") {
+			t.Fatalf("existing-profile fallthrough error dropped attempt evidence: %v", err)
+		}
+	})
 }
 
 type wizardMutationReader struct {

--- a/internal/cli/team_rules_draft_test.go
+++ b/internal/cli/team_rules_draft_test.go
@@ -64,7 +64,7 @@ func TestValidateTeamRulesDraftRejectsStructuralDrift(t *testing.T) {
 }
 
 func TestRunTeamRulesInitUsesConfiguredDrafterBeforeWrite(t *testing.T) {
-	project, profile := setupTeamRulesDraftProfile(t, &drafter.Config{Chain: []string{drafter.BackendYoetz, drafter.BackendClaude}})
+	project, profile := setupTeamRulesDraftProfile(t, &drafter.Config{Chain: []string{drafter.BackendYoetz, drafter.BackendClaude}, Model: "fast-model"})
 	installTeamRulesDraftRunner(t, func(_ context.Context, cfg *drafter.Config, request drafter.Request) (drafter.Result, error) {
 		if cfg == nil || len(cfg.EffectiveBackends()) != 2 || cfg.EffectiveBackends()[0] != drafter.BackendYoetz || cfg.EffectiveBackends()[1] != drafter.BackendClaude {
 			t.Fatalf("team-rules drafter config = %+v", cfg)

--- a/internal/drafter/config.go
+++ b/internal/drafter/config.go
@@ -215,6 +215,17 @@ func Validate(c *Config) error {
 	if len(c.Command) == 0 && len(backends) == 1 && backends[0] == BackendYoetz && strings.TrimSpace(c.Effort) != "" {
 		return fmt.Errorf("effort: the yoetz preset has no effort flag; use a custom command template with {effort}")
 	}
+	// gh#760: the yoetz preset silently omits --model when Config.Model is
+	// empty (buildCommand), which yoetz itself only rejects at invocation
+	// time with "Error: provider is required". Refuse it up front instead,
+	// for a lone yoetz backend or yoetz as any hop in a chain.
+	if len(c.Command) == 0 && strings.TrimSpace(c.Model) == "" {
+		for _, backend := range backends {
+			if backend == BackendYoetz {
+				return fmt.Errorf("model: required for the yoetz preset backend")
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/drafter/config_test.go
+++ b/internal/drafter/config_test.go
@@ -58,6 +58,8 @@ func TestValidateRejectsInvalidConfig(t *testing.T) {
 		{name: "missing-model-token", cfg: Config{Backend: BackendCustom, Command: []string{"tool"}, Model: "x"}, want: "must include {model}"},
 		{name: "missing-model-value", cfg: Config{Backend: BackendCustom, Command: []string{"tool", "{model}"}}, want: "required when command contains {model}"},
 		{name: "yoetz-effort", cfg: Config{Backend: BackendYoetz, Effort: "low"}, want: "yoetz preset has no effort"},
+		{name: "yoetz-no-model", cfg: Config{Backend: BackendYoetz}, want: "model: required for the yoetz preset backend"},
+		{name: "yoetz-no-model-chain-hop", cfg: Config{Chain: []string{BackendClaude, BackendYoetz}}, want: "model: required for the yoetz preset backend"},
 		{name: "backend-and-chain", cfg: Config{Backend: BackendClaude, Chain: []string{BackendCodex}}, want: "mutually exclusive"},
 		{name: "empty-chain-hop", cfg: Config{Chain: []string{BackendClaude, " "}}, want: "chain[1]"},
 		{name: "in-session-chain-hop", cfg: Config{Chain: []string{BackendClaude, BackendInSession}}, want: "implicit after chain exhaustion"},

--- a/internal/drafter/run.go
+++ b/internal/drafter/run.go
@@ -196,7 +196,16 @@ func buildCommand(config Config, promptPath, outputPath string) ([]string, bool,
 	} else {
 		switch config.EffectiveBackend() {
 		case BackendYoetz:
-			command = []string{"yoetz", "ask", "--prompt-file", "{prompt}", "--output-final", "{out}", "--response-format", "text", "--no-notify"}
+			// --output-final always JSON-serializes the whole RunResult
+			// envelope (content, artifacts, usage, ...), independent of
+			// --response-format (yoetz 0.5.62, verified against source):
+			// that flag only shapes what is requested FROM the model
+			// provider, not what yoetz itself writes to --output-final. So
+			// this reads stdout instead (gh#760): --format text pins yoetz's
+			// own stdout rendering to raw content regardless of the
+			// YOETZ_AGENT env var, which otherwise flips the unset-flag
+			// default to json.
+			command = []string{"yoetz", "ask", "--prompt-file", "{prompt}", "--format", "text", "--response-format", "text", "--no-notify"}
 			if model := strings.TrimSpace(config.Model); model != "" {
 				command = append(command, "--model", model)
 			}

--- a/internal/drafter/run_test.go
+++ b/internal/drafter/run_test.go
@@ -245,7 +245,7 @@ IFS= read -r line
 printf 'codex:%s\n' "$line"
 `)
 	t.Setenv("PATH", bin)
-	cfg := &Config{Chain: []string{BackendYoetz, BackendCodex}}
+	cfg := &Config{Chain: []string{BackendYoetz, BackendCodex}, Model: "gemini/flash"}
 	result, err := Run(context.Background(), cfg, Request{Prompt: "fallback"})
 	if err != nil {
 		t.Fatalf("Run chain: %v", err)
@@ -263,7 +263,7 @@ func TestRunOrderedChainExhaustionFallsBackInSession(t *testing.T) {
 	writeNamedExecutable(t, bin, BackendYoetz, "#!/bin/sh\nexit 11\n")
 	writeNamedExecutable(t, bin, BackendClaude, "#!/bin/sh\nexit 12\n")
 	t.Setenv("PATH", bin)
-	cfg := &Config{Chain: []string{BackendYoetz, BackendClaude}}
+	cfg := &Config{Chain: []string{BackendYoetz, BackendClaude}, Model: "gemini/flash"}
 	result, err := Run(context.Background(), cfg, Request{Prompt: "draft"})
 	if err != nil {
 		t.Fatalf("Run exhaustion: %v", err)
@@ -309,9 +309,9 @@ func TestBuildCommandPresets(t *testing.T) {
 		{
 			name:       "yoetz",
 			cfg:        Config{Backend: BackendYoetz, Model: "gemini/flash"},
-			want:       []string{"yoetz", "ask", "--prompt-file", "/tmp/p", "--output-final", "/tmp/o", "--response-format", "text", "--no-notify", "--model", "gemini/flash"},
+			want:       []string{"yoetz", "ask", "--prompt-file", "/tmp/p", "--format", "text", "--response-format", "text", "--no-notify", "--model", "gemini/flash"},
 			promptFile: true,
-			outputFile: true,
+			outputFile: false,
 		},
 		{
 			name: "claude",
@@ -334,6 +334,52 @@ func TestBuildCommandPresets(t *testing.T) {
 				t.Fatalf("buildCommand = %v/%v/%v, want %v/%v/%v", got, promptFile, outputFile, tc.want, tc.promptFile, tc.outputFile)
 			}
 		})
+	}
+}
+
+// TestYoetzPresetReadsStdoutNotOutputFinal proves the yoetz preset (gh#760)
+// no longer relies on --output-final: yoetz 0.5.62 always JSON-serializes
+// the whole RunResult envelope there regardless of --response-format, so
+// the drafter would previously return that raw JSON envelope as the draft
+// text. The fake "yoetz" binary below reproduces the real CLI's behavior of
+// printing raw content to stdout under --format text and, unlike the real
+// CLI, also fails loudly if it ever sees --output-final -- proving the
+// preset argv no longer requests it.
+func TestYoetzPresetReadsStdoutNotOutputFinal(t *testing.T) {
+	bin := t.TempDir()
+	writeNamedExecutable(t, bin, BackendYoetz, `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--output-final" ]; then
+    printf 'unexpected --output-final in argv\n' >&2
+    exit 1
+  fi
+done
+saw_format=0
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--format" ] && [ "$arg" = "text" ]; then
+    saw_format=1
+  fi
+  prev="$arg"
+done
+if [ "$saw_format" != "1" ]; then
+  printf 'missing --format text in argv\n' >&2
+  exit 1
+fi
+printf '{"content": "should never be parsed as an envelope"}\n'
+`)
+	t.Setenv("PATH", bin)
+	cfg := &Config{Backend: BackendYoetz, Model: "gemini/flash"}
+	result, err := Run(context.Background(), cfg, Request{Prompt: "draft"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := `{"content": "should never be parsed as an envelope"}`
+	if result.Text != want {
+		t.Fatalf("Text = %q, want the raw stdout line unparsed: %q", result.Text, want)
+	}
+	if result.UseInSession || result.Fallback || result.Evidence.ExitCode != 0 {
+		t.Fatalf("result = %+v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

Four drafter defects surfaced diagnosing the 2026-08-27 wizard failure (the fourth added via a 2026-08-30 comment on the issue):

1. **yoetz JSON envelope**: the yoetz preset passed `--output-final {out}` and read the file as raw Markdown. Verified against the local yoetz source (installed `0.5.62`, ahead of both the issue's `0.5.49`/`0.5.58` references): `--output-final` always JSON-serializes the whole `RunResult{content, artifacts, ...}` envelope (`maybe_write_output` in `main.rs`), completely independent of `--response-format` — that flag only shapes what's requested *from* the model provider. Fix: drop `--output-final`, add `--format text` explicitly (yoetz's own stdout format flag, pinned so an inherited `YOETZ_AGENT=1` can't flip its default to json), and read stdout — which `ask.rs` prints as raw `result.content` under `--format text`.
2. **Dropped attempt evidence**: `internal/cli/simple_wizard.go`'s two in-session-fallthrough sites (new-profile and existing-profile brief drafting) returned an error without the per-attempt evidence (`attempt[1] backend=... command=... fall-through=...`) the validation-error path already renders via `cliDrafterErrorEvidence`. Both now call the same helper.
3. **Missing model not caught at readiness**: a yoetz hop with no model only failed at actual invocation with yoetz's own opaque `Error: provider is required`. `drafter.Validate()` now refuses it up front (covers a lone yoetz backend or yoetz as any chain hop). `setup` already calls `ValidateGlobal` before writing, so this is free there; wizard readiness now runs the same check before the drafter ever runs.
4. **CommonMark bullet markers**: `allMarkdownBullets` and `validateSimpleStartTeamShape`'s exact-prefix roster match only ever accepted `- ` bullets, rejecting valid `* `/`+ ` bullets (repro'd 2026-08-30 with gemini-2.5-flash). Both are fed by `nonEmptyTrimmedLines`, which now normalizes a leading `* `/`+ ` marker to `- ` — one change point, no risk to Goal/Source prose (never bullet-constrained, and only an exact 2-char-plus-space prefix qualifies).

## Named acceptance tests
- `TestYoetzPresetReadsStdoutNotOutputFinal`
- `TestInSessionFallthroughIncludesAttemptEvidence`
- `TestSetupRejectsYoetzHopWithoutModel`
- `TestWizardReadinessFailsOnYoetzWithoutModel`
- `TestAllMarkdownBulletsAcceptsAsteriskAndPlusMarkers` (+ `TestNormalizeMarkdownBulletMarkerLeavesNonBulletProseUntouched`)

Closes #760.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean, `go vet ./...`
- [x] `go test ./...` — all packages pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing/failing identically on unmodified main (unrelated sandbox/PTY flake, verified independently on both this and the prior gh#755 PR).
- [x] `make ci` targets other than `test` (fmt-check, readme-html-check, docs-html-check, skills-check, skill-routing-check, skill-command-check, skill-invocation-check, release-validator-test, go-files-scope-test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)