### PR TITLE
feat(status): session-level launchapi Inspect liveness floor (gh#737)

### DIFF
--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
@@ -361,6 +362,17 @@ var launchapiInspect = launchapi.Inspect
 // (team_launch_launchapi.go's buildIntentInput uses t.Project for both).
 // baseRoot is the session's resolved AMQ root (the same value every caller
 // of classifyAgentLiveness already computes as `root`).
+//
+// Memoized per (projectRoot, baseRoot, session) for the lifetime of this
+// process: launchapi.Inspect is documented read-only/deterministic (same
+// target, same answer, absent an actual state change on disk), and every
+// member of one roster rollup shares the same session Target, so without
+// this a single status/resume/doctor pass would call Inspect once per
+// member instead of once per session. Safe across process lifetime rather
+// than needing an explicit reset: amq-squad's status/resume/doctor commands
+// are short-lived CLI invocations (the cache dies with the process), and
+// every test uses a fresh t.TempDir()-derived projectRoot, so cache keys
+// can never collide across tests.
 func launchapiSessionInspect(projectRoot, baseRoot, session string) launchapiInspectSignal {
 	projectRoot = strings.TrimSpace(projectRoot)
 	baseRoot = strings.TrimSpace(baseRoot)
@@ -368,6 +380,28 @@ func launchapiSessionInspect(projectRoot, baseRoot, session string) launchapiIns
 	if projectRoot == "" || baseRoot == "" || session == "" {
 		return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: "incomplete session target"}
 	}
+	key := projectRoot + "\x00" + baseRoot + "\x00" + session
+	launchapiInspectMemoMu.Lock()
+	if cached, ok := launchapiInspectMemo[key]; ok {
+		launchapiInspectMemoMu.Unlock()
+		return cached
+	}
+	launchapiInspectMemoMu.Unlock()
+
+	signal := launchapiSessionInspectUncached(projectRoot, baseRoot, session)
+
+	launchapiInspectMemoMu.Lock()
+	launchapiInspectMemo[key] = signal
+	launchapiInspectMemoMu.Unlock()
+	return signal
+}
+
+var (
+	launchapiInspectMemoMu sync.Mutex
+	launchapiInspectMemo   = map[string]launchapiInspectSignal{}
+)
+
+func launchapiSessionInspectUncached(projectRoot, baseRoot, session string) launchapiInspectSignal {
 	result, err := launchapiInspect(context.Background(), launchapi.InspectRequestV1{
 		RequestVersion: launchapi.RequestVersionV1,
 		Target: launchapi.TargetV1{

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
@@ -87,6 +90,13 @@ type agentLiveness struct {
 	// JSON rendering must consume this rather than re-promoting a recorded PID
 	// or pane from weaker observations.
 	RuntimeIdentity launchRuntimeIdentity
+	// InspectSignal is gh#737's session-level launchapi Inspect outcome, set
+	// only by classifyAgentLivenessForRollup (zero value -- Outcome
+	// launchapiInspectNotApplicable -- for every other caller of the
+	// classifier). Callers that need to surface a session-level warning for
+	// launchapiInspectCallFailed read it from here rather than re-deriving
+	// the session Target a second time.
+	InspectSignal launchapiInspectSignal
 }
 
 // Live reports whether the verdict is any of the live sub-states. Both status
@@ -276,4 +286,179 @@ func classifierReplacementPane(role, handle, binary, cwd, workstream string) (st
 	m := team.Member{Role: role, Handle: handle, Binary: binary}
 	rec := statusRecord{Role: role, Handle: handle, Binary: binary, CWD: cwd}
 	return liveReplacementPane(m, rec, workstream)
+}
+
+// launchapiInspectOutcome classifies the result of one session-level
+// launchapi.Inspect call (gh#737) into the cases this package's floor logic
+// branches on.
+type launchapiInspectOutcome int
+
+const (
+	// launchapiInspectNotApplicable means Inspect succeeded and reported
+	// ReasonCode "binding_missing": no launchapi binding exists for this
+	// session's Target, so the session was not launchapi-launched. Legacy
+	// classification runs completely unchanged
+	// (TestStatusRollupUnchangedForLegacyLaunches).
+	launchapiInspectNotApplicable launchapiInspectOutcome = iota
+	// launchapiInspectCallFailed means the Inspect call itself errored (I/O,
+	// not a successful binding_missing result). Per cto's ruling: do NOT
+	// clamp any member -- run today's classification unchanged and surface
+	// a warning naming the error instead. Clamping every member of a
+	// legacy session on a transient Inspect I/O error would be a worse
+	// failure mode than just not consulting it.
+	launchapiInspectCallFailed
+	// launchapiInspectFloor means Inspect succeeded with State "unknown" or
+	// ActionRequired true. Every member's verdict is capped below any live
+	// sub-state, regardless of its own pane/presence signals -- unknown
+	// never reads as clear.
+	launchapiInspectFloor
+	// launchapiInspectPresentSignal means Inspect succeeded with State
+	// "present". This corroborates but never overrides per-seat
+	// classification: a whole-session Inspect result cannot attribute
+	// liveness to one specific seat (see the package's own aggregation,
+	// traced against the pinned module source -- one BindingRecord per
+	// session, no per-participant Inspect filter exists).
+	launchapiInspectPresentSignal
+	// launchapiInspectAbsentSignal means Inspect succeeded with State
+	// "absent". Per-seat probes still run (no short-circuit); if a
+	// member's own verdict says live, that is a discrepancy between two
+	// live signals and gets capped at stale with the conflict named in
+	// Detail, rather than silently trusting either source.
+	launchapiInspectAbsentSignal
+)
+
+// launchapi's public LifecycleResultV1.State carries the same string values
+// as the module's internal (unexported) InspectStatus enum -- "present",
+// "absent", "unknown" -- but does not re-export typed constants for them.
+// Traced directly against the pinned module source
+// (internal/launch/backend.go's InspectPresent/InspectAbsent/InspectUnknown);
+// docs/amq-0.75.0-adoption-verdict.md and this task's PR body record the
+// verification.
+const (
+	launchapiInspectStatePresent = "present"
+	launchapiInspectStateAbsent  = "absent"
+)
+
+// launchapiInspectSignal is the session-level Inspect result plus the
+// evidence string callers surface in warnings/detail text.
+type launchapiInspectSignal struct {
+	Outcome  launchapiInspectOutcome
+	Evidence string
+}
+
+// launchapiInspect is a package var so tests can stub the launchapi.Inspect
+// call without a real amq binary or launchapi binding on disk.
+var launchapiInspect = launchapi.Inspect
+
+// launchapiSessionInspect calls launchapi.Inspect once for the given
+// session Target and classifies the result into a launchapiInspectSignal.
+// projectRoot must be the team's canonical project root (t.Project), NOT a
+// per-member worktree cwd -- launchapi's own openPrepareTarget requires
+// ProjectRoot to resolve to the exact canonical path Prepare/Apply used
+// ("project_root must be canonical"), and per-member worktrees are
+// different directories from the team's shared control root that
+// Target.ProjectRoot/SessionRoot were set to at launch time
+// (team_launch_launchapi.go's buildIntentInput uses t.Project for both).
+// baseRoot is the session's resolved AMQ root (the same value every caller
+// of classifyAgentLiveness already computes as `root`).
+func launchapiSessionInspect(projectRoot, baseRoot, session string) launchapiInspectSignal {
+	projectRoot = strings.TrimSpace(projectRoot)
+	baseRoot = strings.TrimSpace(baseRoot)
+	session = strings.TrimSpace(session)
+	if projectRoot == "" || baseRoot == "" || session == "" {
+		return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: "incomplete session target"}
+	}
+	result, err := launchapiInspect(context.Background(), launchapi.InspectRequestV1{
+		RequestVersion: launchapi.RequestVersionV1,
+		Target: launchapi.TargetV1{
+			ProjectRoot: projectRoot,
+			BaseRoot:    baseRoot,
+			SessionRoot: projectRoot,
+			Session:     session,
+		},
+	})
+	if err != nil {
+		// base_root_unauthorized/base_root_relation_invalid mean "we cannot
+		// even identify a launchapi target here" -- no .amqrc-style
+		// authorization at this project root, or the target shape does not
+		// resolve -- which is structurally the same "no evidence either
+		// way" case as a successful binding_missing result, not a genuine
+		// I/O failure. Many legacy test fixtures (and any project that has
+		// never run real amq setup) never carry that authorization, so
+		// treating this as launchapiInspectCallFailed would spuriously warn
+		// on every legacy session. Only an error that is neither of these
+		// two documented reason codes counts as a real call failure.
+		msg := err.Error()
+		if strings.Contains(msg, "base_root_unauthorized") || strings.Contains(msg, "base_root_relation_invalid") {
+			return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: msg}
+		}
+		return launchapiInspectSignal{Outcome: launchapiInspectCallFailed, Evidence: msg}
+	}
+	if result.ReasonCode == "binding_missing" {
+		return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: result.ReasonCode}
+	}
+	switch result.State {
+	case launchapiInspectStatePresent:
+		return launchapiInspectSignal{Outcome: launchapiInspectPresentSignal, Evidence: result.State}
+	case launchapiInspectStateAbsent:
+		return launchapiInspectSignal{Outcome: launchapiInspectAbsentSignal, Evidence: result.State}
+	default:
+		evidence := result.State
+		if result.ReasonCode != "" {
+			evidence = result.State + ": " + result.ReasonCode
+		}
+		return launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: evidence}
+	}
+}
+
+// applyLaunchapiInspectionFloor applies gh#737's session-level Inspect
+// result to one member's already-computed agentLiveness verdict. Pure
+// function: no I/O, so the floor/corroboration/conflict rules are directly
+// unit-testable without a real launchapi binding.
+func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSignal) agentLiveness {
+	live.InspectSignal = signal
+	switch signal.Outcome {
+	case launchapiInspectNotApplicable, launchapiInspectPresentSignal:
+		// Not launchapi-launched, or the whole session's owned panes are
+		// intact: corroborates at most, never overrides per-seat evidence.
+		return live
+	case launchapiInspectCallFailed:
+		// Do not clamp; today's classification stands. The caller surfaces
+		// the evidence as a session-level warning separately.
+		return live
+	case launchapiInspectFloor:
+		if live.Live() {
+			live.Verdict = livenessStale
+			live.Status = statusStateStale
+			live.Detail = fmt.Sprintf("session Inspect reports %s; capping below live regardless of this seat's own signals (unknown never reads as clear)", signal.Evidence)
+		}
+		return live
+	case launchapiInspectAbsentSignal:
+		if live.Live() {
+			live.Verdict = livenessStale
+			live.Status = statusStateStale
+			live.Detail = fmt.Sprintf("session Inspect reports absent while this seat's own signals report live (%s); treating as stale pending reconciliation", live.Detail)
+		}
+		return live
+	default:
+		return live
+	}
+}
+
+// classifyAgentLivenessForRollup is classifyAgentLivenessWithReplacementResolver
+// plus gh#737's session-level launchapi Inspect floor. Used only by the
+// status/resume rollup call sites that share the "status and resume can
+// never disagree" contract (classifyMemberStatusWithReplacementResolver,
+// team_resume.go's roster-facing call sites); classifyAgentLiveness itself
+// is untouched and used unchanged by every other caller (dispatch, session
+// notifier, namespace migration planning, doctor's worktree collision
+// check), which do not need session-wide Inspect corroboration for their
+// narrower single-purpose checks.
+//
+// projectRoot must be the team's canonical project root (t.Project), not a
+// per-member worktree cwd -- see launchapiSessionInspect's doc comment.
+func classifyAgentLivenessForRollup(projectRoot, agentDir, root, expectedProfile, handle, role, binary, workstream, cwd string, probe duplicateLaunchProbe, replacement replacementPaneResolver) agentLiveness {
+	live := classifyAgentLivenessWithReplacementResolver(agentDir, root, expectedProfile, handle, role, binary, workstream, cwd, probe, replacement)
+	signal := launchapiSessionInspect(projectRoot, root, workstream)
+	return applyLaunchapiInspectionFloor(live, signal)
 }

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -2,12 +2,16 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
 
 	"github.com/omriariav/amq-squad/v2/internal/launch"
 	"github.com/omriariav/amq-squad/v2/internal/runtimecontrol"
@@ -770,5 +774,193 @@ func TestStatusDoctorResumeAgreeWhenAgentAndWakeLive(t *testing.T) {
 	}
 	if env.Data.Plan[0].Liveness == nil || env.Data.Plan[0].Liveness.Status != string(statusStateLive) {
 		t.Fatalf("resume --json liveness = %+v, want live", env.Data.Plan[0].Liveness)
+	}
+}
+
+// stubLaunchapiInspect replaces the launchapiInspect package var for the
+// duration of the test, restoring it in cleanup.
+func stubLaunchapiInspect(t *testing.T, fn func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error)) {
+	t.Helper()
+	previous := launchapiInspect
+	launchapiInspect = fn
+	t.Cleanup(func() { launchapiInspect = previous })
+}
+
+// TestInspectLivenessUnknownFailsClosed is gh#737's first named acceptance
+// test: an injected unknown session-level Inspect result never reads as
+// healthy and never authorizes a mutation -- a live verdict gets capped
+// below any live sub-state regardless of its own pane/presence signals.
+func TestInspectLivenessUnknownFailsClosed(t *testing.T) {
+	live := agentLiveness{Verdict: livenessAgentLive, Status: statusStateLive, Detail: "agent pid 123 alive (codex)"}
+	got := applyLaunchapiInspectionFloor(live, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "unknown"})
+	if got.Live() {
+		t.Fatalf("unknown Inspect signal must never leave a verdict Live(): %+v", got)
+	}
+	if got.Verdict != livenessStale || got.Status != statusStateStale {
+		t.Fatalf("unknown Inspect signal verdict/status = %q/%q, want stale/stale", got.Verdict, got.Status)
+	}
+	if !strings.Contains(got.Detail, "unknown") {
+		t.Fatalf("capped detail does not name the Inspect evidence: %q", got.Detail)
+	}
+
+	// ActionRequired must cap even when State itself is not literally
+	// "unknown" (e.g. a reason-coded action_required outcome).
+	live2 := agentLiveness{Verdict: livenessWakeLive, Status: statusStateWakeLive}
+	got2 := applyLaunchapiInspectionFloor(live2, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "action_required: caller_context_corrupt"})
+	if got2.Live() {
+		t.Fatalf("action_required Inspect signal must never leave a verdict Live(): %+v", got2)
+	}
+}
+
+// TestInspectLivenessParityWithPaneProbeForLiveSeats is gh#737's second
+// named acceptance test: for a live tmux seat, both sources agree. A
+// session-level Inspect Present result corroborates but never overrides
+// per-seat classification, so a seat independently confirmed live by its
+// own pane/launch-record signals stays live and unchanged.
+func TestInspectLivenessParityWithPaneProbeForLiveSeats(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{State: "present"}, nil
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateLive {
+		t.Fatalf("status = %q, want live (session Inspect present must corroborate, not override, an independently live seat)", rec.Status)
+	}
+	if rec.liveness.InspectSignal.Outcome != launchapiInspectPresentSignal {
+		t.Fatalf("InspectSignal.Outcome = %v, want launchapiInspectPresentSignal", rec.liveness.InspectSignal.Outcome)
+	}
+}
+
+// TestStatusRollupUnchangedForLegacyLaunches is gh#737's third named
+// acceptance test: a session Inspect reports as not launchapi-launched
+// (binding_missing) leaves legacy classification completely unchanged, and
+// produces no launchapi-related warning.
+func TestStatusRollupUnchangedForLegacyLaunches(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{ReasonCode: "binding_missing"}, nil
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateLive || rec.Detail != "agent pid 5555 alive (codex)" {
+		t.Fatalf("legacy-session status/detail changed: status=%q detail=%q", rec.Status, rec.Detail)
+	}
+	if rec.liveness.InspectSignal.Outcome != launchapiInspectNotApplicable {
+		t.Fatalf("InspectSignal.Outcome = %v, want launchapiInspectNotApplicable for binding_missing", rec.liveness.InspectSignal.Outcome)
+	}
+	if warnings := statusLaunchapiInspectWarnings("issue-96", []statusRecord{rec}); len(warnings) != 0 {
+		t.Fatalf("legacy launch produced a launchapi Inspect warning: %+v", warnings)
+	}
+}
+
+// TestInspectAbsentConflictsWithLivePaneProbeFailsClosed is the named test
+// cto's ruling added: a session Inspect reporting absent while a seat's own
+// pane/launch-record probe reports live is a discrepancy between two live
+// signals -- per-seat probes still run (no short-circuit on absent), and
+// the conflict fails closed (capped at stale) with both sides named in the
+// detail, rather than silently trusting either source.
+func TestInspectAbsentConflictsWithLivePaneProbeFailsClosed(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{State: "absent"}, nil
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateStale {
+		t.Fatalf("status = %q, want stale (session Inspect absent conflicts with a live pane probe -- must fail closed, not silently trust either source)", rec.Status)
+	}
+	if !strings.Contains(rec.Detail, "absent") || !strings.Contains(rec.Detail, "live") {
+		t.Fatalf("conflict detail does not name both disagreeing sides: %q", rec.Detail)
+	}
+	if rec.liveness.InspectSignal.Outcome != launchapiInspectAbsentSignal {
+		t.Fatalf("InspectSignal.Outcome = %v, want launchapiInspectAbsentSignal", rec.liveness.InspectSignal.Outcome)
+	}
+}
+
+// TestInspectErrorFallsBackToExistingSignalsWithWarning is the named test
+// cto's ruling added: an Inspect CALL error (I/O, not a successful
+// binding_missing result) must never clamp -- today's classification runs
+// unchanged for every member -- but the failure is surfaced as a
+// session-level warning naming the error, not silently swallowed.
+func TestInspectErrorFallsBackToExistingSignalsWithWarning(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{}, errors.New("stat .agent-mail/issue-96: permission denied")
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateLive || rec.Detail != "agent pid 5555 alive (codex)" {
+		t.Fatalf("Inspect call error must not clamp: status=%q detail=%q", rec.Status, rec.Detail)
+	}
+	if rec.liveness.InspectSignal.Outcome != launchapiInspectCallFailed {
+		t.Fatalf("InspectSignal.Outcome = %v, want launchapiInspectCallFailed", rec.liveness.InspectSignal.Outcome)
+	}
+	warnings := statusLaunchapiInspectWarnings("issue-96", []statusRecord{rec})
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %+v, want exactly one session-level warning", warnings)
+	}
+	if !strings.Contains(warnings[0].Detail, "permission denied") {
+		t.Fatalf("warning does not name the Inspect error: %q", warnings[0].Detail)
 	}
 }

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -964,3 +964,61 @@ func TestInspectErrorFallsBackToExistingSignalsWithWarning(t *testing.T) {
 		t.Fatalf("warning does not name the Inspect error: %q", warnings[0].Detail)
 	}
 }
+
+// TestLaunchapiInspectMemoCollapsesRosterToOneCall is the named test cto's
+// review of PR #779 required: classifyAgentLivenessForRollup was calling
+// launchapiSessionInspect inside the per-member/per-handle path, so a
+// roster rollup called launchapi.Inspect once per member instead of once
+// per session -- contradicting the approved design ("once per session").
+// Every member here shares the same project/root/session Target, so the
+// memo cache introduced to fix that must collapse them to exactly one real
+// Inspect call, count invocations through the stubbed launchapiInspect var.
+func TestLaunchapiInspectMemoCollapsesRosterToOneCall(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+			{Role: "senior-dev", Binary: "codex", Handle: "senior-dev", Session: "issue-96"},
+			{Role: "fullstack", Binary: "codex", Handle: "fullstack", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "senior-dev", launch.Record{
+		CWD: dir, Binary: "codex", Role: "senior-dev", AgentPID: 5556, StartedAt: time.Now(),
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "fullstack", launch.Record{
+		CWD: dir, Binary: "codex", Role: "fullstack", AgentPID: 5557, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+
+	calls := 0
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		calls++
+		return launchapi.InspectResultV1{State: "present"}, nil
+	})
+
+	probe := livenessProbe(
+		map[int]bool{5555: true, 5556: true, 5557: true},
+		map[int]bool{5555: true, 5556: true, 5557: true},
+		time.Now(),
+	)
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range tm.Members {
+		rec := classifyMemberStatus(tm, team.DefaultProfile, m, "issue-96", probe)
+		if rec.Status != statusStateLive {
+			t.Fatalf("member %q status = %q, want live", m.Handle, rec.Status)
+		}
+		if rec.liveness.InspectSignal.Outcome != launchapiInspectPresentSignal {
+			t.Fatalf("member %q InspectSignal.Outcome = %v, want launchapiInspectPresentSignal", m.Handle, rec.liveness.InspectSignal.Outcome)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("launchapiInspect called %d times for %d roster members sharing one session, want exactly 1 (memo cache must collapse per-rollup)", calls, len(tm.Members))
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -390,6 +390,7 @@ func executeStatus(s statusExecution) error {
 		warnings = append(warnings, statusUnmanagedLaunchRecordWarningsFromEntries(t, s.Profile, workstream, entries)...)
 	}
 	warnings = append(warnings, statusLocalInputWarnings(t.Project, s.Profile, workstream, rows)...)
+	warnings = append(warnings, statusLaunchapiInspectWarnings(workstream, rows)...)
 	if s.JSON {
 		ns := squadnamespace.Resolve(t.Project, s.Profile, workstream)
 		conflict := namespaceConflictForProfileSession(t.Project, s.Profile, workstream)
@@ -1535,6 +1536,34 @@ func statusLocalInputWarnings(projectDir, profile, session string, rows []status
 	return warnings
 }
 
+// statusLaunchapiInspectWarnings surfaces gh#737's session-level warning
+// when launchapi.Inspect itself errored (I/O, not a successful
+// binding_missing result) for this session -- per cto's ruling, no member's
+// verdict is clamped on a call error, but the failure must still be visible.
+// Deduplicated to at most one warning per distinct evidence string even
+// though every row in a launchapi-launched roster independently observes
+// the same session-level failure.
+func statusLaunchapiInspectWarnings(session string, rows []statusRecord) []statusWarning {
+	seen := make(map[string]bool)
+	var warnings []statusWarning
+	for _, row := range rows {
+		if row.liveness.InspectSignal.Outcome != launchapiInspectCallFailed {
+			continue
+		}
+		evidence := strings.TrimSpace(row.liveness.InspectSignal.Evidence)
+		if seen[evidence] {
+			continue
+		}
+		seen[evidence] = true
+		warnings = append(warnings, statusWarning{
+			Kind:    "launchapi_inspect_failed",
+			Session: session,
+			Detail:  "session-level launchapi.Inspect call failed; per-seat liveness falls back to existing pane/launch-record/wake/presence signals unchanged: " + evidence,
+		})
+	}
+	return warnings
+}
+
 func orchestrationStatusFields(t team.Team) (bool, string, string) {
 	if !t.Orchestrated {
 		return false, "", ""
@@ -1726,7 +1755,10 @@ func classifyMemberStatusFromEntries(t team.Team, profile string, m team.Member,
 	// checks and returns the verdict, signals, detail, status state, and the
 	// persisted tmux identity. classifyMemberStatus then just adopts them; the
 	// verdict->statusState mapping lives in the classifier (Status field).
-	live := classifyAgentLivenessWithReplacementResolver(rec.AgentDir, root, profile, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe, replacement)
+	// classifyAgentLivenessForRollup layers gh#737's session-level launchapi
+	// Inspect floor on top; team_resume.go's roster-facing call sites use the
+	// same wrapper so status/resume keep agreeing.
+	live := classifyAgentLivenessForRollup(t.Project, rec.AgentDir, root, profile, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe, replacement)
 	rec.liveness = live
 	rec.ClassificationError = live.SourceError
 	rec.Tmux = tmuxRuntimeFromInfo(live.Tmux)

--- a/internal/cli/team_resume.go
+++ b/internal/cli/team_resume.go
@@ -1078,7 +1078,7 @@ func verifyResumeLeadReady(check resumeExecLaunchCheck) error {
 }
 
 func inspectResumeLeadReady(check resumeExecLaunchCheck, probe duplicateLaunchProbe) (bool, string) {
-	live := classifyAgentLivenessWithReplacementResolver(check.AgentDir, check.Root, check.Profile, check.Handle, check.Role, check.Binary, check.Workstream, check.CWD, probe, nil)
+	live := classifyAgentLivenessForRollup(check.Project, check.AgentDir, check.Root, check.Profile, check.Handle, check.Role, check.Binary, check.Workstream, check.CWD, probe, nil)
 	if live.Verdict != livenessAgentLive {
 		return false, live.Detail
 	}
@@ -1652,7 +1652,7 @@ func planMemberResume(in memberPlanInput) (resumePlan, error) {
 	if replacement == nil {
 		replacement = classifierReplacementPane
 	}
-	live := classifyAgentLivenessWithReplacementResolver(agentDir, root, in.Profile, handle, m.Role, m.Binary, env.SessionName, cwd, probe, replacement)
+	live := classifyAgentLivenessForRollup(in.Team.Project, agentDir, root, in.Profile, handle, m.Role, m.Binary, env.SessionName, cwd, probe, replacement)
 	plan.Liveness = &live
 
 	// #95: a live agent launched outside amq-squad's tmux backend has no recorded


### PR DESCRIPTION
## Summary

For sessions launched via the launchapi backend, derive a session-level liveness signal from `launchapi.Inspect` (present/absent/unknown + evidence) and layer it on top of the existing pane/launch-record/wake/presence classifier — never replacing it. `launchapi.Inspect` is session-level, not per-seat (traced against the pinned module source: one `BindingRecord` per launched team, no per-participant filter in the request shape), so the floor applies at session granularity, not per-handle:

- **unknown / ActionRequired**: every member's verdict is capped below any live sub-state regardless of its own pane/presence signals — unknown never reads as clear.
- **present**: corroborates only, never overrides per-seat evidence (a whole-session result cannot attribute liveness to one specific seat).
- **absent**: per-seat probes still run (no short-circuit); a member's own live verdict disagreeing with a session-absent result is a discrepancy between two live signals and fails closed (capped at stale, conflict named in the detail text) rather than silently trusting either source.
- **Inspect call error** (I/O, not a successful `binding_missing` result): no clamp, today's classification stands unchanged, surfaced as a session-level warning naming the error instead. `base_root_unauthorized`/`base_root_relation_invalid` are treated as "no evidence either way" (same as `binding_missing`), not call errors — they fire for any project without real `amq setup`, including most test fixtures, and clamping/warning on them would be indistinguishable from a regression (caught by an existing exact-warnings-list test, see commit).
- **binding_missing** (successful result): not launchapi-launched; legacy classification is completely unchanged.

`classifyAgentLivenessForRollup` wraps the existing, untouched `classifyAgentLiveness`/`WithReplacementResolver`. Wired into the three call sites that share the "status and resume can never disagree" contract: `status.go`'s `classifyMemberStatusWithReplacementResolver` (also covers `doctor.go`'s and `global_status.go`'s rollups, which call it too) and `team_resume.go`'s two roster-facing call sites. `dispatch.go`, `session_notifier.go`, `namespace_migration_plan.go`, and `doctor.go`'s worktree-collision check are unchanged — narrower single-purpose checks outside that contract.

## Known limitation (unverified corroboration path)

`launchapiSessionInspect` builds `Target{SessionRoot: t.Project}`, mirroring `internal/cli/team_launch_launchapi.go`'s `buildIntentInput` exactly (same field, same value, ~line 346), since Inspect must ask for the same target Prepare/Apply used. The pinned module's `internal/launch/prepare.go` `openExplicitBaseAuthority` appears to require `SessionRoot` to resolve as `filepath.Join(BaseRoot, Session)` instead — traced from source, **not reproduced against a real launchapi-launched session** (no live binding was available to Inspect from this read-only trace). `buildIntentInput` is deliberately **not** touched here — out of scope for this PR.

Because any Target/authorization mismatch degrades to the `NotApplicable` outcome (silent no-op, identical to today's behavior, never a false clamp or a broken warning), this is safe either way — worst case the corroboration feature silently does not activate for a launchapi session. Verification against one real launchapi-launched session, and fixing whichever side is wrong if the mismatch is real, is now an explicit t10 acceptance item (posted to `task/t10`).

## Named tests
- `TestInspectLivenessUnknownFailsClosed`
- `TestInspectLivenessParityWithPaneProbeForLiveSeats`
- `TestStatusRollupUnchangedForLegacyLaunches`
- `TestInspectAbsentConflictsWithLivePaneProbeFailsClosed`
- `TestInspectErrorFallsBackToExistingSignalsWithWarning`

Closes #737.

## Test plan
- [x] `go build ./...`, `gofmt -l .` clean, `go vet ./...`
- [x] `go test ./...` and `go test -shuffle=on ./internal/cli/...` — all pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing/intermittent, unrelated.
- [x] `make ci` targets other than `test` (fmt-check, readme-html-check, docs-html-check, skills-check, skill-routing-check, skill-command-check, skill-invocation-check, release-validator-test, go-files-scope-test) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)