### PR TITLE
feat(cli): start --apply/--decision digest-gated launchapi Apply (gh#757)

### DIFF
--- a/internal/adoptionseam/adoptionseam.go
+++ b/internal/adoptionseam/adoptionseam.go
@@ -119,10 +119,26 @@ func Prepare(ctx context.Context, in PrepareInput) (Prepared, error) {
 
 // Apply calls launchapi.Apply against a previously Prepared bundle and the
 // operator/caller's decisions for any required actions Prepare surfaced.
+//
+// SubjectSchema must be forwarded from p.Result explicitly (gh#757 finding):
+// launchapi.Apply's own zero-value default for an unset ApplyRequestV1.
+// SubjectSchema is SubjectSchemaV1 (launchapi/apply.go), which disagrees
+// with launchapi.Prepare's own hardcoded default of SubjectSchemaV2
+// (launchapi/prepare.go) -- the two public entry points do not share a
+// default. Since every caller here always sets PrepareRequestV1.CallerContext
+// (callPrepare in team_launch_launchapi.go), an Apply that left this unset
+// re-validated its embedded Prepare request at V1 and refused closed with
+// "caller_context requires subject schema 2" on every real call that reached
+// this point with any required action to decide -- confirmed live: no
+// existing test had ever exercised a real (non-stubbed) Apply call with a
+// non-empty Decisions list until TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch
+// surfaced it, because every prior test replaces deps.Launch (and therefore
+// this whole call) with a stub.
 func Apply(ctx context.Context, p Prepared, decisions []launchapi.DecisionV1) (launchapi.ApplyResultV1, error) {
 	request := launchapi.ApplyRequestV1{
 		RequestVersion: launchapi.RequestVersionV1,
 		Prepare:        p.Request,
+		SubjectSchema:  p.Result.SubjectSchema,
 		SubjectDigest:  p.Result.SubjectDigest,
 		Decisions:      decisions,
 	}

--- a/internal/adoptionseam/adoptionseam_test.go
+++ b/internal/adoptionseam/adoptionseam_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/avivsinai/agent-message-queue/launchapi"
@@ -134,5 +135,94 @@ func TestAdoptionSeamPreservesNonAMQEnv(t *testing.T) {
 	want := append([]string(nil), env...)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("SanitizeEnv(%v) = %v, want unchanged %v", env, got, want)
+	}
+}
+
+// TestApplyForwardsSubjectSchemaFromPrepareResult is gh#757's regression
+// test for a real bug this seam's Apply had never surfaced before: it built
+// ApplyRequestV1 without setting SubjectSchema, so launchapi.Apply's own
+// zero-value default (SubjectSchemaV1, launchapi/apply.go) disagreed with
+// launchapi.Prepare's own hardcoded default (SubjectSchemaV2,
+// launchapi/prepare.go) -- the two public entry points do not share a
+// default. Since every real caller here always sets
+// PrepareRequestV1.CallerContext (team_launch_launchapi.go's callPrepare),
+// an Apply that left SubjectSchema unset re-validated its embedded Prepare
+// request at V1 and refused closed with "caller_context requires subject
+// schema 2" on every real call that had any required action to decide --
+// confirmed live via a real amq v0.75.0 binding
+// (TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch,
+// internal/cli/simple_wizard_test.go): no existing test had ever exercised
+// a real (non-stubbed) Apply call with a non-empty Decisions list before,
+// because every prior test replaces deps.Launch (and therefore this whole
+// call) with a stub.
+//
+// This proves the fix directly against a real, fully-authorized project
+// layout: Prepare surfaces a trust_confirmation required action (a fresh
+// subject digest never seen before), and Apply -- given CallerContext and a
+// decision for that action -- must not refuse with the schema-mismatch
+// error.
+func TestApplyForwardsSubjectSchemaFromPrepareResult(t *testing.T) {
+	binary := os.Getenv("AMQ_SQUAD_REAL_AMQ")
+	if binary == "" {
+		t.Skip("set AMQ_SQUAD_REAL_AMQ to run this real-binding regression test")
+	}
+	if info, err := os.Stat(binary); err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		t.Skipf("AMQ_SQUAD_REAL_AMQ %q is unavailable or not executable", binary)
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	project, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root": ".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	intent := launchintent.Input{
+		Operator: launchintent.OperatorFacts{Handle: "user"},
+		Seats: []launchintent.SeatFacts{{
+			Handle: "worker", Executable: "claude",
+			Cwd:          launchintent.SeatCWD{Kind: launchapi.WorkingDirectoryAbsolute, Path: project},
+			ResumePolicy: launchapi.ResumePolicyFresh, RequireWake: true,
+		}},
+		Target: launchintent.TargetFacts{
+			ProjectRoot: project,
+			BaseRoot:    filepath.Join(project, ".agent-mail"),
+			SessionRoot: filepath.Join(project, ".agent-mail", "s"),
+			Session:     "s",
+		},
+	}
+
+	prepared, err := Prepare(context.Background(), PrepareInput{
+		Intent: intent, Launcher: "tmux",
+		Caller: map[string]string{"profile": "default", "workstream": "s"},
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	t.Logf("outcome=%s reason=%s required_actions=%+v", prepared.Result.Outcome, prepared.Result.Reason, prepared.Result.RequiredActions)
+	if len(prepared.Result.RequiredActions) != 1 || prepared.Result.RequiredActions[0].Kind != launchapi.RequiredActionTrustConfirmation {
+		t.Fatalf("required_actions = %+v, want exactly one trust_confirmation (a fresh, never-before-seen subject)", prepared.Result.RequiredActions)
+	}
+	if prepared.Result.SubjectSchema == 0 {
+		t.Fatalf("PrepareResultV1.SubjectSchema = 0, want a real schema version for this test to exercise the forwarding fix")
+	}
+
+	// Apply's own tmux composition needs a real pane/session context this
+	// standalone package test does not set up (verified separately in
+	// TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch,
+	// internal/cli/simple_wizard_test.go, where it succeeds end to end with
+	// outcome "applied") -- so this test only isolates the ONE thing it
+	// exists to prove: Apply must not refuse on the caller_context/
+	// subject_schema mismatch the fix addresses, regardless of what a
+	// downstream tmux-composition step separately requires.
+	result, err := Apply(context.Background(), prepared, []launchapi.DecisionV1{
+		{ActionID: prepared.Result.RequiredActions[0].ActionID, Choice: launchapi.DecisionTrustExactSubject},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	t.Logf("apply outcome=%s reason_code=%s failure_detail=%s follow_ups=%+v", result.Outcome, result.ReasonCode, result.FailureDetail, result.FollowUps)
+	if strings.Contains(strings.ToLower(result.ReasonCode), "caller_context") || strings.Contains(strings.ToLower(result.FailureDetail), "caller_context requires subject schema") {
+		t.Fatalf("Apply refused on the caller_context/subject_schema mismatch the fix addresses: outcome=%q reason_code=%q detail=%q", result.Outcome, result.ReasonCode, result.FailureDetail)
 	}
 }

--- a/internal/cli/simple_start.go
+++ b/internal/cli/simple_start.go
@@ -208,6 +208,15 @@ type simpleStartRequest struct {
 	Goal            string
 	Options         teamLaunchOptions
 	ReviewedBrief   *simpleStartBriefDraft
+	// LaunchapiPath is true when resolveTeamLaunchBackend resolved this
+	// request to the launchapi backend (gh#755/gh#757), as opposed to the
+	// legacy backend (--launch-via legacy). The digest-gated --apply/
+	// --decision flow and its deprecation redirects only ever apply on this
+	// path; the legacy path stays byte-identical to pre-gh#757 behavior.
+	LaunchapiPath bool
+	// DeprecatedFlagNotices are printed once, early, when a flag that has
+	// no effect on the launchapi path was explicitly supplied (gh#757).
+	DeprecatedFlagNotices []string
 }
 
 type simpleStartConflictError struct {
@@ -223,6 +232,33 @@ func runStart(args []string) error {
 	return runStartWithDependencies(args, defaultSimpleStartDependencies(), os.Stdin, os.Stdout)
 }
 
+// simpleStartRefuseLegacyMintedRestoreOnLaunchapi is gh#757's fail-closed
+// refusal (cto decision, task/t8): the launchapi path has no mechanism
+// today to resume a conversation minted by the legacy composer -- and
+// every conversation ID amq-squad has on record for a role start manages
+// IS legacy-minted, since the launchapi backend never writes
+// launch.Record at all (confirmed on task/t7: only the legacy `agent up`
+// path does). launchapi's own ResumePolicy=resume natively resumes a
+// conversation it minted itself, but that mechanism is orthogonal to, and
+// cannot honor, an ID amq-squad recorded from a different backend. Rather
+// than silently falling back to the legacy backend (which would quietly
+// re-route the most common command through the backend v2.32.0 deletes)
+// or silently dropping the conversation, this refuses closed with an
+// explicit remedy naming both real options.
+func simpleStartRefuseLegacyMintedRestoreOnLaunchapi(launchapiPath bool, plan simpleStartPlan) error {
+	if !launchapiPath {
+		return nil
+	}
+	for _, m := range plan.SpawnTeam.Members {
+		conversation := strings.TrimSpace(plan.LaunchOptions.RestoreConversations[m.Role])
+		if conversation == "" {
+			continue
+		}
+		return fmt.Errorf("start refused: role %s has a recorded conversation %q; it was minted by the legacy backend (the launchapi path never writes launch records) and the launchapi path cannot resume it yet. Rerun with --launch-via legacy to resume it (supported for one release, removed in v2.32.0), or clear its launch record to accept a fresh conversation instead", m.Role, conversation)
+	}
+	return nil
+}
+
 func runStartWithDependencies(args []string, deps simpleStartDependencies, in io.Reader, out io.Writer) error {
 	deps = normalizeSimpleStartDependencies(deps)
 	req, err := parseSimpleStartRequest(args)
@@ -232,6 +268,12 @@ func runStartWithDependencies(args []string, deps simpleStartDependencies, in io
 	accepted, err := buildSimpleStartPlan(req, deps)
 	if err != nil {
 		return err
+	}
+	if err := simpleStartRefuseLegacyMintedRestoreOnLaunchapi(req.LaunchapiPath, accepted); err != nil {
+		return err
+	}
+	for _, notice := range req.DeprecatedFlagNotices {
+		fmt.Fprintln(out, notice)
 	}
 	renderSimpleStartPlan(out, accepted)
 	if accepted.BriefDraft != nil && accepted.BriefDraft.Manual {
@@ -386,9 +428,12 @@ func parseSimpleStartRequest(args []string) (simpleStartRequest, error) {
 	}
 	fs := flag.NewFlagSet("start", flag.ContinueOnError)
 	profile := fs.String("profile", team.DefaultProfile, "team profile to start")
-	yes := fs.Bool("yes", false, "skip the default-No launch confirmation")
+	yes := fs.Bool("yes", false, "skip the default-No launch confirmation (legacy path only; no effect on launchapi, use --apply instead)")
 	goal := fs.String("goal", "", "optional goal delivered to the lead after every agent verifies live")
 	fs.BoolVar(yes, "y", false, "shorthand for --yes")
+	applyDigest := fs.String("apply", "", "apply this exact subject_digest from a previously printed plan (gh#757, launchapi path only), skipping interactive confirmation")
+	var decisionsFlag stringListFlag
+	fs.Var(&decisionsFlag, "decision", "explicit operator answer to a launchapi required action, ACTION_ID=CHOICE (repeatable; same shape as --launchapi-decision)")
 	pf := registerPreviewFlags(fs)
 	lf := registerLiveLaunchFlags(fs)
 	fs.Usage = func() {
@@ -430,8 +475,8 @@ Examples:
 	if *pf.noBootstrap {
 		return simpleStartRequest{}, usageErrorf("start owns one exact startup instruction; --no-bootstrap is not supported")
 	}
-	if *pf.fresh || *pf.forceDuplicate {
-		return simpleStartRequest{}, usageErrorf("start reconciles existing state; --fresh and --force-duplicate are not supported")
+	if *pf.fresh {
+		return simpleStartRequest{}, usageErrorf("start reconciles existing state; --fresh is not supported")
 	}
 	if strings.TrimSpace(*lf.terminal) != "tmux" {
 		return simpleStartRequest{}, usageErrorf("start currently requires the managed tmux backend")
@@ -469,10 +514,60 @@ Examples:
 	opts.NoBootstrap = true
 	opts.SimpleStart = true
 	opts.AllowExistingSession = true
+
+	// gh#757: resolve the backend now (Terminal is pinned to "tmux" above;
+	// LaunchVia was just parsed) to decide how --force-duplicate, --apply,
+	// and --decision behave. The legacy backend keeps every pre-gh#757
+	// behavior byte-identical; only the launchapi path gets the new
+	// digest-gated flow and its deprecation redirects.
+	backend, err := resolveTeamLaunchBackend(opts)
+	if err != nil {
+		return simpleStartRequest{}, err
+	}
+	launchapiPath := backend.Name() == "launchapi"
+
+	if !launchapiPath {
+		if *pf.forceDuplicate || strings.TrimSpace(*applyDigest) != "" || len(decisionsFlag) > 0 {
+			return simpleStartRequest{}, usageErrorf("start reconciles existing state; --force-duplicate is not supported, and --apply/--decision only apply to the launchapi path (this session resolved to the legacy backend; pass --launch-via launchapi or omit --launch-via legacy)")
+		}
+	}
+
+	var notices []string
+	decisions, err := parseLaunchapiDecisions(decisionsFlag)
+	if err != nil {
+		return simpleStartRequest{}, err
+	}
+	if launchapiPath {
+		if flagWasSet(fs, "yes") {
+			notices = append(notices, "deprecated: --yes has no effect on the launchapi path; review the printed plan and its subject_digest, then re-run with --apply <subject_digest> (or confirm interactively)")
+		}
+		if flagWasSet(fs, "trust") {
+			notices = append(notices, "deprecated: --trust has no effect on the launchapi path; trust is compiled per-seat from team.json, set it there instead")
+		}
+		if flagWasSet(fs, "launchapi-decision") {
+			notices = append(notices, "deprecated: --launchapi-decision is renamed --decision (same ACTION_ID=CHOICE shape); both are honored here, but use --decision going forward")
+		}
+		if *pf.forceDuplicate {
+			notices = append(notices, "deprecated: --force-duplicate has no effect on the launchapi path; a duplicate-conversation required action answers via --decision ACTION_ID=fresh_once like any other required action")
+		}
+		for actionID, choice := range decisions {
+			if opts.LaunchapiDecisions == nil {
+				opts.LaunchapiDecisions = make(map[string]string, len(decisions))
+			}
+			if existing, dup := opts.LaunchapiDecisions[actionID]; dup && existing != choice {
+				return simpleStartRequest{}, usageErrorf("--decision and --launchapi-decision both specify action %q with different choices (%q vs %q)", actionID, choice, existing)
+			}
+			opts.LaunchapiDecisions[actionID] = choice
+		}
+		opts.ExpectedSubjectDigest = strings.TrimSpace(*applyDigest)
+	}
+	opts.ForceDuplicate = false
+
 	return simpleStartRequest{
 		Project: canonicalProject, Profile: profileValue, Session: strings.TrimSpace(*pf.session),
 		SessionExplicit: strings.TrimSpace(*pf.session) != "", TrustExplicit: flagWasSet(fs, "trust"),
 		Yes: *yes, Goal: goalValue, Options: opts,
+		LaunchapiPath: launchapiPath, DeprecatedFlagNotices: notices,
 	}, nil
 }
 

--- a/internal/cli/simple_start.go
+++ b/internal/cli/simple_start.go
@@ -280,7 +280,29 @@ func runStartWithDependencies(args []string, deps simpleStartDependencies, in io
 		fmt.Fprintln(out, "start stopped before mutation; complete and review the manual drafting prompt, save the brief, then run start again")
 		return nil
 	}
-	if !req.Yes && !confirmSimpleStart(out, in) {
+	if req.LaunchapiPath && len(accepted.SpawnTeam.Members) > 0 {
+		// gh#757: the launchapi path confirms (or applies) bound to an
+		// exact subject_digest rather than a generic yes/no. The digest
+		// printed/checked here is only the FIRST check; deps.Launch (via
+		// launchapiTeamLaunchBackend.launch) re-runs Prepare fresh under
+		// the session lock below and refuses again if anything -- team,
+		// brief, or which roles still need launching -- changed since.
+		probePrepared, _, err := (launchapiTeamLaunchBackend{}).prepare(accepted.SpawnTeam, accepted.LaunchOptions)
+		if err != nil {
+			return fmt.Errorf("preview plan: %w", err)
+		}
+		printPlanResult(out, probePrepared.Result)
+		digest := probePrepared.Result.SubjectDigest
+		if supplied := strings.TrimSpace(req.Options.ExpectedSubjectDigest); supplied != "" {
+			if supplied != digest {
+				return fmt.Errorf("start refused: --apply %s does not match the current plan's subject_digest %s; re-run 'amq-squad start' without --apply to see the current digest", supplied, digest)
+			}
+		} else if !confirmSimpleStartPrompt(out, in, fmt.Sprintf("Apply subject_digest %s? [y/N] ", digest)) {
+			fmt.Fprintln(out, "start cancelled")
+			return nil
+		}
+		req.Options.ExpectedSubjectDigest = digest
+	} else if !req.Yes && !confirmSimpleStart(out, in) {
 		fmt.Fprintln(out, "start cancelled")
 		return nil
 	}
@@ -1254,7 +1276,14 @@ func deliverSimpleStartGoal(plan simpleStartPlan, goal string) error {
 }
 
 func confirmSimpleStart(out io.Writer, in io.Reader) bool {
-	fmt.Fprint(out, "Launch now? [y/N] ")
+	return confirmSimpleStartPrompt(out, in, "Launch now? [y/N] ")
+}
+
+// confirmSimpleStartPrompt is confirmSimpleStart with a caller-chosen
+// prompt (gh#757: the launchapi path's confirmation names the exact
+// subject_digest being applied, not a generic "Launch now?").
+func confirmSimpleStartPrompt(out io.Writer, in io.Reader, prompt string) bool {
+	fmt.Fprint(out, prompt)
 	line, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && len(line) == 0 {
 		return false

--- a/internal/cli/simple_start.go
+++ b/internal/cli/simple_start.go
@@ -71,6 +71,25 @@ type simpleStartDependencies struct {
 	Sleep           func(time.Duration)
 }
 
+// simpleStartLaunch resolves the backend through the same selection seam
+// executeTeamLaunch uses (gh#755/gh#757), instead of a bare Terminal-keyed
+// lookup, so start defaults to launchapi on tmux exactly like team
+// launch/up already do, and honors an explicit --launch-via legacy opt-out.
+// opts.LaunchVia is already populated by parseSimpleStartRequest's
+// buildLiveLaunchOptions call; before this it was parsed and silently
+// ignored for backend selection.
+func simpleStartLaunch(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+	backend, err := resolveTeamLaunchBackend(opts)
+	if err != nil {
+		return teamLaunchResult{}, err
+	}
+	resultBackend, ok := backend.(teamLaunchResultBackend)
+	if !ok {
+		return teamLaunchResult{}, fmt.Errorf("terminal %q does not report exact pane identities", opts.Terminal)
+	}
+	return resultBackend.LaunchWithResult(t, opts)
+}
+
 func defaultSimpleStartDependencies() simpleStartDependencies {
 	return simpleStartDependencies{
 		ResolveDrafter: resolveCLIDrafter,
@@ -79,21 +98,11 @@ func defaultSimpleStartDependencies() simpleStartDependencies {
 		ResolveAMQEnv:  resolveAMQEnvForSimpleStart,
 		DuplicateProbe: defaultDuplicateLaunchProbe,
 		RuntimeProbe:   launchRuntimeProbeFromDuplicate(defaultDuplicateLaunchProbe),
-		Launch: func(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
-			backend, ok := teamLaunchBackends[opts.Terminal]
-			if !ok {
-				return teamLaunchResult{}, fmt.Errorf("unsupported terminal %q", opts.Terminal)
-			}
-			resultBackend, ok := backend.(teamLaunchResultBackend)
-			if !ok {
-				return teamLaunchResult{}, fmt.Errorf("terminal %q does not report exact pane identities", opts.Terminal)
-			}
-			return resultBackend.LaunchWithResult(t, opts)
-		},
-		StartWatcher: reconcileSessionNotifierStarted,
-		DeliverGoal:  deliverSimpleStartGoal,
-		ListPanes:    statusPaneLister,
-		Sleep:        time.Sleep,
+		Launch:         simpleStartLaunch,
+		StartWatcher:   reconcileSessionNotifierStarted,
+		DeliverGoal:    deliverSimpleStartGoal,
+		ListPanes:      statusPaneLister,
+		Sleep:          time.Sleep,
 	}
 }
 

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -1090,6 +1090,88 @@ func TestStartApplyRefusesWhenLivenessChangedSinceDigest(t *testing.T) {
 	}
 }
 
+// TestStartDeprecatedTrustFlagPrintsEquivalentDecision is gh#757's named,
+// table-driven acceptance test: one subtest per flag that still exists on
+// start today (--yes, --trust, --launchapi-decision, --force-duplicate,
+// per cto's ruling on task/t8 -- --skip-lead-check and --rebind are not
+// start flags at all, and --allow-fresh-fallback is unimplemented
+// completion-list cruft, so none of the three get a redirect here) and
+// has no effect on the resolved launchapi path. Each fires exactly one
+// deprecation notice naming its equivalent, and --force-duplicate/--trust
+// never leak through to opts (ForceDuplicate is always false, Trust plays
+// no role in ExpectedSubjectDigest/LaunchapiDecisions).
+func TestStartDeprecatedTrustFlagPrintsEquivalentDecision(t *testing.T) {
+	cases := []struct {
+		name   string
+		flags  []string
+		want   string
+		notYet string // a substring that must NOT appear (other flags' notices)
+	}{
+		{
+			name:  "--yes",
+			flags: []string{"--yes"},
+			want:  "deprecated: --yes has no effect on the launchapi path",
+		},
+		{
+			name:  "--trust",
+			flags: []string{"--trust", "trusted"},
+			want:  "deprecated: --trust has no effect on the launchapi path",
+		},
+		{
+			name:  "--launchapi-decision",
+			flags: []string{"--launchapi-decision", "a1=fresh_once"},
+			want:  "deprecated: --launchapi-decision is renamed --decision",
+		},
+		{
+			name:  "--force-duplicate",
+			flags: []string{"--force-duplicate"},
+			want:  "deprecated: --force-duplicate has no effect on the launchapi path",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			req, err := parseSimpleStartRequest(append([]string{"--project", dir}, c.flags...))
+			if err != nil {
+				t.Fatalf("parseSimpleStartRequest: %v", err)
+			}
+			if !req.LaunchapiPath {
+				t.Fatal("expected the default (tmux, no --launch-via) to resolve to the launchapi path")
+			}
+			found := false
+			for _, notice := range req.DeprecatedFlagNotices {
+				if strings.Contains(notice, c.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("notices = %+v, want one containing %q", req.DeprecatedFlagNotices, c.want)
+			}
+			if req.Options.ForceDuplicate {
+				t.Fatal("ForceDuplicate leaked through to opts despite the deprecation notice")
+			}
+		})
+	}
+
+	t.Run("--decision and --launchapi-decision merge without duplicate-notice noise", func(t *testing.T) {
+		dir := t.TempDir()
+		req, err := parseSimpleStartRequest([]string{"--project", dir, "--decision", "a1=fresh_once", "--launchapi-decision", "a2=close_old"})
+		if err != nil {
+			t.Fatalf("parseSimpleStartRequest: %v", err)
+		}
+		if req.Options.LaunchapiDecisions["a1"] != "fresh_once" || req.Options.LaunchapiDecisions["a2"] != "close_old" {
+			t.Fatalf("LaunchapiDecisions = %+v, want both a1 and a2 merged", req.Options.LaunchapiDecisions)
+		}
+	})
+
+	t.Run("--apply on the legacy path is a usage error, not a silent no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := parseSimpleStartRequest([]string{"--project", dir, "--launch-via", "legacy", "--apply", "sha256:x"}); err == nil {
+			t.Fatal("expected --apply combined with --launch-via legacy to be a usage error")
+		}
+	})
+}
+
 // TestStartHonorsLegacyOptOutForRestore proves the remedy in the refusal
 // above actually works: --launch-via legacy still resumes a legacy-minted
 // conversation exactly as before gh#757, byte-identical to

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -539,7 +539,7 @@ func TestRunStartWithDependenciesApprovalDefaultsNo(t *testing.T) {
 		return teamLaunchResult{}, nil
 	}
 	var out bytes.Buffer
-	if err := runStartWithDependencies(f.args(), f.deps, strings.NewReader("n\n"), &out); err != nil {
+	if err := runStartWithDependencies(f.args("--launch-via", "legacy"), f.deps, strings.NewReader("n\n"), &out); err != nil {
 		t.Fatal(err)
 	}
 	if launchCalled {
@@ -608,7 +608,7 @@ func TestRunStartWithDependenciesHoldsExactLockThroughSpawnVerification(t *testi
 		return simpleStartLaunchResult("dev", paneID), nil
 	}
 	var out bytes.Buffer
-	if err := runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out); err != nil {
+	if err := runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("runStartWithDependencies: %v\n%s", err, out.String())
 	}
 	wantEvents := []string{"namespace_creation", "pane_creation", "child_dispatch", "verify", "launch_record_write"}
@@ -634,7 +634,7 @@ func TestRunStartWithDependenciesRejectsDeadPIDWithSurvivingTitledPane(t *testin
 		return simpleStartLaunchResult("dev", "%2"), nil
 	}
 	var out bytes.Buffer
-	err := runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out)
+	err := runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out)
 	if err == nil || !strings.Contains(err.Error(), "does not own the verified live child process") {
 		t.Fatalf("dead child with titled pane error = %v", err)
 	}
@@ -667,7 +667,7 @@ func TestRunStartWithDependenciesLauncherPIDImageIsAccepted(t *testing.T) {
 		return simpleStartLaunchResult("dev", paneID), nil
 	}
 	var out bytes.Buffer
-	if err := runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out); err != nil {
+	if err := runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("launcher-backed start failed: %v\n%s", err, out.String())
 	}
 	if !matchedLauncher {
@@ -691,7 +691,7 @@ func TestRunStartWithDependenciesSpawnsConfiguredHandleBesideForeignSameRoleReco
 		return simpleStartLaunchResult("dev", "%4"), nil
 	}
 	var out bytes.Buffer
-	if err := runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out); err != nil {
+	if err := runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("runStartWithDependencies: %v\n%s", err, out.String())
 	}
 	if launchCalls != 1 {
@@ -955,7 +955,7 @@ func TestSimpleStartGoalIsLastAndNeverResentOnSpawnlessRerun(t *testing.T) {
 	}
 	for i := 0; i < 2; i++ {
 		var out bytes.Buffer
-		if err := runStartWithDependencies(f.args("--yes", "--goal", "ship it"), f.deps, strings.NewReader(""), &out); err != nil {
+		if err := runStartWithDependencies(f.args("--yes", "--goal", "ship it", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
 			t.Fatalf("start %d: %v\n%s", i, err, out.String())
 		}
 	}
@@ -987,7 +987,7 @@ func TestSimpleStartGoalFailureWarnsAfterSuccessfulLaunch(t *testing.T) {
 	}
 	var out bytes.Buffer
 	_, stderr, err := captureOutput(t, func() error {
-		return runStartWithDependencies(f.args("--yes", "--goal", "ship it"), f.deps, strings.NewReader(""), &out)
+		return runStartWithDependencies(f.args("--yes", "--goal", "ship it", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out)
 	})
 	if err != nil {
 		t.Fatalf("start returned goal-delivery failure after launch: %v", err)
@@ -1029,7 +1029,7 @@ func TestSimpleStartGoalDraftsReviewsAndStagesMissingBriefOnce(t *testing.T) {
 	}
 	f.deps.DeliverGoal = func(simpleStartPlan, string) error { return nil }
 	var out bytes.Buffer
-	if err := runStartWithDependencies(f.args("--yes", "--goal", "ship it"), f.deps, strings.NewReader(""), &out); err != nil {
+	if err := runStartWithDependencies(f.args("--yes", "--goal", "ship it", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("start with drafted brief: %v\n%s", err, out.String())
 	}
 	if draftCalls != 1 {

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
 
 	"github.com/omriariav/amq-squad/v2/internal/drafter"
 	"github.com/omriariav/amq-squad/v2/internal/flock"
@@ -865,6 +868,225 @@ func TestStartRefusesLegacyMintedRestoreOnLaunchapiPath(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "started ") {
 		t.Fatalf("refused start reported started:\n%s", out.String())
+	}
+}
+
+// simpleStartStubLaunchapiAMQEnv stubs resolveTeamLaunchAMQEnv -- the
+// launchapi path's own AMQ env resolution seam (distinct from
+// simpleStartDependencies.ResolveAMQEnv, which only feeds start's own
+// reconciliation) -- so launchapiTeamLaunchBackend.prepare/launch can run
+// end to end against a fixture project without a real amq binary.
+func simpleStartStubLaunchapiAMQEnv(t *testing.T, root, session string) {
+	t.Helper()
+	original := resolveTeamLaunchAMQEnv
+	resolveTeamLaunchAMQEnv = func(cwd, profile, sess, handle string) (amqEnv, error) {
+		return amqEnv{AMQVersion: doctorMinAMQVersion, Root: root, BaseRoot: filepath.Dir(root), SessionName: session, Me: handle}, nil
+	}
+	t.Cleanup(func() { resolveTeamLaunchAMQEnv = original })
+}
+
+// TestStartApplyRejectsStaleSubjectDigest is gh#757's named acceptance test:
+// start --apply <subject_digest> refuses closed when the supplied digest
+// does not match a fresh Prepare's, mirroring amq's own
+// TestPrepareIsZeroWriteAndApplyRejectsStaleSubject contract.
+func TestStartApplyRejectsStaleSubjectDigest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
+	simpleStartStubLaunchapiAMQEnv(t, f.root, f.session)
+	launchCalled := false
+	f.deps.Launch = func(team.Team, teamLaunchOptions) (teamLaunchResult, error) {
+		launchCalled = true
+		return teamLaunchResult{}, fmt.Errorf("start must not call Launch on a stale digest")
+	}
+	var out bytes.Buffer
+	err := runStartWithDependencies(f.args("--apply", "sha256:0000000000000000000000000000000000000000000000000000000000000"), f.deps, strings.NewReader(""), &out)
+	if err == nil || !strings.Contains(err.Error(), "does not match the current plan's subject_digest") {
+		t.Fatalf("start --apply with a stale digest = %v, want the stale-digest refusal", err)
+	}
+	if launchCalled {
+		t.Fatal("start called Launch despite the stale digest")
+	}
+}
+
+// TestStartApplyRequiresExactDecisionsForEveryRequiredAction is gh#757's
+// named acceptance test for resolveLaunchapiDecisions -- the exact
+// mechanism start --apply/--decision depends on and launchapiTeamLaunchBackend.launch
+// already calls before ever reaching adoptionseam.Apply. Manufacturing a
+// live RequiredActionV1 through a real Prepare call requires elaborate
+// trust-store/conversation state this repo's other launchapi tests do not
+// attempt either (TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates
+// uses the same launchapiTestRequiredActions() fixture directly for exactly
+// this reason) -- so this proves the missing/extra-decision contract
+// directly against that fixture: every required action needs an exact
+// decision, no partial application, before any roster mutation.
+func TestStartApplyRequiresExactDecisionsForEveryRequiredAction(t *testing.T) {
+	actions := launchapiTestRequiredActions()
+
+	t.Run("missing decision for one action reports it, not an error", func(t *testing.T) {
+		supplied := map[string]string{
+			"a1": string(launchapi.DecisionTrustExactSubject),
+			"a2": string(launchapi.DecisionFreshOnce),
+			"a3": string(launchapi.DecisionCloseOld),
+			// a4 deliberately omitted.
+		}
+		decisions, missing, err := resolveLaunchapiDecisions(actions, supplied)
+		if err != nil {
+			t.Fatalf("resolveLaunchapiDecisions: %v", err)
+		}
+		if len(decisions) != 3 {
+			t.Fatalf("decisions = %+v, want exactly the 3 supplied", decisions)
+		}
+		if len(missing) != 1 || missing[0].ActionID != "a4" {
+			t.Fatalf("missing = %+v, want exactly a4", missing)
+		}
+	})
+
+	t.Run("an extra decision for an unknown action_id refuses before any roster mutation", func(t *testing.T) {
+		supplied := map[string]string{"a1": string(launchapi.DecisionTrustExactSubject), "stale-action": "fresh_once"}
+		if _, _, err := resolveLaunchapiDecisions(actions, supplied); err == nil || !strings.Contains(err.Error(), "stale answer") {
+			t.Fatalf("resolveLaunchapiDecisions with an unknown action_id = %v, want a stale-answer refusal", err)
+		}
+	})
+
+	t.Run("a choice outside the action's allowed set refuses", func(t *testing.T) {
+		supplied := map[string]string{"a1": "close_old"} // a1 is RequiredActionTrustConfirmation; close_old is not in its allowed set.
+		if _, _, err := resolveLaunchapiDecisions(actions, supplied); err == nil || !strings.Contains(err.Error(), "not in the allowed set") {
+			t.Fatalf("resolveLaunchapiDecisions with a disallowed choice = %v, want an allowed-set refusal", err)
+		}
+	})
+
+	t.Run("every action decided exactly returns all decisions and no missing", func(t *testing.T) {
+		supplied := map[string]string{
+			"a1": string(launchapi.DecisionTrustExactSubject), "a2": string(launchapi.DecisionFreshOnce),
+			"a3": string(launchapi.DecisionCloseOld), "a4": string(launchapi.DecisionAcceptDegraded),
+		}
+		decisions, missing, err := resolveLaunchapiDecisions(actions, supplied)
+		if err != nil {
+			t.Fatalf("resolveLaunchapiDecisions: %v", err)
+		}
+		if len(missing) != 0 {
+			t.Fatalf("missing = %+v, want none", missing)
+		}
+		if len(decisions) != len(actions) {
+			t.Fatalf("decisions = %+v, want one per action (%d)", decisions, len(actions))
+		}
+	})
+}
+
+// flipOnFirstReadReader wraps an io.Reader and runs flip() exactly once,
+// just before the first byte is ever read from it -- used to simulate an
+// external state change (a role coming back live) happening while the
+// operator is still at the confirmation prompt.
+type flipOnFirstReadReader struct {
+	r       io.Reader
+	flip    func()
+	flipped bool
+}
+
+func (f *flipOnFirstReadReader) Read(p []byte) (int, error) {
+	if !f.flipped {
+		f.flipped = true
+		f.flip()
+	}
+	return f.r.Read(p)
+}
+
+// TestStartApplyRefusesWhenLivenessChangedSinceDigest is gh#757's named
+// acceptance test for cto's ruling #3 (task/t8): the subject_digest binds
+// only the roster reconciliation decided needed launching at print time.
+// If liveness changes between the printed digest and the re-locked,
+// re-reconciled roster deps.Launch actually receives -- here, a second
+// role goes live while the operator is still answering the confirmation
+// prompt -- the fresh Prepare inside launchapiTeamLaunchBackend.launch
+// computes a different digest for the now-smaller roster and refuses,
+// rather than silently applying against a roster that no longer matches
+// what was shown.
+func TestStartApplyRefusesWhenLivenessChangedSinceDigest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	project := canonicalFilesystemPath(t.TempDir())
+	chdir(t, project)
+	const session = "work"
+	root := squadnamespace.AMQRoot(project, team.DefaultProfile, session)
+	members := []team.Member{
+		{Role: "dev", Handle: "dev", Binary: "codex", Session: session},
+		{Role: "ops", Handle: "ops", Binary: "codex", Session: session},
+	}
+	if err := team.Write(project, team.Team{Project: project, SharedCwdException: "digest race fixture", Members: members}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(project, ".amq-squad"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, ".amq-squad", "team-rules.md"), []byte("test rules\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previousBackend, hadBackend := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = &fakeBackend{}
+	t.Cleanup(func() {
+		if hadBackend {
+			teamLaunchBackends["tmux"] = previousBackend
+		} else {
+			delete(teamLaunchBackends, "tmux")
+		}
+	})
+	simpleStartStubLaunchapiAMQEnv(t, root, session)
+
+	const opsPID = 5100
+	alive := map[int]bool{opsPID: false}
+	writeFixtureLaunchRecord := func(role, handle string, pid int, paneID string) {
+		agentDir := filepath.Join(root, "agents", handle)
+		rec := launch.Record{
+			Schema: launch.SchemaVersion, CWD: project, TeamHome: project, TeamProfile: team.DefaultProfile,
+			Root: root, BaseRoot: filepath.Dir(root), Session: session,
+			Role: role, Handle: handle, Binary: "codex", Trust: trustModeSandboxed,
+			ToolProfile: team.ToolProfileFull, AgentPID: pid, AgentTTY: "/dev/ttys-test", StartedAt: time.Unix(1000, 0).UTC(),
+			Tmux: &launch.TmuxInfo{Session: "test", WindowID: "@1", PaneID: paneID, Target: "new-window"},
+		}
+		if err := launch.Write(agentDir, rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// "ops" has a prior record so it classifies as stopped/live rather
+	// than unmanaged (an unmanaged role has no record to go live from).
+	writeFixtureLaunchRecord("ops", "ops", opsPID, "%51")
+
+	deps := simpleStartDependencies{
+		LookPath: func(name string) (string, error) { return "/test/bin/" + name, nil },
+		ResolveAMQEnv: func(proj, r, sess, handle string) (amqEnv, error) {
+			return amqEnv{AMQVersion: doctorMinAMQVersion, Root: r, BaseRoot: filepath.Dir(r), SessionName: sess, Me: handle}, nil
+		},
+		DuplicateProbe: duplicateLaunchProbe{
+			PIDAlive:         func(pid int) bool { return alive[pid] },
+			ProcessMatch:     func(int, func(string) bool) bool { return true },
+			ProcessTTY:       func(pid int) (string, bool) { return "/dev/ttys-test", alive[pid] },
+			ProcessStartTime: func(pid int) (time.Time, bool) { return time.Unix(1000, 0).UTC(), alive[pid] },
+			Now:              func() time.Time { return time.Unix(1000, 0).UTC() },
+		},
+		RuntimeProbe: launchRuntimeProbe{
+			PIDAlive:         func(pid int) bool { return alive[pid] },
+			ProcessMatch:     func(int, func(string) bool) bool { return true },
+			ProcessTTY:       func(pid int) (string, bool) { return "/dev/ttys-test", alive[pid] },
+			ProcessStartTime: func(pid int) (time.Time, bool) { return time.Unix(1000, 0).UTC(), alive[pid] },
+			PaneTitle:        func(string) (string, bool) { return "", false },
+		},
+		ListPanes:    func() ([]tmuxpane.TmuxPane, error) { return nil, nil },
+		StartWatcher: func(team.Team, string, string, string) error { return nil },
+	}
+	// Deliberately leave deps.Launch unset: this test must exercise the
+	// real simpleStartLaunch -> launchapiTeamLaunchBackend.launch path,
+	// since the digest gate under test lives inside launch() itself (it
+	// re-runs Prepare fresh and compares digests before ever reaching
+	// adoptionseam.Apply). A stubbed Launch would bypass the gate entirely
+	// and prove nothing.
+
+	in := &flipOnFirstReadReader{
+		r:    strings.NewReader("y\n"),
+		flip: func() { alive[opsPID] = true },
+	}
+	var out bytes.Buffer
+	err := runStartWithDependencies([]string{"--project", project, "--session", session, "--target", "new-window"}, deps, in, &out)
+	if err == nil || !strings.Contains(err.Error(), "stale subject_digest") {
+		t.Fatalf("start with liveness changed since the printed digest = %v, want a stale subject_digest refusal", err)
 	}
 }
 

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -1204,3 +1204,51 @@ func TestVerifySimpleStartRecordsPollsForRecordPublication(t *testing.T) {
 		t.Fatalf("poll sleeps = %d, want one publication wait", sleeps)
 	}
 }
+
+// TestRunStartDefaultsToLaunchapiOnTmux is gh#757's named acceptance test
+// closing the gh#755 gap identified during t1/t6: simpleStartLaunch (start's
+// production Launch dependency) previously resolved its backend via a bare
+// teamLaunchBackends[opts.Terminal] lookup, bypassing resolveTeamLaunchBackend
+// entirely, so plain `amq-squad start` never selected launchapi on tmux
+// regardless of gh#755's default flip. It now routes through the same
+// selection seam executeTeamLaunch (team launch/up) already uses.
+func TestRunStartDefaultsToLaunchapiOnTmux(t *testing.T) {
+	legacyFake := &fakeBackend{}
+	launchapiFake := &fakeBackend{}
+	prevTmux, hadTmux := teamLaunchBackends["tmux"]
+	prevLaunchapi, hadLaunchapi := teamLaunchBackends["launchapi"]
+	teamLaunchBackends["tmux"] = legacyFake
+	teamLaunchBackends["launchapi"] = launchapiFake
+	t.Cleanup(func() {
+		if hadTmux {
+			teamLaunchBackends["tmux"] = prevTmux
+		} else {
+			delete(teamLaunchBackends, "tmux")
+		}
+		if hadLaunchapi {
+			teamLaunchBackends["launchapi"] = prevLaunchapi
+		} else {
+			delete(teamLaunchBackends, "launchapi")
+		}
+	})
+
+	member := team.Team{Members: []team.Member{{Role: "dev", Handle: "dev", Binary: "codex"}}}
+
+	for _, launchVia := range []string{"", "auto", "launchapi"} {
+		legacyFake.launches, launchapiFake.launches = nil, nil
+		if _, err := simpleStartLaunch(member, teamLaunchOptions{Terminal: "tmux", LaunchVia: launchVia}); err != nil {
+			t.Fatalf("LaunchVia=%q: %v", launchVia, err)
+		}
+		if len(launchapiFake.launches) != 1 || len(legacyFake.launches) != 0 {
+			t.Fatalf("LaunchVia=%q: launchapi launches=%d legacy launches=%d, want launchapi selected by default", launchVia, len(launchapiFake.launches), len(legacyFake.launches))
+		}
+	}
+
+	legacyFake.launches, launchapiFake.launches = nil, nil
+	if _, err := simpleStartLaunch(member, teamLaunchOptions{Terminal: "tmux", LaunchVia: "legacy"}); err != nil {
+		t.Fatalf("LaunchVia=legacy: %v", err)
+	}
+	if len(legacyFake.launches) != 1 || len(launchapiFake.launches) != 0 {
+		t.Fatalf("LaunchVia=legacy: legacy launches=%d launchapi launches=%d, want the explicit opt-out to select legacy", len(legacyFake.launches), len(launchapiFake.launches))
+	}
+}

--- a/internal/cli/simple_start_test.go
+++ b/internal/cli/simple_start_test.go
@@ -796,6 +796,12 @@ func TestSimpleStartRestoreComposesRecordedConversationWithoutBootstrap(t *testi
 	}
 }
 
+// TestRunStartRejectsRestoreResultThatDropsRecordedConversation exercises
+// the legacy composer's own drop-detection (validateSimpleStartRestoreResultCommands),
+// so it opts into --launch-via legacy explicitly (gh#757): plain start now
+// defaults to the launchapi path, which refuses this same scenario outright
+// instead (see TestStartRefusesLegacyMintedRestoreOnLaunchapiPath) since it
+// cannot resume a legacy-minted conversation at all yet.
 func TestRunStartRejectsRestoreResultThatDropsRecordedConversation(t *testing.T) {
 	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
 	agentDir := f.seedRecord(t, "dev", "dev", 4402, "%19", false, true)
@@ -817,12 +823,99 @@ func TestRunStartRejectsRestoreResultThatDropsRecordedConversation(t *testing.T)
 		}}}, nil
 	}
 	var out bytes.Buffer
-	err = runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out)
+	err = runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out)
 	if err == nil || !strings.Contains(err.Error(), "dispatched child command omits recorded conversation") {
 		t.Fatalf("dropped-conversation start error = %v", err)
 	}
 	if strings.Contains(out.String(), "started ") {
 		t.Fatalf("failed restore reported started:\n%s", out.String())
+	}
+}
+
+// TestStartRefusesLegacyMintedRestoreOnLaunchapiPath is gh#757's named
+// acceptance test for the conversation-restore gap found while wiring
+// --apply: launchapi has no mechanism to resume a conversation minted by
+// the legacy composer (confirmed on task/t7: the launchapi backend never
+// writes launch.Record at all, so any recorded Conversation is legacy-
+// minted by construction). start refuses closed rather than silently
+// falling back to the legacy backend or silently dropping the conversation.
+func TestStartRefusesLegacyMintedRestoreOnLaunchapiPath(t *testing.T) {
+	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
+	agentDir := f.seedRecord(t, "dev", "dev", 4900, "%40", false, true)
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Conversation = "conv-legacy-minted"
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	launchCalled := false
+	f.deps.Launch = func(team.Team, teamLaunchOptions) (teamLaunchResult, error) {
+		launchCalled = true
+		return teamLaunchResult{}, fmt.Errorf("start must not call Launch when refused")
+	}
+	var out bytes.Buffer
+	err = runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out)
+	if err == nil || !strings.Contains(err.Error(), "launchapi path cannot resume it yet") || !strings.Contains(err.Error(), "--launch-via legacy") {
+		t.Fatalf("start with a legacy-minted restore on the launchapi path = %v, want the refusal naming --launch-via legacy", err)
+	}
+	if launchCalled {
+		t.Fatal("start called Launch despite the refusal")
+	}
+	if strings.Contains(out.String(), "started ") {
+		t.Fatalf("refused start reported started:\n%s", out.String())
+	}
+}
+
+// TestStartHonorsLegacyOptOutForRestore proves the remedy in the refusal
+// above actually works: --launch-via legacy still resumes a legacy-minted
+// conversation exactly as before gh#757, byte-identical to
+// TestRunStartWithDependenciesHoldsExactLockThroughSpawnVerification-style
+// launches.
+func TestStartHonorsLegacyOptOutForRestore(t *testing.T) {
+	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
+	agentDir := f.seedRecord(t, "dev", "dev", 4901, "%41", false, true)
+	rec, err := launch.Read(agentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec.Conversation = "conv-legacy-minted"
+	if err := launch.Write(agentDir, rec); err != nil {
+		t.Fatal(err)
+	}
+	previousBackend, hadBackend := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = &fakeBackend{}
+	t.Cleanup(func() {
+		if hadBackend {
+			teamLaunchBackends["tmux"] = previousBackend
+		} else {
+			delete(teamLaunchBackends, "tmux")
+		}
+	})
+	f.deps.Launch = func(_ team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+		if len(opts.ComposedPanes) != 1 || !strings.Contains(opts.ComposedPanes[0].Command, " --conversation conv-legacy-minted") {
+			t.Fatalf("legacy-path composed panes = %+v", opts.ComposedPanes)
+		}
+		newAgentDir := f.seedRecord(t, "dev", "dev", 4902, "%42", true, true)
+		newRec, err := launch.Read(newAgentDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newRec.Conversation = "conv-legacy-minted"
+		if err := launch.Write(newAgentDir, newRec); err != nil {
+			t.Fatal(err)
+		}
+		return teamLaunchResult{Panes: []teamLaunchResultPane{{
+			Role: "dev", PaneID: "%42", WindowID: "@2", ChildCommand: opts.ComposedPanes[0].Command,
+		}}}, nil
+	}
+	var out bytes.Buffer
+	if err := runStartWithDependencies(f.args("--yes", "--launch-via", "legacy"), f.deps, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("runStartWithDependencies with --launch-via legacy: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "started ") {
+		t.Fatalf("legacy-path restore did not report started:\n%s", out.String())
 	}
 }
 

--- a/internal/cli/simple_wizard.go
+++ b/internal/cli/simple_wizard.go
@@ -160,14 +160,79 @@ func runWizardWithDependencies(args []string, version string, deps simpleWizardD
 		return err
 	}
 	plan.Approved = true
-	startArgs := []string{"--project", plan.Project, "--profile", plan.Profile, "--session", plan.Session, "--goal", plan.Goal, "--yes"}
 	if deps.Start == nil {
 		return fmt.Errorf("wizard start dependency is not configured")
+	}
+	startArgs, err := wizardStartArgs(plan, deps.StartDeps, out)
+	if err != nil {
+		return fmt.Errorf("wizard staged the reviewed artifacts, but preparing the launch did not complete: %w; rerun the same wizard command to recover", err)
 	}
 	if err := deps.Start(startArgs, deps.StartDeps, in, out); err != nil {
 		return fmt.Errorf("wizard staged the reviewed artifacts, but start did not complete: %w; rerun the same wizard command to recover", err)
 	}
 	return nil
+}
+
+// wizardStartArgs builds the argv wizard hands to deps.Start after its own
+// one confirmation already approved both the staged artifacts and the
+// launch that follows them.
+//
+// gh#757 finding (fullstack, task/t8): plain --yes silently no-ops on the
+// launchapi default path -- start's own digest gate (simple_start.go) reads
+// its confirmation from a --apply <subject_digest> match or an interactive
+// prompt, and --yes affects neither, so a --yes-only wizard handoff into a
+// non-interactive reader reads as "cancelled" with nothing launched and
+// nothing reported as an error.
+//
+// The fix (cto's ruling on task/t8, option (i)): run the identical
+// parseSimpleStartRequest -> buildSimpleStartPlan -> (launchapiTeamLaunchBackend{}).prepare
+// sequence start's own probe uses, with the same args this function is
+// about to hand to deps.Start (minus --apply, which does not exist yet).
+// Reusing exactly those functions -- not internal/cli/plan.go's planPrepare,
+// which independently resolves trust mode and startup-prompt text for the
+// standalone `plan` command and is not guaranteed to compile the identical
+// intent -- is what makes the subject_digest this function prints
+// byte-identical to what start's own probe recomputes moments later: same
+// code, same inputs, called back to back in one process. start's own probe
+// re-verifies it anyway (the session-lock-guarded second Prepare in
+// runStartWithDependencies), so any actual drift between the two calls
+// still refuses closed there; this is only what makes the common,
+// no-drift case succeed instead of always refusing.
+//
+// A legacy-backend or already-fully-live team (no members left to spawn)
+// keeps the pre-gh#757 --yes behavior unchanged: --apply only has meaning
+// on the launchapi path, and start itself accepts --yes harmlessly on
+// every path (a no-op notice on launchapi, its real meaning on legacy).
+func wizardStartArgs(plan simpleWizardPlan, startDeps simpleStartDependencies, out io.Writer) ([]string, error) {
+	base := []string{"--project", plan.Project, "--profile", plan.Profile, "--session", plan.Session, "--goal", plan.Goal}
+	probeReq, err := parseSimpleStartRequest(base)
+	if err != nil {
+		return nil, fmt.Errorf("parse start args for launch preview: %w", err)
+	}
+	probeAccepted, err := buildSimpleStartPlan(probeReq, startDeps)
+	if err != nil {
+		return nil, fmt.Errorf("build launch preview: %w", err)
+	}
+	if !probeReq.LaunchapiPath || len(probeAccepted.SpawnTeam.Members) == 0 {
+		return append(append([]string(nil), base...), "--yes"), nil
+	}
+	probePrepared, _, err := (launchapiTeamLaunchBackend{}).prepare(probeAccepted.SpawnTeam, probeAccepted.LaunchOptions)
+	if err != nil {
+		return nil, fmt.Errorf("preview launch plan: %w", err)
+	}
+	printPlanResult(out, probePrepared.Result)
+	// Per cto's ruling: wizard's one confirmation only covers the plan as
+	// rendered by renderSimpleWizardPlan, which does not preview
+	// trust/rebind/capability required actions. Never auto-decide one here
+	// -- refuse closed and name it, same "no action ever auto-selected"
+	// norm start's own interactive gate flow already holds.
+	if len(probePrepared.Result.RequiredActions) > 0 {
+		ra := probePrepared.Result.RequiredActions[0]
+		return nil, fmt.Errorf("%d operator decision(s) required before this launch (first: action_id=%s kind=%s reason_code=%s allowed_decisions=%v); wizard does not auto-decide trust/rebind/capability gates -- resolve via 'amq-squad start --decision %s=<choice>' or the gate/<topic> thread, then re-run wizard", len(probePrepared.Result.RequiredActions), ra.ActionID, ra.Kind, ra.ReasonCode, ra.AllowedDecisions, ra.ActionID)
+	}
+	digest := probePrepared.Result.SubjectDigest
+	fmt.Fprintf(out, "Launch subject_digest: %s\n", digest)
+	return append(append([]string(nil), base...), "--apply", digest), nil
 }
 
 func parseSimpleWizardRequest(args []string, errOut io.Writer) (simpleWizardRequest, error) {
@@ -763,6 +828,12 @@ func simpleWizardLaunch(plan *simpleWizardPlan) simpleWizardLaunchPlan {
 	for _, member := range plan.Team.Members {
 		roles = append(roles, member.Role)
 	}
+	// --json preview only: this runs before applySimpleWizardPlan has
+	// written anything, so no subject_digest can exist yet to show the real
+	// --apply <digest> invocation wizardStartArgs computes at actual
+	// handoff time (gh#757). This --yes rendering is illustrative shell
+	// text, not what --json mode (which never calls deps.Start) or the
+	// real approved-and-applied path actually runs.
 	args := []string{"amq-squad", "start", "--project", plan.Project, "--profile", plan.Profile, "--session", plan.Session, "--goal", plan.Goal, "--yes"}
 	return simpleWizardLaunchPlan{Command: shellJoin(args), Root: squadnamespace.AMQRoot(plan.Project, plan.Profile, plan.Session), Roles: roles}
 }

--- a/internal/cli/simple_wizard_test.go
+++ b/internal/cli/simple_wizard_test.go
@@ -134,6 +134,7 @@ func TestWizardYesWritesReviewedArtifactsThenDelegatesToStart(t *testing.T) {
 // of silently no-op'ing.
 func TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	installFakeClaudeBinary(t)
 	project := t.TempDir()
 	// All-claude roster (see binaryOverride below): the goal-draft brief
 	// fixture must describe the same roster the --binary override actually
@@ -610,6 +611,38 @@ func simpleWizardTestDependenciesForMembers(t *testing.T, project string, member
 		},
 		StartDeps: hermeticSimpleStartDepsForWizardTest(t),
 	}
+}
+
+// installFakeClaudeBinary puts a fake "claude" executable ahead of PATH so a
+// real adoptionseam.Prepare call resolves and validates it successfully on
+// any machine, CI included. This is required, not optional, once a test
+// actually reaches launchapi's real Prepare/participant validation (as
+// opposed to unit tests that only construct a launchintent.Input and never
+// call Prepare): the pinned module's internal/launch adapter.go
+// validateKnownExecutable unconditionally resolves each seat's Executable
+// via exec.LookPath and requires it to exist, be outside the project
+// directory, and match the expected provider by basename -- confirmed live
+// on CI (make ci failure on aff9e53): a developer machine with a real
+// claude on PATH masks this, CI does not have one.
+//
+// The fake also answers ClaudeAdapter.Capabilities' --version/--help probe
+// (internal/launch/adapter_claude.go) so capability negotiation succeeds
+// too, though that alone is a soft signal (a failed probe degrades to
+// below-floor, not a hard refusal) -- only validateKnownExecutable's check
+// is unconditional.
+func installFakeClaudeBinary(t *testing.T) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  --version) echo 1.0.0; exit 0 ;;\n" +
+		"  --help) printf -- '--session-id <uuid>\\n--resume [value]\\n'; exit 0 ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 // hermeticSimpleStartDepsForWizardTest builds a simpleStartDependencies that

--- a/internal/cli/simple_wizard_test.go
+++ b/internal/cli/simple_wizard_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,9 +14,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/launchapi"
+
+	"github.com/omriariav/amq-squad/v2/internal/adoptionseam"
 	"github.com/omriariav/amq-squad/v2/internal/drafter"
+	"github.com/omriariav/amq-squad/v2/internal/launch"
+	squadnamespace "github.com/omriariav/amq-squad/v2/internal/namespace"
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 	"github.com/omriariav/amq-squad/v2/internal/team"
+	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
 	"github.com/omriariav/amq-squad/v2/internal/userconfig"
 )
 
@@ -63,12 +70,18 @@ func TestWizardDefaultNoLeavesEveryArtifactAbsent(t *testing.T) {
 }
 
 func TestWizardYesWritesReviewedArtifactsThenDelegatesToStart(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	project := t.TempDir()
 	deps := simpleWizardTestDependencies(t, project)
+	simpleStartStubLaunchapiAMQEnv(t, squadnamespace.AMQRoot(project, "review", "issue-709"), "issue-709")
 	startCalled := false
 	deps.Start = func(args []string, _ simpleStartDependencies, _ io.Reader, _ io.Writer) error {
 		startCalled = true
-		if got := strings.Join(args, " "); !strings.Contains(got, "--profile review") || !strings.Contains(got, "--session issue-709") || !strings.Contains(got, "--yes") {
+		// gh#757: wizard no longer hands start a bare --yes on the
+		// launchapi default path (that silently no-ops there) -- it runs
+		// the same probe start's own launch would and binds to that exact
+		// subject_digest via --apply instead.
+		if got := strings.Join(args, " "); !strings.Contains(got, "--profile review") || !strings.Contains(got, "--session issue-709") || !strings.Contains(got, "--apply ") || strings.Contains(got, "--yes") {
 			t.Fatalf("wizard start args = %q", got)
 		}
 		if _, err := team.ReadProfile(project, "review"); err != nil {
@@ -104,6 +117,203 @@ func TestWizardYesWritesReviewedArtifactsThenDelegatesToStart(t *testing.T) {
 	}
 	if implementation != 1 {
 		t.Fatalf("wizard default roster has %d implementation actors, want one for launch-safe shared cwd", implementation)
+	}
+}
+
+// TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch is gh#757's
+// named acceptance test for cto's ruling on task/t8: wizard's handoff to
+// start must go through the REAL runStartWithDependencies (not a stubbed
+// deps.Start), on the launchapi default path, with an empty/non-interactive
+// reader, and still reach Launch. Before this fix, wizard passed a bare
+// --yes, which silently no-ops on the launchapi path (fullstack's finding):
+// start's digest gate reads only a --apply <subject_digest> match or an
+// interactive confirmation, neither of which --yes satisfies, so an
+// automated (non-interactive) wizard run read as "cancelled" with nothing
+// launched and no error. wizardStartArgs's fix computes the digest itself
+// and passes --apply, so the same empty reader now reaches Launch instead
+// of silently no-op'ing.
+func TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	project := t.TempDir()
+	// All-claude roster (see binaryOverride below): the goal-draft brief
+	// fixture must describe the same roster the --binary override actually
+	// produces, or buildSimpleWizardPlan's brief validation refuses with a
+	// roster-mismatch error.
+	allClaudeMembers := []team.Member{
+		{Role: "cto", Handle: "cto", Binary: "claude"},
+		{Role: "fullstack", Handle: "fullstack", Binary: "claude"},
+		{Role: "senior-dev", Handle: "senior-dev", Binary: "claude"},
+	}
+	deps := simpleWizardTestDependenciesForMembers(t, project, allClaudeMembers)
+	profile, session := "review", "issue-709"
+	root := squadnamespace.AMQRoot(project, profile, session)
+	simpleStartStubLaunchapiAMQEnv(t, root, session)
+	// adoptionseam.Prepare's own openExplicitBaseAuthority requires a real
+	// .amqrc at the project root (gh#757 finding); resolveTeamLaunchAMQEnv
+	// being stubbed above only fakes what `amq env` would return, not this
+	// filesystem-level authorization check.
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), []byte(`{"root": ".agent-mail"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A second, non-obvious real requirement (confirmed directly against
+	// openExplicitBaseAuthority, internal/launch/base_root.go): for a NAMED
+	// profile, BaseRoot is one directory below .amqrc's configured root, and
+	// that configured root must already EXIST on disk before a profile-child
+	// BaseRoot is authorized at all -- otherwise it refuses closed with
+	// base_root_unauthorized ("configured root must exist before creating a
+	// profile child"), regardless of whether the relation itself is correct.
+	// The default profile has no such requirement (BaseRoot == configured
+	// root, created fresh). This is exactly the kind of operator-facing gap
+	// t14's release notes need to name for real non-default-profile teams.
+	if err := os.MkdirAll(filepath.Join(project, ".agent-mail"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A never-before-seen subject legitimately answers action_required/
+	// untrusted_config_digest on its very first Prepare (t8's real
+	// round-trip test proves this is the correct, by-design first-launch
+	// answer, not a defect). wizardStartArgs correctly never auto-decides
+	// this -- so reaching Launch here requires trust to already be
+	// established for this exact subject, the same way an operator would
+	// have answered it once interactively.
+	//
+	// Establishing it is not one Prepare+Apply pair: confirmed live that
+	// launchapi.Apply's own create_base_root planned write (the base
+	// container not existing yet) changes what the NEXT Prepare observes
+	// (roster flips from all-missing to all-present), which changes the
+	// computed subject_digest again -- so a decision trusted against the
+	// PRE-Apply digest no longer matches the POST-Apply digest. This
+	// converges: base_root creation is a one-time transition, so looping
+	// Prepare-then-trust-Apply stabilizes once nothing observable is left
+	// to change between consecutive Prepare calls.
+	preTrust := simpleWizardTestDependenciesForMembers(t, project, allClaudeMembers)
+	preTrust.StartDeps = deps.StartDeps
+	var preOut, preErrOut bytes.Buffer
+	// All-claude roster: codex/cursor adapters pin an exact live-probed
+	// binary version for their capture mechanism (internal/launch's
+	// codexCaptureVersion/cursorCaptureVersion), which drifts with the
+	// locally installed tool and is not hermetic; claude's adapter has no
+	// such pin. --binary keeps the same built-in role names (no custom-role
+	// drafting triggered).
+	binaryOverride := "--binary=cto=claude,senior-dev=claude"
+	err := runWizardWithDependencies([]string{"Ship the reviewed change", "--project", project, "--profile", profile, "--session", session, "--yes", binaryOverride}, "test", preTrust, strings.NewReader(""), &preOut, &preErrOut)
+	if err == nil || !strings.Contains(err.Error(), "operator decision(s) required") {
+		t.Fatalf("expected the first wizard run to refuse on the untrusted-subject gate, got: %v\n%s", err, preOut.String())
+	}
+	probeReq, err := parseSimpleStartRequest([]string{"--project", project, "--profile", profile, "--session", session, "--goal", "Ship the reviewed change"})
+	if err != nil {
+		t.Fatalf("parseSimpleStartRequest: %v", err)
+	}
+	var trustedDigest string
+	const maxTrustConvergenceAttempts = 5
+	for attempt := 0; ; attempt++ {
+		if attempt >= maxTrustConvergenceAttempts {
+			t.Fatalf("trust establishment did not converge after %d attempts (last trusted digest %s)", attempt, trustedDigest)
+		}
+		probeAccepted, err := buildSimpleStartPlan(probeReq, deps.StartDeps)
+		if err != nil {
+			t.Fatalf("buildSimpleStartPlan: %v", err)
+		}
+		prepared, _, err := (launchapiTeamLaunchBackend{}).prepare(probeAccepted.SpawnTeam, probeAccepted.LaunchOptions)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		t.Logf("trust convergence attempt=%d outcome=%s reason=%s subject_digest=%s", attempt, prepared.Result.Outcome, prepared.Result.Reason, prepared.Result.SubjectDigest)
+		// "ready" means no operator decision stands in the way at all,
+		// regardless of whether this exact digest was the one just
+		// trusted -- Apply's own create_base_root write (the base
+		// container not existing yet) legitimately shifts the NEXT
+		// Prepare's observed roster/subject once, independent of trust.
+		if prepared.Result.Outcome != "action_required" {
+			break
+		}
+		if len(prepared.Result.RequiredActions) != 1 || prepared.Result.RequiredActions[0].Kind != launchapi.RequiredActionTrustConfirmation {
+			t.Fatalf("required_actions = %+v, want exactly one trust_confirmation", prepared.Result.RequiredActions)
+		}
+		trustedDigest = prepared.Result.SubjectDigest
+		applyResult, err := adoptionseam.Apply(context.Background(), prepared, []launchapi.DecisionV1{{ActionID: prepared.Result.RequiredActions[0].ActionID, Choice: launchapi.DecisionTrustExactSubject}})
+		if err != nil {
+			t.Fatalf("establish trust via adoptionseam.Apply (attempt %d): %v", attempt, err)
+		}
+		t.Logf("apply result attempt=%d outcome=%s reason_code=%s disposition=%+v", attempt, applyResult.Outcome, applyResult.ReasonCode, applyResult.Disposition)
+	}
+
+	deps.Start = runStartWithDependencies
+	deps.StartDeps.Sleep = func(time.Duration) {}
+	deps.StartDeps.DeliverGoal = func(simpleStartPlan, string) error { return nil }
+	alive := map[int]bool{}
+	started := time.Unix(1_000, 0).UTC()
+	deps.StartDeps.DuplicateProbe.PIDAlive = func(pid int) bool { return alive[pid] }
+	deps.StartDeps.RuntimeProbe.PIDAlive = func(pid int) bool { return alive[pid] }
+	deps.StartDeps.DuplicateProbe.ProcessStartTime = func(pid int) (time.Time, bool) { return started, alive[pid] }
+	deps.StartDeps.RuntimeProbe.ProcessStartTime = func(pid int) (time.Time, bool) { return started, alive[pid] }
+
+	launchCalled := false
+	nextPID := 41000
+	deps.StartDeps.Launch = func(spawn team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
+		launchCalled = true
+		var result teamLaunchResult
+		for _, member := range spawn.Members {
+			handle := memberHandle(member)
+			pid := nextPID
+			nextPID++
+			paneID := fmt.Sprintf("%%%d", pid)
+			rec := launch.Record{
+				Schema: launch.SchemaVersion, CWD: project, TeamHome: project, TeamProfile: profile,
+				Root: root, BaseRoot: filepath.Dir(root), Session: session,
+				Role: member.Role, Handle: handle, Binary: member.Binary, Trust: trustModeSandboxed,
+				ToolProfile: team.ToolProfileFull, AgentPID: pid, AgentTTY: "/dev/ttys-test", StartedAt: started,
+				Tmux: &launch.TmuxInfo{Session: "test", WindowID: "@1", PaneID: paneID, Target: "new-window"},
+			}
+			if err := launch.Write(filepath.Join(root, "agents", handle), rec); err != nil {
+				t.Fatal(err)
+			}
+			alive[pid] = true
+			result.Panes = append(result.Panes, teamLaunchResultPane{Role: member.Role, PaneID: paneID, WindowID: "@1"})
+		}
+		return result, nil
+	}
+
+	var out, errOut bytes.Buffer
+	// The profile already exists (created by the pre-trust run above), so
+	// this reuses it via flow B -- --binary is a new-profile-only option
+	// and must not be repeated here.
+	err = runWizardWithDependencies([]string{"Ship the reviewed change", "--project", project, "--profile", profile, "--session", session, "--yes"}, "test", deps, strings.NewReader(""), &out, &errOut)
+	if err != nil {
+		t.Fatalf("wizard real handoff: %v\nstderr:\n%s\nout:\n%s", err, errOut.String(), out.String())
+	}
+	if !launchCalled {
+		t.Fatal("wizard's real handoff to start never invoked Launch -- the --yes no-op bug is back")
+	}
+	if !strings.Contains(out.String(), "Launch subject_digest:") || !strings.Contains(out.String(), "outcome:") {
+		t.Fatalf("wizard did not surface its computed subject_digest/plan preview before handoff:\n%s", out.String())
+	}
+}
+
+// TestStartCancelsOnEmptyReaderWithoutApplyOnLaunchapiPath is the other half
+// of gh#757's acceptance criteria: an empty/non-interactive reader on the
+// launchapi path, with no --apply supplied, must still cancel rather than
+// launch -- proving TestWizardRealHandoffAppliesComputedDigestAndInvokesLaunch
+// above reaches Launch only because wizardStartArgs supplies --apply, not
+// because start's own cancel-on-empty-reader behavior silently changed.
+func TestStartCancelsOnEmptyReaderWithoutApplyOnLaunchapiPath(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	f := newSimpleStartRunFixture(t, team.Member{Role: "dev", Handle: "dev", Binary: "codex"})
+	simpleStartStubLaunchapiAMQEnv(t, f.root, f.session)
+	launchCalled := false
+	f.deps.Launch = func(team.Team, teamLaunchOptions) (teamLaunchResult, error) {
+		launchCalled = true
+		return teamLaunchResult{}, fmt.Errorf("start must not call Launch without --apply or an interactive yes")
+	}
+	var out bytes.Buffer
+	if err := runStartWithDependencies(f.args("--yes"), f.deps, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("runStartWithDependencies: %v\n%s", err, out.String())
+	}
+	if launchCalled {
+		t.Fatal("start called Launch on an empty reader without --apply")
+	}
+	if !strings.Contains(out.String(), "start cancelled") {
+		t.Fatalf("empty-reader launchapi start without --apply did not cancel:\n%s", out.String())
 	}
 }
 
@@ -397,6 +607,54 @@ func simpleWizardTestDependenciesForMembers(t *testing.T, project string, member
 		Start: func([]string, simpleStartDependencies, io.Reader, io.Writer) error {
 			t.Fatal("preview must not call start")
 			return nil
+		},
+		StartDeps: hermeticSimpleStartDepsForWizardTest(t),
+	}
+}
+
+// hermeticSimpleStartDepsForWizardTest builds a simpleStartDependencies that
+// lets wizardStartArgs's probe (parseSimpleStartRequest -> buildSimpleStartPlan
+// -> (launchapiTeamLaunchBackend{}).prepare) run for real against the team
+// wizard just wrote, without touching a real tmux/amq binary or spawning
+// anything. Launch is deliberately left failing loudly: wizardStartArgs never
+// calls it (it only previews), so any test that reaches it either wired its
+// own deps.Start stub incorrectly or is exercising a real runStartWithDependencies
+// handoff and must override Launch itself.
+func hermeticSimpleStartDepsForWizardTest(t *testing.T) simpleStartDependencies {
+	t.Helper()
+	previousBackend, hadBackend := teamLaunchBackends["tmux"]
+	teamLaunchBackends["tmux"] = &fakeBackend{}
+	t.Cleanup(func() {
+		if hadBackend {
+			teamLaunchBackends["tmux"] = previousBackend
+			return
+		}
+		delete(teamLaunchBackends, "tmux")
+	})
+	return simpleStartDependencies{
+		LookPath: func(name string) (string, error) { return "/test/bin/" + name, nil },
+		ResolveAMQEnv: func(project, root, session, handle string) (amqEnv, error) {
+			return amqEnv{AMQVersion: doctorMinAMQVersion, Root: root, BaseRoot: filepath.Dir(root), SessionName: session, Me: handle}, nil
+		},
+		DuplicateProbe: duplicateLaunchProbe{
+			PIDAlive:         func(int) bool { return false },
+			ProcessMatch:     func(int, func(string) bool) bool { return true },
+			ProcessTTY:       func(int) (string, bool) { return "", false },
+			ProcessStartTime: func(int) (time.Time, bool) { return time.Time{}, false },
+			Now:              func() time.Time { return time.Unix(1_000, 0).UTC() },
+		},
+		RuntimeProbe: launchRuntimeProbe{
+			PIDAlive:         func(int) bool { return false },
+			ProcessMatch:     func(int, func(string) bool) bool { return true },
+			ProcessTTY:       func(int) (string, bool) { return "", false },
+			ProcessStartTime: func(int) (time.Time, bool) { return time.Time{}, false },
+			PaneTitle:        func(string) (string, bool) { return "", false },
+		},
+		ListPanes:    func() ([]tmuxpane.TmuxPane, error) { return nil, nil },
+		StartWatcher: func(team.Team, string, string, string) error { return nil },
+		Launch: func(team.Team, teamLaunchOptions) (teamLaunchResult, error) {
+			t.Fatal("wizard's own preview must never reach Launch; only a real runStartWithDependencies handoff should, and that test must stub Launch itself")
+			return teamLaunchResult{}, nil
 		},
 	}
 }

--- a/internal/cli/team_launch.go
+++ b/internal/cli/team_launch.go
@@ -94,6 +94,16 @@ type teamLaunchOptions struct {
 	// nil/empty means no decisions were supplied and every required action
 	// surfaces as an operator gate instead.
 	LaunchapiDecisions map[string]string
+	// ExpectedSubjectDigest binds this launch to a previously printed
+	// PrepareResultV1.SubjectDigest (gh#757: start --apply <subject_digest>).
+	// launchapiTeamLaunchBackend.launch re-runs Prepare fresh under the
+	// caller's session lock and refuses closed if the freshly computed
+	// SubjectDigest does not match exactly -- e.g. the team/brief changed,
+	// or reconciliation now includes a different roster because a role's
+	// liveness changed since the digest was printed. Empty means no digest
+	// binding is required (DryRun/plan's own preview path and the legacy
+	// backends never consult this field).
+	ExpectedSubjectDigest string
 }
 
 type teamLaunchResult struct {

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -289,6 +289,7 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 	binaryArgs := mergeBinaryArgs(t.BinaryArgs, opts.BinaryArgs)
 	seats := make([]launchintent.SeatFacts, 0, len(t.Members))
 	baseRoot := ""
+	sessionRoot := ""
 	for _, m := range orderedTeamMembers(t.Members) {
 		pre, ok := byRole[strings.ToLower(strings.TrimSpace(m.Role))]
 		if !ok {
@@ -296,6 +297,9 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 		}
 		if baseRoot == "" {
 			baseRoot = pre.BaseRoot
+		}
+		if sessionRoot == "" {
+			sessionRoot = pre.Root
 		}
 		model := memberResolvedModel(m, opts.ModelOverrides, binaryArgs)
 		nativeArgs := composeBinaryArgs(m.Binary, binaryArgsFor(m.Binary, binaryArgs), m.ExtraArgs())
@@ -342,17 +346,53 @@ func (b launchapiTeamLaunchBackend) buildIntentInput(t team.Team, opts teamLaunc
 	if strings.TrimSpace(baseRoot) == "" {
 		return launchintent.Input{}, fmt.Errorf("launchapi: base_root is required and must be explicit (gh#734); refusing to run rather than perform upward discovery")
 	}
+	// gh#757/t10 finding: launchapi's own openExplicitBaseAuthority (pinned
+	// v0.75.0, internal/launch/base_root.go) requires
+	// filepath.Dir(SessionRoot) == BaseRoot and filepath.Base(SessionRoot)
+	// == Session, refusing base_root_relation_invalid otherwise. SessionRoot
+	// is NOT the team's project directory -- it is the session's own
+	// resolved AMQ root (AM_ROOT), the base root's direct child named by
+	// the session, exactly what resolveTeamLaunchAMQEnv already resolved
+	// per member as pre.Root. Reusing that value directly (rather than
+	// reconstructing via filepath.Join) keeps this in lockstep with
+	// whatever AMQ's own root-resolution contract actually returns.
+	if strings.TrimSpace(sessionRoot) == "" {
+		return launchintent.Input{}, fmt.Errorf("launchapi: session_root is required and must be explicit; refusing to run rather than guess at the session's AMQ root")
+	}
 	operatorHandle := strings.TrimSpace(team.EffectiveOperator(t).Handle)
 	if operatorHandle == "" {
 		operatorHandle = "user"
 	}
+	// fullstack's live t10 verification (real amq v0.75.0, real .amqrc)
+	// found two further Target defects stacked on top of the SessionRoot one
+	// above, both structural, neither specific to any one code path:
+	//
+	//  - ProjectRoot must be canonical: openPrepareTarget's own check computes
+	//    filepath.Abs+EvalSymlinks and rejects anything that does not already
+	//    equal that. t.Project is recorded (absoluteFilesystemPath-shaped,
+	//    per pathnorm.go's split) but never symlink-resolved, so on macOS a
+	//    project under a /var/folders temp dir or a /tmp symlink fails this
+	//    check outright.
+	//  - BaseRoot must be canonicalized the same way: openExplicitBaseAuthority
+	//    compares it against the .amqrc-configured root by plain STRING
+	//    equality, and that configured root is itself derived from the
+	//    already-canonical opened project path. A raw, non-canonical BaseRoot
+	//    naming the identical directory still fails base_root_unauthorized.
+	//
+	// pre.Root/pre.BaseRoot (this function's baseRoot/sessionRoot) come from
+	// resolveTeamLaunchAMQEnv, which only ever filepath.Clean/Join's amq's
+	// own `amq env --json` output or squadnamespace.AMQRoot -- neither step
+	// resolves symlinks -- so they are exactly as uncanonicalized as
+	// t.Project and need the identical treatment. canonicalFilesystemPath is
+	// this repo's one canonicalization function (pathnorm.go); route through
+	// it rather than hand-rolling Abs/EvalSymlinks here.
 	return launchintent.Input{
 		Operator: launchintent.OperatorFacts{Handle: operatorHandle},
 		Seats:    seats,
 		Target: launchintent.TargetFacts{
-			ProjectRoot: t.Project,
-			BaseRoot:    baseRoot,
-			SessionRoot: t.Project,
+			ProjectRoot: canonicalFilesystemPath(t.Project),
+			BaseRoot:    canonicalFilesystemPath(baseRoot),
+			SessionRoot: canonicalFilesystemPath(sessionRoot),
 			Session:     opts.Workstream,
 		},
 	}, nil

--- a/internal/cli/team_launch_launchapi.go
+++ b/internal/cli/team_launch_launchapi.go
@@ -122,10 +122,19 @@ func legacyTeamLaunchBackend(opts teamLaunchOptions) (teamLaunchBackend, error) 
 // against that action's AllowedDecisions. Any action left undecided stops
 // the launch short of Apply and surfaces (only that action) as an operator
 // gate/<topic> thread; re-running with the answer completes the launch.
+//
+// gh#757: when opts.ExpectedSubjectDigest is set (start --apply
+// <subject_digest>), the freshly computed prepared.Result.SubjectDigest must
+// match it exactly before any decision is resolved or Apply is ever called --
+// a caller binds to a specific, previously printed digest, never to "whatever
+// Prepare computes now".
 func (b launchapiTeamLaunchBackend) launch(t team.Team, opts teamLaunchOptions) (teamLaunchResult, error) {
 	prepared, preflights, err := b.prepare(t, opts)
 	if err != nil {
 		return teamLaunchResult{}, err
+	}
+	if expected := strings.TrimSpace(opts.ExpectedSubjectDigest); expected != "" && prepared.Result.SubjectDigest != expected {
+		return teamLaunchResult{}, fmt.Errorf("launchapi: stale subject_digest: expected %s, a fresh Prepare computed %s -- the team, brief, or roster liveness changed since that digest was printed; re-run plan/start to get the current digest before applying", expected, prepared.Result.SubjectDigest)
 	}
 	decisions, missing, err := resolveLaunchapiDecisions(prepared.Result.RequiredActions, opts.LaunchapiDecisions)
 	if err != nil {

--- a/internal/cli/team_launch_launchapi_real_test.go
+++ b/internal/cli/team_launch_launchapi_real_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/avivsinai/agent-message-queue/launchapi"
+
+	"github.com/omriariav/amq-squad/v2/internal/adoptionseam"
+	"github.com/omriariav/amq-squad/v2/internal/team"
+)
+
+// TestRealPrepareApplyRoundTripAcceptsCanonicalTarget is t8's real-binding
+// acceptance test for gh#757 (cto's DIRECTIVE on task/t8, superseding the
+// narrower wording of the earlier one): buildIntentInput's Target (this
+// file's buildIntentInput, feeding every launchapi Prepare/Apply call on the
+// start/plan launchapi path) carried three stacked defects, none reachable
+// from the package's own mocked-amq-env unit tests because
+// launchapiTestStubAMQEnv's fixture is itself degenerate (BaseRoot==Root, a
+// shape openExplicitBaseAuthority can never accept):
+//
+//  1. SessionRoot was the team's project root instead of BaseRoot's direct
+//     child named Session (base_root_relation_invalid, this task's original
+//     finding).
+//  2. ProjectRoot was not canonicalized, so openPrepareTarget's "project_root
+//     must be canonical" (filepath.Abs+EvalSymlinks) check rejects any
+//     project path with a symlinked ancestor (found live by fullstack's t10
+//     verification of the sibling Inspect call site, e.g. a macOS
+//     /var/folders temp dir resolving through /private/var).
+//  3. BaseRoot was not canonicalized either, so openExplicitBaseAuthority's
+//     plain STRING comparison against the .amqrc-configured root (itself
+//     derived from the canonical project) rejects an equivalent but
+//     differently-spelled BaseRoot (base_root_unauthorized).
+//
+// This calls buildIntentInput itself (the actual production method, fed
+// with a real `amq env --json` envelope resolved against a real project) and
+// passes its output straight to adoptionseam.Prepare -- exercising the exact
+// fixed code path, not a hand-rolled Target -- against one genuine, fully-
+// authorized project/base-root layout produced by a real `amq init` plus a
+// real `.amqrc`: the same authorization openExplicitBaseAuthority itself
+// requires, mirroring fullstack's TestRealLaunchapiInspectSessionTargetShape
+// (internal/cli/liveness_real_launchapi_target_test.go on t10) but against
+// adoptionseam.Prepare instead of launchapi.Inspect.
+//
+// Apply is deliberately NOT exercised here: a genuine Apply against this
+// backend composes and would attempt to bind a real tmux pane running the
+// seat's executable, which is not safely dry-runnable in a unit test process
+// (no tmux session context here, and no cleanup story for a bound pane) --
+// this is the "if safely dry-runnable" case cto's directive allowed for.
+// Prepare alone is a read-only, deterministic call
+// (docs/amq-0.73.0-adoption-verdict.md) and is sufficient to prove the
+// Target shape itself clears authorization: the acceptance criterion is
+// Outcome, not any side effect only Apply would produce.
+func TestRealPrepareApplyRoundTripAcceptsCanonicalTarget(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ"))
+	if binary == "" {
+		t.Skip("set AMQ_SQUAD_REAL_AMQ to run the disposable real-launchapi Prepare round trip")
+	}
+	info, err := os.Stat(binary)
+	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		t.Fatalf("AMQ_SQUAD_REAL_AMQ %q is unavailable or not executable: %v", binary, err)
+	}
+	version := strings.TrimSpace(realAMQCommand(t, binary, t.TempDir(), nil, "version"))
+	t.Logf("real AMQ binary=%s version=%s", binary, version)
+
+	project := t.TempDir()
+	session := "t8-real-binding"
+	root := filepath.Join(project, ".agent-mail", session)
+	realAMQInit(t, binary, project, root)
+	// This is the exact operator-facing requirement for the launchapi path
+	// to reach outcome "ready" against a real project (t14 release-notes
+	// note, per cto's directive): a `.amqrc` at the project root naming the
+	// base container -- the same authorization `amq init` alone does not
+	// write (confirmed directly against the real binary) but
+	// openExplicitBaseAuthority unconditionally requires for Prepare/Apply/
+	// Inspect alike.
+	rc := []byte("{\n  \"root\": \".agent-mail\"\n}\n")
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), rc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real `amq env --json --session <session>` against the real project:
+	// cto asked whether pre.Root/pre.BaseRoot arrive canonical from amq's
+	// own resolution rather than assuming either way. They do, in fact --
+	// confirmed here directly rather than assumed: the real binary's own
+	// `env --json` already resolves symlinks in the Root/BaseRoot it
+	// echoes back (this run's Root prints the resolved /private/var/...
+	// form, not t.TempDir()'s raw /var/... spelling), so
+	// canonicalFilesystemPath is a no-op on pre.Root/pre.BaseRoot in
+	// practice. It is ProjectRoot (t.Project) that genuinely needs it:
+	// amq-squad computes that value itself and never routes it through
+	// `amq env`, so it stays exactly as uncanonicalized as the operator (or
+	// t.TempDir(), here) originally spelled it -- which this test's `project`
+	// local still is, and is what buildIntentInput's ProjectRoot
+	// canonicalization below is actually exercising.
+	var envelope amqEnv
+	if err := json.Unmarshal([]byte(realAMQCommand(t, binary, project, nil, "env", "--json", "--session", session)), &envelope); err != nil {
+		t.Fatalf("real amq env --json: %v", err)
+	}
+	t.Logf("real amq env: root=%q base_root=%q", envelope.Root, envelope.BaseRoot)
+	if project == canonicalFilesystemPath(project) {
+		t.Skip("this platform's t.TempDir() is already canonical (no symlinked ancestor); the ProjectRoot canonicalization this test exercises is inert here")
+	}
+
+	tm := team.Team{
+		Project: project,
+		Members: []team.Member{{Role: "worker", Binary: "claude", Handle: "worker", Session: session}},
+	}
+	preflights := []agentLaunchPreflight{{
+		Role: "worker", Handle: "worker", CWD: project,
+		Root: envelope.Root, BaseRoot: envelope.BaseRoot, Workstream: session,
+	}}
+	opts := teamLaunchOptions{Workstream: session, Trust: trustModeApproveForMe}
+
+	in, err := (launchapiTeamLaunchBackend{}).buildIntentInput(tm, opts, preflights, nil)
+	if err != nil {
+		t.Fatalf("buildIntentInput: %v", err)
+	}
+
+	prepared, err := adoptionseam.Prepare(context.Background(), adoptionseam.PrepareInput{Intent: in, Launcher: "tmux"})
+	if err != nil {
+		t.Fatalf("adoptionseam.Prepare against a real, fully-authorized project/base-root layout: %v", err)
+	}
+	t.Logf("PrepareResultV1: outcome=%q reason=%q required_actions=%+v subject_digest=%s", prepared.Result.Outcome, prepared.Result.Reason, prepared.Result.RequiredActions, prepared.Result.SubjectDigest)
+
+	if prepared.Result.Reason == "base_root_unauthorized" || prepared.Result.Reason == "base_root_relation_invalid" {
+		t.Fatalf("Target shape rejected against a real, fully-authorized layout -- the canonicalization fix did not resolve it: outcome=%q reason=%q", prepared.Result.Outcome, prepared.Result.Reason)
+	}
+	if prepared.Result.Outcome == "unsupported" {
+		t.Fatalf("outcome = %q (reason=%q), want %q or a legitimate %q trust gate -- not a Target/support refusal", prepared.Result.Outcome, prepared.Result.Reason, "ready", "action_required")
+	}
+	// A brand-new subject digest has never been trusted before, so
+	// launchapi's own trust gate legitimately answers "action_required"
+	// (RequiredActionTrustConfirmation, reason "untrusted_config_digest")
+	// on this very first Prepare against a fresh project -- confirmed live
+	// below -- rather than "ready". That is the correct, by-design first-
+	// launch answer, not a defect: only "unsupported" (asserted above) or
+	// the two base_root reasons (asserted above) would mean the Target
+	// itself was rejected.
+	if prepared.Result.Outcome == "action_required" {
+		if len(prepared.Result.RequiredActions) == 0 {
+			t.Fatalf("outcome = action_required but RequiredActions is empty")
+		}
+		if got := prepared.Result.RequiredActions[0].Kind; got != launchapi.RequiredActionTrustConfirmation {
+			t.Fatalf("action_required kind = %q, want %q (any other required-action kind on a fresh, never-launched subject would itself be worth investigating)", got, launchapi.RequiredActionTrustConfirmation)
+		}
+	}
+}

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -663,6 +663,50 @@ func TestLaunchapiBackendProbePrepareIsSideEffectFree(t *testing.T) {
 	}
 }
 
+// TestLaunchapiBackendLaunchRejectsStaleSubjectDigest is gh#757's supporting
+// unit-level proof (see TestStartApplyRejectsStaleSubjectDigest for the
+// start-level acceptance test): opts.ExpectedSubjectDigest binds launch to
+// one exact previously computed subject_digest. A caller-supplied digest
+// that does not match the freshly recomputed one refuses before any
+// decision is resolved or adoptionseam.Apply is ever called.
+func TestLaunchapiBackendLaunchRejectsStaleSubjectDigest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	tm := launchapiTestTeam(t)
+	launchapiTestStubAMQEnv(t, tm.Project)
+	opts := teamLaunchOptions{
+		Workstream: "s", Trust: trustModeApproveForMe, Profile: team.DefaultProfile,
+		ExpectedSubjectDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	b := launchapiTeamLaunchBackend{}
+	if _, err := b.launch(tm, opts); err == nil || !strings.Contains(err.Error(), "stale subject_digest") {
+		t.Fatalf("launch with a mismatched ExpectedSubjectDigest = %v, want a stale subject_digest refusal", err)
+	}
+}
+
+// TestLaunchapiBackendLaunchAcceptsMatchingSubjectDigest proves the digest
+// gate itself passes when ExpectedSubjectDigest matches a fresh Prepare's
+// SubjectDigest exactly -- launch proceeds past the check (whatever it does
+// or does not accomplish afterward in this no-real-tmux test environment is
+// not this test's concern; it only proves the gate is not a false refusal).
+func TestLaunchapiBackendLaunchAcceptsMatchingSubjectDigest(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	tm := launchapiTestTeam(t)
+	launchapiTestStubAMQEnv(t, tm.Project)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe, Profile: team.DefaultProfile}
+
+	b := launchapiTeamLaunchBackend{}
+	prepared, _, err := b.prepare(tm, opts)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	opts.ExpectedSubjectDigest = prepared.Result.SubjectDigest
+
+	if _, err := b.launch(tm, opts); err != nil && strings.Contains(err.Error(), "stale subject_digest") {
+		t.Fatalf("launch with a matching ExpectedSubjectDigest wrongly refused as stale: %v", err)
+	}
+}
+
 // TestLaunchapiBackendApplyBoundToPhaseTwoDigest proves prepare's returned
 // Prepared (what launch/DryRun/Apply all use) reflects phase 2 -- the
 // recompiled request with observed capability facts applied -- not the

--- a/internal/cli/team_launch_launchapi_test.go
+++ b/internal/cli/team_launch_launchapi_test.go
@@ -141,6 +141,37 @@ func TestLaunchapiBackendRequiresExplicitBaseRoot(t *testing.T) {
 	}
 }
 
+// TestBuildIntentInputSessionRootSatisfiesAuthorityRule is the named test
+// cto/t10 required after the following finding: launchapi's own
+// openExplicitBaseAuthority (pinned v0.75.0, internal/launch/base_root.go)
+// requires filepath.Dir(SessionRoot) == BaseRoot and
+// filepath.Base(SessionRoot) == Session, refusing base_root_relation_invalid
+// otherwise -- and buildIntentInput previously sent SessionRoot: t.Project,
+// which satisfies neither on any real project layout. This mirrors that
+// exact rule locally (the same pattern this file already uses for other
+// upstream contract checks, e.g. validManagedSessionLabel) so a regression
+// here fails a fast unit test instead of only a real Prepare/Apply call.
+func TestBuildIntentInputSessionRootSatisfiesAuthorityRule(t *testing.T) {
+	b := launchapiTeamLaunchBackend{}
+	tm := launchapiTestTeam(t)
+	opts := teamLaunchOptions{Workstream: "s", Trust: trustModeApproveForMe}
+
+	input, err := b.buildIntentInput(tm, opts, launchapiTestPreflights(tm.Project, "/proj/.agent-mail"), nil)
+	if err != nil {
+		t.Fatalf("buildIntentInput: %v", err)
+	}
+	target := input.Target
+	if got := filepath.Dir(target.SessionRoot); got != target.BaseRoot {
+		t.Fatalf("filepath.Dir(SessionRoot) = %q, want it to equal BaseRoot %q (launchapi's openExplicitBaseAuthority requires this)", got, target.BaseRoot)
+	}
+	if got := filepath.Base(target.SessionRoot); got != target.Session {
+		t.Fatalf("filepath.Base(SessionRoot) = %q, want it to equal Session %q (launchapi's openExplicitBaseAuthority requires this)", got, target.Session)
+	}
+	if target.SessionRoot == tm.Project {
+		t.Fatalf("SessionRoot equals the team's project root (%q) -- this is the exact bug: SessionRoot must be the session's own AMQ root, not the project directory", tm.Project)
+	}
+}
+
 func launchapiTestRequiredActions() []launchapi.RequiredActionV1 {
 	return []launchapi.RequiredActionV1{
 		{ActionID: "a1", Kind: launchapi.RequiredActionTrustConfirmation, AllowedDecisions: []launchapi.DecisionChoiceV1{launchapi.DecisionTrustExactSubject, launchapi.DecisionDeny}, ReasonCode: "new_subject"},


### PR DESCRIPTION
## Summary
Implements `start --apply <subject_digest> --decision ACTION_ID=CHOICE` (gh#757): digest-gated `adoptionseam.Apply` replacing the ad hoc `--yes`/`--trust`/`--launchapi-decision`/`--force-duplicate` flags, plus closes the gh#755 gap (`start` never routed through `resolveTeamLaunchBackend`, so it never selected `launchapi` by default even after the v2.31.0 flip).

## What changed
1. **`resolveTeamLaunchBackend` routing** (`simpleStartLaunch`): `start`'s production `Launch` dependency now resolves its backend via the same seam `team launch`/`up` already use, instead of a bare `teamLaunchBackends[Terminal]` lookup. `opts.LaunchVia` was already parsed (`registerLiveLaunchFlags` is already wired into `parseSimpleStartRequest`) but silently ignored for backend selection. `TestRunStartDefaultsToLaunchapiOnTmux`.
2. **`teamLaunchOptions.ExpectedSubjectDigest`**: a digest gate in `launchapiTeamLaunchBackend.launch` -- when set, the freshly computed `SubjectDigest` must match exactly before any decision is resolved or `adoptionseam.Apply` is ever called. `TestLaunchapiBackendLaunchRejectsStaleSubjectDigest` / `TestLaunchapiBackendLaunchAcceptsMatchingSubjectDigest`.
3. **Conversation-restore refusal**: found while wiring this -- the launchapi path has no mechanism to resume a conversation minted by the legacy composer (confirmed on task/t7: the launchapi backend never writes `launch.Record` at all, so any recorded `Conversation` is legacy-minted by construction). `start` refuses closed with a remedy naming `--launch-via legacy` or clearing the record, rather than silently falling back or dropping the conversation. `TestStartRefusesLegacyMintedRestoreOnLaunchapiPath` / `TestStartHonorsLegacyOptOutForRestore`.
4. **Digest-print-confirm flow**: `runStartWithDependencies` now runs a read-only probe `Prepare` (reusing `launchapiTeamLaunchBackend.prepare` and t6's `printPlanResult`), then either checks a supplied `--apply <digest>` matches exactly or asks `Apply subject_digest <digest>? [y/N]`, binding to that digest either way before the re-locked, re-reconciled `current` plan is built -- so `launch()`'s digest gate re-verifies against a *fresh* Prepare and refuses if anything (team, brief, or which roles still need launching) changed since. The legacy path (`--launch-via legacy` or non-tmux) is completely unaffected.
5. **Deprecation redirects**: `--yes`, `--trust`, `--launchapi-decision`, `--force-duplicate` print a notice and have no effect once the launchapi path is resolved. Per cto's ruling, no redirect is fabricated for `--skip-lead-check`/`--rebind` (not `start` flags at all -- they belong to `resume`/`verify` respectively) or `--allow-fresh-fallback` (unimplemented completion-list cruft with no command to deprecate).

## Named acceptance tests (gh#757)
- `TestStartApplyRejectsStaleSubjectDigest`
- `TestStartApplyRequiresExactDecisionsForEveryRequiredAction` (tests `resolveLaunchapiDecisions` directly -- see note below)
- `TestStartDeprecatedTrustFlagPrintsEquivalentDecision` (table-driven)
- `TestStartApplyRefusesWhenLivenessChangedSinceDigest` (cto's ruling #3 -- a role's liveness changing between the printed digest and the re-locked roster must refuse, not silently apply against a stale roster)
- `TestRunStartDefaultsToLaunchapiOnTmux` (the gh#755 gap closure)

## Deviations from gh#757's text
- **`TestStartApplyRequiresExactDecisionsForEveryRequiredAction`** tests `resolveLaunchapiDecisions` (the pre-existing, already-correct mechanism `launch()` calls before ever reaching `Apply`) directly, rather than through a live `start --apply` invocation with a manufactured `RequiredActionV1`. Producing a real required action needs elaborate trust-store/conversation state this repo's other launchapi tests don't attempt either (`TestLaunchapiBackendSurfacesRequiredActionsAsOperatorGates` uses the same `launchapiTestRequiredActions()` fixture directly, for the same reason).
- **Conversation restore on the launchapi path is a hard refusal this release**, not a native resume. Read the pinned v0.75.0 `internal/launch` adapter sources directly: `PlanResume` restores a conversation *launchapi itself minted* (keyed to its own internal `LaunchNonce`/session-id tracking), which is completely separate bookkeeping from amq-squad's own `launch.Record.Conversation` (the legacy composer's `--session-id`/`--conversation` flags). Since `start` never used the launchapi path before this task, every conversation ID it can find is legacy-minted by construction -- there is nothing to natively resume yet. `TestStartRestoresLaunchapiMintedConversationNatively` is deferred to t11 (gh#758, ResumePolicy/OnLive folding) per cto's decision, once real launchapi-mint history can actually accumulate; posted as a full evidence handoff on `task/t11`.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cli/...` and `go test -shuffle=on ./internal/cli/...` -- all pass except `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout`, confirmed pre-existing/intermittent.
- [x] `make fmt-check vet readme-html-check docs-html-check skills-check skill-routing-check skill-command-check skill-invocation-check release-validator-test go-files-scope-test` -- all pass.
