### PR TITLE
t10 gh#766: doctor launchapi Compatibility/floor reporting + Observations-based status liveness

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,12 +10,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/avivsinai/agent-message-queue/launchapi"
+
+	"github.com/omriariav/amq-squad/v2/internal/adoptionseam"
 	"github.com/omriariav/amq-squad/v2/internal/rules"
 	"github.com/omriariav/amq-squad/v2/internal/team"
 	"github.com/omriariav/amq-squad/v2/internal/tmuxpane"
@@ -657,6 +661,9 @@ func countNonOK(checks []doctorCheck) int {
 func runDoctorChecks(d doctorExecution) ([]doctorCheck, string) {
 	checks := []doctorCheck{}
 	checks = append(checks, doctorCheckAMQVersion(d))
+	checks = append(checks, doctorCheckLaunchapiCompatibility(d))
+	checks = append(checks, doctorCheckAdoptionFloor(d))
+	checks = append(checks, doctorCheckAMQModulePin(d))
 	checks = append(checks, doctorCheckAMQIdentityPin(d))
 	checks = append(checks, doctorCheckAMQRootAuthority(d))
 	checks = append(checks, doctorCheckAMQOps(d))
@@ -1179,6 +1186,116 @@ func doctorCheckAMQVersion(d doctorExecution) doctorCheck {
 		Status: doctorOK,
 		Detail: fmt.Sprintf("amq %s (min %s)", got, doctorMinAMQVersion),
 	}
+}
+
+// doctorCheckLaunchapiCompatibility reports the launchapi contract this
+// build was compiled against (gh#766). launchapi.Compatibility() is a pure,
+// static function -- no I/O, no amq env resolution -- so this check can
+// never fail; it exists purely to surface the negotiated contract surface
+// (ContractSemver, Features) alongside `amq doctor`'s own version report.
+func doctorCheckLaunchapiCompatibility(d doctorExecution) doctorCheck {
+	compat := launchapi.Compatibility()
+	// Detail intentionally reports the feature COUNT, not the raw feature
+	// name strings: those are internal launchapi negotiation keys (e.g.
+	// "managed_tmux_v1"), not operator-meaningful text, and several literal
+	// substring collisions with other doctor checks' own bare-word matching
+	// in tests (e.g. "tmux") -- caught by TestExecuteDoctorTmuxMissingFails.
+	return doctorCheck{
+		Name:   "launchapi compatibility",
+		Status: doctorOK,
+		Detail: fmt.Sprintf("contract %s (%d negotiable feature(s))", compat.ContractSemver, len(compat.Features)),
+	}
+}
+
+// pinnedAMQModulePath is the launchapi module amq-squad's go.mod pins.
+const pinnedAMQModulePath = "github.com/avivsinai/agent-message-queue"
+
+// pinnedAMQModuleVersion resolves the linked agent-message-queue module
+// version via runtime/debug.ReadBuildInfo(). A package var so tests can
+// stub it: `go test -c` binaries in this toolchain embed zero dependency
+// entries (see adoptionseam's TestPinnedAMQModuleAtOrAboveAdoptionFloor doc
+// comment for the confirmed empirical finding across packages), so a real
+// ReadBuildInfo call inside `go test` would always report not-found
+// regardless of what is actually pinned. A normally built/installed binary
+// (not a test binary) does carry the real Deps list.
+var pinnedAMQModuleVersion = defaultPinnedAMQModuleVersion
+
+func defaultPinnedAMQModuleVersion() (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == pinnedAMQModulePath {
+			return dep.Version, true
+		}
+	}
+	return "", false
+}
+
+// doctorCheckAdoptionFloor warns (never fails) when the PATH `amq` binary
+// reports a version below adoptionseam.AdoptionFloorAMQVersion -- the
+// version the launchapi backend's negotiated contract was verified against
+// (gh#766). This is advisory: the actual enforcement for the in-process
+// launchapi path is the go.mod pin itself (adoptionseam's
+// TestPinnedAMQModuleAtOrAboveAdoptionFloor), since this seam never shells
+// out to the amq CLI. An old PATH amq only matters to the legacy
+// composer/wake path, which doctorCheckAMQVersion's doctorMinAMQVersion
+// already floors separately (a lower, distinct requirement).
+func doctorCheckAdoptionFloor(d doctorExecution) doctorCheck {
+	const name = "amq vs launchapi adoption floor"
+	env, err := d.ResolveAMQEnv(d.ProjectDir)
+	if err != nil || strings.TrimSpace(env.AMQVersion) == "" {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "amq version unavailable; see 'amq version' check"}
+	}
+	got := strings.TrimSpace(env.AMQVersion)
+	parsed, ok := parseSemverParts(got)
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("amq returned unparseable version %q; see 'amq version' check", got)}
+	}
+	floor, _ := parseSemverParts(adoptionseam.AdoptionFloorAMQVersion)
+	if compareSemverParts(parsed, floor) < 0 {
+		return doctorCheck{Name: name, Status: doctorWarn,
+			Detail: fmt.Sprintf("PATH amq %s is below the launchapi adoption floor %s; the launchapi launch backend was verified against %s and later -- older amq releases are untested for it (advisory only, does not block legacy operation)", got, adoptionseam.AdoptionFloorAMQVersion, adoptionseam.AdoptionFloorAMQVersion)}
+	}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("amq %s meets the launchapi adoption floor %s", got, adoptionseam.AdoptionFloorAMQVersion)}
+}
+
+// doctorCheckAMQModulePin warns (never fails) when the PATH `amq` binary
+// reports a version newer than the github.com/avivsinai/agent-message-queue
+// module amq-squad's go.mod pins (gh#766). The launchapi backend runs
+// in-process against the pinned module, not the PATH amq binary, so a newer
+// PATH amq cannot make the launchapi path use newer behavior either way --
+// this is purely a heads-up that amq-squad's own launchapi integration has
+// not yet been verified against what the operator has installed.
+func doctorCheckAMQModulePin(d doctorExecution) doctorCheck {
+	const name = "amq vs pinned launchapi module"
+	env, err := d.ResolveAMQEnv(d.ProjectDir)
+	if err != nil || strings.TrimSpace(env.AMQVersion) == "" {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "amq version unavailable; see 'amq version' check"}
+	}
+	got := strings.TrimSpace(env.AMQVersion)
+	parsed, ok := parseSemverParts(got)
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("amq returned unparseable version %q; see 'amq version' check", got)}
+	}
+	resolve := pinnedAMQModuleVersion
+	if resolve == nil {
+		resolve = defaultPinnedAMQModuleVersion
+	}
+	pinned, found := resolve()
+	if !found {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "pinned launchapi module version unavailable (unstamped/test build); check skipped"}
+	}
+	pinnedParsed, ok := parseSemverParts(pinned)
+	if !ok {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("pinned module version %q unparseable; check skipped", pinned)}
+	}
+	if compareSemverParts(parsed, pinnedParsed) > 0 {
+		return doctorCheck{Name: name, Status: doctorWarn,
+			Detail: fmt.Sprintf("PATH amq %s is newer than the %s module this build pins (%s); amq-squad's launchapi integration has not been verified against %s", got, pinnedAMQModulePath, pinned, got)}
+	}
+	return doctorCheck{Name: name, Status: doctorOK, Detail: fmt.Sprintf("amq %s is at or below the pinned launchapi module version %s", got, pinned)}
 }
 
 func doctorCheckAMQIdentityPin(d doctorExecution) doctorCheck {

--- a/internal/cli/doctor_launchapi_compatibility_test.go
+++ b/internal/cli/doctor_launchapi_compatibility_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omriariav/amq-squad/v2/internal/adoptionseam"
+)
+
+// TestDoctorReportsLaunchapiCompatibility is gh#766's first named acceptance
+// test: doctor reports launchapi.Compatibility()'s negotiated contract
+// (semver + feature surface) alongside amq doctor's own version report. The
+// check is pure/static, so it never fails and never needs amq env.
+func TestDoctorReportsLaunchapiCompatibility(t *testing.T) {
+	got := doctorCheckLaunchapiCompatibility(doctorExecution{})
+	if got.Status != doctorOK {
+		t.Fatalf("status = %q, want ok (this check is pure and cannot fail): %q", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "contract") {
+		t.Fatalf("detail missing the contract semver: %q", got.Detail)
+	}
+}
+
+// TestDoctorFlagsAMQBinaryBelowAdoptionFloor is gh#766's second named
+// acceptance test: a PATH amq older than adoptionseam.AdoptionFloorAMQVersion
+// warns (never fails) -- advisory, since the actual floor enforcement for
+// the in-process launchapi path is the go.mod pin, not the PATH binary.
+func TestDoctorFlagsAMQBinaryBelowAdoptionFloor(t *testing.T) {
+	d := doctorExecution{
+		ResolveAMQEnv: func(string) (amqEnv, error) {
+			return amqEnv{AMQVersion: "v0.60.0"}, nil
+		},
+	}
+	got := doctorCheckAdoptionFloor(d)
+	if got.Status != doctorWarn {
+		t.Fatalf("status = %q, want warn: %q", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "v0.60.0") || !strings.Contains(got.Detail, adoptionseam.AdoptionFloorAMQVersion) {
+		t.Fatalf("detail must name both the PATH version and the floor: %q", got.Detail)
+	}
+
+	atFloor := doctorCheckAdoptionFloor(doctorExecution{
+		ResolveAMQEnv: func(string) (amqEnv, error) {
+			return amqEnv{AMQVersion: adoptionseam.AdoptionFloorAMQVersion}, nil
+		},
+	})
+	if atFloor.Status != doctorOK {
+		t.Fatalf("at-floor status = %q, want ok: %q", atFloor.Status, atFloor.Detail)
+	}
+}
+
+// TestDoctorFlagsAMQBinaryAboveModulePin is gh#766's third named acceptance
+// test: a PATH amq newer than the go.mod-pinned agent-message-queue module
+// warns (never fails) -- amq-squad's launchapi integration runs in-process
+// against the pinned module regardless of what is on PATH.
+func TestDoctorFlagsAMQBinaryAboveModulePin(t *testing.T) {
+	previous := pinnedAMQModuleVersion
+	defer func() { pinnedAMQModuleVersion = previous }()
+	pinnedAMQModuleVersion = func() (string, bool) { return "v0.75.0", true }
+
+	d := doctorExecution{
+		ResolveAMQEnv: func(string) (amqEnv, error) {
+			return amqEnv{AMQVersion: "v0.76.0"}, nil
+		},
+	}
+	got := doctorCheckAMQModulePin(d)
+	if got.Status != doctorWarn {
+		t.Fatalf("status = %q, want warn: %q", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "v0.76.0") || !strings.Contains(got.Detail, "v0.75.0") {
+		t.Fatalf("detail must name both the PATH version and the pinned version: %q", got.Detail)
+	}
+
+	atOrBelow := doctorCheckAMQModulePin(doctorExecution{
+		ResolveAMQEnv: func(string) (amqEnv, error) {
+			return amqEnv{AMQVersion: "v0.75.0"}, nil
+		},
+	})
+	if atOrBelow.Status != doctorOK {
+		t.Fatalf("at-pin status = %q, want ok: %q", atOrBelow.Status, atOrBelow.Detail)
+	}
+
+	pinnedAMQModuleVersion = func() (string, bool) { return "", false }
+	unavailable := doctorCheckAMQModulePin(doctorExecution{
+		ResolveAMQEnv: func(string) (amqEnv, error) {
+			return amqEnv{AMQVersion: "v0.75.0"}, nil
+		},
+	})
+	if unavailable.Status != doctorOK {
+		t.Fatalf("unavailable-pin status = %q, want ok (skip, not warn/fail): %q", unavailable.Status, unavailable.Detail)
+	}
+}

--- a/internal/cli/liveness.go
+++ b/internal/cli/liveness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -98,6 +99,12 @@ type agentLiveness struct {
 	// launchapiInspectCallFailed read it from here rather than re-deriving
 	// the session Target a second time.
 	InspectSignal launchapiInspectSignal
+	// LaunchapiObservation is gh#766's structured per-seat detail matched out
+	// of InspectSignal.Observations by handle (nil when no launchapi
+	// Observation names this handle, including every non-rollup caller and
+	// every legacy session). Corroborates/explains only, same as
+	// InspectSignal -- never changes Verdict/Status.
+	LaunchapiObservation *launchapiObservationJSON
 }
 
 // Live reports whether the verdict is any of the live sub-states. Both status
@@ -345,6 +352,61 @@ const (
 type launchapiInspectSignal struct {
 	Outcome  launchapiInspectOutcome
 	Evidence string
+	// Observations is the session-wide per-participant detail InspectResultV1
+	// carries (it is an alias of LifecycleResultV1, which has the identical
+	// Observations field Prepare's result does -- gh#766's status-liveness
+	// scope reuses this already-fetched data rather than issuing a second
+	// Prepare call per rollup; see task/t10's approved deviation). One
+	// session Inspect covers every member of the roster (memoized above), so
+	// callers match their own handle out of this slice.
+	Observations []launchapi.ParticipantObservationV1
+}
+
+// launchapiObservationJSON is the machine-readable summary of one member's
+// matched ParticipantObservationV1, surfaced on statusRecord (gh#766) so
+// --json consumers get structured launchapi liveness detail instead of
+// having to parse Detail prose.
+type launchapiObservationJSON struct {
+	Handle      string `json:"handle"`
+	Runnable    bool   `json:"runnable"`
+	Execution   string `json:"execution,omitempty"`
+	ReasonCode  string `json:"reason_code,omitempty"`
+	Disposition string `json:"disposition,omitempty"`
+}
+
+// launchapiObservationForHandle finds the ParticipantObservationV1 matching
+// handle in a session Inspect's Observations, if any.
+func launchapiObservationForHandle(observations []launchapi.ParticipantObservationV1, handle string) *launchapiObservationJSON {
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		return nil
+	}
+	for _, obs := range observations {
+		if strings.TrimSpace(obs.Handle) == handle {
+			return &launchapiObservationJSON{
+				Handle:      obs.Handle,
+				Runnable:    obs.Runnable,
+				Execution:   obs.Execution,
+				ReasonCode:  obs.ReasonCode,
+				Disposition: obs.Disposition,
+			}
+		}
+	}
+	return nil
+}
+
+// launchapiObservationIsNotable reports whether a matched observation adds
+// or contradicts information beyond what per-seat pane/wake/presence
+// evidence already established -- the bar for appending it to human-readable
+// Detail (task/t10's ruling: corroborate/explain, never restate the
+// unsurprising case). Not runnable, or a non-empty reason code, are the
+// notable cases; a plain "runnable, no reason code" observation matches the
+// ordinary live case and would just be noise.
+func launchapiObservationIsNotable(obs *launchapiObservationJSON) bool {
+	if obs == nil {
+		return false
+	}
+	return !obs.Runnable || strings.TrimSpace(obs.ReasonCode) != ""
 }
 
 // launchapiInspect is a package var so tests can stub the launchapi.Inspect
@@ -402,12 +464,36 @@ var (
 )
 
 func launchapiSessionInspectUncached(projectRoot, baseRoot, session string) launchapiInspectSignal {
+	// SessionRoot must be BaseRoot's direct child named Session -- the
+	// pinned module's openExplicitBaseAuthority (internal/launch/base_root.go)
+	// enforces filepath.Dir(SessionRoot)==BaseRoot && filepath.Base(SessionRoot)
+	// ==Session unconditionally whenever BaseRoot is set, for Prepare, Apply,
+	// and Inspect alike. SessionRoot==ProjectRoot (the prior value here)
+	// fails that check on any real project, so every real call read back as
+	// base_root_relation_invalid -- NotApplicable, not a false clamp, but the
+	// session-level Inspect floor was never actually corroborating anything.
+	//
+	// ProjectRoot must also be canonical (openPrepareTarget: "project_root
+	// must be canonical", comparing against filepath.Abs+EvalSymlinks of the
+	// same value), AND BaseRoot must resolve against the SAME representation
+	// openExplicitBaseAuthority derives from .amqrc's configured root
+	// (itself computed from the canonicalized project) -- both confirmed
+	// against a real launchapi binding: t.Project/baseRoot are not
+	// guaranteed to be symlink-free (e.g. a macOS /var/folders temp project
+	// root resolves to /private/var/folders/..., and BaseRoot is normally
+	// derived from ProjectRoot), so leaving either uncanonicalized fails
+	// base_root_unauthorized ("must be the configured root or one direct
+	// child") even after the SessionRoot fix above, since it is a plain
+	// string comparison against the canonicalized configured root, not a
+	// path-equivalence check. canonicalFilesystemPath is this repo's one
+	// canonicalization function (pathnorm.go) -- route both through it
+	// rather than hand-rolling Abs/EvalSymlinks here.
 	result, err := launchapiInspect(context.Background(), launchapi.InspectRequestV1{
 		RequestVersion: launchapi.RequestVersionV1,
 		Target: launchapi.TargetV1{
-			ProjectRoot: projectRoot,
-			BaseRoot:    baseRoot,
-			SessionRoot: projectRoot,
+			ProjectRoot: canonicalFilesystemPath(projectRoot),
+			BaseRoot:    canonicalFilesystemPath(baseRoot),
+			SessionRoot: filepath.Join(canonicalFilesystemPath(baseRoot), session),
 			Session:     session,
 		},
 	})
@@ -429,19 +515,19 @@ func launchapiSessionInspectUncached(projectRoot, baseRoot, session string) laun
 		return launchapiInspectSignal{Outcome: launchapiInspectCallFailed, Evidence: msg}
 	}
 	if result.ReasonCode == "binding_missing" {
-		return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: result.ReasonCode}
+		return launchapiInspectSignal{Outcome: launchapiInspectNotApplicable, Evidence: result.ReasonCode, Observations: result.Observations}
 	}
 	switch result.State {
 	case launchapiInspectStatePresent:
-		return launchapiInspectSignal{Outcome: launchapiInspectPresentSignal, Evidence: result.State}
+		return launchapiInspectSignal{Outcome: launchapiInspectPresentSignal, Evidence: result.State, Observations: result.Observations}
 	case launchapiInspectStateAbsent:
-		return launchapiInspectSignal{Outcome: launchapiInspectAbsentSignal, Evidence: result.State}
+		return launchapiInspectSignal{Outcome: launchapiInspectAbsentSignal, Evidence: result.State, Observations: result.Observations}
 	default:
 		evidence := result.State
 		if result.ReasonCode != "" {
 			evidence = result.State + ": " + result.ReasonCode
 		}
-		return launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: evidence}
+		return launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: evidence, Observations: result.Observations}
 	}
 }
 
@@ -449,16 +535,32 @@ func launchapiSessionInspectUncached(projectRoot, baseRoot, session string) laun
 // result to one member's already-computed agentLiveness verdict. Pure
 // function: no I/O, so the floor/corroboration/conflict rules are directly
 // unit-testable without a real launchapi binding.
-func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSignal) agentLiveness {
+func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSignal, handle string) agentLiveness {
 	live.InspectSignal = signal
+	live.LaunchapiObservation = launchapiObservationForHandle(signal.Observations, handle)
 	switch signal.Outcome {
-	case launchapiInspectNotApplicable, launchapiInspectPresentSignal:
-		// Not launchapi-launched, or the whole session's owned panes are
-		// intact: corroborates at most, never overrides per-seat evidence.
+	case launchapiInspectNotApplicable:
+		// Not launchapi-launched (or Inspect could not identify a target
+		// here at all): per-seat evidence stands exactly as-is, no note.
+		return live
+	case launchapiInspectPresentSignal:
+		// The whole session's owned panes are intact: corroborates at most,
+		// never overrides per-seat evidence. But a launchapi-launched seat
+		// never writes amq-squad's own launch.Record (t10/gh#766 finding:
+		// launchapi's composed tmux pane execs the raw agent binary
+		// directly, bypassing internal/cli/launch.go's bootstrap, the only
+		// launch.Record writer) -- without this note the Detail would read
+		// as plain wake/presence evidence with no explanation for why a
+		// launch record never showed up.
+		live.Detail = launchapiNoLaunchRecordDetail(live)
+		live.Detail = launchapiAppendObservationDetail(live)
 		return live
 	case launchapiInspectCallFailed:
 		// Do not clamp; today's classification stands. The caller surfaces
-		// the evidence as a session-level warning separately.
+		// the evidence as a session-level warning separately. Same
+		// no-launch-record annotation as the present-signal case above.
+		live.Detail = launchapiNoLaunchRecordDetail(live)
+		live.Detail = launchapiAppendObservationDetail(live)
 		return live
 	case launchapiInspectFloor:
 		if live.Live() {
@@ -466,6 +568,7 @@ func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSi
 			live.Status = statusStateStale
 			live.Detail = fmt.Sprintf("session Inspect reports %s; capping below live regardless of this seat's own signals (unknown never reads as clear)", signal.Evidence)
 		}
+		live.Detail = launchapiAppendObservationDetail(live)
 		return live
 	case launchapiInspectAbsentSignal:
 		if live.Live() {
@@ -473,10 +576,50 @@ func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSi
 			live.Status = statusStateStale
 			live.Detail = fmt.Sprintf("session Inspect reports absent while this seat's own signals report live (%s); treating as stale pending reconciliation", live.Detail)
 		}
+		live.Detail = launchapiAppendObservationDetail(live)
 		return live
 	default:
 		return live
 	}
+}
+
+// launchapiAppendObservationDetail appends the matched launchapi Observation
+// to Detail when it is notable (adds or contradicts, per task/t10's ruling)
+// -- an ordinary "runnable, no reason code" observation stays silent since it
+// just restates what per-seat evidence already established.
+func launchapiAppendObservationDetail(live agentLiveness) string {
+	if !launchapiObservationIsNotable(live.LaunchapiObservation) {
+		return live.Detail
+	}
+	obs := live.LaunchapiObservation
+	note := fmt.Sprintf("launchapi observes: runnable=%t", obs.Runnable)
+	if obs.Execution != "" {
+		note += " execution=" + obs.Execution
+	}
+	if obs.ReasonCode != "" {
+		note += " reason=" + obs.ReasonCode
+	}
+	if strings.TrimSpace(live.Detail) == "" {
+		return note
+	}
+	return live.Detail + "; " + note
+}
+
+// launchapiNoLaunchRecordDetail prefixes an explanatory note onto a seat's
+// existing Detail when that seat has no launch.Record but the session's
+// Inspect call meaningfully engaged (gh#766 acceptance): a launchapi-launched
+// worker seat structurally never gets one (see the call sites' comments), so
+// without this a launchapi seat's Detail otherwise reads as ordinary bare
+// wake/presence evidence with no explanation for the missing record.
+func launchapiNoLaunchRecordDetail(live agentLiveness) string {
+	if live.LaunchFound {
+		return live.Detail
+	}
+	note := "no launch record (launchapi-launched); classified from wake/presence + session Inspect"
+	if strings.TrimSpace(live.Detail) == "" {
+		return note
+	}
+	return note + " (" + live.Detail + ")"
 }
 
 // classifyAgentLivenessForRollup is classifyAgentLivenessWithReplacementResolver
@@ -494,5 +637,5 @@ func applyLaunchapiInspectionFloor(live agentLiveness, signal launchapiInspectSi
 func classifyAgentLivenessForRollup(projectRoot, agentDir, root, expectedProfile, handle, role, binary, workstream, cwd string, probe duplicateLaunchProbe, replacement replacementPaneResolver) agentLiveness {
 	live := classifyAgentLivenessWithReplacementResolver(agentDir, root, expectedProfile, handle, role, binary, workstream, cwd, probe, replacement)
 	signal := launchapiSessionInspect(projectRoot, root, workstream)
-	return applyLaunchapiInspectionFloor(live, signal)
+	return applyLaunchapiInspectionFloor(live, signal, handle)
 }

--- a/internal/cli/liveness_real_launchapi_target_test.go
+++ b/internal/cli/liveness_real_launchapi_target_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRealLaunchapiInspectSessionTargetShape is t10's real-binding
+// verification (cto's ruling on task/t10 acceptance item 5, gh#766): t7's
+// "Known limitation" flagged that liveness.go's launchapiSessionInspect sent
+// Target.SessionRoot=ProjectRoot, and the pinned launchapi module's
+// openExplicitBaseAuthority requires SessionRoot to be BaseRoot's direct
+// child named Session instead -- unresolved without a live binding at the
+// time. Source-tracing (openPrepareTarget/openExplicitBaseAuthority in the
+// pinned v0.75.0 module) confirmed the mismatch independently of this test;
+// this proves it against one real, fully-initialized .amqrc/base-root layout
+// produced by a real `amq init` plus the .amqrc launchapi's own authority
+// check requires (amq init itself does not write one -- confirmed directly
+// against the real binary; a bare `amq env` resolution does not need it, but
+// launchapi's openExplicitBaseAuthority does, per realAMQRootAuthorityCompatibilityContract's
+// existing fixture convention).
+//
+// This same live run ALSO caught two further real defects beyond the
+// originally-suspected SessionRoot mismatch, both now fixed above:
+// ProjectRoot must be canonical (openPrepareTarget's literal "project_root
+// must be canonical" check, comparing against filepath.Abs+EvalSymlinks),
+// and BaseRoot must be canonicalized the same way for
+// openExplicitBaseAuthority's configured-root string comparison to match --
+// t.Project/baseRoot are not guaranteed symlink-free (a macOS temp dir under
+// /var/folders resolves through /private/var), so both were failing
+// independently of the SessionRoot shape being correct.
+//
+// A real launchapi launch never occurred against this fixture, so the
+// expected fired outcome is launchapiInspectNotApplicable via a clean
+// binding_missing ReasonCode (Inspect correctly identifies the target and
+// finds no launchapi lifecycle state there yet) -- NOT any of the three
+// pre-fix failure modes, which were all launchapiInspectNotApplicable via a
+// Target-validation error instead of a real answer. All map to the same
+// launchapiInspectOutcome enum value, so the Evidence string is what
+// actually distinguishes "corroboration inert because inapplicable" from
+// "corroboration inert because the request itself was malformed".
+func TestRealLaunchapiInspectSessionTargetShape(t *testing.T) {
+	binary := strings.TrimSpace(os.Getenv("AMQ_SQUAD_REAL_AMQ"))
+	if binary == "" {
+		t.Skip("set AMQ_SQUAD_REAL_AMQ to run the disposable real-launchapi Target shape proof")
+	}
+	info, err := os.Stat(binary)
+	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		t.Fatalf("AMQ_SQUAD_REAL_AMQ %q is unavailable or not executable: %v", binary, err)
+	}
+	version := strings.TrimSpace(realAMQCommand(t, binary, t.TempDir(), nil, "version"))
+	t.Logf("real AMQ binary=%s version=%s", binary, version)
+
+	project := t.TempDir()
+	session := "t10-real-binding"
+	root := filepath.Join(project, ".agent-mail", session)
+	realAMQInit(t, binary, project, root)
+	baseRoot := filepath.Dir(root)
+	rc := []byte("{\n  \"root\": \".agent-mail\"\n}\n")
+	if err := os.WriteFile(filepath.Join(project, ".amqrc"), rc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	signal := launchapiSessionInspect(project, baseRoot, session)
+	t.Logf("launchapiSessionInspect outcome=%v evidence=%q", signal.Outcome, signal.Evidence)
+
+	if strings.Contains(signal.Evidence, "base_root_relation_invalid") || strings.Contains(signal.Evidence, "base_root_unauthorized") {
+		t.Fatalf("Target shape rejected against a real, fully-initialized .amqrc/base-root layout -- the fix did not resolve the SessionRoot mismatch: outcome=%v evidence=%q", signal.Outcome, signal.Evidence)
+	}
+	if signal.Outcome != launchapiInspectNotApplicable {
+		t.Fatalf("outcome = %v, want launchapiInspectNotApplicable (no launchapi launch occurred against this fixture, so binding_missing is the correct fired outcome): evidence=%q", signal.Outcome, signal.Evidence)
+	}
+	if !strings.Contains(signal.Evidence, "binding_missing") {
+		t.Fatalf("evidence = %q, want binding_missing (a clean 'no binding here yet' result, not a Target validation failure)", signal.Evidence)
+	}
+}

--- a/internal/cli/liveness_test.go
+++ b/internal/cli/liveness_test.go
@@ -792,7 +792,7 @@ func stubLaunchapiInspect(t *testing.T, fn func(context.Context, launchapi.Inspe
 // below any live sub-state regardless of its own pane/presence signals.
 func TestInspectLivenessUnknownFailsClosed(t *testing.T) {
 	live := agentLiveness{Verdict: livenessAgentLive, Status: statusStateLive, Detail: "agent pid 123 alive (codex)"}
-	got := applyLaunchapiInspectionFloor(live, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "unknown"})
+	got := applyLaunchapiInspectionFloor(live, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "unknown"}, "cto")
 	if got.Live() {
 		t.Fatalf("unknown Inspect signal must never leave a verdict Live(): %+v", got)
 	}
@@ -806,7 +806,7 @@ func TestInspectLivenessUnknownFailsClosed(t *testing.T) {
 	// ActionRequired must cap even when State itself is not literally
 	// "unknown" (e.g. a reason-coded action_required outcome).
 	live2 := agentLiveness{Verdict: livenessWakeLive, Status: statusStateWakeLive}
-	got2 := applyLaunchapiInspectionFloor(live2, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "action_required: caller_context_corrupt"})
+	got2 := applyLaunchapiInspectionFloor(live2, launchapiInspectSignal{Outcome: launchapiInspectFloor, Evidence: "action_required: caller_context_corrupt"}, "cto")
 	if got2.Live() {
 		t.Fatalf("action_required Inspect signal must never leave a verdict Live(): %+v", got2)
 	}
@@ -1020,5 +1020,169 @@ func TestLaunchapiInspectMemoCollapsesRosterToOneCall(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("launchapiInspect called %d times for %d roster members sharing one session, want exactly 1 (memo cache must collapse per-rollup)", calls, len(tm.Members))
+	}
+}
+
+// TestStatusExplainsMissingLaunchRecordForLaunchapiSeats is gh#766's
+// launchapi-seat Detail-wording acceptance item (from cto's ruling on
+// task/t10): a launchapi-launched worker seat never writes amq-squad's own
+// launch.Record, so a seat classified purely from wake/presence plus a
+// meaningfully-engaged session Inspect must say so explicitly rather than
+// reading as unexplained weaker evidence. No launch.json is written for
+// this member -- only a wake lock -- to reproduce exactly that gap.
+func TestStatusExplainsMissingLaunchRecordForLaunchapiSeats(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	root := filepath.Join(base, "issue-96")
+	agentDir := filepath.Join(root, "agents", "cto")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWakeLock(t, agentDir, wakeLockFile{PID: 4321, Root: root, Started: time.Now()})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{State: "present"}, nil
+	})
+
+	now := time.Now()
+	probe := duplicateLaunchProbe{
+		PIDAlive: func(pid int) bool { return pid == 4321 },
+		ProcessMatch: func(pid int, predicate func(args string) bool) bool {
+			return pid == 4321 && predicate("amq wake --me cto --root "+root)
+		},
+		Now: func() time.Time { return now },
+	}
+
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatalf("read team: %v", err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateWakeLive {
+		t.Fatalf("status = %q, want wake-live", rec.Status)
+	}
+	if !strings.Contains(rec.Detail, "no launch record (launchapi-launched)") {
+		t.Fatalf("detail does not explain the missing launch record: %q", rec.Detail)
+	}
+	if !strings.Contains(rec.Detail, "session Inspect") {
+		t.Fatalf("detail does not name session Inspect as the classification source: %q", rec.Detail)
+	}
+	if rec.liveness.InspectSignal.Outcome != launchapiInspectPresentSignal {
+		t.Fatalf("InspectSignal.Outcome = %v, want launchapiInspectPresentSignal", rec.liveness.InspectSignal.Outcome)
+	}
+}
+
+// TestStatusSurfacesNotableLaunchapiObservation is gh#766's Observations
+// acceptance item (cto's ruling on task/t10): a session Inspect's matched
+// ParticipantObservationV1 for this handle corroborates/explains Detail and
+// is surfaced structurally on statusRecord.LaunchapiObservation for --json
+// consumers, but never overrides per-seat Status -- exactly the scenario
+// cto named: Runnable=false alongside a seat this repo's own pane/launch
+// evidence independently reports live.
+func TestStatusSurfacesNotableLaunchapiObservation(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{
+			State: "present",
+			Observations: []launchapi.ParticipantObservationV1{
+				{Handle: "cto", Runnable: false, Execution: "blocked", ReasonCode: "caller_context_stale"},
+			},
+		}, nil
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if rec.Status != statusStateLive {
+		t.Fatalf("status = %q, want live (a notable Observation corroborates/explains, never overrides per-seat evidence)", rec.Status)
+	}
+	if !strings.Contains(rec.Detail, "launchapi observes") || !strings.Contains(rec.Detail, "runnable=false") || !strings.Contains(rec.Detail, "caller_context_stale") {
+		t.Fatalf("detail does not surface the notable observation: %q", rec.Detail)
+	}
+	if rec.LaunchapiObservation == nil {
+		t.Fatal("LaunchapiObservation is nil, want the matched observation")
+	}
+	if rec.LaunchapiObservation.Handle != "cto" || rec.LaunchapiObservation.Runnable || rec.LaunchapiObservation.Execution != "blocked" || rec.LaunchapiObservation.ReasonCode != "caller_context_stale" {
+		t.Fatalf("LaunchapiObservation = %+v, want the matched fields", rec.LaunchapiObservation)
+	}
+
+	encoded, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal statusRecord: %v", err)
+	}
+	var decoded struct {
+		LaunchapiObservation *struct {
+			Handle      string `json:"handle"`
+			Runnable    bool   `json:"runnable"`
+			Execution   string `json:"execution"`
+			ReasonCode  string `json:"reason_code"`
+			Disposition string `json:"disposition"`
+		} `json:"launchapi_observation"`
+	}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal statusRecord JSON: %v", err)
+	}
+	if decoded.LaunchapiObservation == nil {
+		t.Fatalf("JSON output has no launchapi_observation field: %s", encoded)
+	}
+	if decoded.LaunchapiObservation.Handle != "cto" || decoded.LaunchapiObservation.Runnable || decoded.LaunchapiObservation.ReasonCode != "caller_context_stale" {
+		t.Fatalf("launchapi_observation JSON shape = %+v, want the matched fields", decoded.LaunchapiObservation)
+	}
+}
+
+// TestStatusOmitsUnremarkableLaunchapiObservation proves the corroborate-or-
+// silence rule: a Runnable=true observation with no reason code matches the
+// ordinary live case and must not add Detail noise, even though
+// LaunchapiObservation itself is still populated for --json consumers.
+func TestStatusOmitsUnremarkableLaunchapiObservation(t *testing.T) {
+	base := setupFakeAMQSessionRoots(t)
+	dir := seedTeam(t, team.Team{
+		Workstream: "issue-96",
+		Members: []team.Member{
+			{Role: "cto", Binary: "codex", Handle: "cto", Session: "issue-96"},
+		},
+	})
+	writeMemberLaunchRecord(t, base, "issue-96", "cto", launch.Record{
+		CWD: dir, Binary: "codex", Role: "cto", AgentPID: 5555, StartedAt: time.Now(),
+	})
+	withStubPaneLister(t, nil, nil)
+	stubLaunchapiInspect(t, func(context.Context, launchapi.InspectRequestV1) (launchapi.InspectResultV1, error) {
+		return launchapi.InspectResultV1{
+			State: "present",
+			Observations: []launchapi.ParticipantObservationV1{
+				{Handle: "cto", Runnable: true, Execution: "running"},
+			},
+		}, nil
+	})
+
+	probe := livenessProbe(map[int]bool{5555: true}, map[int]bool{5555: true}, time.Now())
+	tm, err := team.ReadProfile(dir, team.DefaultProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := classifyMemberStatus(tm, team.DefaultProfile, tm.Members[0], "issue-96", probe)
+	if strings.Contains(rec.Detail, "launchapi observes") {
+		t.Fatalf("detail should stay silent for an unremarkable observation: %q", rec.Detail)
+	}
+	if rec.LaunchapiObservation == nil || !rec.LaunchapiObservation.Runnable {
+		t.Fatalf("LaunchapiObservation = %+v, want it still populated (runnable=true) for --json even though Detail stayed silent", rec.LaunchapiObservation)
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -211,6 +211,13 @@ type statusRecord struct {
 	// NOC launch generation, registration id, and timestamp rather than asking
 	// clients to infer registration from wake liveness or prose.
 	OrchestratorRegistration *launch.OrchestratorRegistration `json:"orchestrator_registration,omitempty"`
+	// LaunchapiObservation is gh#766's structured launchapi liveness detail:
+	// the session Inspect's ParticipantObservationV1 matched to this
+	// member's handle, when the session was launchapi-launched and Inspect
+	// meaningfully engaged. Absent for legacy sessions and for every seat
+	// Inspect could not identify. Corroborates/explains Detail only -- never
+	// changes status/record_state.
+	LaunchapiObservation *launchapiObservationJSON `json:"launchapi_observation,omitempty"`
 	// WakeAutoDrain reports that this member's wake sidecar is configured to
 	// inject a drain instruction on each durable-message arrival (the launch
 	// record carries WakeInjectCmd). It means inbound messages are processed
@@ -1760,6 +1767,7 @@ func classifyMemberStatusFromEntries(t team.Team, profile string, m team.Member,
 	// same wrapper so status/resume keep agreeing.
 	live := classifyAgentLivenessForRollup(t.Project, rec.AgentDir, root, profile, rec.Handle, m.Role, m.Binary, workstream, rec.CWD, probe, replacement)
 	rec.liveness = live
+	rec.LaunchapiObservation = live.LaunchapiObservation
 	rec.ClassificationError = live.SourceError
 	rec.Tmux = tmuxRuntimeFromInfo(live.Tmux)
 	if live.LaunchFound {


### PR DESCRIPTION
## Summary
- `doctor` reports `launchapi.Compatibility()`'s negotiated contract (`launchapi compatibility` check), warns (never fails) when the PATH `amq` is below `adoptionseam.AdoptionFloorAMQVersion`, and warns when it is newer than the go.mod-pinned `agent-message-queue` module version.
- `status`'s per-seat Detail explicitly names a launchapi-launched seat's missing `launch.Record` (`"no launch record (launchapi-launched); classified from wake/presence + session Inspect"`) instead of reading as unexplained weaker evidence.
- `status`'s session Inspect result now surfaces the matched `ParticipantObservationV1` for each seat: a structured `statusRecord.launchapi_observation` field for `--json` consumers, plus a Detail corroboration note when the observation is notable (not runnable, or carries a reason code) -- silent when it just restates the ordinary live case.
- Fixes t7's "Known limitation": `launchapiSessionInspect`'s Target sent `SessionRoot=ProjectRoot` and an uncanonicalized `ProjectRoot`/`BaseRoot`. The pinned launchapi module's `openExplicitBaseAuthority` rejects all three unconditionally (confirmed live against a real amq v0.75.0 binding, not just source-traced) -- meaning t7's session-level Inspect floor was silently inert in production until this fix. `TestRealLaunchapiInspectSessionTargetShape` (real-AMQ-gated) proves a clean `binding_missing` result now fires instead of a Target-validation error.

## Acceptance
Named tests from gh#766: `TestDoctorReportsLaunchapiCompatibility`, `TestDoctorFlagsAMQBinaryBelowAdoptionFloor`, `TestDoctorFlagsAMQBinaryAboveModulePin`.

Additional tests from task/t10's design rulings: `TestStatusExplainsMissingLaunchRecordForLaunchapiSeats`, `TestStatusSurfacesNotableLaunchapiObservation`, `TestStatusOmitsUnremarkableLaunchapiObservation`, `TestRealLaunchapiInspectSessionTargetShape` (real-AMQ-gated).

## Deviation from gh#766's literal text
The issue says status liveness comes from `PrepareResultV1.Observations`. `InspectResultV1` is a type alias for `LifecycleResultV1`, which carries the identical `Observations []ParticipantObservationV1` field -- so this reuses the Inspect call status/resume rollups already make once per session (t7/gh#737) rather than issuing a second `Prepare` call per rollup. Functionally equivalent to the issue's intent, zero extra I/O, and Inspect is semantically the more appropriate source (current lifecycle state vs. Prepare's preview). Approved by cto on task/t10 before implementation, with the condition that any Observations field needed that turns out to be Prepare-only would be reported rather than silently adding a Prepare call -- none were.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- All named/new tests pass individually, including the real-AMQ-gated one (verified against a real installed `amq` v0.75.0 binary, not just skip-checked).
- `go test ./...` and `go test -shuffle=on ./internal/cli/...` clean except the confirmed pre-existing `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout` flake.
- `make ci` non-test targets (fmt-check, readme/docs-html-check, skills-check, skill-routing/command/invocation-check, release-validator-test, go-files-scope-test) all pass.

## Coordination note
The real-binding verification here also surfaced that `team_launch_launchapi.go`'s `buildIntentInput` needed the identical three-field fix (SessionRoot/ProjectRoot/BaseRoot) for the `Prepare`/`Apply` path used by t2/t6/t8 -- reported urgently on task/t8 (out of this PR's file-ownership scope per cto's directive) and already fixed there (PR #780, head 92ee60f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)