### PR TITLE
fix(worktreeplan): base-drift acknowledgement + gone-worktree cleanup reconciliation (gh#739, gh#740)

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -217,6 +217,7 @@ var completionCommonFlags = []string{
 	"--action-id",
 	"--attempt-id",
 	"--actions",
+	"--acknowledge-base-drift",
 	"--agent",
 	"--all",
 	"--all-profiles",

--- a/internal/cli/worktree.go
+++ b/internal/cli/worktree.go
@@ -38,8 +38,8 @@ func runWorktree(args []string) error {
 		fmt.Fprint(os.Stderr, `amq-squad worktree - deterministic isolated worker worktrees
 
 Usage:
-  amq-squad worktree plan --role R --task ID --base SHA --scope PATH... --session S [--profile P] [--path PATH] [--branch REF] [--repo PATH] [--json]
-  amq-squad worktree materialize --role R --task ID --base SHA --scope PATH... --session S [--profile P] [--path PATH] [--branch REF] [--repo PATH] --yes [--json]
+  amq-squad worktree plan --role R --task ID --base SHA --scope PATH... --session S [--profile P] [--path PATH] [--branch REF] [--repo PATH] [--acknowledge-base-drift] [--json]
+  amq-squad worktree materialize --role R --task ID --base SHA --scope PATH... --session S [--profile P] [--path PATH] [--branch REF] [--repo PATH] [--acknowledge-base-drift] --yes [--json]
   amq-squad worktree inspect --session S [--profile P] [--role R] [--json]
   amq-squad worktree activate --role R --session S [--profile P] --yes [--json]
   amq-squad worktree handoff --role R [--sha SHA] --session S [--profile P] --yes [--json]
@@ -50,7 +50,11 @@ Usage:
 plan is read-only. Mutating commands are explicit --yes operations. cleanup only
 removes a clean worktree at the exact registered path; it may adopt a clean
 sequential-task branch and remove verified bootstrap/canonical-copy AMQ residue,
-but it never deletes an unknown directory or branch.
+but it never deletes an unknown directory or branch. If the registered path is
+already gone entirely (no directory, no Git registration), cleanup reconciles
+the stale plan entry as cleaned instead of refusing. --acknowledge-base-drift
+explicitly advances a session's accepted base past its write-once pin; every
+other canonical-root check stays a hard failure with no override.
 `)
 		if len(args) == 0 {
 			return usageErrorf("worktree requires a subcommand")
@@ -99,6 +103,7 @@ func runWorktreePlan(args []string, materialize bool) error {
 	session := fs.String("session", "", "workstream session")
 	registerScopedFlagAliases(fs, project, session, profile)
 	yes := fs.Bool("yes", false, "confirm materialization")
+	acknowledgeBaseDrift := fs.Bool("acknowledge-base-drift", false, "explicitly advance the session's accepted base when --base has drifted, instead of failing closed")
 	jsonOut := fs.Bool("json", false, "emit a schema-versioned JSON envelope")
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -120,6 +125,7 @@ func runWorktreePlan(args []string, materialize bool) error {
 	request := worktreeplan.Request{
 		Role: *role, TaskID: *taskID, Base: *base, Scope: scopes,
 		Path: *path, Branch: *branch, RepoRoot: *repo, AMQRoot: scope.amqRoot,
+		AcknowledgeBaseDrift: *acknowledgeBaseDrift,
 	}
 	var set worktreeplan.Set
 	var plan worktreeplan.Record

--- a/internal/worktreeplan/model.go
+++ b/internal/worktreeplan/model.go
@@ -68,8 +68,14 @@ type Record struct {
 	PreviousExplicit bool       `json:"previous_cwd_explicit,omitempty"`
 	CleanupDecision  string     `json:"cleanup_decision,omitempty"`
 	CleanupStartedAt *time.Time `json:"cleanup_started_at,omitempty"`
-	CreatedAt        *time.Time `json:"created_at,omitempty"`
-	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	// CleanupReconciledOrphan is true only when Cleanup reconciled this
+	// record from a worktree that was already gone (gh#740: removed with a
+	// raw `git worktree remove` outside the normal lifecycle) rather than
+	// removing a still-registered worktree itself. Never set on an ordinary
+	// cleanup.
+	CleanupReconciledOrphan bool       `json:"cleanup_reconciled_orphan,omitempty"`
+	CreatedAt               *time.Time `json:"created_at,omitempty"`
+	UpdatedAt               *time.Time `json:"updated_at,omitempty"`
 }
 
 // Set is the complete session-scoped materialization contract.
@@ -97,6 +103,12 @@ type Request struct {
 	Branch   string
 	RepoRoot string
 	AMQRoot  string
+	// AcknowledgeBaseDrift explicitly re-pins the session's write-once
+	// AcceptedBaseSHA to Base's resolved commit when it has already drifted
+	// (gh#739), instead of failing closed with "accepted base drift". Every
+	// other canonical-root check (team-home, control-root, AMQ-root) stays a
+	// hard failure with no override.
+	AcknowledgeBaseDrift bool
 }
 
 type CleanupRequest struct {

--- a/internal/worktreeplan/service.go
+++ b/internal/worktreeplan/service.go
@@ -263,7 +263,17 @@ func (s *Service) Cleanup(req CleanupRequest) (Record, error) {
 		}
 		if !status.Registered {
 			if !recovering {
-				return fmt.Errorf("refuse cleanup of unknown path %s: it is not a registered Git worktree", record.Path)
+				if status.Orphaned {
+					return fmt.Errorf("refuse cleanup of unknown path %s: a directory exists there but it is not a registered Git worktree", record.Path)
+				}
+				// gh#740: the worktree is genuinely gone (no directory, no
+				// Git registration -- e.g. removed with a raw `git worktree
+				// remove` outside the normal lifecycle). Reconcile the
+				// stale plan entry as cleaned instead of permanently
+				// blocking the role; the status.Registered guard below
+				// already skips the `worktree remove` step since there is
+				// nothing left to remove.
+				record.CleanupReconciledOrphan = true
 			}
 		} else {
 			if status.Dirty {
@@ -457,7 +467,13 @@ func (s *Service) prepare(set Set, exists bool, req Request) (Set, Record, int, 
 		return Set{}, Record{}, -1, fmt.Errorf("canonical AMQ root drift: session plan is %s, request is %s", set.AMQRoot, requestedAMQRoot)
 	}
 	if set.AcceptedBaseSHA != "" && set.AcceptedBaseSHA != baseSHA {
-		return Set{}, Record{}, -1, fmt.Errorf("accepted base drift: session plan is %s, request resolves to %s", set.AcceptedBaseSHA, baseSHA)
+		// gh#739: fail closed by default; a caller can only advance the
+		// session's write-once accepted base through the explicit
+		// AcknowledgeBaseDrift opt-in, never silently.
+		if !req.AcknowledgeBaseDrift {
+			return Set{}, Record{}, -1, fmt.Errorf("accepted base drift: session plan is %s, request resolves to %s (rerun with --acknowledge-base-drift to advance it)", set.AcceptedBaseSHA, baseSHA)
+		}
+		set.AcceptedBaseSHA = baseSHA
 	}
 	if set.AcceptedBaseSHA == "" {
 		set.AcceptedBaseSHA = baseSHA

--- a/internal/worktreeplan/service_test.go
+++ b/internal/worktreeplan/service_test.go
@@ -309,6 +309,63 @@ func TestPlannedBranchCrashRecoveryAndCleanupRefusals(t *testing.T) {
 	}
 }
 
+// TestCleanupReconcilesGoneWorktreeAsCleaned proves gh#740's fix: a plan
+// entry whose registered worktree was already removed entirely outside the
+// normal lifecycle (a raw `git worktree remove` plus branch delete, exactly
+// the issue's repro) is reconciled as cleaned instead of permanently
+// blocking the role, and the reconciliation is recorded on the durable
+// record via CleanupReconciledOrphan. This is deliberately a DIFFERENT
+// scenario from TestPlannedBranchCrashRecoveryAndCleanupRefusals's
+// unknown-path case, which recreates an empty directory at the path first
+// (an ambiguous stray-directory case gh#740 explicitly leaves refused, and
+// this test's own final assertion re-proves that ordinary/refused cleanups
+// never carry the marker).
+func TestCleanupReconcilesGoneWorktreeAsCleaned(t *testing.T) {
+	repo := newTestRepo(t)
+	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
+	service := newTestService(t, configured, team.DefaultProfile, "gone")
+	req := Request{Role: "worker", TaskID: "t1", Base: "HEAD", Scope: []string{"runtime/**"}, AMQRoot: filepath.Join(repo, ".agent-mail", "gone")}
+	_, materialized, err := service.Materialize(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, repo, "worktree", "remove", materialized.Path)
+	runGit(t, repo, "branch", "-D", materialized.Branch)
+	if pathExists(materialized.Path) {
+		t.Fatal("test setup: path should be fully gone")
+	}
+
+	reconciled, err := service.Cleanup(CleanupRequest{Role: "worker", Decision: "rejected"})
+	if err != nil {
+		t.Fatalf("reconciling cleanup of a gone worktree: %v", err)
+	}
+	if reconciled.State != StateCleaned {
+		t.Fatalf("reconciled state = %s, want cleaned", reconciled.State)
+	}
+	if !reconciled.CleanupReconciledOrphan {
+		t.Fatal("reconciled record does not carry CleanupReconciledOrphan")
+	}
+	if reconciled.CleanupDecision != "rejected" {
+		t.Fatalf("reconciled cleanup decision = %q, want rejected", reconciled.CleanupDecision)
+	}
+
+	// Regression: an ordinary, still-registered cleanup never carries the
+	// orphan-reconciliation marker.
+	req.TaskID = "t2"
+	_, ordinary, err := service.Materialize(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinaryCleaned, err := service.Cleanup(CleanupRequest{Role: "worker", Decision: "accepted"})
+	if err != nil {
+		t.Fatalf("ordinary cleanup: %v", err)
+	}
+	if ordinaryCleaned.CleanupReconciledOrphan {
+		t.Fatalf("ordinary cleanup of a live worktree %s wrongly carries CleanupReconciledOrphan", ordinary.Path)
+	}
+}
+
 func TestInspectionDiagnosesSharedIndexAndCoordinationDivergence(t *testing.T) {
 	repo := newTestRepo(t)
 	configured := writeTestTeam(t, repo, team.DefaultProfile, "one", "two")
@@ -388,6 +445,88 @@ func TestAcceptedBaseDriftAndHandoffDrift(t *testing.T) {
 	req.Base = "HEAD"
 	if _, _, err := service.Materialize(req); err == nil || !strings.Contains(err.Error(), "accepted base drift") {
 		t.Fatalf("accepted base error = %v", err)
+	}
+}
+
+// TestMaterializeStillFailsClosedOnDriftWithoutAcknowledgement proves
+// gh#739's default behavior is unchanged: a drifted --base without the
+// explicit AcknowledgeBaseDrift opt-in still fails closed, byte-identical to
+// TestAcceptedBaseDriftAndHandoffDrift's own assertion, and never advances
+// the stored accepted base as a side effect of the refused call.
+func TestMaterializeStillFailsClosedOnDriftWithoutAcknowledgement(t *testing.T) {
+	repo := newTestRepo(t)
+	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
+	service := newTestService(t, configured, team.DefaultProfile, "drift-noack")
+	req := Request{Role: "worker", TaskID: "t1", Base: "HEAD", Scope: []string{"runtime/**"}, AMQRoot: filepath.Join(repo, ".agent-mail", "drift-noack")}
+	if _, _, err := service.Materialize(req); err != nil {
+		t.Fatal(err)
+	}
+	original, err := service.Inspect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalBase := memberStatus(t, original, "worker").BaseSHA
+
+	if err := os.WriteFile(filepath.Join(repo, "next.txt"), []byte("next\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-m", "new base")
+	req.Base = "HEAD"
+	req.AcknowledgeBaseDrift = false
+	if _, _, err := service.Materialize(req); err == nil ||
+		!strings.Contains(err.Error(), "accepted base drift") || !strings.Contains(err.Error(), "--acknowledge-base-drift") {
+		t.Fatalf("accepted base error = %v, want the fail-closed drift refusal naming the opt-in flag", err)
+	}
+	after, err := service.Inspect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := memberStatus(t, after, "worker").BaseSHA; got != originalBase {
+		t.Fatalf("refused materialize advanced the stored accepted base: %s -> %s", originalBase, got)
+	}
+}
+
+// TestMaterializeAdvancesAcceptedBaseWithExplicitAcknowledgement proves
+// gh#739's fix: --acknowledge-base-drift re-pins the session's write-once
+// accepted base to the newly resolved --base instead of erroring, and the
+// worktree actually materializes at that new base.
+func TestMaterializeAdvancesAcceptedBaseWithExplicitAcknowledgement(t *testing.T) {
+	repo := newTestRepo(t)
+	configured := writeTestTeam(t, repo, team.DefaultProfile, "worker")
+	service := newTestService(t, configured, team.DefaultProfile, "drift-ack")
+	req := Request{Role: "worker", TaskID: "t1", Base: "HEAD", Scope: []string{"runtime/**"}, AMQRoot: filepath.Join(repo, ".agent-mail", "drift-ack")}
+	_, first, err := service.Materialize(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalBase := first.BaseSHA
+
+	if err := os.WriteFile(filepath.Join(repo, "next.txt"), []byte("next\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-m", "dependency merged")
+	advancedBase := runGit(t, repo, "rev-parse", "HEAD")
+
+	if _, err := service.Cleanup(CleanupRequest{Role: "worker", Decision: "rejected"}); err != nil {
+		t.Fatal(err)
+	}
+	req.TaskID = "t2"
+	req.Base = "HEAD"
+	req.AcknowledgeBaseDrift = true
+	set, advanced, err := service.Materialize(req)
+	if err != nil {
+		t.Fatalf("acknowledged materialize: %v", err)
+	}
+	if advanced.BaseSHA == originalBase {
+		t.Fatalf("acknowledged materialize did not advance BaseSHA past %s", originalBase)
+	}
+	if strings.TrimSpace(advancedBase) != advanced.BaseSHA {
+		t.Fatalf("advanced BaseSHA = %s, want the new HEAD %s", advanced.BaseSHA, advancedBase)
+	}
+	if set.AcceptedBaseSHA != advanced.BaseSHA {
+		t.Fatalf("session AcceptedBaseSHA = %s, want it re-pinned to %s", set.AcceptedBaseSHA, advanced.BaseSHA)
 	}
 }
 


### PR DESCRIPTION
## Summary

**gh#739**: `worktree plan`/`materialize`'s accepted-base drift check is already fail-closed as currently coded (`internal/worktreeplan/service.go:459-461`) — this corrects the issue's original repro text, which predates that state and described the drift check silently proceeding at the wrong base. What was actually missing: no way to legitimately advance a session's write-once `accepted_base_sha` once a dependency task merged, short of hand-editing the store. I hit this live during this squad's own t3→t4 transition today and used the documented `git reset --hard` workaround; it's now cited as evidence in the fix. Adds `--acknowledge-base-drift` to `worktree plan`/`materialize`: when the base has drifted and the flag is set, the session's accepted base re-pins to the new resolution instead of erroring. Every other canonical-root check (team-home, control-root, AMQ-root) stays a hard, non-overridable failure, and the default (no flag) path is byte-identical to today.

**gh#740**: `worktree cleanup` refused to reconcile a plan entry whose worktree had already been removed entirely outside the normal lifecycle (a raw `git worktree remove` + branch delete), permanently blocking the role until a throwaway worktree was recreated at the exact stale path+branch just to unstick it. `inspectRecord` already distinguishes this genuinely-gone case (`Orphaned=false`) from an ambiguous stray directory sitting at the path (`Orphaned=true`) — the latter stays refused, unchanged, exactly as `TestPlannedBranchCrashRecoveryAndCleanupRefusals` already proved. `Cleanup` now reconciles the genuinely-gone case directly as `cleaned` (nothing is left to remove) and records it on the durable record via the new `Record.CleanupReconciledOrphan` marker, verified absent on ordinary cleanups.

## Named tests
- `TestMaterializeAdvancesAcceptedBaseWithExplicitAcknowledgement`
- `TestMaterializeStillFailsClosedOnDriftWithoutAcknowledgement`
- `TestCleanupReconcilesGoneWorktreeAsCleaned` (+ regression assertion that an ordinary cleanup never carries the marker)

Closes #739, closes #740.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean, `go vet ./...`
- [x] `go test ./...` and `go test -shuffle=on ./internal/cli/...` — all pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing/unrelated (independently verified this exact CI lane on the sibling PR #776 today, so it was checked deliberately here, not assumed).
- [x] `make ci` targets other than `test` (fmt-check, readme-html-check, docs-html-check, skills-check, skill-routing-check, skill-command-check, skill-invocation-check, release-validator-test, go-files-scope-test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)