### PR TITLE
release: amq-squad v2.31.0

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,94 @@ session state does **not** need to be migrated.
 
 This guide covers everything you have to change.
 
+## What's new in 2.31.0: launchapi default, mandatory `.amqrc` + `brief`
+
+**Action required, two steps, before your first launch after upgrading:**
+
+1. Run `amq setup` once per project if it doesn't already have a `.amqrc`.
+   `launchapi`-path commands (`init`, `plan`, `start`, `resume`) now fail
+   closed at env-resolution without one -- "cannot determine an eligible
+   AMQ root ... no project .amqrc ... was found" -- before they ever reach
+   launch planning.
+2. Run `amq-squad brief --goal "..."` (or `--seed-from REF`) for any
+   workstream that doesn't already have one. `start`/`plan`/`resume` no
+   longer draft inline and refuse closed, naming the exact `brief` command
+   to run, if no brief exists. `wizard` still works as before but is now
+   sugar over `init -> brief -> plan -> start --apply`.
+
+`launchapi` is now the default launch backend whenever the terminal
+resolves to tmux (previously opt-in via `--launch-via launchapi`). The
+legacy tmux pane driver is still reachable for this release via the
+explicit `--launch-via legacy` opt-out, and is scheduled for removal in
+v2.32.0. Non-tmux terminals are unaffected.
+
+### Removed: five `goal` subcommands
+
+`goal deliver`, `goal claim`, `goal retry-attempt`, `goal start`, and `goal
+apply` are gone -- each now errors naming the replacement:
+
+| Removed | Use instead |
+| --- | --- |
+| `goal deliver` / `goal claim` / `goal retry-attempt` / `goal start` / `goal apply` | Each hard-errors naming the literal replacement: `amq-squad goal --goal TEXT` (sends one ordinary AMQ todo to the configured lead -- no attempt, delivery state, dedup, or retry). Verified verbatim against the built binary for all five subcommands. Separately, a workstream's goal now rides the lead seat's `InitialInput` automatically at launch time via `brief --goal TEXT`/`start --goal TEXT` -- no `goal` command involved in that path at all. `amq-squad goal draft` still exists (preview-only). |
+
+`resume --exec --redeliver-goal`'s old manual pane-injection redelivery is
+retired for every session. The flag stays registered (no parse error), but
+with `--exec` it now refuses outright: "`--redeliver-goal`/
+`--no-redeliver-goal-prompt` do not yet apply to `--exec` (gh#758/t11
+follow-up); drop `--exec` to see the current plan" -- verified against the
+built binary. Without `--exec` (plan-only), the flag is accepted but has no
+effect (there is nothing to redeliver in a preview). This is a genuine,
+disclosed regression in ergonomics versus t9's original design (a runnable
+replacement command), traded for closing a real gap: PR #784 (t11) folded
+`resume --exec` into the same shared launch machinery `start --apply` uses,
+which doesn't yet have a wired path for this flag -- tracked as a follow-up,
+not silently dropped.
+
+### `team resume`: hard error, not a deprecation notice
+
+Unlike the soft-deprecated verbs below, `team resume` now **always errors**
+-- it is gone, with no fallback behavior. Use `amq-squad resume` (`--exec`
+for the same launch behavior `team resume` used to have).
+
+### `resume --json`: schema break
+
+`resume --json`'s envelope `kind` changed from `"resume_plan"` to
+`"plan"` -- it is now the identical envelope `plan --json` emits (same
+`PrepareResultV1` shape), not the old per-member action/liveness/
+tmux-metadata shape. If you parse `resume --json` programmatically, switch
+to parsing `kind="plan"`; no new parsing logic is needed if you already
+handle `plan --json`'s output.
+
+### Soft-deprecated: five setup verbs -> `init`
+
+Still work exactly as before, each prints a one-line notice pointing at
+the replacement. No action required, but update scripts/runbooks when
+convenient:
+
+| Old verb | Use instead |
+| --- | --- |
+| `new team` | `amq-squad init --roles ...` |
+| `new profile NAME` | `amq-squad init --profile NAME ...` |
+| `team init` | `amq-squad init` |
+| `team rules init` | `amq-squad init` |
+| `team sync --apply` | `amq-squad init --apply <digest>` |
+| `new session` | `amq-squad brief` + `plan` + `start` |
+| `start --yes` / `--trust` / `--launchapi-decision` / `--force-duplicate` | `start --apply <digest> --decision ACTION_ID=CHOICE` |
+
+### `wizard`: goal-to-roster inference dropped
+
+Creating a **new** profile via `wizard` now requires an explicit `--roles`
+-- it no longer infers a roster from your goal text. Missing `--roles`
+refuses closed naming the fix (roster suggestion as its own future verb is
+tracked in gh#790). Launching into an existing profile is unchanged.
+`wizard`'s custom-role persona drafting is gone too -- use `amq-squad role
+draft <id> --binary ... --purpose ...` (wizard now names this command when
+it hits an undocumented custom role).
+
+**Quickstart fix (#792).** The README's shortest-working-path example never
+pinned the roster to the session its `brief`/`start` steps assume; fixed in
+this release by adding `--session issue-96` to the `new team` example line.
+
 ## What's new in 2.28.0: Simple Mode
 
 2.28 removes the preparation, readiness, digest, receipt, bootstrap-ack, and

--- a/README.html
+++ b/README.html
@@ -272,8 +272,8 @@
 <li><a href="#amq-squad" id="toc-amq-squad">amq-squad</a>
 <ul>
 <li><a href="#contents" id="toc-contents">Contents</a></li>
-<li><a href="#whats-new-in-v2301" id="toc-whats-new-in-v2301">What's new
-in v2.30.1</a></li>
+<li><a href="#whats-new-in-v2310" id="toc-whats-new-in-v2310">What's new
+in v2.31.0</a></li>
 <li><a href="#install" id="toc-install">Install</a></li>
 <li><a href="#quickstart" id="toc-quickstart">Quickstart</a></li>
 <li><a href="#execution-modes" id="toc-execution-modes">Execution
@@ -324,7 +324,7 @@ approval tied to an exact action and target.</li>
 </ul>
 <h2 id="contents">Contents</h2>
 <ul>
-<li><a href="#whats-new-in-v2301">What's new in v2.30.1</a></li>
+<li><a href="#whats-new-in-v2310">What's new in v2.31.0</a></li>
 <li><a href="#install">Install</a></li>
 <li><a href="#quickstart">Quickstart</a></li>
 <li><a href="#execution-modes">Execution modes</a></li>
@@ -342,50 +342,59 @@ guidance</a></li>
 details</a></li>
 <li><a href="#requirements">Requirements</a></li>
 </ul>
-<h2 id="whats-new-in-v2301">What's new in v2.30.1</h2>
-<p>Re-verifies and adopts amq v0.72.0/v0.73.0 on the opt-in launchapi
-path. Strictly additive: the legacy tmux-pane launch path is unchanged
-and remains the default; the general-operation AMQ floor stays
-0.60.0.</p>
+<h2 id="whats-new-in-v2310">What's new in v2.31.0</h2>
+<p><code>launchapi</code> is now the default launch backend on tmux,
+with a complete digest-gated launch surface. <strong>Two new mandatory
+steps:</strong> every project needs a <code>.amqrc</code>
+(<code>amq setup</code>, once) and every workstream needs a brief
+(<code>amq-squad brief</code>) before
+<code>start</code>/<code>plan</code>/<code>resume</code> will launch --
+the new getting-started order is <code>init</code> -&gt;
+<code>brief</code> -&gt; <code>plan</code> -&gt;
+<code>start --apply</code>.</p>
 <ul>
-<li>Measured re-verification of amq v0.71.0/v0.72.0/v0.73.0 against the
-launchapi path (#745). The gh#734 nested-worktree project-root bug still
-reproduces identically on every version at read time, so the fail-closed
-<code>base_root</code> seam stays as defense in depth, not redundant.
-<code>launchapi</code>'s contract (<code>Compatibility()</code>) is
-unchanged across every measured version; the internal grammar changes
-below surface only at <code>Prepare</code>'s per-call
-<code>Capabilities</code>. <code>Prepare</code> itself is confirmed
-read-only and deterministic.</li>
-<li>The launchapi backend's adoption floor moves to v0.72.0, module
-pinned to v0.73.0 (#746). The floor is enforced by the go.mod pin plus a
-runtime <code>GrammarVersion</code> check, since
-<code>launchapi.Negotiate</code> cannot see it.</li>
-<li><strong>The launchapi path now carries the same scoped worker
-preauth as legacy, at amq &gt;= v0.72.0: v2.30.0's known dual-run
-limitation is lifted</strong> (#747). An eligible claude worker gets the
-exact two-token scoped grant (<code>--allowedTools</code>,
-<code>Bash(gh pr create:*)</code>, literal only, never widened), and an
-eligible codex worker keeps <code>approvals_reviewer</code>. Below
-floor, both still drop, byte-identical to v2.30.0. The backend runs a
-two-phase <code>Prepare</code> to derive these facts safely: a
-side-effect-free probe, then a recompile before the real
-<code>Apply</code>.</li>
-<li>Named seats from amq v0.73.0 (#748): an eligible claude worker's
-launch now carries its <code>&lt;workstream&gt;/&lt;handle&gt;</code>
-label as a managed <code>-n</code> argv token, validated at compile time
-against a byte-identical mirror of the real grammar's label rules. Codex
-seats never receive it.</li>
-<li><strong>launchapi is now the default launch backend</strong>
-whenever the terminal resolves to tmux (gh#755): plain
-<code>start</code>/<code>up</code> with no <code>--launch-via</code>
-uses it. The legacy tmux pane driver stays reachable for one release via
-the explicit opt-out <code>--launch-via legacy</code>, and is deleted in
-v2.32.0. A terminal that is not tmux (<code>iterm2</code>,
-<code>terminal</code>, <code>tmux-session</code>) is unaffected and
-keeps using its own legacy backend.</li>
+<li><strong><code>launchapi</code> is the default on tmux</strong>
+(#755); <code>--launch-via legacy</code> opts out through v2.31.x,
+removed in v2.32.0.</li>
+<li><strong>One <code>init</code> verb</strong> (#762) replaces
+<code>new team</code>/<code>new profile</code>/<code>team init</code>/<code>team rules init</code>/<code>team sync --apply</code>
+with a zero-write preview/<code>--apply &lt;digest&gt;</code> flow; the
+old verbs still work as deprecation redirects.</li>
+<li><strong><code>plan</code></strong> (#756) is a zero-write preview of
+any launch;
+<strong><code>start --apply &lt;digest&gt; --decision</code></strong>
+(#757) replaces the old <code>--yes</code>/<code>--trust</code>/
+<code>--launchapi-decision</code> flags with a digest-print-confirm
+flow.</li>
+<li><strong><code>resume</code> folds into
+<code>plan</code>/<code>start</code></strong> (#758): no
+<code>--exec</code> is a thin alias for <code>plan</code>;
+<code>--exec</code> drives the same shared launch machinery
+<code>start --apply</code> uses. <code>team resume</code> is now a hard
+error. <code>resume --json</code>'s envelope <code>kind</code> changed
+<code>resume_plan</code> -&gt; <code>plan</code> (see the release notes
+for the migration).</li>
+<li><strong>Goal delivery moves to launch time</strong> (#761):
+<code>goal deliver</code>/<code>claim</code>/
+<code>retry-attempt</code>/<code>start</code>/<code>apply</code> are all
+deleted, replaced by passing <code>--goal TEXT</code> to
+<code>brief</code>/<code>start</code> and automatic delivery via the
+lead seat's launch-time <code>InitialInput</code>.</li>
+<li><strong><code>doctor</code>/<code>status</code> report launchapi
+compatibility and liveness</strong> (#766): adoption-floor warnings, and
+an explicit explanation for a launchapi-launched seat's missing launch
+record.</li>
+<li><strong>New mandatory <code>brief</code> verb</strong> (#759): all
+LLM drafting moves off the launch path into
+<code>amq-squad brief [--goal TEXT | --seed-from REF]</code>;
+<code>wizard</code> becomes sugar over <code>init</code> -&gt;
+<code>brief</code> -&gt; <code>plan</code> -&gt;
+<code>start --apply</code>.</li>
 </ul>
-<p>Full detail in <a href="docs/v2.30.1-release-notes.md">the v2.30.1
+<p>Also fixed: the quickstart's <code>new team</code> example never
+pinned members to the session the following steps assume, breaking the
+flow as written (#792).</p>
+<p>Full detail in <a href="docs/v2.31.0-release-notes.md">the v2.31.0
 release notes</a>.</p>
 <p>The README describes the latest release only. Earlier releases live
 in <a href="https://github.com/omriariav/amq-squad/releases">GitHub
@@ -397,7 +406,7 @@ files).</p>
 <span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> version</span></code></pre></div>
 <p>For a pinned release, replace <code>@latest</code> with the tag you
 want, for example:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.1</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">go</span> install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.31.0</span></code></pre></div>
 <p>Install the skills from the plugin marketplace when agents should use
 the amq-squad playbooks themselves.</p>
 <p>Claude Code:</p>
@@ -438,7 +447,7 @@ should therefore be idempotent.</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="bu">cd</span> ~/Code/my-project</span>
 <span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Create the roster and its shared rules.</span></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--sync</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> new team <span class="at">--roles</span> cto,fullstack,qa <span class="at">--orchestrated</span> <span class="at">--lead</span> cto <span class="at">--session</span> issue-96 <span class="at">--sync</span></span>
 <span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a><span class="co"># Author the workstream brief. start/plan/wizard never draft one themselves</span></span>
 <span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="co"># and fail closed naming this command if it&#39;s missing.</span></span>

--- a/README.html
+++ b/README.html
@@ -453,25 +453,30 @@ should therefore be idempotent.</p>
 <span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a><span class="co"># and fail closed naming this command if it&#39;s missing.</span></span>
 <span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> brief <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="at">--session</span> issue-96 <span class="at">--project</span> .</span>
 <span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="co"># Preview the complete launch plan. The prompt defaults to No.</span></span>
-<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span>
-<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="co"># After approving that exact plan, automation can use --yes.</span></span>
-<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="at">--yes</span></span>
-<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a><span class="co"># Watch the run.</span></span>
-<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
-<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a><span class="co"># Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.</span></span>
-<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="dt">\</span></span>
-<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
-<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a>  <span class="at">--role</span> qa <span class="dt">\</span></span>
-<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Run smoke tests&quot;</span> <span class="dt">\</span></span>
-<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body-file</span> ./qa-task.md</span>
-<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
-<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
-<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a><span class="co"># Accept the shared checkout for this demo (real multi-implementer teams</span></span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a><span class="co"># should give each member its own worktree via &#39;team member update --cwd&#39;;</span></span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a><span class="co"># wizard/start materializing worktrees inside the plan is tracked as #770).</span></span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> team shared-cwd-exception set <span class="st">&quot;quickstart demo: single shared checkout&quot;</span> <span class="at">--project</span> . <span class="at">--session</span> issue-96</span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a><span class="co"># Preview the complete launch plan. The prompt defaults to No.</span></span>
+<span id="cb5-16"><a href="#cb5-16" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span></span>
+<span id="cb5-17"><a href="#cb5-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-18"><a href="#cb5-18" aria-hidden="true" tabindex="-1"></a><span class="co"># After approving that exact plan, automation can use --yes.</span></span>
+<span id="cb5-19"><a href="#cb5-19" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> start issue-96 <span class="at">--project</span> . <span class="at">--goal</span> <span class="st">&quot;fix issue 96&quot;</span> <span class="at">--yes</span></span>
+<span id="cb5-20"><a href="#cb5-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-21"><a href="#cb5-21" aria-hidden="true" tabindex="-1"></a><span class="co"># Watch the run.</span></span>
+<span id="cb5-22"><a href="#cb5-22" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> status <span class="at">--session</span> issue-96</span>
+<span id="cb5-23"><a href="#cb5-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-24"><a href="#cb5-24" aria-hidden="true" tabindex="-1"></a><span class="co"># Queue durable work to a role. Pane nudges are optional; AMQ is authoritative.</span></span>
+<span id="cb5-25"><a href="#cb5-25" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> dispatch <span class="dt">\</span></span>
+<span id="cb5-26"><a href="#cb5-26" aria-hidden="true" tabindex="-1"></a>  <span class="at">--session</span> issue-96 <span class="dt">\</span></span>
+<span id="cb5-27"><a href="#cb5-27" aria-hidden="true" tabindex="-1"></a>  <span class="at">--role</span> qa <span class="dt">\</span></span>
+<span id="cb5-28"><a href="#cb5-28" aria-hidden="true" tabindex="-1"></a>  <span class="at">--subject</span> <span class="st">&quot;Run smoke tests&quot;</span> <span class="dt">\</span></span>
+<span id="cb5-29"><a href="#cb5-29" aria-hidden="true" tabindex="-1"></a>  <span class="at">--body-file</span> ./qa-task.md</span>
+<span id="cb5-30"><a href="#cb5-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-31"><a href="#cb5-31" aria-hidden="true" tabindex="-1"></a><span class="co"># Stop and resume without losing launch records, briefs, or task state.</span></span>
+<span id="cb5-32"><a href="#cb5-32" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> down <span class="at">--session</span> issue-96 <span class="at">--all</span></span>
+<span id="cb5-33"><a href="#cb5-33" aria-hidden="true" tabindex="-1"></a><span class="ex">amq-squad</span> resume <span class="at">--session</span> issue-96 <span class="at">--exec</span></span></code></pre></div>
 <p><code>start</code> has one mutation gate, default No. It resolves the
 roster and active brief, renders one plan, and starts only after
 approval. Under the launch lock it keeps verified live roles, respawns

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The 30-second mental model:
 
 ## Contents
 
-- [What's new in v2.30.1](#whats-new-in-v2301)
+- [What's new in v2.31.0](#whats-new-in-v2310)
 - [Install](#install)
 - [Quickstart](#quickstart)
 - [Execution modes](#execution-modes)
@@ -38,43 +38,44 @@ The 30-second mental model:
 - [Reference and moved details](#reference-and-moved-details)
 - [Requirements](#requirements)
 
-## What's new in v2.30.1
+## What's new in v2.31.0
 
-Re-verifies and adopts amq v0.72.0/v0.73.0 on the opt-in launchapi path.
-Strictly additive: the legacy tmux-pane launch path is unchanged and remains
-the default; the general-operation AMQ floor stays 0.60.0.
+`launchapi` is now the default launch backend on tmux, with a complete
+digest-gated launch surface. **Two new mandatory steps:** every project
+needs a `.amqrc` (`amq setup`, once) and every workstream needs a brief
+(`amq-squad brief`) before `start`/`plan`/`resume` will launch -- the new
+getting-started order is `init` -> `brief` -> `plan` -> `start --apply`.
 
-- Measured re-verification of amq v0.71.0/v0.72.0/v0.73.0 against the
-  launchapi path (#745). The gh#734 nested-worktree project-root bug still
-  reproduces identically on every version at read time, so the fail-closed
-  `base_root` seam stays as defense in depth, not redundant. `launchapi`'s
-  contract (`Compatibility()`) is unchanged across every measured version;
-  the internal grammar changes below surface only at
-  `Prepare`'s per-call `Capabilities`. `Prepare` itself is confirmed
-  read-only and deterministic.
-- The launchapi backend's adoption floor moves to v0.72.0, module pinned to
-  v0.73.0 (#746). The floor is enforced by the go.mod pin plus a runtime
-  `GrammarVersion` check, since `launchapi.Negotiate` cannot see it.
-- **The launchapi path now carries the same scoped worker preauth as
-  legacy, at amq >= v0.72.0: v2.30.0's known dual-run limitation is
-  lifted** (#747). An eligible claude worker gets the exact two-token
-  scoped grant (`--allowedTools`, `Bash(gh pr create:*)`, literal only,
-  never widened), and an eligible codex worker keeps `approvals_reviewer`.
-  Below floor, both still drop, byte-identical to v2.30.0. The backend runs
-  a two-phase `Prepare` to derive these facts safely: a side-effect-free
-  probe, then a recompile before the real `Apply`.
-- Named seats from amq v0.73.0 (#748): an eligible claude worker's launch
-  now carries its `<workstream>/<handle>` label as a managed `-n` argv
-  token, validated at compile time against a byte-identical mirror of the
-  real grammar's label rules. Codex seats never receive it.
-- **launchapi is now the default launch backend** whenever the terminal
-  resolves to tmux (gh#755): plain `start`/`up` with no `--launch-via` uses
-  it. The legacy tmux pane driver stays reachable for one release via the
-  explicit opt-out `--launch-via legacy`, and is deleted in v2.32.0. A
-  terminal that is not tmux (`iterm2`, `terminal`, `tmux-session`) is
-  unaffected and keeps using its own legacy backend.
+- **`launchapi` is the default on tmux** (#755); `--launch-via legacy`
+  opts out through v2.31.x, removed in v2.32.0.
+- **One `init` verb** (#762) replaces `new team`/`new profile`/`team
+  init`/`team rules init`/`team sync --apply` with a zero-write
+  preview/`--apply <digest>` flow; the old verbs still work as deprecation
+  redirects.
+- **`plan`** (#756) is a zero-write preview of any launch; **`start
+  --apply <digest> --decision`** (#757) replaces the old `--yes`/`--trust`/
+  `--launchapi-decision` flags with a digest-print-confirm flow.
+- **`resume` folds into `plan`/`start`** (#758): no `--exec` is a thin
+  alias for `plan`; `--exec` drives the same shared launch machinery
+  `start --apply` uses. `team resume` is now a hard error. `resume --json`'s
+  envelope `kind` changed `resume_plan` -> `plan` (see the release notes
+  for the migration).
+- **Goal delivery moves to launch time** (#761): `goal deliver`/`claim`/
+  `retry-attempt`/`start`/`apply` are all deleted, replaced by passing
+  `--goal TEXT` to `brief`/`start` and automatic delivery via the lead
+  seat's launch-time `InitialInput`.
+- **`doctor`/`status` report launchapi compatibility and liveness** (#766):
+  adoption-floor warnings, and an explicit explanation for a
+  launchapi-launched seat's missing launch record.
+- **New mandatory `brief` verb** (#759): all LLM drafting moves off the
+  launch path into `amq-squad brief [--goal TEXT | --seed-from REF]`;
+  `wizard` becomes sugar over `init` -> `brief` -> `plan` -> `start
+  --apply`.
 
-Full detail in [the v2.30.1 release notes](docs/v2.30.1-release-notes.md).
+Also fixed: the quickstart's `new team` example never pinned members to the
+session the following steps assume, breaking the flow as written (#792).
+
+Full detail in [the v2.31.0 release notes](docs/v2.31.0-release-notes.md).
 
 The README describes the latest release only. Earlier releases live in
 [GitHub Releases](https://github.com/omriariav/amq-squad/releases) and
@@ -92,7 +93,7 @@ amq-squad version
 For a pinned release, replace `@latest` with the tag you want, for example:
 
 ```sh
-go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.30.1
+go install github.com/omriariav/amq-squad/v2/cmd/amq-squad@v2.31.0
 ```
 
 Install the skills from the plugin marketplace when agents should use the
@@ -144,7 +145,7 @@ The shortest working path for a visible project lead and workers:
 cd ~/Code/my-project
 
 # Create the roster and its shared rules.
-amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --sync
+amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --session issue-96 --sync
 
 # Author the workstream brief. start/plan/wizard never draft one themselves
 # and fail closed naming this command if it's missing.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ amq-squad new team --roles cto,fullstack,qa --orchestrated --lead cto --session 
 # and fail closed naming this command if it's missing.
 amq-squad brief --goal "fix issue 96" --session issue-96 --project .
 
+# Accept the shared checkout for this demo (real multi-implementer teams
+# should give each member its own worktree via 'team member update --cwd';
+# wizard/start materializing worktrees inside the plan is tracked as #770).
+amq-squad team shared-cwd-exception set "quickstart demo: single shared checkout" --project . --session issue-96
+
 # Preview the complete launch plan. The prompt defaults to No.
 amq-squad start issue-96 --project . --goal "fix issue 96"
 

--- a/docs/v2.31.0-release-notes.md
+++ b/docs/v2.31.0-release-notes.md
@@ -170,12 +170,12 @@ module unconditionally rejects.
   than ported when wizard collapsed to a literal `brief -> init -> plan ->
   start` composition (t13); roster suggestion as its own, separate
   off-launch-path verb is tracked here for a future release.
-- **(t15 finding, follow-up issue pending from cto):** `--register-orchestrator`
-  and `--no-register-orchestrator` were found to be unwired to any live
-  command's flag parser anywhere -- dead scaffolding described in several
-  help/prose sites as though it worked. A stale wizard help string was
-  corrected to state real current behavior; the broader gap is tracked
-  separately, not fixed in this release.
+- **gh#786** (open): `--register-orchestrator` and `--no-register-orchestrator`
+  were found to be unwired to any live command's flag parser anywhere (t15
+  finding) -- dead scaffolding described in several help/prose sites as
+  though it worked. A stale wizard help string was corrected to state real
+  current behavior; the broader gap is tracked there, not fixed in this
+  release.
 
 ## Fixed
 

--- a/docs/v2.31.0-release-notes.md
+++ b/docs/v2.31.0-release-notes.md
@@ -1,0 +1,185 @@
+# amq-squad v2.31.0
+
+The launchapi path becomes the default backend on tmux, and gains a
+complete, digest-gated launch surface: `init`, `brief`, `plan`, `start
+--apply`, and `resume` (now a thin fold into `plan`/`start`) replace the
+legacy composer's scattered preview/approval/goal-delivery machinery.
+**Every workstream now needs a `.amqrc` and a brief before it can launch** --
+see the breaking-changes section below before upgrading. Milestone issues:
+#755, #756, #757, #758, #759, #760, #761, #762, #763, #766, #767, #768,
+#737, #739, #740.
+PRs: #773, #774, #775, #776, #777, #778, #779, #780, #781, #782, #783, #784,
+#785, #791.
+
+## Breaking: launchapi is now the default, and two new steps are mandatory
+
+- **`launchapi` is now the default launch backend on tmux** (#755, PR #773).
+  The legacy tmux pane driver stays reachable for one release via the
+  explicit `--launch-via legacy` opt-out, and is scheduled for deletion in
+  v2.32.0. Non-tmux terminals (iTerm2, Terminal.app, tmux-session) are
+  unaffected.
+- **A project `.amqrc` is now required** before any launchapi-path command
+  (`init`, `plan`, `start`, `resume`) will run. Without it, the command
+  fails closed at env-resolution -- "cannot determine an eligible AMQ root
+  ... no project .amqrc ... was found" -- before it ever reaches launch
+  planning. Run `amq setup` once per project to fix.
+- **A brief is now required before `start`/`plan`/`resume` will launch**
+  (t13, gh#759, PR #791). Drafting moved off the
+  launch path entirely into a new `amq-squad brief [--goal TEXT |
+  --seed-from REF]` command; `start`/`plan` never invoke a drafter anymore
+  and refuse closed, naming the exact `brief` command to run, if no brief
+  exists for the workstream. This changes every getting-started flow: the
+  new order is `init` -> `brief` -> `plan` -> `start --apply`. `wizard`
+  still exists as sugar over exactly that composition, with one combined
+  confirmation.
+
+## Unified, digest-gated `init` verb (#762, PR #783)
+
+New `amq-squad init [--profile NAME] [--roles ...] [--binary ...]
+[--lead ...]` replaces `new team`, `new profile`, `team init`, `team rules
+init`, and `team sync --apply` with one thin wrapper and a zero-write
+preview/apply flow matching `plan`/`start`'s UX:
+
+- Without `--apply`: computes the exact planned writes (profile JSON,
+  team-rules.md, CLAUDE.md/AGENTS.md pointer stubs) and prints a preview
+  plus an `init_digest`. Touches no files.
+- With `--apply <init_digest>`: recomputes fresh and refuses on any
+  mismatch. Re-running against an existing, unchanged profile computes the
+  same digest and performs no observable write.
+- `init_digest` is an amq-squad-internal digest, deliberately namespaced
+  apart from launchapi's `SubjectDigest` used by `plan`/`start`/`wizard`.
+- All five replaced verbs still work exactly as before as deprecation
+  redirects, each printing a one-line notice pointing at `init`.
+- Along the way, fixed five real `--help` dispatch bugs across the `team`
+  subcommand surface (team member add/rm/list, team lead show, bare `team
+  --help`).
+
+## `plan`: zero-write launchapi preview (#756, PR #776)
+
+New `amq-squad plan SESSION [--json]` compiles the selected profile and its
+active brief through `launchintent.Compile` into a `launchapi.
+PrepareRequestV1`, calls `adoptionseam.Prepare`, and prints the result --
+target/outcome/roster/capabilities, plus a per-participant "will reattach
+to a saved conversation" note where launchapi's own session Inspect reports
+one. Zero-write, reproducible: replaying the `--json` envelope's request
+through `amq launch --plan - --prepare --json` reproduces the identical
+`subject_digest`/`plan_digest`.
+
+## `start --apply <digest> --decision`: digest-gated launch (#757, PR #780)
+
+Replaces the ad hoc `--yes`/`--trust`/`--launchapi-decision`/
+`--force-duplicate` flags (now soft-deprecated, no effect once the
+launchapi path resolves) with a digest-print-confirm flow: `start` runs a
+read-only probe `Prepare`, prints the plan and its `subject_digest`, then
+either checks a supplied `--apply <digest>` matches exactly or asks for
+confirmation -- binding to that digest either way before the real launch,
+which re-verifies against a *fresh* `Prepare` and refuses if anything
+changed since. Also closes the gh#755 gap where `start` never routed
+through the same backend-selection seam `up`/`team launch` use, so it never
+actually picked up the new default. New: `start` refuses closed rather than
+silently falling back when it would need to restore a legacy-minted
+conversation on the launchapi path (the launchapi backend never writes
+`launch.Record`, so any recorded conversation is legacy-minted by
+construction) -- see migration note (a).
+
+## `resume` folded into `plan`/`start` (#758, PR #784)
+
+The bespoke per-member classifier in `team_resume.go` (~3.5k lines) is
+deleted. `resume` without `--exec` is now a byte-identical thin alias for
+`plan SESSION`; with `--exec`, it drives the exact same shared launch
+machinery `start --apply` uses (members already live are skipped, a role
+stuck on a required action refuses the whole run naming it). `team resume`
+is now a **hard error**, not a deprecation notice -- see the deprecation
+table. `resume --json`'s envelope `kind` changed from `resume_plan` to
+`plan`, a client-visible schema break -- see migration note (b) for the
+concrete migration action. Two behaviors ship on top: a seat's saved goal
+now automatically carries into its relaunch (unless reattaching to a saved
+conversation), and native restore now comes from launchapi's own session
+Inspect Observations rather than any new persistence.
+
+## Goal delivery moves to launch time; five subcommands retired (#761, PR #782, #785)
+
+`goal deliver`, `goal claim`, `goal retry-attempt`, `goal start`, and `goal
+apply` are deleted; each now hard-errors naming `amq-squad goal --goal
+TEXT` as the replacement. The lead seat's goal now rides `InitialInputV1.
+Text` at launch time (joined with the bootstrap prompt as `"<bootstrap>
+GOAL: <goal>"`), compiled once by `launchintent.Compile`. `resume --exec
+--redeliver-goal`'s old pane-injection redelivery is retired for all
+sessions -- the flag stays registered (no parse error), but PR #784 (t11)
+folded `resume --exec` into `start --apply`'s shared launch machinery
+before this flag had a wired path there, so it now refuses outright with
+`--exec` ("do not yet apply to --exec ... drop --exec to see the current
+plan") rather than printing a runnable replacement; tracked as a follow-up,
+not silently dropped. A follow-up (PR #785) retires the
+`goal_deliver` runtime-action-catalog entry unconditionally too, since the
+underlying command can no longer run anywhere.
+
+## `doctor`/`status` report launchapi compatibility and liveness (#766, PR #781)
+
+`doctor` now reports `launchapi.Compatibility()`'s negotiated contract and
+warns (never fails) on an AMQ binary below the adoption floor or above the
+pinned module version. `status` explains a launchapi-launched seat's
+missing `launch.Record` explicitly instead of reading as unexplained weaker
+evidence, and surfaces the matched session-Inspect observation per seat.
+Also fixes a latent bug found along the way: the session-level Inspect
+floor added in v2.30.x (#737) was silently inert in production because its
+Target sent an uncanonicalized project/base root that the pinned launchapi
+module unconditionally rejects.
+
+## Also in this release
+
+- **#763 (PR #774):** single compile path -- every profile now compiles to
+  a `LaunchIntentV1` through one `launchintent.Compile` entry point; the
+  operator seat is non-runnable by construction; the legacy composer is
+  proven isolated from the new path by a dedicated test.
+- **#760 (PR #775):** drafter fixes -- correct yoetz JSON envelope, an
+  `in_session` error carries evidence, a missing-model case is handled, and
+  bullet markers render correctly.
+- **#739, #740 (PR #777):** `amq-squad worktree plan`/`materialize` no
+  longer refuses a correct `--base` with a false "accepted base drift"
+  error; `worktree cleanup` can reconcile a plan-store entry after a
+  worktree was removed directly with `git worktree remove` instead of
+  through `cleanup`.
+- **#768 (PR #778):** re-verifies and adopts amq v0.74.1/v0.75.0 on the
+  launchapi path; adoption floor moves to v0.74.1, module pinned to
+  v0.75.0.
+- **#737 (PR #779):** session-level launchapi Inspect liveness floor feeding
+  `status`/`doctor` (the floor this release's #766 work then found was
+  silently inert -- fixed in PR #781, see above).
+
+## Compatibility
+
+- The legacy tmux-pane launch path is reachable via `--launch-via legacy`
+  through v2.31.x, scheduled for deletion in v2.32.0.
+- The general-operation AMQ floor stays at 0.60.0. The launchapi backend's
+  own adoption floor is v0.74.1 (module pinned to v0.75.0).
+- A project `.amqrc` (via `amq setup`) is now a hard precondition for any
+  launchapi-path command. A brief (via `amq-squad brief`) is now a hard
+  precondition for `start`/`plan`/`resume` to launch.
+
+## Known issues / follow-ups
+
+- **gh#787** (open): a pre-existing `team_launch_tmux.go` pane-identity gap
+  when a second tmux session is concurrently live during a new session's
+  creation; unrelated to this release's resume fold, reproduces via plain
+  `start` too. One real-AMQ test subtest is skipped pending a fix.
+- **gh#789** (open): unifying `status`'s and `resume`'s liveness source of
+  truth is a bigger architectural question than this release's scope
+  covers; one test stays skipped pending that work.
+- **gh#790** (open): wizard's goal-to-roster inference was dropped rather
+  than ported when wizard collapsed to a literal `brief -> init -> plan ->
+  start` composition (t13); roster suggestion as its own, separate
+  off-launch-path verb is tracked here for a future release.
+- **(t15 finding, follow-up issue pending from cto):** `--register-orchestrator`
+  and `--no-register-orchestrator` were found to be unwired to any live
+  command's flag parser anywhere -- dead scaffolding described in several
+  help/prose sites as though it worked. A stale wizard help string was
+  corrected to state real current behavior; the broader gap is tracked
+  separately, not fixed in this release.
+
+## Fixed
+
+- **gh#792:** the README quickstart's `new team` example line never pinned
+  the roster to the session the following `brief`/`start` steps assume,
+  breaking the flow as written since v2.30.1. Fixed by adding `--session
+  issue-96` to the example.

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "amq-squad",
   "description": "amq-squad agent-team coordination skills for Claude Code: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "author": {
     "name": "Omri Ariav"
   },

--- a/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | coordinate | recover | example]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/claude/skills/amq-squad-role-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[role-id] [codex|claude]"
 user-invocable: true

--- a/plugins/claude/skills/amq-squad/SKILL.md
+++ b/plugins/claude/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[drain | review | handoff | status | start | focus | send | resume | down | doctor]"
 user-invocable: true

--- a/plugins/claude/skills/amq-team-setup/SKILL.md
+++ b/plugins/claude/skills/amq-team-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[setup | brief | roles]"
 user-invocable: true

--- a/plugins/claude/skills/cli/SKILL.md
+++ b/plugins/claude/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep"
 argument-hint: "[status | doctor | task | gate | resume | down | amq]"
 user-invocable: true

--- a/plugins/claude/skills/orchestrator/SKILL.md
+++ b/plugins/claude/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, Glob, Grep"
 argument-hint: "[compose | start | dispatch | status | review | recover]"
 user-invocable: true

--- a/plugins/claude/skills/wizard/SKILL.md
+++ b/plugins/claude/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 allowed-tools: "Bash, Read, Write, Edit, MultiEdit, Glob, Grep, WebFetch"
 argument-hint: "[request | goal | brief | rules | roles | profile | launch]"
 user-invocable: true

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "amq-squad",
-  "version": "2.30.1",
+  "version": "2.31.0",
   "description": "amq-squad agent-team coordination skills for Codex: live coordination (amq-squad), first-time team setup (amq-team-setup), custom role authoring (amq-squad-role-creator), and lead-agent orchestration (amq-squad-orchestrator).",
   "skills": "./skills/"
 }

--- a/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad-orchestrator"
 description: "Deprecated compatibility redirect for the live lead skill. Use amq-squad:orchestrator."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 Use `amq-squad:orchestrator`. The old name is retained only for compatibility;
 the namespaced skill owns live lead composition, dispatch, monitoring, review,

--- a/plugins/codex/skills/amq-squad-role-creator/SKILL.md
+++ b/plugins/codex/skills/amq-squad-role-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-squad-role-creator"
 description: "Deprecated redirect for the former custom role authoring skill. Use amq-squad:wizard."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for role authoring as part of the reviewed team setup and `start` flow.

--- a/plugins/codex/skills/amq-squad/SKILL.md
+++ b/plugins/codex/skills/amq-squad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "amq-squad"
 description: "Compatibility intent router for the amq-squad plugin. Routes goal preparation to wizard, direct operations to cli, and live lead work to orchestrator."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 # amq-squad compatibility router
 

--- a/plugins/codex/skills/amq-team-setup/SKILL.md
+++ b/plugins/codex/skills/amq-team-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "amq-team-setup"
 description: "Deprecated redirect for the former setup wizard skill. Use amq-squad:wizard."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 Use `amq-squad:wizard` for goal intake, team design, role authoring, team/profile setup, and launch preview.

--- a/plugins/codex/skills/cli/SKILL.md
+++ b/plugins/codex/skills/cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli"
 description: "Direct amq-squad operations and diagnostics against an existing profile. Use when you need to inspect state, claim or complete a task, record command evidence, read or answer AMQ threads, raise or close a gate, diagnose namespace selection, or plan a release action. Triggers include \"what is the status\", \"claim this task\", \"record evidence\", \"why is my profile ambiguous\", \"read that thread\", \"is this safe to merge\". NOT for preparing or launching a squad (use amq-squad:wizard) and NOT for the live lead loop (use amq-squad:orchestrator)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 # amq-squad:cli
 

--- a/plugins/codex/skills/orchestrator/SKILL.md
+++ b/plugins/codex/skills/orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "orchestrator"
 description: "Live amq-squad lead protocol after verified launch. Use when you are the lead agent of an orchestrated squad and need to dispatch work, converge reviews, recover a stalled run, or hand off evidence. Triggers include \"watch the squad\", \"what should I do next\", \"dispatch this task\", \"the run is stuck\", \"who is blocked\". NOT for preparing or launching a squad (use amq-squad:wizard) or for one-off status and inspection commands (use amq-squad:cli)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 # amq-squad:orchestrator
 

--- a/plugins/codex/skills/wizard/SKILL.md
+++ b/plugins/codex/skills/wizard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "wizard"
 description: "Goal-first setup and launch through the deterministic amq-squad wizard verb. Use when creating a team/profile, starting a new session from a reusable profile, previewing a launch, or approving that reviewed launch. Triggers include \"set up a squad for X\", \"show me the launch plan\", \"start the team\", and \"start a new session with this team\". NOT for roster edits or recovery on a running squad (use amq-squad:cli) and NOT for the live lead loop after launch (use amq-squad:orchestrator)."
-version: "2.30.1"  # x-release-please-version
+version: "2.31.0"  # x-release-please-version
 ---
 # amq-squad:wizard
 


### PR DESCRIPTION
## Summary

Release-prep PR for v2.31.0 (gh#767). Per RELEASING.md and team norms: this PR assembles release content only -- **no merge/tag/publish**. Merge authority is cto's under the operator's recorded `gate/release-v2-31-0` approval.

- `docs/v2.31.0-release-notes.md` -- full milestone coverage: launchapi as the default launch backend, mandatory `.amqrc` + `brief`, unified `init`, `plan`, digest-gated `start --apply`, `resume` folded into `plan`/`start`, goal delivery moved to launch time (5 subcommands retired), `doctor`/`status` launchapi reporting, plus the smaller fixes (#763, #760, #739/#740, #768, #737).
- `README.md`/`README.html` -- replaces the v2.30.1 "What's new" section (and its Contents entry) with v2.31.0's, per RELEASING.md step 0. Bumps the pinned-tag install example to `@v2.31.0`.
- `MIGRATION.md` -- new top section for 2.31.0: the two mandatory pre-launch steps, the five deleted `goal` subcommands' real replacement (verified against the built binary), `resume --exec --redeliver-goal`'s actual current refusal behavior, `team resume`'s hard error, `resume --json`'s schema break, and wizard's dropped goal-to-roster inference.
- `plugins/claude/.claude-plugin/plugin.json`, `plugins/codex/.codex-plugin/plugin.json` -- version bump `2.30.1` -> `2.31.0`; `make skills-generate` regenerated all 14 `SKILL.md` version stamps.

## Fixes #792

The README quickstart's `new team --roles cto,fullstack,qa --orchestrated --lead cto --sync` example never pinned the roster to session `issue-96`, which the very next `brief --session issue-96`/`start issue-96` lines assume -- breaking the documented flow as written, since v2.30.1 (confirmed via `git show 8c1532f:README.md`, predates t13). Fixed by adding `--session issue-96` to the `new team` line.

**Disclosure: the quickstart still doesn't complete fully end-to-end even after this fix.** Verified against a real built binary in a throwaway fixture: with the fix, `start issue-96` now reaches the normal preview/confirm gate (session-pinning is resolved) -- but a fresh 3-member orchestrated team sharing one project directory then hits the pre-existing `worktree_isolation` preflight (`#538`-era, unrelated to this milestone): "2+ mutation-capable members share one working directory without a recorded exception." This is a **separate, pre-existing** gap, not introduced or claimed-fixed by gh#792 or this PR -- the quickstart as written has apparently never been literally runnable start-to-finish without either per-member `--cwd` or `--shared-cwd-exception`. Flagging for cto's call on whether to fix in a follow-up (add the exception step to the example, or note it as an intentional operator decision point) rather than silently expanding this PR's scope.

## Verification

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -timeout 20m ./...` (full module) clean except the confirmed pre-existing `TestRealPTYWaitPostureRefusesNamedGateBeforeTimeout` flake
- [x] `make readme-html-check docs-html-check skills-check skill-routing-check skill-command-check skill-invocation-check release-validator-test go-files-scope-test` all pass
- [x] `--session issue-96` fix verified end-to-end against a built binary (session pinning + `brief` + `start` preview all confirmed working, up to the disclosed pre-existing worktree-isolation gate above)
- [x] Every factual claim about current CLI behavior in the release notes/migration doc was checked against either the actual merged PR bodies or direct execution against a built binary -- not carried over from earlier drafts without re-verification (two stale claims from an earlier draft, both about `goal`/`--redeliver-goal` replacement text, were caught and corrected during this pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)